### PR TITLE
Tighten dashboard MFA reset flow and SSO viewer MFA RBAC

### DIFF
--- a/apps/emqx_dashboard/README.md
+++ b/apps/emqx_dashboard/README.md
@@ -26,7 +26,7 @@ The feature is only accessible from enterprise edition dashboard.
 
 MFA is disabled by default. To enable MFA, the admin needs to set the `dashboard.default_mfa` configuration item to `none` or `{mechanism: totp}`.
 
-To enable MFA for a specific user, the admin needs to call the API `users/{username}/mfa` with `POST` body `{"mechanism": "totp"}`.
+To enable or reset MFA for a specific user, the admin needs to call the API `users/{username}/mfa` with `POST` body `{"mechanism": "totp"}`.
 
 To disable MFA for a specific user, the admin needs to call the API `users/{username}/mfa` with `DELETE` method.
 
@@ -58,4 +58,3 @@ Detailed steps are:
 
 - Security Concern: The password is vulnerable to brute-force attacks until the MFA token is validated for the first time.
 - Permission Restrictions: The POST and DELETE methods on the `users/{username}/mfa` endpoint are restricted to the `administrator` users or the current bearer token owner, meaning a `viewer` role user cannot change another user's MFA settings.
-

--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -32,7 +32,8 @@
     %%   mfa_pending => #{type => setup | challenge,
     %%                    token => binary(),
     %%                    secret => binary(),        %% setup only
-    %%                    timestamp => integer()}
+    %%                    timestamp => integer(),
+    %%                    failed_attempts => non_neg_integer()}
     %%     Short-lived SSO MFA session token for TOTP setup or verification.
     %%     Only used when MFA is required after SSO login.
     %%     For regular (non-SSO) login, no pending state is required.

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -32,8 +32,7 @@
     change_password_trusted/2,
     change_password/3,
     enable_mfa/2,
-    reset_mfa/1,
-    admin_enable_mfa/1,
+    reinit_mfa/2,
     set_mfa_pending/2,
     clear_mfa_pending/1,
     get_mfa_pending/1,
@@ -208,56 +207,28 @@ enable_mfa(Username, Mechanism) ->
 
 reinit_mfa(Username, Mechanism) ->
     {ok, State} = emqx_dashboard_mfa:init(Mechanism),
-    {ok, ok} = set_mfa_state(Username, State),
-    _ = emqx_dashboard_token:destroy_by_username(Username),
-    ok.
-
-%% @doc Admin re-enables MFA for a user.
-%% Clears the disabled state so force_mfa takes effect on next SSO login.
-%% For SSO users, the next login will trigger TOTP setup from scratch.
-%% For local users, the admin should call enable_mfa/2 separately.
--spec admin_enable_mfa(dashboard_username()) -> ok | {error, term()}.
-admin_enable_mfa(Username) ->
-    case get_mfa_state(Username) of
-        {ok, disabled} ->
-            Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
-                update_extra(Username, fun(Extra) ->
-                    maps:without([mfa_state, mfa_pending], Extra)
-                end)
-            end),
-            case Res of
-                {atomic, ok} -> ok;
-                {aborted, Reason} -> {error, Reason}
-            end;
-        _ ->
-            {error, <<"MFA is not admin-disabled">>}
-    end.
-
-%% @doc Reset MFA for a user — remove both mfa_state and mfa_pending.
--spec reset_mfa(dashboard_username()) -> {ok, ok} | {error, term()}.
-reset_mfa(Username) ->
-    case lookup_user(Username) of
-        [] ->
-            {error, <<"username_not_found">>};
-        [_] ->
-            Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
-                update_extra(Username, fun(Extra) ->
-                    maps:without([mfa_state, mfa_pending], Extra)
-                end)
-            end),
-            case Res of
-                {atomic, ok} ->
-                    _ = emqx_dashboard_token:destroy_by_username(Username),
-                    {ok, ok};
-                {aborted, Reason} ->
-                    {error, Reason}
-            end
+    case reset_mfa_state(Username, State) of
+        {ok, ok} ->
+            _ = emqx_dashboard_token:destroy_by_username(Username),
+            ok;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %% @doc Set MFA state in the extra map.
 set_mfa_state(Username, MfaState) ->
     Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
         update_extra(Username, fun(Extra) -> Extra#{mfa_state => MfaState} end)
+    end),
+    return(Res).
+
+%% @doc Set MFA state and clear mfa_pending in the extra map.
+reset_mfa_state(Username, MfaState) ->
+    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        update_extra(
+            Username,
+            fun(Extra) -> maps:without([mfa_pending], Extra#{mfa_state => MfaState}) end
+        )
     end),
     return(Res).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -464,7 +464,10 @@ change_mfa(post, #{bindings := #{username := Username0}, body := Settings} = Req
             {204};
         {error, <<"username_not_found">>} ->
             ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
-            {404, ?USER_NOT_FOUND, <<"User not found">>}
+            {404, ?USER_NOT_FOUND, <<"User not found">>};
+        {error, Reason} ->
+            ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
+            {400, ?BAD_REQUEST, Reason}
     end.
 
 register_unsuccessful_login(Username, <<"password_error">>) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -169,23 +169,14 @@ schema("/users/:username/mfa") ->
             parameters => sso_parameters(fields([username_in_path])),
             'requestBody' => emqx_dashboard_schema:mfa_fields(),
             responses => #{
-                204 => <<"MFA setting is reset">>,
+                204 => <<"MFA setting is updated">>,
                 404 => response_schema(404)
             }
         },
         delete => #{
             tags => [<<"Dashboard">>],
             desc => ?DESC(delete_mfa),
-            parameters => sso_parameters(fields([username_in_path])) ++
-                [
-                    {reset,
-                        mk(boolean(), #{
-                            desc => ?DESC(mfa_reset_param),
-                            in => query,
-                            required => false,
-                            example => false
-                        })}
-                ],
+            parameters => sso_parameters(fields([username_in_path])),
             responses => #{
                 204 => <<"MFA setting is deleted">>,
                 404 => response_schema(404)
