### PR TITLE
feat(gcp connectors): add attached service account authentication support

### DIFF
--- a/apps/emqx_bridge_bigquery/mix.exs
+++ b/apps/emqx_bridge_bigquery/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeBigQuery.MixProject do
   def project do
     [
       app: :emqx_bridge_bigquery,
-      version: "6.2.0",
+      version: "6.2.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery.hrl
+++ b/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery.hrl
@@ -11,7 +11,13 @@
 -define(ACTION_TYPE, bigquery).
 -define(ACTION_TYPE_BIN, <<"bigquery">>).
 
+%% Used by WIF authn
 -define(TOKEN_TAB, emqx_bridge_bigquery_tokens).
+
+%% Used by attached service account authn
+%% Stores _responses_ to token requests (`{ok, Token} | {error, term()}`)
+-define(SA_TOKEN_RESP_TAB, emqx_bridge_bigquery_sa_token).
+-define(SA_SERVER_REF, emqx_bridge_bigquery_token_cache).
 
 %% END ifndef(__EMQX_BRIDGE_BIGQUERY_HRL__)
 -endif.

--- a/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
+++ b/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
@@ -118,7 +118,9 @@ on_start(ConnResId, ConnConfig0) ->
         host => Host,
         port => Port,
         supervisor => ?SUP,
-        token_table => ?TOKEN_TAB
+        token_table => ?TOKEN_TAB,
+        sa_server_ref => ?SA_SERVER_REF,
+        sa_token_table => ?SA_TOKEN_RESP_TAB
     },
     maybe
         {ok, ExtraInfo, Client} ?= emqx_bridge_gcp_pubsub_client:start(ConnResId, ConnConfig),
@@ -135,7 +137,9 @@ on_start(ConnResId, ConnConfig0) ->
 on_stop(ConnResId, _ConnState) ->
     Ctx = #{
         supervisor => ?SUP,
-        token_table => ?TOKEN_TAB
+        token_table => ?TOKEN_TAB,
+        sa_server_ref => ?SA_SERVER_REF,
+        sa_token_table => ?SA_TOKEN_RESP_TAB
     },
     Res = emqx_bridge_gcp_pubsub_client:stop(ConnResId, Ctx),
     ?tp("bigquery_connector_stop", #{instance_id => ConnResId}),

--- a/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
+++ b/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
@@ -120,9 +120,9 @@ on_start(ConnResId, ConnConfig0) ->
         supervisor => ?SUP,
         token_table => ?TOKEN_TAB
     },
-    ProjectId = emqx_bridge_gcp_pubsub_client:get_project_id(ConnConfig),
     maybe
-        {ok, Client} ?= emqx_bridge_gcp_pubsub_client:start(ConnResId, ConnConfig),
+        {ok, ExtraInfo, Client} ?= emqx_bridge_gcp_pubsub_client:start(ConnResId, ConnConfig),
+        #{project_id := ProjectId} = ExtraInfo,
         ConnState = #{
             ?client => Client,
             ?installed_channels => #{},

--- a/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
+++ b/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
@@ -133,7 +133,11 @@ on_start(ConnResId, ConnConfig0) ->
 
 -spec on_stop(connector_resource_id(), connector_state()) -> ok.
 on_stop(ConnResId, _ConnState) ->
-    Res = emqx_bridge_gcp_pubsub_client:stop(ConnResId, ?SUP, ?TOKEN_TAB),
+    Ctx = #{
+        supervisor => ?SUP,
+        token_table => ?TOKEN_TAB
+    },
+    Res = emqx_bridge_gcp_pubsub_client:stop(ConnResId, Ctx),
     ?tp("bigquery_connector_stop", #{instance_id => ConnResId}),
     Res.
 

--- a/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_sup.erl
+++ b/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_sup.erl
@@ -47,8 +47,9 @@ init([]) ->
         intensity => 10,
         period => 1
     },
-    ChildSpecs = [],
+    ChildSpecs = [emqx_bridge_bigquery_token_cache:child_spec()],
     create_token_table(),
+    emqx_bridge_bigquery_token_cache:create_tables(),
     {ok, {SupFlags, ChildSpecs}}.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_token_cache.erl
+++ b/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_token_cache.erl
@@ -1,0 +1,64 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_bigquery_token_cache).
+
+%% API
+-export([
+    start_link/0,
+    child_spec/0,
+
+    create_tables/0,
+    get_or_refresh/2,
+    get_or_refresh/3,
+    unregister/1,
+    clear_cache/0,
+    clear_cache/1
+]).
+
+-include("emqx_bridge_bigquery.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+start_link() ->
+    Opts = #{table => ?SA_TOKEN_RESP_TAB},
+    emqx_connector_jwt_token_cache:start_link({local, ?MODULE}, Opts).
+
+child_spec() ->
+    #{
+        id => ?MODULE,
+        start => {?MODULE, start_link, []},
+        restart => permanent,
+        shutdown => 5_000,
+        type => worker,
+        modules => [?MODULE, emqx_connector_jwt_token_cache]
+    }.
+
+create_tables() ->
+    emqx_connector_jwt_token_cache:create_tables(?SA_TOKEN_RESP_TAB).
+
+get_or_refresh(ClientId, RefreshFn) ->
+    emqx_connector_jwt_token_cache:get_or_refresh(?MODULE, ?SA_TOKEN_RESP_TAB, ClientId, RefreshFn).
+
+get_or_refresh(ClientId, RefreshFn, Opts) ->
+    emqx_connector_jwt_token_cache:get_or_refresh(
+        ?MODULE, ?SA_TOKEN_RESP_TAB, ClientId, RefreshFn, Opts
+    ).
+
+unregister(ClientId) ->
+    emqx_connector_jwt_token_cache:unregister(?MODULE, ClientId).
+
+%% For debug/test/manual ops
+clear_cache() ->
+    emqx_connector_jwt_token_cache:clear_cache(?SA_TOKEN_RESP_TAB).
+
+%% For debug/test/manual ops
+clear_cache(ClientId) ->
+    emqx_connector_jwt_token_cache:clear_cache(?SA_TOKEN_RESP_TAB, ClientId).

--- a/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
+++ b/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
@@ -38,6 +38,7 @@
 -define(async, async).
 -define(service_account_json, service_account_json).
 -define(wif_oidc, wif_oidc).
+-define(attached_service_account, attached_service_account).
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
@@ -113,7 +114,9 @@ init_per_testcase(TestCase, TCConfig0) ->
                     <<"service_account_json">> => emqx_utils_json:encode(ServiceAccountJSON)
                 };
             ?wif_oidc ->
-                wif_oidc_auth()
+                wif_oidc_auth();
+            ?attached_service_account ->
+                attached_service_account_auth()
         end,
     ConnectorConfig = connector_config(#{
         <<"authentication">> => Authentication
@@ -218,6 +221,11 @@ wif_oidc_auth() ->
         }
     }.
 
+attached_service_account_auth() ->
+    #{
+        <<"type">> => <<"attached_service_account">>
+    }.
+
 mock_wif_auth_calls() ->
     Mod = emqx_bridge_gcp_pubsub_auth_wif_worker,
     on_exit(fun meck:unload/0),
@@ -234,15 +242,44 @@ mock_wif_auth_calls() ->
     end),
     ok.
 
+mock_attached_service_account_auth_calls() ->
+    Mod = emqx_bridge_gcp_pubsub_client,
+    on_exit(fun meck:unload/0),
+    meck:new(Mod, [passthrough]),
+    meck:expect(Mod, do_metadata_request, fun(#{url := URL}) ->
+        case URL of
+            <<
+                "http://metadata.google.internal/computeMetadata"
+                "/v1/project/project-id"
+            >> ->
+                {ok, 200, [{<<"Content-Type">>, <<"application/text">>}], <<"myproject">>};
+            <<
+                "http://metadata.google.internal/computeMetadata"
+                "/v1/instance/service-accounts/default/token"
+            >> ->
+                NowS = erlang:system_time(seconds),
+                ExpiresInS = NowS + 3600,
+                simple_token_reply(#{
+                    <<"access_token">> => <<"attached_sa_token">>,
+                    <<"expires_in">> => ExpiresInS
+                })
+        end
+    end),
+    ok.
+
 simple_token_reply(Key, Token) ->
