### PR TITLE
fix(coap): port token takeover fixes to release-60

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -297,11 +297,29 @@ handle_call(subscriptions, _From, Channel = #channel{session = Session}) ->
     {reply, {ok, maps:to_list(Subs)}, Channel};
 handle_call({check_token, ReqToken}, _From, Channel = #channel{token = Token}) ->
     {reply, ReqToken == Token, Channel};
+handle_call(
+    {check_token_and_get_clientinfo, ReqToken},
+    _From,
+    Channel = #channel{token = Token, clientinfo = ClientInfo}
+) ->
+    %% Do not propagate sensitive credentials via takeover probing API.
+    SanitizedClientInfo = maps:remove(password, ClientInfo),
+    Reply =
+        case ReqToken == Token of
+            true -> {ok, SanitizedClientInfo};
+            false -> false
+        end,
+    {reply, Reply, Channel};
 handle_call(kick, _From, Channel) ->
     NChannel = ensure_disconnected(kicked, Channel),
     shutdown_and_reply(kicked, ok, NChannel);
 handle_call(discard, _From, Channel) ->
     shutdown_and_reply(discarded, ok, Channel);
+handle_call({takeover, 'begin'}, _From, Channel = #channel{session = Session}) ->
+    {reply, Session, Channel};
+handle_call({takeover, 'end'}, _From, Channel) ->
+    NChannel = ensure_disconnected(takenover, Channel),
+    shutdown_and_reply(takenover, [], NChannel);
 handle_call(Req, _From, Channel) ->
     ?SLOG(error, #{msg => "unexpected_call", call => Req}),
     {reply, ignored, Channel}.
@@ -329,6 +347,11 @@ handle_cast(Req, Channel) ->
 -spec handle_info(Info :: term(), channel()) ->
     ok | {ok, channel()} | {shutdown, Reason :: term(), channel()}.
 handle_info({subscribe, _AutoSubs}, Channel) ->
+    {ok, Channel};
+handle_info(
+    {sock_closed, _Reason},
+    #channel{connection_required = true, conn_state = connected} = Channel
+) ->
     {ok, Channel};
 handle_info({sock_closed, Reason}, Channel) ->
     shutdown(Reason, Channel);
@@ -385,9 +408,11 @@ check_auth_state(Msg, #channel{connection_required = true} = Channel) ->
             call_session(handle_request, Msg, Channel);
         false ->
             URIQuery = emqx_coap_message:extract_uri_query(Msg),
-            case maps:get(<<"token">>, URIQuery, undefined) of
+            case get_query_value(<<"token">>, URIQuery) of
                 undefined ->
-                    ?SLOG(debug, #{msg => "token_required_in_conn_mode", message => Msg});
+                    %% Connection mode policy: reject requests without token/clientid.
+                    ?SLOG(debug, #{msg => "token_required_in_conn_mode", message => Msg}),
+                    missing_token_or_clientid_reply(Msg, Channel);
                 _ ->
                     check_token(Msg, Channel)
             end
@@ -427,24 +452,128 @@ check_token(
     } = Channel
 ) ->
     #{clientid := ClientId} = ClientInfo,
-    case emqx_coap_message:extract_uri_query(Msg) of
-        #{
-            <<"clientid">> := ClientId,
-            <<"token">> := Token
-        } ->
-            call_session(handle_request, Msg, Channel);
-        _ ->
-            %% This channel is create by this DELETE command, so here can safely close this channel
-            case Token =:= undefined andalso is_delete_connection_request(Msg) of
-                true ->
-                    Reply = emqx_coap_message:piggyback({ok, deleted}, Msg),
-                    {shutdown, normal, Reply, Channel};
-                false ->
-                    ErrMsg = <<"Missing token or clientid in connection mode">>,
-                    Reply = emqx_coap_message:piggyback({error, bad_request}, ErrMsg, Msg),
-                    {ok, {outgoing, Reply}, Channel}
+    URIQuery = emqx_coap_message:extract_uri_query(Msg),
+    ReqClientId = get_query_value(<<"clientid">>, URIQuery),
+    ReqToken = get_query_value(<<"token">>, URIQuery),
+    case Token =:= undefined andalso is_delete_connection_request(Msg) of
+        true ->
+            Reply = emqx_coap_message:piggyback({ok, deleted}, Msg),
+            {shutdown, normal, Reply, Channel};
+        false ->
+            case {ReqClientId, ReqToken} of
+                {ClientId, Token} when ReqClientId =/= undefined, ReqToken =/= undefined ->
+                    call_session(handle_request, Msg, Channel);
+                {ClientId, ReqToken1} when
+                    ReqClientId =/= undefined, ReqToken1 =/= undefined, ReqToken1 =/= Token
+                ->
+                    %% Same clientid with mismatched token should be rejected directly.
+                    invalid_token_reply(Msg, Channel);
+                {ReqClientId1, ReqToken1} when
+                    ReqClientId1 =/= undefined,
+                    ReqToken1 =/= undefined,
+                    ReqClientId1 =/= ClientId
+                ->
+                    try_takeover_with_token(Msg, ReqClientId1, ReqToken1, Channel);
+                _ ->
+                    missing_token_or_clientid_reply(Msg, Channel)
             end
     end.
+
+try_takeover_with_token(Msg, ReqClientId, ReqToken, Channel) ->
+    case emqx_gateway_cm:call(coap, ReqClientId, {check_token_and_get_clientinfo, ReqToken}) of
+        {ok, ResumeClientInfo} ->
+            takeover_and_handle_request(Msg, ReqClientId, ReqToken, ResumeClientInfo, Channel);
+        undefined ->
+            invalid_token_reply(Msg, Channel);
+        false ->
+            invalid_token_reply(Msg, Channel);
+        _ ->
+            invalid_token_reply(Msg, Channel)
+    end.
+
+takeover_and_handle_request(Msg, ReqClientId, ReqToken, ResumeClientInfo, Channel) ->
+    #channel{ctx = Ctx, conninfo = ConnInfo, clientinfo = ClientInfo0} = Channel,
+    NClientInfo = merge_takeover_clientinfo(ReqClientId, ClientInfo0, ResumeClientInfo),
+    CreateSessionFun = fun(_, _) -> emqx_coap_session:new() end,
+    case
+        emqx_gateway_ctx:open_session(
+            Ctx, false, NClientInfo, ConnInfo, CreateSessionFun, emqx_coap_session
+        )
+    of
+        {ok, #{session := Session, present := true}} ->
+            Channel0 = Channel#channel{
+                session = Session,
+                clientinfo = NClientInfo,
+                token = ReqToken
+            },
+            NChannel = ensure_connected(Channel0),
+            call_session(handle_request, Msg, NChannel);
+        {ok, #{present := false}} ->
+            ok = maybe_unregister_channel(ReqClientId),
+            invalid_token_reply(Msg, Channel);
+        _ ->
+            invalid_token_reply(Msg, Channel)
+    end.
+
+merge_takeover_clientinfo(ReqClientId, ClientInfo0, ResumeClientInfo) ->
+    BaseClientInfo = ClientInfo0#{clientid => ReqClientId},
+    lists:foldl(
+        fun(Key, Acc) ->
+            case maps:find(Key, ResumeClientInfo) of
+                {ok, Value} ->
+                    Acc#{Key => Value};
+                error ->
+                    Acc
+            end
+        end,
+        BaseClientInfo,
+        [username, is_superuser, auth_expire_at, mountpoint, enable_authn]
+    ).
+
+invalid_token_reply(Msg, Channel) ->
+    ErrMsg = <<"Invalid token or clientid in connection mode">>,
+    Reply = emqx_coap_message:piggyback({error, unauthorized}, ErrMsg, Msg),
+    {ok, {outgoing, Reply}, Channel}.
+
+missing_token_or_clientid_reply(Msg, Channel) ->
+    ErrMsg = <<"Missing token or clientid in connection mode">>,
+    Reply = emqx_coap_message:piggyback({error, bad_request}, ErrMsg, Msg),
+    {ok, {outgoing, Reply}, Channel}.
+
+maybe_unregister_channel(ReqClientId) ->
+    try emqx_gateway_cm:unregister_channel(coap, ReqClientId) of
+        ok ->
+            ok
+    catch
+        _:Reason ->
+            ?SLOG(warning, #{
+                msg => "failed_unregister_takeover_fallback_channel",
+                clientid => ReqClientId,
+                reason => Reason
+            }),
+            ok
+    end.
+
+get_query_value(Key, URIQuery) ->
+    RawValue =
+        case maps:find(Key, URIQuery) of
+            {ok, Value} ->
+                Value;
+            error ->
+                maps:get(binary_to_list(Key), URIQuery, undefined)
+        end,
+    normalize_query_value(RawValue).
+
+normalize_query_value(undefined) ->
+    undefined;
+normalize_query_value(Value) when is_binary(Value) ->
+    Value;
+normalize_query_value(Value) when is_list(Value) ->
+    list_to_binary(Value);
+normalize_query_value(Value) when is_integer(Value) ->
+    integer_to_binary(Value);
+normalize_query_value(Value) ->
+    Value.
 
 run_conn_hooks(
     Input,
@@ -598,14 +727,27 @@ metrics_inc(Name, Ctx) ->
 ensure_connected(
     Channel = #channel{
         ctx = Ctx,
-        conninfo = ConnInfo,
+        conninfo = ConnInfo0,
         clientinfo = ClientInfo
     }
 ) ->
+    ConnInfo = ensure_conninfo_required_fields(ClientInfo, ConnInfo0),
     NConnInfo = ConnInfo#{connected_at => erlang:system_time(millisecond)},
     _ = run_hooks(Ctx, 'client.connack', [NConnInfo, connection_accepted, #{}]),
     ok = run_hooks(Ctx, 'client.connected', [ClientInfo, NConnInfo]),
     schedule_connection_expire(Channel#channel{conninfo = NConnInfo, conn_state = connected}).
+
+ensure_conninfo_required_fields(ClientInfo, ConnInfo0) ->
+    ClientId = maps:get(clientid, ClientInfo, maps:get(clientid, ConnInfo0, undefined)),
+    ConnInfo1 =
+        case ClientId of
+            undefined -> ConnInfo0;
+            _ -> ConnInfo0#{clientid => ClientId}
+        end,
+    ConnInfo1#{
+        proto_name => maps:get(proto_name, ConnInfo1, <<"CoAP">>),
+        proto_ver => maps:get(proto_ver, ConnInfo1, <<"1">>)
+    }.
 
 %%--------------------------------------------------------------------
 %% Ensure disconnected

--- a/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
@@ -24,25 +24,59 @@ find_or_create(CId, Transport, Peer, Opts) ->
             emqx_gateway_conn:start_link(Transport, Peer, Opts)
     end.
 
-get_connection_id(_Transport, _Peer, State, Data) ->
-    case parse_incoming(Data, [], State) of
-        {[Msg | _] = Packets, NState} ->
-            case emqx_coap_message:extract_uri_query(Msg) of
-                #{
-                    <<"clientid">> := ClientId
-                } ->
-                    {ok, ClientId, Packets, NState};
-                _ ->
-                    ErrMsg = <<"Missing token or clientid in connection mode">>,
-                    Reply = emqx_coap_message:piggyback({error, bad_request}, ErrMsg, Msg),
-                    Bin = emqx_coap_frame:serialize_pkt(
-                        Reply, emqx_coap_frame:serialize_opts()
-                    ),
-                    {error, Bin}
-            end;
+get_connection_id(_Transport, Peer, State, Data) ->
+    {ParseState, BoundCId} = split_state(State),
+    case parse_incoming(Data, [], ParseState) of
+        {[#coap_message{} = Msg | _] = Packets, NState} ->
+            {CId, NBoundCId} = choose_cid(Msg, BoundCId, Peer),
+            {ok, CId, Packets, merge_state(NState, NBoundCId)};
         _Error ->
             invalid
     end.
+
+peer_id(Peer) ->
+    {peer, Peer}.
+
+split_state(#{parse_state := ParseState, cid := BoundCId}) ->
+    {ParseState, BoundCId};
+split_state(#{parse_state := ParseState}) ->
+    {ParseState, undefined};
+split_state(ParseState) ->
+    {ParseState, undefined}.
+
+merge_state(ParseState, BoundCId) ->
+    #{parse_state => ParseState, cid => BoundCId}.
+
+choose_cid(Msg, BoundCId, Peer) ->
+    URIQuery = emqx_coap_message:extract_uri_query(Msg),
+    ReqClientId = normalize_clientid(extract_clientid(URIQuery)),
+    select_cid(ReqClientId, BoundCId, Peer).
+
+extract_clientid(URIQuery) ->
+    case maps:find(<<"clientid">>, URIQuery) of
+        {ok, ClientId} ->
+            ClientId;
+        error ->
+            maps:get("clientid", URIQuery, undefined)
+    end.
+
+normalize_clientid(undefined) ->
+    undefined;
+normalize_clientid(ClientId) when is_binary(ClientId) ->
+    ClientId;
+normalize_clientid(ClientId) when is_list(ClientId) ->
+    list_to_binary(ClientId);
+normalize_clientid(_Other) ->
+    undefined.
+
+select_cid(undefined, undefined, Peer) ->
+    {peer_id(Peer), undefined};
+select_cid(undefined, BoundCId, _Peer) ->
+    {BoundCId, BoundCId};
+select_cid(ReqClientId, undefined, _Peer) ->
+    {ReqClientId, ReqClientId};
+select_cid(_ReqClientId, BoundCId, _Peer) ->
+    {BoundCId, BoundCId}.
 
 dispatch(Pid, _State, Packet) ->
     erlang:send(Pid, Packet).

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -11,6 +11,7 @@
 %% API
 -export([
     new/0,
+    resume/2,
     process_subscribe/4
 ]).
 
@@ -75,6 +76,10 @@ new() ->
         observe_manager = emqx_coap_observe_res:new_manager(),
         created_at = erlang:system_time(millisecond)
     }.
+
+-spec resume(emqx_types:clientinfo(), session()) -> session().
+resume(_ClientInfo, Session = #session{}) ->
+    Session.
 
 %%--------------------------------------------------------------------
 %% Info, Stats

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -659,6 +659,158 @@ t_connectionless_pubsub(_) ->
     do(Fun),
     update_coap_with_connection_mode(true).
 
+t_request_with_partial_token_params(_) ->
+    with_connection(fun(Channel, Token) ->
+        URI1 = compose_uri(
+            ?PS_PREFIX ++ "/only_clientid",
+            #{"clientid" => <<"client1">>},
+            false
+        ),
+        Req1 = make_req(post, <<"x">>),
+        ?assertMatch({error, bad_request, _}, do_request(Channel, URI1, Req1)),
+
+        URI2 = compose_uri(
+            ?PS_PREFIX ++ "/only_token",
+            #{"token" => list_to_binary(Token)},
+            false
+        ),
+        Req2 = make_req(post, <<"x">>),
+        ?assertMatch({error, bad_request, _}, do_request(Channel, URI2, Req2)),
+        true
+    end).
+
+t_token_takeover_across_udp_sessions(_) ->
+    {ok, Sock1, Channel1} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    Token = connection(Channel1),
+    timer:sleep(100),
+    ?assertNotEqual([], emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)),
+    er_coap_channel:close(Channel1),
+    er_coap_udp_socket:close(Sock1),
+    timer:sleep(100),
+    ?assertNotEqual([], emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)),
+
+    {ok, Sock2, Channel2} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    URI = compose_uri(
+        ?PS_PREFIX ++ "/coap/udp_takeover",
+        #{
+            "clientid" => <<"client1">>,
+            "token" => list_to_binary(Token)
+        },
+        false
+    ),
+    Req = make_req(post, <<"x">>),
+    ?assertMatch({ok, changed, _}, do_request(Channel2, URI, Req)),
+    ?assertEqual(1, length(emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>))),
+    disconnection(Channel2, Token),
+    er_coap_channel:close(Channel2),
+    er_coap_udp_socket:close(Sock2).
+
+t_invalid_token_rejected_across_udp_sessions(_) ->
+    {ok, Sock1, Channel1} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    Token = connection(Channel1),
+    er_coap_channel:close(Channel1),
+    er_coap_udp_socket:close(Sock1),
+    timer:sleep(100),
+    ?assertNotEqual([], emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)),
+
+    {ok, Sock2, Channel2} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    URI = compose_uri(
+        ?PS_PREFIX ++ "/coap/udp_invalid_token",
+        #{
+            "clientid" => <<"client1">>,
+            "token" => <<"wrong-token">>
+        },
+        false
+    ),
+    Req = make_req(post, <<"x">>),
+    ?assertMatch({error, uauthorized, _}, do_request(Channel2, URI, Req)),
+    disconnection(Channel2, Token),
+    er_coap_channel:close(Channel2),
+    er_coap_udp_socket:close(Sock2).
+
+t_wrong_clientid_with_valid_token_rejected_across_udp_sessions(_) ->
+    {ok, Sock1, Channel1} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    Token = connection(Channel1),
+    er_coap_channel:close(Channel1),
+    er_coap_udp_socket:close(Sock1),
+    timer:sleep(100),
+    ?assertNotEqual([], emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)),
+
+    {ok, Sock2, Channel2} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    URI = compose_uri(
+        ?PS_PREFIX ++ "/coap/udp_wrong_clientid",
+        #{
+            "clientid" => <<"client2">>,
+            "token" => list_to_binary(Token)
+        },
+        false
+    ),
+    Req = make_req(post, <<"x">>),
+    ?assertMatch({error, uauthorized, _}, do_request(Channel2, URI, Req)),
+    disconnection(Channel2, Token),
+    er_coap_channel:close(Channel2),
+    er_coap_udp_socket:close(Sock2).
+
+t_proxy_conn_reuse_bound_clientid_when_missing(_) ->
+    Peer = {{127, 0, 0, 1}, 12345},
+    State0 = emqx_coap_proxy_conn:initialize([]),
+    Msg1 = #coap_message{
+        type = con,
+        method = post,
+        id = 1,
+        options = #{
+            uri_path => [<<"mqtt">>, <<"connection">>],
+            uri_query => #{<<"clientid">> => <<"client1">>}
+        }
+    },
+    Bin1 = emqx_coap_frame:serialize_pkt(Msg1, emqx_coap_frame:serialize_opts()),
+    {ok, <<"client1">>, _Packets1, State1} =
+        emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State0, Bin1),
+    Msg2 = #coap_message{
+        type = con,
+        method = put,
+        id = 2,
+        options = #{
+            uri_path => [<<"mqtt">>, <<"connection">>],
+            uri_query => #{}
+        }
+    },
+    Bin2 = emqx_coap_frame:serialize_pkt(Msg2, emqx_coap_frame:serialize_opts()),
+    ?assertMatch(
+        {ok, <<"client1">>, _Packets2, _State2},
+        emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State1, Bin2)
+    ).
+
+t_proxy_conn_keep_bound_clientid_on_different_clientid(_) ->
+    Peer = {{127, 0, 0, 1}, 12345},
+    State0 = emqx_coap_proxy_conn:initialize([]),
+    Msg1 = #coap_message{
+        type = con,
+        method = post,
+        id = 1,
+        options = #{
+            uri_path => [<<"mqtt">>, <<"connection">>],
+            uri_query => #{<<"clientid">> => <<"client1">>}
+        }
+    },
+    Bin1 = emqx_coap_frame:serialize_pkt(Msg1, emqx_coap_frame:serialize_opts()),
+    {ok, <<"client1">>, _Packets1, State1} =
+        emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State0, Bin1),
+    Msg2 = #coap_message{
+        type = con,
+        method = post,
+        id = 2,
+        options = #{
+            uri_path => [<<"mqtt">>, <<"connection">>],
+            uri_query => #{<<"clientid">> => <<"client2">>}
+        }
+    },
+    Bin2 = emqx_coap_frame:serialize_pkt(Msg2, emqx_coap_frame:serialize_opts()),
+    ?assertMatch(
+        {ok, <<"client1">>, _Packets2, _State2},
+        emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State1, Bin2)
+    ).
+
 %%--------------------------------------------------------------------
 %% helpers
 

