### PR TITLE
feat: support config distribution port connect options for perf tunings

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -42,6 +42,8 @@
 
 -define(DEFAULT_NODE_NAME, <<"emqx@127.0.0.1">>).
 
+-define(DEFAULT_KERNEL_INET_DIST_CONNECT_OPTIONS, <<"[{buffer,1048576}]">>).
+
 %% Static apps which merge their configs into the merged emqx.conf
 %% The list can not be made a dynamic read at run-time as it is used
 %% by nodetool to generate app.<time>.config before EMQX is started
@@ -503,6 +505,16 @@ fields("node") ->
                     default => 8192,
                     importance => ?IMPORTANCE_LOW,
                     'readOnly' => true
+                }
+            )},
+        {"dist_connect_options",
+            sc(
+                binary(),
+                #{
+                    desc => ?DESC(dist_connect_options),
+                    default => ?DEFAULT_KERNEL_INET_DIST_CONNECT_OPTIONS,
+                    importance => ?IMPORTANCE_LOW,
+                    'readOnly' => false
                 }
             )},
         {"max_ets_tables",
@@ -1258,11 +1270,16 @@ translation("prometheus") ->
     ];
 translation("vm_args") ->
     [
-        {"+P", fun tr_vm_args_process_limit/1}
+        {"+P", fun tr_vm_args_process_limit/1},
+        {"-kernel inet_dist_connect_options", fun tr_kernel_inet_dist_connect_options/1}
     ].
 
 tr_vm_args_process_limit(Conf) ->
     2 * conf_get("node.max_ports", Conf, ?DEFAULT_MAX_PORTS).
+
+tr_kernel_inet_dist_connect_options(Conf) ->
+    Val = conf_get("node.dist_connect_options", Conf, [?DEFAULT_KERNEL_INET_DIST_CONNECT_OPTIONS]),
+    lists:flatten(io_lib:format("~0p", [Val])).
 
 tr_prometheus_collectors(Conf) ->
     [

--- a/changes/ee/perf-17152.en.md
+++ b/changes/ee/perf-17152.en.md
@@ -1,0 +1,4 @@
+Added support for configuring Erlang inet port options for the distribution port, with a default `buffer` size of 1 MB.
+
+Previously, the Erlang distribution port used an extremely small default port buffer (1460 bytes, or ~9 KB on some platforms), which caused performance bottlenecks even when the distribution port buffer (`+zdbbl`) was configured to a much larger value (e.g., 32 MB). This affected cluster communication reliability and could manifest as `erpc timeout` errors, Mnesia transaction congestions, and degraded multi-core node support.
+

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -91,6 +91,14 @@ dist_buffer_size.desc:
 dist_buffer_size.label:
 """Erlang's dist buffer size(KB)"""
 
+dist_connect_options.desc:
+"""Erlang's distribution port connect options for performance tuning.
+Defines a list of extra socket options to be used when connecting to other distributed Erlang nodes.
+See https://www.erlang.org/doc/apps/kernel/gen_tcp.html#connect/4"""
+
+dist_connect_options.label:
+"""Erlang's distribution port connect options"""
+
 common_handler_max_depth.desc:
 """Maximum depth for Erlang term log formatting and Erlang process message queue inspection."""
 


### PR DESCRIPTION
Fixes [EMQX-15239](https://emqx.atlassian.net/browse/EMQX-15239)


Support config erlang `port` port options for distribution port and have default buffer size to 1 MB. 

Without this feature, erlang dist port has performance issues where the erlang port buffer is too small (default 1460 Bytes, some platform 9KB) even dist port buffer  (vmarg +zdbbl )is set to much larger (e.g 32MB). 

This issue was found in emqx 4.4, now ports the solution to 6.0. 

note: user could check dist port port options in use with 
```
rp([recon:port_info(element(6,X)) || X<-ets:tab2list(sys_dist)]).
```
If the buffer is too small, enlarge it with 
```
inet:setopts(Socket, [{buffer, 1024*1024}])
```

NOTE1: It may solve lots of issues of 'erpc timeout', 'mnesia congestions' , it may also help to support more core nodes. 
NOTE2: buffer location map:
```
=================
dist port buffer (+zdbbl)
-----------------------
erl port buffer (inet opt: buffer). <--- this PR targeting. 
------------------------
Linux socket buffer (inet opt: sndbuf, rcvbuf)
=================
```
Release version:
<!-- uncomment for v5:
5.8.10, 5.10.4
-->

<!-- uncomment for v6:
6.0.3, 6.1.2, 6.2.0
-->

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-15239]: https://emqx.atlassian.net/browse/EMQX-15239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