### PR TITLE
fix(mqtt source): add handlers to indices before restarting connector when session resumes (r58)

### DIFF
--- a/.ci/docker-compose-file/toxiproxy.json
+++ b/.ci/docker-compose-file/toxiproxy.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "mqtt_self_tcp",
+    "listen": "0.0.0.0:1883",
+    "upstream": "erlang:1883",
+    "enabled": true
+  },
+  {
     "name": "influxdb_tcp",
     "listen": "0.0.0.0:8086",
     "upstream": "influxdb_tcp:8086",

--- a/apps/emqx_bridge_mqtt/docker-ct
+++ b/apps/emqx_bridge_mqtt/docker-ct
@@ -1,0 +1,1 @@
+toxiproxy

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_mqtt, [
     {description, "EMQX MQTT Broker Bridge"},
-    {vsn, "0.2.11"},
+    {vsn, "0.2.12"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -101,15 +101,23 @@ resource_type() -> mqtt.
 callback_mode() -> async_if_possible.
 
 -spec on_start(connector_resource_id(), map()) -> {ok, connector_state()} | {error, term()}.
-on_start(ResourceId, #{server := Server} = Conf) ->
-    ?SLOG(info, #{
-        msg => "starting_mqtt_connector",
-        connector => ResourceId,
+on_start(ConnResId, #{server := Server} = Conf) ->
+    ?tp(info, "starting_mqtt_connector", #{
+        connector => ConnResId,
         config => emqx_utils:redact(Conf)
     }),
     TopicToHandlerIndex = emqx_topic_index:new(),
-    StartConf = Conf#{topic_to_handler_index => TopicToHandlerIndex},
-    case start_mqtt_clients(ResourceId, StartConf) of
+    ok = emqx_resource:allocate_resource(
+        ConnResId,
+        topic_to_handler_index,
+        TopicToHandlerIndex
+    ),
+    PartialConnState = Conf#{
+        topic_to_handler_index => TopicToHandlerIndex,
+        server => Server
+    },
+    maybe_add_sources_with_sessions_to_topic_handler(ConnResId, Conf, PartialConnState),
+    case start_mqtt_clients(ConnResId, PartialConnState) of
         {ok, Result1} ->
             {ok, Result1#{
                 installed_channels => #{},
@@ -118,7 +126,7 @@ on_start(ResourceId, #{server := Server} = Conf) ->
                 server => Server
             }};
         {error, Reason} ->
-            ets:delete(TopicToHandlerIndex),
+            ets_delete(TopicToHandlerIndex),
             {error, emqx_maybe:define(explain_error(Reason), Reason)}
     end.
 
@@ -161,36 +169,28 @@ on_add_channel(
     NewState = OldState#{installed_channels => NewInstalledChannels},
     {ok, NewState};
 on_add_channel(
-    _ResourceId,
+    ConnResId,
     #{
         installed_channels := InstalledChannels,
         pool_name := PoolName,
         pool_size := PoolSize,
-        topic_to_handler_index := TopicToHandlerIndex,
-        server := Server
+        topic_to_handler_index := _TopicToHandlerIndex,
+        server := _Server
     } = OldState,
     ChannelId,
-    #{hookpoints := HookPoints} = ChannelConfig
+    #{hookpoints := _HookPoints} = ChannelConfig
 ) ->
-    %% Add ingress channel
-    RemoteParams0 = maps:get(parameters, ChannelConfig),
-    {LocalParams, RemoteParams} = take(local, RemoteParams0, #{}),
-    ChannelState0 = #{
-        hookpoints => HookPoints,
-        server => Server,
-        config_root => sources,
-        local => LocalParams,
-        remote => RemoteParams
-    },
-    ChannelState1 = mk_ingress_config(ChannelId, ChannelState0, TopicToHandlerIndex),
-    ok = emqx_bridge_mqtt_ingress:subscribe_channel(PoolName, ChannelState1),
+    ChannelState = do_add_sources_with_sessions_to_topic_handler(
+        ConnResId, OldState, ChannelId, ChannelConfig
+    ),
+    ok = emqx_bridge_mqtt_ingress:subscribe_channel(PoolName, ChannelState),
     ReconnectContext = #{
         chan_res_id => ChannelId,
-        ingress_config => ChannelState1,
+        ingress_config => ChannelState,
         pool_size => PoolSize
     },
     ok = emqx_bridge_mqtt_ingress:add_reconnect_callback(PoolName, ReconnectContext),
-    NewInstalledChannels = maps:put(ChannelId, ChannelState1, InstalledChannels),
+    NewInstalledChannels = maps:put(ChannelId, ChannelState, InstalledChannels),
     NewState = OldState#{installed_channels => NewInstalledChannels},
     {ok, NewState}.
 
@@ -208,8 +208,10 @@ on_remove_channel(
             %% maybe the channel failed to be added, just ignore it
             {ok, OldState};
         {ok, ChannelState} ->
+            %% No need to call unsubscribe if state is already gone.
+            IsTableValid = undefined /= ets:info(TopicToHandlerIndex, name),
             case ChannelState of
-                #{config_root := sources} ->
+                #{config_root := sources} when IsTableValid ->
                     ok = emqx_bridge_mqtt_ingress:remove_reconnect_callback(PoolName, ChannelId),
                     ok = emqx_bridge_mqtt_ingress:unsubscribe_channel(
                         PoolName, ChannelState, ChannelId, TopicToHandlerIndex
@@ -311,28 +313,21 @@ get_available_clientid_info(#{} = Conf, ClientOpts) ->
             )
     end.
 
-on_stop(ResourceId, State) ->
+on_stop(ConnResId, _State) ->
     ?SLOG(info, #{
         msg => "stopping_mqtt_connector",
-        resource_id => ResourceId
+        resource_id => ConnResId
     }),
     %% on_stop can be called with State = undefined
-    StateMap =
-        case State of
-            Map when is_map(State) ->
-                Map;
-            _ ->
-                #{}
-        end,
-    case maps:get(topic_to_handler_index, StateMap, undefined) of
+    Allocated = emqx_resource:get_allocated_resources(ConnResId),
+    case maps:get(topic_to_handler_index, Allocated, undefined) of
         undefined ->
             ok;
         TopicToHandlerIndex ->
-            ets:delete(TopicToHandlerIndex)
+            ets_delete(TopicToHandlerIndex)
     end,
-    Allocated = emqx_resource:get_allocated_resources(ResourceId),
     ok = stop_helper(Allocated),
-    ?tp(mqtt_connector_stopped, #{instance_id => ResourceId}),
+    ?tp(mqtt_connector_stopped, #{instance_id => ConnResId}),
     ok.
 
 stop_helper(#{pool_name := PoolName}) ->
@@ -656,6 +651,55 @@ mk_client_event_handler(Name, TopicToHandlerIndex) ->
         disconnected => {fun ?MODULE:handle_disconnect/1, []}
     }.
 
+%% If we have `clean_start = false`, then we must add the sources' topics to the topic
+%% handler index before starting the MQTT clients.  Otherwise, upon connecting, there
+%% might be some messages arriving that were queued in the session which will have no
+%% handler assigned, and thus will be lost.
+%%
+%% When the channel is properly added to the state, adding the topics to the indices
+%% should be idempotent.
+maybe_add_sources_with_sessions_to_topic_handler(
+    _ConnResId, #{clean_start := true} = _ConnConfig, _PartialConnState
+) ->
+    ok;
+maybe_add_sources_with_sessions_to_topic_handler(ConnResId, #{} = _ConnConfig, PartialConnState) ->
+    lists:foreach(
+        fun
+            ({ChannelId, #{config_root := sources} = ChannelConfig}) ->
+                do_add_sources_with_sessions_to_topic_handler(
+                    ConnResId, PartialConnState, ChannelId, ChannelConfig
+                );
+            (_) ->
+                ok
+        end,
+        emqx_bridge_v2:get_channels_for_connector(ConnResId)
+    ).
+
+do_add_sources_with_sessions_to_topic_handler(
+    _ConnResId, PartialConnState, ChannelId, ChannelConfig
+) ->
+    #{
+        server := Server,
+        topic_to_handler_index := TopicToHandlerIndex
+    } = PartialConnState,
+    #{hookpoints := HookPoints} = ChannelConfig,
+    %% Add ingress channel
+    RemoteParams0 = maps:get(parameters, ChannelConfig),
+    {LocalParams, RemoteParams} = take(local, RemoteParams0, #{}),
+    ChannelState0 = #{
+        hookpoints => HookPoints,
+        server => Server,
+        config_root => sources,
+        local => LocalParams,
+        remote => RemoteParams
+    },
+    %% This has the side-effect of adding a topic to the indices.
+    mk_ingress_config(
+        ChannelId,
+        ChannelState0,
+        TopicToHandlerIndex
+    ).
+
 -spec connect(pid(), name()) ->
     {ok, pid()} | {error, _Reason}.
 connect(Pid, Name) ->
@@ -727,3 +771,13 @@ is_expected_to_have_workers(#{available_clientids := []} = _ConnState) ->
     false;
 is_expected_to_have_workers(_ConnState) ->
     true.
+
+%% Can't just call `emqx_utils_ets:delete/1` for anonymous tables.
+ets_delete(Tid) ->
+    case ets:info(Tid, name) of
+        undefined ->
+            ok;
+        _ ->
+            ets:delete(Tid),
+            ok
+    end.

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_subscriber_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_subscriber_SUITE.erl
@@ -31,21 +31,26 @@
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
 -define(ON_ALL(NODES, BODY), erpc:multicall(NODES, fun() -> BODY end)).
 
--define(assertReceivePublish(TOPIC, EXPR, TIMEOUT), begin
-    ?assertMatch(
-        EXPR,
-        maps:update_with(
-            payload,
-            fun emqx_utils_json:decode/1,
-            element(2, ?assertReceive({publish, #{topic := TOPIC}}, TIMEOUT, #{topic => TOPIC}))
+-define(assertReceivePublish(EXPR, GUARD, EXTRA, TIMEOUT),
+    (fun() ->
+        lists:foreach(
+            fun(Pub0) ->
+                Pub = maps:update_with(
+                    payload,
+                    fun emqx_utils_json:decode/1,
+                    Pub0
+                ),
+                self() ! {decoded, Pub}
+            end,
+            drain_publishes([])
         ),
-        #{
-            topic => TOPIC,
-            mailbox => ?drainMailbox()
-        }
-    )
-end).
--define(assertReceivePublish(TOPIC, EXPR), ?assertReceivePublish(TOPIC, EXPR, 1_000)).
+        {decoded, __X} = ?assertReceive({decoded, EXPR} when ((GUARD)), TIMEOUT, EXTRA),
+        __X
+    end)()
+).
+-define(assertReceivePublish(EXPR), ?assertReceivePublish(EXPR, true, #{}, 1_000)).
+-define(assertReceivePublish(EXPR, EXTRA), ?assertReceivePublish(EXPR, true, EXTRA, 1_000)).
+-define(assertReceivePublish(EXPR, GUARD, EXTRA), ?assertReceivePublish(EXPR, GUARD, EXTRA, 1_000)).
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
@@ -171,6 +176,14 @@ end_per_testcase(_TestCase, Config) ->
 %%------------------------------------------------------------------------------
 %% Helper fns
 %%------------------------------------------------------------------------------
+
+drain_publishes(Acc) ->
+    receive
+        {publish, Msg} ->
+            drain_publishes([Msg | Acc])
+    after 200 ->
+        lists:reverse(Acc)
+    end.
 
 connector_config() ->
     #{
@@ -800,16 +813,14 @@ do_t_resubscribe_on_fast_failure(CleanStart, ProtoVer, TCConfig) ->
     emqtt:publish(Pub1, <<"u/a">>, <<"2">>),
     %% Sanity check: sources should be working.
     ?assertReceivePublish(
-        RepublishTopicA,
-        #{payload := #{<<"payload">> := <<"1">>}}
+        #{topic := RepublishTopicA, payload := #{<<"payload">> := <<"1">>}}
     ),
     %% We receive this multiple times because it's an ordinary subscription, so each node
     %% receives and forwards it.
     lists:foreach(
         fun(_) ->
             ?assertReceivePublish(
-                RepublishTopicB,
-                #{payload := #{<<"payload">> := <<"2">>}}
+                #{topic := RepublishTopicB, payload := #{<<"payload">> := <<"2">>}}
             )
         end,
         lists:seq(1, NumNodes)
@@ -838,16 +849,16 @@ do_t_resubscribe_on_fast_failure(CleanStart, ProtoVer, TCConfig) ->
     emqtt:stop(Pub2),
 
     ?assertReceivePublish(
-        RepublishTopicA,
-        #{payload := #{<<"payload">> := <<"3">>}},
+        #{topic := RepublishTopicA, payload := #{<<"payload">> := <<"3">>}},
+        true,
+        #{},
         3_000
     ),
     lists:foreach(
         fun(N) ->
             ct:pal("expecting B message ~b", [N]),
             ?assertReceivePublish(
-                RepublishTopicB,
-                #{payload := #{<<"payload">> := <<"4">>}}
+                #{topic := RepublishTopicB, payload := #{<<"payload">> := <<"4">>}}
             )
         end,
         lists:seq(1, NumNodes)
@@ -876,10 +887,131 @@ do_t_resubscribe_on_fast_failure(CleanStart, ProtoVer, TCConfig) ->
     emqtt:stop(Pub3),
 
     ?assertReceivePublish(
-        RepublishTopicA,
-        #{payload := #{<<"payload">> := <<"5">>}},
+        #{topic := RepublishTopicA, payload := #{<<"payload">> := <<"5">>}},
+        true,
+        #{},
         3_000
     ),
     ?assertNotReceive({publish, _}),
+
+    ok.
+
+%% Verifies the following scenario:
+%%
+%% 1) Create a connector, source and rule pointing to a toxiproxy server, which can point to
+%%    the broker itself.
+%% 2) Cut the connection with toxiproxy.
+%% 3) Send a few QoS 1 messages to the source’s topic.
+%% 4) Wait for 2 connector health checks, so that the connector state is wiped out by the
+%%    resource manager restart attempts.
+%% 5) Restore the connection in toxiproxy.
+%%
+%% When connection is reestablished, the messages that were queued up in the connector's
+%% session should trigger the rule actions.
+t_reconnect_with_session(TCConfig) when is_list(TCConfig) ->
+    ProxyName = <<"mqtt_self_tcp">>,
+    ProxyHost = "toxiproxy",
+    ProxyPort = 8474,
+    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
+
+    NodeBin = atom_to_binary(node()),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    ProtoVer = <<"v3">>,
+    {201, #{<<"status">> := <<"connected">>}} = create_connector_api(TCConfig, #{
+        <<"server">> => <<"toxiproxy:1883">>,
+        <<"clean_start">> => false,
+        <<"proto_ver">> => ProtoVer,
+        <<"static_clientids">> => [#{<<"node">> => NodeBin, <<"ids">> => [ClientId]}],
+        <<"resource_opts">> => #{
+            %% Quick interval so we can wait for a couple attempts before proceeding.
+            <<"health_check_interval">> => <<"200ms">>
+        }
+    }),
+    {201, #{<<"parameters">> := #{<<"topic">> := RemoteTopic}}} =
+        create_source_api(TCConfig, #{}),
+    #{id := RuleId, topic := RepublishTopic} = simple_create_rule_api(TCConfig),
+    C = start_client(TCConfig),
+    {ok, _, [_]} = emqtt:subscribe(C, RepublishTopic, [{qos, 2}]),
+    %% Sanity check: source is initially working fine.
+    emqx:publish(emqx_message:make(RemoteTopic, <<"1">>)),
+    ?assertReceivePublish(#{payload := #{<<"payload">> := <<"1">>}}),
+
+    %% Cut the connection
+    on_exit(fun() -> emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort) end),
+    {ok, _} = emqx_common_test_helpers:enable_failure(down, ProxyName, ProxyHost, ProxyPort),
+
+    %% Enqueue some messages into the session.
+    lists:foreach(
+        fun(N) ->
+            Payload = integer_to_binary(N),
+            emqx:publish(emqx_message:make(<<"me">>, 1, RemoteTopic, Payload))
+        end,
+        lists:seq(2, 4)
+    ),
+
+    %% Wait for at least 2 health checks.
+    ct:sleep(2 * 200 + 100),
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            {200, #{<<"status">> := <<"disconnected">>}},
+            get_connector_api(TCConfig)
+        )
+    ),
+    ?assertMatch(
+        #{
+            counters := #{
+                %% only the smoke test message
+                'matched' := 1,
+                'passed' := 1,
+                'failed' := 0,
+                'failed.exception' := 0,
+                'failed.no_result' := 0,
+                'actions.total' := 1,
+                'actions.success' := 1,
+                'actions.failed' := 0,
+                'actions.failed.out_of_service' := 0,
+                'actions.failed.unknown' := 0
+            }
+        },
+        emqx_bridge_v2_testlib:get_rule_metrics(RuleId)
+    ),
+
+    %% Restore connection.  Should trigger rule actions.
+    {ok, _} = emqx_common_test_helpers:heal_failure(down, ProxyName, ProxyHost, ProxyPort),
+
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            {200, #{<<"status">> := <<"connected">>}},
+            get_connector_api(TCConfig)
+        )
+    ),
+    ?retry(
+        500,
+        10,
+        ?assertMatch(
+            #{
+                counters := #{
+                    'matched' := 4,
+                    'passed' := 4,
+                    'failed' := 0,
+                    'failed.exception' := 0,
+                    'failed.no_result' := 0,
+                    'actions.total' := 4,
+                    'actions.success' := 4,
+                    'actions.failed' := 0,
+                    'actions.failed.out_of_service' := 0,
+                    'actions.failed.unknown' := 0
+                }
+            },
+            emqx_bridge_v2_testlib:get_rule_metrics(RuleId)
+        )
+    ),
+    ?assertReceivePublish(#{payload := #{<<"payload">> := <<"2">>}}),
+    ?assertReceivePublish(#{payload := #{<<"payload">> := <<"3">>}}),
+    ?assertReceivePublish(#{payload := #{<<"payload">> := <<"4">>}}),
 
     ok.

--- a/changes/ee/fix-17085.en.md
+++ b/changes/ee/fix-17085.en.md
@@ -1,0 +1,1 @@
+Fixed an issue with MQTT Sources in which, if its Connector used `clean_start = false` and reconnected to a broker with a session containing messages, those messages would not trigger rule actions.


### PR DESCRIPTION
Port of fix to `release-58`

Fixes https://emqx.atlassian.net/browse/EMQX-15223

Release version:
5.8.11, 5.10.4

## Summary

Steps to reproduce:

1) Create a connector, source and rule pointing to a toxiproxy server, which can point to
   the broker itself.
2) Cut the connection with toxiproxy.
3) Send a few QoS 1 messages to the source’s topic. 4) Wait for 2 connector health checks, so that the connector state is wiped out by the
   resource manager restart attempts.
5) Restore the connection in toxiproxy.

The new clients do receive the messages, but the ETS table holding the topic → handler mapping is empty, and thus triggers no action.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
