### PR TITLE
fix(mt api): disambiguate paginated list responses with Link header

### DIFF
--- a/apps/emqx_mt/src/emqx_mt.erl
+++ b/apps/emqx_mt/src/emqx_mt.erl
@@ -8,15 +8,20 @@
 -export([
     list_ns/0,
     list_ns/2,
+    list_ns_from/2,
     list_ns_details/0,
     list_ns_details/2,
+    list_ns_details_from/2,
     list_managed_ns/0,
     list_managed_ns/2,
+    list_managed_ns_from/2,
     list_managed_ns_details/0,
     list_managed_ns_details/2,
+    list_managed_ns_details_from/2,
     list_clients/1,
     list_clients/2,
     list_clients/3,
+    list_clients_from/3,
     count_clients/1,
     immediate_node_clear/1
 ]).
@@ -51,6 +56,13 @@ list_clients(Ns, LastClientId, Limit) ->
     (Limit < 1 orelse Limit > ?MAX_PAGE_SIZE) andalso error({bad_page_limit, Limit}),
     emqx_mt_state:list_clients(Ns, LastClientId, Limit).
 
+%% @doc List clients of the given tenant, inclusive of `FirstClientId'.
+-spec list_clients_from(tns(), clientid(), non_neg_integer()) ->
+    {ok, [clientid()]} | {error, not_found}.
+list_clients_from(Ns, FirstClientId, Limit) ->
+    (Limit < 1 orelse Limit > ?MAX_PAGE_SIZE) andalso error({bad_page_limit, Limit}),
+    emqx_mt_state:list_clients_from(Ns, FirstClientId, Limit).
+
 %% @doc Count clients of the given tenant.
 %% `{error, not_found}' is returned if there is not any client found.
 -spec count_clients(tns()) -> {ok, non_neg_integer()} | {error, not_found}.
@@ -69,6 +81,11 @@ list_ns() ->
 list_ns(LastNs, Limit) ->
     emqx_mt_state:list_ns(LastNs, Limit).
 
+%% @doc List namespaces inclusively from `FirstNs'.
+-spec list_ns_from(tns(), non_neg_integer()) -> [tns()].
+list_ns_from(FirstNs, Limit) ->
+    emqx_mt_state:list_ns_from(FirstNs, Limit).
+
 -doc """
 List first page of known namespaces with extra details.
 
@@ -81,6 +98,11 @@ list_ns_details() ->
 -spec list_ns_details(tns(), non_neg_integer()) -> [tns_details()].
 list_ns_details(LastNs, Limit) ->
     emqx_mt_state:list_ns_details(LastNs, Limit).
+
+%% @doc List namespaces with details inclusively from `FirstNs'.
+-spec list_ns_details_from(tns(), non_neg_integer()) -> [tns_details()].
+list_ns_details_from(FirstNs, Limit) ->
+    emqx_mt_state:list_ns_details_from(FirstNs, Limit).
 
 -doc """
 List first page of managed namespaces.
@@ -101,6 +123,13 @@ list_managed_ns(LastNs, Limit) ->
     emqx_mt_state:list_managed_ns(LastNs, Limit).
 
 -doc """
