### PR TITLE
Revert "fix(grpc compiler): call `grpc_client:unary` if no input stream"

### DIFF
--- a/apps/emqx_mix_utils/lib/emqx/grpc/template/client.eex
+++ b/apps/emqx_mix_utils/lib/emqx/grpc/template/client.eex
@@ -49,19 +49,19 @@
 <% end %>
 <%!-- IF2 --%>
 <%= if (not method.input_stream) and method.output_stream do %>
--spec <%= method.snake_case %>(<%= method.pb_module %>:'<%= method.input %>'(), grpc_client:options())
+-spec <%= method.snake_case %>(grpc_client:options())
     -> {ok, grpc_client:grpcstream()}
      | {error, term()}.
-<%= method.snake_case %>(Req, Options) ->
-    <%= method.snake_case %>(Req, #{}, Options).
+<%= method.snake_case %>(Options) ->
+    <%= method.snake_case %>(#{}, Options).
 
--spec <%= method.snake_case %>(<%= method.pb_module %>:'<%= method.input %>'(), grpc:metadata(), grpc_client:options())
+-spec <%= method.snake_case %>(grpc:metadata(), grpc_client:options())
     -> {ok, grpc_client:grpcstream()}
      | {error, term()}.
-<%= method.snake_case %>(Req, Metadata, Options) ->
-    grpc_client:unary(?DEF(<<"/<%= unmodified_service_name %>/<%= method.unmodified_method %>">>,
+<%= method.snake_case %>(Metadata, Options) ->
+    grpc_client:open(?DEF(<<"/<%= unmodified_service_name %>/<%= method.unmodified_method %>">>,
                           '<%= method.input %>', '<%= method.output %>', <<"<%= method.message_type %>">>),
-                     Req, Metadata, Options).
+                     Metadata, Options).
 <%!-- END IF2 --%>
 <% end %>
 <%!-- IF3 --%>


### PR DESCRIPTION
This reverts commit 237fb1f9a56afddf05e764ecfcb0cb9d4effe94f.

The "fix" was actually incorrect due to misunderstanding.  No code in the current branches was actually affected.

Release version:
6.0.3, 6.1.2, 6.2.0
