### PR TITLE
feat(emqx_prometheus): expose license max_sessions and issued_at gauges

### DIFF
--- a/apps/emqx_license/src/emqx_license_checker.erl
+++ b/apps/emqx_license/src/emqx_license_checker.erl
@@ -31,6 +31,7 @@
     update/1,
     dump/0,
     expiry_epoch/0,
+    date_to_expiry_epoch/1,
     purge/0,
     limits/0,
     print_warnings/1,

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -551,7 +551,9 @@ emqx_collect(K = emqx_authentication_success_anonymous, D) -> counter_metrics(?M
 emqx_collect(K = emqx_authentication_failure, D) -> counter_metrics(?MG(K, D));
 %%--------------------------------------------------------------------
 %% License
+emqx_collect(K = emqx_license_max_sessions, D) -> gauge_metric(?MG(K, D));
 emqx_collect(K = emqx_license_expiry_at, D) -> gauge_metric(?MG(K, D));
+emqx_collect(K = emqx_license_issued_at, D) -> gauge_metric(?MG(K, D));
 %%--------------------------------------------------------------------
 %% Certs
 emqx_collect(K = emqx_cert_expiry_at, D) -> gauge_metrics(?MG(K, D));
@@ -984,11 +986,44 @@ maybe_license_collect_json_data(RawData) ->
 %% license
 license_metric_meta() ->
     [
-        {emqx_license_expiry_at, gauge, undefined}
+        {emqx_license_max_sessions, gauge, undefined},
+        {emqx_license_expiry_at, gauge, undefined},
+        {emqx_license_issued_at, gauge, undefined}
     ].
 
 license_data() ->
-    #{emqx_license_expiry_at => emqx_license_checker:expiry_epoch()}.
+    Dump =
+        try
+            emqx_license_checker:dump()
+        catch
+            _:_ -> []
+        end,
+    MaxSessions =
+        case proplists:get_value(max_sessions, Dump, 0) of
+            N when is_integer(N) -> N;
+            _ -> 0
+        end,
+    ExpiryAt = license_date_to_epoch(proplists:get_value(expiry_at, Dump, undefined)),
+    IssuedAt = license_date_to_epoch(proplists:get_value(start_at, Dump, undefined)),
+    #{
+        emqx_license_max_sessions => MaxSessions,
+        emqx_license_expiry_at => ExpiryAt,
+        emqx_license_issued_at => IssuedAt
+    }.
+
+%% start_at / expiry_at from emqx_license_checker:dump/0 are binary "YYYY-MM-DD"
+%% (output of emqx_license_parser_v20220101:format_date/1).
+license_date_to_epoch(undefined) ->
+    0;
+license_date_to_epoch(Bin) when is_binary(Bin) ->
+    try
+        [Y, M, D] = [binary_to_integer(P) || P <- binary:split(Bin, <<"-">>, [global])],
+        emqx_license_checker:date_to_expiry_epoch({Y, M, D})
+    catch
+        _:_ -> 0
+    end;
+license_date_to_epoch(_) ->
+    0.
 
 %%========================================
 %% Certs

--- a/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
@@ -154,7 +154,17 @@ maybe_meck_license() ->
             ok;
         ee ->
             meck:new(emqx_license_checker, [non_strict, passthrough, no_link]),
-            meck:expect(emqx_license_checker, expiry_epoch, fun() -> 1859673600 end)
+            meck:expect(emqx_license_checker, expiry_epoch, fun() -> 1859673600 end),
+            %% 1859673600 epoch corresponds to 2028-12-06; mirror it in dump/0
+            %% so the gauge for emqx_license_expiry_at stays bit-exact equal.
+            meck:expect(emqx_license_checker, dump, fun() ->
+                [
+                    {customer, "TestCo"},
+                    {max_sessions, 1000},
+                    {start_at, <<"2024-01-01">>},
+                    {expiry_at, <<"2028-12-06">>}
+                ]
+            end)
     end.
 
 maybe_unmeck_license() ->

--- a/apps/emqx_prometheus/test/emqx_prometheus_cluster_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_cluster_SUITE.erl
@@ -72,7 +72,17 @@ mk_cluster(TestCase, #{n := NumNodes} = Opts, TCConfig) ->
     on_exit(fun() -> ok = emqx_cth_cluster:stop(Nodes) end),
     ?ON_ALL(Nodes, begin
         meck:new(emqx_license_checker, [non_strict, passthrough, no_link]),
-        meck:expect(emqx_license_checker, expiry_epoch, fun() -> 1859673600 end)
+        meck:expect(emqx_license_checker, expiry_epoch, fun() -> 1859673600 end),
+        %% 1859673600 epoch corresponds to 2028-12-06; mirror it in dump/0
+        %% so the gauge for emqx_license_expiry_at stays bit-exact equal.
+        meck:expect(emqx_license_checker, dump, fun() ->
+            [
+                {customer, "TestCo"},
+                {max_sessions, 1000},
+                {start_at, <<"2024-01-01">>},
+                {expiry_at, <<"2028-12-06">>}
+            ]
+        end)
     end),
     Nodes.
 

--- a/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
@@ -329,7 +329,9 @@ metric_meta(<<"emqx_cluster_nodes_stopped">>) -> ?meta(0, 1, 1);
 metric_meta(<<"emqx_conf_sync_txid">>) -> ?meta(0, 1, 1);
 %% END
 metric_meta(<<"emqx_cert_expiry_at">>) -> ?meta(2, 2, 2);
+metric_meta(<<"emqx_license_max_sessions">>) -> ?meta(0, 0, 0);
 metric_meta(<<"emqx_license_expiry_at">>) -> ?meta(0, 0, 0);
+metric_meta(<<"emqx_license_issued_at">>) -> ?meta(0, 0, 0);
 %% broker instr
 metric_meta(<<"emqx_instr_", _Tail/binary>>) -> #{};
 %% mria metric with label `shard` and `node` when not in mode `node`
@@ -719,8 +721,17 @@ eval_foreach_assert(FunctionName, Ms) ->
 %% license always map
 assert_json_data__license(M, _) ->
     case emqx_release:edition() of
-        ce -> ok;
-        ee -> ?assertMatch(#{emqx_license_expiry_at := _}, M)
+        ce ->
+            ok;
+        ee ->
+            ?assertMatch(
+                #{
+                    emqx_license_max_sessions := _,
+                    emqx_license_expiry_at := _,
+                    emqx_license_issued_at := _
+                },
+                M
+            )
     end.
 
 -define(assert_node_foreach(Ms), lists:foreach(fun(M) -> ?assertMatch(#{node := _}, M) end, Ms)).

--- a/changes/ee/feat-17162.en.md
+++ b/changes/ee/feat-17162.en.md
@@ -1,0 +1,3 @@
+Added two per-node Prometheus gauges for license information: `emqx_license_max_sessions` and `emqx_license_issued_at`, alongside the existing `emqx_license_expiry_at`.
+
+Operators can now alert on license inconsistencies across cluster nodes by comparing these gauges. The implementation fetches all three values from a single `emqx_license_checker:dump/0` gen_server call, eliminating a redundant round-trip on every Prometheus scrape.


### PR DESCRIPTION


Release version:
<!-- uncomment for v5:
5.8.10, 5.10.4
-->

6.0.3, 6.1.2, 6.2.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
When a client connection terminates due to emsgsize (message too large
for the socket send buffer), log at warning level instead of info to
improve visibility of this error condition.

(cherry picked from commit ce52d8e)