### PR TITLE
Support newer Datalayers CT images

### DIFF
--- a/.ci/docker-compose-file/docker-compose-datalayers-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-datalayers-tcp.yaml
@@ -1,7 +1,7 @@
 services:
   datalayers_server_tcp:
     container_name: datalayers_tcp
-    image: datalayers/datalayers:v2.3.8
+    image: datalayers/datalayers:${DATALAYERS_TAG:-v2.3.21}
     expose:
       # gRPC
       - "8360"

--- a/.ci/docker-compose-file/docker-compose-datalayers-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-datalayers-tls.yaml
@@ -1,7 +1,7 @@
 services:
   datalayers_server_tls:
     container_name: datalayers_tls
-    image: datalayers/datalayers:v2.3.8
+    image: datalayers/datalayers:${DATALAYERS_TAG:-v2.3.21}
     expose:
       # gRPCs
       - "8362"

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -106,6 +106,7 @@ jobs:
           PGSQL_TAG: "13"
           REDIS_TAG: "7.0"
           INFLUXDB_TAG: "2.5.0"
+          DATALAYERS_TAG: "v2.3.21"
           TDENGINE_TAG: "3.0.2.4"
           OPENTS_TAG: "9aa7f88"
           MINIO_TAG: "RELEASE.2023-03-20T20-16-18Z"


### PR DESCRIPTION
## Summary

- Update Datalayers CT docker-compose files to use `DATALAYERS_TAG`, defaulting to `v2.3.21`.
- Set the GitHub Actions CT default `DATALAYERS_TAG` to `v2.3.21`.
- Keep the same compose files usable with `DATALAYERS_TAG=v2.4.0` for compatibility coverage.

## Validation

- `git diff --check`
- `DATALAYERS_TAG=v2.3.21 docker compose -f .ci/docker-compose-file/docker-compose.yaml -f .ci/docker-compose-file/docker-compose-datalayers-tcp.yaml -f .ci/docker-compose-file/docker-compose-datalayers-tls.yaml config | rg 'image: datalayers/datalayers'`
- `DATALAYERS_TAG=v2.4.0 docker compose -f .ci/docker-compose-file/docker-compose.yaml -f .ci/docker-compose-file/docker-compose-datalayers-tcp.yaml -f .ci/docker-compose-file/docker-compose-datalayers-tls.yaml config | rg 'image: datalayers/datalayers'`
- `DATALAYERS_TAG=v2.3.21 ./scripts/ct/run.sh --app apps/emqx_bridge_datalayers` equivalent manual run in the CT container after preinstalling Hex archive: 227 succeeded, 0 skipped
- `DATALAYERS_TAG=v2.4.0 ./scripts/ct/run.sh --app apps/emqx_bridge_datalayers`: 227 succeeded, 0 skipped