--- a/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
@@ -104,3 +104,109 @@ t_connection(_Config) ->
 
     er_coap_channel:close(Channel),
     er_coap_dtls_socket:close(Sock).
+
+t_same_dtls_session_token_request(_Config) ->
+    {ok, Sock, Channel} = er_coap_dtls_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    Prefix = ?MQTT_PREFIX ++ "/connection",
+    Queries0 = #{
+        "clientid" => <<"client1">>,
+        "username" => <<"admin">>,
+        "password" => <<"public">>
+    },
+    URI0 = emqx_coap_SUITE:compose_uri(Prefix, Queries0, false),
+    Req0 = emqx_coap_SUITE:make_req(post),
+    {ok, created, Data} = emqx_coap_SUITE:do_request(Channel, URI0, Req0),
+    #coap_content{payload = BinToken} = Data,
+    Token = binary_to_list(BinToken),
+
+    URI1 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/same_session",
+        #{
+            "clientid" => <<"client1">>,
+            "token" => Token
+        },
+        false
+    ),
+    Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    {ok, changed, _} = emqx_coap_SUITE:do_request(Channel, URI1, Req1),
+
+    er_coap_channel:close(Channel),
+    er_coap_dtls_socket:close(Sock).
+
+t_wrong_clientid_with_valid_token_rejected(_Config) ->
+    {ok, Sock1, Channel1} = er_coap_dtls_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    Prefix = ?MQTT_PREFIX ++ "/connection",
+    Queries0 = #{
+        "clientid" => <<"client1">>,
+        "username" => <<"admin">>,
+        "password" => <<"public">>
+    },
+    URI0 = emqx_coap_SUITE:compose_uri(Prefix, Queries0, false),
+    Req0 = emqx_coap_SUITE:make_req(post),
+    {ok, created, Data} = emqx_coap_SUITE:do_request(Channel1, URI0, Req0),
+    #coap_content{payload = BinToken} = Data,
+    Token = binary_to_list(BinToken),
+
+    er_coap_channel:close(Channel1),
+    er_coap_dtls_socket:close(Sock1),
+    timer:sleep(100),
+    ?assertNotEqual([], emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)),
+
+    {ok, Sock2, Channel2} = er_coap_dtls_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+    URI1 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/test",
+        #{
+            "clientid" => <<"client2">>,
+            "token" => Token
+        },
+        false
+    ),
+    Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    ?assertMatch({error, uauthorized, _}, emqx_coap_SUITE:do_request(Channel2, URI1, Req1)),
+
+    er_coap_channel:close(Channel2),
+    er_coap_dtls_socket:close(Sock2).
+
+t_partial_token_params_rejected(_Config) ->
+    {ok, Sock, Channel} = er_coap_dtls_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    Prefix = ?MQTT_PREFIX ++ "/connection",
+    Queries0 = #{
+        "clientid" => <<"client1">>,
+        "username" => <<"admin">>,
+        "password" => <<"public">>
+    },
+    URI0 = emqx_coap_SUITE:compose_uri(Prefix, Queries0, false),
+    Req0 = emqx_coap_SUITE:make_req(post),
+    {ok, created, Data} = emqx_coap_SUITE:do_request(Channel, URI0, Req0),
+    #coap_content{payload = BinToken} = Data,
+    Token = binary_to_list(BinToken),
+
+    URI1 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/missing_token",
+        #{"clientid" => <<"client1">>},
+        false
+    ),
+    Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    ?assertMatch({error, bad_request, _}, emqx_coap_SUITE:do_request(Channel, URI1, Req1)),
+
+    URI2 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/missing_clientid",
+        #{"token" => Token},
+        false
+    ),
+    Req2 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    ?assertMatch({error, bad_request, _}, emqx_coap_SUITE:do_request(Channel, URI2, Req2)),
+
+    er_coap_channel:close(Channel),
+    er_coap_dtls_socket:close(Sock).

