### PR TITLE
Support authorization source preconditions

### DIFF
--- a/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
@@ -370,7 +370,7 @@ ensure_deleted(#{enable := false}, _) ->
 ensure_deleted(SourceState, #{clear_metric := ClearMetric}) ->
     Type = type(SourceState),
     Module = authz_module(Type),
-    Module:destroy(SourceState),
+    Module:destroy(cleanup_precondition(SourceState)),
     ClearMetric andalso emqx_metrics_worker:clear_metrics(authz_metrics, Type).
 
 %% Called for both sources and raw sources
@@ -397,11 +397,45 @@ create_sources(Sources) ->
 
 create_source(#{type := Type} = Source) ->
     Module = authz_module(Type),
-    Module:create(Source).
+    case compile_precondition(Source) of
+        {ok, Precondition} ->
+            SourceState = Module:create(cleanup_precondition(Source)),
+            maybe_add_precondition(SourceState, Precondition);
+        {error, Reason} ->
+            error(#{cause => "bad_precondition_expression", reason => Reason})
+    end.
 
 update_source(Type, OldSourceState, NewSource) ->
     Module = authz_module(Type),
-    Module:update(OldSourceState, NewSource).
+    case compile_precondition(NewSource) of
+        {ok, Precondition} ->
+            SourceState = Module:update(
+                cleanup_precondition(OldSourceState),
+                cleanup_precondition(NewSource)
+            ),
+            maybe_add_precondition(SourceState, Precondition);
+        {error, Reason} ->
+            error(#{cause => "bad_precondition_expression", reason => Reason})
+    end.
+
+compile_precondition(Source) ->
+    Expr = maps:get(precondition, Source, undefined),
+    do_compile_precondition(Expr).
+
+do_compile_precondition(undefined) ->
+    {ok, undefined};
+do_compile_precondition(<<>>) ->
+    {ok, undefined};
+do_compile_precondition(Expr) ->
+    emqx_variform:compile(Expr).
+
+cleanup_precondition(Source) ->
+    maps:remove(precondition, Source).
+
+maybe_add_precondition(SourceState, undefined) ->
+    SourceState;
+maybe_add_precondition(SourceState, Precondition) ->
+    SourceState#{precondition => Precondition}.
 
 init_metrics(Source) ->
     Type = type(Source),
@@ -499,13 +533,32 @@ do_authorize(_Client, _Action, _Topic, []) ->
     nomatch;
 do_authorize(Client, Action, Topic, [#{enable := false} = _SourceState | SourceStates]) ->
     do_authorize(Client, Action, Topic, SourceStates);
-do_authorize(
+do_authorize(Client, Action, Topic, [#{precondition := Precondition} = SourceState | SourceStates]) ->
+    case check_precondition(Precondition, Client, Action, Topic) of
+        true ->
+            do_authorize_with_source(Client, Action, Topic, SourceState, SourceStates);
+        Other ->
+            Type = type(SourceState),
+            emqx_metrics_worker:inc(authz_metrics, Type, total),
+            emqx_metrics_worker:inc(authz_metrics, Type, ignore),
+            ?TRACE("AUTHZ", "authorization_precondition_not_met", #{
+                authorize_type => Type,
+                expression => emqx_variform:decompile(Precondition),
+                result => Other
+            }),
+            do_authorize(Client, Action, Topic, SourceStates)
+    end;
+do_authorize(Client, Action, Topic, [SourceState | SourceStates]) ->
+    do_authorize_with_source(Client, Action, Topic, SourceState, SourceStates).
+
+do_authorize_with_source(
     #{
         username := Username
     } = Client,
     Action = ?authz_action(_PubSub),
     Topic,
-    [SourceState | SourceStates]
+    SourceState,
+    SourceStates
 ) ->
     Type = type(SourceState),
     Module = authz_module(Type),
@@ -555,6 +608,21 @@ do_authorize(
             do_authorize(Client, Action, Topic, SourceStates);
         {matched, _Permission} = Matched ->
             {Matched, Type}
+    end.
+
+check_precondition(undefined, _Client, _Action, _Topic) ->
+    true;
+check_precondition(Precondition, Client0, Action, Topic) ->
+    Client = emqx_auth_template:rename_client_info_vars(Client0),
+    Vars = Client#{
+        action => maps:get(action_type, Action),
+        topic => Topic
+    },
+    case emqx_variform:render(Precondition, Vars) of
+        {ok, <<"true">>} ->
+            true;
+        Other ->
+            Other
     end.
 
 inc_metrics(Type, nomatch) ->

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
@@ -206,6 +206,12 @@ authz_common_fields(Type) ->
                 default => true,
                 importance => ?IMPORTANCE_NO_DOC,
                 desc => ?DESC(enable)
+            })},
+        {precondition,
+            ?HOCON(binary(), #{
+                default => <<>>,
+                validator => fun validate_precondition/1,
+                desc => ?DESC(precondition)
             })}
     ].
 
@@ -270,8 +276,25 @@ default_authz() ->
     #{
         <<"type">> => <<"file">>,
         <<"enable">> => true,
+        <<"precondition">> => <<>>,
         <<"path">> => <<"${EMQX_ETC_DIR}/acl.conf">>
     }.
+
+validate_precondition(undefined) ->
+    ok;
+validate_precondition(<<>>) ->
+    ok;
+validate_precondition(Expression) ->
+    case emqx_variform:compile(Expression) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            {error, #{
+                cause => "bad_precondition_expression",
+                expression => Expression,
+                reason => Reason
+            }}
+    end.
 
 common_field() ->
     [

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
@@ -337,6 +337,7 @@ t_replace_all(_) ->
         emqx_conf:get([authorization, sources], [])
     ),
     %% hooks status
+    SourceStates = emqx_authz:lookup_states(),
     ?assertMatch(
         [
             #{type := file, enable := true},
@@ -346,8 +347,9 @@ t_replace_all(_) ->
             #{type := mongodb, enable := true},
             #{type := http, enable := true}
         ],
-        emqx_authz:lookup_states()
+        SourceStates
     ),
+    ?assert(lists:all(fun(State) -> not maps:is_key(precondition, State) end, SourceStates)),
     Ids = [http, mongodb, mysql, postgresql, redis, file],
     %% metrics
     lists:foreach(
@@ -480,6 +482,119 @@ t_get_enabled_authzs_some_enabled(_Config) ->
         ?SOURCE_POSTGRESQL, ?SOURCE_REDIS#{<<"enable">> := false}
     ]),
     ?assertEqual([postgresql], emqx_authz:get_enabled_authzs()).
