### PR TITLE
chore(tests): remove redundant checks

### DIFF
--- a/apps/emqx_auth_ldap/test/emqx_authn_ldap_bind_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authn_ldap_bind_SUITE.erl
@@ -37,15 +37,10 @@ end_per_testcase(_, Config) ->
 
 init_per_suite(Config) ->
     _ = application:load(emqx_conf),
-    case emqx_common_test_helpers:is_tcp_server_available(?LDAP_HOST, ?LDAP_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_ldap], #{
-                work_dir => ?config(priv_dir, Config)
-            }),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_ldap}
-    end.
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_ldap], #{
+        work_dir => ?config(priv_dir, Config)
+    }),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     emqx_authn_test_lib:delete_authenticators(

--- a/apps/emqx_auth_ldap/test/emqx_authz_ldap_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authz_ldap_SUITE.erl
@@ -20,22 +20,16 @@ groups() ->
     emqx_authz_test_lib:table_groups(t_run_case, cases()).
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?LDAP_HOST, ?LDAP_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx,
-                    {emqx_conf,
-                        "authorization.no_match = deny, authorization.cache.enable = false"},
-                    emqx_auth,
-                    emqx_auth_ldap
-                ],
-                #{work_dir => emqx_cth_suite:work_dir(Config)}
-            ),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_ldap}
-    end.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            {emqx_conf, "authorization.no_match = deny, authorization.cache.enable = false"},
+            emqx_auth,
+            emqx_auth_ldap
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     Apps = ?config(apps, Config),

--- a/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
@@ -35,15 +35,10 @@ end_per_testcase(_TestCase, _Config) ->
     ok = mc_worker_api:disconnect(?MONGO_CLIENT).
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?MONGO_HOST, ?MONGO_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mongodb], #{
-                work_dir => ?config(priv_dir, Config)
-            }),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_mongo}
-    end.
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mongodb], #{
+        work_dir => ?config(priv_dir, Config)
+    }),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     emqx_authn_test_lib:delete_authenticators(

--- a/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_tls_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_tls_SUITE.erl
@@ -32,15 +32,10 @@ end_per_testcase(_TestCase, _Config) ->
     ok.
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?MONGO_HOST, ?MONGO_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mongodb], #{
-                work_dir => ?config(priv_dir, Config)
-            }),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_mongo}
-    end.
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mongodb], #{
+        work_dir => ?config(priv_dir, Config)
+    }),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     emqx_authn_test_lib:delete_authenticators(

--- a/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
@@ -33,22 +33,16 @@ groups() ->
         emqx_authz_test_lib:table_groups(t_run_case, cases()).
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?MONGO_HOST, ?MONGO_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx,
-                    {emqx_conf,
-                        "authorization.no_match = deny, authorization.cache.enable = false"},
-                    emqx_auth,
-                    emqx_auth_mongodb
-                ],
-                #{work_dir => ?config(priv_dir, Config)}
-            ),
-            [{suite_apps, Apps} | Config];
-        false ->
-            {skip, no_mongo}
-    end.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            {emqx_conf, "authorization.no_match = deny, authorization.cache.enable = false"},
+            emqx_auth,
+            emqx_auth_mongodb
+        ],
+        #{work_dir => ?config(priv_dir, Config)}
+    ),
+    [{suite_apps, Apps} | Config].
 
 end_per_suite(Config) ->
     ok = emqx_authz_test_lib:restore_authorizers(),

--- a/apps/emqx_auth_postgresql/test/emqx_authn_postgresql_tls_SUITE.erl
+++ b/apps/emqx_auth_postgresql/test/emqx_authn_postgresql_tls_SUITE.erl
@@ -33,15 +33,10 @@ init_per_testcase(_, Config) ->
 
 init_per_suite(Config) ->
     _ = application:load(emqx_conf),
