### PR TITLE
fix(modules): make topic_metrics add/remove idempotent on replicate

### DIFF
--- a/apps/emqx_modules/src/emqx_modules_conf.erl
+++ b/apps/emqx_modules/src/emqx_modules_conf.erl
@@ -58,18 +58,28 @@ topic_metrics() ->
     {ok, emqx_types:topic()}
     | {error, term()}.
 add_topic_metrics(Topic) ->
-    case cfg_update([topic_metrics], ?FUNCTION_NAME, Topic) of
-        {ok, _} -> {ok, Topic};
-        {error, Reason} -> {error, Reason}
+    case lists:member(Topic, topic_metrics()) of
+        true ->
+            {error, already_existed};
+        false ->
+            case cfg_update([topic_metrics], ?FUNCTION_NAME, Topic) of
+                {ok, _} -> {ok, Topic};
+                {error, Reason} -> {error, Reason}
+            end
     end.
 
 -spec remove_topic_metrics(emqx_types:topic()) ->
     ok
     | {error, term()}.
 remove_topic_metrics(Topic) ->
-    case cfg_update([topic_metrics], ?FUNCTION_NAME, Topic) of
-        {ok, _} -> ok;
-        {error, Reason} -> {error, Reason}
+    case lists:member(Topic, topic_metrics()) of
+        false ->
+            {error, not_found};
+        true ->
+            case cfg_update([topic_metrics], ?FUNCTION_NAME, Topic) of
+                {ok, _} -> ok;
+                {error, Reason} -> {error, Reason}
+            end
     end.
 
 %%--------------------------------------------------------------------
@@ -102,7 +112,10 @@ pre_config_update(_, {add_topic_metrics, Topic0}, RawConf) ->
             Topic = #{<<"topic">> => Topic0},
             case lists:member(Topic, RawConf) of
                 true ->
-                    {error, already_existed};
+                    %% Idempotent on replicate: tolerate raw-config drift where
+                    %% the topic is already present. Initiator-side duplicate
+                    %% is filtered by add_topic_metrics/1.
+                    {ok, RawConf};
                 _ ->
                     {ok, RawConf ++ [Topic]}
             end;
@@ -110,13 +123,10 @@ pre_config_update(_, {add_topic_metrics, Topic0}, RawConf) ->
             Error
     end;
 pre_config_update(_, {remove_topic_metrics, Topic0}, RawConf) ->
+    %% Idempotent on replicate: no-op if the topic is absent. Initiator-side
+    %% missing-topic is filtered by remove_topic_metrics/1.
     Topic = #{<<"topic">> => Topic0},
-    case lists:member(Topic, RawConf) of
-        true ->
-            {ok, RawConf -- [Topic]};
-        _ ->
-            {error, not_found}
-    end;
+    {ok, RawConf -- [Topic]};
 pre_config_update(_, {merge_topics, NewConf}, OldConf) ->
     case validate_topic_metrics_list(NewConf) of
         ok ->
