### PR TITLE
ci(grpc compiler): various fixes and improvements for grpc mix task compiler

### DIFF
--- a/apps/emqx_exhook/mix.exs
+++ b/apps/emqx_exhook/mix.exs
@@ -13,9 +13,14 @@ defmodule EMQXExhook.MixProject do
       # used by our `Mix.Tasks.Compile.Grpc` compiler
       grpc_opts: %{
         gpb_opts: [
+          :use_packages,
+          :maps,
+          :strings_as_binaries,
           module_name_prefix: ~c"emqx_",
           module_name_suffix: ~c"_pb",
-          o: ~c"src/pb"
+          report_errors: false,
+          rename: {:msg_name, :snake_case},
+          rename: {:msg_fqname, :base_name}
         ],
         proto_dirs: ["priv/protos"],
         out_dir: "src/pb"

--- a/apps/emqx_gateway_exproto/.gitignore
+++ b/apps/emqx_gateway_exproto/.gitignore
@@ -17,10 +17,4 @@ _build
 *.iml
 rebar3.crashdump
 *~
-src/emqx_exproto_pb.erl
-src/emqx_exproto_v_1_connection_adapter_bhvr.erl
-src/emqx_exproto_v_1_connection_adapter_client.erl
-src/emqx_exproto_v_1_connection_handler_bhvr.erl
-src/emqx_exproto_v_1_connection_handler_client.erl
-src/emqx_exproto_v_1_connection_unary_handler_bhvr.erl
-src/emqx_exproto_v_1_connection_unary_handler_client.erl
+src/generated/

--- a/apps/emqx_gateway_exproto/mix.exs
+++ b/apps/emqx_gateway_exproto/mix.exs
@@ -11,8 +11,14 @@ defmodule EMQXGatewayExproto.MixProject do
       # used by our `Mix.Tasks.Compile.Grpc` compiler
       grpc_opts: %{
         gpb_opts: [
+          :use_packages,
+          :maps,
+          :strings_as_binaries,
           module_name_prefix: ~c"emqx_",
-          module_name_suffix: ~c"_pb"
+          module_name_suffix: ~c"_pb",
+          report_errors: false,
+          rename: {:msg_name, :snake_case},
+          rename: {:msg_fqname, :base_name}
         ],
         proto_dirs: ["priv/protos"],
         out_dir: "src"

--- a/apps/emqx_gateway_exproto/mix.exs
+++ b/apps/emqx_gateway_exproto/mix.exs
@@ -21,7 +21,7 @@ defmodule EMQXGatewayExproto.MixProject do
           rename: {:msg_fqname, :base_name}
         ],
         proto_dirs: ["priv/protos"],
-        out_dir: "src"
+        out_dir: "src/generated"
       },
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_mix_utils/lib/emqx/grpc/template/client.eex
+++ b/apps/emqx_mix_utils/lib/emqx/grpc/template/client.eex
@@ -49,19 +49,19 @@
 <% end %>
 <%!-- IF2 --%>
 <%= if (not method.input_stream) and method.output_stream do %>
--spec <%= method.snake_case %>(grpc_client:options())
+-spec <%= method.snake_case %>(<%= method.pb_module %>:'<%= method.input %>'(), grpc_client:options())
     -> {ok, grpc_client:grpcstream()}
      | {error, term()}.