-    case emqx_common_test_helpers:is_tcp_server_available(?PGSQL_HOST, ?PGSQL_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_postgresql], #{
-                work_dir => ?config(priv_dir, Config)
-            }),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_pgsql_tls}
-    end.
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_postgresql], #{
+        work_dir => ?config(priv_dir, Config)
+    }),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     emqx_authn_test_lib:delete_authenticators(

--- a/apps/emqx_auth_redis/test/emqx_authn_redis_SUITE.erl
+++ b/apps/emqx_auth_redis/test/emqx_authn_redis_SUITE.erl
@@ -35,22 +35,17 @@ end_per_testcase(_TestCase, _Config) ->
     ok.
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?REDIS_HOST, ?REDIS_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_redis], #{
-                work_dir => ?config(priv_dir, Config)
-            }),
-            {ok, _} = emqx_resource:create_local(
-                ?REDIS_RESOURCE,
-                ?AUTHN_RESOURCE_GROUP,
-                emqx_redis,
-                redis_config(),
-                #{}
-            ),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_redis}
-    end.
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_redis], #{
+        work_dir => ?config(priv_dir, Config)
+    }),
+    {ok, _} = emqx_resource:create_local(
+        ?REDIS_RESOURCE,
+        ?AUTHN_RESOURCE_GROUP,
+        emqx_redis,
+        redis_config(),
+        #{}
+    ),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     emqx_authn_test_lib:delete_authenticators(

--- a/apps/emqx_auth_redis/test/emqx_authn_redis_tls_SUITE.erl
+++ b/apps/emqx_auth_redis/test/emqx_authn_redis_tls_SUITE.erl
@@ -30,15 +30,10 @@ init_per_testcase(_, Config) ->
     Config.
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?REDIS_HOST, ?REDIS_TLS_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_redis], #{
-                work_dir => ?config(priv_dir, Config)
-            }),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_redis}
-    end.
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_redis], #{
+        work_dir => ?config(priv_dir, Config)
+    }),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     emqx_authn_test_lib:delete_authenticators(

--- a/apps/emqx_auth_redis/test/emqx_authz_redis_SUITE.erl
+++ b/apps/emqx_auth_redis/test/emqx_authz_redis_SUITE.erl
@@ -22,23 +22,17 @@ groups() ->
     emqx_authz_test_lib:table_groups(t_run_case, cases()).
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?REDIS_HOST, ?REDIS_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx,
-                    {emqx_conf,
-                        "authorization.no_match = deny, authorization.cache.enable = false"},
-                    emqx_auth,
-                    emqx_auth_redis
-                ],
-                #{work_dir => ?config(priv_dir, Config)}
-            ),
-            ok = create_redis_resource(),
-            [{suite_apps, Apps} | Config];
-        false ->
-            {skip, no_redis}
-    end.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            {emqx_conf, "authorization.no_match = deny, authorization.cache.enable = false"},
+            emqx_auth,
+            emqx_auth_redis
+        ],
+        #{work_dir => ?config(priv_dir, Config)}
+    ),
+    ok = create_redis_resource(),
+    [{suite_apps, Apps} | Config].
 
 end_per_suite(Config) ->
     ok = emqx_authz_test_lib:restore_authorizers(),

--- a/apps/emqx_bridge_azure_blob_storage/test/emqx_bridge_azure_blob_storage_SUITE.erl
+++ b/apps/emqx_bridge_azure_blob_storage/test/emqx_bridge_azure_blob_storage_SUITE.erl
@@ -59,43 +59,32 @@ groups() ->
 
 init_per_suite(Config) ->
     Endpoint = os:getenv("AZURITE_ENDPOINT", "http://toxiproxy:10000/"),
-    #{host := Host, port := Port} = uri_string:parse(Endpoint),
     ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
     ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
     ProxyName = "azurite_plain",
     emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
-    case emqx_common_test_helpers:is_tcp_server_available(Host, Port) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx,
-                    emqx_conf,
-                    emqx_bridge_azure_blob_storage,
-                    emqx_bridge,
-                    emqx_rule_engine,
-                    emqx_schema_registry,
-                    emqx_management,
-                    emqx_mgmt_api_test_util:emqx_dashboard()
-                ],
-                #{work_dir => emqx_cth_suite:work_dir(Config)}
-            ),
-            {ok, _Api} = emqx_common_test_http:create_default_app(),
-            [
-                {apps, Apps},
-                {proxy_name, ProxyName},
-                {proxy_host, ProxyHost},
-                {proxy_port, ProxyPort},
-                {endpoint, Endpoint}
-                | Config
-            ];
-        false ->
-            case os:getenv("IS_CI") of
-                "yes" ->
-                    throw(no_azurite);
-                _ ->
-                    {skip, no_azurite}
-            end
-    end.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_bridge_azure_blob_storage,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_schema_registry,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    {ok, _Api} = emqx_common_test_http:create_default_app(),
+    [
+        {apps, Apps},
+        {proxy_name, ProxyName},
+        {proxy_host, ProxyHost},
+        {proxy_port, ProxyPort},
+        {endpoint, Endpoint}
+        | Config
+    ].
 
 end_per_suite(Config) ->
     Apps = ?config(apps, Config),

