### PR TITLE
chore: restrict erts limits for nodetool invocations

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -466,7 +466,8 @@ gen_node_id() {
 }
 
 call_nodetool() {
-    "$ERTS_DIR/bin/escript" "$RUNNER_ROOT_DIR/bin/nodetool" "$@"
+    ERL_FLAGS="${ERL_FLAGS:-} +P 65536 +Q 65536 +S 2" \
+        "$ERTS_DIR/bin/escript" "$RUNNER_ROOT_DIR/bin/nodetool" "$@"
 }
 
 # Control a node


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

This PR applies ERTS system limits to `nodetool` invocations, similar to those already used for most maintenance scripts, in order to limit resource usage (especially, memory) of maintenance activities that can be prohibitively expensive in some environments.

For example, running `nodetool` under Kind K8s with extremely high nofile limit causes it to consume ~2GiB right after starting.

## PR Checklist

- [ ] ~~The changes are covered with new or existing tests~~
    Verified manually.
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