+
+t_bad_precondition(_) ->
+    Source = ?SOURCE_HTTP#{<<"precondition">> => <<"not a valid precondition">>},
+    ?assertMatch(
+        {error, #{
+            kind := validation_error,
+            matched_type := "authz:http_get",
+            path := "authorization.sources.1.precondition",
+            reason := #{
+                cause := "bad_precondition_expression",
+                expression := <<"not a valid precondition">>
+            }
+        }},
+        emqx_authz:update(?CMD_REPLACE, [Source])
+    ).
+
+t_precondition_render_error_skips_source(_Config) ->
+    Source = ?SOURCE_HTTP#{<<"precondition">> => <<"nth(1, undefined_var)">>},
+    {ok, _} = emqx_authz:update(?CMD_REPLACE, [Source]),
+    ?check_trace(
+        begin
+            ClientInfo = emqx_authz_test_lib:base_client_info(),
+            deny = emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t">>),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([], ?of_kind(fake_source_authz, Trace)),
+            ?assertMatch(
+                #{counters := #{total := 1, ignore := 1}},
+                emqx_metrics_worker:get_metrics(authz_metrics, http)
+            ),
+            ok
+        end
+    ).
+
+t_precondition_skips_source(_Config) ->
+    ClientInfo = #{
+        username => <<"u">>,
+        clientid => <<"c">>,
+        listener => <<"tcp:default">>,
+        client_attrs => #{<<"biz">> => <<"device">>},
+        is_superuser => false
+    },
+    HttpSource = ?SOURCE_HTTP#{<<"precondition">> => <<"str_eq(client_attrs.biz, 'order')">>},
+    RedisSource = ?SOURCE_REDIS#{<<"precondition">> => <<"str_eq(client_attrs.biz, 'device')">>},
+    {ok, _} = emqx_authz:update(?CMD_REPLACE, [HttpSource, RedisSource]),
+    ?check_trace(
+        begin
+            deny = emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t">>),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [
+                    #{src := #{type := redis}}
+                ],
+                ?of_kind(fake_source_authz, Trace)
+            ),
+            ok
+        end
+    ).
+
+t_precondition_request_vars(_Config) ->
+    ClientInfo = #{
+        username => <<"u">>,
+        clientid => <<"c">>,
+        listener => <<"tcp:default">>,
+        client_attrs => #{<<"biz">> => <<"device">>},
+        is_superuser => false
+    },
+    TopicSource = ?SOURCE_HTTP#{
+        <<"precondition">> => <<"topic_match(topic, topic_join([clientid, '#']))">>
+    },
+    {ok, _} = emqx_authz:update(?CMD_REPLACE, [TopicSource]),
+    ?check_trace(
+        begin
+            deny = emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"c/t">>),
+            deny = emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"other/t">>),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([_], ?of_kind(fake_source_authz, Trace)),
+            ok
+        end
+    ),
+    ActionSource = ?SOURCE_HTTP#{<<"precondition">> => <<"str_eq(action, 'publish')">>},
+    {ok, _} = emqx_authz:update(?CMD_REPLACE, [ActionSource]),
+    ?check_trace(
+        begin
+            deny = emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t">>),
+            deny = emqx_access_control:authorize(ClientInfo, ?AUTHZ_SUBSCRIBE, <<"c/t">>),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([_], ?of_kind(fake_source_authz, Trace)),
+            ok
+        end
+    ).
+
+t_precondition_qos_is_not_available(_Config) ->
+    Source = ?SOURCE_HTTP#{<<"precondition">> => <<"num_eq(qos, 1)">>},
+    {ok, _} = emqx_authz:update(?CMD_REPLACE, [Source]),
+    ?check_trace(
+        begin
+            ClientInfo = emqx_authz_test_lib:base_client_info(),
+            deny = emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH(?QOS_1), <<"t">>),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([], ?of_kind(fake_source_authz, Trace)),
+            ok
+        end
+    ).
 
 t_subscribe_deny_disconnect_publishes_last_will_testament(_Config) ->
     {ok, _} = emqx_authz:update(?CMD_REPLACE, [?SOURCE_FILE2]),

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_source_http_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_source_http_SUITE.erl
@@ -65,6 +65,7 @@ end_per_suite(Config) ->
     ok.
 
 init_per_testcase(t_api, Config) ->
