### PR TITLE
ci: bump OTP version to 27.3.4.2-7

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -1,7 +1,7 @@
 services:
   kdc:
     hostname: kdc.emqx.net
-    image:  ghcr.io/emqx/emqx-builder/6.0-7:1.18.3-27.3.4.2-6-ubuntu24.04
+    image:  ghcr.io/emqx/emqx-builder/6.1-3:1.18.3-27.3.4.2-7-ubuntu24.04
     container_name: kdc.emqx.net
     expose:
       - 88 # kdc

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   erlang:
     hostname: erlang.emqx.net
     container_name: erlang
-    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/6.0-7:1.18.3-27.3.4.2-6-ubuntu24.04}
+    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/6.1-3:1.18.3-27.3.4.2-7-ubuntu24.04}
     env_file:
       - credentials.env
       - conf.env

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -59,7 +59,7 @@ on:
       otp_vsn:
         required: false
         type: string
-        default: '27.3.4.2-6'
+        default: '27.3.4.2-7'
       elixir_vsn:
         required: false
         type: string
@@ -67,7 +67,7 @@ on:
       builder_vsn:
         required: false
         type: string
-        default: '6.0-7'
+        default: '6.1-3'
 
 permissions:
   contents: read

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.3.4.2-6
+erlang 27.3.4.2-7
 elixir 1.18.3-otp-27

--- a/changes/ee/fix-17164.en.md
+++ b/changes/ee/fix-17164.en.md
@@ -1,0 +1,1 @@
+Upgrade Erlang/OTP from 27.3.4.2-6 to 27.3.4.2-7.

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/6.0-7:1.18.3-27.3.4.2-6-debian13
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/6.1-3:1.18.3-27.3.4.2-7-debian13
 ARG RUN_FROM=debian:13-slim
 ARG SOURCE_TYPE=src # tgz
 

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 # https://github.com/emqx/emqx-builder
-export EMQX_BUILDER_VSN=6.0-7
-export OTP_VSN=27.3.4.2-6
+export EMQX_BUILDER_VSN=6.1-3
+export OTP_VSN=27.3.4.2-7
 export ELIXIR_VSN=1.18.3
 export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-ubuntu24.04
 export EMQX_DOCKER_BUILD_FROM=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-debian13


### PR DESCRIPTION
Release version: 5.10.4

## Summary

Bump Erlang/OTP from `27.3.4.2-6` to `27.3.4.2-7` and the EMQX builder image from `ghcr.io/emqx/emqx-builder/6.0-7` to `ghcr.io/emqx/emqx-builder/6.1-3`.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)