### PR TITLE
Fix influxdb unicode write handling on release-510

### DIFF
--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.erl
@@ -439,6 +439,6 @@ unescape(_EscapeChars, _SepChars, [] = L, Acc) ->
 str(A) when is_atom(A) ->
     atom_to_list(A);
 str(B) when is_binary(B) ->
-    binary_to_list(B);
+    unicode:characters_to_list(B);
 str(S) when is_list(S) ->
     S.

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -923,7 +923,13 @@ data_filter(Number) when is_number(Number) -> Number;
 data_filter(Bool) when is_boolean(Bool) -> Bool;
 data_filter(Data) -> bin(Data).
 
-bin(Data) -> emqx_utils_conv:bin(Data).
+bin(Data) when is_list(Data) ->
+    case io_lib:printable_unicode_list(Data) of
+        true -> unicode:characters_to_binary(Data);
+        false -> emqx_utils_conv:bin(Data)
+    end;
+bin(Data) ->
+    emqx_utils_conv:bin(Data).
 
 %% helper funcs
 log_error_points(InstId, Errs) ->

--- a/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_SUITE.erl
+++ b/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_SUITE.erl
@@ -382,25 +382,22 @@ delete_all_rules() ->
         emqx_rule_engine:get_rules()
     ).
 
-create_rule_and_action_http(Config) ->
-    create_rule_and_action_http(Config, _Overrides = #{}).
+create_rule_and_action(Config) ->
+    create_rule_and_action(Config, _Overrides = #{}).
 
-create_rule_and_action_http(Config, Overrides) ->
+create_rule_and_action(Config, Overrides) ->
     InfluxDBName = ?config(influxdb_name, Config),
     Type = influxdb_type_bin(?config(influxdb_type, Config)),
     BridgeId = emqx_bridge_resource:bridge_id(Type, InfluxDBName),
     Params0 = #{
+        id => emqx_guid:to_hexstr(emqx_guid:gen()),
         enable => true,
         sql => <<"SELECT * FROM \"t/topic\"">>,
-        actions => [BridgeId]
+        actions => [BridgeId],
+        description => <<"influxdb bridge test rule">>
     },
     Params = emqx_utils_maps:deep_merge(Params0, Overrides),
-    Path = emqx_mgmt_api_test_util:api_path(["rules"]),
-    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
-    case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
-        Error -> Error
-    end.
+    emqx_rule_engine:create_rule(Params).
 
 send_message(Config, Payload) ->
     Name = ?config(influxdb_name, Config),
@@ -519,6 +516,26 @@ assert_persisted_data(ClientId, Expected, PersistedData) ->
         Expected
     ),
     ok.
+
+send_message_and_wait(Config, SentData) ->
+    QueryMode = ?config(query_mode, Config),
+    case QueryMode of
+        async ->
+            ?assertMatch(ok, send_message(Config, SentData));
+        sync ->
+            ?assertMatch({ok, 204, _}, send_message(Config, SentData))
+    end,
+    ct:sleep(1500).
+
+wait_for_persisted_data(Config, ClientId, Expected) ->
+    ?retry(
+        _Sleep = 500,
+        _Attempts = 10,
+        begin
+            PersistedData = query_by_clientid(ClientId, Config),
+            assert_persisted_data(ClientId, Expected, PersistedData)
+        end
+    ).
 
 resource_id(Config) ->
     Type = influxdb_type_bin(?config(influxdb_type, Config)),
@@ -802,6 +819,48 @@ t_empty_timestamp(Config) ->
         baz4 => {<<"1u">>, <<"string">>}
     },
     assert_persisted_data(ClientId, Expected, PersistedData).
+
+t_write_fixed_unicode_text(Config) ->
+    ?assertMatch(
+        {ok, _},
+        create_bridge(
+            Config,
+            #{
+                <<"write_syntax">> =>
+                    <<"mqtt,clientid=${clientid} fixed_text=\"固定中文\""/utf8>>
+            }
+        )
+    ),
+    ClientId = emqx_guid:to_hexstr(emqx_guid:gen()),
+    SentData = #{
+        <<"clientid">> => ClientId,
+        <<"topic">> => atom_to_binary(?FUNCTION_NAME),
+        <<"payload">> => #{},
+        <<"timestamp">> => erlang:system_time(millisecond)
+    },
+    send_message_and_wait(Config, SentData),
+    Expected = #{fixed_text => {<<"固定中文"/utf8>>, <<"string">>}},
+    wait_for_persisted_data(Config, ClientId, Expected).
+
+t_write_unicode_mqtt_payload(Config) ->
+    ?assertMatch(
+        {ok, _},
+        create_bridge(
+            Config,
+            #{
+                <<"write_syntax">> =>
+                    <<"mqtt,clientid=${clientid} payload_text=\"${payload}\""/utf8>>
+            }
+        )
+    ),
+    {ok, _} = create_rule_and_action(Config, #{sql => <<"SELECT * FROM \"t/topic\"">>}),
+    ClientId = emqx_guid:to_hexstr(emqx_guid:gen()),
+    Payload = <<"MQTT 消息中文"/utf8>>,
+    Msg = emqx_message:make(ClientId, <<"t/topic">>, Payload),
+    emqx:publish(Msg),
+    ct:sleep(1500),
+    Expected = #{payload_text => {Payload, <<"string">>}},
+    wait_for_persisted_data(Config, ClientId, Expected).
 
 %% influxdb returns timestamps without trailing zeros such as
 %% "2023-02-28T17:21:51.63678163Z"
@@ -1220,7 +1279,7 @@ t_missing_field(Config) ->
         ),
     %% note: we don't select foo here, but we interpolate it in the
     %% fields, so it'll become undefined.