+    {ok, _} = emqx_authz:update(replace, []),
     meck:new(emqx_utils, [non_strict, passthrough, no_history, no_link]),
     meck:expect(emqx_utils, gen_id, fun() -> "fake" end),
 
@@ -79,13 +80,16 @@ init_per_testcase(t_api, Config) ->
     ),
     Config;
 init_per_testcase(_, Config) ->
+    {ok, _} = emqx_authz:update(replace, []),
     Config.
 
 end_per_testcase(t_api, _Config) ->
+    {ok, _} = emqx_authz:update(replace, []),
     meck:unload(emqx_utils),
     meck:unload(emqx),
     ok;
 end_per_testcase(_, _Config) ->
+    {ok, _} = emqx_authz:update(replace, []),
     ok.
 
 %%------------------------------------------------------------------------------
@@ -129,5 +133,65 @@ t_http_headers_api(_) ->
         } when map_size(M) =:= 0,
         emqx_utils_json:decode(Result4)
     ).
+
+t_http_precondition_api(_) ->
+    Precondition1 = <<"str_eq(username, 'u1')">>,
+    Source1 = maps:merge(?SOURCE_HTTP, #{<<"precondition">> => Precondition1}),
+    {ok, 204, _} = request(post, uri(["authorization", "sources"]), Source1),
+
+    {ok, 200, Result1} = request(get, uri(["authorization", "sources", "http"]), []),
+    ?assertMatch(
+        #{
+            <<"type">> := <<"http">>,
+            <<"precondition">> := Precondition1
+        },
+        emqx_utils_json:decode(Result1)
+    ),
+    ?assertMatch(#{type := http, precondition := #{}}, emqx_authz:lookup_state(http)),
+
+    Precondition2 = <<"str_eq(topic, 't/1')">>,
+    Source2 = maps:merge(?SOURCE_HTTP, #{<<"precondition">> => Precondition2}),
+    {ok, 204, _} = request(put, uri(["authorization", "sources", "http"]), Source2),
+
+    {ok, 200, Result2} = request(get, uri(["authorization", "sources", "http"]), []),
+    ?assertMatch(
+        #{
+            <<"type">> := <<"http">>,
+            <<"precondition">> := Precondition2
+        },
+        emqx_utils_json:decode(Result2)
+    ),
+
+    {ok, 204, _} = request(
+        put,
+        uri(["authorization", "sources", "http"]),
+        maps:merge(?SOURCE_HTTP, #{<<"precondition">> => <<>>})
+    ),
+    ?assertNot(maps:is_key(precondition, emqx_authz:lookup_state(http))).
+
+t_bad_precondition_api(_) ->
+    BadSource = maps:merge(?SOURCE_HTTP, #{<<"precondition">> => <<"not a valid precondition">>}),
+    {ok, 400, Result} = request(post, uri(["authorization", "sources"]), BadSource),
+    ?assertMatch(
+        #{
+            <<"code">> := <<"BAD_REQUEST">>,
+            <<"message">> := Message
+        } when is_binary(Message),
+        emqx_utils_json:decode(Result)
+    ),
+    #{<<"message">> := Message} = emqx_utils_json:decode(Result),
+    ?assertMatch(
+        #{
+            <<"kind">> := <<"validation_error">>,
+            <<"matched_type">> := <<"authz:http_get">>,
+            <<"path">> := <<"root.precondition">>,
+            <<"reason">> := #{
+                <<"cause">> := <<"bad_precondition_expression">>,
+                <<"expression">> := <<"not a valid precondition">>
+            }
+        },
+        emqx_utils_json:decode(Message)
+    ),
+    ?assertEqual([], emqx_authz:lookup_states()).
 
 data_dir() -> emqx:data_dir().