+List managed namespaces inclusively from `FirstNs'.
+""".
+-spec list_managed_ns_from(tns(), non_neg_integer()) -> [tns()].
+list_managed_ns_from(FirstNs, Limit) ->
+    emqx_mt_state:list_managed_ns_from(FirstNs, Limit).
+
+-doc """
 List first page of managed namespaces with extra details.
 
 Default page size is 100.
@@ -118,6 +147,13 @@ The second argument is the number of managed namespaces to return.
 -spec list_managed_ns_details(tns(), non_neg_integer()) -> [tns_details()].
 list_managed_ns_details(LastNs, Limit) ->
     emqx_mt_state:list_managed_ns_details(LastNs, Limit).
+
+-doc """
+List managed namespaces with details inclusively from `FirstNs'.
+""".
+-spec list_managed_ns_details_from(tns(), non_neg_integer()) -> [tns_details()].
+list_managed_ns_details_from(FirstNs, Limit) ->
+    emqx_mt_state:list_managed_ns_details_from(FirstNs, Limit).
 
 %% @doc Immediately clear session records of the given node.
 %% If a node is down, the records of the node will be cleared after a delay.

--- a/apps/emqx_mt/src/emqx_mt_api.erl
+++ b/apps/emqx_mt/src/emqx_mt_api.erl
@@ -86,6 +86,7 @@ schema("/mt/ns_list") ->
             description => ?DESC("ns_list"),
             parameters => [
                 last_ns_in_query(),
+                first_ns_in_query(),
                 limit_in_query()
             ],
             responses =>
@@ -94,7 +95,8 @@ schema("/mt/ns_list") ->
                         emqx_dashboard_swagger:schema_with_examples(
                             array(binary()),
                             example_ns_list()
-                        )
+                        ),
+                    400 => error_schema('BAD_REQUEST', ?DESC("cursor_conflict"))
                 }
         }
     };
@@ -106,6 +108,7 @@ schema("/mt/ns_list_details") ->
             description => ?DESC("ns_list_details"),
             parameters => [
                 last_ns_in_query(),
+                first_ns_in_query(),
                 limit_in_query()
             ],
             responses =>
@@ -114,7 +117,8 @@ schema("/mt/ns_list_details") ->
                         emqx_dashboard_swagger:schema_with_examples(
                             array(ref(ns_with_details_out)),
                             example_ns_list_details()
-                        )
+                        ),
+                    400 => error_schema('BAD_REQUEST', ?DESC("cursor_conflict"))
                 }
         }
     };
@@ -127,6 +131,7 @@ schema("/mt/ns/:ns/client_list") ->
             parameters => [
                 param_path_ns(),
                 last_clientid_in_query(),
+                first_clientid_in_query(),
                 limit_in_query()
             ],
             responses =>
@@ -136,6 +141,7 @@ schema("/mt/ns/:ns/client_list") ->
                             array(binary()),
                             example_client_list()
                         ),
+                    400 => error_schema('BAD_REQUEST', ?DESC("cursor_conflict")),
                     404 => error_schema('NOT_FOUND', ?DESC("namespace_not_found"))
                 }
         }
@@ -162,6 +168,7 @@ schema("/mt/managed_ns_list") ->
             description => ?DESC("managed_ns_list"),
             parameters => [
                 last_ns_in_query(),
+                first_ns_in_query(),
                 limit_in_query()
             ],
             responses =>
@@ -170,7 +177,8 @@ schema("/mt/managed_ns_list") ->
                         emqx_dashboard_swagger:schema_with_examples(
                             array(binary()),
                             example_ns_list()
-                        )
+                        ),
+                    400 => error_schema('BAD_REQUEST', ?DESC("cursor_conflict"))
                 }
         }
     };
@@ -182,6 +190,7 @@ schema("/mt/managed_ns_list_details") ->
             description => ?DESC("managed_ns_list_details"),
             parameters => [
                 last_ns_in_query(),
+                first_ns_in_query(),
                 limit_in_query()
             ],
             responses =>
@@ -190,7 +199,8 @@ schema("/mt/managed_ns_list_details") ->
                         emqx_dashboard_swagger:schema_with_examples(
                             array(ref(ns_with_details_out)),
                             example_ns_list_details()
-                        )
+                        ),
+                    400 => error_schema('BAD_REQUEST', ?DESC("cursor_conflict"))
                 }
         }
     };
@@ -374,6 +384,18 @@ last_ns_in_query() ->
             }
         )}.
 
+first_ns_in_query() ->
+    {first_ns,
+        mk(
+            binary(),
+            #{
+                in => query,
+                required => false,
+                example => <<"ns1">>,
+                desc => ?DESC("first_ns_in_query")
+            }
+        )}.
+
 limit_in_query() ->
     {limit,
         mk(
@@ -395,6 +417,18 @@ last_clientid_in_query() ->
                 required => false,
                 example => <<"clientid1">>,
                 desc => ?DESC("last_clientid_in_query")
+            }
+        )}.
+
+first_clientid_in_query() ->
+    {first_clientid,
+        mk(
+            binary(),
+            #{
+                in => query,
+                required => false,
+                example => <<"clientid1">>,
+                desc => ?DESC("first_clientid_in_query")
             }
         )}.
 
@@ -461,28 +495,34 @@ error_schema(Code, ?DESC(_) = MessageRef) ->
 
 '/mt/ns_list'(get, Params) ->
     QS = maps:get(query_string, Params, #{}),
-    LastNs = maps:get(<<"last_ns">>, QS, ?MIN_NS),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    Items = emqx_mt:list_ns(LastNs, Limit + 1),
-    paginated_response(Items, Limit, <<"last_ns">>, fun identity/1).
+    maybe
+        {ok, Cursor} ?= ns_cursor(QS),
+        Items = list_ns_dispatch(Cursor, Limit + 1),
+        paginated_response(Items, Limit, Cursor, fun identity/1)
+    end.
 
 '/mt/ns_list_details'(get, Params) ->
     QS = maps:get(query_string, Params, #{}),
-    LastNs = maps:get(<<"last_ns">>, QS, ?MIN_NS),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    Details = emqx_mt:list_ns_details(LastNs, Limit + 1),
-    Items = lists:map(fun ns_details_out/1, Details),
-    paginated_response(Items, Limit, <<"last_ns">>, fun ns_details_cursor/1).
+    maybe
+        {ok, Cursor} ?= ns_cursor(QS),
+        Details = list_ns_details_dispatch(Cursor, Limit + 1),
+        Items = lists:map(fun ns_details_out/1, Details),
+        paginated_response(Items, Limit, Cursor, fun ns_details_cursor/1)
+    end.
 
 '/mt/ns/:ns/client_list'(get, #{bindings := #{ns := Ns}} = Params) ->
     QS = maps:get(query_string, Params, #{}),
-    LastClientId = maps:get(<<"last_clientid">>, QS, ?MIN_CLIENTID),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    case emqx_mt:list_clients(Ns, LastClientId, Limit + 1) of
-        {ok, Clients} ->
-            paginated_response(Clients, Limit, <<"last_clientid">>, fun identity/1);
-        {error, not_found} ->
-            ?NOT_FOUND("Namespace not found")
+    maybe
+        {ok, Cursor} ?= clientid_cursor(QS),
+        case list_clients_dispatch(Ns, Cursor, Limit + 1) of
+            {ok, Clients} ->
+                paginated_response(Clients, Limit, Cursor, fun identity/1);
+            {error, not_found} ->
+                ?NOT_FOUND("Namespace not found")
+        end
     end.
 
 '/mt/ns/:ns/client_count'(get, #{bindings := #{ns := Ns}}) ->
@@ -493,18 +533,22 @@ error_schema(Code, ?DESC(_) = MessageRef) ->
 
 '/mt/managed_ns_list'(get, Params) ->
     QS = maps:get(query_string, Params, #{}),
-    LastNs = maps:get(<<"last_ns">>, QS, ?MIN_NS),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    Items = emqx_mt:list_managed_ns(LastNs, Limit + 1),
-    paginated_response(Items, Limit, <<"last_ns">>, fun identity/1).
+    maybe
+        {ok, Cursor} ?= ns_cursor(QS),
+        Items = list_managed_ns_dispatch(Cursor, Limit + 1),
+        paginated_response(Items, Limit, Cursor, fun identity/1)
+    end.
 
 '/mt/managed_ns_list_details'(get, Params) ->
     QS = maps:get(query_string, Params, #{}),
-    LastNs = maps:get(<<"last_ns">>, QS, ?MIN_NS),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    Details = emqx_mt:list_managed_ns_details(LastNs, Limit + 1),
-    Items = lists:map(fun ns_details_out/1, Details),
-    paginated_response(Items, Limit, <<"last_ns">>, fun ns_details_cursor/1).
+    maybe
+        {ok, Cursor} ?= ns_cursor(QS),
+        Details = list_managed_ns_details_dispatch(Cursor, Limit + 1),
+        Items = lists:map(fun ns_details_out/1, Details),
+        paginated_response(Items, Limit, Cursor, fun ns_details_cursor/1)
+    end.
 
 '/mt/ns/:ns'(post, #{bindings := #{ns := Ns}}) ->
     handle_create_managed_ns(Ns);
@@ -961,15 +1005,72 @@ ns_not_found() ->
 managed_ns_not_found() ->
     ?NOT_FOUND(<<"Managed namespace not found">>).
 
+%% Parse the `last_ns`/`first_ns` query params into an internal cursor tagged
+%% tuple, or reject with 400 if both are present.
+ns_cursor(QS) ->
+    cursor(QS, <<"last_ns">>, <<"first_ns">>, ?MIN_NS).
+
+clientid_cursor(QS) ->
+    cursor(QS, <<"last_clientid">>, <<"first_clientid">>, ?MIN_CLIENTID).
+
+cursor(QS, LastKey, FirstKey, DefaultLast) ->
+    Last = maps:find(LastKey, QS),
+    First = maps:find(FirstKey, QS),
+    case {Last, First} of
+        {{ok, _}, {ok, _}} ->
+            ?BAD_REQUEST(
+                iolist_to_binary([
+                    <<"`">>,
+                    LastKey,
+                    <<"` and `">>,
+                    FirstKey,
+                    <<"` are mutually exclusive; use at most one.">>
+                ])
+            );
+        {{ok, V}, error} ->
+            {ok, {last, LastKey, V}};
+        {error, {ok, V}} ->
+            {ok, {first, FirstKey, V}};
+        {error, error} ->
+            {ok, {last, LastKey, DefaultLast}}
+    end.
+
+list_ns_dispatch({last, _, Ns}, Limit) -> emqx_mt:list_ns(Ns, Limit);
+list_ns_dispatch({first, _, Ns}, Limit) -> emqx_mt:list_ns_from(Ns, Limit).
+
+list_ns_details_dispatch({last, _, Ns}, Limit) -> emqx_mt:list_ns_details(Ns, Limit);
+list_ns_details_dispatch({first, _, Ns}, Limit) -> emqx_mt:list_ns_details_from(Ns, Limit).
+
+list_managed_ns_dispatch({last, _, Ns}, Limit) -> emqx_mt:list_managed_ns(Ns, Limit);
+list_managed_ns_dispatch({first, _, Ns}, Limit) -> emqx_mt:list_managed_ns_from(Ns, Limit).
+
+list_managed_ns_details_dispatch({last, _, Ns}, Limit) ->
+    emqx_mt:list_managed_ns_details(Ns, Limit);
+list_managed_ns_details_dispatch({first, _, Ns}, Limit) ->
+    emqx_mt:list_managed_ns_details_from(Ns, Limit).
+
+list_clients_dispatch(Ns, {last, _, Id}, Limit) -> emqx_mt:list_clients(Ns, Id, Limit);
+list_clients_dispatch(Ns, {first, _, Id}, Limit) -> emqx_mt:list_clients_from(Ns, Id, Limit).
+
 %% Emit a 200 response; attach an RFC 8288 `Link; rel="next"` header when the
 %% backend returned Limit+1 items, indicating the caller can fetch another page.
-paginated_response(Items, Limit, CursorKey, CursorFn) ->
+%% The Link preserves the cursor mode the caller used: `last_*` in its exclusive
+%% form, `first_*` in its inclusive form.
+paginated_response(Items, Limit, Cursor, CursorFn) ->
     case length(Items) > Limit of
         true ->
             Page = lists:sublist(Items, Limit),
-            Cursor = CursorFn(lists:last(Page)),
+            {CursorKey, CursorValue} =
+                case Cursor of
+                    {last, Key, _} ->
+                        {Key, CursorFn(lists:last(Page))};
+                    {first, Key, _} ->
+                        %% Items has Limit+1 entries; the (Limit+1)-th is the
+                        %% next inclusive cursor the client should use.
+                        {Key, CursorFn(lists:nth(Limit + 1, Items))}
+                end,
             Query = uri_string:compose_query([
-                {CursorKey, Cursor},
+                {CursorKey, CursorValue},
                 {<<"limit">>, integer_to_binary(Limit)}
             ]),
             Link = iolist_to_binary([<<"<?">>, Query, <<">; rel=\"next\"">>]),

--- a/apps/emqx_mt/src/emqx_mt_api.erl
+++ b/apps/emqx_mt/src/emqx_mt_api.erl
@@ -463,22 +463,26 @@ error_schema(Code, ?DESC(_) = MessageRef) ->
     QS = maps:get(query_string, Params, #{}),
     LastNs = maps:get(<<"last_ns">>, QS, ?MIN_NS),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    ?OK(emqx_mt:list_ns(LastNs, Limit)).
+    Items = emqx_mt:list_ns(LastNs, Limit + 1),
+    paginated_response(Items, Limit, <<"last_ns">>, fun identity/1).
 
 '/mt/ns_list_details'(get, Params) ->
     QS = maps:get(query_string, Params, #{}),
     LastNs = maps:get(<<"last_ns">>, QS, ?MIN_NS),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    Details = emqx_mt:list_ns_details(LastNs, Limit),
-    ?OK(lists:map(fun ns_details_out/1, Details)).
+    Details = emqx_mt:list_ns_details(LastNs, Limit + 1),
+    Items = lists:map(fun ns_details_out/1, Details),
+    paginated_response(Items, Limit, <<"last_ns">>, fun ns_details_cursor/1).
 
 '/mt/ns/:ns/client_list'(get, #{bindings := #{ns := Ns}} = Params) ->
     QS = maps:get(query_string, Params, #{}),
     LastClientId = maps:get(<<"last_clientid">>, QS, ?MIN_CLIENTID),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    case emqx_mt:list_clients(Ns, LastClientId, Limit) of
-        {ok, Clients} -> ?OK(Clients);
-        {error, not_found} -> ?NOT_FOUND("Namespace not found")
+    case emqx_mt:list_clients(Ns, LastClientId, Limit + 1) of
+        {ok, Clients} ->
+            paginated_response(Clients, Limit, <<"last_clientid">>, fun identity/1);
+        {error, not_found} ->
+            ?NOT_FOUND("Namespace not found")
     end.
 
 '/mt/ns/:ns/client_count'(get, #{bindings := #{ns := Ns}}) ->
@@ -491,14 +495,16 @@ error_schema(Code, ?DESC(_) = MessageRef) ->
     QS = maps:get(query_string, Params, #{}),
     LastNs = maps:get(<<"last_ns">>, QS, ?MIN_NS),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    ?OK(emqx_mt:list_managed_ns(LastNs, Limit)).
+    Items = emqx_mt:list_managed_ns(LastNs, Limit + 1),
+    paginated_response(Items, Limit, <<"last_ns">>, fun identity/1).
 
 '/mt/managed_ns_list_details'(get, Params) ->
     QS = maps:get(query_string, Params, #{}),
     LastNs = maps:get(<<"last_ns">>, QS, ?MIN_NS),
     Limit = maps:get(<<"limit">>, QS, ?DEFAULT_PAGE_SIZE),
-    Details = emqx_mt:list_managed_ns_details(LastNs, Limit),
-    ?OK(lists:map(fun ns_details_out/1, Details)).
+    Details = emqx_mt:list_managed_ns_details(LastNs, Limit + 1),
+    Items = lists:map(fun ns_details_out/1, Details),
+    paginated_response(Items, Limit, <<"last_ns">>, fun ns_details_cursor/1).
 
 '/mt/ns/:ns'(post, #{bindings := #{ns := Ns}}) ->
     handle_create_managed_ns(Ns);
@@ -954,3 +960,24 @@ ns_not_found() ->
 
 managed_ns_not_found() ->
     ?NOT_FOUND(<<"Managed namespace not found">>).
+
+%% Emit a 200 response; attach an RFC 8288 `Link; rel="next"` header when the
+%% backend returned Limit+1 items, indicating the caller can fetch another page.
+paginated_response(Items, Limit, CursorKey, CursorFn) ->
+    case length(Items) > Limit of
+        true ->
+            Page = lists:sublist(Items, Limit),
+            Cursor = CursorFn(lists:last(Page)),
+            Query = uri_string:compose_query([
+                {CursorKey, Cursor},
+                {<<"limit">>, integer_to_binary(Limit)}
+            ]),
+            Link = iolist_to_binary([<<"<?">>, Query, <<">; rel=\"next\"">>]),
+            {200, #{<<"link">> => Link}, Page};
+        false ->
+            ?OK(Items)
+    end.
+
+identity(X) -> X.
+
+ns_details_cursor(#{<<"name">> := Name}) -> Name.

--- a/apps/emqx_mt/src/emqx_mt_state.erl
+++ b/apps/emqx_mt/src/emqx_mt_state.erl
@@ -11,13 +11,17 @@
 
 -export([
     list_ns/2,
+    list_ns_from/2,
     list_ns_details/2,
+    list_ns_details_from/2,
     is_known_ns/1,
     count_clients/1,
     evict_ccache/0,
     evict_ccache/1,
     list_clients/3,
+    list_clients_from/3,
     list_clients_no_check/3,
+    list_clients_from_no_check/3,
     is_known_client/2
 ]).
 
@@ -31,7 +35,9 @@
 %% Managed namespaces
 -export([
     list_managed_ns/2,
+    list_managed_ns_from/2,
     list_managed_ns_details/2,
+    list_managed_ns_details_from/2,
     create_managed_ns/1,
     delete_managed_ns/1,
     is_known_managed_ns/1,
@@ -222,6 +228,22 @@ do_list_ns(Table, LastNs, Limit) ->
             [Ns | do_list_ns(Table, Ns, Limit - 1)]
     end.
 
+%% @doc List namespaces starting inclusively at `FirstNs'.
+%% Compared to `list_ns/2' the behavior differs only on the first element: if
+%% `FirstNs' itself is present in the table, it is included in the result;
+%% otherwise the next key in lexicographical order is used.
+-spec list_ns_from(tns(), pos_integer()) -> [tns()].
+list_ns_from(FirstNs, Limit) ->
+    do_list_ns_from(?NS_TAB, FirstNs, Limit).
+
+do_list_ns_from(_Table, _FirstNs, 0) ->
+    [];
+do_list_ns_from(Table, FirstNs, Limit) ->
+    case ets:member(Table, FirstNs) of
+        true -> [FirstNs | do_list_ns(Table, FirstNs, Limit - 1)];
+        false -> do_list_ns(Table, FirstNs, Limit)
+    end.
+
 %% @doc List namespaces with extra details.
 %% The second argument is the last namespace from the previous page.
 %% The third argument is the number of namespaces to return.
@@ -238,6 +260,22 @@ do_list_ns_details(Table, LastNs, Limit) ->
         {Ns, [Rec]} ->
             Details = get_ns_details(Table, Rec),
             [Details | do_list_ns_details(Table, Ns, Limit - 1)]
+    end.
+
+%% @doc List namespaces with extra details starting inclusively at `FirstNs'.
+-spec list_ns_details_from(tns(), pos_integer()) -> [tns_details()].
+list_ns_details_from(FirstNs, Limit) ->
+    do_list_ns_details_from(?NS_TAB, FirstNs, Limit).
+
+do_list_ns_details_from(_Table, _FirstNs, 0) ->
+    [];
+do_list_ns_details_from(Table, FirstNs, Limit) ->
+    case ets:lookup(Table, FirstNs) of
+        [Rec] ->
+            Details = get_ns_details(Table, Rec),
+            [Details | do_list_ns_details(Table, FirstNs, Limit - 1)];
+        [] ->
+            do_list_ns_details(Table, FirstNs, Limit)
     end.
 
 get_ns_details(?NS_TAB, #?NS_TAB{ns = Ns, value = []}) ->
@@ -262,6 +300,13 @@ list_managed_ns(LastNs, Limit) ->
     do_list_ns(?CONFIG_TAB, LastNs, Limit).
 
 -doc """