-    {ok, 200, [{<<"Content-Type">>, <<"application/json">>}],
-        emqx_utils_json:encode(#{Key => Token})}.
+    simple_token_reply(#{Key => Token}).
+
+simple_token_reply(Body) ->
+    {ok, 200, [{<<"Content-Type">>, <<"application/json">>}], emqx_utils_json:encode(Body)}.
 
 get_config(K, TCConfig) -> emqx_bridge_v2_testlib:get_value(K, TCConfig).
 
 auth_of(TCConfig) ->
     emqx_common_test_helpers:get_matrix_prop(
-        TCConfig, [?service_account_json, ?wif_oidc], ?service_account_json
+        TCConfig,
+        [?service_account_json, ?wif_oidc, ?attached_service_account],
+        ?service_account_json
     ).
 
 group_path(Config, Default) ->
@@ -549,9 +586,20 @@ start_client(Opts) ->
 
 %% * Worker process is removed from supervisor.
 %% * Token is deleted from table.
-ensure_token_resources_cleared() ->
-    ?assertMatch([], supervisor:which_children(?SUP)),
+ensure_wif_token_resources_cleared() ->
+    ?assertMatch(
+        [],
+        [
+            Child
+         || Child = {Id, _, _, _} <- supervisor:which_children(?SUP),
+            Id /= emqx_bridge_bigquery_token_cache
+        ]
+    ),
     ?assertMatch([], ets:tab2list(?TOKEN_TAB)),
+    ok.
+
+ensure_attached_service_account_token_resources_cleared() ->
+    ?assertMatch([], ets:tab2list(?SA_TOKEN_RESP_TAB)),
     ok.
 
 %%------------------------------------------------------------------------------
@@ -831,7 +879,7 @@ t_wif_auth(matrix) ->
 t_wif_auth(TCConfig) when is_list(TCConfig) ->
     mock_wif_auth_calls(),
     %% Sanity check
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
 
     ?assertMatch(
         {201, #{
@@ -861,7 +909,7 @@ t_wif_auth(TCConfig) when is_list(TCConfig) ->
     %% Verify resource cleanup
     emqx_bridge_v2_testlib:delete_all_rules(),
     emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
     ok.
 
 -doc """
@@ -874,7 +922,7 @@ t_wif_auth_optional_audience(matrix) ->
 t_wif_auth_optional_audience(TCConfig) when is_list(TCConfig) ->
     mock_wif_auth_calls(),
     %% Sanity check
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
 
     ?assertMatch(
         {201, #{
@@ -891,4 +939,51 @@ t_wif_auth_optional_audience(TCConfig) when is_list(TCConfig) ->
             }
         })
     ),
+    ok.
+
+-doc """
+Simple smoke test for using attached service account authentication.
+
+It cannot really emulate the real GCP IAM authentication process, but it does emulate the
+calls to get a token and use the stored token.
+""".
+t_attached_service_account_auth() ->
+    [{matrix, true}].
+t_attached_service_account_auth(matrix) ->
+    [[?attached_service_account]];
+t_attached_service_account_auth(TCConfig) ->
+    mock_attached_service_account_auth_calls(),
+    %% Sanity check
+    ensure_attached_service_account_token_resources_cleared(),
+
+    ?assertMatch(
+        {201, #{
+            <<"status">> := <<"connected">>,
+            <<"authentication">> := #{<<"type">> := <<"attached_service_account">>}
+        }},
+        create_connector_api(TCConfig, #{})
+    ),
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_action_api(TCConfig, #{})
+    ),
+    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    Payload = <<"payload">>,
+    emqtt:publish(C, Topic, Payload),
+    Payload64 = base64:encode(Payload),
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            [[_ClientId, Payload64, Topic, _PublishedAt]],
+            scan_table(TCConfig)
+        )
+    ),
+
+    %% Verify resource cleanup
+    emqx_bridge_v2_testlib:delete_all_rules(),
+    emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
+    ensure_attached_service_account_token_resources_cleared(),
+
     ok.

--- a/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
+++ b/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
@@ -332,7 +332,7 @@ start_control_client() ->
             port => ?PORT
         },
     PoolName = <<"control_connector">>,
-    {ok, Client} = emqx_bridge_gcp_pubsub_client:start(PoolName, ClientConfig),
+    {ok, _ExtraInfo, Client} = emqx_bridge_gcp_pubsub_client:start(PoolName, ClientConfig),
     Client.
 
 stop_control_client(TCConfig) ->

--- a/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
+++ b/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
@@ -337,7 +337,7 @@ start_control_client() ->
 
 stop_control_client(TCConfig) ->
     Client = get_value(client, TCConfig),
-    ok = emqx_bridge_gcp_pubsub_client:stop(Client, ?SUP, ?TOKEN_TAB),
+    ok = emqx_bridge_gcp_pubsub_client:stop(Client),
     ok.
 
 render(TemplateStr, Context) ->

--- a/apps/emqx_bridge_gcp_pubsub/mix.exs
+++ b/apps/emqx_bridge_gcp_pubsub/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeGcpPubsub.MixProject do
   def project do
     [
       app: :emqx_bridge_gcp_pubsub,
-      version: "6.2.0",
+      version: "6.2.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.hrl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.hrl
@@ -5,6 +5,12 @@
 -ifndef(__EMQX_BRIDGE_GCP_PUBSUB_HRL__).
 -define(__EMQX_BRIDGE_GCP_PUBSUB_HRL__, true).
 
+%% Used by WIF authn
 -define(TOKEN_TAB, emqx_bridge_gcp_pubsub_tokens).
+
+%% Used by attached service account authn
+%% Stores _responses_ to token requests (`{ok, Token} | {error, term()}`)
+-define(SA_TOKEN_RESP_TAB, emqx_bridge_gcp_pubsub_sa_token).
+-define(SA_SERVER_REF, emqx_bridge_gcp_pubsub_token_cache).
 
 -endif.

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -23,7 +23,6 @@
 -export([reply_delegator/3]).
 
 -export([
-    get_project_id/1,
     pubsub_get_topic/3
 ]).
 
@@ -53,6 +52,10 @@
     pool_name := binary(),
     project_id := project_id()
 }.
+-type extra_info() :: #{
+    project_id := project_id(),
+    any() => term()
+}.
 -type auth_state() :: service_account_json_auth_state().
 -type service_account_json_auth_state() :: #{
     type := service_account_json,
@@ -71,6 +74,7 @@
     authentication_config/0,
     service_account_json/0,
     state/0,
+    extra_info/0,
     headers/0,
     body/0,
     status_code/0,
@@ -87,7 +91,7 @@
 %% API
 %%-------------------------------------------------------------------------------------------------
 
--spec start(resource_id(), config()) -> {ok, state()} | {error, term()}.
+-spec start(resource_id(), config()) -> {ok, extra_info(), state()} | {error, term()}.
 start(
     ResourceId,
     #{
@@ -152,14 +156,16 @@ do_start_pool(ResourceId, State, Config) ->
     case ehttpc_sup:start_pool(ResourceId, PoolOpts) of
         {ok, _} ->
             ?tp(gcp_ehttpc_pool_started, #{pool_name => ResourceId}),
-            {ok, State};
+            ExtraInfo = maps:with([project_id], State),
+            {ok, ExtraInfo, State};
         {error, {already_started, _}} ->
             ?tp(gcp_ehttpc_pool_already_started, #{pool_name => ResourceId}),
             _ = ehttpc_sup:stop_pool(ResourceId),
             ok = emqx_connector_jwt:delete_jwt(?JWT_TABLE, ResourceId),
             case ehttpc_sup:start_pool(ResourceId, PoolOpts) of
                 {ok, _} ->
-                    {ok, State};
+                    ExtraInfo = maps:with([project_id], State),
+                    {ok, ExtraInfo, State};
                 {error, Reason} ->
                     ?tp(gcp_ehttpc_pool_start_failure, #{
                         pool_name => ResourceId,
@@ -259,14 +265,6 @@ get_status(#{connect_timeout := _, pool_name := _} = State) ->
 %%-------------------------------------------------------------------------------------------------
 %% API
 %%-------------------------------------------------------------------------------------------------
-
-get_project_id(#{authentication := #{type := service_account_json} = AuthConfig}) ->
-    #{service_account_json := ServiceAccountJSON0} = AuthConfig,
-    #{<<"project_id">> := ProjectId} = emqx_utils_json:decode(ServiceAccountJSON0),
-    ProjectId;
-get_project_id(#{authentication := #{type := wif} = AuthConfig}) ->
-    #{gcp_project_id := ProjectId} = AuthConfig,
-    ProjectId.
 
 -spec pubsub_get_topic(topic(), state(), request_opts()) -> {ok, map()} | {error, term()}.
 pubsub_get_topic(Topic, ClientState, ReqOpts) ->

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -15,7 +15,7 @@
 -export([
     start/2,
     stop/1,
-    stop/3,
+    stop/2,
     query_sync/2,
     query_async/3,
     get_status/1
@@ -61,6 +61,13 @@
     type := service_account_json,
     jwt_config := emqx_connector_jwt:jwt_config()
 }.
+-type stop_ctx() :: #{
+    sa_token_table => ets:table(),
+    sa_server_ref => gen_server:server_ref(),
+    token_table => ets:table(),
+    supervisor => gen_server:server_ref()
+}.
+
 -type headers() :: [{binary(), iodata()}].
 -type body() :: iodata().
 -type status_code() :: 100..599.
@@ -75,6 +82,7 @@
     service_account_json/0,
     state/0,
     extra_info/0,
+    stop_ctx/0,
     headers/0,
     body/0,
     status_code/0,
@@ -184,18 +192,17 @@ do_start_pool(ResourceId, State, Config) ->
 -spec stop(state()) -> ok | {error, term()}.
 stop(Client) ->
     #{pool_name := ResourceId} = Client,
-    {Sup, Tab} =
+    Ctx =
         case Client of
             #{auth_config := #{type := wif, token_table := Tab0, supervisor := Sup0}} ->
-                {Sup0, Tab0};
+                #{token_table => Tab0, supervisor => Sup0};
             _ ->
-                {undefined, undefined}
+                #{}
         end,
-    stop(ResourceId, Sup, Tab).
+    stop(ResourceId, Ctx).
 
--spec stop(resource_id(), undefined | supervisor:sup_ref(), undefined | ets:table()) ->
-    ok | {error, term()}.
-stop(ResourceId, Sup, Tab) ->
+-spec stop(resource_id(), stop_ctx()) -> ok | {error, term()}.
+stop(ResourceId, Ctx) ->
     ?tp(gcp_client_stop, #{instance_id => ResourceId, resource_id => ResourceId}),
     ?SLOG(info, #{
         msg => "stopping_gcp_client",
@@ -203,8 +210,7 @@ stop(ResourceId, Sup, Tab) ->
     }),
     ok = emqx_connector_jwt:delete_jwt(?JWT_TABLE, ResourceId),
     maybe
-        true ?= Sup /= undefined,
-        true ?= Tab /= undefined,
+        #{token_table := Tab, supervisor := Sup} ?= Ctx,
         ok = stop_worker_and_clear_token(ResourceId, Sup, Tab)
     end,
     case ehttpc_sup:stop_pool(ResourceId) of

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -23,7 +23,8 @@
 -export([reply_delegator/3]).
 
 -export([
-    pubsub_get_topic/3
+    pubsub_get_topic/3,
+    do_get_attached_sa_token/0
 ]).
 
 %% Only for tests.
@@ -395,7 +396,7 @@ do_get_attached_sa_token() ->
     end.
 
 get_or_refresh_attached_sa_token(ServerRef, Tab, ResId) ->
-    RefreshFn = fun do_get_attached_sa_token/0,
+    RefreshFn = {?MODULE, do_get_attached_sa_token, []},
     case emqx_connector_jwt_token_cache:get_or_refresh(ServerRef, Tab, ResId, RefreshFn) of
         {ok, Token} ->
             {ok, Token};

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -27,7 +27,7 @@
 ]).
 
 %% Only for tests.
--export([get_transport/1]).
+-export([get_transport/1, do_metadata_request/1]).
 
 -type service_account_json() :: map().
 -type project_id() :: binary().
@@ -56,10 +56,26 @@
     project_id := project_id(),
     any() => term()
 }.
--type auth_state() :: service_account_json_auth_state().
+-type auth_state() ::
+    service_account_json_auth_state()
+    | wif_auth_state()
+    | attached_service_account_auth_state().
 -type service_account_json_auth_state() :: #{
     type := service_account_json,
     jwt_config := emqx_connector_jwt:jwt_config()
+}.
+-type wif_auth_state() :: #{
+    type := wif,
+    gcp_project_id := project_id(),
+    resource_id := resource_id(),
+    token_table := ets:table(),
+    supervisor := gen_server:server_ref()
+}.
+-type attached_service_account_auth_state() :: #{
+    type := attached_service_account,
+    resource_id := resource_id(),
+    sa_token_table := ets:table(),
+    sa_server_ref := gen_server:server_ref()
 }.
 -type stop_ctx() :: #{
     sa_token_table => ets:table(),
@@ -194,6 +210,14 @@ stop(Client) ->
     #{pool_name := ResourceId} = Client,
     Ctx =
         case Client of
+            #{
+                auth_config := #{
+                    type := attached_service_account,
+                    sa_token_table := Tab0,
+                    sa_server_ref := ServerRef
+                }
+            } ->
+                #{sa_token_table => Tab0, sa_server_ref => ServerRef};
             #{auth_config := #{type := wif, token_table := Tab0, supervisor := Sup0}} ->
                 #{token_table => Tab0, supervisor => Sup0};
             _ ->
@@ -212,6 +236,11 @@ stop(ResourceId, Ctx) ->
     maybe
         #{token_table := Tab, supervisor := Sup} ?= Ctx,
         ok = stop_worker_and_clear_token(ResourceId, Sup, Tab)
+    end,
+    maybe
+        #{sa_token_table := Tab1, sa_server_ref := ServerRef} ?= Ctx,
+        _ = emqx_connector_jwt_token_cache:unregister(ServerRef, ResourceId),
+        _ = emqx_connector_jwt_token_cache:clear_cache(Tab1, ResourceId)
     end,
     case ehttpc_sup:stop_pool(ResourceId) of
         ok ->
@@ -307,17 +336,103 @@ get_transport(Type) ->
             {Transport0, HostPort0}
     end.
 
+do_metadata_request(Params) ->
+    #{url := URL} = Params,
+    Method = get,
+    Headers = [{<<"Metadata-Flavor">>, <<"Google">>}],
+    Body = <<"">>,
+    ReqOpts = [],
+    case hackney:request(Method, URL, Headers, Body, ReqOpts) of
+        {ok, Code, RespHeaders, ClientRef} ->
+            {ok, RespBody} = hackney:body(ClientRef),
+            {ok, Code, RespHeaders, RespBody};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%%-------------------------------------------------------------------------------------------------
+%% Helper fns (attached service account authn)
+%%-------------------------------------------------------------------------------------------------
+
+get_attached_project_id() ->
+    URL = <<
+        "http://metadata.google.internal/computeMetadata"
+        "/v1/project/project-id"
+    >>,
+    Params = #{url => URL},
+    case ?MODULE:do_metadata_request(Params) of
+        {ok, 200, _, ProjectId} ->
+            {ok, ProjectId};
+        {ok, Status, Headers, Body} ->
+            Ctx = #{status => Status, headers => Headers, body => Body},
+            {error, {bad_project_id_response, Ctx}};
+        Error ->
+            {error, {bad_project_id_response, Error}}
+    end.
+
+do_get_attached_sa_token() ->
+    URL = <<
+        "http://metadata.google.internal/computeMetadata"
+        "/v1/instance/service-accounts/default/token"
+    >>,
+    Params = #{url => URL},
+    case ?MODULE:do_metadata_request(Params) of
+        {ok, 200, _, RespBody} ->
+            case emqx_utils_json:safe_decode(RespBody) of
+                {ok, #{<<"access_token">> := Token, <<"expires_in">> := ExpiryS}} ->
+                    ExpiryMS = erlang:convert_time_unit(ExpiryS, second, millisecond),
+                    {ok, ExpiryMS, Token};
+                {ok, BadResp} ->
+                    {error, {bad_token_response, BadResp}};
+                {error, Reason} ->
+                    {error, {bad_token_response, Reason}}
+            end;
+        {ok, Status, Headers, RespBody} ->
+            Ctx = #{status => Status, headers => Headers, body => RespBody},
+            {error, {bad_token_response, Ctx}};
+        Error ->
+            {error, {bad_token_response, Error}}
+    end.
+
+get_or_refresh_attached_sa_token(ServerRef, Tab, ResId) ->
+    RefreshFn = fun do_get_attached_sa_token/0,
+    case emqx_connector_jwt_token_cache:get_or_refresh(ServerRef, Tab, ResId, RefreshFn) of
+        {ok, Token} ->
+            {ok, Token};
+        {error, Reason} ->
+            {error, {get_sa_token_failed, Reason}}
+    end.
+
 %%-------------------------------------------------------------------------------------------------
 %% Helper fns
 %%-------------------------------------------------------------------------------------------------
 
 maybe_initialize_auth_resources(
+    ResourceId, #{authentication := #{type := attached_service_account}} = Config
+) ->
+    #{
+        authentication := AuthConfig0,
+        sa_server_ref := ServerRef,
+        sa_token_table := Tab
+    } = Config,
+    maybe
+        {ok, ProjectId} ?= get_attached_project_id(),
+        {ok, _} ?= get_or_refresh_attached_sa_token(ServerRef, Tab, ResourceId),
+        AuthConfig1 = maps:with([type], AuthConfig0),
+        AuthConfig = AuthConfig1#{
+            resource_id => ResourceId,
+            sa_token_table => Tab,
+            sa_server_ref => ServerRef
+        },
+        {ok, #{auth_config => AuthConfig, project_id => ProjectId}}
+    end;
+maybe_initialize_auth_resources(
     ResourceId, #{authentication := #{type := service_account_json}} = Config
 ) ->
     {ok, parse_jwt_config(ResourceId, Config)};
 maybe_initialize_auth_resources(ResourceId, #{authentication := #{type := wif}} = Config) ->
-    #{authentication := #{gcp_project_id := ProjectId} = AuthConfig0} = Config,
     #{
+        authentication := #{gcp_project_id := ProjectId} = AuthConfig0,
         supervisor := Sup,
         token_table := Tab
     } = Config,
@@ -559,6 +674,14 @@ fmt(FmtStr, Context) ->
     iolist_to_binary(emqx_template:render_strict(Template, Context)).
 
 -spec get_authorization_header(auth_state()) -> [{binary(), binary()}].
+get_authorization_header(#{type := attached_service_account} = AuthConfig) ->
+    #{
+        sa_server_ref := ServerRef,
+        sa_token_table := Tab,
+        resource_id := ResId
+    } = AuthConfig,
+    {ok, JWT} = get_or_refresh_attached_sa_token(ServerRef, Tab, ResId),
+    [{<<"Authorization">>, <<"Bearer ", JWT/binary>>}];
 get_authorization_header(#{type := service_account_json, jwt_config := JWTConfig}) ->
     JWT = emqx_connector_jwt:ensure_jwt(JWTConfig),
     [{<<"Authorization">>, <<"Bearer ", JWT/binary>>}];

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -106,7 +106,9 @@ on_start(ConnectorResId, Config0) ->
         host => Host,
         port => Port,
         supervisor => ?SUP,
-        token_table => ?TOKEN_TAB
+        token_table => ?TOKEN_TAB,
+        sa_server_ref => ?SA_SERVER_REF,
+        sa_token_table => ?SA_TOKEN_RESP_TAB
     },
     case emqx_bridge_gcp_pubsub_client:start(ConnectorResId, Config) of
         {ok, ExtraInfo, Client} ->
@@ -128,7 +130,9 @@ on_stop(ConnectorResId, ConnectorState) ->
     ok = stop_consumers(ConnectorState),
     Ctx = #{
         supervisor => ?SUP,
-        token_table => ?TOKEN_TAB
+        token_table => ?TOKEN_TAB,
+        sa_server_ref => ?SA_SERVER_REF,
+        sa_token_table => ?SA_TOKEN_RESP_TAB
     },
     emqx_bridge_gcp_pubsub_client:stop(ConnectorResId, Ctx).
 

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -108,9 +108,9 @@ on_start(ConnectorResId, Config0) ->
         supervisor => ?SUP,
         token_table => ?TOKEN_TAB
     },
-    ProjectId = emqx_bridge_gcp_pubsub_client:get_project_id(Config),
     case emqx_bridge_gcp_pubsub_client:start(ConnectorResId, Config) of
-        {ok, Client} ->
+        {ok, ExtraInfo, Client} ->
+            #{project_id := ProjectId} = ExtraInfo,
             ConnectorState = #{
                 client => Client,
                 installed_sources => #{},

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -126,7 +126,11 @@ on_stop(ConnectorResId, ConnectorState) ->
     ?tp(gcp_pubsub_consumer_stop_enter, #{}),
     clear_unhealthy(ConnectorState),
     ok = stop_consumers(ConnectorState),
-    emqx_bridge_gcp_pubsub_client:stop(ConnectorResId, ?SUP, ?TOKEN_TAB).
+    Ctx = #{
+        supervisor => ?SUP,
+        token_table => ?TOKEN_TAB
+    },
+    emqx_bridge_gcp_pubsub_client:stop(ConnectorResId, Ctx).
 
 -spec on_get_status(resource_id(), connector_state()) ->
     ?status_connected | ?status_connecting.

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -110,7 +110,11 @@ on_start(InstanceId, Config0) ->
 
 -spec on_stop(connector_resource_id(), connector_state()) -> ok | {error, term()}.
 on_stop(InstanceId, _State) ->
-    emqx_bridge_gcp_pubsub_client:stop(InstanceId, ?SUP, ?TOKEN_TAB).
+    Ctx = #{
+        supervisor => ?SUP,
+        token_table => ?TOKEN_TAB
+    },
+    emqx_bridge_gcp_pubsub_client:stop(InstanceId, Ctx).
 
 -spec on_get_status(connector_resource_id(), connector_state()) ->
     ?status_connected | {?status_disconnected, term()}.

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -95,9 +95,9 @@ on_start(InstanceId, Config0) ->
         supervisor => ?SUP,
         token_table => ?TOKEN_TAB
     },
-    ProjectId = emqx_bridge_gcp_pubsub_client:get_project_id(Config),
     case emqx_bridge_gcp_pubsub_client:start(InstanceId, Config) of
-        {ok, Client} ->
+        {ok, ExtraInfo, Client} ->
+            #{project_id := ProjectId} = ExtraInfo,
             State = #{
                 client => Client,
                 installed_actions => #{},

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -93,7 +93,9 @@ on_start(InstanceId, Config0) ->
         host => Host,
         port => Port,
         supervisor => ?SUP,
-        token_table => ?TOKEN_TAB
+        token_table => ?TOKEN_TAB,
+        sa_server_ref => ?SA_SERVER_REF,
+        sa_token_table => ?SA_TOKEN_RESP_TAB
     },
     case emqx_bridge_gcp_pubsub_client:start(InstanceId, Config) of
         {ok, ExtraInfo, Client} ->
@@ -112,7 +114,9 @@ on_start(InstanceId, Config0) ->
 on_stop(InstanceId, _State) ->
     Ctx = #{
         supervisor => ?SUP,
-        token_table => ?TOKEN_TAB
+        token_table => ?TOKEN_TAB,
+        sa_server_ref => ?SA_SERVER_REF,
+        sa_token_table => ?SA_TOKEN_RESP_TAB
     },
     emqx_bridge_gcp_pubsub_client:stop(InstanceId, Ctx).
 

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_schema_lib.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_schema_lib.erl
@@ -33,6 +33,7 @@ authentication_field() ->
     {authentication,
         mk(
             emqx_schema:mkunion(type, #{
+                <<"attached_service_account">> => ref(auth_attached_service_account),
                 <<"service_account_json">> => ref(auth_service_account_json),
                 <<"wif">> => ref(auth_wif)
             }),
@@ -101,6 +102,13 @@ legacy_service_account_json_root_converter(Conf0, _HoconOpts) ->
 namespace() ->
     "gcp_pubsub".
 
+fields(auth_attached_service_account) ->
+    [
+        {type,
+            mk(attached_service_account, #{
+                required => true, desc => ?DESC("auth_attached_service_account")
+            })}
+    ];
 fields(auth_service_account_json) ->
     [
         {type,
@@ -200,6 +208,8 @@ desc(authentication) ->
     ?DESC(authentication);
 desc(auth_service_account_json) ->
     ?DESC(auth_service_account_json);
+desc(auth_attached_service_account) ->
+    ?DESC(auth_attached_service_account);
 desc(auth_wif) ->
     ?DESC(auth_wif);
 desc(auth_wif_oidc_client_credentials) ->

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_sup.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_sup.erl
@@ -47,8 +47,9 @@ init([]) ->
         intensity => 10,
         period => 1
     },
-    ChildSpecs = [],
+    ChildSpecs = [emqx_bridge_gcp_pubsub_token_cache:child_spec()],
     create_token_table(),
+    emqx_bridge_gcp_pubsub_token_cache:create_tables(),
     {ok, {SupFlags, ChildSpecs}}.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_token_cache.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_token_cache.erl
@@ -1,0 +1,64 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_gcp_pubsub_token_cache).
+
+%% API
+-export([
+    start_link/0,
+    child_spec/0,
+
+    create_tables/0,
+    get_or_refresh/2,
+    get_or_refresh/3,
+    unregister/1,
+    clear_cache/0,
+    clear_cache/1
+]).
+
+-include("emqx_bridge_gcp_pubsub.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+start_link() ->
+    Opts = #{table => ?SA_TOKEN_RESP_TAB},
+    emqx_connector_jwt_token_cache:start_link({local, ?MODULE}, Opts).
+
+child_spec() ->
+    #{
+        id => ?MODULE,
+        start => {?MODULE, start_link, []},
+        restart => permanent,
+        shutdown => 5_000,
+        type => worker,
+        modules => [?MODULE, emqx_connector_jwt_token_cache]
+    }.
+
+create_tables() ->
+    emqx_connector_jwt_token_cache:create_tables(?SA_TOKEN_RESP_TAB).
+
+get_or_refresh(ClientId, RefreshFn) ->
+    emqx_connector_jwt_token_cache:get_or_refresh(?MODULE, ?SA_TOKEN_RESP_TAB, ClientId, RefreshFn).
+
+get_or_refresh(ClientId, RefreshFn, Opts) ->
+    emqx_connector_jwt_token_cache:get_or_refresh(
+        ?MODULE, ?SA_TOKEN_RESP_TAB, ClientId, RefreshFn, Opts
+    ).
+
+unregister(ClientId) ->
+    emqx_connector_jwt_token_cache:unregister(?MODULE, ClientId).
+
+%% For debug/test/manual ops
+clear_cache() ->
+    emqx_connector_jwt_token_cache:clear_cache(?SA_TOKEN_RESP_TAB).
+
+%% For debug/test/manual ops
+clear_cache(ClientId) ->
+    emqx_connector_jwt_token_cache:clear_cache(?SA_TOKEN_RESP_TAB, ClientId).

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -23,6 +23,7 @@
 -define(custom_cluster, custom_cluster).
 -define(service_account_json, service_account_json).
 -define(wif_oidc, wif_oidc).
+-define(attached_service_account, attached_service_account).
 
 -define(SUP, emqx_bridge_gcp_pubsub_sup).
 
@@ -176,7 +177,9 @@ init_per_testcase(TestCase, TCConfig0) ->
                     <<"service_account_json">> => emqx_utils_json:encode(ServiceAccountJSON)
                 };
             ?wif_oidc ->
-                wif_oidc_auth()
+                wif_oidc_auth();
+            ?attached_service_account ->
+                attached_service_account_auth()
         end,
     ConnectorConfig = connector_config(#{
         <<"authentication">> => Authentication
@@ -376,6 +379,11 @@ wif_oidc_auth() ->
         }
     }.
 
+attached_service_account_auth() ->
+    #{
+        <<"type">> => <<"attached_service_account">>
+    }.
+
 mock_wif_auth_calls() ->
     Mod = emqx_bridge_gcp_pubsub_auth_wif_worker,
     on_exit(fun meck:unload/0),
@@ -392,15 +400,44 @@ mock_wif_auth_calls() ->
     end),
     ok.
 
+mock_attached_service_account_auth_calls() ->
+    Mod = emqx_bridge_gcp_pubsub_client,
+    on_exit(fun meck:unload/0),
+    meck:new(Mod, [passthrough]),
+    meck:expect(Mod, do_metadata_request, fun(#{url := URL}) ->
+        case URL of
+            <<
+                "http://metadata.google.internal/computeMetadata"
+                "/v1/project/project-id"
+            >> ->
+                {ok, 200, [{<<"Content-Type">>, <<"application/text">>}], <<"myproject">>};
+            <<
+                "http://metadata.google.internal/computeMetadata"
+                "/v1/instance/service-accounts/default/token"
+            >> ->
+                NowS = erlang:system_time(seconds),
+                ExpiresInS = NowS + 3600,
+                simple_token_reply(#{
+                    <<"access_token">> => <<"attached_sa_token">>,
+                    <<"expires_in">> => ExpiresInS
+                })
+        end
+    end),
+    ok.
+
 simple_token_reply(Key, Token) ->
-    {ok, 200, [{<<"Content-Type">>, <<"application/json">>}],
-        emqx_utils_json:encode(#{Key => Token})}.
+    simple_token_reply(#{Key => Token}).
+
+simple_token_reply(Body) ->
+    {ok, 200, [{<<"Content-Type">>, <<"application/json">>}], emqx_utils_json:encode(Body)}.
 
 get_config(K, TCConfig) -> emqx_bridge_v2_testlib:get_value(K, TCConfig).
 
 auth_of(TCConfig) ->
     emqx_common_test_helpers:get_matrix_prop(
-        TCConfig, [?service_account_json, ?wif_oidc], ?service_account_json
+        TCConfig,
+        [?service_account_json, ?wif_oidc, ?attached_service_account],
+        ?service_account_json
     ).
 
 group_path(Config, Default) ->
@@ -885,9 +922,20 @@ assert_persisted_service_account_json_is_binary(TCConfig) ->
 
 %% * Worker process is removed from supervisor.
 %% * Token is deleted from table.
-ensure_token_resources_cleared() ->
-    ?assertMatch([], supervisor:which_children(?SUP)),
+ensure_wif_token_resources_cleared() ->
+    ?assertMatch(
+        [],
+        [
+            Child
+         || Child = {Id, _, _, _} <- supervisor:which_children(?SUP),
+            Id /= emqx_bridge_gcp_pubsub_token_cache
+        ]
+    ),
     ?assertMatch([], ets:tab2list(?TOKEN_TAB)),
+    ok.
+
+ensure_attached_service_account_token_resources_cleared() ->
+    ?assertMatch([], ets:tab2list(?SA_TOKEN_RESP_TAB)),
     ok.
 
 %%------------------------------------------------------------------------------
@@ -2284,7 +2332,7 @@ t_wif_auth(matrix) ->
 t_wif_auth(TCConfig) ->
     mock_wif_auth_calls(),
     %% Sanity check
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
 
     PubSubTopic = get_config(pubsub_topic, TCConfig),
     ?assertMatch(
@@ -2315,7 +2363,7 @@ t_wif_auth(TCConfig) ->
     %% Verify resource cleanup
     emqx_bridge_v2_testlib:delete_all_rules(),
     emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
     ok.
 
 -doc """
@@ -2328,7 +2376,7 @@ t_wif_auth_optional_audience(matrix) ->
 t_wif_auth_optional_audience(TCConfig) when is_list(TCConfig) ->
     mock_wif_auth_calls(),
     %% Sanity check
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
 
     ?assertMatch(
         {201, #{
@@ -2345,4 +2393,52 @@ t_wif_auth_optional_audience(TCConfig) when is_list(TCConfig) ->
             }
         })
     ),
+    ok.
+
+-doc """
+Simple smoke test for using attached service account authentication.
+
+It cannot really emulate the real GCP IAM authentication process, but it does emulate the
+calls to get a token and use the stored token.
+""".
+t_attached_service_account_auth() ->
+    [{matrix, true}].
+t_attached_service_account_auth(matrix) ->
+    [[?local, ?attached_service_account]];
+t_attached_service_account_auth(TCConfig) ->
+    mock_attached_service_account_auth_calls(),
+    %% Sanity check
+    ensure_attached_service_account_token_resources_cleared(),
+
+    PubSubTopic = get_config(pubsub_topic, TCConfig),
+    ?assertMatch(
+        {201, #{
+            <<"status">> := <<"connected">>,
+            <<"authentication">> := #{<<"type">> := <<"attached_service_account">>}
+        }},
+        create_connector_api(TCConfig, #{})
+    ),
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_source_api(TCConfig, #{})
+    ),
+    #{topic := RepublishTopic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    QoS = 2,
+    {ok, _, [_]} = emqtt:subscribe(C, RepublishTopic, [{qos, QoS}]),
+
+    Payload0 = emqx_guid:to_hexstr(emqx_guid:gen()),
+    Messages0 = [#{<<"data">> => Payload0}],
+    pubsub_publish(TCConfig, PubSubTopic, Messages0),
+    {ok, Published0} = receive_published(),
+    ?assertMatch(
+        [#{payload := #{<<"value">> := Payload0}}],
+        Published0
+    ),
+
+    %% Verify resource cleanup
+    emqx_bridge_v2_testlib:delete_all_rules(),
+    emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
+    ensure_attached_service_account_token_resources_cleared(),
+
     ok.

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -550,7 +550,7 @@ start_control_client(GCPEmulatorHost, GCPEmulatorPort) ->
             port => GCPEmulatorPort
         },
     PoolName = <<"control_connector">>,
-    {ok, Client} = emqx_bridge_gcp_pubsub_client:start(PoolName, ClientConfig),
+    {ok, _ExtraInfo, Client} = emqx_bridge_gcp_pubsub_client:start(PoolName, ClientConfig),
     Client.
 
 stop_control_client(Client) ->

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -39,6 +39,7 @@
 -define(without_batch, without_batch).
 -define(service_account_json, service_account_json).
 -define(wif_oidc, wif_oidc).
+-define(attached_service_account, attached_service_account).
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
@@ -110,7 +111,9 @@ init_per_testcase(TestCase, TCConfig) ->
                     <<"service_account_json">> => emqx_utils_json:encode(ServiceAccountJSON)
                 };
             ?wif_oidc ->
-                wif_oidc_auth()
+                wif_oidc_auth();
+            ?attached_service_account ->
+                attached_service_account_auth()
         end,
     ConnectorConfig = connector_config(#{
         <<"authentication">> => Authentication
@@ -212,6 +215,11 @@ wif_oidc_auth() ->
         }
     }.
 
+attached_service_account_auth() ->
+    #{
+        <<"type">> => <<"attached_service_account">>
+    }.
+
 mock_wif_auth_calls() ->
     Mod = emqx_bridge_gcp_pubsub_auth_wif_worker,
     on_exit(fun meck:unload/0),
@@ -228,9 +236,36 @@ mock_wif_auth_calls() ->
     end),
     ok.
 
