### PR TITLE
fix(retainer): restore retainer.enable to decouple retain protocol support from storage

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -30,8 +30,7 @@
 -export([
     on_session_subscribed/3,
     on_message_publish/1,
-    post_config_update/5,
-    on_config_zones_updated/2
+    post_config_update/5
 ]).
 
 %% Internal APIs
@@ -147,12 +146,6 @@ on_message_publish(Msg) ->
 post_config_update([retainer], _UpdateReq, NewConf, OldConf, _AppEnvs) ->
     ok = call({update_config, NewConf, OldConf}).
 
-on_config_zones_updated(_OldZones, NewZones) ->
-    case is_enabled(NewZones) of
-        true -> call(start);
-        false -> call(stop)
-    end.
-
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
@@ -223,12 +216,7 @@ is_started() ->
 
 -spec is_enabled() -> boolean().
 is_enabled() ->
-    Zones = emqx_config:get([zones], #{}),
-    is_enabled(Zones).
-
--spec is_enabled(emqx_config:config()) -> boolean().
-is_enabled(Zones) ->
-    lists:any(fun is_enabled_for_zone/1, maps:values(Zones)).
+    emqx_conf:get([retainer, enable], true).
 
 %%------------------------------------------------------------------------------
 %% Internal APIs
@@ -266,11 +254,10 @@ with_backend(Fun) ->
 init([]) ->
     erlang:process_flag(trap_exit, true),
     emqx_conf:add_handler([retainer], ?MODULE),
-    ok = emqx_hooks:add('config.zones_updated', {?MODULE, on_config_zones_updated, []}, ?HP_LOWEST),
     State = new_state(),
     RetainerConfig = emqx:get_config([retainer]),
     {ok,
-        case is_enabled() of
+        case maps:get(enable, RetainerConfig) of
             false ->
                 %% Cleanup in case of previous crash
                 stop_retainer(State);
@@ -279,18 +266,13 @@ init([]) ->
                 start_retainer(State, RetainerConfig, BackendConfig)
         end}.
 
-handle_call({update_config, _NewConf, _OldConf}, _From, #{is_started := false} = State) ->
-    {reply, ok, State};
-handle_call({update_config, NewConf, OldConf}, _From, #{is_started := true} = State) ->
+handle_call({update_config, NewConf, OldConf}, _From, State) ->
     State2 = update_config(State, NewConf, OldConf),
-    ok = emqx_retainer_limiter:update(),
+    case maps:get(enable, NewConf) of
+        true -> ok = emqx_retainer_limiter:update();
+        false -> ok
+    end,
     {reply, ok, State2};
-handle_call(start, _From, #{is_started := IsStarted} = State0) ->
-    State = update_status(State0, IsStarted, true),
-    {reply, ok, State};
-handle_call(stop, _From, #{is_started := IsStarted} = State0) ->
-    State = update_status(State0, IsStarted, false),
-    {reply, ok, State};
 handle_call(is_started, _From, State = #{is_started := IsStarted}) ->
     {reply, IsStarted, State};
 handle_call(Req, _From, State) ->
@@ -312,7 +294,6 @@ handle_info(Info, State) ->
 
 terminate(_Reason, #{is_started := IsStarted} = State) ->
     emqx_conf:remove_handler([retainer]),
-    emqx_hooks:del('config.zones_updated', {?MODULE, on_config_zones_updated}),
     IsStarted andalso stop_retainer(State),
     ok.
 
@@ -333,9 +314,6 @@ new_state() ->
         clear_timer => undefined
     }.
 
-is_enabled_for_zone(ZoneConfig) ->
-    emqx_utils_maps:deep_get([mqtt, retain_available], ZoneConfig, false).
-
 -spec start_clear_expired() -> ok.
 start_clear_expired() ->
     Opts = #{
@@ -346,7 +324,23 @@ start_clear_expired() ->
     ok.
 
 -spec update_config(state(), hocon:config(), hocon:config()) -> state().
+update_config(State, NewConfig, OldConfig) ->
+    update_config(
+        maps:get(enable, NewConfig),
+        maps:get(enable, OldConfig),
+        State,
+        NewConfig,
+        OldConfig
+    ).
+
+-spec update_config(boolean(), boolean(), state(), hocon:config(), hocon:config()) -> state().
+update_config(false, _, State, _, _) ->
+    stop_retainer(State);
+update_config(true, false, State, NewConfig, _) ->
+    start_retainer(State, NewConfig, enabled_backend_config(NewConfig));
 update_config(
+    true,
+    true,
     #{clear_timer := ClearTimer} = State,
     NewConfig,
     OldConfig
@@ -371,25 +365,6 @@ update_config(
             State2 = stop_retainer(State),
             start_retainer(State2, NewConfig, NewBackendConfig)
     end.
-
--spec update_status(state(), boolean(), boolean()) -> state().
-update_status(State0, From, To) ->
-    State = do_update_status(State0, From, To),
-    ?tp(retainer_status_updated, #{from => From, to => To}),
-    State.
-
-do_update_status(State, Status, Status) ->
-    State;
-do_update_status(State, false, true) ->
-    start_retainer(State);
-do_update_status(State, true, false) ->
-    stop_retainer(State).
-
--spec start_retainer(state()) -> state().
-start_retainer(State) ->
-    RetainerConfig = emqx:get_config([retainer]),
-    BackendConfig = enabled_backend_config(RetainerConfig),
-    start_retainer(State, RetainerConfig, BackendConfig).
 
 -spec start_retainer(state(), hocon:config(), hocon:config()) -> state().
 start_retainer(

--- a/apps/emqx_retainer/src/emqx_retainer_schema.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_schema.erl
@@ -37,7 +37,6 @@ fields("retainer") ->
                 #{
                     desc => ?DESC(enable),
                     default => true,
-                    deprecated => {since, "5.9.0"},
                     importance => ?IMPORTANCE_NO_DOC
                 }
             )},

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -28,7 +28,9 @@ groups() ->
         {mnesia_without_indices, [sequence], index_related_tests()},
         {mnesia_with_indices, [sequence], index_related_tests()},
         {mnesia_reindex, [sequence], [t_reindex]},
-        {index_agnostic, [sequence], [t_disable_then_start, t_start_stop_on_setting_change]},
+        {index_agnostic, [sequence], [
+            t_disable_then_start, t_start_stop_on_setting_change
+        ]},
         {disabled, [t_disabled]}
     ].
 
@@ -59,8 +61,8 @@ retainer {
 
 %% erlfmt-ignore
 -define(DISABLED_CONF, <<"
-mqtt {
-  retain_available = false
+retainer {
+  enable = false
 }
 ">>).
 
@@ -103,11 +105,14 @@ end_per_testcase(_TestCase, _Config) ->
     reset_rates_to_default(),
     ok.
 
-emqx_retainer_app_spec() ->
+emqx_retainer_app_spec(disabled) ->
+    {emqx_retainer, ?DISABLED_CONF};
+emqx_retainer_app_spec(_) ->
     {emqx_retainer, ?BASE_CONF}.
 
-emqx_conf_app_spec(disabled) ->
-    {emqx_conf, ?DISABLED_CONF};
+emqx_retainer_app_spec() ->
+    emqx_retainer_app_spec(default).
+
 emqx_conf_app_spec(_) ->
     emqx_conf.
 
@@ -116,7 +121,7 @@ start_apps(Group, Config) ->
         [
             emqx,
             emqx_conf_app_spec(Group),
-            emqx_retainer_app_spec()
+            emqx_retainer_app_spec(Group)
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
@@ -894,18 +899,13 @@ t_get_basic_usage_info(_Config) ->
 %%
 %% stop/start in enable/disable state
 t_disable_then_start(_Config) ->
-    %% Disable retainer by config
-    ?assertWaitEvent(
-        set_retain_available(false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => false}),
     ?assertNot(is_retainer_started()),
     ok = application:stop(emqx_retainer),
     ?assertNot(is_retainer_started()),
     ok = application:ensure_started(emqx_retainer),
     ?assertNot(is_retainer_started()),
-    set_retain_available(true),
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => true}),
     ?assert(is_retainer_started()),
     ok = application:stop(emqx_retainer),
     ?assertNot(is_retainer_started()),
@@ -914,54 +914,18 @@ t_disable_then_start(_Config) ->
     ok.
 
 t_start_stop_on_setting_change(_Config) ->
-    %% Disable retainer by default, it should not be started
-    ?assertWaitEvent(
-        set_retain_available(false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
+    %% `mqtt.retain_available` no longer controls whether retainer is started.
+    ?assert(is_retainer_started()),
+    {ok, _} = set_retain_available(false),
+    ?assert(is_retainer_started()),
+    {ok, _} = set_retain_available_for_zone(default, false),
+    ?assert(is_retainer_started()),
+
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => false}),
     ?assertNot(is_retainer_started()),
 
-    %% Enable retainer by default, it should be started because
-    %% default zone will receive global default values
-    ?assertWaitEvent(
-        set_retain_available(true),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assert(is_retainer_started()),
-
-    %% Disable by default and enable in zone
-    ?assertWaitEvent(
-        set_retain_available(false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assertNot(is_retainer_started()),
-    ?assertWaitEvent(
-        set_retain_available_for_zone(default, true),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assert(is_retainer_started()),
-
-    %% Enable by default and disable explicitly in zones, the retainer should be stopped
-    ?assertWaitEvent(
-        set_retain_available(true),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assert(is_retainer_started()),
-    ?assertWaitEvent(
-        set_retain_available_for_zone(default, false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assertWaitEvent(
-        set_retain_available_for_zone(zone1, false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
+    {ok, _} = set_retain_available(true),
+    {ok, _} = set_retain_available_for_zone(default, true),
     ?assertNot(is_retainer_started()),
     ok.
 


### PR DESCRIPTION
## Summary
- restore `retainer.enable` as a real runtime switch for the retainer subsystem
- remove the deprecated marker that marked `retainer.enable` as deprecated since `5.9.0`
- keep retainer process lifecycle independent from `mqtt.retain_available`

## Background
`retainer.enable` was deprecated in **EMQX 5.9.0**. The deprecation landed on **2025-01-22** in commit `7fda77cfc5` (`feat(retainer): deprecate retainer.enable flag`).

After that change, the retainer runtime lifecycle was effectively driven by `mqtt.retain_available`, and `retainer.enable` stopped being a real operational switch.

## Why add it back
Some deployments need these two concerns to stay independent:
- whether the MQTT protocol should advertise/support retained messages
- whether EMQX should actually run the retainer subsystem and store retained data

If `mqtt.retain_available = false`, the current publish path returns `RC_RETAIN_NOT_SUPPORTED` and then disconnects the client on the publish handling path. That means disabling `mqtt.retain_available` is too strong for users who only want to stop storing retained data.

This patch restores the older operational behavior so users can keep protocol support enabled while disabling actual retain storage through `retainer.enable = false`.

## Behavior after this patch
- `mqtt.retain_available` continues to control protocol capability advertisement/validation
- `retainer.enable` once again controls whether the retainer subsystem starts and stores retained data
- users can enable retain protocol support without forcing EMQX to write retained messages

## Test Plan
- [x] `./rebar3 ct --suite apps/emqx_retainer/test/emqx_retainer_SUITE.erl`
- [x] `./rebar3 ct --suite apps/emqx_retainer/test/emqx_retainer_SUITE.erl --group index_agnostic`
- [x] `./rebar3 ct --suite apps/emqx_retainer/test/emqx_retainer_SUITE.erl --group disabled`
- [x] `./rebar3 ct --suite apps/emqx_retainer/test/emqx_retainer_backend_SUITE.erl`
- [x] `./rebar3 ct --suite apps/emqx_retainer/test/emqx_retainer_mqtt_v5_SUITE.erl,apps/emqx_retainer/test/emqx_retainer_cli_SUITE.erl`