--- a/apps/emqx_utils/src/emqx_variform_bif.erl
+++ b/apps/emqx_utils/src/emqx_variform_bif.erl
@@ -62,7 +62,7 @@
 -export([nth/2]).
 
 %% Topic functions
--export([topic_join/1, topic_join/2, topic_match/2]).
+-export([topic_join/1, topic_join/2, topic_match/2, topic_split/1]).
 
 %% Random functions
 -export([rand_str/1, rand_int/1]).
@@ -442,33 +442,17 @@ topic_match(_, NULL) when ?IS_NULL(NULL) ->
 topic_match(Topic0, Filter0) ->
     Topic = any_to_str(Topic0),
     Filter = any_to_str(Filter0),
-    match_topic_words(topic_words(Topic), topic_words(Filter)).
+    emqx_topic:match(emqx_topic:words(Topic), emqx_topic:words(Filter)).
+
+topic_split(NULL) when ?IS_NULL(NULL) ->
+    ?BADARG();
+topic_split(Topic0) ->
+    emqx_topic:words(any_to_str(Topic0)).
 
 topic_word(NULL) when ?IS_NULL(NULL) ->
     ?BADARG();
 topic_word(Word) ->
     any_to_str(Word).
-
-topic_words(Topic) ->
-    binary:split(Topic, <<"/">>, [global]).
-
-match_topic_words([<<"$", _/binary>> | _], [Wildcard | _]) when
-    Wildcard =:= <<"#">>; Wildcard =:= <<"+">>
-->
-    false;
-match_topic_words(Topic, Filter) ->
-    match_topic_tokens(Topic, Filter).
-
-match_topic_tokens([], []) ->
-    true;
-match_topic_tokens([H | T1], [H | T2]) ->
-    match_topic_tokens(T1, T2);
-match_topic_tokens([_H | T1], [<<"+">> | T2]) ->
-    match_topic_tokens(T1, T2);
-match_topic_tokens(_, [<<"#">>]) ->
-    true;
-match_topic_tokens(_, _) ->
-    false.
 
 unescape_string(Input) -> unescape_string(Input, []).
 