-    {ok, _} = create_rule_and_action_http(Config, #{sql => <<"select * from \"t/topic\"">>}),
+    {ok, _} = create_rule_and_action(Config, #{sql => <<"select * from \"t/topic\"">>}),
     ClientId0 = emqx_guid:to_hexstr(emqx_guid:gen()),
     ClientId1 = emqx_guid:to_hexstr(emqx_guid:gen()),
     %% Message with the field that we "forgot" to select in the rule

--- a/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_tests.erl
+++ b/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_tests.erl
@@ -403,6 +403,22 @@ valid_write_syntax_escaped_chars_test_() ->
 valid_write_syntax_escaped_chars_with_extra_spaces_test_() ->
     test_pairs(?VALID_LINE_PARSED_ESCAPED_CHARS_EXTRA_SPACES_PAIRS).
 
+unicode_write_syntax_test_() ->
+    Tag = unicode:characters_to_list(<<"标签"/utf8>>),
+    Field = unicode:characters_to_list(<<"固定中文"/utf8>>),
+    Expected = #{
+        measurement => "m",
+        tags => [{"tag", Tag}],
+        fields => [{"f", {quoted, Field}}],
+        timestamp => undefined
+    },
+    [
+        ?_assertEqual(
+            [Expected],
+            to_influx_lines(<<"m,tag=标签 f=\"固定中文\""/utf8>>)
+        )
+    ].
+
 influxdb_api_v1_connector_ping_with_auth_test_() ->
     _ = emqx_utils:interactive_load(emqx_bridge_enterprise),
     BaseConf = parse(influxdb_api_v1_connector_hocon()),

--- a/changes/ee/fix-17105.en.md
+++ b/changes/ee/fix-17105.en.md
@@ -1,1 +1,1 @@
-Fixed the InfluxDB connector/action to preserve Unicode text, including Chinese characters, when writing values from `write_syntax` literals or MQTT payloads.
+Fixed the InfluxDB connector/action to preserve Unicode text, when writing values from `write_syntax` literals or MQTT payloads.

--- a/changes/ee/fix-17105.en.md
+++ b/changes/ee/fix-17105.en.md
@@ -1,0 +1,1 @@
+Fixed the InfluxDB connector/action to preserve Unicode text, including Chinese characters, when writing values from `write_syntax` literals or MQTT payloads.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15228

Release version: 5.10.4

## Summary

This PR fixes Unicode handling for the InfluxDB connector/action when writing Chinese text on `release-510`.

Root cause:
- `write_syntax` parsing converted binaries with `binary_to_list/1`, which breaks UTF-8 text into byte lists.
- the connector value conversion path treated printable lists as generic lists instead of UTF-8 strings, so Chinese tag and field values could be written incorrectly.

What changed:
- parse InfluxDB `write_syntax` binaries as Unicode character lists before template preprocessing.
- convert printable Unicode lists to UTF-8 binaries in the InfluxDB connector before encoding line protocol.
- add a regression test for fixed Chinese text in `write_syntax`.
- add integration tests covering:
  - fixed Chinese written by InfluxDB Action
  - Chinese carried in MQTT payload and written through InfluxDB Action
- simplify rule creation in the integration suite by using `emqx_rule_engine:create_rule/1` directly so the tests do not depend on a fixed dashboard port.

Impact:
- fixed Chinese literals in InfluxDB Action now persist correctly.
- Chinese MQTT payloads routed through InfluxDB Action now persist correctly.
- the regression coverage now exercises API v1/v2 over TCP/TLS and sync/async with/without batching.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

## Validation
- `./rebar3 eunit --module emqx_bridge_influxdb_tests --name eunit@127.0.0.1 -v`
- Common Test matrix for both Chinese scenarios on:
  - `apiv1_tcp`
  - `apiv1_tls`
  - `apiv2_tcp`
  - `apiv2_tls`
  with sync/async and with/without batching

