### PR TITLE
fix(sso): accept JWKS content-type with +json suffix

### DIFF
--- a/apps/emqx_dashboard_sso/mix.exs
+++ b/apps/emqx_dashboard_sso/mix.exs
@@ -27,7 +27,7 @@ defmodule EMQXDashboardSso.MixProject do
       {:emqx_ldap, in_umbrella: true},
       {:emqx_dashboard, in_umbrella: true},
       {:esaml, github: "emqx/esaml", tag: "v1.1.4"},
-      {:oidcc, github: "emqx/oidcc", tag: "v3.2.0-1", manager: :rebar3}
+      {:oidcc, github: "emqx/oidcc", tag: "3.2.1", manager: :rebar3}
     ]
   end
 end

--- a/apps/emqx_dashboard_sso/rebar.config
+++ b/apps/emqx_dashboard_sso/rebar.config
@@ -5,5 +5,5 @@
     {emqx_ldap, {path, "../../apps/emqx_ldap"}},
     {emqx_dashboard, {path, "../../apps/emqx_dashboard"}},
     {esaml, {git, "https://github.com/emqx/esaml", {tag, "v1.1.4"}}},
-    {oidcc, {git, "https://github.com/emqx/oidcc.git", {tag, "v3.2.0-1"}}}
+    {oidcc, {git, "https://github.com/emqx/oidcc.git", {tag, "3.2.1"}}}
 ]}.

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
@@ -24,6 +24,7 @@
 -define(ON_ALL(NODES, BODY), erpc:multicall(NODES, fun() -> BODY end)).
 
 -define(AUTH_HEADER_FN_PD_KEY, {?MODULE, auth_header_fn}).
+-define(OIDC_PATH_PREFIX, "/oidc").
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
@@ -287,6 +288,9 @@ oidc_provider_params() ->
         }
     }.
 
+oidc_provider_params(Issuer) ->
+    (oidc_provider_params())#{<<"issuer">> => emqx_utils_conv:bin(Issuer)}.
+
 %%------------------------------------------------------------------------------
 %% Test cases
 %%------------------------------------------------------------------------------
@@ -441,3 +445,61 @@ t_stop_cleanup(TCConfig) ->
     ?assertEqual([], supervisor:which_children(emqx_dashboard_sso_oidc_sup)),
 
     ok.
+
+t_jwks_content_type_suffix(TCConfig) ->
+    start_apps(?FUNCTION_NAME, TCConfig),
+    Node = node(),
+    {ok, {Port, _Pid}} = emqx_utils_http_test_server:start_link(random, "/[...]"),
+    on_exit(fun() -> ok = emqx_utils_http_test_server:stop() end),
+    ok = emqx_utils_http_test_server:set_handler(fun oidc_content_type_handler/2),
+
+    Issuer = host(Port) ++ ?OIDC_PATH_PREFIX,
+    ProviderParams = oidc_provider_params(Issuer),
+    ?assertMatch({200, _}, create_backend(Node, ProviderParams, #{})),
+
+    ?retry(
+        20,
+        100,
+        begin
+            {302, Headers, _Body} = login_sso(Node, #{}),
+            ?assertMatch({_, _}, lists:keyfind("location", 1, Headers))
+        end
+    ).
+
+oidc_content_type_handler(
+    #{method := <<"GET">>, path := <<?OIDC_PATH_PREFIX, "/.well-known/openid-configuration">>} =
+        Req0,
+    State
+) ->
+    Port = cowboy_req:port(Req0),
+    Issuer = iolist_to_binary(host(Port) ++ ?OIDC_PATH_PREFIX),
+    Body = emqx_utils_json:encode(#{
+        issuer => Issuer,
+        jwks_uri => <<Issuer/binary, "/jwks">>,
+        authorization_endpoint => <<Issuer/binary, "/authorize">>,
+        scopes_supported => [<<"openid">>],
+        response_types_supported => [<<"code">>],
+        subject_types_supported => [<<"public">>],
+        id_token_signing_alg_values_supported => [<<"RS256">>]
+    }),
+    Req = cowboy_req:reply(
+        200,
+        #{<<"content-type">> => <<"application/json">>},
+        Body,
+        Req0
+    ),
+    {ok, Req, State};
+oidc_content_type_handler(
+    #{method := <<"GET">>, path := <<?OIDC_PATH_PREFIX, "/jwks">>} = Req0,
+    State
+) ->
+    Req = cowboy_req:reply(
+        200,
+        #{<<"content-type">> => <<"application/jwk-set+json; charset=utf-8">>},
+        emqx_utils_json:encode(#{keys => []}),
+        Req0
+    ),
+    {ok, Req, State};
+oidc_content_type_handler(Req0, State) ->
+    Req = cowboy_req:reply(404, #{}, <<>>, Req0),
+    {ok, Req, State}.

--- a/changes/ee/fix-17101.en.md
+++ b/changes/ee/fix-17101.en.md
@@ -1,0 +1,1 @@
+Fixed OIDC SSO login failing with `provider_not_ready` when the identity provider returns a JWKS response whose `Content-Type` uses the `+json` structured syntax suffix (for example, `application/jwk-set+json; charset=utf-8`). Such responses are now accepted as valid JWKS content.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/16834

Release version: 5.10.4

## Summary

Some OIDC providers return the JWKS endpoint with a structured-suffix JSON media type such as `application/jwk-set+json; charset=utf-8`. The vendored `oidcc` version in v5 rejected that response as `invalid_content_type`, which left the provider in a `provider_not_ready` state and caused dashboard OIDC SSO login to fail.

This ports the v6 fix to v5 by bumping `oidcc` to `3.2.1`, which accepts `application/*+json` JWKS responses, and adds a regression test that starts a mock OIDC provider whose JWKS endpoint replies with `application/jwk-set+json; charset=utf-8` and verifies the login flow still redirects successfully.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
