### PR TITLE
chore(plugins): review follow-ups for PR #17094

### DIFF
--- a/plugins/emqx_offline_messages/.gitignore
+++ b/plugins/emqx_offline_messages/.gitignore
@@ -1,6 +1,0 @@
-_build/
-.rebar3/
-rebar.lock
-rebar3.crashdump
-*.beam
-erl_crash.dump

--- a/plugins/emqx_offline_messages/README.md
+++ b/plugins/emqx_offline_messages/README.md
@@ -8,23 +8,21 @@ Currently supports the following database backends:
 
 ## Usage
 
-<!-- Do not update plugin version manually, use make bump-version-patch/minor/major instead -->
-<!-- TODO: when plugin is uploaded to s3 download from  https://packages.emqx.io/emqx-plugins/e5.10.4/emqx_offline_messages-2.0.0.tar
+<!-- TODO: when plugin is uploaded to s3 download from https://packages.emqx.io/emqx-plugins/e5.10.4/emqx_offline_messages-2.0.0.tar.gz
 
 Download the plugin:
 
 ```bash
-wget https://github.com/emqx/emqx-offline-message-plugin/releases/download/v2.0.0/emqx_offline_message_plugin-2.0.0.tar.gz
+wget https://packages.emqx.io/emqx-plugins/e5.10.4/emqx_offline_messages-2.0.0.tar.gz
 ```
 -->
 
 Install the plugin:
 
-<!-- Do not update plugin version manually, use make bump-version-patch/minor/major instead -->
 ```bash
 curl -u key:secret -X POST http://localhost:18083/api/v5/plugins/install \
 -H "Content-Type: multipart/form-data" \
--F "plugin=@emqx_offline_message_plugin-2.0.0.tar.gz"
+-F "plugin=@emqx_offline_messages-2.0.0.tar.gz"
 ```
 
 Check the plugin is installed:
@@ -55,17 +53,28 @@ mqttx sub -q 1 -t 't/2' -i $(pwgen 20 -1)
 
 ## Release
 
-An EMQX plugin release is a tar file including including a subdirectory of this plugin's name and it's version, that contains:
+An EMQX plugin release is a tar file containing a subdirectory named after the
+plugin and its version, which includes:
 
-1. A JSON format metadata file describing the plugin
-2. Versioned directories for all applications needed for this plugin (source and binaries).
-3. Confirm the OTP version used by EMQX that the plugin will be installed on (See also [./.tool-versions](./.tool-versions)).
+1. A JSON metadata file describing the plugin.
+2. Versioned directories for all applications needed by the plugin (source and binaries).
+3. The OTP major version used to build the plugin (must match the target EMQX release;
+   see [./.tool-versions](./.tool-versions)).
 
-In a shell from this plugin's working directory execute `make rel` to have the package created like:
+To cut a new plugin release:
 
-```
-_build/default/emqx_plugrel/emqx_plugin_template-<vsn>.tar.gz
-```
+1. Edit [VERSION](./VERSION) directly (this is the authoritative plugin version;
+   also bump `vsn` in [src/emqx_offline_messages.app.src](./src/emqx_offline_messages.app.src)
+   to keep them in sync).
+2. From the repo root, run:
+   ```
+   make plugin-emqx_offline_messages
+   ```
+   which produces:
+   ```
+   _build/plugins/emqx_offline_messages-<vsn>.tar.gz
+   ```
+
 ## Format
 
 Format all the files in your project by running:

--- a/plugins/emqx_offline_messages/smoke/smoke_redis.sh
+++ b/plugins/emqx_offline_messages/smoke/smoke_redis.sh
@@ -63,19 +63,6 @@ wait_api() {
     exit 1
 }
 
