### PR TITLE
feat(resource): add buffer worker dispatch strategy

### DIFF
--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -467,6 +467,7 @@ common_action_resource_opts_subfields() ->
         batch_size,
         batch_time,
         buffer_mode,
+        buffer_worker_dispatch_strategy,
         buffer_seg_bytes,
         health_check_interval,
         health_check_interval_jitter,

--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -467,7 +467,7 @@ common_action_resource_opts_subfields() ->
         batch_size,
         batch_time,
         buffer_mode,
-        buffer_worker_dispatch_strategy,
+        dispatch_strategy,
         buffer_seg_bytes,
         health_check_interval,
         health_check_interval_jitter,

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -2617,6 +2617,7 @@ common_action_resource_opts() ->
         <<"batch_size">> => 1,
         <<"batch_time">> => <<"0ms">>,
         <<"buffer_mode">> => <<"memory_only">>,
+        <<"buffer_worker_dispatch_strategy">> => <<"per_clientid">>,
         <<"buffer_seg_bytes">> => <<"10MB">>,
         <<"health_check_interval">> => <<"1s">>,
         <<"health_check_interval_jitter">> => <<"0s">>,

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -2617,7 +2617,7 @@ common_action_resource_opts() ->
         <<"batch_size">> => 1,
         <<"batch_time">> => <<"0ms">>,
         <<"buffer_mode">> => <<"memory_only">>,
-        <<"buffer_worker_dispatch_strategy">> => <<"per_clientid">>,
+        <<"dispatch_strategy">> => <<"per_clientid">>,
         <<"buffer_seg_bytes">> => <<"10MB">>,
         <<"health_check_interval">> => <<"1s">>,
         <<"health_check_interval_jitter">> => <<"0s">>,

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_SUITE.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_SUITE.erl
@@ -179,6 +179,7 @@ action_config(Overrides) ->
                     <<"batch_size">>,
                     <<"batch_time">>,
                     <<"buffer_mode">>,
+                    <<"buffer_worker_dispatch_strategy">>,
                     <<"buffer_seg_bytes">>,
                     <<"health_check_interval_jitter">>,
                     <<"inflight_window">>,

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_SUITE.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_SUITE.erl
@@ -179,7 +179,7 @@ action_config(Overrides) ->
                     <<"batch_size">>,
                     <<"batch_time">>,
                     <<"buffer_mode">>,
-                    <<"buffer_worker_dispatch_strategy">>,
+                    <<"dispatch_strategy">>,
                     <<"buffer_seg_bytes">>,
                     <<"health_check_interval_jitter">>,
                     <<"inflight_window">>,

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_testlib.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_testlib.erl
@@ -130,7 +130,7 @@ action_config(Overrides) ->
                     <<"batch_size">>,
                     <<"batch_time">>,
                     <<"buffer_mode">>,
-                    <<"buffer_worker_dispatch_strategy">>,
+                    <<"dispatch_strategy">>,
                     <<"buffer_seg_bytes">>,
                     <<"health_check_interval_jitter">>,
                     <<"inflight_window">>,

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_testlib.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_testlib.erl
@@ -130,6 +130,7 @@ action_config(Overrides) ->
                     <<"batch_size">>,
                     <<"batch_time">>,
                     <<"buffer_mode">>,
+                    <<"buffer_worker_dispatch_strategy">>,
                     <<"buffer_seg_bytes">>,
                     <<"health_check_interval_jitter">>,
                     <<"inflight_window">>,

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -47,6 +47,7 @@
 -type query_opts() :: #{
     %% The key used for picking a resource worker
     pick_key => term(),
+    buffer_worker_dispatch_strategy => per_clientid | random,
     timeout => timeout(),
     expire_at => infinity | integer(),
     async_reply_fun => reply_fun(),
@@ -110,6 +111,9 @@
     %% Used by resource manager to decide whether to wait for resource to be
     %% `?status_connected` before returning or timing out.  Defaults to `false`.
     async_start => boolean(),
