### PR TITLE
fix(coap): update er_coap_client unauthorized code

### DIFF
--- a/apps/emqx_gateway/test/emqx_gateway_authz_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_authz_SUITE.erl
@@ -86,7 +86,7 @@ t_case_coap_publish(_) ->
     end,
     Case = fun(Channel, Token) ->
         Fun(Channel, Token, <<"/publish">>, ?checkMatch({ok, changed, _})),
-        Fun(Channel, Token, <<"/badpublish">>, ?checkMatch({error, uauthorized})),
+        Fun(Channel, Token, <<"/badpublish">>, ?checkMatch({error, unauthorized})),
         true
     end,
     Mod:with_connection(Case).
@@ -103,7 +103,7 @@ t_case_coap_subscribe(_) ->
     end,
     Case = fun(Channel, Token) ->
         Fun(Channel, Token, <<"/subscribe">>, ?checkMatch({ok, content, _})),
-        Fun(Channel, Token, <<"/badsubscribe">>, ?checkMatch({error, uauthorized})),
+        Fun(Channel, Token, <<"/badsubscribe">>, ?checkMatch({error, unauthorized})),
         true
     end,
     Mod:with_connection(Case).

--- a/apps/emqx_gateway_coap/mix.exs
+++ b/apps/emqx_gateway_coap/mix.exs
@@ -34,7 +34,7 @@ defmodule EMQXGatewayCoap.MixProject do
   defp test_deps() do
     if UMP.test_env?() do
       [
-        {:er_coap_client, github: "emqx/er_coap_client", tag: "v1.1.0"}
+        {:er_coap_client, github: "emqx/er_coap_client", tag: "v1.1.1"}
       ]
     else
       []

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -723,7 +723,7 @@ t_invalid_token_rejected_across_udp_sessions(_) ->
         false
     ),
     Req = make_req(post, <<"x">>),
-    ?assertMatch({error, uauthorized, _}, do_request(Channel2, URI, Req)),
+    ?assertMatch({error, unauthorized, _}, do_request(Channel2, URI, Req)),
     disconnection(Channel2, Token),
     er_coap_channel:close(Channel2),
     er_coap_udp_socket:close(Sock2).
@@ -746,7 +746,7 @@ t_wrong_clientid_with_valid_token_rejected_across_udp_sessions(_) ->
         false
     ),
     Req = make_req(post, <<"x">>),
-    ?assertMatch({error, uauthorized, _}, do_request(Channel2, URI, Req)),
+    ?assertMatch({error, unauthorized, _}, do_request(Channel2, URI, Req)),
     disconnection(Channel2, Token),
     er_coap_channel:close(Channel2),
     er_coap_udp_socket:close(Sock2).

--- a/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
@@ -170,7 +170,7 @@ t_wrong_clientid_with_valid_token_rejected(_Config) ->
         false
     ),
     Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
-    ?assertMatch({error, uauthorized, _}, emqx_coap_SUITE:do_request(Channel2, URI1, Req1)),
+    ?assertMatch({error, unauthorized, _}, emqx_coap_SUITE:do_request(Channel2, URI1, Req1)),
 
     er_coap_channel:close(Channel2),
     er_coap_dtls_socket:close(Sock2).


### PR DESCRIPTION
Fixes N/A

Release version:
6.0.3

## Summary

This PR updates the CoAP gateway test dependency `er_coap_client` from `v1.1.0` to `v1.1.1`. The new dependency tag includes emqx/er_coap_client#7, which fixes the CoAP `4.01 Unauthorized` response code mapping from the misspelled `{error, uauthorized}` atom to `{error, unauthorized}`.

The affected CoAP authorization tests now assert the corrected atom in:

- `apps/emqx_gateway/test/emqx_gateway_authz_SUITE.erl`
- `apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl`
- `apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl`

Validation performed locally:

- `MIX_ENV=emqx-enterprise-test ./mix deps.get`
- `MIX_ENV=emqx-enterprise-test ./mix deps.compile er_coap_client --force`
- `MIX_ENV=emqx-enterprise-test ./mix deps` confirmed `er_coap_client 1.1.1` locked at `f2b98b9 (tag: v1.1.1)`
- `MIX_ENV=emqx-enterprise-test ./mix compile`
- Direct smoke test confirmed CoAP `4.01` decodes as `{error, unauthorized}`

The focused CoAP CT cases were attempted, but this local machine has port `1883` already in use, so `emqx_coap_SUITE:init_per_suite` failed before running the cases and both cases were auto skipped.

## PR Checklist

- ~For internal contributor: there is a jira ticket to track this change~
- [x] The changes are covered with new or existing tests
- ~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~
  - Not user-visible; this updates a test-only CoAP client dependency and matching test assertions, so no changelog is needed.
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
  - No schema changes.