-<%= method.snake_case %>(Options) ->
-    <%= method.snake_case %>(#{}, Options).
+<%= method.snake_case %>(Req, Options) ->
+    <%= method.snake_case %>(Req, #{}, Options).
 
--spec <%= method.snake_case %>(grpc:metadata(), grpc_client:options())
+-spec <%= method.snake_case %>(<%= method.pb_module %>:'<%= method.input %>'(), grpc:metadata(), grpc_client:options())
     -> {ok, grpc_client:grpcstream()}
      | {error, term()}.
-<%= method.snake_case %>(Metadata, Options) ->
-    grpc_client:open(?DEF(<<"/<%= unmodified_service_name %>/<%= method.unmodified_method %>">>,
+<%= method.snake_case %>(Req, Metadata, Options) ->
+    grpc_client:unary(?DEF(<<"/<%= unmodified_service_name %>/<%= method.unmodified_method %>">>,
                           '<%= method.input %>', '<%= method.output %>', <<"<%= method.message_type %>">>),
-                     Metadata, Options).
+                     Req, Metadata, Options).
 <%!-- END IF2 --%>
 <% end %>
 <%!-- IF3 --%>

--- a/apps/emqx_mix_utils/lib/emqx/grpc/template/client.eex
+++ b/apps/emqx_mix_utils/lib/emqx/grpc/template/client.eex
@@ -26,24 +26,24 @@
 <%= for method <- methods do %>
 <%!-- IF1 --%>
 <%= if (not method.input_stream) and (not method.output_stream) do %>
--spec <%= method.snake_case %>(<%= method.pb_module %>:<%= method.input %>())
-    -> {ok, <%= method.pb_module %>:<%= method.output %>(), grpc:metadata()}
+-spec <%= method.snake_case %>(<%= method.pb_module %>:'<%= method.input %>'())
+    -> {ok, <%= method.pb_module %>:'<%= method.output %>'(), grpc:metadata()}
      | {error, term()}.
 <%= method.snake_case %>(Req) ->
     <%= method.snake_case %>(Req, #{}, #{}).
 
--spec <%= method.snake_case %>(<%= method.pb_module %>:<%= method.input %>(), grpc:options())
-    -> {ok, <%= method.pb_module %>:<%= method.output %>(), grpc:metadata()}
+-spec <%= method.snake_case %>(<%= method.pb_module %>:'<%= method.input %>'(), grpc:options())
+    -> {ok, <%= method.pb_module %>:'<%= method.output %>'(), grpc:metadata()}
      | {error, term()}.
 <%= method.snake_case %>(Req, Options) ->
     <%= method.snake_case %>(Req, #{}, Options).
 
--spec <%= method.snake_case %>(<%= method.pb_module %>:<%= method.input %>(), grpc:metadata(), grpc_client:options())
-    -> {ok, <%= method.pb_module %>:<%= method.output %>(), grpc:metadata()}
+-spec <%= method.snake_case %>(<%= method.pb_module %>:'<%= method.input %>'(), grpc:metadata(), grpc_client:options())
+    -> {ok, <%= method.pb_module %>:'<%= method.output %>'(), grpc:metadata()}
      | {error, term()}.
 <%= method.snake_case %>(Req, Metadata, Options) ->
     grpc_client:unary(?DEF(<<"/<%= unmodified_service_name %>/<%= method.unmodified_method %>">>,
-                           <%= method.input %>, <%= method.output %>, <<"<%= method.message_type %>">>),
+                           '<%= method.input %>', '<%= method.output %>', <<"<%= method.message_type %>">>),
                       Req, Metadata, Options).
 <%!-- END IF1 --%>
 <% end %>
@@ -60,7 +60,7 @@
      | {error, term()}.
 <%= method.snake_case %>(Metadata, Options) ->
     grpc_client:open(?DEF(<<"/<%= unmodified_service_name %>/<%= method.unmodified_method %>">>,
-                          <%= method.input %>, <%= method.output %>, <<"<%= method.message_type %>">>),
+                          '<%= method.input %>', '<%= method.output %>', <<"<%= method.message_type %>">>),
                      Metadata, Options).
 <%!-- END IF2 --%>
 <% end %>
@@ -77,7 +77,7 @@
      | {error, term()}.
 <%= method.snake_case %>(Metadata, Options) ->
     grpc_client:open(?DEF(<<"/<%= unmodified_service_name %>/<%= method.unmodified_method %>">>,
-                          <%= method.input %>, <%= method.output %>, <<"<%= method.message_type %>">>),
+                          '<%= method.input %>', '<%= method.output %>', <<"<%= method.message_type %>">>),
                      Metadata, Options).
 <% end %>
 <%!-- END IF3 --%>

--- a/apps/emqx_mix_utils/lib/emqx/grpc/template/service.eex
+++ b/apps/emqx_mix_utils/lib/emqx/grpc/template/service.eex
@@ -10,8 +10,8 @@
 <%= for method <- methods do %>
 
 <%= if (not method.input_stream) and (not method.output_stream) do %>
--callback <%= method.snake_case %>(<%= method.pb_module %>:<%= method.input %>(), grpc:metadata())
-    -> {ok, <%= method.pb_module %>:<%= method.output %>(), grpc:metadata()}
+-callback <%= method.snake_case %>(<%= method.pb_module %>:'<%= method.input %>'(), grpc:metadata())
+    -> {ok, <%= method.pb_module %>:'<%= method.output %>'(), grpc:metadata()}
      | {error, grpc_stream:error_response()}.
 <% end %>
 

--- a/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
@@ -44,6 +44,7 @@ defmodule Mix.Tasks.Compile.Grpc do
       app_root: app_root,
       app_build_path: app_build_path,
       out_dir: out_dir,
+      proto_dirs: proto_dirs,
       gpb_opts: gpb_opts
     }
 
@@ -65,6 +66,7 @@ defmodule Mix.Tasks.Compile.Grpc do
       app_root: app_root,
       app_build_path: app_build_path,
       out_dir: out_dir,
+      proto_dirs: proto_dirs,
       gpb_opts: gpb_opts
     } = context
 