+mock_attached_service_account_auth_calls() ->
+    Mod = emqx_bridge_gcp_pubsub_client,
+    on_exit(fun meck:unload/0),
+    meck:new(Mod, [passthrough]),
+    meck:expect(Mod, do_metadata_request, fun(#{url := URL}) ->
+        case URL of
+            <<
+                "http://metadata.google.internal/computeMetadata"
+                "/v1/project/project-id"
+            >> ->
+                {ok, 200, [{<<"Content-Type">>, <<"application/text">>}], <<"myproject">>};
+            <<
+                "http://metadata.google.internal/computeMetadata"
+                "/v1/instance/service-accounts/default/token"
+            >> ->
+                NowS = erlang:system_time(seconds),
+                ExpiresInS = NowS + 3600,
+                simple_token_reply(#{
+                    <<"access_token">> => <<"attached_sa_token">>,
+                    <<"expires_in">> => ExpiresInS
+                })
+        end
+    end),
+    ok.
+
 simple_token_reply(Key, Token) ->
-    {ok, 200, [{<<"Content-Type">>, <<"application/json">>}],
-        emqx_utils_json:encode(#{Key => Token})}.
+    simple_token_reply(#{Key => Token}).
+
+simple_token_reply(Body) ->
+    {ok, 200, [{<<"Content-Type">>, <<"application/json">>}], emqx_utils_json:encode(Body)}.
 
 get_config(K, TCConfig) -> emqx_bridge_v2_testlib:get_value(K, TCConfig).
 
@@ -238,7 +273,9 @@ get_config(K, TCConfig, Default) -> proplists:get_value(K, TCConfig, Default).
 
 auth_of(TCConfig) ->
     emqx_common_test_helpers:get_matrix_prop(
-        TCConfig, [?service_account_json, ?wif_oidc], ?service_account_json
+        TCConfig,
+        [?service_account_json, ?wif_oidc, ?attached_service_account],
+        ?service_account_json
     ).
 
 group_path(Config, Default) ->
@@ -796,9 +833,20 @@ assert_persisted_service_account_json_is_binary(TCConfig) ->
 
 %% * Worker process is removed from supervisor.
 %% * Token is deleted from table.
-ensure_token_resources_cleared() ->
-    ?assertMatch([], supervisor:which_children(?SUP)),
+ensure_wif_token_resources_cleared() ->
+    ?assertMatch(
+        [],
+        [
+            Child
+         || Child = {Id, _, _, _} <- supervisor:which_children(?SUP),
+            Id /= emqx_bridge_gcp_pubsub_token_cache
+        ]
+    ),
     ?assertMatch([], ets:tab2list(?TOKEN_TAB)),
+    ok.
+
+ensure_attached_service_account_token_resources_cleared() ->
+    ?assertMatch([], ets:tab2list(?SA_TOKEN_RESP_TAB)),
     ok.
 
 %%------------------------------------------------------------------------------
@@ -2142,7 +2190,7 @@ t_wif_auth(matrix) ->
 t_wif_auth(TCConfig) ->
     mock_wif_auth_calls(),
     %% Sanity check
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
 
     ?assertMatch(
         {201, #{
@@ -2178,7 +2226,7 @@ t_wif_auth(TCConfig) ->
     %% Verify resource cleanup
     emqx_bridge_v2_testlib:delete_all_rules(),
     emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
     ok.
 
 -doc """
@@ -2191,7 +2239,7 @@ t_wif_auth_initial_token_timeout(matrix) ->
 t_wif_auth_initial_token_timeout(TCConfig) ->
     mock_wif_auth_calls(),
     %% Sanity check
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
 
     %% Make the initial token request timeout
     Mod = emqx_bridge_gcp_pubsub_auth_wif_worker,
@@ -2234,7 +2282,7 @@ t_wif_token_worker_already_started(matrix) ->
 t_wif_token_worker_already_started(TCConfig) ->
     mock_wif_auth_calls(),
     %% Sanity check
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
 
     Mod = emqx_bridge_gcp_pubsub_client,
     meck:new(Mod, [passthrough]),
@@ -2264,7 +2312,7 @@ t_wif_auth_optional_audience(matrix) ->
 t_wif_auth_optional_audience(TCConfig) when is_list(TCConfig) ->
     mock_wif_auth_calls(),
     %% Sanity check
-    ensure_token_resources_cleared(),
+    ensure_wif_token_resources_cleared(),
 
     ?assertMatch(
         {201, #{
@@ -2281,4 +2329,57 @@ t_wif_auth_optional_audience(TCConfig) when is_list(TCConfig) ->
             }
         })
     ),
+    ok.
+
+-doc """
+Simple smoke test for using attached service account authentication.
+
+It cannot really emulate the real GCP IAM authentication process, but it does emulate the
+calls to get a token and use the stored token.
+""".
+t_attached_service_account_auth() ->
+    [{matrix, true}].
+t_attached_service_account_auth(matrix) ->
+    [[?mocked_gcp, ?attached_service_account]];
+t_attached_service_account_auth(TCConfig) ->
+    mock_attached_service_account_auth_calls(),
+    %% Sanity check
+    ensure_attached_service_account_token_resources_cleared(),
+
+    ?assertMatch(
+        {201, #{
+            <<"status">> := <<"connected">>,
+            <<"authentication">> := #{<<"type">> := <<"attached_service_account">>}
+        }},
+        create_connector_api(TCConfig, #{})
+    ),
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_action_api(TCConfig, #{})
+    ),
+    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    Payload = <<"payload">>,
+    emqtt:publish(C, Topic, Payload),
+    HeaderValidator = fun(Headers) ->
+        ?assertMatch(#{<<"authorization">> := <<"Bearer attached_sa_token">>}, Headers)
+    end,
+    DecodedMessages = receive_http_request(TCConfig, #{header_validator => HeaderValidator}),
+    ?assertMatch(
+        [
+            #{
+                <<"data">> := #{
+                    <<"topic">> := Topic,
+                    <<"payload">> := Payload
+                }
+            }
+        ],
+        DecodedMessages
+    ),
+
+    %% Verify resource cleanup
+    emqx_bridge_v2_testlib:delete_all_rules(),
+    emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
+    ensure_attached_service_account_token_resources_cleared(),
+
     ok.

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -2250,7 +2250,7 @@ t_wif_token_worker_already_started(TCConfig) ->
      || {_, {_Mod, start, Args}, _} <- meck:history(Mod)
     ],
 
-    ?assertMatch({ok, _}, apply(Mod, start, Args)),
+    ?assertMatch({ok, _, _}, apply(Mod, start, Args)),
 
     ok.
 

--- a/apps/emqx_bridge_kafka/mix.exs
+++ b/apps/emqx_bridge_kafka/mix.exs
@@ -45,6 +45,7 @@ defmodule EMQXBridgeKafka.MixProject do
       :brod_oauth,
       :telemetry,
       {:emqx_connector, in_umbrella: true, runtime: false},
+      {:emqx_connector_jwt, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
     ])

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_oauth_authn.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_oauth_authn.erl
@@ -6,6 +6,9 @@
 %% API
 -export([mk_token_callback/1]).
 
+%% Internal exports
+-export([refresh_token/1]).
+
 %% Internal exports (only for mocking/tests)
 -export([do_request/1]).
 
@@ -21,49 +24,7 @@
 %%------------------------------------------------------------------------------
 
 mk_token_callback(#{grant_type := client_credentials} = Opts) ->
-    #{
-        endpoint_uri := URI,
-        client_id := TokenClientId,
-        client_secret := TokenClientSecret
-    } = Opts,
-    RefreshFn = fun() ->
-        Scope = maps:get(scope, Opts, undefined),
-        Params = lists:flatten([
-            {"grant_type", "client_credentials"},
-            {"client_id", TokenClientId},
-            {"client_secret", emqx_secret:term(TokenClientSecret)},
-            [{"scope", Scope} || Scope /= undefined]
-        ]),
-        Body = uri_string:compose_query(Params),
-        Timeout = maps:get(timeout, Opts, 30_000),
-        ConnectTimeout = maps:get(connect_timeout, Opts, 15_000),
-        Resp = ?MODULE:do_request(#{
-            uri => URI,
-            body => Body,
-            timeout => Timeout,
-            connect_timeout => ConnectTimeout
-        }),
-        case Resp of
-            {ok, {{_, 200, _}, _, RespBody}} ->
-                case emqx_utils_json:safe_decode(RespBody) of
-                    {ok, #{<<"access_token">> := Token, <<"expires_in">> := ExpiryS}} ->
-                        ExpiryMS = erlang:convert_time_unit(ExpiryS, second, millisecond),
-                        {ok, ExpiryMS, Token};
-                    {ok, #{<<"access_token">> := Token}} ->
-                        ExpiryMS = get_expiry_ms(Token),
-                        {ok, ExpiryMS, Token};
-                    {ok, BadResp} ->
-                        {error, {bad_token_response, BadResp}};
-                    {error, Reason} ->
-                        {error, {bad_token_response, Reason}}
-                end;
-            {ok, {{_, Status, _}, Headers, BadResp}} ->
-                Details = #{status => Status, headers => Headers, body => BadResp},
-                {error, {bad_token_response, Details}};
-            {error, Reason} ->
-                {error, {failed_to_fetch_token, Reason}}
-        end
-    end,
+    RefreshFn = {?MODULE, refresh_token, [Opts]},
     fun(#{client_id := KafkaClientId} = _Context) ->
         case emqx_bridge_kafka_token_cache:get_or_refresh(KafkaClientId, RefreshFn) of
             {ok, Token} ->
@@ -76,6 +37,49 @@ mk_token_callback(#{grant_type := client_credentials} = Opts) ->
 %%------------------------------------------------------------------------------
 %% Internal exports
 %%------------------------------------------------------------------------------
+
+refresh_token(Opts) ->
+    #{
+        endpoint_uri := URI,
+        client_id := TokenClientId,
+        client_secret := TokenClientSecret
+    } = Opts,
+    Scope = maps:get(scope, Opts, undefined),
+    Params = lists:flatten([
+        {"grant_type", "client_credentials"},
+        {"client_id", TokenClientId},
+        {"client_secret", emqx_secret:term(TokenClientSecret)},
+        [{"scope", Scope} || Scope /= undefined]
+    ]),
+    Body = uri_string:compose_query(Params),
+    Timeout = maps:get(timeout, Opts, 30_000),
+    ConnectTimeout = maps:get(connect_timeout, Opts, 15_000),
+    Resp = ?MODULE:do_request(#{
+        uri => URI,
+        body => Body,
+        timeout => Timeout,
+        connect_timeout => ConnectTimeout
+    }),
+    case Resp of
+        {ok, {{_, 200, _}, _, RespBody}} ->
+            case emqx_utils_json:safe_decode(RespBody) of
+                {ok, #{<<"access_token">> := Token, <<"expires_in">> := ExpiryS}} ->
+                    ExpiryMS = erlang:convert_time_unit(ExpiryS, second, millisecond),
+                    {ok, ExpiryMS, Token};
+                {ok, #{<<"access_token">> := Token}} ->
+                    ExpiryMS = get_expiry_ms(Token),
+                    {ok, ExpiryMS, Token};
+                {ok, BadResp} ->
+                    {error, {bad_token_response, BadResp}};
+                {error, Reason} ->
+                    {error, {bad_token_response, Reason}}
+            end;
+        {ok, {{_, Status, _}, Headers, BadResp}} ->
+            Details = #{status => Status, headers => Headers, body => BadResp},
+            {error, {bad_token_response, Details}};
+        {error, Reason} ->
+            {error, {failed_to_fetch_token, Reason}}
+    end.
 
 %% Only exposed for mocking/tests
 do_request(Params) ->

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_token_cache.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_token_cache.erl
@@ -3,8 +3,6 @@
 %%--------------------------------------------------------------------
 -module(emqx_bridge_kafka_token_cache).
 
--behaviour(gen_server).
-
 %% API
 -export([
     start_link/0,
@@ -17,15 +15,6 @@
     clear_cache/1
 ]).
 
-%% `gen_server' API
--export([
-    init/1,
-    terminate/2,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2
-]).
-
 -include("emqx_bridge_kafka_internal.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
 
@@ -33,205 +22,32 @@
 %% Type declarations
 %%------------------------------------------------------------------------------
 
--define(registered, registered).
--define(timers, timers).
-
--define(KEY(CLIENT_ID), CLIENT_ID).
--define(TOKEN_ROW(KEY, DEADLINE, TOKEN), {KEY, DEADLINE, TOKEN}).
-
-%% Calls/casts/infos
--record(register_refresh, {client_id, refresh_fn, opts}).
--record(unregister, {client_id}).
--record(refresh, {client_id}).
-
 %%------------------------------------------------------------------------------
 %% API
 %%------------------------------------------------------------------------------
 
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, _Opts = #{}, []).
+    Opts = #{table => ?TOKEN_RESP_TAB},
+    emqx_connector_jwt_token_cache:start_link({local, ?MODULE}, Opts).
 
 create_tables() ->
-    _ = emqx_utils_ets:new(?TOKEN_RESP_TAB, [ordered_set, public]),
-    ok.
+    emqx_connector_jwt_token_cache:create_tables(?TOKEN_RESP_TAB).
 
 get_or_refresh(ClientId, RefreshFn) ->
-    get_or_refresh(ClientId, RefreshFn, _Opts = #{}).
+    emqx_connector_jwt_token_cache:get_or_refresh(?MODULE, ?TOKEN_RESP_TAB, ClientId, RefreshFn).
 
 get_or_refresh(ClientId, RefreshFn, Opts) ->
-    case get_cached(ClientId) of
-        {ok, Response} ->
-            Response;
-        error ->
-            call(#register_refresh{client_id = ClientId, refresh_fn = RefreshFn, opts = Opts})
-    end.
+    emqx_connector_jwt_token_cache:get_or_refresh(
+        ?MODULE, ?TOKEN_RESP_TAB, ClientId, RefreshFn, Opts
+    ).
 
 unregister(ClientId) ->
-    call(#unregister{client_id = ClientId}).
+    emqx_connector_jwt_token_cache:unregister(?MODULE, ClientId).
 
 %% For debug/test/manual ops
 clear_cache() ->
-    true = ets:delete_all_objects(?TOKEN_RESP_TAB),
-    ok.
+    emqx_connector_jwt_token_cache:clear_cache(?TOKEN_RESP_TAB).
 
 %% For debug/test/manual ops
 clear_cache(ClientId) ->
-    true = ets:delete(?TOKEN_RESP_TAB, ?KEY(ClientId)),
-    ok.
-
-%%------------------------------------------------------------------------------
-%% `gen_server' API
-%%------------------------------------------------------------------------------
-
-init(_Opts) ->
-    State = #{
-        ?registered => #{},
-        ?timers => #{}
-    },
-    {ok, State}.
-
-terminate(_Reason, _State) ->
-    ok.
-
-handle_call(
-    #register_refresh{client_id = ClientId, refresh_fn = RefreshFn, opts = Opts}, _From, State0
-) ->
-    {Reply, State} = handle_register_refresh(ClientId, RefreshFn, Opts, State0),
-    {reply, Reply, State};
-handle_call(#unregister{client_id = ClientId}, _From, State0) ->
-    State = handle_unregister(ClientId, State0),
-    {reply, ok, State};
-handle_call(Call, _From, State) ->
-    {reply, {error, {unknown_call, Call}}, State}.
-
-handle_cast(_Cast, State) ->
-    {noreply, State}.
-
-handle_info({timeout, _TRef, #refresh{client_id = ClientId}}, #{?timers := Timers0} = State0) when
-    is_map_key(ClientId, Timers0)
-->
-    Timers = maps:remove(ClientId, Timers0),
-    State1 = State0#{?timers := Timers},
-    State = handle_refresh(ClientId, State1),
-    {noreply, State};
-handle_info(_Info, State) ->
-    {noreply, State}.
-
-%%------------------------------------------------------------------------------
-%% Internal fns
-%%------------------------------------------------------------------------------
-
-call(Call) ->
-    gen_server:call(?MODULE, Call, infinity).
-
-get_cached(ClientId) ->
-    NowMS = now_ms(),
-    case ets:lookup(?TOKEN_RESP_TAB, ?KEY(ClientId)) of
-        [?TOKEN_ROW(?KEY(ClientId), Deadline, Response)] when Deadline > NowMS ->
-            {ok, Response};
-        _ ->
-            error
-    end.
-
-handle_register_refresh(ClientId, RefreshFn, Opts, State0) ->
-    %% Might've been just stored by a previous call.
-    case get_cached(ClientId) of
-        {ok, Response} ->
-            %% Store provided refresh fn, as it could be an updated version.
-            State = maps:update_with(
-                ?registered,
-                fun(R) -> R#{ClientId => {RefreshFn, Opts}} end,
-                State0
-            ),
-            {Response, State};
-        error ->
-            do_handle_register_refresh(ClientId, RefreshFn, Opts, State0)
-    end.
-
-do_handle_register_refresh(ClientId, RefreshFn, Opts, State0) ->
-    case do_fetch_token(ClientId, RefreshFn) of
-        {ok, ExpiryMS, Token} ->
-            State1 = store_token_and_schedule_refresh(ExpiryMS, ClientId, Token, State0),
-            State = maps:update_with(
-                ?registered,
-                fun(R) -> R#{ClientId => {RefreshFn, Opts}} end,
-                State1
-            ),
-            {{ok, Token}, State};
-        {error, Reason} ->
-            CacheFailuresFor = maps:get(cache_failures_for, Opts, timer:seconds(1)),
-            Deadline = now_ms() + CacheFailuresFor,
-            _ = ets:insert(?TOKEN_RESP_TAB, ?TOKEN_ROW(?KEY(ClientId), Deadline, {error, Reason})),
-            {{error, Reason}, State0}
-    end.
-
-do_fetch_token(ClientId, RefreshFn) ->
-    try
-        RefreshFn()
-    catch
-        Kind:Reason:Stacktrace ->
-            ?tp(error, "kafka_token_refresh_exception", #{
-                client_id => ClientId,
-                kind => Kind,
-                reason => Reason,
-                stacktrace => Stacktrace
-            }),
-            {error, {Kind, Reason}}
-    end.
-
-handle_unregister(ClientId, State0) ->
-    _ = ets:delete(?TOKEN_RESP_TAB, ?KEY(ClientId)),
-    State1 = maps:update_with(?registered, fun(R) -> maps:remove(ClientId, R) end, State0),
-    clear_refresh_timer(ClientId, State1).
-
-handle_refresh(ClientId, #{?registered := Registered} = State0) when
-    not is_map_key(ClientId, Registered)
-->
-    %% Shouldn't be possible
-    ?tp(error, "kafka_token_refresh_unknown_clientid", #{clientid => ClientId}),
-    State0;
-handle_refresh(ClientId, #{?registered := Registered} = State0) ->
-    {RefreshFn, Opts} = maps:get(ClientId, Registered),
-    ?tp(info, "kafka_token_refreshing", #{client_id => ClientId}),
-    case do_fetch_token(ClientId, RefreshFn) of
-        {ok, ExpiryMS, Token} ->
-            ?tp(info, "kafka_token_refreshed", #{client_id => ClientId, expiry_ms => ExpiryMS}),
-            store_token_and_schedule_refresh(ExpiryMS, ClientId, Token, State0);
-        {error, Reason} ->
-            ?tp(warning, "kafka_token_refresh_failed", #{client_id => ClientId, reason => Reason}),
-            RetryTime = maps:get(retry_interval, Opts, timer:seconds(5)),
-            ensure_refresh_timer(ClientId, RetryTime, State0)
-    end.
-
-store_token_and_schedule_refresh(ExpiryMS, ClientId, Token, State0) ->
-    Deadline = now_ms() + ExpiryMS,
-    _ = ets:insert(?TOKEN_RESP_TAB, ?TOKEN_ROW(?KEY(ClientId), Deadline, {ok, Token})),
-    %% Tokens typically last for 1 hour
-    RefreshTime = ceil(ExpiryMS * 0.75),
-    ?tp("kafka_token_success", #{
-        client_id => ClientId,
-        expiry_ms => ExpiryMS,
-        refresh_after => RefreshTime
-    }),
-    ensure_refresh_timer(ClientId, RefreshTime, State0).
-
-ensure_refresh_timer(ClientId, _Time, #{?timers := Timers} = State) when
-    is_map_key(ClientId, Timers)
-->
-    State;
-ensure_refresh_timer(ClientId, Time, #{?timers := Timers0} = State0) ->
-    TRef = emqx_utils:start_timer(Time, #refresh{client_id = ClientId}),
-    Timers = Timers0#{ClientId => TRef},
-    State0#{?timers := Timers}.
-
-clear_refresh_timer(ClientId, #{?timers := Timers0} = State0) ->
-    case maps:take(ClientId, Timers0) of
-        error ->
-            State0;
-        {TRef, Timers} ->
-            emqx_utils:cancel_timer(TRef),
-            State0#{?timers := Timers}
-    end.
-
-now_ms() ->
-    erlang:system_time(millisecond).
+    emqx_connector_jwt_token_cache:clear_cache(?TOKEN_RESP_TAB, ClientId).

--- a/apps/emqx_connector_jwt/mix.exs
+++ b/apps/emqx_connector_jwt/mix.exs
@@ -28,6 +28,7 @@ defmodule EMQXConnectorJWT.MixProject do
   def deps() do
     UMP.deps([
       {:emqx_resource, in_umbrella: true},
+      :snabbkaffe,
       :jose
     ])
   end

--- a/apps/emqx_connector_jwt/src/emqx_connector_jwt_token_cache.erl
+++ b/apps/emqx_connector_jwt/src/emqx_connector_jwt_token_cache.erl
@@ -196,7 +196,7 @@ do_handle_register_refresh(ResId, RefreshFn, Opts, State0) ->
 
 do_fetch_token(ResId, RefreshFn) ->
     try
-        RefreshFn()
+        call_refresh_fn(RefreshFn)
     catch
         Kind:Reason:Stacktrace ->
             ?tp(error, "token_refresh_exception", #{
@@ -207,6 +207,11 @@ do_fetch_token(ResId, RefreshFn) ->
             }),
             {error, {Kind, Reason}}
     end.
+
+call_refresh_fn(RefreshFn) when is_function(RefreshFn, 0) ->
+    RefreshFn();
+call_refresh_fn({M, F, A}) ->
+    apply(M, F, A).
 
 handle_unregister(ResId, State0) ->
     #{?table := Tab} = State0,

--- a/apps/emqx_connector_jwt/src/emqx_connector_jwt_token_cache.erl
+++ b/apps/emqx_connector_jwt/src/emqx_connector_jwt_token_cache.erl
@@ -3,6 +3,21 @@
 %%--------------------------------------------------------------------
 -module(emqx_connector_jwt_token_cache).
 
+-moduledoc """
+This `gen_server` serves as a refresher of tokens are simple to obtain with a single
+request.
+
+- `get_or_refresh` is called with a caller identifier, the table where tokens are stored,
+  and a supplied refresh function that fetches the token if needed.  If the token is
+  absent or expired, a fresh one is fetched, cached and returned.  By calling this, it
+  also registers the refresh function associated with the caller id, so that this token is
+  refreshed automatically at about 3/4 of its expiry time.
+
+- `unregister` is called when the caller is terminating and wants to clear up its
+  resources.  It prevents further refreshes and removes the token from the table
+  associated with the caller id.
+""".
+
 -behaviour(gen_server).
 
 %% API
@@ -55,6 +70,12 @@ start_link(#{} = Opts) ->
 start_link(ServerName, #{} = Opts) ->
     gen_server:start_link(ServerName, ?MODULE, Opts, []).
 
+-doc """
+Creates the table used by the refresher process.
+
+It's best called by a supervisor so that a process restart does not drop all stored
+tokens.
+""".
 create_tables(TabName) ->
     _ = emqx_utils_ets:new(TabName, [ordered_set, public]),
     ok.

--- a/apps/emqx_connector_jwt/src/emqx_connector_jwt_token_cache.erl
+++ b/apps/emqx_connector_jwt/src/emqx_connector_jwt_token_cache.erl
@@ -1,0 +1,247 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_connector_jwt_token_cache).
+
+-behaviour(gen_server).
+
+%% API
+-export([
+    start_link/1,
+    start_link/2,
+
+    create_tables/1,
+    get_or_refresh/4,
+    get_or_refresh/5,
+    unregister/2,
+    clear_cache/1,
+    clear_cache/2
+]).
+
+%% `gen_server' API
+-export([
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-include_lib("snabbkaffe/include/trace.hrl").
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-define(registered, registered).
+-define(table, table).
+-define(timers, timers).
+
+-define(KEY(RES_ID), RES_ID).
+-define(TOKEN_ROW(KEY, DEADLINE, TOKEN), {KEY, DEADLINE, TOKEN}).
+
+%% Calls/casts/infos
+-record(register_refresh, {res_id, refresh_fn, opts}).
+-record(unregister, {res_id}).
+-record(refresh, {res_id}).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+start_link(#{} = Opts) ->
+    gen_server:start_link(?MODULE, Opts, []).
+
+start_link(ServerName, #{} = Opts) ->
+    gen_server:start_link(ServerName, ?MODULE, Opts, []).
+
+create_tables(TabName) ->
+    _ = emqx_utils_ets:new(TabName, [ordered_set, public]),
+    ok.
+
+get_or_refresh(ServerRef, Tab, ResId, RefreshFn) ->
+    get_or_refresh(ServerRef, Tab, ResId, RefreshFn, _Opts = #{}).
+
+get_or_refresh(ServerRef, Tab, ResId, RefreshFn, Opts) ->
+    case get_cached(Tab, ResId) of
+        {ok, Response} ->
+            Response;
+        error ->
+            call(ServerRef, #register_refresh{res_id = ResId, refresh_fn = RefreshFn, opts = Opts})
+    end.
+
+unregister(ServerRef, ResId) ->
+    call(ServerRef, #unregister{res_id = ResId}).
+
+%% For debug/test/manual ops
+clear_cache(Tab) ->
+    true = ets:delete_all_objects(Tab),
+    ok.
+
+%% For debug/test/manual ops
+clear_cache(Tab, ResId) ->
+    true = ets:delete(Tab, ?KEY(ResId)),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% `gen_server' API
+%%------------------------------------------------------------------------------
+
+init(Opts) ->
+    #{table := Tab} = Opts,
+    State = #{
+        ?table => Tab,
+        ?registered => #{},
+        ?timers => #{}
+    },
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+handle_call(
+    #register_refresh{res_id = ResId, refresh_fn = RefreshFn, opts = Opts}, _From, State0
+) ->
+    {Reply, State} = handle_register_refresh(ResId, RefreshFn, Opts, State0),
+    {reply, Reply, State};
+handle_call(#unregister{res_id = ResId}, _From, State0) ->
+    State = handle_unregister(ResId, State0),
+    {reply, ok, State};
+handle_call(Call, _From, State) ->
+    {reply, {error, {unknown_call, Call}}, State}.
+
+handle_cast(_Cast, State) ->
+    {noreply, State}.
+
+handle_info({timeout, _TRef, #refresh{res_id = ResId}}, #{?timers := Timers0} = State0) when
+    is_map_key(ResId, Timers0)
+->
+    Timers = maps:remove(ResId, Timers0),
+    State1 = State0#{?timers := Timers},
+    State = handle_refresh(ResId, State1),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+call(ServerRef, Call) ->
+    gen_server:call(ServerRef, Call, infinity).
+
+get_cached(Tab, ResId) ->
+    NowMS = now_ms(),
+    case ets:lookup(Tab, ?KEY(ResId)) of
+        [?TOKEN_ROW(?KEY(ResId), Deadline, Response)] when Deadline > NowMS ->
+            {ok, Response};
+        _ ->
+            error
+    end.
+
+handle_register_refresh(ResId, RefreshFn, Opts, State0) ->
+    #{?table := Tab} = State0,
+    %% Might've been just stored by a previous call.
+    case get_cached(Tab, ResId) of
+        {ok, Response} ->
+            %% Store provided refresh fn, as it could be an updated version.
+            State = maps:update_with(
+                ?registered,
+                fun(R) -> R#{ResId => {RefreshFn, Opts}} end,
+                State0
+            ),
+            {Response, State};
+        error ->
+            do_handle_register_refresh(ResId, RefreshFn, Opts, State0)
+    end.
+
+do_handle_register_refresh(ResId, RefreshFn, Opts, State0) ->
+    #{?table := Tab} = State0,
+    case do_fetch_token(ResId, RefreshFn) of
+        {ok, ExpiryMS, Token} ->
+            State1 = store_token_and_schedule_refresh(ExpiryMS, ResId, Token, State0),
+            State = maps:update_with(
+                ?registered,
+                fun(R) -> R#{ResId => {RefreshFn, Opts}} end,
+                State1
+            ),
+            {{ok, Token}, State};
+        {error, Reason} ->
+            CacheFailuresFor = maps:get(cache_failures_for, Opts, timer:seconds(1)),
+            Deadline = now_ms() + CacheFailuresFor,
+            _ = ets:insert(Tab, ?TOKEN_ROW(?KEY(ResId), Deadline, {error, Reason})),
+            {{error, Reason}, State0}
+    end.
+
+do_fetch_token(ResId, RefreshFn) ->
+    try
+        RefreshFn()
+    catch
+        Kind:Reason:Stacktrace ->
+            ?tp(error, "token_refresh_exception", #{
+                res_id => ResId,
+                kind => Kind,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
+            {error, {Kind, Reason}}
+    end.
+
+handle_unregister(ResId, State0) ->
+    #{?table := Tab} = State0,
+    _ = ets:delete(Tab, ?KEY(ResId)),
+    State1 = maps:update_with(?registered, fun(R) -> maps:remove(ResId, R) end, State0),
+    clear_refresh_timer(ResId, State1).
+
+handle_refresh(ResId, #{?registered := Registered} = State0) when
+    not is_map_key(ResId, Registered)
+->
+    %% Shouldn't be possible
+    ?tp(error, "token_refresh_unknown_clientid", #{clientid => ResId}),
+    State0;
+handle_refresh(ResId, #{?registered := Registered} = State0) ->
+    {RefreshFn, Opts} = maps:get(ResId, Registered),
+    ?tp(info, "token_refreshing", #{res_id => ResId}),
+    case do_fetch_token(ResId, RefreshFn) of
+        {ok, ExpiryMS, Token} ->
+            ?tp(info, "token_refreshed", #{res_id => ResId, expiry_ms => ExpiryMS}),
+            store_token_and_schedule_refresh(ExpiryMS, ResId, Token, State0);
+        {error, Reason} ->
+            ?tp(warning, "token_refresh_failed", #{res_id => ResId, reason => Reason}),
+            RetryTime = maps:get(retry_interval, Opts, timer:seconds(5)),
+            ensure_refresh_timer(ResId, RetryTime, State0)
+    end.
+
+store_token_and_schedule_refresh(ExpiryMS, ResId, Token, State0) ->
+    #{?table := Tab} = State0,
+    Deadline = now_ms() + ExpiryMS,
+    _ = ets:insert(Tab, ?TOKEN_ROW(?KEY(ResId), Deadline, {ok, Token})),
+    %% Tokens typically last for 1 hour
+    RefreshTime = ceil(ExpiryMS * 0.75),
+    ?tp("token_success", #{
+        res_id => ResId,
+        expiry_ms => ExpiryMS,
+        refresh_after => RefreshTime
+    }),
+    ensure_refresh_timer(ResId, RefreshTime, State0).
+
+ensure_refresh_timer(ResId, _Time, #{?timers := Timers} = State) when
+    is_map_key(ResId, Timers)
+->
+    State;
+ensure_refresh_timer(ResId, Time, #{?timers := Timers0} = State0) ->
+    TRef = emqx_utils:start_timer(Time, #refresh{res_id = ResId}),
+    Timers = Timers0#{ResId => TRef},
+    State0#{?timers := Timers}.
+
+clear_refresh_timer(ResId, #{?timers := Timers0} = State0) ->
+    case maps:take(ResId, Timers0) of
+        error ->
+            State0;
+        {TRef, Timers} ->
+            emqx_utils:cancel_timer(TRef),
+            State0#{?timers := Timers}
+    end.
+
+now_ms() ->
+    erlang:system_time(millisecond).

--- a/apps/emqx_connector_jwt/test/emqx_connector_jwt_token_cache_SUITE.erl
+++ b/apps/emqx_connector_jwt/test/emqx_connector_jwt_token_cache_SUITE.erl
@@ -1,7 +1,7 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
--module(emqx_bridge_kafka_token_cache_SUITE).
+-module(emqx_connector_jwt_token_cache_SUITE).
 
 -compile(nowarn_export_all).
 -compile(export_all).
@@ -18,6 +18,7 @@
 -import(emqx_common_test_helpers, [on_exit/1]).
 
 -define(client_id, <<"some:client:id">>).
+-define(tab, ?MODULE).
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
@@ -31,10 +32,9 @@ groups() ->
 
 init_per_suite(TCConfig) ->
     Apps = emqx_cth_suite:start(
-        [emqx_bridge_kafka],
+        [emqx_connector_jwt],
         #{work_dir => emqx_cth_suite:work_dir(TCConfig)}
     ),
-    emqx_bridge_kafka_testlib:wait_until_kafka_is_up(),
     [
         {apps, Apps}
         | TCConfig
@@ -46,11 +46,13 @@ end_per_suite(TCConfig) ->
     ok.
 
 init_per_testcase(_TestCase, TCConfig) ->
+    ok = emqx_connector_jwt_token_cache:create_tables(?tab),
+    {ok, _} = emqx_connector_jwt_token_cache:start_link({local, ?MODULE}, #{table => ?tab}),
     TCConfig.
 
 end_per_testcase(_TestCase, _TCConfig) ->
     emqx_common_test_helpers:call_janitor(),
-    emqx_bridge_kafka_token_cache:clear_cache(),
+    emqx_connector_jwt_token_cache:clear_cache(?tab),
     ok.
 
 %%------------------------------------------------------------------------------
@@ -93,12 +95,12 @@ get_or_refresh(RefreshFn) ->
     get_or_refresh(?client_id, RefreshFn).
 
 get_or_refresh(ClientId, RefreshFn) ->
-    on_exit(fun() -> emqx_bridge_kafka_token_cache:unregister(ClientId) end),
-    emqx_bridge_kafka_token_cache:get_or_refresh(ClientId, RefreshFn).
+    on_exit(fun() -> emqx_connector_jwt_token_cache:unregister(?MODULE, ClientId) end),
+    emqx_connector_jwt_token_cache:get_or_refresh(?MODULE, ?tab, ClientId, RefreshFn).
 
 get_or_refresh(ClientId, RefreshFn, Opts) ->
-    on_exit(fun() -> emqx_bridge_kafka_token_cache:unregister(ClientId) end),
-    emqx_bridge_kafka_token_cache:get_or_refresh(ClientId, RefreshFn, Opts).
+    on_exit(fun() -> emqx_connector_jwt_token_cache:unregister(?MODULE, ClientId) end),
+    emqx_connector_jwt_token_cache:get_or_refresh(?MODULE, ?tab, ClientId, RefreshFn, Opts).
 
 %%------------------------------------------------------------------------------
 %% Test cases
@@ -201,7 +203,7 @@ t_smoke_clear_one_cache(_TCConfig) ->
     ?assertReceive({fetched, #{times_called := 1, client_id := ClientIdA}}),
     ?assertReceive({fetched, #{times_called := 1, client_id := ClientIdB}}),
 
-    ?assertMatch(ok, emqx_bridge_kafka_token_cache:clear_cache(ClientIdA)),
+    ?assertMatch(ok, emqx_connector_jwt_token_cache:clear_cache(?tab, ClientIdA)),
 
     ?assertMatch({ok, <<"a2">>}, get_or_refresh(ClientIdA, RefreshFnA)),
     ?assertMatch({ok, <<"b1">>}, get_or_refresh(ClientIdB, RefreshFnB)),

--- a/changes/ee/feat-17129.en.md
+++ b/changes/ee/feat-17129.en.md
@@ -1,0 +1,1 @@
+Added support for using Attached Service Account authentication to GCP-based connectors (GCP PubSub Producer and Consumer, BigQuery).  Now, when EMQX is deployed on a GCP VM with an attached Service Account to the instance, it can query the internal metadata endpoint to automatically get a token for these connectors.

--- a/rel/i18n/emqx_bridge_gcp_pubsub_schema_lib.hocon
+++ b/rel/i18n/emqx_bridge_gcp_pubsub_schema_lib.hocon
@@ -16,6 +16,11 @@ When a GCP Service Account is created (as described in https://developers.google
     desc: "Authenticate using a JSON containing the GCP Service Account credentials."
   }
 
+  auth_attached_service_account {
+    label: "Attached Service Account"
+    desc: "Authenticate using the GCP Service Account credentials attached to the Compute Engine instance where EMQX runs."
+  }
+
   auth_service_account_json_type {
     label: "Service Account JSON"
     desc: "Service Account JSON"


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15230

Release version:
6.3.0

## Summary

Attached Service Account authentication for GCP Connectors works very similarly to Kafka's MSK authentication.  To reuse the already tested logic from Kafka MSK authn, we moved the token cache logic from Kafka's application to `emqx_connector_jwt`. 

See individual commits.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests (also tested manually in a GCP VM)
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