+    %% Controls how buffer workers are picked when query opts do not specify
+    %% `pick_key'.
+    buffer_worker_dispatch_strategy => per_clientid | random,
     %% used only for authn authz resources to indicate the owner authenticator or authorizer
     owner_id => binary() | atom()
 }.

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -47,7 +47,7 @@
 -type query_opts() :: #{
     %% The key used for picking a resource worker
     pick_key => term(),
-    dispatch_strategy => per_clientid | random,
+    buffer_worker_dispatch_strategy => per_clientid | random,
     timeout => timeout(),
     expire_at => infinity | integer(),
     async_reply_fun => reply_fun(),

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -47,7 +47,7 @@
 -type query_opts() :: #{
     %% The key used for picking a resource worker
     pick_key => term(),
-    buffer_worker_dispatch_strategy => per_clientid | random,
+    dispatch_strategy => per_clientid | random,
     timeout => timeout(),
     expire_at => infinity | integer(),
     async_reply_fun => reply_fun(),
@@ -113,7 +113,7 @@
     async_start => boolean(),
     %% Controls how buffer workers are picked when query opts do not specify
     %% `pick_key'.
-    buffer_worker_dispatch_strategy => per_clientid | random,
+    dispatch_strategy => per_clientid | random,
     %% used only for authn authz resources to indicate the owner authenticator or authorizer
     owner_id => binary() | atom()
 }.

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -549,20 +549,45 @@ get_callback_mode(Mod, State) ->
 
 -spec get_query_opts(module(), map()) -> #{timeout => timeout()}.
 get_query_opts(Mod, ActionOrSourceConfig) ->
+    CommonQueryOpts = common_query_opts(ActionOrSourceConfig),
     case erlang:function_exported(Mod, query_opts, 1) of
         true ->
-            Mod:query_opts(ActionOrSourceConfig);
+            case Mod:query_opts(ActionOrSourceConfig) of
+                {error, _} = Error ->
+                    Error;
+                QueryOpts ->
+                    maps:merge(CommonQueryOpts, QueryOpts)
+            end;
         false ->
-            case
-                emqx_utils_maps:deep_get([resource_opts, request_ttl], ActionOrSourceConfig, false)
-            of
-                Timeout when is_integer(Timeout) orelse Timeout =:= infinity ->
-                    %% request_ttl is configured
-                    #{timeout => Timeout};
-                _ ->
-                    %% emqx_resource has a default value (15s)
-                    #{}
-            end
+            CommonQueryOpts
+    end.
+
+common_query_opts(ActionOrSourceConfig) ->
+    maps:merge(
+        request_ttl_query_opts(ActionOrSourceConfig),
+        buffer_worker_dispatch_strategy_query_opts(ActionOrSourceConfig)
+    ).
+
+request_ttl_query_opts(ActionOrSourceConfig) ->
+    case emqx_utils_maps:deep_get([resource_opts, request_ttl], ActionOrSourceConfig, false) of
+        Timeout when is_integer(Timeout) orelse Timeout =:= infinity ->
+            %% request_ttl is configured
+            #{timeout => Timeout};
+        _ ->
+            %% emqx_resource has a default value (15s)
+            #{}
+    end.
+
+buffer_worker_dispatch_strategy_query_opts(ActionOrSourceConfig) ->
+    case
+        emqx_utils_maps:deep_get(
+            [resource_opts, buffer_worker_dispatch_strategy], ActionOrSourceConfig, false
+        )
+    of
+        Strategy when Strategy =:= per_clientid; Strategy =:= random ->
+            #{buffer_worker_dispatch_strategy => Strategy};
+        _ ->
+            #{}
     end.
 
 -spec call_start(resource_id(), module(), resource_config()) ->

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -221,7 +221,7 @@
 
 -callback query_mode(Config :: term()) -> resource_query_mode().
 
--callback query_opts(Config :: term()) -> #{timeout => timeout()}.
+-callback query_opts(Config :: term()) -> query_opts() | {error, term()}.
 
 %% This callback handles the installation of a specified channel.
 %%
@@ -547,26 +547,23 @@ get_callback_mode(Mod, State) ->
             undefined
     end.
 
--spec get_query_opts(module(), map()) -> #{timeout => timeout()}.
+-spec get_query_opts(module(), map()) -> query_opts() | {error, term()}.
 get_query_opts(Mod, ActionOrSourceConfig) ->