--- a/changes/ee/fix-17141.en.md
+++ b/changes/ee/fix-17141.en.md
@@ -1,0 +1,1 @@
+Fixed CoAP connection-mode token takeover so reconnecting UDP/DTLS clients can resume with a valid token while invalid token/clientid combinations are rejected. Also ensured required connection info fields are present before running CoAP takeover connected hooks.


### PR DESCRIPTION
Backports #16996 and #17004

Release version:
6.0.3

## Summary

This ports the CoAP connection-mode token takeover fixes from `release-62` back to `release-60`.

* `emqx_coap_channel` now validates takeover token/clientid combinations without self-calling the current channel, resumes the existing CoAP session when the token belongs to a disconnected connection, and preserves required client/connection metadata before running connected hooks.
* `emqx_coap_proxy_conn` now keeps routing later UDP packets for a peer to the first bound clientid, including packets that omit or change `clientid`, so takeover validation happens in the channel instead of losing the original routing context.
* `emqx_coap_session` exposes `resume/2` for gateway session takeover compatibility.
* Regression coverage was added to the `release-60` CoAP suites that still exist, instead of restoring `release-62`-only split test suites. This keeps the later `release-60 -> release-62` merge focused on equivalent behavior rather than resurrected test files.

Validation run:

* `make test-compile`
* `env ERL_FLAGS="-kernel prevent_overlapping_partitions false" PROFILE=emqx-enterprise-test ./mix ct --suites apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl --cases t_request_with_partial_token_params,t_token_takeover_across_udp_sessions,t_invalid_token_rejected_across_udp_sessions,t_wrong_clientid_with_valid_token_rejected_across_udp_sessions,t_proxy_conn_reuse_bound_clientid_when_missing,t_proxy_conn_keep_bound_clientid_on_different_clientid`
* `env ERL_FLAGS="-kernel prevent_overlapping_partitions false" PROFILE=emqx-enterprise-test ./mix ct --suites apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl --cases t_same_dtls_session_token_request,t_wrong_clientid_with_valid_token_rejected,t_partial_token_params_rejected`
* `EMQX_NODE__RPC__PORT=5379 CT_NODE_NAME='coaptest@127.0.0.1' make apps/emqx_gateway_coap-ct`
* `./scripts/erlfmt -c apps/emqx_gateway_coap/src/emqx_coap_channel.erl apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl apps/emqx_gateway_coap/src/emqx_coap_session.erl apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl`
* `git diff --check`

## PR Checklist

- ~For internal contributor: there is a jira ticket to track this change~
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

No schema changes are included.