### PR TITLE
fix(coap): update unauthorized code on release-61

### DIFF
--- a/apps/emqx_gateway/test/emqx_gateway_authz_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_authz_SUITE.erl
@@ -86,7 +86,7 @@ t_case_coap_publish(_) ->
     end,
     Case = fun(Channel, Token) ->
         Fun(Channel, Token, <<"/publish">>, ?checkMatch({ok, changed, _})),
-        Fun(Channel, Token, <<"/badpublish">>, ?checkMatch({error, uauthorized})),
+        Fun(Channel, Token, <<"/badpublish">>, ?checkMatch({error, unauthorized})),
         true
     end,
     Mod:with_connection(Case).
@@ -103,7 +103,7 @@ t_case_coap_subscribe(_) ->
     end,
     Case = fun(Channel, Token) ->
         Fun(Channel, Token, <<"/subscribe">>, ?checkMatch({ok, content, _})),
-        Fun(Channel, Token, <<"/badsubscribe">>, ?checkMatch({error, uauthorized})),
+        Fun(Channel, Token, <<"/badsubscribe">>, ?checkMatch({error, unauthorized})),
         true
     end,
     Mod:with_connection(Case).

--- a/apps/emqx_gateway_coap/mix.exs
+++ b/apps/emqx_gateway_coap/mix.exs
@@ -34,7 +34,7 @@ defmodule EMQXGatewayCoap.MixProject do
   defp test_deps() do
     if UMP.test_env?() do
       [
-        {:er_coap_client, github: "emqx/er_coap_client", tag: "v1.1.0"}
+        {:er_coap_client, github: "emqx/er_coap_client", tag: "v1.1.1"}
       ]
     else
       []

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -398,7 +398,7 @@ t_request_with_token_no_connection(_) ->
     Action = fun(Channel) ->
         URI = pubsub_uri("no_connection", "tok"),
         Req = make_req(get, <<>>, [{observe, 0}]),
-        ?assertMatch({error, uauthorized, _}, do_request(Channel, URI, Req))
+        ?assertMatch({error, unauthorized, _}, do_request(Channel, URI, Req))
     end,
     do(Action).
 
@@ -457,7 +457,7 @@ t_invalid_token_request(_) ->
         URI = pubsub_uri("abc", "badtoken"),
         Req = make_req(get, <<>>, [{observe, 0}]),
         try
-            ?assertMatch({error, uauthorized, _}, do_request(Channel, URI, Req))
+            ?assertMatch({error, unauthorized, _}, do_request(Channel, URI, Req))
         after
             disconnection(Channel, Token)
         end
@@ -499,15 +499,11 @@ t_pubsub_unauthorized(_) ->
             URI = pubsub_uri("deny", Token),
             Req1 = make_req(post, <<"payload">>),
             case do_request(Channel, URI, Req1) of
-                {error, uauthorized} -> ok;
-                {error, uauthorized, _} -> ok;
                 {error, unauthorized, _} -> ok;
                 {error, unauthorized} -> ok
             end,
             Req2 = make_req(get, <<>>, [{observe, 0}]),
             case do_request(Channel, URI, Req2) of
-                {error, uauthorized} -> ok;
-                {error, uauthorized, _} -> ok;
                 {error, unauthorized, _} -> ok;
                 {error, unauthorized} -> ok
             end,

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -1109,7 +1109,7 @@ t_invalid_token_rejected_across_udp_sessions(_) ->
         false
     ),
     Req = make_req(post, <<"x">>),
-    ?assertMatch({error, uauthorized, _}, do_request(Channel2, URI, Req)),
+    ?assertMatch({error, unauthorized, _}, do_request(Channel2, URI, Req)),
     disconnection(Channel2, Token),
     er_coap_channel:close(Channel2),
     er_coap_udp_socket:close(Sock2).
@@ -1132,7 +1132,7 @@ t_wrong_clientid_with_valid_token_rejected_across_udp_sessions(_) ->
         false
     ),
     Req = make_req(post, <<"x">>),
-    ?assertMatch({error, uauthorized, _}, do_request(Channel2, URI, Req)),
+    ?assertMatch({error, unauthorized, _}, do_request(Channel2, URI, Req)),
     disconnection(Channel2, Token),
     er_coap_channel:close(Channel2),
     er_coap_udp_socket:close(Sock2).

--- a/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
@@ -169,7 +169,7 @@ t_wrong_clientid_with_valid_token_rejected(_Config) ->
         false
     ),
     Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
-    ?assertMatch({error, uauthorized, _}, emqx_coap_SUITE:do_request(Channel2, URI1, Req1)),
+    ?assertMatch({error, unauthorized, _}, emqx_coap_SUITE:do_request(Channel2, URI1, Req1)),
 
     er_coap_channel:close(Channel2),
     er_coap_dtls_socket:close(Sock2).


### PR DESCRIPTION
Fixes N/A

Release version:
6.1.1

## Summary

This PR ports the CoAP unauthorized-code fix to `release-61`.

It first cherry-picks the `release-60` fix that updates the CoAP gateway test dependency `er_coap_client` from `v1.1.0` to `v1.1.1`; that dependency tag includes emqx/er_coap_client#7, where CoAP `4.01 Unauthorized` now decodes as `{error, unauthorized}` instead of `{error, uauthorized}`.

`release-61` also has newer CoAP tests in `apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl`, so this PR adds a second commit to update those new cases to expect only the corrected `unauthorized` atom.

Validation performed locally:

- `rg "uauthorized" . --glob '!deps/**' --glob '!_build/**' --glob '!.git/**'` found no tracked-source occurrences\n- `MIX_ENV=emqx-enterprise-test ./mix deps.compile er_coap_client --force`\n- `MIX_ENV=emqx-enterprise-test ./mix deps` confirmed `er_coap_client 1.1.1` locked at `f2b98b9 (tag: v1.1.1)`\n- Direct smoke test confirmed CoAP `4.01` decodes as `{error, unauthorized}`\n\nFull `MIX_ENV=emqx-enterprise-test ./mix compile` was attempted but blocked by release-61 dependency setup in this copied worktree: the local `mix.lock`/`deps` initially came from release-60, and full `deps.get` started pulling large release-61-only dependencies such as RabbitMQ `v4.2.1` before being stopped. The CoAP dependency itself was updated and verified directly.\n\n## PR Checklist\n\n- [ ] For internal contributor: there is a jira ticket to track this change\n- [x] The changes are covered with new or existing tests\n- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files\n  - Not user-visible; this updates a test-only CoAP client dependency and matching test assertions, so no changelog is needed.\n- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)\n  - No schema changes.\n