@@ -451,41 +442,24 @@ change_pwd(post, #{bindings := #{username := Username}, body := Params}) ->
 
 change_mfa(delete, #{bindings := #{username := Username0}} = Req) ->
     Username = username(Req, Username0),
-    QS = maps:get(query_string, Req, #{}),
-    Reset = maps:get(<<"reset">>, QS, false),
-    IsReset = Reset =:= true orelse Reset =:= <<"true">>,
-    case IsReset of
-        true ->
-            LogMeta = #{msg => "dashboard_user_mfa_reset", username => Username},
-            case emqx_dashboard_admin:reset_mfa(Username) of
-                {ok, ok} ->
-                    ?SLOG(info, LogMeta#{result => success}),
-                    {204};
-                {error, <<"username_not_found">>} ->
-                    ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
-                    {404, ?USER_NOT_FOUND, <<"User not found">>}
-            end;
-        false ->
-            LogMeta = #{msg => "dashboard_user_mfa_delete", username => Username},
-            case emqx_dashboard_admin:disable_mfa(Username) of
-                ok ->
-                    ?SLOG(info, LogMeta#{result => success}),
-                    {204};
-                {error, <<"username_not_found">>} ->
-                    ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
-                    {404, ?USER_NOT_FOUND, <<"User not found">>};
-                {error, Reason} ->
-                    ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
-                    {400, ?BAD_REQUEST, Reason}
-            end
+    LogMeta = #{msg => "dashboard_user_mfa_delete", username => Username},
+    case emqx_dashboard_admin:disable_mfa(Username) of
+        ok ->
+            ?SLOG(info, LogMeta#{result => success}),
+            {204};
+        {error, <<"username_not_found">>} ->
+            ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
+            {404, ?USER_NOT_FOUND, <<"User not found">>};
+        {error, Reason} ->
+            ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
+            {400, ?BAD_REQUEST, Reason}
     end;
 change_mfa(post, #{bindings := #{username := Username0}, body := Settings} = Req) ->
     Username = username(Req, Username0),
     Mechanism = maps:get(<<"mechanism">>, Settings),
-    {ok, State} = emqx_dashboard_mfa:init(Mechanism),
     LogMeta = #{msg => "dashboard_user_mfa_setup", username => Username},
-    case emqx_dashboard_admin:set_mfa_state(Username, State) of
-        {ok, ok} ->
+    case emqx_dashboard_admin:reinit_mfa(Username, Mechanism) of
+        ok ->
             ?SLOG(info, LogMeta#{result => success}),
             {204};
         {error, <<"username_not_found">>} ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -178,7 +178,7 @@ schema("/users/:username/mfa") ->
             desc => ?DESC(delete_mfa),
             parameters => sso_parameters(fields([username_in_path])),
             responses => #{
-                204 => <<"MFA setting is deleted">>,
+                204 => <<"MFA setting is disabled">>,
                 404 => response_schema(404)
             }
         }
@@ -442,7 +442,7 @@ change_pwd(post, #{bindings := #{username := Username}, body := Params}) ->
 
 change_mfa(delete, #{bindings := #{username := Username0}} = Req) ->
     Username = username(Req, Username0),
-    LogMeta = #{msg => "dashboard_user_mfa_delete", username => Username},
+    LogMeta = #{msg => "dashboard_user_mfa_disable", username => Username},
     case emqx_dashboard_admin:disable_mfa(Username) of
         ok ->
             ?SLOG(info, LogMeta#{result => success}),

--- a/apps/emqx_dashboard/src/emqx_dashboard_mfa.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_mfa.erl
@@ -23,6 +23,7 @@
     create_verify_token/1,
     verify_temp_token/2,
     peek_temp_token/2,
+    record_temp_token_failure/2,
     generate_token/1
 ]).
 
@@ -42,6 +43,7 @@
 %% Temporary token validity: 5 minutes
 -define(TEMP_TOKEN_TTL_SEC, 300).
 -define(TOKEN_BYTES, 32).
+-define(MAX_TEMP_TOKEN_FAILURES, 5).
 
 %% @doc Translate binary format mechanism name to atom.
 -spec mechanism(binary()) -> mechanism().
@@ -162,14 +164,76 @@ create_verify_token(Username) ->
 -spec verify_temp_token(dashboard_username(), binary()) ->
     {ok, term(), temp_token_purpose()} | {error, term()}.
 verify_temp_token(SsoUsername, Token) ->
-    case emqx_dashboard_admin:get_mfa_pending(SsoUsername) of
-        {ok, #{token := StoredToken, type := Type, timestamp := Timestamp} = Pending} when
+    return_mfa_pending_transaction(
+        mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+            case lookup_valid_temp_token(SsoUsername, Token, write) of
+                {ok, #{type := Type} = Pending, Admin, Extra} ->
+                    clear_mfa_pending(Admin, Extra),
+                    {ok, SsoUsername, to_purpose(Type, Pending)};
+                {error, _} = Error ->
+                    Error
+            end
+        end)
+    ).
+
+%% @doc Peek at a temporary token without consuming it.
+-spec peek_temp_token(dashboard_username(), binary()) ->
+    {ok, term(), temp_token_purpose()} | {error, term()}.
+peek_temp_token(SsoUsername, Token) ->
+    return_mfa_pending_transaction(
+        mria:ro_transaction(?DASHBOARD_SHARD, fun() ->
+            case lookup_valid_temp_token(SsoUsername, Token, read) of
+                {ok, #{type := Type} = Pending, _Admin, _Extra} ->
+                    {ok, SsoUsername, to_purpose(Type, Pending)};
+                {error, _} = Error ->
+                    Error
+            end
+        end)
+    ).
+
+%% @doc Record a failed TOTP attempt for a temporary token.
+%% The token remains usable until the failure count reaches the limit.
+-spec record_temp_token_failure(dashboard_username(), binary()) -> ok | {error, term()}.
+record_temp_token_failure(SsoUsername, Token) ->
+    return_mfa_pending_transaction(
+        mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+            case lookup_valid_temp_token(SsoUsername, Token, write) of
+                {ok, Pending, Admin, Extra} ->
+                    FailedAttempts = maps:get(failed_attempts, Pending, 0) + 1,
+                    case FailedAttempts >= ?MAX_TEMP_TOKEN_FAILURES of
+                        true ->
+                            clear_mfa_pending(Admin, Extra);
+                        false ->
+                            set_mfa_pending(
+                                Admin, Extra, Pending#{failed_attempts => FailedAttempts}
+                            )
+                    end,
+                    ok;
+                {error, _} = Error ->
+                    Error
+            end
+        end)
+    ).
+
+lookup_valid_temp_token(SsoUsername, Token, LockKind) ->
+    case read_admin(SsoUsername, LockKind) of
+        [#?ADMIN{extra = Extra0} = Admin] ->
+            Extra = upgrade_extra(Extra0),
+            validate_pending_token(Admin, Extra, Token);
+        [] ->
+            {error, invalid_token}
+    end.
+
+validate_pending_token(Admin, Extra, Token) ->
+    case Extra of
+        #{
+            mfa_pending := #{token := StoredToken, type := _Type, timestamp := Timestamp} = Pending
+        } when
             StoredToken =:= Token
         ->
             case is_token_valid(Timestamp) of
                 true ->
-                    {ok, ok} = emqx_dashboard_admin:clear_mfa_pending(SsoUsername),
-                    {ok, SsoUsername, to_purpose(Type, Pending)};
+                    {ok, Pending, Admin, Extra};
                 false ->
                     {error, token_expired}
             end;
@@ -177,23 +241,24 @@ verify_temp_token(SsoUsername, Token) ->
             {error, invalid_token}
     end.
 
-%% @doc Peek at a temporary token without consuming it.
--spec peek_temp_token(dashboard_username(), binary()) ->
-    {ok, term(), temp_token_purpose()} | {error, term()}.
-peek_temp_token(SsoUsername, Token) ->
-    case emqx_dashboard_admin:get_mfa_pending(SsoUsername) of
-        {ok, #{token := StoredToken, type := Type, timestamp := Timestamp} = Pending} when
-            StoredToken =:= Token
-        ->
-            case is_token_valid(Timestamp) of
-                true ->
-                    {ok, SsoUsername, to_purpose(Type, Pending)};
-                false ->
-                    {error, token_expired}
-            end;
-        _ ->
-            {error, invalid_token}
-    end.
+read_admin(Username, read) ->
+    mnesia:read(?ADMIN, Username);
+read_admin(Username, write) ->
+    mnesia:wread({?ADMIN, Username}).
+
+set_mfa_pending(Admin, Extra, Pending) ->
+    ok = mnesia:write(Admin#?ADMIN{extra = Extra#{mfa_pending => Pending}}).
+
+clear_mfa_pending(Admin, Extra) ->
+    ok = mnesia:write(Admin#?ADMIN{extra = maps:without([mfa_pending], Extra)}).
+
+return_mfa_pending_transaction({atomic, Result}) ->
+    Result;
+return_mfa_pending_transaction({aborted, Reason}) ->
+    {error, Reason}.
+
+upgrade_extra([]) -> #{};
+upgrade_extra(Map) when is_map(Map) -> Map.
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_dashboard/src/emqx_dashboard_mfa.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_mfa.erl
@@ -218,8 +218,7 @@ record_temp_token_failure(SsoUsername, Token) ->
 lookup_valid_temp_token(SsoUsername, Token, LockKind) ->
     case read_admin(SsoUsername, LockKind) of
         [#?ADMIN{extra = Extra0} = Admin] ->
-            Extra = upgrade_extra(Extra0),
-            validate_pending_token(Admin, Extra, Token);
+            validate_pending_token(Admin, Extra0, Token);
         [] ->
             {error, invalid_token}
     end.
@@ -256,9 +255,6 @@ return_mfa_pending_transaction({atomic, Result}) ->
     Result;
 return_mfa_pending_transaction({aborted, Reason}) ->
     {error, Reason}.
-
-upgrade_extra([]) -> #{};
-upgrade_extra(Map) when is_map(Map) -> Map.
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_dashboard/src/emqx_dashboard_mfa.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_mfa.erl
@@ -254,7 +254,25 @@ clear_mfa_pending(Admin, Extra) ->
 return_mfa_pending_transaction({atomic, Result}) ->
     Result;
 return_mfa_pending_transaction({aborted, Reason}) ->
-    {error, Reason}.
+    {error, normalize_mfa_pending_transaction_error(Reason)};
+return_mfa_pending_transaction({timeout, {atomic, Result}}) ->
+    Result;
+return_mfa_pending_transaction({timeout, {aborted, Reason}}) ->
+    {error, normalize_mfa_pending_transaction_error(Reason)};
+return_mfa_pending_transaction({timeout, {error, Reason}}) ->
+    {error, normalize_mfa_pending_transaction_error(Reason)}.
+
+normalize_mfa_pending_transaction_error(invalid_token) ->
+    invalid_token;
+normalize_mfa_pending_transaction_error(token_expired) ->
+    token_expired;
+normalize_mfa_pending_transaction_error({error, invalid_token}) ->
+    invalid_token;
+normalize_mfa_pending_transaction_error({error, token_expired}) ->
+    token_expired;
+normalize_mfa_pending_transaction_error(Reason) ->
+    logger:warning("unexpected_mfa_pending_transaction_error: ~0p", [Reason]),
+    internal_error.
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
@@ -278,8 +278,8 @@ t_enable_by_config(_Config) ->
     {ok, 200, _} = login(LoginBody),
     ok.
 
-%% Reset MFA — completely removes MFA record.
-%% After reset, the user is back to "never configured" state.
+%% DELETE MFA ignores the historical reset query parameter.
+%% Resetting/re-keying MFA should be done with POST /users/:username/mfa.
 t_reset_mfa({init, Config}) ->
     ok = mock_totp(),
     _ = emqx_dashboard_admin:clear_mfa_state(<<"viewer1">>),
@@ -296,18 +296,27 @@ t_reset_mfa(_Config) ->
     AdminJwtToken = admin_jwt_token(),
     %% enable MFA for viewer1
     ?assertMatch({ok, 204, _}, enable_mfa(<<"viewer1">>)),
+    {ok, #{secret := Secret0}} = emqx_dashboard_admin:get_mfa_state(<<"viewer1">>),
     %% login with TOTP to complete setup
-    ?assertMatch({ok, 200, _}, login(LoginBody)),
+    {ok, 200, LoginRsp} = login(LoginBody),
+    #{<<"token">> := JwtToken} = json_map(LoginRsp),
+    ?assertMatch({ok, <<"viewer1">>}, emqx_dashboard_admin:verify_token(fake_req(), JwtToken)),
     ?assertMatch(#{<<"mfa">> := <<"totp">>}, get_user(<<"viewer1">>)),
-    %% admin resets MFA
-    ?assertMatch({ok, 204, _}, reset_mfa(<<"viewer1">>, AdminJwtToken)),
-    %% MFA state should be "none" (record deleted, not "disabled")
-    ?assertMatch(#{<<"mfa">> := <<"none">>}, get_user(<<"viewer1">>)),
+    %% POST is the reset/re-key operation.
+    ?assertMatch({ok, 204, _}, enable_mfa(<<"viewer1">>, AdminJwtToken)),
+    {ok, #{secret := Secret1}} = emqx_dashboard_admin:get_mfa_state(<<"viewer1">>),
+    ?assertNotEqual(Secret0, Secret1),
+    timer:sleep(5),
+    ?assertMatch({error, not_found}, emqx_dashboard_admin:verify_token(fake_req(), JwtToken)),
+    ?assertMatch(#{<<"mfa">> := <<"totp">>}, get_user(<<"viewer1">>)),
+    %% reset=true is no longer a hard reset. It behaves like ordinary DELETE.
+    ?assertMatch({ok, 204, _}, delete_mfa_with_reset_query(<<"viewer1">>, AdminJwtToken)),
+    ?assertMatch(#{<<"mfa">> := <<"disabled">>}, get_user(<<"viewer1">>)),
     %% should be able to login without TOTP now
     LoginNoTotp = maps:remove(<<"mfa_token">>, LoginBody),
     ?assertMatch({ok, 200, _}, login(LoginNoTotp)),
-    %% reset non-existent user should return 404
-    ?assertMatch({ok, 404, _}, reset_mfa(<<"nonexistent_user">>, AdminJwtToken)),
+    %% non-existent user should return 404
+    ?assertMatch({ok, 404, _}, delete_mfa_with_reset_query(<<"nonexistent_user">>, AdminJwtToken)),
     ok.
 
 %%------------------------------------------------------------------------------
@@ -342,9 +351,15 @@ enable_mfa(User, JwtToken) ->
 disable_mfa(User, JwtToken) ->
     request_api(delete, api_path(["users", User, mfa]), auth_header(JwtToken), #{}).
 
-reset_mfa(User, JwtToken) ->
+delete_mfa_with_reset_query(User, JwtToken) ->
     Url = binary_to_list(iolist_to_binary(api_path(["users", User, "mfa"]))),
     request_api(delete, Url, "reset=true", auth_header(JwtToken), #{}).
+
+fake_req() ->
+    #{
+        method => <<"GET">>,
+        path => erlang:list_to_binary(emqx_dashboard_swagger:relative_uri("/fake"))
+    }.
 
 get_user(Name) ->
     Users = list_users(),

--- a/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
@@ -306,7 +306,7 @@ t_reset_mfa(_Config) ->
     ?assertMatch({ok, 204, _}, enable_mfa(<<"viewer1">>, AdminJwtToken)),
     {ok, #{secret := Secret1}} = emqx_dashboard_admin:get_mfa_state(<<"viewer1">>),
     ?assertNotEqual(Secret0, Secret1),
-    timer:sleep(5),
+    ok = gen_server:call(emqx_dashboard_token, dummy, infinity),
     ?assertMatch({error, not_found}, emqx_dashboard_admin:verify_token(fake_req(), JwtToken)),
     ?assertMatch(#{<<"mfa">> := <<"totp">>}, get_user(<<"viewer1">>)),
     %% reset=true is no longer a hard reset. It behaves like ordinary DELETE.
@@ -317,6 +317,21 @@ t_reset_mfa(_Config) ->
     ?assertMatch({ok, 200, _}, login(LoginNoTotp)),
     %% non-existent user should return 404
     ?assertMatch({ok, 404, _}, delete_mfa_with_reset_query(<<"nonexistent_user">>, AdminJwtToken)),
+    ok.
+
+t_reset_mfa_reinit_error({init, Config}) ->
+    ok = meck:new(emqx_dashboard_admin, [passthrough, no_history]),
+    Config;
+t_reset_mfa_reinit_error({'end', _Config}) ->
+    ok = meck:unload(emqx_dashboard_admin);
+t_reset_mfa_reinit_error(_Config) ->
+    ok = meck:expect(emqx_dashboard_admin, reinit_mfa, fun(_, _) -> {error, <<"boom">>} end),
+    Req = #{
+        bindings => #{username => <<"viewer1">>},
+        body => #{<<"mechanism">> => <<"totp">>},
+        query_string => #{<<"backend">> => <<"local">>}
+    },
+    ?assertMatch({400, 'BAD_REQUEST', <<"boom">>}, emqx_dashboard_api:change_mfa(post, Req)),
     ok.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.app.src
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.app.src
@@ -1,6 +1,6 @@
 {application, emqx_dashboard_rbac, [
     {description, "EMQX Dashboard RBAC"},
-    {vsn, "0.2.0"},
+    {vsn, "0.2.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -18,11 +18,12 @@
 %% API
 check_rbac(Req, Username, Extra) ->
     Role = role(Extra),
+    Backend = backend(Extra),
     Method = cowboy_req:method(Req),
     AbsPath = cowboy_req:path(Req),
     case emqx_dashboard_swagger:get_relative_uri(AbsPath) of
         {ok, Path} ->
-            check_rbac(Role, Method, Path, Username);
+            check_rbac(Role, Method, Path, Username, Backend);
         _ ->
             false
     end.
@@ -39,6 +40,11 @@ role(#{role := Role}) ->
     Role;
 role(Role) when is_binary(Role) ->
     Role.
+
+backend(#{backend := Backend}) ->
+    Backend;
+backend(_) ->
+    ?BACKEND_LOCAL.
 
 valid_dashboard_role(Role) ->
     valid_role(dashboard, Role).
@@ -57,32 +63,40 @@ valid_role(Type, Role) ->
     end.
 
 %% ===================================================================
-check_rbac(?ROLE_SUPERUSER, _, _, _) ->
+check_rbac(?ROLE_SUPERUSER, _, _, _, _) ->
     true;
-check_rbac(?ROLE_VIEWER, <<"GET">>, _, _) ->
+check_rbac(?ROLE_VIEWER, <<"GET">>, _, _, _) ->
     true;
-check_rbac(?ROLE_API_PUBLISHER, <<"POST">>, <<"/publish">>, _) ->
+check_rbac(?ROLE_API_PUBLISHER, <<"POST">>, <<"/publish">>, _, _) ->
     true;
-check_rbac(?ROLE_API_PUBLISHER, <<"POST">>, <<"/publish/bulk">>, _) ->
+check_rbac(?ROLE_API_PUBLISHER, <<"POST">>, <<"/publish/bulk">>, _, _) ->
     true;
 %% everyone should allow to logout
-check_rbac(?ROLE_VIEWER, <<"POST">>, <<"/logout">>, _) ->
+check_rbac(?ROLE_VIEWER, <<"POST">>, <<"/logout">>, _, _) ->
     true;
 %% viewer should allow to change self password and (re)setup multi-factor auth for self,
 %% superuser should allow to change any user
-check_rbac(?ROLE_VIEWER, <<"POST">>, <<"/users/", SubPath/binary>>, Username) ->
+check_rbac(?ROLE_VIEWER, <<"POST">>, <<"/users/", SubPath/binary>>, Username, _) ->
     case binary:split(SubPath, <<"/">>, [global]) of
         [Username, <<"change_pwd">>] -> true;
         [Username, <<"mfa">>] -> true;
         _ -> false
     end;
-check_rbac(?ROLE_VIEWER, <<"DELETE">>, <<"/users/", SubPath/binary>>, Username) ->
+check_rbac(?ROLE_VIEWER, <<"DELETE">>, <<"/users/", SubPath/binary>>, Username, Backend) ->
     case binary:split(SubPath, <<"/">>, [global]) of
-        [Username, <<"mfa">>] -> true;
+        [Username, <<"mfa">>] -> not is_forced_sso_mfa(Backend);
         _ -> false
     end;
-check_rbac(_, _, _, _) ->
+check_rbac(_, _, _, _, _) ->
     false.
+
+is_forced_sso_mfa(?BACKEND_LOCAL) ->
+    false;
+is_forced_sso_mfa(Backend) ->
+    case emqx:get_config([dashboard, sso, Backend], undefined) of
+        #{force_mfa := true} -> true;
+        _ -> false
+    end.
 
 role_list(dashboard) ->
     [?ROLE_VIEWER, ?ROLE_SUPERUSER];

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -90,6 +90,8 @@ check_rbac(?ROLE_VIEWER, <<"DELETE">>, <<"/users/", SubPath/binary>>, Username, 
 check_rbac(_, _, _, _, _) ->
     false.
 
+%% force_mfa is an SSO-backend policy only; regular dashboard accounts
+%% authenticated via the local backend do not participate in SSO MFA enforcement.
 is_forced_sso_mfa(?BACKEND_LOCAL) ->
     false;
 is_forced_sso_mfa(Backend) ->

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -210,6 +210,32 @@ t_setup_mfa(_) ->
 t_delete_mfa(_) ->
     test_mfa(fun delete_mfa/2).
 
+t_delete_mfa_sso_force_mfa(_) ->
+    SsoBackend = saml,
+    SsoUser = <<"sso_viewermfa">>,
+    LocalUser = <<"local_viewermfa">>,
+    Password = <<"xyz124abc">>,
+    Desc = <<"desc">>,
+    SsoConfig = emqx:get_config([dashboard, sso, SsoBackend], #{}),
+    {ok, _} = emqx_dashboard_admin:add_sso_user(SsoBackend, SsoUser, ?ROLE_VIEWER, Desc),
+    {ok, _} = emqx_dashboard_admin:add_user(LocalUser, Password, ?ROLE_VIEWER, Desc),
+    {ok, #{role := ?ROLE_VIEWER, token := SsoToken}} = emqx_dashboard_admin:sign_token(
+        ?SSO_USERNAME(SsoBackend, SsoUser), <<>>
+    ),
+    {ok, #{role := ?ROLE_VIEWER, token := LocalToken}} = emqx_dashboard_admin:sign_token(
+        LocalUser, Password
+    ),
+    try
+        ok = emqx_config:put([dashboard, sso, SsoBackend], SsoConfig#{force_mfa => false}),
+        ?assertEqual({ok, SsoUser}, delete_mfa(SsoToken, SsoUser)),
+        ok = emqx_config:put([dashboard, sso, SsoBackend], SsoConfig#{force_mfa => true}),
+        ?assertEqual({error, unauthorized_role}, delete_mfa(SsoToken, SsoUser)),
+        ?assertEqual({ok, LocalUser}, delete_mfa(LocalToken, LocalUser))
+    after
+        ok = emqx_config:put([dashboard, sso, SsoBackend], SsoConfig)
+    end,
+    ok.
+
 test_mfa(VerifyFn) ->
     Viewer1 = <<"viewermfa1">>,
     Viewer2 = <<"viewermfa2">>,

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa.erl
@@ -29,13 +29,8 @@
     | {mfa_setup, binary(), map()}
     | {mfa_verify, binary()}.
 check_sso_mfa(User, Backend) ->
-    case get_force_mfa(Backend) of
-        false ->
-            {ok, login};
-        true ->
-            #?ADMIN{username = Username} = User,
-            check_user_mfa_state(Username, User)
-    end.
+    #?ADMIN{username = Username} = User,
+    check_user_mfa_state(Username, get_force_mfa(Backend)).
 
 %% @doc Get force_mfa config for a given SSO backend.
 -spec get_force_mfa(atom()) -> boolean().
@@ -49,17 +44,19 @@ get_force_mfa(Backend) ->
 %% Internal functions
 %%--------------------------------------------------------------------
 
--spec check_user_mfa_state(term(), dashboard_user()) ->
+-spec check_user_mfa_state(term(), boolean()) ->
     {ok, login}
     | {mfa_setup, binary(), map()}
     | {mfa_verify, binary()}.
-check_user_mfa_state(Username, _User) ->
+check_user_mfa_state(Username, ForceMfa) ->
     MfaState = emqx_dashboard_admin:get_mfa_state(Username),
     case classify_mfa_state(MfaState) of
         admin_disabled ->
             {ok, login};
-        not_configured ->
+        not_configured when ForceMfa ->
             init_and_create_setup(Username);
+        not_configured ->
+            {ok, login};
         setup_required ->
             %% Secret exists (from enable_mfa/reinit) but user hasn't scanned QR yet
             {ok, #{secret := Secret}} = MfaState,

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa_api.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa_api.erl
@@ -354,7 +354,9 @@ response_schema(401) ->
 
 format_error(token_expired) -> <<"Token expired">>;
 format_error(invalid_token) -> <<"Invalid token">>;
-format_error(Reason) when is_binary(Reason) -> Reason.
+format_error(internal_error) -> <<"Internal error">>;
+format_error(Reason) when is_binary(Reason) -> Reason;
+format_error(_) -> <<"Internal error">>.
 
 parse_backend(BackendBin) ->
     emqx_dashboard_sso:parse_backend(BackendBin).

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa_api.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa_api.erl
@@ -158,8 +158,8 @@ mfa_setup_info(post, #{
 mfa_setup_info(post, _) ->
     {400, #{code => ?BAD_REQUEST, message => <<"Missing required fields">>}}.
 
-%% @doc Handle MFA setup: verify the setup token, verify TOTP code,
-%% finalize MFA binding, and issue JWT.
+%% @doc Handle MFA setup: validate the setup token, verify TOTP code,
+%% consume the token, finalize MFA binding, and issue JWT.
 mfa_setup(post, #{
     body := #{
         <<"setup_token">> := SetupToken,
@@ -171,9 +171,9 @@ mfa_setup(post, #{
     case parse_backend(BackendBin) of
         {ok, BackendAtom} ->
             SsoUsername = ?SSO_USERNAME(BackendAtom, Username),
-            case emqx_dashboard_mfa:verify_temp_token(SsoUsername, SetupToken) of
+            case emqx_dashboard_mfa:peek_temp_token(SsoUsername, SetupToken) of
                 {ok, SsoUsername, {setup, TotpSecret}} ->
-                    do_mfa_setup(SsoUsername, TotpCode, TotpSecret);
+                    do_mfa_setup(SsoUsername, SetupToken, TotpCode, TotpSecret);
                 {ok, _SsoUsername, _WrongPurpose} ->
                     {401, #{code => ?UNAUTHORIZED, message => <<"Invalid token type">>}};
                 {error, Reason} ->
@@ -185,8 +185,8 @@ mfa_setup(post, #{
 mfa_setup(post, _) ->
     {400, #{code => ?BAD_REQUEST, message => <<"Missing required fields">>}}.
 
-%% @doc Handle MFA verify: verify the verify token, check TOTP code,
-%% and issue JWT.
+%% @doc Handle MFA verify: validate the verify token, check TOTP code,
+%% consume the token, and issue JWT.
 mfa_verify(post, #{
     body := #{
         <<"verify_token">> := VerifyToken,
@@ -198,9 +198,9 @@ mfa_verify(post, #{
     case parse_backend(BackendBin) of
         {ok, BackendAtom} ->
             SsoUsername = ?SSO_USERNAME(BackendAtom, Username),
-            case emqx_dashboard_mfa:verify_temp_token(SsoUsername, VerifyToken) of
+            case emqx_dashboard_mfa:peek_temp_token(SsoUsername, VerifyToken) of
                 {ok, SsoUsername, verify} ->
-                    do_mfa_verify(SsoUsername, TotpCode);
+                    do_mfa_verify(SsoUsername, VerifyToken, TotpCode);
                 {ok, _SsoUsername, _WrongPurpose} ->
                     {401, #{code => ?UNAUTHORIZED, message => <<"Invalid token type">>}};
                 {error, Reason} ->
@@ -216,16 +216,31 @@ mfa_verify(post, _) ->
 %% Internal functions
 %%--------------------------------------------------------------------
 
-do_mfa_setup(SsoUsername, TotpCode, TotpSecret) ->
+do_mfa_setup(SsoUsername, SetupToken, TotpCode, TotpSecret) ->
     %% Build MFA state from the secret stored in the setup token.
     MfaState = #{mechanism => totp, secret => TotpSecret},
     case emqx_dashboard_mfa:verify(MfaState, TotpCode) of
         ok ->
-            finalize_mfa_setup(SsoUsername, MfaState#{first_verify_ts => erlang:system_time(second)});
+            consume_token_and_respond(
+                SsoUsername,
+                SetupToken,
+                {setup, TotpSecret},
+                fun() ->
+                    finalize_mfa_setup(
+                        SsoUsername,
+                        MfaState#{first_verify_ts => erlang:system_time(second)}
+                    )
+                end
+            );
         {ok, NewState} ->
-            finalize_mfa_setup(SsoUsername, NewState);
+            consume_token_and_respond(
+                SsoUsername,
+                SetupToken,
+                {setup, TotpSecret},
+                fun() -> finalize_mfa_setup(SsoUsername, NewState) end
+            );
         {error, _} ->
-            {401, #{code => ?UNAUTHORIZED, message => <<"Invalid TOTP code">>}}
+            bad_totp_response(SsoUsername, SetupToken)
     end.
 
 finalize_mfa_setup(SsoUsername, MfaState) ->
@@ -249,12 +264,14 @@ finalize_mfa_setup(SsoUsername, MfaState) ->
             {401, #{code => ?UNAUTHORIZED, message => format_error(Reason)}}
     end.
 
-do_mfa_verify(SsoUsername, TotpCode) ->
+do_mfa_verify(SsoUsername, VerifyToken, TotpCode) ->
     case resolve_sso_user(SsoUsername) of
         {ok, Backend, Name, User} ->
             case emqx_dashboard_admin:get_mfa_state(SsoUsername) of
                 {ok, #{mechanism := totp} = MfaState} ->
-                    verify_and_respond(MfaState, TotpCode, SsoUsername, User, Name, Backend);
+                    verify_and_respond(
+                        MfaState, TotpCode, SsoUsername, VerifyToken, User, Name, Backend
+                    );
                 _ ->
                     {401, #{code => ?UNAUTHORIZED, message => <<"MFA state not found">>}}
             end;
@@ -262,14 +279,42 @@ do_mfa_verify(SsoUsername, TotpCode) ->
             {401, #{code => ?UNAUTHORIZED, message => format_error(Reason)}}
     end.
 
-verify_and_respond(MfaState, TotpCode, SsoUsername, User, Name, Backend) ->
+verify_and_respond(MfaState, TotpCode, SsoUsername, VerifyToken, User, Name, Backend) ->
     case emqx_dashboard_mfa:verify(MfaState, TotpCode) of
         ok ->
-            sign_and_respond(User, Name, Backend);
+            consume_token_and_respond(
+                SsoUsername,
+                VerifyToken,
+                verify,
+                fun() -> sign_and_respond(User, Name, Backend) end
+            );
         {ok, NewState} ->
-            persist_state_and_respond(SsoUsername, NewState, User, Name, Backend);
+            consume_token_and_respond(
+                SsoUsername,
+                VerifyToken,
+                verify,
+                fun() -> persist_state_and_respond(SsoUsername, NewState, User, Name, Backend) end
+            );
         {error, _} ->
-            {401, #{code => ?UNAUTHORIZED, message => <<"Invalid TOTP code">>}}
+            bad_totp_response(SsoUsername, VerifyToken)
+    end.
+
+consume_token_and_respond(SsoUsername, Token, ExpectedPurpose, RespondFun) ->
+    case emqx_dashboard_mfa:verify_temp_token(SsoUsername, Token) of
+        {ok, SsoUsername, ExpectedPurpose} ->
+            RespondFun();
+        {ok, _SsoUsername, _WrongPurpose} ->
+            {401, #{code => ?UNAUTHORIZED, message => <<"Invalid token type">>}};
+        {error, Reason} ->
+            {401, #{code => ?UNAUTHORIZED, message => format_error(Reason)}}
+    end.
+
+bad_totp_response(SsoUsername, Token) ->
+    case emqx_dashboard_mfa:record_temp_token_failure(SsoUsername, Token) of
+        ok ->
+            {401, #{code => ?UNAUTHORIZED, message => <<"Invalid TOTP code">>}};
+        {error, Reason} ->
+            {401, #{code => ?UNAUTHORIZED, message => format_error(Reason)}}
     end.
 
 persist_state_and_respond(SsoUsername, NewState, User, Name, Backend) ->

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
@@ -190,11 +190,9 @@ callback(_Req = #{body := Body}, #{sp := SP, dashboard_addr := DashboardAddr} = 
             Subject = Assertion#esaml_assertion.subject,
             Username = iolist_to_binary(Subject#esaml_subject.name),
             gen_redirect_response(DashboardAddr, Username);
-        {error, Reason0} ->
-            Reason = [
-                "Access denied, assertion failed validation:\n", io_lib:format("~p\n", [Reason0])
-            ],
-            {error, iolist_to_binary(Reason)}
+        {error, Reason} ->
+            ?SLOG(error, #{msg => "failed_to_validate_assertion", reason => Reason}),
+            {error, <<"Access denied, assertion failed validation">>}
     end.
 
 convert_certs(

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
@@ -310,29 +310,6 @@ t_admin_disable_mfa(_Config) ->
     ?assertEqual({ok, disabled}, emqx_dashboard_admin:get_mfa_state(SsoUsername)),
     ok.
 
-t_admin_enable_mfa({init, Config}) ->
-    Config;
-t_admin_enable_mfa({'end', _Config}) ->
-    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
-    ok;
-t_admin_enable_mfa(_Config) ->
-    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
-    %% First enable MFA (setup_required state)
-    ok = emqx_dashboard_admin:enable_mfa(SsoUsername, totp),
-    %% Simulate first verify to move to enabled state
-    {ok, #{secret := _Secret}} = emqx_dashboard_admin:get_mfa_state(SsoUsername),
-    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, #{
-        mechanism => totp, secret => <<"OLDSECRET">>, first_verify_ts => 12345
-    }),
-    %% Admin disables MFA
-    ok = emqx_dashboard_admin:disable_mfa(SsoUsername),
-    ?assertEqual({ok, disabled}, emqx_dashboard_admin:get_mfa_state(SsoUsername)),
-    %% Admin re-enables MFA — clears disabled state entirely.
-    %% For SSO users, the next login with force_mfa=true will trigger fresh setup.
-    ok = emqx_dashboard_admin:admin_enable_mfa(SsoUsername),
-    ?assertEqual({error, no_mfa_state}, emqx_dashboard_admin:get_mfa_state(SsoUsername)),
-    ok.
-
 %%====================================================================
 %% SSO MFA API endpoint tests
 %%====================================================================

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
@@ -19,6 +19,7 @@
 -define(SSO_BACKEND, ldap).
 -define(SSO_USER, <<"sso_testuser">>).
 -define(SSO_USER2, <<"sso_testuser2">>).
+-define(MAX_BAD_TOTP_ATTEMPTS, 5).
 
 -define(EE_ONLY(EXPR, NON_EE),
     case emqx_release:edition() of
@@ -212,6 +213,53 @@ t_verify_token_consumed(_Config) ->
     ?assertMatch({error, invalid_token}, emqx_dashboard_mfa:verify_temp_token(Username, Token)),
     ok.
 
+t_verify_token_consumed_once_under_concurrency({init, Config}) ->
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"test_concurrent_consumed_user">>, <<"TestPass1!">>, ?ROLE_VIEWER, <<>>
+    ),
+    Config;
+t_verify_token_consumed_once_under_concurrency({'end', _Config}) ->
+    _ = emqx_dashboard_admin:remove_user(<<"test_concurrent_consumed_user">>),
+    ok;
+t_verify_token_consumed_once_under_concurrency(_Config) ->
+    Username = <<"test_concurrent_consumed_user">>,
+    Secret = <<"SECRET">>,
+    Token = emqx_dashboard_mfa:create_setup_token(Username, Secret),
+    Results = concurrent_call(
+        50,
+        fun() -> emqx_dashboard_mfa:verify_temp_token(Username, Token) end
+    ),
+    Successes = [
+        Result
+     || {ok, _Pid, Result = {ok, ResultUsername, {setup, ResultSecret}}} <- Results,
+        ResultUsername =:= Username,
+        ResultSecret =:= Secret
+    ],
+    ?assertEqual(1, length(Successes)),
+    ok.
+
+t_record_temp_token_failure_once_per_transaction({init, Config}) ->
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"test_concurrent_failed_attempts_user">>, <<"TestPass1!">>, ?ROLE_VIEWER, <<>>
+    ),
+    Config;
+t_record_temp_token_failure_once_per_transaction({'end', _Config}) ->
+    _ = emqx_dashboard_admin:remove_user(<<"test_concurrent_failed_attempts_user">>),
+    ok;
+t_record_temp_token_failure_once_per_transaction(_Config) ->
+    Username = <<"test_concurrent_failed_attempts_user">>,
+    Token = emqx_dashboard_mfa:create_setup_token(Username, <<"SECRET">>),
+    Results = concurrent_call(
+        50,
+        fun() -> emqx_dashboard_mfa:record_temp_token_failure(Username, Token) end
+    ),
+    OkResults = [ok || {ok, _Pid, ok} <- Results],
+    InvalidTokenResults = [Error || {ok, _Pid, Error = {error, invalid_token}} <- Results],
+    ?assertEqual(?MAX_BAD_TOTP_ATTEMPTS, length(OkResults)),
+    ?assertEqual(50 - ?MAX_BAD_TOTP_ATTEMPTS, length(InvalidTokenResults)),
+    ?assertEqual({error, invalid_token}, emqx_dashboard_mfa:peek_temp_token(Username, Token)),
+    ok.
+
 %%====================================================================
 %% Integration tests for check_sso_mfa flow
 %%====================================================================
@@ -383,6 +431,85 @@ t_mfa_setup_api(_Config) ->
     ?assertMatch(#{<<"token">> := _, <<"license">> := _}, Rsp),
     ok.
 
+t_mfa_setup_retry_after_bad_totp({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    Config;
+t_mfa_setup_retry_after_bad_totp({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_mfa_setup_retry_after_bad_totp(_Config) ->
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    {mfa_setup, SetupToken, _QRInfo} = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    Body = #{
+        <<"setup_token">> => SetupToken,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+    {ok, 401, BadRspBody} = request_api(
+        post,
+        api_path(["sso", "mfa", "setup"]),
+        no_auth_header,
+        Body#{<<"totp_code">> => <<"999999">>}
+    ),
+    ?assertMatch(#{<<"code">> := <<"UNAUTHORIZED">>}, json_map(BadRspBody)),
+    {ok, 200, GoodRspBody} = request_api(
+        post,
+        api_path(["sso", "mfa", "setup"]),
+        no_auth_header,
+        Body#{<<"totp_code">> => ?GOOD_TOTP}
+    ),
+    ?assertMatch(#{<<"token">> := _, <<"license">> := _}, json_map(GoodRspBody)),
+    ok.
+
+t_mfa_setup_token_cleared_after_too_many_bad_totp({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    _ = emqx_dashboard_admin:clear_mfa_pending(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    Config;
+t_mfa_setup_token_cleared_after_too_many_bad_totp({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    _ = emqx_dashboard_admin:clear_mfa_pending(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_mfa_setup_token_cleared_after_too_many_bad_totp(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    {mfa_setup, SetupToken, _QRInfo} = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    Body = #{
+        <<"setup_token">> => SetupToken,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+
+    assert_bad_totp_attempts(["sso", "mfa", "setup"], Body, ?MAX_BAD_TOTP_ATTEMPTS - 1),
+    ?assertMatch(
+        {ok, SsoUsername, {setup, _}},
+        emqx_dashboard_mfa:peek_temp_token(SsoUsername, SetupToken)
+    ),
+
+    assert_bad_totp_attempts(["sso", "mfa", "setup"], Body, 1),
+    ?assertEqual(
+        {error, invalid_token}, emqx_dashboard_mfa:peek_temp_token(SsoUsername, SetupToken)
+    ),
+
+    {ok, 401, GoodRspBody} = request_api(
+        post,
+        api_path(["sso", "mfa", "setup"]),
+        no_auth_header,
+        Body#{<<"totp_code">> => ?GOOD_TOTP}
+    ),
+    ?assertMatch(
+        #{<<"code">> := <<"UNAUTHORIZED">>, <<"message">> := <<"Invalid token">>},
+        json_map(GoodRspBody)
+    ),
+    ok.
+
 t_mfa_verify_api({init, Config}) ->
     mock_force_mfa(?SSO_BACKEND, true),
     ok = mock_totp(),
@@ -464,6 +591,89 @@ t_mfa_verify_bad_totp(_Config) ->
     ),
     Rsp = json_map(RspBody),
     ?assertMatch(#{<<"code">> := <<"UNAUTHORIZED">>}, Rsp),
+    ok.
+
+t_mfa_verify_retry_after_bad_totp({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    MfaState = #{mechanism => totp, secret => <<"VERIFYSECRET">>, first_verify_ts => 1000},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    Config;
+t_mfa_verify_retry_after_bad_totp({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_mfa_verify_retry_after_bad_totp(_Config) ->
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    {mfa_verify, VerifyToken} = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    Body = #{
+        <<"verify_token">> => VerifyToken,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+    {ok, 401, BadRspBody} = request_api(
+        post,
+        api_path(["sso", "mfa", "verify"]),
+        no_auth_header,
+        Body#{<<"totp_code">> => <<"999999">>}
+    ),
+    ?assertMatch(#{<<"code">> := <<"UNAUTHORIZED">>}, json_map(BadRspBody)),
+    {ok, 200, GoodRspBody} = request_api(
+        post,
+        api_path(["sso", "mfa", "verify"]),
+        no_auth_header,
+        Body#{<<"totp_code">> => ?GOOD_TOTP}
+    ),
+    ?assertMatch(#{<<"token">> := _, <<"license">> := _}, json_map(GoodRspBody)),
+    ok.
+
+t_mfa_verify_token_cleared_after_too_many_bad_totp({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    MfaState = #{mechanism => totp, secret => <<"VERIFYSECRET">>, first_verify_ts => 1000},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    _ = emqx_dashboard_admin:clear_mfa_pending(SsoUsername),
+    Config;
+t_mfa_verify_token_cleared_after_too_many_bad_totp({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    _ = emqx_dashboard_admin:clear_mfa_pending(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_mfa_verify_token_cleared_after_too_many_bad_totp(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    {mfa_verify, VerifyToken} = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    Body = #{
+        <<"verify_token">> => VerifyToken,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+
+    assert_bad_totp_attempts(["sso", "mfa", "verify"], Body, ?MAX_BAD_TOTP_ATTEMPTS - 1),
+    ?assertMatch(
+        {ok, SsoUsername, verify},
+        emqx_dashboard_mfa:peek_temp_token(SsoUsername, VerifyToken)
+    ),
+
+    assert_bad_totp_attempts(["sso", "mfa", "verify"], Body, 1),
+    ?assertEqual(
+        {error, invalid_token}, emqx_dashboard_mfa:peek_temp_token(SsoUsername, VerifyToken)
+    ),
+
+    {ok, 401, GoodRspBody} = request_api(
+        post,
+        api_path(["sso", "mfa", "verify"]),
+        no_auth_header,
+        Body#{<<"totp_code">> => ?GOOD_TOTP}
+    ),
+    ?assertMatch(
+        #{<<"code">> := <<"UNAUTHORIZED">>, <<"message">> := <<"Invalid token">>},
+        json_map(GoodRspBody)
+    ),
     ok.
 
 %%====================================================================
@@ -732,6 +942,43 @@ t_mfa_setup_unknown_backend(_Config) ->
         post, api_path(["sso", "mfa", "setup"]), no_auth_header, Body
     ),
     ok.
+
+assert_bad_totp_attempts(PathParts, Body, Times) ->
+    lists:foreach(
+        fun(_) ->
+            {ok, 401, RspBody} = request_api(
+                post,
+                api_path(PathParts),
+                no_auth_header,
+                Body#{<<"totp_code">> => <<"999999">>}
+            ),
+            ?assertMatch(
+                #{<<"code">> := <<"UNAUTHORIZED">>, <<"message">> := <<"Invalid TOTP code">>},
+                json_map(RspBody)
+            )
+        end,
+        lists:seq(1, Times)
+    ).
+
+concurrent_call(WorkerCount, Fun) ->
+    Parent = self(),
+    Ref = make_ref(),
+    Pids = [
+        spawn_link(fun() ->
+            receive
+                {go, Ref} ->
+                    Parent ! {Ref, self(), Fun()}
+            end
+        end)
+     || _ <- lists:seq(1, WorkerCount)
+    ],
+    [Pid ! {go, Ref} || Pid <- Pids],
+    [
+        receive
+            {Ref, Pid, Result} -> {ok, Pid, Result}
+        end
+     || Pid <- Pids
+    ].
 
 mock_force_mfa(Backend, Value) ->
     %% Set force_mfa config for a specific SSO backend.

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
@@ -229,6 +229,47 @@ t_check_sso_mfa_no_force(_Config) ->
     ?assertEqual({ok, login}, Result),
     ok.
 
+t_check_sso_mfa_enabled_no_force({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, false),
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER2),
+    MfaState = #{mechanism => totp, secret => <<"TESTSECRET">>, first_verify_ts => 1000},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    Config;
+t_check_sso_mfa_enabled_no_force({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    _ = emqx_dashboard_admin:clear_mfa_pending(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER2)),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER2)),
+    ok;
+t_check_sso_mfa_enabled_no_force(_Config) ->
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER2),
+    Result = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    %% force_mfa=false, MFA enabled => still require verification
+    ?assertMatch({mfa_verify, _VerifyToken}, Result),
+    {mfa_verify, VerifyToken} = Result,
+    ?assert(is_binary(VerifyToken)),
+    ok.
+
+t_check_sso_mfa_setup_required_no_force({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, false),
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    MfaState = #{mechanism => totp, secret => <<"SETUPSECRET">>},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    Config;
+t_check_sso_mfa_setup_required_no_force({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    _ = emqx_dashboard_admin:clear_mfa_pending(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_check_sso_mfa_setup_required_no_force(_Config) ->
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    Result = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    %% force_mfa=false, MFA setup is pending => still require setup
+    ?assertMatch({mfa_setup, _SetupToken, _QRInfo}, Result),
+    {mfa_setup, SetupToken, QRInfo} = Result,
+    ?assert(is_binary(SetupToken)),
+    ?assertEqual(#{secret => <<"SETUPSECRET">>, mechanism => totp}, QRInfo),
+    ok.
+
 t_check_sso_mfa_not_configured({init, Config}) ->
     mock_force_mfa(?SSO_BACKEND, true),
     ok = mock_totp(),

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -91,11 +91,10 @@ password_expire_in_seconds.desc:
 """Time in seconds until the password expiresc."""
 
 change_mfa.desc:
-"""Setup MFA for a dashboard user."""
+"""Set up or reset MFA for a dashboard user. Calling this endpoint generates a fresh TOTP secret."""
 
 delete_mfa.desc:
-"""Delete MFA state for a dashboard user.
-After the state is deleted, the user will have MFA explicitly disabled, to re-enabled MFA, call the `POST` method."""
+"""Disable MFA for a dashboard user. To reset or re-key TOTP, call the `POST` method."""
 
 mfa_token.desc:
 """Multifactor authentication token."""
@@ -105,11 +104,5 @@ mfa_status.desc:
 - `none`: no MFA enabled
 - `disabled`: MFA is disabled for the user
 - Otherwise: The MFA mechanism in use, e.g. `totp`"""
-
-reset_mfa.desc:
-"""Reset MFA for a dashboard user. Completely removes the MFA record so the user must re-bind TOTP on next login. Unlike disabling MFA (which preserves the state as explicitly disabled), reset returns the user to a clean state as if MFA was never configured."""
-
-mfa_reset_param.desc:
-"""When true, completely removes the MFA record (hard reset). The user must re-bind TOTP on next login if force_mfa is enabled. When false (default), soft-disables MFA: marks as admin-disabled so force_mfa won't re-trigger setup."""
 
 }

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -88,7 +88,7 @@ backend.desc:
 """User account source"""
 
 password_expire_in_seconds.desc:
-"""Time in seconds until the password expiresc."""
+"""Time in seconds until the password expires."""
 
 change_mfa.desc:
 """Set up or reset MFA for a dashboard user. Calling this endpoint generates a fresh TOTP secret."""


### PR DESCRIPTION
Fixes 
- https://emqx.atlassian.net/browse/EMQX-15227
- https://emqx.atlassian.net/browse/EMQX-15226

Release version: 5.10.4

## Summary

This PR aligns dashboard MFA reset behavior with the frontend flow, tightens viewer permissions for forced-MFA SSO users, and hardens SSO MFA temporary token handling.

- removes the dedicated hard-reset path on `DELETE /users/:username/mfa?reset=true` and standardizes reset/re-key behavior on `POST /users/:username/mfa`
- updates `apps/emqx_dashboard/src/emqx_dashboard_api.erl`, `apps/emqx_dashboard/src/emqx_dashboard_admin.erl`, `rel/i18n/emqx_dashboard_api.hocon`, and `apps/emqx_dashboard/README.md` so `POST` regenerates the TOTP secret, clears pending MFA state, and invalidates existing dashboard JWTs
- updates dashboard MFA tests in `apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl` to cover the new reset/re-key semantics and old-query compatibility behavior
- tightens RBAC in `apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl` so a viewer can no longer disable their own MFA when they are an SSO user whose backend has `force_mfa = true`
- adds coverage in `apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl` for SSO viewer deletion with `force_mfa = false/true`, while preserving the existing local-user and setup behavior
- updates `apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa.erl` so existing per-user SSO MFA state is honored even when backend `force_mfa = false`; `force_mfa` now only decides whether `not_configured` users must start setup
- updates `apps/emqx_dashboard/src/emqx_dashboard_mfa.erl` and `apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa_api.erl` so SSO MFA temp tokens are only consumed after a successful `setup` or `verify`, incorrect TOTP codes can be retried until TTL / max-attempt invalidation, and failed-attempt accounting is handled atomically
- adds API and concurrency coverage in `apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl` for retry-after-failure, max-attempt invalidation, one-time token consumption, and atomic failed-attempt accounting
- sanitizes the SAML assertion validation error path in `apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl` so frontend responses no longer expose raw validation details
- removes the unused `admin_enable_mfa/1` path and its dead test from `apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl`

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- ~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

## Validation
- `./rebar3 ct -v --readable=true --name test@127.0.0.1 --suite apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl --case t_reset_mfa`
- `./rebar3 ct -v --readable=true --name test@127.0.0.1 --suite apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl --case t_reset_mfa_reinit_error`
- `./rebar3 ct -v --readable=true --name test@127.0.0.1 --suite apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl --case t_delete_mfa_sso_force_mfa`
- `./rebar3 ct -v --readable=true --name test@127.0.0.1 --suite apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl --case t_delete_mfa`
- `./rebar3 ct -v --readable=true --name test@127.0.0.1 --suite apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl --case t_setup_mfa`
- `./rebar3 ct -v --readable=true --name test@127.0.0.1 --suite apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl`
- `./rebar3 ct -v --readable=true --name test@127.0.0.1 --suite apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl`
