### PR TITLE
fix(rule_engine): ignore invalid metadata timestamps

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -531,8 +531,8 @@ code_change(_OldVsn, State, _Extra) ->
 %%----------------------------------------------------------------------------------------
 
 with_parsed_rule(Params = #{id := RuleId, sql := Sql, actions := Actions}, CreatedAt0, Fun) ->
-    CreatedAt = emqx_utils_maps:deep_get([metadata, created_at], Params, CreatedAt0),
-    LastModifiedAt = emqx_utils_maps:deep_get([metadata, last_modified_at], Params, CreatedAt),
+    CreatedAt = metadata_timestamp(Params, created_at, CreatedAt0),
+    LastModifiedAt = metadata_timestamp(Params, last_modified_at, CreatedAt),
     case emqx_rule_sqlparser:parse(Sql) of
         {ok, Select} ->
             Rule0 = #{
@@ -568,6 +568,12 @@ with_parsed_rule(Params = #{id := RuleId, sql := Sql, actions := Actions}, Creat
             {ok, Rule};
         {error, Reason} ->
             {error, Reason}
+    end.
+
+metadata_timestamp(Params, Key, Default) ->
+    case emqx_utils_maps:deep_get([metadata, Key], Params, Default) of
+        Timestamp when is_integer(Timestamp) -> Timestamp;
+        _ -> Default
     end.
 
 do_insert_rule(#{id := Id} = Rule) ->

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -65,6 +65,9 @@ request(Method, Path, Params, Opts) ->
 
 request(Method, Path, Params, QueryParams0, Opts) when is_list(QueryParams0) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    request(Method, Path, Params, QueryParams0, AuthHeader, Opts).
+
+request(Method, Path, Params, QueryParams0, AuthHeader, Opts) when is_list(QueryParams0) ->
     QueryParams = uri_string:compose_query(QueryParams0, [{encoding, utf8}]),
     case emqx_mgmt_api_test_util:request_api(Method, Path, QueryParams, AuthHeader, Params, Opts) of
         {ok, {Status, Headers, Body0}} ->
@@ -147,13 +150,15 @@ delete_rule(RuleId) ->
 list_rules() ->
     Method = get,
     Path = emqx_mgmt_api_test_util:api_path(["rules"]),
-    Res = request(Method, Path, _Params = ""),
+    AuthHeader = emqx_dashboard_SUITE:auth_header_(),
+    Res = request(Method, Path, _Params = "", _QueryParams = [], AuthHeader, #{return_all => true}),
     emqx_mgmt_api_test_util:simplify_result(Res).
 
 get_rule(Id) ->
     Method = get,
     Path = emqx_mgmt_api_test_util:api_path(["rules", Id]),
-    Res = request(Method, Path, _Params = ""),
+    AuthHeader = emqx_dashboard_SUITE:auth_header_(),
+    Res = request(Method, Path, _Params = "", _QueryParams = [], AuthHeader, #{return_all => true}),
     emqx_mgmt_api_test_util:simplify_result(Res).
 
 simulate_rule(Id, Params) ->
@@ -1028,14 +1033,14 @@ t_rule_metadata_bad_timestamp_repro(_Config) ->
     ?assertNotEqual(<<"2026-04-22">>, CreatedAt),
     ?assertMatch(
         {200, #{
-            created_at := CreatedAtResp,
-            last_modified_at := UpdatedAtResp
+            <<"created_at">> := CreatedAtResp,
+            <<"last_modified_at">> := UpdatedAtResp
         }} when is_binary(CreatedAtResp) andalso is_binary(UpdatedAtResp),
-        emqx_rule_engine_api:'/rules/:id'(get, #{bindings => #{id => Id}})
+        get_rule(Id)
     ),
     ?assertMatch(
-        {200, #{data := [#{id := Id}]}},
-        emqx_rule_engine_api:'/rules'(get, #{query_string => #{}})
+        {200, #{<<"data">> := [#{<<"id">> := Id}]}},
+        list_rules()
     ),
     ok.
 

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -1008,6 +1008,37 @@ t_last_modified_at(_Config) ->
     ),
     ok.
 
+t_rule_metadata_bad_timestamp_repro(_Config) ->
+    Id = <<"bad_metadata_ts">>,
+    RuleParams = #{
+        id => Id,
+        sql => <<"select * from \"t/bad-metadata\"">>,
+        actions => [],
+        metadata => #{
+            created_at => <<"2026-04-22">>
+        }
+    },
+    on_exit(fun() ->
+        ok = emqx_rule_engine:delete_rule(Id)
+    end),
+    {ok, #{id := Id, created_at := CreatedAt, updated_at := UpdatedAt}} =
+        emqx_rule_engine:create_rule(RuleParams),
+    ?assert(is_integer(CreatedAt)),
+    ?assert(is_integer(UpdatedAt)),
+    ?assertNotEqual(<<"2026-04-22">>, CreatedAt),
+    ?assertMatch(
+        {200, #{
+            created_at := CreatedAtResp,
+            last_modified_at := UpdatedAtResp
+        }} when is_binary(CreatedAtResp) andalso is_binary(UpdatedAtResp),
+        emqx_rule_engine_api:'/rules/:id'(get, #{bindings => #{id => Id}})
+    ),
+    ?assertMatch(
+        {200, #{data := [#{id := Id}]}},
+        emqx_rule_engine_api:'/rules'(get, #{query_string => #{}})
+    ),
+    ok.
+
 %% This verifies that we don't attempt to transform keys in the `details' value of an
 %% alarm activated/deactivated rule test to atoms.
 t_alarm_details_with_unknown_atom_key(_Config) ->

--- a/changes/ee/fix-17106.en.md
+++ b/changes/ee/fix-17106.en.md
@@ -1,0 +1,10 @@
+Ignored invalid rule metadata timestamps during rule creation and updates.
+
+Previously, if a rule contained a non-integer `metadata.created_at` or
+`metadata.last_modified_at` value such as a date string, EMQX could store
+that invalid value and later fail with an internal error when listing or
+retrieving the rule through the API.
+
+EMQX now ignores invalid metadata timestamp values and falls back to the
+normal generated timestamps, so rule API responses remain available even
+when malformed metadata is provided.


### PR DESCRIPTION
Fixes 

Release version: 5.10.4

## Summary

Ignore invalid rule metadata timestamps when rules are created or updated.

Previously, a non-integer `metadata.created_at` or `metadata.last_modified_at` value could be stored in a rule and later cause `/rules` and `/rules/:id` responses to fail while formatting timestamps. This change keeps only integer metadata timestamps and falls back to the normal generated timestamps for invalid values.

The change adds a regression test that seeds a malformed rule and verifies the rule APIs still return successfully.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
