### PR TITLE
fix(rocketmq): isolate connectors via rocketmq-client-erl v0.7.1 (v6)

### DIFF
--- a/apps/emqx_bridge_rocketmq/mix.exs
+++ b/apps/emqx_bridge_rocketmq/mix.exs
@@ -29,7 +29,7 @@ defmodule EMQXBridgeRocketmq.MixProject do
 
   def deps() do
     UMP.deps([
-      {:rocketmq, github: "emqx/rocketmq-client-erl", tag: "v0.7.0"},
+      {:rocketmq, github: "emqx/rocketmq-client-erl", tag: "v0.7.1"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}

--- a/apps/emqx_bridge_rocketmq/mix.exs
+++ b/apps/emqx_bridge_rocketmq/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeRocketmq.MixProject do
   def project do
     [
       app: :emqx_bridge_rocketmq,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),
@@ -29,7 +29,7 @@ defmodule EMQXBridgeRocketmq.MixProject do
 
   def deps() do
     UMP.deps([
-      {:rocketmq, github: "emqx/rocketmq-client-erl", tag: "v0.6.1"},
+      {:rocketmq, github: "emqx/rocketmq-client-erl", tag: "v0.7.0"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}

--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
@@ -250,13 +250,15 @@ on_batch_query(_InstanceId, Query, _State) ->
 on_get_status(_InstanceId, #{client_id := ClientId}) ->
     case rocketmq_client_sup:find_client(ClientId) of
         {ok, Pid} ->
-            status_result(rocketmq_client:get_status(Pid));
+            status_result(rocketmq_client:get_connection_state(Pid));
         _ ->
             ?status_connecting
     end.
 
-status_result(_Status = true) -> ?status_connected;
-status_result(_Status) -> ?status_connecting.
+status_result(connected) -> ?status_connected;
+status_result(connecting) -> ?status_connecting;
+status_result(disconnected) -> ?status_disconnected;
+status_result({error, _}) -> ?status_connecting.
 
 %%========================================================================================
 %% Helper fns

--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
@@ -257,8 +257,21 @@ on_get_status(_InstanceId, #{client_id := ClientId}) ->
 
 status_result(connected) -> ?status_connected;
 status_result(connecting) -> ?status_connecting;
-status_result(disconnected) -> ?status_disconnected;
+status_result({disconnected, Reason}) -> {?status_disconnected, format_reason(Reason)};
 status_result({error, _}) -> ?status_connecting.
+
+format_reason({tcp_connect_error, {Host, Port, Why}}) ->
+    iolist_to_binary(io_lib:format("TCP connect to ~s:~p failed: ~0p", [Host, Port, Why]));
+format_reason({tls_connect_error, {Host, Port, Why}}) ->
+    iolist_to_binary(io_lib:format("TLS handshake with ~s:~p failed: ~0p", [Host, Port, Why]));
+format_reason(tcp_closed) ->
+    <<"TCP connection closed by peer">>;
+format_reason(ssl_closed) ->
+    <<"TLS connection closed by peer">>;
+format_reason({ssl_error, Why}) ->
+    iolist_to_binary(io_lib:format("TLS error: ~0p", [Why]));
+format_reason(Other) ->
+    iolist_to_binary(io_lib:format("~0p", [Other])).
 
 %%========================================================================================
 %% Helper fns

--- a/changes/ee/fix-17113.en.md
+++ b/changes/ee/fix-17113.en.md
@@ -1,0 +1,3 @@
+Fixed RocketMQ connector isolation: a misconfigured or unreachable RocketMQ connector no longer destabilises other RocketMQ connectors on the same node. Previously, one connector with an unreachable broker could stall the shared client supervisor for up to 60 seconds, causing sibling connectors to flap with `resource_health_check_timed_out` and for dashboard operations on them to hang.
+
+The default TCP/TLS connect timeout is also lowered from 60 seconds to 10 seconds so a misconfigured server surfaces as failed quickly instead of appearing stuck.


### PR DESCRIPTION
Release version:
6.0.3

## Summary

Bumps the RocketMQ client dep to `v0.7.0`, which moves the client's TCP/TLS connect off `rocketmq_client_sup`'s critical path via `handle_continue/2`, lowers the default connect timeout from 60s to 10s, and switches `find_client/1` to a `whereis/1`-first lookup (with a supervisor fallback for restart windows).

### Why

`rocketmq_client_sup` is a singleton shared by every RocketMQ connector in the node. Before this change, `rocketmq_client:init/1` did a synchronous `gen_tcp:connect/4` with a 60-second timeout inside the supervisor's `start_child` call. While that connect was in flight, every other connector's `start_child`, `terminate_child`, and `which_children` (used by the health check) serialised behind it. A single misconfigured broker (for example an unreachable IP) caused sibling connectors to flip to `resource_health_check_timed_out` and dashboard operations on them to hang for ~60 seconds.

### Verified with the docker repro

Using `emqx/emqx:5.10.3` + the `.ci` RocketMQ compose stack, one good connector + one bad connector (unreachable IP):

| | Before | After |
|---|---|---|
| `start_resource_failed` / `fail_to_connect_rocketmq_server` crashers | many | 0 |
| `clean_allocated_resources_exception` `{badmatch,{error,not_found}}` | present | 0 |
| `resource_health_check_timed_out` on **good** connector | present | 0 |
| Good connector stability over 2 min with bad connector enabled | flapped | held `connected` |
| `PUT` disable of good while bad is mid-connect | 60.0s | 3.1s |

### Upstream dep PRs

- https://github.com/emqx/rocketmq-client-erl/pull/34
- https://github.com/emqx/rocketmq-client-erl/pull/35

Companion v5 PR: #17112

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)