--- a/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_producer_SUITE.erl
+++ b/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_producer_SUITE.erl
@@ -32,40 +32,30 @@ init_per_suite(Config) ->
     ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
     ProxyName = "kafka_sasl_ssl",
     emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
-    case emqx_common_test_helpers:is_tcp_server_available(KafkaHost, KafkaPort) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx_conf,
-                    emqx,
-                    emqx_management,
-                    emqx_resource,
-                    %% Just for test helpers
-                    brod,
-                    emqx_bridge_confluent,
-                    emqx_bridge,
-                    emqx_rule_engine,
-                    emqx_mgmt_api_test_util:emqx_dashboard()
-                ],
-                #{work_dir => ?config(priv_dir, Config)}
-            ),
-            [
-                {tc_apps, Apps},
-                {proxy_name, ProxyName},
-                {proxy_host, ProxyHost},
-                {proxy_port, ProxyPort},
-                {kafka_host, KafkaHost},
-                {kafka_port, KafkaPort}
-                | Config
-            ];
-        false ->
-            case os:getenv("IS_CI") of
-                "yes" ->
-                    throw(no_kafka);
-                _ ->
-                    {skip, no_kafka}
-            end
-    end.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx_conf,
+            emqx,
+            emqx_management,
+            emqx_resource,
+            %% Just for test helpers
+            brod,
+            emqx_bridge_confluent,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => ?config(priv_dir, Config)}
+    ),
+    [
+        {tc_apps, Apps},
+        {proxy_name, ProxyName},
+        {proxy_host, ProxyHost},
+        {proxy_port, ProxyPort},
+        {kafka_host, KafkaHost},
+        {kafka_port, KafkaPort}
+        | Config
+    ].
 
 end_per_suite(Config) ->
     Apps = ?config(tc_apps, Config),

--- a/apps/emqx_bridge_couchbase/test/emqx_bridge_couchbase_SUITE.erl
+++ b/apps/emqx_bridge_couchbase/test/emqx_bridge_couchbase_SUITE.erl
@@ -39,39 +39,29 @@ init_per_suite(Config) ->
     ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
     ProxyName = "couchbase",
     emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
-    case emqx_common_test_helpers:is_tcp_server_available(Host, Port) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx,
-                    emqx_conf,
-                    emqx_bridge_couchbase,
-                    emqx_bridge,
-                    emqx_rule_engine,
-                    emqx_management,
-                    emqx_mgmt_api_test_util:emqx_dashboard()
-                ],
-                #{work_dir => emqx_cth_suite:work_dir(Config)}
-            ),
-            [
-                {apps, Apps},
-                {proxy_name, ProxyName},
-                {proxy_host, ProxyHost},
-                {proxy_port, ProxyPort},
-                {server, Server},
-                {host, Host},
-                {direct_host, DirectHost},
-                {admin_port, AdminPort}
-                | Config
-            ];
-        false ->
-            case os:getenv("IS_CI") of
-                "yes" ->
-                    throw(no_couchbase);
-                _ ->
-                    {skip, no_couchbase}
-            end
-    end.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_bridge_couchbase,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [
+        {apps, Apps},
+        {proxy_name, ProxyName},
+        {proxy_host, ProxyHost},
+        {proxy_port, ProxyPort},
+        {server, Server},
+        {host, Host},
+        {direct_host, DirectHost},
+        {admin_port, AdminPort}
+        | Config
+    ].
 
 end_per_suite(Config) ->
     Apps = ?config(apps, Config),

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
@@ -81,70 +81,65 @@ init_per_group(DatalayersType, Config0) when
                     proxy_name => "datalayers_https"
                 }
         end,