@@ -75,7 +77,9 @@ defmodule Mix.Tasks.Compile.Grpc do
     suffix = Keyword.get(gpb_opts, :module_name_suffix, ~c"")
     mod_name = ~c"#{prefix}#{basename}#{suffix}"
 
-    opts = [i: ~c".", o: out_dir] ++ gpb_opts
+    includes = Enum.map(proto_dirs, &{:i, to_charlist(&1)})
+
+    opts = [o: out_dir] ++ includes ++ gpb_opts
 
     if stale?(proto_src, manifest_modified_time) do
       Process.put(@stale?, true)

--- a/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
@@ -76,22 +76,26 @@ defmodule Mix.Tasks.Compile.Grpc do
     prefix = Keyword.get(gpb_opts, :module_name_prefix, ~c"")
     suffix = Keyword.get(gpb_opts, :module_name_suffix, ~c"")
     mod_name = ~c"#{prefix}#{basename}#{suffix}"
+    generated_src = Path.join([app_root, out_dir, "#{mod_name}.erl"])
 
     includes = Enum.map(proto_dirs, &{:i, to_charlist(&1)})
 
     opts = [o: out_dir] ++ includes ++ gpb_opts
 
-    if stale?(proto_src, manifest_modified_time) do
+    proto_compilation_needed? =
+      stale?(proto_src, manifest_modified_time) ||
+      stale?(generated_src, manifest_modified_time)
+
+    if proto_compilation_needed? do
       Process.put(@stale?, true)
       debug("compiling proto file: #{proto_src}")
       File.mkdir_p!(out_dir)
       # TODO: better error logging...
       :ok = :gpb_compile.file(to_charlist(proto_src), opts)
     else
-      debug("proto file up to date, not compiling: #{proto_src}")
+      debug("proto file and generated source up to date, not compiling: #{proto_src}")
     end
 
-    generated_src = Path.join([app_root, out_dir, "#{mod_name}.erl"])
     gpb_include_dir = :code.lib_dir(:gpb) |> Path.join("include")
 
     if stale?(generated_src, manifest_modified_time) do

--- a/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
@@ -75,27 +75,14 @@ defmodule Mix.Tasks.Compile.Grpc do
     suffix = Keyword.get(gpb_opts, :module_name_suffix, ~c"")
     mod_name = ~c"#{prefix}#{basename}#{suffix}"
 
-    opts = [
-      :use_packages,
-      :maps,
-      :strings_as_binaries,
-      i: ~c".",
-      o: out_dir,
-      report_errors: false,
-      rename: {:msg_name, :snake_case},
-      rename: {:msg_fqname, :base_name}
-    ]
+    opts = [i: ~c".", o: out_dir] ++ gpb_opts
 
     if stale?(proto_src, manifest_modified_time) do
       Process.put(@stale?, true)
       debug("compiling proto file: #{proto_src}")
       File.mkdir_p!(out_dir)
       # TODO: better error logging...
-      :ok =
-        :gpb_compile.file(
-          to_charlist(proto_src),
-          opts ++ gpb_opts
-        )
+      :ok = :gpb_compile.file(to_charlist(proto_src), opts)
     else
       debug("proto file up to date, not compiling: #{proto_src}")
     end

--- a/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
@@ -18,6 +18,18 @@ defmodule Mix.Tasks.Compile.Grpc do
   defp manifest(), do: Path.join(Mix.Project.manifest_path(), @manifest)
 
   @impl true
+  def clean() do
+    Mix.Project.get!()
+    config = Mix.Project.config()
+
+    %{
+      out_dir: out_dir
+    } = config[:grpc_opts]
+
+    File.rm_rf!(out_dir)
+  end
+
+  @impl true
   def run(_args) do
     Mix.Project.get!()
     config = Mix.Project.config()

