### PR TITLE
fix(crl): accept DER-encoded CRL bodies and warn on undecodable ones

### DIFF
--- a/apps/emqx/src/emqx_crl_cache.erl
+++ b/apps/emqx/src/emqx_crl_cache.erl
@@ -205,6 +205,11 @@ do_http_fetch_and_cache(URL, HTTPTimeoutMS) ->
         {ok, {{_, 200, _}, _, Body}} ->
             case parse_crls(Body) of
                 error ->
+                    ?SLOG(warning, #{
+                        msg => "crl_http_fetch_decode_failed",
+                        url => URL,
+                        hint => "body is neither PEM nor DER"
+                    }),
                     {error, invalid_crl};
                 CRLs ->
                     %% Note: must ensure it's a string and not a
@@ -222,7 +227,17 @@ do_http_fetch_and_cache(URL, HTTPTimeoutMS) ->
 
 parse_crls(Bin) ->
     try
-        [CRL || {'CertificateList', CRL, not_encrypted} <- public_key:pem_decode(Bin)]
+        case [CRL || {'CertificateList', CRL, not_encrypted} <- public_key:pem_decode(Bin)] of
+            [] ->
+                %% Body wasn't PEM. RFC 5280 §5 mandates application/pkix-crl
+                %% (DER) for CRLs distributed over HTTP, so try decoding the
+                %% body as a single DER CertificateList. der_decode/2 raises
+                %% on garbage, which is caught below and reported as `error`.
+                _ = public_key:der_decode('CertificateList', Bin),
+                [Bin];
+            CRLs ->
+                CRLs
+        end
     catch
         _:_ ->
             error

--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -583,6 +583,8 @@ t_refresh_request_error(_Config) ->
     emqx_config_handler:stop(),
     ok.
 
+%% A body that is neither PEM nor DER must be reported as a decode failure
+%% so the listener does not silently cache an empty CRL list.
 t_refresh_invalid_response(_Config) ->
     meck:expect(
         emqx_crl_cache,
@@ -597,17 +599,51 @@ t_refresh_invalid_response(_Config) ->
     ?check_trace(
         ?wait_async_action(
             ?assertEqual(ok, emqx_crl_cache:refresh(URL)),
-            #{?snk_kind := crl_cache_insert},
+            #{?snk_kind := crl_refresh_failure},
             5_000
         ),
         fun(Trace) ->
             ?assertMatch(
-                [#{crls := []}],
-                ?of_kind(crl_cache_insert, Trace)
+                [#{error := invalid_crl} | _],
+                ?of_kind(crl_refresh_failure, Trace)
             ),
+            ?assertEqual([], ?of_kind(crl_cache_insert, Trace)),
             ok
         end
     ),
+    ok = snabbkaffe:stop(),
+    emqx_config_handler:stop(),
+    ok.
+
+%% RFC 5280 §5 mandates application/pkix-crl (DER) over HTTP. EMQX must
+%% decode such bodies and cache the CRL, not silently insert {der, []}.
+t_refresh_der_response(Config) ->
+    CRLDer = ?config(crl_der, Config),
+    meck:expect(
+        emqx_crl_cache,
+        http_get,
+        fun(_URL, _HTTPTimeout) ->
+            {ok, {{"HTTP/1.0", 200, 'OK'}, [], CRLDer}}
+        end
+    ),
+    emqx_config_handler:start_link(),
+    {ok, _} = emqx_crl_cache:start_link(),
+    URL = "http://localhost/crl.der",
+    URLBin = iolist_to_binary(URL),
+    Ref = get_crl_cache_table(),
+    ?check_trace(
+        ?wait_async_action(
+            ?assertEqual(ok, emqx_crl_cache:refresh(URL)),
+            #{?snk_kind := crl_cache_insert},
+            5_000
+        ),
+        fun(Trace) ->
+            Inserts = [maps:with([url, crls], E) || E <- ?of_kind(crl_cache_insert, Trace)],
+            ?assertEqual([#{url => URL, crls => [CRLDer]}], Inserts),
+            ok
+        end
+    ),
+    ?assertEqual([{URLBin, [CRLDer]}], ets:tab2list(Ref)),
     ok = snabbkaffe:stop(),
     emqx_config_handler:stop(),
     ok.

--- a/changes/ee/fix-17140.en.md
+++ b/changes/ee/fix-17140.en.md
@@ -1,0 +1,5 @@
+Fixed a silent failure when EMQX fetched a Certificate Revocation List (CRL) over HTTP from a server that returns a DER-encoded body (`Content-Type: application/pkix-crl`, the format mandated by RFC 5280 §5).
+
+Previously, EMQX only decoded PEM-encoded CRL bodies; a DER body was silently treated as zero CRLs and cached as an empty list, causing every TLS handshake on `enable_crl_check = true` listeners to fail with `bad_crls, no_relevant_crls` and no log line indicating what went wrong.
+
+EMQX now decodes both PEM and DER CRL bodies. When a fetched body is neither, a warning is logged with the URL so the misconfiguration is visible.


### PR DESCRIPTION
Fixes #17135

Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

`emqx_crl_cache:parse_crls/1` only decoded PEM bodies. RFC 5280 §5 mandates `application/pkix-crl` (DER) for CRLs distributed over HTTP, and many CAs serve CRLs that way by default. On a DER body, `public_key:pem_decode/1` returns `[]` (it does not raise), so the empty list was silently cached as `{der, []}` and every TLS handshake on `enable_crl_check = true` listeners then failed with `{bad_crls, no_relevant_crls}` — with no log line indicating that the CRL fetch decoded zero CRLs.

- `parse_crls/1`: when the PEM-decode comprehension yields `[]`, fall back to `public_key:der_decode('CertificateList', Bin)` inside the existing `try/catch`. On valid DER, the original body is stored as a single CRL; on garbage, the catch still surfaces the failure as `error`.
- `do_http_fetch_and_cache/2`: when `parse_crls/1` returns `error`, emit a `?SLOG(warning, ...)` with the URL and a hint that the body is neither PEM nor DER, so the misconfiguration is visible instead of silent.

CT covers the DER-body path (`t_refresh_der_response`) and updates `t_refresh_invalid_response` to assert that an undecodable body now surfaces as `crl_refresh_failure` with `error => invalid_crl` rather than a silent empty insert.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)