-    case emqx_common_test_helpers:is_tcp_server_available(DatalayersHost, DatalayersPort) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx_conf,
-                    emqx_bridge_datalayers,
-                    emqx_connector,
-                    emqx_bridge,
-                    emqx_rule_engine,
-                    emqx_management,
-                    emqx_mgmt_api_test_util:emqx_dashboard()
-                ],
-                #{work_dir => emqx_cth_suite:work_dir(Config0)}
-            ),
-            Config = [{apps, Apps}, {use_tls, UseTLS} | Config0],
-            {Name, ConnConfString, ConnConfMap, ActionConfString, ActionConfMap} = datalayers_config(
-                DatalayersHost, DatalayersPort, Config
-            ),
-            EHttpcPoolNameBin = <<(atom_to_binary(?MODULE))/binary, "_apiv1">>,
-            EHttpcPoolName = binary_to_atom(EHttpcPoolNameBin),
-            {EHttpcTransport, EHttpcTransportOpts} =
-                case UseTLS of
-                    true -> {tls, [{verify, verify_none}]};
-                    false -> {tcp, []}
-                end,
-            EHttpcPoolOpts = [
-                {host, DatalayersHost},
-                {port, DatalayersPort},
-                {pool_size, 1},
-                {transport, EHttpcTransport},
-                {transport_opts, EHttpcTransportOpts}
-            ],
+    Apps = emqx_cth_suite:start(
+        [
+            emqx_conf,
+            emqx_bridge_datalayers,
+            emqx_connector,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config0)}
+    ),
+    Config = [{apps, Apps}, {use_tls, UseTLS} | Config0],
+    {Name, ConnConfString, ConnConfMap, ActionConfString, ActionConfMap} = datalayers_config(
+        DatalayersHost, DatalayersPort, Config
+    ),
+    EHttpcPoolNameBin = <<(atom_to_binary(?MODULE))/binary, "_apiv1">>,
+    EHttpcPoolName = binary_to_atom(EHttpcPoolNameBin),
+    {EHttpcTransport, EHttpcTransportOpts} =
+        case UseTLS of
+            true -> {tls, [{verify, verify_none}]};
+            false -> {tcp, []}
+        end,
+    EHttpcPoolOpts = [
+        {host, DatalayersHost},
+        {port, DatalayersPort},
+        {pool_size, 1},
+        {transport, EHttpcTransport},
+        {transport_opts, EHttpcTransportOpts}
+    ],
 
-            {ok, _} = ehttpc_sup:start_pool(EHttpcPoolName, EHttpcPoolOpts),
-            NewConfig =
-                [
-                    {proxy_host, ProxyHost},
-                    {proxy_port, ProxyPort},
-                    {proxy_name, ProxyName},
+    {ok, _} = ehttpc_sup:start_pool(EHttpcPoolName, EHttpcPoolOpts),
+    NewConfig =
+        [
+            {proxy_host, ProxyHost},
+            {proxy_port, ProxyPort},
+            {proxy_name, ProxyName},
 
-                    {datalayers_host, DatalayersHost},
-                    {datalayers_port, DatalayersPort},
-                    {ehttpc_pool_name, EHttpcPoolName},
+            {datalayers_host, DatalayersHost},
+            {datalayers_port, DatalayersPort},
+            {ehttpc_pool_name, EHttpcPoolName},
 
-                    {bridge_kind, action},
-                    {bridge_type, datalayers},
-                    {bridge_name, Name},
-                    {bridge_config, ActionConfMap},
-                    {bridge_config_string, ActionConfString},
-                    {action_type, datalayers},
-                    {action_name, Name},
-                    {action_config, ActionConfMap},
+            {bridge_kind, action},
+            {bridge_type, datalayers},
+            {bridge_name, Name},
+            {bridge_config, ActionConfMap},
+            {bridge_config_string, ActionConfString},
+            {action_type, datalayers},
+            {action_name, Name},
+            {action_config, ActionConfMap},
 
-                    {connector_name, Name},
-                    {connector_type, datalayers},
-                    {connector_config, ConnConfMap},
-                    {connector_config_string, ConnConfString}
-                    | Config
-                ],
-            ensure_database(NewConfig),
-            NewConfig;
-        false ->
-            {skip, no_datalayers}
-    end;
+            {connector_name, Name},
+            {connector_type, datalayers},
+            {connector_config, ConnConfMap},
+            {connector_config_string, ConnConfString}
+            | Config
+        ],
+    ensure_database(NewConfig),
+    NewConfig;
 init_per_group(sync_query, Config) ->
     [{query_mode, sync} | Config];
 init_per_group(async_query, Config) ->

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_SUITE.erl
@@ -106,57 +106,52 @@ init_per_group(GroupName, Config0) when
             ]
         )
     ),