+List managed namespaces starting inclusively at `FirstNs'.
+""".
+-spec list_managed_ns_from(tns(), pos_integer()) -> [tns()].
+list_managed_ns_from(FirstNs, Limit) ->
+    do_list_ns_from(?CONFIG_TAB, FirstNs, Limit).
+
+-doc """
 List managed namespaces with extra details.
 
 The second argument is the last namespace from the previous page.
@@ -271,6 +316,13 @@ The third argument is the number of namespaces to return.
 -spec list_managed_ns_details(tns(), pos_integer()) -> [tns_details()].
 list_managed_ns_details(LastNs, Limit) ->
     do_list_ns_details(?CONFIG_TAB, LastNs, Limit).
+
+-doc """
+List managed namespaces with extra details starting inclusively at `FirstNs'.
+""".
+-spec list_managed_ns_details_from(tns(), pos_integer()) -> [tns_details()].
+list_managed_ns_details_from(FirstNs, Limit) ->
+    do_list_ns_details_from(?CONFIG_TAB, FirstNs, Limit).
 
 fold_managed_nss(Fn, Acc) ->
     do_fold_managed_nss(ets:first(?CONFIG_TAB), Fn, Acc).
@@ -373,6 +425,36 @@ list_clients(Ns, LastClientId, Limit) ->
 list_clients_no_check(Ns, LastClientId, Limit) ->
     PrevKey = ?RECORD_KEY(Ns, LastClientId, ?MIN_PID),
     do_list_clients(PrevKey, Limit, []).
+
+%% @doc List clients in a namespace starting inclusively at `FirstClientId'.
+%% Compared to `list_clients/3' the behavior differs only on the first element:
+%% if `FirstClientId' itself has records, it is included in the result.
+-spec list_clients_from(tns(), clientid(), non_neg_integer()) ->
+    {ok, [clientid()]} | {error, not_found}.
+list_clients_from(Ns, FirstClientId, Limit) ->
+    case is_known_ns(Ns) of
+        false -> {error, not_found};
+        true -> {ok, list_clients_from_no_check(Ns, FirstClientId, Limit)}
+    end.
+
+-spec list_clients_from_no_check(tns(), clientid(), non_neg_integer()) ->
+    [clientid()].
+list_clients_from_no_check(_Ns, _FirstClientId, 0) ->
+    [];
+list_clients_from_no_check(Ns, FirstClientId, Limit) ->
+    %% Any real pid sorts strictly after the integer ?MIN_PID, so this sentinel
+    %% key is guaranteed to be just before any `(Ns, FirstClientId, _)' record.
+    %% `ets:next/2' from this sentinel returns the first record whose clientid
+    %% is greater than or equal to `FirstClientId', which is exactly the
+    %% inclusive semantics we want. We then delegate to the existing walker to
+    %% de-duplicate further pids for the same clientid.
+    Seed = ?RECORD_KEY(Ns, FirstClientId, ?MIN_PID),
+    case ets:next(?RECORD_TAB, Seed) of
+        ?RECORD_KEY(Ns, ClientId, _) = Key ->
+            do_list_clients(Key, Limit - 1, [ClientId]);
+        _ ->
+            []
+    end.
 
 do_list_clients(_Key, 0, Acc) ->
     lists:reverse(Acc);

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -154,13 +154,31 @@ list_clients(Ns, QueryParams) ->
     URL = ns_url(Ns, "client_list"),
     simple_request(#{method => get, url => URL, query_params => QueryParams}).
 
+list_clients_headers(Ns, QueryParams) ->
+    URL = ns_url(Ns, "client_list"),
+    simple_request(#{
+        method => get, url => URL, query_params => QueryParams, return_headers => true
+    }).
+
 list_nss(QueryParams) ->
     URL = url("ns_list"),
     simple_request(#{method => get, url => URL, query_params => QueryParams}).
 
+list_nss_headers(QueryParams) ->
+    URL = url("ns_list"),
+    simple_request(#{
+        method => get, url => URL, query_params => QueryParams, return_headers => true
+    }).
+
 list_nss_details(QueryParams) ->
     URL = url("ns_list_details"),
     simple_request(#{method => get, url => URL, query_params => QueryParams}).
+
+list_nss_details_headers(QueryParams) ->
+    URL = url("ns_list_details"),
+    simple_request(#{
+        method => get, url => URL, query_params => QueryParams, return_headers => true
+    }).
 
 maybe_json_decode(X) ->
     case emqx_utils_json:safe_decode(X) of
@@ -197,9 +215,21 @@ list_managed_nss(QueryParams) ->
     URL = emqx_mgmt_api_test_util:api_path(["mt", "managed_ns_list"]),
     simple_request(#{method => get, url => URL, query_params => QueryParams}).
 
+list_managed_nss_headers(QueryParams) ->
+    URL = emqx_mgmt_api_test_util:api_path(["mt", "managed_ns_list"]),
+    simple_request(#{
+        method => get, url => URL, query_params => QueryParams, return_headers => true
+    }).
+
 list_managed_nss_details(QueryParams) ->
     URL = emqx_mgmt_api_test_util:api_path(["mt", "managed_ns_list_details"]),
     simple_request(#{method => get, url => URL, query_params => QueryParams}).
+
+list_managed_nss_details_headers(QueryParams) ->
+    URL = emqx_mgmt_api_test_util:api_path(["mt", "managed_ns_list_details"]),
+    simple_request(#{
+        method => get, url => URL, query_params => QueryParams, return_headers => true
+    }).
 
 create_managed_ns(Ns) ->
     Path = emqx_mgmt_api_test_util:api_path(["mt", "ns", Ns]),
@@ -1355,3 +1385,106 @@ t_namespaced_user_api_checks(_TCConfig) ->
     ),
 
     ok.
+
+-doc """
+Verifies that the paginated list endpoints emit an RFC 8288
+`Link: <?...>; rel="next"` response header when more pages are available,
+and no such header when the current page is the last one. The query-only
+URI-reference in the Link header, once resolved against the request URL,
+must carry the caller back to the next page of results.
+""".
+t_list_pagination_link_header(_Config) ->
+    Ns1 = <<"pagns1">>,
+    Ns2 = <<"pagns2">>,
+    %% Populate `?CONFIG_TAB` (managed_ns_list*) with two entries.
+    ?assertMatch({204, _}, create_managed_ns(Ns1)),
+    ?assertMatch({204, _}, create_managed_ns(Ns2)),
+    %% Populate `?NS_TAB` (ns_list*) with two entries by connecting clients.
+    %% Also create 2 clients under Ns1 to exercise the client_list endpoint.
+    ClientId1 = <<"pag-c-1">>,
+    ClientId2 = <<"pag-c-2">>,
+    ClientId3 = <<"pag-c-3">>,
+    C1 = connect(ClientId1, Ns1),
+    C2 = connect(ClientId2, Ns1),
+    C3 = connect(ClientId3, Ns2),
+    ?retry(200, 50, ?assertMatch({200, [Ns1, Ns2]}, list_nss(#{}))),
+
+    %% Exact-one-page: limit == total items => no Link header.
+    assert_no_link(list_managed_nss_headers(#{<<"limit">> => <<"2">>})),
+    assert_no_link(list_managed_nss_details_headers(#{<<"limit">> => <<"2">>})),
+    assert_no_link(list_nss_headers(#{<<"limit">> => <<"2">>})),
+    assert_no_link(list_nss_details_headers(#{<<"limit">> => <<"2">>})),
+    assert_no_link(list_clients_headers(Ns1, #{<<"limit">> => <<"2">>})),
+
+    %% More-pages: limit < total items => Link header present with cursor
+    %% pointing at the last item of the returned page. Following the cursor
+    %% must yield the next item(s).
+    assert_next_link_roundtrip(
+        fun(QS) -> list_managed_nss_headers(QS) end,
+        #{<<"limit">> => <<"1">>},
+        <<"last_ns">>,
+        Ns1,
+        1
+    ),
+    assert_next_link_roundtrip(
+        fun(QS) -> list_nss_headers(QS) end,
+        #{<<"limit">> => <<"1">>},
+        <<"last_ns">>,
+        Ns1,
+        1
+    ),
+    assert_next_link_roundtrip(
+        fun(QS) -> list_managed_nss_details_headers(QS) end,
+        #{<<"limit">> => <<"1">>},
+        <<"last_ns">>,
+        Ns1,
+        1
+    ),
+    assert_next_link_roundtrip(
+        fun(QS) -> list_nss_details_headers(QS) end,
+        #{<<"limit">> => <<"1">>},
+        <<"last_ns">>,
+        Ns1,
+        1
+    ),
+    assert_next_link_roundtrip(
+        fun(QS) -> list_clients_headers(Ns1, QS) end,
+        #{<<"limit">> => <<"1">>},
+        <<"last_clientid">>,
+        ClientId1,
+        1
+    ),
+
+    lists:foreach(fun stop_client/1, [C1, C2, C3]),
+    ok.
+
+assert_no_link({200, Headers, _Body}) ->
+    ?assertEqual(false, lists:keyfind("link", 1, Headers), #{headers => Headers}).
+
+assert_next_link_roundtrip(Fun, QS, CursorKey, ExpectedCursor, ExpectedNextPageSize) ->
+    {200, Headers, Body} = Fun(QS),
+    ?assertEqual(1, length(Body), #{headers => Headers, body => Body}),
+    {"link", LinkVal} = lists:keyfind("link", 1, Headers),
+    NextQS = parse_next_link(LinkVal),
+    ?assertMatch(
+        #{CursorKey := ExpectedCursor, <<"limit">> := <<"1">>},
+        NextQS,
+        #{link => LinkVal}
+    ),
+    {200, NextHeaders, NextBody} = Fun(NextQS),
+    ?assertEqual(
+        ExpectedNextPageSize,
+        length(NextBody),
+        #{headers => NextHeaders, body => NextBody}
+    ),
+    ok.
+
+%% Parse `<?k=v&...>; rel="next"` into a #{binary() => binary()} query map.
+parse_next_link(LinkVal) ->
+    LinkBin = iolist_to_binary(LinkVal),
+    [URIPart | _] = binary:split(LinkBin, <<";">>),
+    Trimmed = string:trim(URIPart),
+    <<"<?", Rest/binary>> = Trimmed,
+    Size = byte_size(Rest) - 1,
+    <<Query:Size/binary, ">">> = Rest,
+    maps:from_list(uri_string:dissect_query(Query)).

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -1542,7 +1542,7 @@ t_list_pagination_first_cursor(_Config) ->
         <<"first_ns">>,
         Ns2,
         [Ns1],
-        2
+        1
     ),
     assert_first_mode_roundtrip(
         fun(QS) -> list_nss_headers(QS) end,
@@ -1550,7 +1550,7 @@ t_list_pagination_first_cursor(_Config) ->
         <<"first_ns">>,
         Ns2,
         [Ns1],
-        2
+        1
     ),
     assert_first_mode_roundtrip(
         fun(QS) -> list_managed_nss_details_headers(QS) end,
@@ -1558,7 +1558,7 @@ t_list_pagination_first_cursor(_Config) ->
         <<"first_ns">>,
         Ns2,
         1,
-        2
+        1
     ),
     assert_first_mode_roundtrip(
         fun(QS) -> list_nss_details_headers(QS) end,
@@ -1566,7 +1566,7 @@ t_list_pagination_first_cursor(_Config) ->
         <<"first_ns">>,
         Ns2,
         1,
-        2
+        1
     ),
     assert_first_mode_roundtrip(
         fun(QS) -> list_clients_headers(Ns1, QS) end,
@@ -1574,7 +1574,7 @@ t_list_pagination_first_cursor(_Config) ->
         <<"first_clientid">>,
         ClientId2,
         [ClientId1],
-        2
+        1
     ),
 
     %% --- Mutex: providing both cursors rejects with 400.

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -1488,3 +1488,168 @@ parse_next_link(LinkVal) ->
     Size = byte_size(Rest) - 1,
     <<Query:Size/binary, ">">> = Rest,
     maps:from_list(uri_string:dissect_query(Query)).
+
+-doc """
+Verifies the inclusive keyset cursor parameters (`first_ns`, `first_clientid`).
+Covers exact-match lookup, paginated continuation where the Link header
+preserves the inclusive cursor mode, and the mutex rule that rejects requests
+providing both an inclusive and an exclusive cursor on the same endpoint.
+""".
+t_list_pagination_first_cursor(_Config) ->
+    Ns1 = <<"pfns1">>,
+    Ns2 = <<"pfns2">>,
+    Ns3 = <<"pfns3">>,
+    ?assertMatch({204, _}, create_managed_ns(Ns1)),
+    ?assertMatch({204, _}, create_managed_ns(Ns2)),
+    ?assertMatch({204, _}, create_managed_ns(Ns3)),
+    ClientId1 = <<"pf-c-1">>,
+    ClientId2 = <<"pf-c-2">>,
+    ClientId3 = <<"pf-c-3">>,
+    C1 = connect(ClientId1, Ns1),
+    C2 = connect(ClientId2, Ns1),
+    C3 = connect(ClientId3, Ns1),
+    C4 = connect(<<"pf-other">>, Ns2),
+    C5 = connect(<<"pf-other">>, Ns3),
+    ?retry(200, 50, ?assertMatch({200, [Ns1, Ns2, Ns3]}, list_nss(#{}))),
+
+    %% --- Exact-match lookup: first_ns equal to an existing key returns that
+    %% key as the first element (up to limit=1 => one-item response).
+    ?assertMatch(
+        {200, [Ns2]},
+        list_managed_nss(#{<<"first_ns">> => Ns2, <<"limit">> => <<"1">>})
+    ),
+    ?assertMatch(
+        {200, [Ns2]},
+        list_nss(#{<<"first_ns">> => Ns2, <<"limit">> => <<"1">>})
+    ),
+    ?assertMatch(
+        {200, [ClientId2]},
+        list_clients(Ns1, #{<<"first_clientid">> => ClientId2, <<"limit">> => <<"1">>})
+    ),
+
+    %% --- first_ns with a value that isn't present advances to the next key
+    %% that exists (like an inclusive lower bound).
+    ?assertMatch(
+        {200, [Ns2, Ns3]},
+        list_managed_nss(#{<<"first_ns">> => <<"pfns15">>, <<"limit">> => <<"5">>})
+    ),
+
+    %% --- Pagination: limit < total with first_ns => Link preserves first_ns
+    %% and points at the next-inclusive cursor.
+    assert_first_mode_roundtrip(
+        fun(QS) -> list_managed_nss_headers(QS) end,
+        #{<<"first_ns">> => Ns1, <<"limit">> => <<"1">>},
+        <<"first_ns">>,
+        Ns2,
+        [Ns1],
+        2
+    ),
+    assert_first_mode_roundtrip(
+        fun(QS) -> list_nss_headers(QS) end,
+        #{<<"first_ns">> => Ns1, <<"limit">> => <<"1">>},
+        <<"first_ns">>,
+        Ns2,
+        [Ns1],
+        2
+    ),
+    assert_first_mode_roundtrip(
+        fun(QS) -> list_managed_nss_details_headers(QS) end,
+        #{<<"first_ns">> => Ns1, <<"limit">> => <<"1">>},
+        <<"first_ns">>,
+        Ns2,
+        1,
+        2
+    ),
+    assert_first_mode_roundtrip(
+        fun(QS) -> list_nss_details_headers(QS) end,
+        #{<<"first_ns">> => Ns1, <<"limit">> => <<"1">>},
+        <<"first_ns">>,
+        Ns2,
+        1,
+        2
+    ),
+    assert_first_mode_roundtrip(
+        fun(QS) -> list_clients_headers(Ns1, QS) end,
+        #{<<"first_clientid">> => ClientId1, <<"limit">> => <<"1">>},
+        <<"first_clientid">>,
+        ClientId2,
+        [ClientId1],
+        2
+    ),
+
+    %% --- Mutex: providing both cursors rejects with 400.
+    ?assertMatch(
+        {400, #{<<"code">> := <<"BAD_REQUEST">>}},
+        list_managed_nss(#{
+            <<"first_ns">> => Ns1,
+            <<"last_ns">> => Ns1,
+            <<"limit">> => <<"1">>
+        })
+    ),
+    ?assertMatch(
+        {400, #{<<"code">> := <<"BAD_REQUEST">>}},
+        list_nss(#{
+            <<"first_ns">> => Ns1,
+            <<"last_ns">> => Ns1,
+            <<"limit">> => <<"1">>
+        })
+    ),
+    ?assertMatch(
+        {400, #{<<"code">> := <<"BAD_REQUEST">>}},
+        list_managed_nss_details(#{
+            <<"first_ns">> => Ns1,
+            <<"last_ns">> => Ns1,
+            <<"limit">> => <<"1">>
+        })
+    ),
+    ?assertMatch(
+        {400, #{<<"code">> := <<"BAD_REQUEST">>}},
+        list_nss_details(#{
+            <<"first_ns">> => Ns1,
+            <<"last_ns">> => Ns1,
+            <<"limit">> => <<"1">>
+        })
+    ),
+    ?assertMatch(
+        {400, #{<<"code">> := <<"BAD_REQUEST">>}},
+        list_clients(Ns1, #{
+            <<"first_clientid">> => ClientId1,
+            <<"last_clientid">> => ClientId1,
+            <<"limit">> => <<"1">>
+        })
+    ),
+
+    lists:foreach(fun stop_client/1, [C1, C2, C3, C4, C5]),
+    ok.
+
+%% Checks that a request using `first_*` cursor returns the expected first
+%% page, that the Link header preserves the `first_*` param name, that the
+%% cursor value points at the next inclusive item, and that following the
+%% Link yields the expected continuation.
+assert_first_mode_roundtrip(
+    Fun, QS, CursorKey, ExpectedCursor, ExpectedFirstPage, ExpectedNextPageSize
+) ->
+    {200, Headers, Body} = Fun(QS),
+    %% First-page content check: if caller gave a list, match it; otherwise
+    %% use it as a length expectation (details endpoints return maps with
+    %% keys beyond just `name`).
+    case is_list(ExpectedFirstPage) of
+        true ->
+            ?assertEqual(ExpectedFirstPage, Body, #{headers => Headers});
+        false ->
+            ?assertEqual(ExpectedFirstPage, length(Body), #{headers => Headers, body => Body})
+    end,
+    {"link", LinkVal} = lists:keyfind("link", 1, Headers),
+    NextQS = parse_next_link(LinkVal),
+    ?assertMatch(
+        #{CursorKey := ExpectedCursor, <<"limit">> := <<"1">>},
+        NextQS,
+        #{link => LinkVal}
+    ),
+    {200, NextHeaders, NextBody} = Fun(NextQS),
+    ?assertEqual(
+        ExpectedNextPageSize,
+        length(NextBody),
+        #{headers => NextHeaders, body => NextBody}
+    ),
+    ok.

--- a/changes/ee/fix-17118.en.md
+++ b/changes/ee/fix-17118.en.md
@@ -1,0 +1,9 @@
+Added pagination cursor signaling to multi-tenancy list endpoints
+(`/mt/ns_list`, `/mt/ns_list_details`, `/mt/managed_ns_list`,
+`/mt/managed_ns_list_details`, `/mt/ns/{ns}/client_list`). When more pages are
+available, responses now carry a standard `Link: <?...>; rel="next"` header
+(RFC 8288) whose URI-reference resolves against the request URL. Absence of
+the header indicates the current response is the last page. This removes the
+prior ambiguity where a full page (`len(results) == limit`) could not be
+distinguished from the exact-boundary "no more data" case without an extra
+request.

--- a/changes/ee/fix-17118.en.md
+++ b/changes/ee/fix-17118.en.md
@@ -1,9 +1,16 @@
-Added pagination cursor signaling to multi-tenancy list endpoints
+Improved pagination on multi-tenancy list endpoints
 (`/mt/ns_list`, `/mt/ns_list_details`, `/mt/managed_ns_list`,
-`/mt/managed_ns_list_details`, `/mt/ns/{ns}/client_list`). When more pages are
-available, responses now carry a standard `Link: <?...>; rel="next"` header
-(RFC 8288) whose URI-reference resolves against the request URL. Absence of
-the header indicates the current response is the last page. This removes the
-prior ambiguity where a full page (`len(results) == limit`) could not be
-distinguished from the exact-boundary "no more data" case without an extra
-request.
+`/mt/managed_ns_list_details`, `/mt/ns/{ns}/client_list`):
+
+- Added an RFC 8288 `Link: <?...>; rel="next"` response header. When more
+  pages are available the header carries the query-only URI-reference of
+  the next page; when absent, the current response is the last page. This
+  removes the prior ambiguity where a full page (`len(results) == limit`)
+  could not be distinguished from the exact-boundary "no more data" case
+  without an extra request.
+- Added inclusive keyset cursor query parameters (`first_ns`,
+  `first_clientid`) alongside the existing exclusive cursors (`last_ns`,
+  `last_clientid`). The inclusive form supports exact-match lookup
+  (e.g. `?first_ns=foo&limit=1`) and is preserved across paginated Link
+  headers when the caller opts in. The two forms are mutually exclusive
+  on a single request; supplying both returns HTTP 400.

--- a/rel/i18n/emqx_mt_api.hocon
+++ b/rel/i18n/emqx_mt_api.hocon
@@ -36,9 +36,25 @@ emqx_mt_api {
     }
     last_ns_in_query {
         desc: """~