@@ -150,6 +160,9 @@ post_config_update(
     case emqx_topic_metrics:register(Topic) of
         ok ->
             ok;
+        {error, already_existed} ->
+            %% Tolerate runtime-state drift on replicate.
+            ok;
         {error, wildcard_not_supported} ->
             {error, #{cause => wildcard_not_supported, topic => Topic}};
         {error, Reason} ->
@@ -164,6 +177,8 @@ post_config_update(
 ) ->
     case emqx_topic_metrics:deregister(Topic) of
         ok -> ok;
+        %% Tolerate runtime-state drift on replicate.
+        {error, topic_not_found} -> ok;
         {error, Reason} -> {error, Reason}
     end;
 post_config_update(_, _UpdateReq, NewConfig, OldConfig, _AppEnvs) ->

--- a/apps/emqx_modules/src/emqx_modules_conf.erl
+++ b/apps/emqx_modules/src/emqx_modules_conf.erl
@@ -8,6 +8,8 @@
 -behaviour(emqx_config_handler).
 -behaviour(emqx_config_backup).
 
+-include_lib("emqx/include/emqx.hrl").
+
 %% Load/Unload
 -export([
     load/0,
@@ -22,8 +24,8 @@
 
 %% config handlers
 -export([
-    pre_config_update/3,
-    post_config_update/5
+    pre_config_update/4,
+    post_config_update/6
 ]).
 
 %% Data backup
@@ -58,28 +60,18 @@ topic_metrics() ->
     {ok, emqx_types:topic()}
     | {error, term()}.
 add_topic_metrics(Topic) ->
-    case lists:member(Topic, topic_metrics()) of
-        true ->
-            {error, already_existed};
-        false ->
-            case cfg_update([topic_metrics], ?FUNCTION_NAME, Topic) of
-                {ok, _} -> {ok, Topic};
-                {error, Reason} -> {error, Reason}
-            end
+    case cfg_update([topic_metrics], ?FUNCTION_NAME, Topic) of
+        {ok, _} -> {ok, Topic};
+        {error, Reason} -> {error, Reason}
     end.
 
 -spec remove_topic_metrics(emqx_types:topic()) ->
     ok
     | {error, term()}.
 remove_topic_metrics(Topic) ->
-    case lists:member(Topic, topic_metrics()) of
-        false ->
-            {error, not_found};
-        true ->
-            case cfg_update([topic_metrics], ?FUNCTION_NAME, Topic) of
-                {ok, _} -> ok;
-                {error, Reason} -> {error, Reason}
-            end
+    case cfg_update([topic_metrics], ?FUNCTION_NAME, Topic) of
+        {ok, _} -> ok;
+        {error, Reason} -> {error, Reason}
     end.
 
 %%--------------------------------------------------------------------
@@ -103,31 +95,42 @@ import_config(_Namespace, _RawConf) ->
 -spec pre_config_update(
     list(atom()),
     emqx_config:update_request(),
-    emqx_config:raw_config()
+    emqx_config:raw_config(),
+    emqx_config:cluster_rpc_opts()
 ) ->
     {ok, emqx_config:update_request()} | {error, term()}.
-pre_config_update(_, {add_topic_metrics, Topic0}, RawConf) ->
+pre_config_update(_, {add_topic_metrics, Topic0}, RawConf, ExtraCtx) ->
     case validate_topic_metric(Topic0) of
         ok ->
             Topic = #{<<"topic">> => Topic0},
             case lists:member(Topic, RawConf) of
                 true ->
-                    %% Idempotent on replicate: tolerate raw-config drift where
-                    %% the topic is already present. Initiator-side duplicate
-                    %% is filtered by add_topic_metrics/1.
-                    {ok, RawConf};
+                    %% Initiator: surface as duplicate.
+                    %% Replicate: tolerate raw-config drift, treat as no-op.
+                    case kind(ExtraCtx) of
+                        ?KIND_INITIATE -> {error, already_existed};
+                        ?KIND_REPLICATE -> {ok, RawConf}
+                    end;
                 _ ->
                     {ok, RawConf ++ [Topic]}
             end;
         {error, _} = Error ->
             Error
     end;
-pre_config_update(_, {remove_topic_metrics, Topic0}, RawConf) ->
-    %% Idempotent on replicate: no-op if the topic is absent. Initiator-side
-    %% missing-topic is filtered by remove_topic_metrics/1.
+pre_config_update(_, {remove_topic_metrics, Topic0}, RawConf, ExtraCtx) ->
     Topic = #{<<"topic">> => Topic0},
-    {ok, RawConf -- [Topic]};
-pre_config_update(_, {merge_topics, NewConf}, OldConf) ->
+    case lists:member(Topic, RawConf) of
+        true ->
+            {ok, RawConf -- [Topic]};
+        _ ->
+            %% Initiator: surface as not_found.
+            %% Replicate: tolerate raw-config drift, treat as no-op.
+            case kind(ExtraCtx) of
+                ?KIND_INITIATE -> {error, not_found};
+                ?KIND_REPLICATE -> {ok, RawConf}
+            end
+    end;
+pre_config_update(_, {merge_topics, NewConf}, OldConf, _ExtraCtx) ->
     case validate_topic_metrics_list(NewConf) of
         ok ->
             KeyFun = fun(#{<<"topic">> := T}) -> T end,
@@ -136,7 +139,7 @@ pre_config_update(_, {merge_topics, NewConf}, OldConf) ->
         {error, _} = Error ->
             Error
     end;
-pre_config_update(_, NewConf, _OldConf) ->
+pre_config_update(_, NewConf, _OldConf, _ExtraCtx) ->
     case validate_topic_metrics_list(NewConf) of
         ok -> {ok, NewConf};
         {error, _} = Error -> Error
@@ -147,7 +150,8 @@ pre_config_update(_, NewConf, _OldConf) ->
     emqx_config:update_request(),
     emqx_config:config(),
     emqx_config:config(),
-    emqx_config:app_envs()
+    emqx_config:app_envs(),
+    emqx_config_handler:extra_context()
 ) ->
     ok | {ok, Result :: any()} | {error, Reason :: term()}.
 post_config_update(
@@ -155,13 +159,15 @@ post_config_update(
     {add_topic_metrics, Topic},
     _NewConfig,
     _OldConfig,
-    _AppEnvs
+    _AppEnvs,
+    ExtraCtx
 ) ->
+    Kind = kind(ExtraCtx),
     case emqx_topic_metrics:register(Topic) of
         ok ->
             ok;
-        {error, already_existed} ->
-            %% Tolerate runtime-state drift on replicate.
+        {error, already_existed} when Kind =:= ?KIND_REPLICATE ->
+            %% Tolerate runtime-state drift on replicate only.
             ok;
         {error, wildcard_not_supported} ->
             {error, #{cause => wildcard_not_supported, topic => Topic}};
@@ -173,15 +179,20 @@ post_config_update(
     {remove_topic_metrics, Topic},
     _NewConfig,
     _OldConfig,
-    _AppEnvs
+    _AppEnvs,
+    ExtraCtx
 ) ->
+    Kind = kind(ExtraCtx),
     case emqx_topic_metrics:deregister(Topic) of
-        ok -> ok;
-        %% Tolerate runtime-state drift on replicate.
-        {error, topic_not_found} -> ok;
-        {error, Reason} -> {error, Reason}
+        ok ->
+            ok;
+        {error, topic_not_found} when Kind =:= ?KIND_REPLICATE ->
+            %% Tolerate runtime-state drift on replicate only.
+            ok;
+        {error, Reason} ->
+            {error, Reason}
     end;
-post_config_update(_, _UpdateReq, NewConfig, OldConfig, _AppEnvs) ->
+post_config_update(_, _UpdateReq, NewConfig, OldConfig, _AppEnvs, _ExtraCtx) ->
     #{
         removed := Removed,
         added := Added
@@ -221,6 +232,10 @@ cfg_update(Path, Action, Params) ->
             #{override_to => cluster}
         )
     ).
+
+%% `kind` is optional in the extra context; absent means initiator.
+kind(ExtraCtx) ->
+    maps:get(kind, ExtraCtx, ?KIND_INITIATE).
 
 %%--------------------------------------------------------------------
 %%  Validation helpers

--- a/apps/emqx_modules/test/emqx_modules_conf_cluster_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_modules_conf_cluster_SUITE.erl
@@ -1,0 +1,107 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_modules_conf_cluster_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(TestCase, Config) ->
+    NodeSpec = #{
+        role => core,
+        apps => [emqx, emqx_conf, emqx_modules]
+    },
+    Nodes = emqx_cth_cluster:start(
+        [
+            {modules_conf_cluster1, NodeSpec},
+            {modules_conf_cluster2, NodeSpec}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(TestCase, Config)}
+    ),
+    [{cluster, Nodes} | Config].
+
+end_per_testcase(_TestCase, Config) ->
+    emqx_cth_cluster:stop(?config(cluster, Config)),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Regression tests
+%%--------------------------------------------------------------------
+
+-doc """
+Regression: raw-config drift on the replicate used to make
+`pre_config_update/3` return `{error, not_found}`, which
+`emqx_cluster_rpc:apply_mfa/3` logs as `cluster_rpc_apply_failed` and raises
+as an alarm; the replicate's commit lag then stops advancing.
+
+After making the removal idempotent at the `pre_config_update/3` layer (while
+keeping `{error, not_found}` at the `emqx_modules_conf:remove_topic_metrics/1`
+entrypoint for API callers), the replicate applies the update as a no-op and
+the cluster commit advances cleanly.
+""".
+t_remove_topic_metrics_replicate_drift_is_tolerated(Config) ->
+    [N1, N2] = ?config(cluster, Config),
+    Topic = <<"t/1">>,
+    {ok, Topic} = ?ON(N1, emqx_modules_conf:add_topic_metrics(Topic)),
+    ?assertEqual([Topic], ?ON(N1, emqx_modules_conf:topic_metrics())),
+    ?assertEqual([Topic], ?ON(N2, emqx_modules_conf:topic_metrics())),
+    %% Simulate raw-config drift: clear only N2's local raw config.
+    ok = ?ON(N2, emqx_config:put_raw([topic_metrics], [])),
+    %% Both initiator and replicate must apply successfully.
+    ok = ?ON(N1, emqx_modules_conf:remove_topic_metrics(Topic)),
+    %% No alarm raised on the replicate.
+    no_alarm = wait_no_alarm(N2, cluster_rpc_apply_failed, 10),
+    %% Replicate's commit lag caught up.
+    #{my_id := MyId, latest := LatestId} =
+        ?ON(N2, emqx_cluster_rpc:get_commit_lag()),
+    ?assertEqual(LatestId, MyId),
+    %% Topic removed on both nodes.
+    ?assertEqual([], ?ON(N1, emqx_modules_conf:topic_metrics())),
+    ?assertEqual([], ?ON(N2, emqx_modules_conf:topic_metrics())),
+    ok.
+
+-doc """
+API contract preserved: removing a topic that the caller's local view does not
+know about still returns `{error, not_found}` at the entrypoint, even though
+the underlying `pre_config_update/3` is now idempotent.
+""".
+t_remove_topic_metrics_api_still_returns_not_found(Config) ->
+    [N1, _N2] = ?config(cluster, Config),
+    ?assertEqual(
+        {error, not_found},
+        ?ON(N1, emqx_modules_conf:remove_topic_metrics(<<"never/added">>))
+    ),
+    ok.
+
+%%--------------------------------------------------------------------
+%% helpers
+%%--------------------------------------------------------------------
+
+wait_no_alarm(Node, Name, 0) ->
+    case [A || A = #{name := N0} <- ?ON(Node, emqx_alarm:get_alarms(activated)), N0 =:= Name] of
+        [] -> no_alarm;
+        [Alarm | _] -> error({unexpected_alarm, Alarm})
+    end;
+wait_no_alarm(Node, Name, N) ->
+    case [A || A = #{name := N0} <- ?ON(Node, emqx_alarm:get_alarms(activated)), N0 =:= Name] of
+        [Alarm | _] ->
+            error({unexpected_alarm, Alarm});
+        [] ->
+            timer:sleep(200),
+            wait_no_alarm(Node, Name, N - 1)
+    end.

--- a/changes/ee/fix-17132.en.md
+++ b/changes/ee/fix-17132.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where adding or removing topic metrics could fail on a replicate node when its raw config or runtime state had drifted, raising a `cluster_rpc_apply_failed` alarm and stalling cluster RPC replication. Duplicate-add and missing-remove are now rejected on the initiator only, while replicates apply the change idempotently.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version:
6.0.3, 6.1.1, 6.2.0

## Summary

When `add_topic_metrics` / `remove_topic_metrics` runs through cluster RPC, the initiator's `pre_config_update/3` validates against raw config and rejects duplicate-add or missing-remove with `{error, already_existed}` / `{error, not_found}`. On a replicate, that same validation re-runs against the replicate's local raw config; if it has drifted (e.g. transient inconsistency), the same error fires there as a `cluster_rpc_apply_failed`, raising an alarm and stalling commit lag.

This change moves the duplicate / missing checks to the user-facing API (`add_topic_metrics/1`, `remove_topic_metrics/1`) so the initiator still gets the expected error, while `pre_config_update/3` and `post_config_update/5` on replicates apply the change idempotently:

- `pre_config_update` on add: existing topic → `{ok, RawConf}` (no-op) instead of `{error, already_existed}`.
- `pre_config_update` on remove: missing topic → `{ok, RawConf -- [Topic]}` (no-op) instead of `{error, not_found}`.
- `post_config_update`: tolerate `emqx_topic_metrics:register/1` returning `{error, already_existed}` and `deregister/1` returning `{error, topic_not_found}`.

New cluster CT suite `emqx_modules_conf_cluster_SUITE` covers replicate-drift tolerance and that the public API still returns `not_found` for the initiator.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)