-    case emqx_common_test_helpers:is_tcp_server_available(DatalayersHost, DatalayersPort) of
-        true ->
-            ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
-            ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
-            emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx_conf,
-                    emqx_bridge_datalayers,
-                    emqx_connector,
-                    emqx_bridge,
-                    emqx_rule_engine,
-                    emqx_management,
-                    emqx_mgmt_api_test_util:emqx_dashboard()
-                ],
-                #{work_dir => emqx_cth_suite:work_dir(Config0)}
-            ),
-            Config = [{apps, Apps}, {use_tls, UseTLS} | Config0],
-            {Name, ConnConfString, ConnConfMap, ActionConfString, ActionConfMap} = datalayers_config(
-                DatalayersHost, DatalayersPort, Config
-            ),
-            NewConfig =
-                [
-                    {proxy_host, ProxyHost},
-                    {proxy_port, ProxyPort},
-                    {proxy_name, ProxyName},
+    ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
+    ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
+    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
+    Apps = emqx_cth_suite:start(
+        [
+            emqx_conf,
+            emqx_bridge_datalayers,
+            emqx_connector,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config0)}
+    ),
+    Config = [{apps, Apps}, {use_tls, UseTLS} | Config0],
+    {Name, ConnConfString, ConnConfMap, ActionConfString, ActionConfMap} = datalayers_config(
+        DatalayersHost, DatalayersPort, Config
+    ),
+    NewConfig =
+        [
+            {proxy_host, ProxyHost},
+            {proxy_port, ProxyPort},
+            {proxy_name, ProxyName},
 
-                    {datalayers_host, DatalayersHost},
-                    {datalayers_port, DatalayersPort},
+            {datalayers_host, DatalayersHost},
+            {datalayers_port, DatalayersPort},
 
-                    {bridge_kind, action},
-                    {bridge_type, datalayers},
-                    {bridge_name, Name},
-                    {bridge_config, ActionConfMap},
-                    {bridge_config_string, ActionConfString},
-                    {action_type, datalayers},
-                    {action_name, Name},
-                    {action_config, ActionConfMap},
+            {bridge_kind, action},
+            {bridge_type, datalayers},
+            {bridge_name, Name},
+            {bridge_config, ActionConfMap},
+            {bridge_config_string, ActionConfString},
+            {action_type, datalayers},
+            {action_name, Name},
+            {action_config, ActionConfMap},
 
-                    {connector_name, Name},
-                    {connector_type, datalayers},
-                    {connector_config, ConnConfMap},
-                    {connector_config_string, ConnConfString}
-                    | Config
-                ],
-            ensure_database(NewConfig),
-            ensure_table(NewConfig),
-            NewConfig;
-        false ->
-            {skip, no_datalayers_arrow}
-    end;
+            {connector_name, Name},
+            {connector_type, datalayers},
+            {connector_config, ConnConfMap},
+            {connector_config_string, ConnConfString}
+            | Config
+        ],
+    ensure_database(NewConfig),
+    ensure_table(NewConfig),
+    NewConfig;
 init_per_group(sync_query, Config) ->
     [{query_mode, sync} | Config];
 init_per_group(async_query, Config) ->

--- a/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_table_SUITE.erl
+++ b/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_table_SUITE.erl
@@ -56,51 +56,31 @@ init_per_group(restapi = Type, Config0) ->
     IotDbVersion = ?VSN_2_0_X,
     DefaultPort = "58080",
     Port = list_to_integer(os:getenv("IOTDB_PLAIN_PORT", DefaultPort)),
-    case emqx_common_test_helpers:is_tcp_server_available(Host, Port) of
-        true ->
-            Config = emqx_bridge_v2_testlib:init_per_group(Type, ?BRIDGE_TYPE_BIN, Config0),
-            [
-                {bridge_host, Host},
-                {bridge_port, Port},
-                {rest_port, Port},
-                {proxy_name, <<"iotdb205_rest">>},
-                {iotdb_version, IotDbVersion},
-                {iotdb_rest_prefix, <<"/rest/table/v1/">>}
-                | Config
-            ];
-        false ->
-            case os:getenv("IS_CI") of
-                "yes" ->
-                    throw(no_iotdb);
-                _ ->
-                    {skip, no_iotdb}
-            end
-    end;
+    Config = emqx_bridge_v2_testlib:init_per_group(Type, ?BRIDGE_TYPE_BIN, Config0),
+    [
+        {bridge_host, Host},
+        {bridge_port, Port},
+        {rest_port, Port},
+        {proxy_name, <<"iotdb205_rest">>},
+        {iotdb_version, IotDbVersion},
+        {iotdb_rest_prefix, <<"/rest/table/v1/">>}
+        | Config
+    ];
 init_per_group(thrift = Type, Config0) ->
     Host = os:getenv("IOTDB_THRIFT_HOST", "toxiproxy.emqx.net"),
     Port = list_to_integer(os:getenv("IOTDB_THRIFT_PORT", "56667")),
     DefaultPort = "58080",
     RestPort = list_to_integer(os:getenv("IOTDB_PLAIN_PORT", DefaultPort)),