--- a/apps/emqx_utils/src/emqx_variform_bif.erl
+++ b/apps/emqx_utils/src/emqx_variform_bif.erl
@@ -430,9 +430,14 @@ topic_join(_, NULL) when ?IS_NULL(NULL) ->
 topic_join(Parent0, Word0) ->
     Parent = any_to_str(Parent0),
     Word = any_to_str(Word0),
-    case binary:last(Parent) of
-        $/ -> <<Parent/binary, Word/binary>>;
-        _ -> <<Parent/binary, $/, Word/binary>>
+    case Parent of
+        <<>> ->
+            ?BADARG();
+        _ ->
+            case binary:last(Parent) of
+                $/ -> <<Parent/binary, Word/binary>>;
+                _ -> <<Parent/binary, $/, Word/binary>>
+            end
     end.
 
 topic_match(NULL, _) when ?IS_NULL(NULL) ->

--- a/apps/emqx_utils/src/emqx_variform_bif.erl
+++ b/apps/emqx_utils/src/emqx_variform_bif.erl
@@ -61,6 +61,9 @@
 %% Array functions
 -export([nth/2]).
 
+%% Topic functions
+-export([topic_join/1, topic_join/2, topic_match/2]).
+
 %% Random functions
 -export([rand_str/1, rand_int/1]).
 
@@ -408,6 +411,64 @@ nth(N, List) when is_integer(N) andalso is_list(List) ->
         L when L < N -> <<>>;
         _ -> lists:nth(N, List)
     end.
+
+%%------------------------------------------------------------------------------
+%% Topic functions
+%%------------------------------------------------------------------------------
+
+topic_join(NULL) when ?IS_NULL(NULL) ->
+    ?BADARG();
+topic_join(Words) when is_list(Words) ->
+    iolist_to_binary(lists:join(<<"/">>, [topic_word(W) || W <- Words]));
+topic_join(_) ->
+    ?BADARG().
+
+topic_join(NULL, _) when ?IS_NULL(NULL) ->
+    ?BADARG();
+topic_join(_, NULL) when ?IS_NULL(NULL) ->
+    ?BADARG();
+topic_join(Parent0, Word0) ->
+    Parent = any_to_str(Parent0),
+    Word = any_to_str(Word0),
+    case binary:last(Parent) of
+        $/ -> <<Parent/binary, Word/binary>>;
+        _ -> <<Parent/binary, $/, Word/binary>>
+    end.
+
+topic_match(NULL, _) when ?IS_NULL(NULL) ->
+    ?BADARG();
+topic_match(_, NULL) when ?IS_NULL(NULL) ->
+    ?BADARG();
+topic_match(Topic0, Filter0) ->
+    Topic = any_to_str(Topic0),
+    Filter = any_to_str(Filter0),
+    match_topic_words(topic_words(Topic), topic_words(Filter)).
+
+topic_word(NULL) when ?IS_NULL(NULL) ->
+    ?BADARG();
+topic_word(Word) ->
+    any_to_str(Word).
+
+topic_words(Topic) ->
+    binary:split(Topic, <<"/">>, [global]).
+
+match_topic_words([<<"$", _/binary>> | _], [Wildcard | _]) when
+    Wildcard =:= <<"#">>; Wildcard =:= <<"+">>
+->
+    false;
+match_topic_words(Topic, Filter) ->
+    match_topic_tokens(Topic, Filter).
+
+match_topic_tokens([], []) ->
+    true;
+match_topic_tokens([H | T1], [H | T2]) ->
+    match_topic_tokens(T1, T2);
+match_topic_tokens([_H | T1], [<<"+">> | T2]) ->
+    match_topic_tokens(T1, T2);
+match_topic_tokens(_, [<<"#">>]) ->
+    true;
+match_topic_tokens(_, _) ->
+    false.
 
 unescape_string(Input) -> unescape_string(Input, []).
 

