### PR TITLE
ci: support cutting -patch.N releases

### DIFF
--- a/scripts/parse-git-ref.sh
+++ b/scripts/parse-git-ref.sh
@@ -45,6 +45,9 @@ elif [[ $1 =~ ^refs/tags/[6-9]\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
 elif [[ $1 =~ ^refs/tags/[6-9]\.[0-9]+\.[0-9]+$ ]]; then
     RELEASE=true
     LATEST=$(is_latest_stable "$1")
+elif [[ $1 =~ ^refs/tags/[6-9]\.[0-9]+\.[0-9]+-patch\.[0-9]+$ ]]; then
+    RELEASE=true
+    LATEST=false
 elif [[ $1 =~ ^refs/tags/.+ ]]; then
     echo "Unrecognized tag: $1" 1>&2
     exit 1

--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -97,6 +97,9 @@ done
 rel_branch() {
     local tag="$1"
     case "$tag" in
+        6.*-patch.*)
+            echo "patch-${tag%-patch.*}"
+            ;;
         6.0.*)
             echo 'release-60'
             ;;

--- a/scripts/rel/sync-remotes.sh
+++ b/scripts/rel/sync-remotes.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # ensure dir
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/../.."
 
-BASE_BRANCHES=( 'release-60' 'release-510' 'release-59' 'release-58' 'release-57' 'release-56' 'release-55' 'master' )
+BASE_BRANCHES=( 'release-62' 'release-61' 'release-60' 'release-510' 'release-59' 'release-58' 'release-57' 'release-56' 'release-55' 'master' )
 
 usage() {
     cat <<EOF
@@ -25,6 +25,9 @@ options:
     * release-59:  []                   # no upstream for 5.9
     * release-510: []                   # no upstream for 5.10
     * release-60:  []                   # no upstream for 6.0
+    * release-61:  []                   # no upstream for 6.1
+    * release-62:  []                   # no upstream for 6.2
+    * patch-*:     []                   # no upstream for patch branches
     * master: [release-5x, release-6x]  # sync release-5x and release-6x to master
 
   -b|--base:
@@ -101,9 +104,9 @@ is_element() {
     return 1
 }
 
-if ! is_element "$BASE_BRANCH" "${BASE_BRANCHES[@]}"; then
+if ! is_element "$BASE_BRANCH" "${BASE_BRANCHES[@]}" && [[ "$BASE_BRANCH" != patch-* ]]; then
     logerr "Cannot work with branch $BASE_BRANCH"
-    logerr "The base branch must be one of: ${BASE_BRANCHES[*]}"
+    logerr "The base branch must be one of: ${BASE_BRANCHES[*]} or a patch-* branch"
     logerr "Change work branch to one of the above."
     logerr "OR: use -b|--base to specify from which base branch is current working branch created"
     exit 1
@@ -172,8 +175,14 @@ upstream_branches() {
         release-60)
             remote_ref "$base"
             ;;
+        release-61)
+            remote_ref "$base"
+            ;;
+        release-62)
+            remote_ref "$base"
+            ;;
         master)
-            remote_refs "$base" 'release-55' 'release-56' 'release-57' 'release-58' 'release-59' 'release-510' 'release-60'
+            remote_refs "$base" 'release-55' 'release-56' 'release-57' 'release-58' 'release-59' 'release-510' 'release-60' 'release-61' 'release-62'
             ;;
     esac
 }


### PR DESCRIPTION
## Summary

- `scripts/parse-git-ref.sh`: recognize `X.Y.Z-patch.N` tags.
- `scripts/rel/cut.sh`: map `6.*-patch.*` tags to `patch-6.*` branches.
- `scripts/rel/sync-remotes.sh`: accept `patch-*` as a valid base branch; also add `release-61`/`release-62` entries that were missing from this file on `release-60`.

Port of the v5 change in #17090.