-    case emqx_common_test_helpers:is_tcp_server_available(Host, Port) of
-        true ->
-            Config = emqx_bridge_v2_testlib:init_per_group(Type, ?BRIDGE_TYPE_BIN, Config0),
-            [
-                {bridge_host, Host},
-                {bridge_port, Port},
-                {rest_port, RestPort},
-                {proxy_name, <<"iotdb205_thrift">>},
-                {iotdb_version, ?PROTOCOL_V3},
-                {iotdb_rest_prefix, <<"/rest/table/v1/">>}
-                | Config
-            ];
-        false ->
-            case os:getenv("IS_CI") of
-                "yes" ->
-                    throw(no_iotdb);
-                _ ->
-                    {skip, no_iotdb}
-            end
-    end;
+    Config = emqx_bridge_v2_testlib:init_per_group(Type, ?BRIDGE_TYPE_BIN, Config0),
+    [
+        {bridge_host, Host},
+        {bridge_port, Port},
+        {rest_port, RestPort},
+        {proxy_name, <<"iotdb205_thrift">>},
+        {iotdb_version, ?PROTOCOL_V3},
+        {iotdb_rest_prefix, <<"/rest/table/v1/">>}
+        | Config
+    ];
 init_per_group(_Group, Config) ->
     Config.
 

--- a/apps/emqx_ldap/test/emqx_ldap_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_SUITE.erl
@@ -38,21 +38,15 @@ end_per_group(_, Config) ->
     proplists:delete(group, Config).
 
 init_per_suite(Config) ->
-    Port = port(tcp),
-    case emqx_common_test_helpers:is_tcp_server_available(?LDAP_HOST, Port) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx,
-                    emqx_conf,
-                    emqx_ldap
-                ],
-                #{work_dir => emqx_cth_suite:work_dir(Config)}
-            ),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_ldap}
-    end.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_ldap
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     Apps = ?config(apps, Config),

--- a/apps/emqx_mongodb/test/emqx_mongodb_SUITE.erl
+++ b/apps/emqx_mongodb/test/emqx_mongodb_SUITE.erl
@@ -23,20 +23,15 @@ groups() ->
     [].
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?MONGO_HOST, ?MONGO_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx_conf,
-                    emqx_connector,
-                    emqx_mongodb
-                ],
-                #{work_dir => emqx_cth_suite:work_dir(Config)}
-            ),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_mongo}
-    end.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx_conf,
+            emqx_connector,
+            emqx_mongodb
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     Apps = ?config(apps, Config),

--- a/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
+++ b/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
@@ -19,16 +19,11 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?MYSQL_HOST, ?MYSQL_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [emqx_conf, emqx_connector],
-                #{work_dir => emqx_cth_suite:work_dir(Config)}
-            ),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_mysql}
-    end.
+    Apps = emqx_cth_suite:start(
+        [emqx_conf, emqx_connector],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(proplists:get_value(apps, Config)).

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -24,16 +24,11 @@ groups() ->
     [].
 
 init_per_suite(Config) ->
-    case emqx_common_test_helpers:is_tcp_server_available(?PGSQL_HOST, ?PGSQL_DEFAULT_PORT) of
-        true ->
-            Apps = emqx_cth_suite:start(
-                [emqx_conf, emqx_connector],
-                #{work_dir => emqx_cth_suite:work_dir(Config)}
-            ),
-            [{apps, Apps} | Config];
-        false ->
-            {skip, no_pgsql}
-    end.
+    Apps = emqx_cth_suite:start(
+        [emqx_conf, emqx_connector],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     Apps = ?config(apps, Config),


### PR DESCRIPTION
Remove the checks:

```erlang
    case emqx_common_test_helpers:is_tcp_server_available(?MONGO_HOST, ?MONGO_DEFAULT_PORT) of
        true ->
            Apps = emqx_cth_suite:start(
               ...
            ),
            [{apps, Apps} | Config];
        false ->
            {skip, no_mongo}
```

The pattern was introduced long ago when the common tests were executed in a single run, to avoid necessity to start all the docker compose files. With [`./scripts/ct/run.sh`](./scripts/ct/run.sh) and per-app runs this seems to be irrelevant anymore.

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
~~- [] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
