### PR TITLE
fix(banned): return original regex string in listing API

### DIFF
--- a/apps/emqx/src/emqx_banned.erl
+++ b/apps/emqx/src/emqx_banned.erl
@@ -114,13 +114,14 @@ check_clientid(ClientId) ->
     do_check({clientid, ClientId}) orelse do_check_rules(#{clientid => ClientId}).
 
 -spec format(emqx_types:banned()) -> map().
-format(#banned{
-    who = Who0,
-    by = By,
-    reason = Reason,
-    at = At,
-    until = Until
-}) ->
+format(#banned{} = Banned0) ->
+    #banned{
+        who = Who0,
+        by = By,
+        reason = Reason,
+        at = At,
+        until = Until
+    } = upgrade_legacy_rule(Banned0),
     {As, Who} = format_who(Who0),
     #{
         as => As,

--- a/apps/emqx_management/test/emqx_mgmt_api_banned_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_banned_SUITE.erl
@@ -8,6 +8,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/emqx.hrl").
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -280,6 +281,47 @@ t_delete(_Config) ->
         {error, {"HTTP/1.1", 404, "Not Found"}},
         delete_banned(binary_to_list(As), binary_to_list(Who))
     ),
+    ok.
+
+%% Pre-OTP-28 stored regex bans as `{clientid_re, {Compiled, Pattern}}`.
+%% The compiled tuple is not JSON-encodable, so listing must return the
+%% original pattern string. Regression test for issue #17133.
+t_list_legacy_re_pattern(_Config) ->
+    emqx_banned:clear(),
+    Now = erlang:system_time(second),
+    ClientIdPattern = <<"^(?!meshqtt_motaba_net$|![0-9a-f]{8}$).+">>,
+    UsernamePattern = <<"LegacyUser.*">>,
+    {ok, CompiledClientId} = re:compile(ClientIdPattern),
+    {ok, CompiledUsername} = re:compile(UsernamePattern),
+    LegacyClientIdBan = #banned{
+        who = {clientid_re, {CompiledClientId, ClientIdPattern}},
+        by = <<"mgmt_api">>,
+        reason = <<>>,
+        at = Now,
+        until = Now + 3600
+    },
+    LegacyUsernameBan = #banned{
+        who = {username_re, {CompiledUsername, UsernamePattern}},
+        by = <<"mgmt_api">>,
+        reason = <<>>,
+        at = Now,
+        until = Now + 3600
+    },
+    true = ets:insert(emqx_banned_rules, LegacyClientIdBan),
+    true = ets:insert(emqx_banned_rules, LegacyUsernameBan),
+    try
+        {ok, #{<<"data">> := Data}} = list_banned(),
+        Bans = lists:sort([{As, Who} || #{<<"as">> := As, <<"who">> := Who} <- Data]),
+        ?assertEqual(
+            [
+                {<<"clientid_re">>, ClientIdPattern},
+                {<<"username_re">>, UsernamePattern}
+            ],
+            Bans
+        )
+    after
+        emqx_banned:clear()
+    end,
     ok.
 
 t_clear(_Config) ->

--- a/changes/ee/fix-17134.en.md
+++ b/changes/ee/fix-17134.en.md
@@ -1,0 +1,1 @@
+Fixed `invalid json term` error returned by the banned clients listing API for client ID and username regex bans created before 6.2.0. The compiled regex retained in the database from the older release is now translated back to the original pattern string when serializing the response.


### PR DESCRIPTION
Fixes #17133

Release version: 6.1.2, 6.2.1

## Summary

Bans created on 6.0.x (OTP 27) for `clientid_re` / `username_re` are stored in mnesia as `{Compiled, Pattern}` tuples — the compiled `re_pattern` plus the original source. 6.1 switched to storing just the `Pattern` binary (commit `4b4716d943`) and added `upgrade_legacy_rule/1` so the read paths (`look_up`, `all_rules`, `do_check_rule`) still work for legacy mnesia rows. The same commit changed `format_who/1` to expect the new shape, but `emqx_banned:format/1` was not adapted, so the legacy 2-tuple flowed straight into the JSON response and `GET /api/v5/banned` failed with `invalid json term`.

The fix runs `upgrade_legacy_rule/1` inside `format/1` so the response always carries the original regex string. A regression test in `emqx_mgmt_api_banned_SUITE` inserts a legacy record directly into ETS and asserts the listing API returns the source pattern.

Targeting `release-61`; the standard release-61 → release-62 sync flow will carry it forward to 6.2.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)