-    CommonQueryOpts = common_query_opts(ActionOrSourceConfig),
+    DispatchStrategyQueryOpts = buffer_worker_dispatch_strategy_query_opts(ActionOrSourceConfig),
     case erlang:function_exported(Mod, query_opts, 1) of
         true ->
             case Mod:query_opts(ActionOrSourceConfig) of
                 {error, _} = Error ->
                     Error;
                 QueryOpts ->
-                    maps:merge(CommonQueryOpts, QueryOpts)
+                    maps:merge(DispatchStrategyQueryOpts, QueryOpts)
             end;
         false ->
-            CommonQueryOpts
+            maps:merge(
+                request_ttl_query_opts(ActionOrSourceConfig),
+                DispatchStrategyQueryOpts
+            )
     end.
-
-common_query_opts(ActionOrSourceConfig) ->
-    maps:merge(
-        request_ttl_query_opts(ActionOrSourceConfig),
-        buffer_worker_dispatch_strategy_query_opts(ActionOrSourceConfig)
-    ).
 
 request_ttl_query_opts(ActionOrSourceConfig) ->
     case emqx_utils_maps:deep_get([resource_opts, request_ttl], ActionOrSourceConfig, false) of

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -578,7 +578,7 @@ request_ttl_query_opts(ActionOrSourceConfig) ->
 buffer_worker_dispatch_strategy_query_opts(ActionOrSourceConfig) ->
     case
         emqx_utils_maps:deep_get(
-            [resource_opts, buffer_worker_dispatch_strategy], ActionOrSourceConfig, false
+            [resource_opts, dispatch_strategy], ActionOrSourceConfig, false
         )
     of
         Strategy when Strategy =:= per_clientid; Strategy =:= random ->

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -176,7 +176,7 @@ sync_query(Id, Request, Opts0) ->
     ?tp(sync_query, #{id => Id, request => Request, query_opts => Opts0}),
     Opts1 = ensure_timeout_query_opts(Opts0, sync),
     Opts = ensure_expire_at(Opts1),
-    PickKey = maps:get(pick_key, Opts, self()),
+    PickKey = pick_key(Opts),
     Timeout = maps:get(timeout, Opts),
     emqx_resource_metrics:matched_inc(Id),
     pick_call(Id, PickKey, #query{request = Request, query_opts = Opts}, Timeout).
@@ -186,13 +186,20 @@ async_query(Id, Request, Opts0) ->
     ?tp(async_query, #{id => Id, request => Request, query_opts => Opts0}),
     Opts1 = ensure_timeout_query_opts(Opts0, async),
     Opts = ensure_expire_at(Opts1),
-    PickKey = maps:get(pick_key, Opts, self()),
+    PickKey = pick_key(Opts),
     emqx_resource_metrics:matched_inc(Id),
     %% When a fallback action is itself unavailable, we emit this initial trace event so
     %% that the frontend can see it was triggered when tracing rules...  Otherwise, if the
     %% fallback never recovers, there will be no trace indicating it was received.
     ?TRACE("QUERY", "async_query_received", #{action_id => Id}),
     pick_cast(Id, PickKey, #query{request = Request, query_opts = Opts}).
+
+pick_key(#{pick_key := PickKey}) ->
+    PickKey;
+pick_key(#{buffer_worker_dispatch_strategy := random}) ->
+    rand:uniform(16#100000000);
+pick_key(_) ->
+    self().
 
 %% simple query the resource without batching and queuing.
 -spec simple_sync_query(id(), request()) -> term().

--- a/apps/emqx_resource/src/schema/emqx_resource_schema.erl
+++ b/apps/emqx_resource/src/schema/emqx_resource_schema.erl
@@ -42,6 +42,7 @@ create_opts(Overrides) ->
         [
             {buffer_mode, fun buffer_mode/1},
             {worker_pool_size, fun worker_pool_size/1},
+            {buffer_worker_dispatch_strategy, fun buffer_worker_dispatch_strategy/1},
             {health_check_interval, fun health_check_interval/1},
             {health_check_interval_jitter, fun health_check_interval_jitter/1},
             {health_check_timeout, fun health_check_timeout/1},
@@ -85,6 +86,12 @@ worker_pool_size(desc) -> ?DESC("worker_pool_size");
 worker_pool_size(default) -> ?WORKER_POOL_SIZE;
 worker_pool_size(required) -> false;
 worker_pool_size(_) -> undefined.
+
+buffer_worker_dispatch_strategy(type) -> enum([per_clientid, random]);
+buffer_worker_dispatch_strategy(desc) -> ?DESC("buffer_worker_dispatch_strategy");
+buffer_worker_dispatch_strategy(default) -> per_clientid;
+buffer_worker_dispatch_strategy(required) -> false;
+buffer_worker_dispatch_strategy(_) -> undefined.
 
 resume_interval(type) -> emqx_schema:timeout_duration_ms();
 resume_interval(importance) -> ?IMPORTANCE_HIDDEN;

--- a/apps/emqx_resource/src/schema/emqx_resource_schema.erl
+++ b/apps/emqx_resource/src/schema/emqx_resource_schema.erl
@@ -42,7 +42,7 @@ create_opts(Overrides) ->
         [
             {buffer_mode, fun buffer_mode/1},
             {worker_pool_size, fun worker_pool_size/1},
-            {buffer_worker_dispatch_strategy, fun buffer_worker_dispatch_strategy/1},
+            {dispatch_strategy, fun dispatch_strategy/1},
             {health_check_interval, fun health_check_interval/1},
             {health_check_interval_jitter, fun health_check_interval_jitter/1},
             {health_check_timeout, fun health_check_timeout/1},
@@ -87,11 +87,11 @@ worker_pool_size(default) -> ?WORKER_POOL_SIZE;
 worker_pool_size(required) -> false;
 worker_pool_size(_) -> undefined.
 
-buffer_worker_dispatch_strategy(type) -> enum([per_clientid, random]);
-buffer_worker_dispatch_strategy(desc) -> ?DESC("buffer_worker_dispatch_strategy");
-buffer_worker_dispatch_strategy(default) -> per_clientid;
-buffer_worker_dispatch_strategy(required) -> false;
-buffer_worker_dispatch_strategy(_) -> undefined.
+dispatch_strategy(type) -> enum([per_clientid, random]);
+dispatch_strategy(desc) -> ?DESC("dispatch_strategy");
+dispatch_strategy(default) -> per_clientid;
+dispatch_strategy(required) -> false;
+dispatch_strategy(_) -> undefined.
 
 resume_interval(type) -> emqx_schema:timeout_duration_ms();
 resume_interval(importance) -> ?IMPORTANCE_HIDDEN;

--- a/apps/emqx_resource/test/emqx_connector_demo.erl
+++ b/apps/emqx_resource/test/emqx_connector_demo.erl
@@ -165,6 +165,8 @@ on_stop(_InstId, #{pid := Pid}) ->
 
 on_query(_InstId, get_state, State) ->
     {ok, State};
+on_query(_InstId, get_query_process, _State) ->
+    {ok, self()};
 on_query(_InstId, get_state_failed, State) ->
     {error, State};
 on_query(_InstId, block, #{pid := Pid}) ->

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -76,9 +76,15 @@ end_per_testcase(_, _Config) ->
 
 init_per_suite(Config) ->
     code:ensure_loaded(?TEST_RESOURCE),
+    ListenerConf =
+        "\n"
+        "listeners.tcp.default.bind = 28883\n"
+        "listeners.ssl.default.bind = 28884\n"
+        "listeners.ws.default.bind = 28083\n"
+        "listeners.wss.default.bind = 28084\n",
     Apps = emqx_cth_suite:start(
         [
-            emqx,
+            {emqx, ListenerConf},
             emqx_conf,
             emqx_resource
         ],
@@ -1001,6 +1007,34 @@ t_query(_) ->
         emqx_resource:query(<<"unknown">>, get_state)
     ),
 
+    ok = emqx_resource:remove_local(?ID).
+
+t_buffer_worker_dispatch_strategy(_) ->
+    ResourceOpts = #{
+        query_mode => sync,
+        worker_pool_size => 4,
+        buffer_worker_dispatch_strategy => random
+    },
+    Config = #{
+        name => test_resource,
+        resource_opts => ResourceOpts
+    },
+    {ok, _} = create(
+        ?ID,
+        ?DEFAULT_RESOURCE_GROUP,
+        ?TEST_RESOURCE,
+        Config,
+        ResourceOpts
+    ),
+    QueryOpts = emqx_resource:get_query_opts(?TEST_RESOURCE, Config),
+    Pids = lists:map(
+        fun(_) ->
+            {ok, Pid} = emqx_resource:query(?ID, get_query_process, QueryOpts),
+            Pid
+        end,
+        lists:seq(1, 100)
+    ),
+    ?assert(length(lists:usort(Pids)) > 1, #{pids => Pids}),
     ok = emqx_resource:remove_local(?ID).
 
 t_query_counter(_) ->

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -1009,11 +1009,11 @@ t_query(_) ->
 
     ok = emqx_resource:remove_local(?ID).
 
-t_buffer_worker_dispatch_strategy(_) ->
+t_dispatch_strategy(_) ->
     ResourceOpts = #{
         query_mode => sync,
         worker_pool_size => 4,
-        buffer_worker_dispatch_strategy => random
+        dispatch_strategy => random
     },
     Config = #{
         name => test_resource,

--- a/apps/emqx_resource/test/emqx_resource_schema_tests.erl
+++ b/apps/emqx_resource/test/emqx_resource_schema_tests.erl
@@ -93,6 +93,30 @@ worker_pool_size_test_() ->
         ?_test(AssertThrow(1025))
     ].
 
+buffer_worker_dispatch_strategy_test_() ->
+    Check = fun(Strategy) ->
+        #{<<"resource_opts">> := #{<<"buffer_worker_dispatch_strategy">> := Parsed}} =
+            emqx_bridge_schema_testlib:http_action_config(#{
+                <<"connector">> => <<"my_connector">>,
+                <<"resource_opts">> => #{<<"buffer_worker_dispatch_strategy">> => Strategy}
+            }),
+        Parsed
+    end,
+    [
+        ?_assertEqual(<<"per_clientid">>, Check(<<"per_clientid">>)),
+        ?_assertEqual(<<"random">>, Check(<<"random">>)),
+        ?_assertThrow(
+            {_, [
+                #{
+                    kind := validation_error,
+                    reason := not_a_enum_symbol,
+                    value := unknown
+                }
+            ]},
+            Check(<<"unknown">>)
+        )
+    ].
+
 %%===========================================================================
 %% Helper functions
 %%===========================================================================

--- a/apps/emqx_resource/test/emqx_resource_schema_tests.erl
+++ b/apps/emqx_resource/test/emqx_resource_schema_tests.erl
@@ -93,12 +93,12 @@ worker_pool_size_test_() ->
         ?_test(AssertThrow(1025))
     ].
 
-buffer_worker_dispatch_strategy_test_() ->
+dispatch_strategy_test_() ->
     Check = fun(Strategy) ->
-        #{<<"resource_opts">> := #{<<"buffer_worker_dispatch_strategy">> := Parsed}} =
+        #{<<"resource_opts">> := #{<<"dispatch_strategy">> := Parsed}} =
             emqx_bridge_schema_testlib:http_action_config(#{
                 <<"connector">> => <<"my_connector">>,
-                <<"resource_opts">> => #{<<"buffer_worker_dispatch_strategy">> => Strategy}
+                <<"resource_opts">> => #{<<"dispatch_strategy">> => Strategy}
             }),
         Parsed
     end,

--- a/apps/emqx_resource/test/emqx_resource_tests.erl
+++ b/apps/emqx_resource/test/emqx_resource_tests.erl
@@ -4,8 +4,39 @@
 
 -module(emqx_resource_tests).
 
+-export([query_opts/1]).
+
 -include_lib("eunit/include/eunit.hrl").
 -include("emqx_resource.hrl").
+
+get_query_opts_test_() ->
+    Config = #{
+        resource_opts => #{
+            request_ttl => 2_000,
+            buffer_worker_dispatch_strategy => random
+        }
+    },
+    [
+        {"preserves callback timeout and adds dispatch strategy",
+            ?_assertEqual(
+                #{
+                    timeout => 1_000,
+                    buffer_worker_dispatch_strategy => random
+                },
+                emqx_resource:get_query_opts(?MODULE, Config)
+            )},
+        {"uses request ttl when callback is not exported",
+            ?_assertEqual(
+                #{
+                    timeout => 2_000,
+                    buffer_worker_dispatch_strategy => random
+                },
+                emqx_resource:get_query_opts(maps, Config)
+            )}
+    ].
+
+query_opts(_Config) ->
+    #{timeout => 1_000}.
 
 is_dry_run_test_() ->
     [

--- a/apps/emqx_resource/test/emqx_resource_tests.erl
+++ b/apps/emqx_resource/test/emqx_resource_tests.erl
@@ -13,7 +13,7 @@ get_query_opts_test_() ->
     Config = #{
         resource_opts => #{
             request_ttl => 2_000,
-            buffer_worker_dispatch_strategy => random
+            dispatch_strategy => random
         }
     },
     [

--- a/changes/ee/feat-17165.en.md
+++ b/changes/ee/feat-17165.en.md
@@ -1,0 +1,3 @@
+Added the `resource_opts.buffer_worker_dispatch_strategy` option for actions.
+
+The new option defaults to `per_clientid`, preserving the previous buffer worker dispatch behavior. Setting it to `random` makes queries without an explicit `pick_key` use a random dispatch key, which helps spread traffic across multiple buffer workers when a small number of clients publish a large amount of messages.

--- a/changes/ee/feat-17165.en.md
+++ b/changes/ee/feat-17165.en.md
@@ -1,3 +1,3 @@
-Added the `resource_opts.buffer_worker_dispatch_strategy` option for actions.
+Added the `resource_opts.dispatch_strategy` option for actions.
 
 The new option defaults to `per_clientid`, preserving the previous buffer worker dispatch behavior. Setting it to `random` makes queries without an explicit `pick_key` use a random dispatch key, which helps spread traffic across multiple buffer workers when a small number of clients publish a large amount of messages.

--- a/rel/i18n/emqx_resource_schema.hocon
+++ b/rel/i18n/emqx_resource_schema.hocon
@@ -19,11 +19,11 @@ This value is to specify the size of each on-disk buffer file."""
 buffer_seg_bytes.label:
 """Segment File Bytes"""
 
-buffer_worker_dispatch_strategy.desc:
-"""The strategy for choosing a buffer worker when a query does not set an explicit pick key. The default value <code>per_clientid</code> preserves the existing behavior. Set to <code>random</code> to spread such queries across buffer workers."""
+dispatch_strategy.desc:
+"""The strategy for dispatching queries when a query does not set an explicit pick key. The default value <code>per_clientid</code> preserves the existing behavior. Set to <code>random</code> to spread such queries across multiple workers."""
 
-buffer_worker_dispatch_strategy.label:
-"""Buffer Worker Dispatch Strategy"""
+dispatch_strategy.label:
+"""Dispatch Strategy"""
 
 creation_opts.desc:
 """Creation options."""

--- a/rel/i18n/emqx_resource_schema.hocon
+++ b/rel/i18n/emqx_resource_schema.hocon
@@ -19,6 +19,12 @@ This value is to specify the size of each on-disk buffer file."""
 buffer_seg_bytes.label:
 """Segment File Bytes"""
 
+buffer_worker_dispatch_strategy.desc:
+"""The strategy for choosing a buffer worker when a query does not set an explicit pick key. The default value <code>per_clientid</code> preserves the existing behavior. Set to <code>random</code> to spread such queries across buffer workers."""
+
+buffer_worker_dispatch_strategy.label:
+"""Buffer Worker Dispatch Strategy"""
+
 creation_opts.desc:
 """Creation options."""
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15257

Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

This PR adds a configurable resource buffer worker dispatch strategy for actions.

Previously, resource buffer workers used the caller process as the default pick key when a query did not provide an explicit `pick_key`. In workloads where a small number of clients publish a large amount of messages, this can concentrate traffic on a single buffer worker even when `worker_pool_size` is greater than one.

The new `resource_opts.dispatch_strategy` option supports:

* `per_clientid` - the default behavior, preserving the existing caller-process based dispatch when no explicit `pick_key` is provided.
* `random` - use a random pick key for each query when no explicit `pick_key` is provided, allowing such traffic to spread across buffer workers.

The schema change is exposed through the common resource schema and the bridge v2 action resource options, so it is available from configuration and HTTP API action payloads. Runtime query option collection now carries this setting into `emqx_resource_buffer_worker`, while explicit `pick_key` values continue to take precedence.

Tests cover schema acceptance/rejection and runtime dispatch across multiple buffer workers.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
