### PR TITLE
ci: include ubuntu22.04 in cron package build matrix

### DIFF
--- a/.github/workflows/build_packages_cron.yaml
+++ b/.github/workflows/build_packages_cron.yaml
@@ -27,6 +27,7 @@ jobs:
           - ['emqx-enterprise', 'release-61']
           - ['emqx-enterprise', 'release-62']
         os:
+          - ubuntu22.04
           - ubuntu24.04
           - amzn2023
 


### PR DESCRIPTION
Restore `ubuntu22.04` to the cron build matrix in `.github/workflows/build_packages_cron.yaml` (alongside `ubuntu24.04`, added in 5f5839f8f8). The runner stays on `ubuntu-24.04`; only the package target list grows.