### PR TITLE
feat(influxdb): expose ping_with_auth for v1 health checks

### DIFF
--- a/apps/emqx_bridge_datalayers/rebar.config
+++ b/apps/emqx_bridge_datalayers/rebar.config
@@ -3,9 +3,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {influxdb,
-        {git, "https://github.com/emqx/influxdb-client-erl",
-            {tag, "1.1.17"}}},
+    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.17"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_datalayers/rebar.config
+++ b/apps/emqx_bridge_datalayers/rebar.config
@@ -5,7 +5,7 @@
 {deps, [
     {influxdb,
         {git, "https://github.com/emqx/influxdb-client-erl",
-            {ref, "refs/heads/moo/ping-with-auth-option"}}},
+            {tag, "1.1.17"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_datalayers/rebar.config
+++ b/apps/emqx_bridge_datalayers/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.17"}}},
+    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.18"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_datalayers/rebar.config
+++ b/apps/emqx_bridge_datalayers/rebar.config
@@ -3,7 +3,9 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.13"}}},
+    {influxdb,
+        {git, "https://github.com/emqx/influxdb-client-erl",
+            {ref, "refs/heads/moo/ping-with-auth-option"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers.app.src
+++ b/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_datalayers, [
     {description, "EMQX Enterprise Datalayers Bridge"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_connector.erl
+++ b/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_connector.erl
@@ -89,8 +89,12 @@ driver_type(#{parameters := #{driver_type := influxdb_v1}}) ->
     influxdb_v1.
 
 convert_config_to_influxdb(Config = #{parameters := Params = #{driver_type := influxdb_v1}}) ->
+    Params1 = Params#{
+        influxdb_type => influxdb_api_v1,
+        v1_auth_transport => query_string
+    },
     Config#{
-        parameters := maps:without([driver_type], Params#{influxdb_type => influxdb_api_v1})
+        parameters := maps:without([driver_type], Params1)
     }.
 
 on_stop(InstId, State) ->

--- a/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_connector.erl
+++ b/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_connector.erl
@@ -79,14 +79,8 @@ on_get_channels(InstId) ->
     emqx_bridge_influxdb_connector:on_get_channels(InstId).
 
 on_start(InstId, Config) ->
-    case driver_type(Config) of
-        influxdb_v1 ->
-            Config1 = convert_config_to_influxdb(Config),
-            emqx_bridge_influxdb_connector:on_start(InstId, Config1)
-    end.
-
-driver_type(#{parameters := #{driver_type := influxdb_v1}}) ->
-    influxdb_v1.
+    Config1 = convert_config_to_influxdb(Config),
+    emqx_bridge_influxdb_connector:on_start(InstId, Config1).
 
 convert_config_to_influxdb(Config = #{parameters := Params = #{driver_type := influxdb_v1}}) ->
     Params1 = Params#{

--- a/apps/emqx_bridge_influxdb/README.md
+++ b/apps/emqx_bridge_influxdb/README.md
@@ -35,6 +35,9 @@ easily ingest IoT data into InfluxDB by leveraging
   version of InfluxDB. Below are several important parameters for `v1`,
   - `server`: The IPv4 or IPv6 address or the hostname to connect to.
   - `database`: InfluxDB database name
+  - `ping_with_auth`: Optional for `v1`. When set to `true`, EMQX includes the configured
+    `username` and `password` on the `/ping` health-check request. By default it is `false`
+    to preserve the legacy health-check behavior.
   - `write_syntax`: Conf of InfluxDB line protocol to write data points. It is a text-based format that provides the measurement, tag set, field set, and timestamp of a data point, and placeholder supported.
 
 

--- a/apps/emqx_bridge_influxdb/README.md
+++ b/apps/emqx_bridge_influxdb/README.md
@@ -32,12 +32,13 @@ easily ingest IoT data into InfluxDB by leveraging
 - [Create bridge API doc](https://docs.emqx.com/en/enterprise/v5.0/admin/api-docs.html#tag/Bridges/paths/~1bridges/post)
   list required parameters for creating a InfluxDB bridge.
   There are two types of InfluxDB API (`v1` and `v2`), please select the right
-  version of InfluxDB. Below are several important parameters for `v1`,
+  version of InfluxDB. Below are several important parameters,
   - `server`: The IPv4 or IPv6 address or the hostname to connect to.
-  - `database`: InfluxDB database name
-  - `ping_with_auth`: Optional for `v1`. When set to `true`, EMQX includes the configured
-    `username` and `password` on the `/ping` health-check request. By default it is `false`
-    to preserve the legacy health-check behavior.
+  - `database`: InfluxDB database name for `v1`
+  - `ping_with_auth`: Optional for `v1` and `v2`. Controls whether EMQX sends authentication on `/ping`
+    health checks. Enable it if the target service requires authentication on `/ping`.
+    The default is `false`.
+  - `bucket` / `org` / `token`: InfluxDB v2 authentication and destination settings
   - `write_syntax`: Conf of InfluxDB line protocol to write data points. It is a text-based format that provides the measurement, tag set, field set, and timestamp of a data point, and placeholder supported.
 
 

--- a/apps/emqx_bridge_influxdb/rebar.config
+++ b/apps/emqx_bridge_influxdb/rebar.config
@@ -3,9 +3,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {influxdb,
-        {git, "https://github.com/emqx/influxdb-client-erl",
-            {tag, "1.1.17"}}},
+    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.17"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_influxdb/rebar.config
+++ b/apps/emqx_bridge_influxdb/rebar.config
@@ -5,7 +5,7 @@
 {deps, [
     {influxdb,
         {git, "https://github.com/emqx/influxdb-client-erl",
-            {ref, "refs/heads/moo/ping-with-auth-option"}}},
+            {tag, "1.1.17"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_influxdb/rebar.config
+++ b/apps/emqx_bridge_influxdb/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.17"}}},
+    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.18"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_influxdb/rebar.config
+++ b/apps/emqx_bridge_influxdb/rebar.config
@@ -3,7 +3,9 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.13"}}},
+    {influxdb,
+        {git, "https://github.com/emqx/influxdb-client-erl",
+            {ref, "refs/heads/moo/ping-with-auth-option"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.app.src
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_influxdb, [
     {description, "EMQX Enterprise InfluxDB Bridge"},
-    {vsn, "0.2.8"},
+    {vsn, "0.2.9"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.erl
@@ -115,6 +115,7 @@ connector_values_v(influxdb_api_v1) ->
     #{
         influxdb_type => influxdb_api_v1,
         database => <<"example_database">>,
+        ping_with_auth => false,
         username => <<"example_username">>,
         password => <<"******">>
     }.

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -477,7 +477,8 @@ protocol_config(#{
         {protocol, http},
         {version, v1},
         {database, str(DB)}
-    ] ++ username(Params) ++ password(Params) ++ ping_with_auth(Params) ++ ssl_config(SSL);
+    ] ++ username(Params) ++ password(Params) ++ ping_with_auth(Params) ++ ssl_config(SSL) ++
+        v1_auth_transport(Params);
 %% api v2 config
 protocol_config(#{
     parameters :=
@@ -492,6 +493,11 @@ protocol_config(#{
         %% TODO: teach `influxdb` to accept 0-arity closures as passwords.
         {token, emqx_secret:unwrap(Token)}
     ] ++ ping_with_auth(Params) ++ ssl_config(SSL).
+
+v1_auth_transport(#{v1_auth_transport := V1AuthTransport}) ->
+    [{v1_auth_transport, V1AuthTransport}];
+v1_auth_transport(_) ->
+    [].
 
 ssl_config(#{enable := false}) ->
     [

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -46,7 +46,7 @@
 -export([precision_field/0]).
 
 %% only for test
--export([is_unrecoverable_error/1]).
+-export([client_config/2, is_unrecoverable_error/1]).
 
 -type ts_precision() :: ns | us | ms | s.
 
@@ -228,7 +228,7 @@ on_get_status(_InstId, #{client := Client}) ->
     end.
 
 transform_bridge_v1_config_to_connector_config(BridgeV1Config) ->
-    IndentKeys = [username, password, database, token, bucket, org],
+    IndentKeys = [username, password, database, token, bucket, org, ping_with_auth],
     ConnConfig0 = maps:without([write_syntax, precision], BridgeV1Config),
     ConnConfig1 =
         case emqx_utils_maps:indent(parameters, IndentKeys, ConnConfig0) of
@@ -324,7 +324,9 @@ influxdb_api_v1_fields() ->
     [
         {database, mk(binary(), #{required => true, desc => ?DESC("database")})},
         {username, mk(binary(), #{desc => ?DESC("username")})},
-        {password, emqx_schema_secret:mk(#{desc => ?DESC("password")})}
+        {password, emqx_schema_secret:mk(#{desc => ?DESC("password")})},
+        {ping_with_auth,
+            mk(boolean(), #{required => false, default => false, desc => ?DESC("ping_with_auth")})}
     ].
 
 influxdb_api_v2_fields() ->
@@ -473,7 +475,7 @@ protocol_config(#{
         {protocol, http},
         {version, v1},
         {database, str(DB)}
-    ] ++ username(Params) ++ password(Params) ++ ssl_config(SSL);
+    ] ++ username(Params) ++ password(Params) ++ ping_with_auth(Params) ++ ssl_config(SSL);
 %% api v2 config
 protocol_config(#{
     parameters := #{influxdb_type := influxdb_api_v2, bucket := Bucket, org := Org, token := Token},
@@ -508,6 +510,11 @@ password(#{password := Password}) ->
     %% TODO: teach `influxdb` to accept 0-arity closures as passwords.
     [{password, str(emqx_secret:unwrap(Password))}];
 password(_) ->
+    [].
+
+ping_with_auth(#{ping_with_auth := PingWithAuth}) ->
+    [{ping_with_auth, PingWithAuth}];
+ping_with_auth(_) ->
     [].
 
 redact_auth(Term) ->

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -333,7 +333,9 @@ influxdb_api_v2_fields() ->
     [
         {bucket, mk(binary(), #{required => true, desc => ?DESC("bucket")})},
         {org, mk(binary(), #{required => true, desc => ?DESC("org")})},
-        {token, emqx_schema_secret:mk(#{required => true, desc => ?DESC("token")})}
+        {token, emqx_schema_secret:mk(#{required => true, desc => ?DESC("token")})},
+        {ping_with_auth,
+            mk(boolean(), #{required => false, default => false, desc => ?DESC("ping_with_auth")})}
     ].
 
 server() ->
@@ -478,7 +480,8 @@ protocol_config(#{
     ] ++ username(Params) ++ password(Params) ++ ping_with_auth(Params) ++ ssl_config(SSL);
 %% api v2 config
 protocol_config(#{
-    parameters := #{influxdb_type := influxdb_api_v2, bucket := Bucket, org := Org, token := Token},
+    parameters :=
+        #{influxdb_type := influxdb_api_v2, bucket := Bucket, org := Org, token := Token} = Params,
     ssl := SSL
 }) ->
     [
@@ -488,7 +491,7 @@ protocol_config(#{
         {org, str(Org)},
         %% TODO: teach `influxdb` to accept 0-arity closures as passwords.
         {token, emqx_secret:unwrap(Token)}
-    ] ++ ssl_config(SSL).
+    ] ++ ping_with_auth(Params) ++ ssl_config(SSL).
 
 ssl_config(#{enable := false}) ->
     [

--- a/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_tests.erl
+++ b/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_tests.erl
@@ -60,6 +60,31 @@
     "measurement,tag=1 field=\"val\\1\""
 ]).
 
+influxdb_api_v1_connector_hocon() ->
+    ""
+    "\n"
+    "connectors.influxdb.my_influxdb {\n"
+    "  enable = true\n"
+    "  server = \"127.0.0.1:8086\"\n"
+    "  parameters {\n"
+    "    influxdb_type = influxdb_api_v1\n"
+    "    database = \"mydb\"\n"
+    "    username = \"user\"\n"
+    "    password = \"pass\"\n"
+    "  }\n"
+    "  ssl {\n"
+    "    enable = false\n"
+    "  }\n"
+    "}\n"
+    "".
+
+parse(Hocon) ->
+    {ok, Conf} = hocon:binary(Hocon),
+    Conf.
+
+check_connector(Conf) when is_map(Conf) ->
+    hocon_tconf:check_plain(emqx_connector_schema, Conf, #{required => false}).
+
 -define(VALID_LINE_PARSED_PAIRS, [
     {"m1,tag=tag1 field=field1 ${timestamp1}", #{
         measurement => "m1",
@@ -359,6 +384,107 @@ valid_write_syntax_escaped_chars_test_() ->
 
 valid_write_syntax_escaped_chars_with_extra_spaces_test_() ->
     test_pairs(?VALID_LINE_PARSED_ESCAPED_CHARS_EXTRA_SPACES_PAIRS).
+
+influxdb_api_v1_connector_ping_with_auth_test_() ->
+    _ = emqx_utils:interactive_load(emqx_bridge_enterprise),
+    BaseConf = parse(influxdb_api_v1_connector_hocon()),
+    Override = fun(Cfg) ->
+        emqx_utils_maps:deep_merge(
+            BaseConf,
+            #{
+                <<"connectors">> => #{
+                    <<"influxdb">> => #{
+                        <<"my_influxdb">> => Cfg
+                    }
+                }
+            }
+        )
+    end,
+    BaseConfig = #{
+        server => <<"127.0.0.1:8086">>,
+        pool_size => 8,
+        ssl => #{enable => false},
+        parameters => #{
+            influxdb_type => influxdb_api_v1,
+            database => <<"mydb">>,
+            username => <<"user">>,
+            password => <<"pass">>
+        }
+    },
+    [
+        {"schema defaults ping_with_auth to false",
+            ?_assertMatch(
+                #{
+                    <<"connectors">> := #{
+                        <<"influxdb">> := #{
+                            <<"my_influxdb">> := #{
+                                <<"parameters">> := #{<<"ping_with_auth">> := false}
+                            }
+                        }
+                    }
+                },
+                check_connector(BaseConf)
+            )},
+        {"schema accepts ping_with_auth=true",
+            ?_assertMatch(
+                #{
+                    <<"connectors">> := #{
+                        <<"influxdb">> := #{
+                            <<"my_influxdb">> := #{
+                                <<"parameters">> := #{<<"ping_with_auth">> := true}
+                            }
+                        }
+                    }
+                },
+                check_connector(
+                    Override(#{<<"parameters">> => #{<<"ping_with_auth">> => true}})
+                )
+            )},
+        {"client_config preserves legacy default when unset",
+            ?_assertEqual(
+                false,
+                proplists:is_defined(
+                    ping_with_auth,
+                    emqx_bridge_influxdb_connector:client_config(test_pool, BaseConfig)
+                )
+            )},
+        {"client_config forwards ping_with_auth=true",
+            ?_assertEqual(
+                true,
+                proplists:get_value(
+                    ping_with_auth,
+                    emqx_bridge_influxdb_connector:client_config(
+                        test_pool,
+                        BaseConfig#{
+                            parameters => maps:merge(
+                                maps:get(parameters, BaseConfig),
+                                #{ping_with_auth => true}
+                            )
+                        }
+                    )
+                )
+            )},
+        {"bridge v1 config conversion indents ping_with_auth",
+            ?_assertMatch(
+                #{
+                    parameters := #{
+                        influxdb_type := influxdb_api_v1,
+                        database := <<"mydb">>,
+                        username := <<"user">>,
+                        password := <<"pass">>,
+                        ping_with_auth := true
+                    }
+                },
+                emqx_bridge_influxdb_connector:transform_bridge_v1_config_to_connector_config(#{
+                    server => <<"127.0.0.1:8086">>,
+                    pool_size => 8,
+                    database => <<"mydb">>,
+                    username => <<"user">>,
+                    password => <<"pass">>,
+                    ping_with_auth => true
+                })
+            )}
+    ].
 
 test_pairs(PairsList) ->
     {Lines, AllExpected} = lists:unzip(PairsList),

--- a/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_tests.erl
+++ b/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_tests.erl
@@ -78,6 +78,24 @@ influxdb_api_v1_connector_hocon() ->
     "}\n"
     "".
 
+influxdb_api_v2_connector_hocon() ->
+    ""
+    "\n"
+    "connectors.influxdb.my_influxdb {\n"
+    "  enable = true\n"
+    "  server = \"127.0.0.1:8086\"\n"
+    "  parameters {\n"
+    "    influxdb_type = influxdb_api_v2\n"
+    "    bucket = \"mybucket\"\n"
+    "    org = \"myorg\"\n"
+    "    token = \"token\"\n"
+    "  }\n"
+    "  ssl {\n"
+    "    enable = false\n"
+    "  }\n"
+    "}\n"
+    "".
+
 parse(Hocon) ->
     {ok, Conf} = hocon:binary(Hocon),
     Conf.
@@ -483,6 +501,87 @@ influxdb_api_v1_connector_ping_with_auth_test_() ->
                     password => <<"pass">>,
                     ping_with_auth => true
                 })
+            )}
+    ].
+
+influxdb_api_v2_connector_ping_with_auth_test_() ->
+    _ = emqx_utils:interactive_load(emqx_bridge_enterprise),
+    BaseConf = parse(influxdb_api_v2_connector_hocon()),
+    Override = fun(Cfg) ->
+        emqx_utils_maps:deep_merge(
+            BaseConf,
+            #{
+                <<"connectors">> => #{
+                    <<"influxdb">> => #{
+                        <<"my_influxdb">> => Cfg
+                    }
+                }
+            }
+        )
+    end,
+    BaseConfig = #{
+        server => <<"127.0.0.1:8086">>,
+        pool_size => 8,
+        ssl => #{enable => false},
+        parameters => #{
+            influxdb_type => influxdb_api_v2,
+            bucket => <<"mybucket">>,
+            org => <<"myorg">>,
+            token => <<"token">>
+        }
+    },
+    [
+        {"schema defaults ping_with_auth to false",
+            ?_assertMatch(
+                #{
+                    <<"connectors">> := #{
+                        <<"influxdb">> := #{
+                            <<"my_influxdb">> := #{
+                                <<"parameters">> := #{<<"ping_with_auth">> := false}
+                            }
+                        }
+                    }
+                },
+                check_connector(BaseConf)
+            )},
+        {"schema accepts ping_with_auth=true",
+            ?_assertMatch(
+                #{
+                    <<"connectors">> := #{
+                        <<"influxdb">> := #{
+                            <<"my_influxdb">> := #{
+                                <<"parameters">> := #{<<"ping_with_auth">> := true}
+                            }
+                        }
+                    }
+                },
+                check_connector(
+                    Override(#{<<"parameters">> => #{<<"ping_with_auth">> => true}})
+                )
+            )},
+        {"client_config preserves legacy default when unset",
+            ?_assertEqual(
+                false,
+                proplists:is_defined(
+                    ping_with_auth,
+                    emqx_bridge_influxdb_connector:client_config(test_pool, BaseConfig)
+                )
+            )},
+        {"client_config forwards ping_with_auth=true",
+            ?_assertEqual(
+                true,
+                proplists:get_value(
+                    ping_with_auth,
+                    emqx_bridge_influxdb_connector:client_config(
+                        test_pool,
+                        BaseConfig#{
+                            parameters => maps:merge(
+                                maps:get(parameters, BaseConfig),
+                                #{ping_with_auth => true}
+                            )
+                        }
+                    )
+                )
             )}
     ].
 

--- a/changes/ee/feat-17098.en.md
+++ b/changes/ee/feat-17098.en.md
@@ -1,1 +1,1 @@
-Added the `ping_with_auth` option to the InfluxDB v1 connector and legacy bridge configuration so health checks can include credentials when required by InfluxDB-compatible services. The default remains `false` to preserve the previous behavior.
+Upgraded influxdb-client-erl from 1.1.13 to 1.1.17, and added the `ping_with_auth` option (default false) for InfluxDB connectors, enabling health checks to include credentials when required by some InfluxDB-compatible services.

--- a/changes/ee/feat-17098.en.md
+++ b/changes/ee/feat-17098.en.md
@@ -1,0 +1,1 @@
+Added the `ping_with_auth` option to the InfluxDB v1 connector and legacy bridge configuration so health checks can include credentials when required by InfluxDB-compatible services. The default remains `false` to preserve the previous behavior.

--- a/changes/ee/feat-17098.en.md
+++ b/changes/ee/feat-17098.en.md
@@ -1,1 +1,1 @@
-Upgraded influxdb-client-erl from 1.1.13 to 1.1.17, and added the `ping_with_auth` option (default false) for InfluxDB connectors, enabling health checks to include credentials when required by some InfluxDB-compatible services.
+Upgraded influxdb-client-erl from 1.1.13 to 1.1.18, and added the `ping_with_auth` option (default false) for InfluxDB connectors, enabling health checks to include credentials when required by some InfluxDB-compatible services.

--- a/mix.exs
+++ b/mix.exs
@@ -284,11 +284,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:ots_erl, github: "emqx/ots_erl", tag: "0.2.3", override: true}
 
   def common_dep(:influxdb),
-    do:
-      {:influxdb,
-       github: "emqx/influxdb-client-erl",
-       tag: "1.1.17",
-       override: true}
+    do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.17", override: true}
 
   def common_dep(:wolff), do: {:wolff, "4.1.7"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}

--- a/mix.exs
+++ b/mix.exs
@@ -284,7 +284,11 @@ defmodule EMQXUmbrella.MixProject do
     do: {:ots_erl, github: "emqx/ots_erl", tag: "0.2.3", override: true}
 
   def common_dep(:influxdb),
-    do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
+    do:
+      {:influxdb,
+       github: "emqx/influxdb-client-erl",
+       ref: "refs/heads/moo/ping-with-auth-option",
+       override: true}
 
   def common_dep(:wolff), do: {:wolff, "4.1.7"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}

--- a/mix.exs
+++ b/mix.exs
@@ -287,7 +287,7 @@ defmodule EMQXUmbrella.MixProject do
     do:
       {:influxdb,
        github: "emqx/influxdb-client-erl",
-       ref: "refs/heads/moo/ping-with-auth-option",
+       tag: "1.1.17",
        override: true}
 
   def common_dep(:wolff), do: {:wolff, "4.1.7"}

--- a/mix.exs
+++ b/mix.exs
@@ -284,7 +284,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:ots_erl, github: "emqx/ots_erl", tag: "0.2.3", override: true}
 
   def common_dep(:influxdb),
-    do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.17", override: true}
+    do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.18", override: true}
 
   def common_dep(:wolff), do: {:wolff, "4.1.7"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}

--- a/rel/i18n/emqx_bridge_influxdb.hocon
+++ b/rel/i18n/emqx_bridge_influxdb.hocon
@@ -61,7 +61,7 @@ ping_with_auth.label:
 """Ping With Auth"""
 
 ping_with_auth.desc:
-"""Only applies to InfluxDB v1. When enabled, EMQX includes the configured username and password in the `/ping` health-check request. The default is `false` to preserve the legacy behavior."""
+"""Controls whether EMQX includes connector credentials in `/ping` health-check requests. Enable this if your InfluxDB service requires authentication on `/ping`. The default is `false`, which preserves the previous behavior and sends `/ping` without authentication."""
 
 influxdb_action.label:
 """InfluxDB Action"""

--- a/rel/i18n/emqx_bridge_influxdb.hocon
+++ b/rel/i18n/emqx_bridge_influxdb.hocon
@@ -57,6 +57,12 @@ connector.label:
 connector.desc:
 """InfluxDB Connector Configs"""
 
+ping_with_auth.label:
+"""Ping With Auth"""
+
+ping_with_auth.desc:
+"""Only applies to InfluxDB v1. When enabled, EMQX includes the configured username and password in the `/ping` health-check request. The default is `false` to preserve the legacy behavior."""
+
 influxdb_action.label:
 """InfluxDB Action"""
 influxdb_action.desc:

--- a/rel/i18n/emqx_bridge_influxdb_connector.hocon
+++ b/rel/i18n/emqx_bridge_influxdb_connector.hocon
@@ -12,6 +12,12 @@ database.desc:
 database.label:
 """Database"""
 
+ping_with_auth.label:
+"""Ping With Auth"""
+
+ping_with_auth.desc:
+"""Controls whether EMQX includes connector credentials in `/ping` health-check requests. Enable this if your InfluxDB service requires authentication on `/ping`. The default is `false`, which preserves the previous behavior and sends `/ping` without authentication."""
+
 influxdb_api_v1.desc:
 """InfluxDB's protocol. Support InfluxDB v1.8 and before."""
 


### PR DESCRIPTION
Fixes N/A

Release version: 5.10.4

## Summary

- Expose `parameters.ping_with_auth` for the InfluxDB v1 connector and legacy bridge config.
- Pass `ping_with_auth` through to `influxdb-client-erl` only for v1 health-check requests.
- Keep the default behavior backward compatible by leaving `ping_with_auth = false` unless explicitly enabled.
- Update the InfluxDB connector examples, README, i18n schema text, and changelog entry.
- Use the tagged `influxdb-client-erl` release `1.1.17` for the connector change.
- Add regression tests covering schema defaulting, config translation, and client option propagation.

## PR Checklist
- ~For internal contributor: there is a jira ticket to track this change~
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/feat-17098.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