--- a/apps/emqx_utils/test/emqx_variform_bif_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_bif_tests.erl
@@ -22,6 +22,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+-define(ASSERT_BADARG(EXPR), ?_assertThrow(#{reason := badarg}, EXPR)).
+
 regex_extract_test_() ->
     [
         ?_assertEqual([<<"12345">>], regex_extract("Order number: 12345", "(\\d+)")),
@@ -110,7 +112,18 @@ bool_not_test_() ->
         ?_assertEqual(false, Not(true))
     ].
 
--define(ASSERT_BADARG(EXPR), ?_assertThrow(#{reason := badarg}, EXPR)).
+topic_test_() ->
+    [
+        ?_assertEqual(<<"client1/#">>, emqx_variform_bif:topic_join([<<"client1">>, <<"#">>])),
+        ?_assertEqual(<<"client1/#">>, emqx_variform_bif:topic_join(<<"client1">>, <<"#">>)),
+        ?_assert(emqx_variform_bif:topic_match(<<"client1/t">>, <<"client1/#">>)),
+        ?_assert(emqx_variform_bif:topic_match(<<"client1/t">>, <<"client1/+">>)),
+        ?_assertNot(emqx_variform_bif:topic_match(<<"client1/t">>, <<"client2/#">>)),
+        ?_assertNot(emqx_variform_bif:topic_match(<<"$SYS/a">>, <<"#">>)),
+        ?ASSERT_BADARG(emqx_variform_bif:topic_join(undefined, <<"#">>)),
+        ?ASSERT_BADARG(emqx_variform_bif:topic_match(undefined, <<"#">>))
+    ].
+
 null_badarg_test_() ->
     [
         ?ASSERT_BADARG(emqx_variform_bif:lower(undefined)),

--- a/apps/emqx_utils/test/emqx_variform_bif_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_bif_tests.erl
@@ -121,6 +121,7 @@ topic_test_() ->
         ?_assertNot(emqx_variform_bif:topic_match(<<"client1/t">>, <<"client2/#">>)),
         ?_assertNot(emqx_variform_bif:topic_match(<<"$SYS/a">>, <<"#">>)),
         ?ASSERT_BADARG(emqx_variform_bif:topic_join(undefined, <<"#">>)),
+        ?ASSERT_BADARG(emqx_variform_bif:topic_join(<<>>, <<"#">>)),
         ?ASSERT_BADARG(emqx_variform_bif:topic_match(undefined, <<"#">>))
     ].
 

--- a/apps/emqx_utils/test/emqx_variform_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_tests.erl
@@ -302,6 +302,18 @@ maps_test_() ->
         {"arity zero", ?_assertEqual({ok, <<"0">>}, render(<<"maps.size(maps.new())">>, #{}))}
     ].
 
+topic_functions_test_() ->
+    [
+        ?_assertEqual(
+            {ok, <<"true">>},
+            render("str_eq(topic_join(topic_split('topic/1')), 'topic/1')", #{})
+        ),
+        ?_assertEqual(
+            {ok, <<"client1/#">>},
+            render("topic_join(topic_split(filter))", #{filter => <<"client1/#">>})
+        )
+    ].
+
 render(Expression, Bindings) ->
     emqx_variform:render(Expression, Bindings).
 

--- a/changes/ee/feat-17145.en.md
+++ b/changes/ee/feat-17145.en.md
@@ -1,1 +1,1 @@
-Authorization sources now support Variform-based preconditions. A source with a precondition is called only when the expression evaluates to `true`, allowing different authorization backends to be selected by client and request context such as client attributes, action, topic, QoS, and retain flag.
+Authorization sources now support Variform-based preconditions. A source with a precondition is called only when the expression evaluates to `true`, allowing different authorization backends to be selected by client and request context such as client attributes, action, and topic.

--- a/changes/ee/feat-17145.en.md
+++ b/changes/ee/feat-17145.en.md
@@ -1,0 +1,1 @@
+Authorization sources now support Variform-based preconditions. A source with a precondition is called only when the expression evaluates to `true`, allowing different authorization backends to be selected by client and request context such as client attributes, action, topic, QoS, and retain flag.

--- a/rel/i18n/emqx_authz_schema.hocon
+++ b/rel/i18n/emqx_authz_schema.hocon
@@ -65,8 +65,8 @@ precondition.desc:
   - `username`: The username of the client
   - `clientid`: The client ID of the client
   - `client_attrs.*`: The client attributes of the client
-  - `cert_common_name`: The subject field from the client's TLS certificate
-  - `cert_subject`: The common name (CN) from the client's TLS certificate
+  - `cert_common_name`: The common name (CN) from the client's TLS certificate
+  - `cert_subject`: The subject field from the client's TLS certificate
   - `peersni`: The SNI (Server Name Indication) sent by TLS client
   - `listener`: The listener ID (e.g. `tcp:default`)
   - `zone`: The associated config zone.

--- a/rel/i18n/emqx_authz_schema.hocon
+++ b/rel/i18n/emqx_authz_schema.hocon
@@ -54,6 +54,35 @@ enable.desc:
 enable.label:
 """enable"""
 
+precondition.label:
+"""Precondition"""
+
+precondition.desc:
+"""~
+  A Variform expression to evaluate with client and request information before calling this authorization source.
+
+  Supported client variables include:
+  - `username`: The username of the client
+  - `clientid`: The client ID of the client
+  - `client_attrs.*`: The client attributes of the client
+  - `cert_common_name`: The subject field from the client's TLS certificate
+  - `cert_subject`: The common name (CN) from the client's TLS certificate
+  - `peersni`: The SNI (Server Name Indication) sent by TLS client
+  - `listener`: The listener ID (e.g. `tcp:default`)
+  - `zone`: The associated config zone.
+
+  Supported request variables include:
+  - `action`: The authorization action, either `publish` or `subscribe`
+  - `topic`: The topic being authorized
+
+  The source is skipped when the expression does not evaluate to true.
+
+  Examples:
+  - Only invoke for publish authorization:
+    `str_eq(action, 'publish')`
+  - Only invoke when the topic matches a client-scoped topic filter:
+    `topic_match(topic, topic_join([clientid, '#']))`~"""
+
 matched.desc:
 """Count of this resource is queried."""
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15237

Release version:
6.3.0

## Summary

Authentication already supports call conditions, but ACL authorization sources could not be conditionally selected. This change lets deployments route different business functions to different authorization backends using Variform expressions over client and request variables.

Key changes:

* Add a common `precondition` option to EMQX authorization sources.
* Compile source preconditions when authorization sources are created or updated, and keep compiled expressions in the shared authorization chain state.
* Evaluate preconditions before calling backend modules; sources are skipped when the expression does not evaluate to `true`.
* Keep backend source modules isolated from the new common field by removing `precondition` before calling backend `create`, `update`, and `destroy` callbacks.
* Add coverage for invalid expressions, runtime Variform errors, source skipping behavior, and HTTP API create/update validation.

The schema change is backward compatible: `precondition` defaults to an empty value, which preserves existing behavior and avoids adding precondition state on the authorization hot path.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/feat-17145.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