--- a/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
@@ -53,6 +53,8 @@ defmodule Mix.Tasks.Compile.Grpc do
 
     Enum.each(proto_srcs, &compile_pb(&1, context))
 
+    manifest_data = Map.put(manifest_data, :app_gpb_opts, gpb_opts)
+
     if Process.get(@stale?, false) do
       write_manifest(manifest(), manifest_data)
     end
@@ -68,6 +70,7 @@ defmodule Mix.Tasks.Compile.Grpc do
     %{
       app_root: app_root,
       app_build_path: app_build_path,
+      manifest_data: manifest_data,
       out_dir: out_dir,
       proto_dirs: proto_dirs,
       gpb_opts: gpb_opts
@@ -87,7 +90,8 @@ defmodule Mix.Tasks.Compile.Grpc do
 
     proto_compilation_needed? =
       stale?(proto_src, manifest_modified_time) ||
-      stale?(generated_src, manifest_modified_time)
+        stale?(generated_src, manifest_modified_time) ||
+        compile_opts_stale?(gpb_opts, manifest_data)
 
     if proto_compilation_needed? do
       Process.put(@stale?, true)
@@ -234,6 +238,11 @@ defmodule Mix.Tasks.Compile.Grpc do
     else
       _ -> true
     end
+  end
+
+  defp compile_opts_stale?(gpb_opts, manifest_data) do
+    previous_gpb_opts = get_in(manifest_data, [:app_gpb_opts]) || :undefined
+    previous_gpb_opts != gpb_opts
   end
 
   defp read_manifest(file) do

--- a/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/compile.grpc.ex
@@ -5,8 +5,11 @@ defmodule Mix.Tasks.Compile.Grpc do
 
   @recursive true
   @manifest_vsn 1
-  @manifest "compile.grpc"
   # TODO: use manifest to track generated files?
+  @manifest "compile.grpc"
+
+  @client_quoted_pt_key {__MODULE__, :client_quoted}
+  @service_quoted_pt_key {__MODULE__, :service_quoted}
 
   @stale? {__MODULE__, :stale?}
 
@@ -135,18 +138,8 @@ defmodule Mix.Tasks.Compile.Grpc do
       |> :code.load_abs()
 
     mod_name = List.to_atom(mod_name)
-
-    service_quoted =
-      [__DIR__, "../../", "emqx/grpc/template/service.eex"]
-      |> Path.join()
-      |> Path.expand()
-      |> EEx.compile_file()
-
-    client_quoted =
-      [__DIR__, "../../", "emqx/grpc/template/client.eex"]
-      |> Path.join()
-      |> Path.expand()
-      |> EEx.compile_file()
+    service_quoted = get_service_quoted_template()
+    client_quoted = get_client_quoted_template()
 
     mod_name.get_service_names()
     |> Enum.each(fn service ->
@@ -202,6 +195,36 @@ defmodule Mix.Tasks.Compile.Grpc do
     end)
 
     :ok
+  end
+
+  defp get_service_quoted_template() do
+    get_memoized(@service_quoted_pt_key, fn ->
+      [__DIR__, "../../", "emqx/grpc/template/service.eex"]
+      |> Path.join()
+      |> Path.expand()
+      |> EEx.compile_file()
+    end)
+  end
+
+  defp get_client_quoted_template() do
+    get_memoized(@client_quoted_pt_key, fn ->
+      [__DIR__, "../../", "emqx/grpc/template/client.eex"]
+      |> Path.join()
+      |> Path.expand()
+      |> EEx.compile_file()
+    end)
+  end
+
+  defp get_memoized(k, compute_fn) do
+    case :persistent_term.get(k, :undefined) do
+      :undefined ->
+        res = compute_fn.()
+        :persistent_term.put(k, res)
+        res
+
+      res ->
+        res
+    end
   end
 
   defp stale?(file, manifest_modified_time) do


### PR DESCRIPTION
Release version:
6.0.3, 6.1.2, 6.2.0, 6.3.0

## Summary

- Improve detection of stale sources/options.
- Delegate specifying most grpc options to application `mix.exs` files.
- Implement `clean/0` callback to clear generated source files.
- Fix generation of clients when input is not streamed but output is.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