-            The last namespace from the previous page.
-            For the first page, use empty string.~"""
+            Exclusive keyset cursor: return namespaces lexicographically
+            greater than this value. For the first page, omit or use the
+            empty string. Mutually exclusive with `first_ns`.~"""
         label: "Last Namespace"
+    }
+    first_ns_in_query {
+        desc: """~
+            Inclusive keyset cursor: return namespaces lexicographically
+            greater than or equal to this value. Useful for exact-match
+            lookup (e.g. `first_ns=foo&limit=1`). Mutually exclusive with
+            `last_ns`.~"""
+        label: "First Namespace"
+    }
+    cursor_conflict {
+        desc: """~
+            The request carried both an inclusive (`first_*`) and an
+            exclusive (`last_*`) keyset cursor. They are mutually exclusive;
+            use at most one.~"""
+        label: "Cursor Parameters Conflict"
     }
     limit_in_query {
         desc: "The number of items to return"
@@ -49,6 +65,14 @@ emqx_mt_api {
             The last client from the previous page.
             For the first page, use empty string.~"""
         label: "Last Client ID"
+    }
+    first_clientid_in_query {
+        desc: """~
+            Inclusive keyset cursor: return client IDs lexicographically
+            greater than or equal to this value. Useful for exact-match
+            lookup (e.g. `first_clientid=foo&limit=1`). Mutually exclusive
+            with `last_clientid`.~"""
+        label: "First Client ID"
     }
     managed_ns_list {
         desc: """~
@@ -154,7 +178,10 @@ emqx_mt_api {
     }
 
 last_clientid_in_query.desc:
-"""Last client ID cursor for pagination."""
+"""~
+Exclusive keyset cursor: return client IDs lexicographically greater than
+this value. For the first page, omit or use the empty string. Mutually
+exclusive with `first_clientid`.~"""
 last_clientid_in_query.label:
 """Last Client ID"""
 

--- a/rel/i18n/emqx_mt_api.hocon
+++ b/rel/i18n/emqx_mt_api.hocon
@@ -3,18 +3,31 @@ emqx_mt_api {
         desc: """~
             List all namespaces
             The namespaces are sorted in lexicographical order,
-            so this API can be used for prefix based fuzzy search.~"""
+            so this API can be used for prefix based fuzzy search.
+            When more pages are available, the response carries a
+            `Link: <?last_ns=...&limit=...>; rel="next"` header (RFC 8288)
+            whose URI-reference resolves against the request URL.
+            Absence of the header indicates the current page is the last.~"""
         label: "List Namespaces"
     }
     ns_list_details {
         desc: """~
             List all namespaces, along with some extra details.
             The namespaces are sorted in lexicographical order,
-            so this API can be used for prefix based fuzzy search.~"""
+            so this API can be used for prefix based fuzzy search.
+            When more pages are available, the response carries a
+            `Link: <?last_ns=...&limit=...>; rel="next"` header (RFC 8288)
+            whose URI-reference resolves against the request URL.
+            Absence of the header indicates the current page is the last.~"""
         label: "List Namespaces with extra details"
     }
     client_list {
-        desc: "List all clients in a namespace"
+        desc: """~
+            List all clients in a namespace.
+            When more pages are available, the response carries a
+            `Link: <?last_clientid=...&limit=...>; rel="next"` header (RFC 8288)
+            whose URI-reference resolves against the request URL.
+            Absence of the header indicates the current page is the last.~"""
         label: "List Clients"
     }
     client_count {
@@ -41,14 +54,22 @@ emqx_mt_api {
         desc: """~
             List all managed namespaces
             The namespaces are sorted in lexicographical order,
-            so this API can be used for prefix based fuzzy search.~"""
+            so this API can be used for prefix based fuzzy search.
+            When more pages are available, the response carries a
+            `Link: <?last_ns=...&limit=...>; rel="next"` header (RFC 8288)
+            whose URI-reference resolves against the request URL.
+            Absence of the header indicates the current page is the last.~"""
         label: "List managed namespaces"
     }
     managed_ns_list_details {
         desc: """~
             List all managed namespaces with extra details.
             The namespaces are sorted in lexicographical order,
-            so this API can be used for prefix based fuzzy search.~"""
+            so this API can be used for prefix based fuzzy search.
+            When more pages are available, the response carries a
+            `Link: <?last_ns=...&limit=...>; rel="next"` header (RFC 8288)
+            whose URI-reference resolves against the request URL.
+            Absence of the header indicates the current page is the last.~"""
         label: "List managed namespaces with extra details"
     }
     create_managed_ns {


### PR DESCRIPTION
Fixes [EMQX-15222](https://emqx.atlassian.net/browse/EMQX-15222)

Release version:
6.0.3

## Summary

The five multi-tenancy list endpoints
(`/mt/ns_list`, `/mt/ns_list_details`, `/mt/managed_ns_list`,
`/mt/managed_ns_list_details`, `/mt/ns/{ns}/client_list`) previously
returned bare JSON arrays with no pagination metadata. When
`len(results) == limit`, the caller could not tell whether more data
existed or the current page happened to land exactly on the boundary;
"next page" requests sometimes returned an empty array.

Handlers now fetch `limit + 1` from the backend; when more items are
available, the response carries an RFC 8288 `Link` header:

```
Link: <?last_ns=ns42&limit=100>; rel="next"
```

The URI-reference is query-only, so it resolves against the request URL
regardless of how the deployment is fronted (proxy, ingress, path
prefix). Absence of the header signals the current response is the last
page.

The response body shape is unchanged — existing consumers continue to
work. Only the `emqx_mt_api` module, its i18n descriptions, and its CT
suite are touched; the backend `emqx_mt_state` functions are untouched.

Key files:
- `apps/emqx_mt/src/emqx_mt_api.erl` — 5 handlers, `paginated_response/4` helper
- `rel/i18n/emqx_mt_api.hocon` — Link header documented on each endpoint
- `apps/emqx_mt/test/emqx_mt_api_SUITE.erl` — new test covers exact-one-page
  (no Link) and more-pages (Link present, cursor roundtrip) for all 5 endpoints

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

[EMQX-15222]: https://emqx.atlassian.net/browse/EMQX-15222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