-wait_redis() {
-    local attempts=60
-    while ((attempts > 0)); do
-        if docker compose exec -T redis redis-cli -a public PING >/dev/null 2>&1; then
-            return 0
-        fi
-        sleep 1
-        ((attempts--))
-    done
-    echo "[redis] Redis did not become ready" >&2
-    exit 1
-}
-
 subscribe_capture() {
     local topic="$1"
     local timeout_s="$2"
@@ -125,9 +112,8 @@ echo "[redis] starting EMQX + Redis"
 cd "$SCRIPT_DIR"
 export PLUGIN
 docker compose down -v --remove-orphans 2>/dev/null || true
-docker compose up -d emqx redis
+docker compose up -d --wait emqx redis
 
-wait_redis
 wait_api
 
 echo "[redis] configuring plugin"

--- a/plugins/emqx_offline_messages/src/emqx_offline_messages.app.src
+++ b/plugins/emqx_offline_messages/src/emqx_offline_messages.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_offline_messages, [
     {description, "EMQX Offline Messages Plugin"},
-    {vsn, "2.0.0"},
+    {vsn, {file, "VERSION"}},
     {modules, []},
     {registered, [emqx_offline_messages_sup]},
     {applications, [

--- a/scripts/apps-version-check.sh
+++ b/scripts/apps-version-check.sh
@@ -107,6 +107,69 @@ for app in ${APPS}; do
     fi
 done
 
+## Plugins (under plugins/) use a VERSION file as the single source of truth;
+## the .app.src reads it via {vsn, {file, "VERSION"}}. Bump VERSION when
+## src/, include/, or priv/ changed against the previous release tag.
+for plugin_dir in plugins/*/; do
+    plugin_dir="${plugin_dir%/}"
+    version_file="$plugin_dir/VERSION"
+
+    if [ ! -f "$version_file" ]; then
+        continue
+    fi
+
+    now_rel_version="$(tr -d '[:space:]' < "$version_file")"
+
+    if git show "$latest_release":"$version_file" >/dev/null 2>&1; then
+        old_rel_version="$(git show "$latest_release":"$version_file" | tr -d '[:space:]')"
+    else
+        echo "IGNORE: $version_file is newly added"
+        continue
+    fi
+
+    if [ "$old_rel_version" = "$now_rel_version" ]; then
+        changed_files="$(git diff "$latest_release" --name-only \
+                             -- "$plugin_dir/src" \
+                             -- "$plugin_dir/include" \
+                             -- "$plugin_dir/priv" \
+                             -- "$plugin_dir/VERSION" \
+                         || true)"
+        changed_lines=0
+        if [ -n "$changed_files" ]; then
+            # shellcheck disable=SC2086
+            changed_lines="$(git diff "$latest_release" --ignore-blank-lines -G "$no_comment_re" \
+                             -- $changed_files | wc -l)"
+        fi
+        if [ "$changed_lines" -gt 0 ]; then
+            log_red "ERROR: $version_file needs a vsn bump"
+            bad_app_count=$(( bad_app_count + 1))
+        fi
+    else
+        # shellcheck disable=SC2207
+        old_semver=($(parse_semver "$old_rel_version"))
+        # shellcheck disable=SC2207
+        now_semver=($(parse_semver "$now_rel_version"))
+        if  [ "${old_semver[0]}" = "${now_semver[0]}" ] && \
+            [ "${old_semver[1]}" = "${now_semver[1]}" ] && \
+            [ "$(( old_semver[2] + 1 ))" = "${now_semver[2]}" ]; then
+            true
+        elif [ "${old_semver[0]}" = "${now_semver[0]}" ] && \
+             [ "$(( old_semver[1] + 1 ))" = "${now_semver[1]}" ] && \
+             [ "${now_semver[2]}" = "0" ]; then
+            true
+        elif [ "$(( old_semver[0] + 1 ))" = "${now_semver[0]}" ] && \
+             [ "${now_semver[1]}" = "0" ] && \
+             [ "${now_semver[2]}" = "0" ]; then
+            true
+        else
+            if ! is_allowed_non_strict "$version_file" "$old_rel_version" "$now_rel_version"; then
+                echo "$version_file: non-strict semver version bump from $old_rel_version to $now_rel_version"
+                bad_app_count=$(( bad_app_count + 1))
+            fi
+        fi
+    fi
+done
+
 if [ $bad_app_count -gt 0 ]; then
     exit 1
 else


### PR DESCRIPTION
## Summary

Follow-up cleanups for [#17094](https://github.com/emqx/emqx/pull/17094):

- Drop `plugins/emqx_offline_messages/.gitignore` — top-level `.gitignore` already covers every pattern it listed.
- Smoke test: replace the `wait_redis` poll loop with `docker compose up --wait`, using the healthcheck already declared in `docker-compose.yml`.
- README: remove the stale `make bump-version-*` / `make rel` references and document that the plugin version is bumped manually by editing `VERSION` (keeping `src/*.app.src` vsn in sync) and running `make plugin-emqx_offline_messages`.
- Extend `scripts/apps-version-check.sh` to iterate `plugins/*/` and enforce:
  1. `VERSION` and `src/<app>.app.src` vsn are identical.
  2. If `VERSION`, `src/`, `include/`, or `priv/` changed against the previous release tag, `VERSION` must be bumped (same semver rules as for `apps/`).

No user-facing behavior change.

## Test plan

- [ ] CI: `apps-version-check` still passes on this branch.
- [ ] Locally run `./plugins/emqx_offline_messages/smoke/smoke_redis.sh` to confirm the `--wait` change does not regress startup.