### PR TITLE
fix(retainer): restore retainer.enable to decouple retain protocol support from storage

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -2,7 +2,7 @@
 {application, emqx_retainer, [
     {description, "EMQX Retainer"},
     % strict semver, bump manually!
-    {vsn, "5.1.2"},
+    {vsn, "5.1.3"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},

--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -30,8 +30,7 @@
 -export([
     on_session_subscribed/3,
     on_message_publish/1,
-    post_config_update/5,
-    on_config_zones_updated/2
+    post_config_update/5
 ]).
 
 %% Internal APIs
@@ -147,12 +146,6 @@ on_message_publish(Msg) ->
 post_config_update([retainer], _UpdateReq, NewConf, OldConf, _AppEnvs) ->
     ok = call({update_config, NewConf, OldConf}).
 
-on_config_zones_updated(_OldZones, NewZones) ->
-    case is_enabled(NewZones) of
-        true -> call(start);
-        false -> call(stop)
-    end.
-
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
@@ -223,12 +216,7 @@ is_started() ->
 
 -spec is_enabled() -> boolean().
 is_enabled() ->
-    Zones = emqx_config:get([zones], #{}),
-    is_enabled(Zones).
-
--spec is_enabled(emqx_config:config()) -> boolean().
-is_enabled(Zones) ->
-    lists:any(fun is_enabled_for_zone/1, maps:values(Zones)).
+    emqx_conf:get([retainer, enable], true).
 
 %%------------------------------------------------------------------------------
 %% Internal APIs
@@ -266,11 +254,10 @@ with_backend(Fun) ->
 init([]) ->
     erlang:process_flag(trap_exit, true),
     emqx_conf:add_handler([retainer], ?MODULE),
-    ok = emqx_hooks:add('config.zones_updated', {?MODULE, on_config_zones_updated, []}, ?HP_LOWEST),
     State = new_state(),
     RetainerConfig = emqx:get_config([retainer]),
     {ok,
-        case is_enabled() of
+        case maps:get(enable, RetainerConfig) of
             false ->
                 %% Cleanup in case of previous crash
                 stop_retainer(State);
@@ -279,18 +266,13 @@ init([]) ->
                 start_retainer(State, RetainerConfig, BackendConfig)
         end}.
 
-handle_call({update_config, _NewConf, _OldConf}, _From, #{is_started := false} = State) ->
-    {reply, ok, State};
-handle_call({update_config, NewConf, OldConf}, _From, #{is_started := true} = State) ->
+handle_call({update_config, NewConf, OldConf}, _From, State) ->
     State2 = update_config(State, NewConf, OldConf),
-    ok = emqx_retainer_limiter:update(),
+    case maps:get(enable, NewConf) of
+        true -> ok = emqx_retainer_limiter:update();
+        false -> ok
+    end,
     {reply, ok, State2};
-handle_call(start, _From, #{is_started := IsStarted} = State0) ->
-    State = update_status(State0, IsStarted, true),
-    {reply, ok, State};
-handle_call(stop, _From, #{is_started := IsStarted} = State0) ->
-    State = update_status(State0, IsStarted, false),
-    {reply, ok, State};
 handle_call(is_started, _From, State = #{is_started := IsStarted}) ->
     {reply, IsStarted, State};
 handle_call(Req, _From, State) ->
@@ -312,7 +294,6 @@ handle_info(Info, State) ->
 
 terminate(_Reason, #{is_started := IsStarted} = State) ->
     emqx_conf:remove_handler([retainer]),
-    emqx_hooks:del('config.zones_updated', {?MODULE, on_config_zones_updated}),
     IsStarted andalso stop_retainer(State),
     ok.
 
@@ -333,9 +314,6 @@ new_state() ->
         clear_timer => undefined
     }.
 
-is_enabled_for_zone(ZoneConfig) ->
-    emqx_utils_maps:deep_get([mqtt, retain_available], ZoneConfig, false).
-
 -spec start_clear_expired() -> ok.
 start_clear_expired() ->
     Opts = #{
@@ -346,7 +324,23 @@ start_clear_expired() ->
     ok.
 
 -spec update_config(state(), hocon:config(), hocon:config()) -> state().
+update_config(State, NewConfig, OldConfig) ->
+    update_config(
+        maps:get(enable, NewConfig),
+        maps:get(enable, OldConfig),
+        State,
+        NewConfig,
+        OldConfig
+    ).
+
+-spec update_config(boolean(), boolean(), state(), hocon:config(), hocon:config()) -> state().
+update_config(false, _, State, _, _) ->
+    stop_retainer(State);
+update_config(true, false, State, NewConfig, _) ->
+    start_retainer(State, NewConfig, enabled_backend_config(NewConfig));
 update_config(
+    true,
+    true,
     #{clear_timer := ClearTimer} = State,
     NewConfig,
     OldConfig
@@ -371,25 +365,6 @@ update_config(
             State2 = stop_retainer(State),
             start_retainer(State2, NewConfig, NewBackendConfig)
     end.
-
--spec update_status(state(), boolean(), boolean()) -> state().
-update_status(State0, From, To) ->
-    State = do_update_status(State0, From, To),
-    ?tp(retainer_status_updated, #{from => From, to => To}),
-    State.
-
-do_update_status(State, Status, Status) ->
-    State;
-do_update_status(State, false, true) ->
-    start_retainer(State);
-do_update_status(State, true, false) ->
-    stop_retainer(State).
-
--spec start_retainer(state()) -> state().
-start_retainer(State) ->
-    RetainerConfig = emqx:get_config([retainer]),
-    BackendConfig = enabled_backend_config(RetainerConfig),
-    start_retainer(State, RetainerConfig, BackendConfig).
 
 -spec start_retainer(state(), hocon:config(), hocon:config()) -> state().
 start_retainer(

--- a/apps/emqx_retainer/src/emqx_retainer_schema.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_schema.erl
@@ -36,8 +36,7 @@ fields("retainer") ->
                 boolean(),
                 #{
                     desc => ?DESC(enable),
-                    default => true,
-                    importance => ?IMPORTANCE_NO_DOC
+                    default => true
                 }
             )},
         {msg_expiry_interval,

--- a/apps/emqx_retainer/src/emqx_retainer_schema.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_schema.erl
@@ -37,7 +37,6 @@ fields("retainer") ->
                 #{
                     desc => ?DESC(enable),
                     default => true,
-                    deprecated => {since, "5.9.0"},
                     importance => ?IMPORTANCE_NO_DOC
                 }
             )},

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -935,6 +935,8 @@ t_retain_available_does_not_control_retainer_lifecycle(_Config) ->
     {ok, _} = set_retain_available(true),
     {ok, _} = set_retain_available_for_zone(default, true),
     ?assertNot(is_retainer_started()),
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => true}),
+    ?assert(is_retainer_started()),
     ok.
 
 t_retain_available_true_honors_retainer_enable(_Config) ->
@@ -943,6 +945,8 @@ t_retain_available_true_honors_retainer_enable(_Config) ->
     TopicReenabled = <<"retained/enable/re-on">>,
     {ok, _} = set_retain_available(true),
     {ok, _} = set_retain_available_for_zone(default, true),
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => true}),
+    ?assert(is_retainer_started()),
     {ok, Client} = emqtt:start_link([{clean_start, true}, {proto_ver, v5}]),
     {ok, _} = emqtt:connect(Client),
 

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -28,13 +28,20 @@ groups() ->
         {mnesia_without_indices, [sequence], index_related_tests()},
         {mnesia_with_indices, [sequence], index_related_tests()},
         {mnesia_reindex, [sequence], [t_reindex]},
-        {index_agnostic, [sequence], [t_disable_then_start, t_start_stop_on_setting_change]},
+        {index_agnostic, [sequence], [
+            t_disable_then_start, t_retain_available_does_not_control_retainer_lifecycle
+        ]},
         {disabled, [t_disabled]}
     ].
 
 index_related_tests() ->
     emqx_common_test_helpers:all(?MODULE) --
-        [t_reindex, t_disable_then_start, t_disabled, t_start_stop_on_setting_change].
+        [
+            t_reindex,
+            t_disable_then_start,
+            t_disabled,
+            t_retain_available_does_not_control_retainer_lifecycle
+        ].
 
 %% erlfmt-ignore
 -define(BASE_CONF, <<"
@@ -59,8 +66,8 @@ retainer {
 
 %% erlfmt-ignore
 -define(DISABLED_CONF, <<"
-mqtt {
-  retain_available = false
+retainer {
+  enable = false
 }
 ">>).
 
@@ -103,11 +110,14 @@ end_per_testcase(_TestCase, _Config) ->
     reset_rates_to_default(),
     ok.
 
-emqx_retainer_app_spec() ->
+emqx_retainer_app_spec(disabled) ->
+    {emqx_retainer, ?DISABLED_CONF};
+emqx_retainer_app_spec(_) ->
     {emqx_retainer, ?BASE_CONF}.
 
-emqx_conf_app_spec(disabled) ->
-    {emqx_conf, ?DISABLED_CONF};
+emqx_retainer_app_spec() ->
+    emqx_retainer_app_spec(default).
+
 emqx_conf_app_spec(_) ->
     emqx_conf.
 
@@ -116,7 +126,7 @@ start_apps(Group, Config) ->
         [
             emqx,
             emqx_conf_app_spec(Group),
-            emqx_retainer_app_spec()
+            emqx_retainer_app_spec(Group)
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
@@ -894,18 +904,13 @@ t_get_basic_usage_info(_Config) ->
 %%
 %% stop/start in enable/disable state
 t_disable_then_start(_Config) ->
-    %% Disable retainer by config
-    ?assertWaitEvent(
-        set_retain_available(false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => false}),
     ?assertNot(is_retainer_started()),
     ok = application:stop(emqx_retainer),
     ?assertNot(is_retainer_started()),
     ok = application:ensure_started(emqx_retainer),
     ?assertNot(is_retainer_started()),
-    set_retain_available(true),
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => true}),
     ?assert(is_retainer_started()),
     ok = application:stop(emqx_retainer),
     ?assertNot(is_retainer_started()),
@@ -913,55 +918,19 @@ t_disable_then_start(_Config) ->
     ?assert(is_retainer_started()),
     ok.
 
-t_start_stop_on_setting_change(_Config) ->
-    %% Disable retainer by default, it should not be started
-    ?assertWaitEvent(
-        set_retain_available(false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
+t_retain_available_does_not_control_retainer_lifecycle(_Config) ->
+    %% `mqtt.retain_available` no longer controls whether retainer is started.
+    ?assert(is_retainer_started()),
+    {ok, _} = set_retain_available(false),
+    ?assert(is_retainer_started()),
+    {ok, _} = set_retain_available_for_zone(default, false),
+    ?assert(is_retainer_started()),
+
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => false}),
     ?assertNot(is_retainer_started()),
 
-    %% Enable retainer by default, it should be started because
-    %% default zone will receive global default values
-    ?assertWaitEvent(
-        set_retain_available(true),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assert(is_retainer_started()),
-
-    %% Disable by default and enable in zone
-    ?assertWaitEvent(
-        set_retain_available(false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assertNot(is_retainer_started()),
-    ?assertWaitEvent(
-        set_retain_available_for_zone(default, true),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assert(is_retainer_started()),
-
-    %% Enable by default and disable explicitly in zones, the retainer should be stopped
-    ?assertWaitEvent(
-        set_retain_available(true),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assert(is_retainer_started()),
-    ?assertWaitEvent(
-        set_retain_available_for_zone(default, false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
-    ?assertWaitEvent(
-        set_retain_available_for_zone(zone1, false),
-        #{?snk_kind := retainer_status_updated},
-        5000
-    ),
+    {ok, _} = set_retain_available(true),
+    {ok, _} = set_retain_available_for_zone(default, true),
     ?assertNot(is_retainer_started()),
     ok.
 

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -29,7 +29,9 @@ groups() ->
         {mnesia_with_indices, [sequence], index_related_tests()},
         {mnesia_reindex, [sequence], [t_reindex]},
         {index_agnostic, [sequence], [
-            t_disable_then_start, t_retain_available_does_not_control_retainer_lifecycle
+            t_disable_then_start,
+            t_retain_available_does_not_control_retainer_lifecycle,
+            t_retain_available_true_honors_retainer_enable
         ]},
         {disabled, [t_disabled]}
     ].
@@ -40,7 +42,8 @@ index_related_tests() ->
             t_reindex,
             t_disable_then_start,
             t_disabled,
-            t_retain_available_does_not_control_retainer_lifecycle
+            t_retain_available_does_not_control_retainer_lifecycle,
+            t_retain_available_true_honors_retainer_enable
         ].
 
 %% erlfmt-ignore
@@ -932,6 +935,37 @@ t_retain_available_does_not_control_retainer_lifecycle(_Config) ->
     {ok, _} = set_retain_available(true),
     {ok, _} = set_retain_available_for_zone(default, true),
     ?assertNot(is_retainer_started()),
+    ok.
+
+t_retain_available_true_honors_retainer_enable(_Config) ->
+    TopicEnabled = <<"retained/enable/on">>,
+    TopicDisabled = <<"retained/enable/off">>,
+    TopicReenabled = <<"retained/enable/re-on">>,
+    {ok, _} = set_retain_available(true),
+    {ok, _} = set_retain_available_for_zone(default, true),
+    {ok, Client} = emqtt:start_link([{clean_start, true}, {proto_ver, v5}]),
+    {ok, _} = emqtt:connect(Client),
+
+    ok = emqtt:publish(Client, TopicEnabled, <<"enabled">>, [{qos, 0}, {retain, true}]),
+    ct:sleep(100),
+    ?assertMatch(
+        {ok, [#message{payload = <<"enabled">>}]}, emqx_retainer:read_message(TopicEnabled)
+    ),
+
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => false}),
+    ok = emqtt:publish(Client, TopicDisabled, <<"disabled">>, [{qos, 0}, {retain, true}]),
+    ct:sleep(100),
+    ?assertEqual({ok, []}, emqx_retainer:read_message(TopicDisabled)),
+
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => true}),
+    ok = emqtt:publish(Client, TopicReenabled, <<"re-enabled">>, [{qos, 0}, {retain, true}]),
+    ct:sleep(100),
+    ?assertMatch(
+        {ok, [#message{payload = <<"re-enabled">>}]},
+        emqx_retainer:read_message(TopicReenabled)
+    ),
+
+    ok = emqtt:disconnect(Client),
     ok.
 
 t_disabled(_Config) ->

--- a/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
@@ -84,6 +84,67 @@ t_config(_Config) ->
     UpdateRawConf = emqx_utils_json:decode(UpdateResJson),
     ?assertEqual(54321, maps:get(<<"max_payload_size">>, UpdateRawConf)).
 
+t_config_enable_toggle_with_retain_available(Config) ->
+    Path = api_path(["mqtt", "retainer"]),
+    Client = ?config(client, Config),
+    TopicDisabled = <<"retained_api_enable_off">>,
+    TopicEnabled = <<"retained_api_enable_on">>,
+    {ok, ConfJson} = request_api(get, Path),
+    RawConf = emqx_utils_json:decode(ConfJson),
+    MqttRawConf0 = emqx_config:get_raw([mqtt]),
+    MqttRawConf = maps:put(<<"retain_available">>, true, MqttRawConf0),
+    {ok, _} = emqx_conf:update([mqtt], MqttRawConf, #{override_to => cluster}),
+    try
+        DisabledConf = RawConf#{<<"enable">> => false},
+        {ok, DisabledJson} = request_api(
+            put,
+            Path,
+            [],
+            auth_header_(),
+            DisabledConf
+        ),
+        ?assertEqual(false, maps:get(<<"enable">>, emqx_utils_json:decode(DisabledJson))),
+
+        _ = emqtt:publish(Client, TopicDisabled, <<"disabled">>, [{qos, 0}, {retain, true}]),
+        timer:sleep(100),
+        ?assertMatch(
+            {error, {"HTTP/1.1", 404, "Not Found"}},
+            request_api(
+                get,
+                api_path(["mqtt", "retainer", "message", binary_to_list(TopicDisabled)])
+            )
+        ),
+
+        EnabledConf = DisabledConf#{<<"enable">> => true},
+        {ok, EnabledJson} = request_api(
+            put,
+            Path,
+            [],
+            auth_header_(),
+            EnabledConf
+        ),
+        ?assertEqual(true, maps:get(<<"enable">>, emqx_utils_json:decode(EnabledJson))),
+
+        _ = emqtt:publish(Client, TopicEnabled, <<"enabled">>, [{qos, 0}, {retain, true}]),
+        timer:sleep(100),
+        {ok, LookupJson} = request_api(
+            get,
+            api_path(["mqtt", "retainer", "message", binary_to_list(TopicEnabled)])
+        ),
+        ?assertMatch(
+            #{
+                topic := TopicEnabled,
+                payload := <<"ZW5hYmxlZA==">>
+            },
+            decode_json(LookupJson)
+        )
+    after
+        _ = request_api(put, Path, [], auth_header_(), RawConf),
+        _ = emqx_conf:update([mqtt], MqttRawConf0, #{override_to => cluster}),
+        _ = emqx_retainer:delete(TopicDisabled),
+        _ = emqx_retainer:delete(TopicEnabled)
+    end.
+
 t_messages1(Config) ->
     C = ?config(client, Config),
 

--- a/changes/ce/fix-17097.en.md
+++ b/changes/ce/fix-17097.en.md
@@ -1,0 +1,5 @@
+Restored `retainer.enable` as a real runtime switch for the retainer subsystem.
+This allows deployments to keep MQTT retained-message protocol support enabled
+while disabling retained-message storage, instead of relying on
+`mqtt.retain_available`, which can reject retained publishes at the protocol
+layer.


### PR DESCRIPTION
Fixes N/A

Release version: 5.9

## Summary

This PR restores `retainer.enable` as a real runtime switch for the retainer subsystem on `release-59`.

The key logic change is that retainer process lifecycle is once again controlled by `retainer.enable`, instead of being implicitly coupled to `mqtt.retain_available`.
This matters for deployments that want to keep retained-message protocol support enabled, but do not want EMQX to actually start the retainer subsystem and persist retained data.

The most relevant changes are:
- `apps/emqx_retainer/src/emqx_retainer.erl`: restore `retainer.enable`-driven init and config-update behavior; decouple runtime start/stop from `mqtt.retain_available`
- `apps/emqx_retainer/src/emqx_retainer_schema.erl`: remove both the deprecated marker and the hidden-doc importance on `retainer.enable`, so the option is visible again in schema-generated docs
- `apps/emqx_retainer/test/emqx_retainer_SUITE.erl`: update regression coverage so tests explicitly verify that `mqtt.retain_available` no longer controls retainer lifecycle, and also verify that with `mqtt.retain_available = true`, toggling `retainer.enable` changes whether retained data is actually stored
- `apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl`: add API-level coverage for `PUT /api/v5/mqtt/retainer`, verifying that `enable=false` stops retained storage while `mqtt.retain_available=true` still allows retained publishes through the protocol path
- `changes/ce/fix-17097.en.md`: add user-facing changelog entry

Reasoning:
- `mqtt.retain_available = false` affects protocol-level retained-message behavior and can reject retained publishes on the MQTT path
- some users need a narrower operational control: keep protocol support enabled while disabling retainer storage and worker startup
- restoring `retainer.enable` provides that control without introducing a new configuration surface on `release-59`

## PR Checklist
- ~For internal contributor: there is a jira ticket to track this change~
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
