### PR TITLE
fix(dashboard): allow namespaced admins to manage own MFA

### DIFF
--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -161,6 +161,28 @@ do_check_rbac(
         _ ->
             false
     end;
+do_check_rbac(
+    #{?role := ?ROLE_SUPERUSER, ?namespace := Namespace, ?actor := Username},
+    Req,
+    ?DASHBOARD_API(post, change_mfa)
+) when is_binary(Namespace) ->
+    %% Namespaced administrators may manage MFA only for themselves.
+    case Req of
+        #{bindings := #{username := Username}} -> true;
+        _ -> false
+    end;
+do_check_rbac(
+    #{?role := ?ROLE_SUPERUSER, ?namespace := Namespace, ?actor := Username} = Actor,
+    Req,
+    ?DASHBOARD_API(delete, change_mfa)
+) when is_binary(Namespace) ->
+    %% Namespaced administrators may manage MFA only for themselves.
+    case Req of
+        #{bindings := #{username := Username}} ->
+            not is_forced_sso_mfa(maps:get(?backend, Actor, ?BACKEND_LOCAL));
+        _ ->
+            false
+    end;
 do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := Namespace}, _Req, ?CONNECTOR_API(_, _)) when
     is_binary(Namespace)
 ->

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -333,26 +333,41 @@ test_mfa(VerifyFn) ->
     Viewer1 = <<"viewermfa1">>,
     Viewer2 = <<"viewermfa2">>,
     SuperUser = <<"adminmfa">>,
+    NamespacedSuperUser = <<"nsadminmfa">>,
     Password = <<"xyz124abc">>,
     Desc = <<"desc">>,
     {ok, _} = emqx_dashboard_admin:add_user(Viewer1, Password, ?ROLE_VIEWER, Desc),
     {ok, _} = emqx_dashboard_admin:add_user(Viewer2, Password, ?ROLE_VIEWER, Desc),
     {ok, _} = emqx_dashboard_admin:add_user(SuperUser, Password, ?ROLE_SUPERUSER, Desc),
+    {ok, _} = emqx_dashboard_admin:add_user(
+        NamespacedSuperUser,
+        Password,
+        <<"ns:ns1::", ?ROLE_SUPERUSER/binary>>,
+        Desc
+    ),
     {ok, #{role := ?ROLE_VIEWER, token := Viewer1Token}} = emqx_dashboard_admin:sign_token(
         Viewer1, Password
     ),
     {ok, #{role := ?ROLE_SUPERUSER, token := SuperToken}} = emqx_dashboard_admin:sign_token(
         SuperUser, Password
     ),
-    %% viewer can change own password
+    {ok, #{role := ?ROLE_SUPERUSER, token := NamespacedSuperToken}} =
+        emqx_dashboard_admin:sign_token(NamespacedSuperUser, Password),
+    %% viewer can change own MFA
     ?assertMatch({ok, #{actor := Viewer1}}, VerifyFn(Viewer1Token, Viewer1)),
-    %% viewer can't change other's password
+    %% viewer can't change other's MFA
     ?assertEqual({error, unauthorized_role}, VerifyFn(Viewer1Token, Viewer2)),
     ?assertEqual({error, unauthorized_role}, VerifyFn(Viewer1Token, SuperUser)),
-    %% superuser can change other's password
+    %% superuser can change other's MFA
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, Viewer1)),
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, Viewer2)),
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, SuperUser)),
+    %% namespaced superuser can change own MFA, but not other dashboard users' MFA
+    ?assertMatch(
+        {ok, #{actor := NamespacedSuperUser}},
+        VerifyFn(NamespacedSuperToken, NamespacedSuperUser)
+    ),
+    ?assertEqual({error, unauthorized_role}, VerifyFn(NamespacedSuperToken, Viewer1)),
     ok.
 
 delete_mfa(Token, Username) ->

--- a/changes/ee/fix-17171.en.md
+++ b/changes/ee/fix-17171.en.md
@@ -1,0 +1,3 @@
+Fixed an RBAC issue that prevented namespaced dashboard administrators from enabling or disabling MFA for their own account.
+
+Namespaced administrators remain restricted from managing MFA settings for other dashboard users.


### PR DESCRIPTION
Fixes 

Release version:

## Summary

Namespaced dashboard administrators were denied `POST` and `DELETE` requests to `/users/:username/mfa`, even when the path username matched their own actor. This meant they could not enroll or reset MFA for themselves.

This updates `emqx_dashboard_rbac` so namespaced administrators can manage MFA only for their own account, while still preventing them from managing other dashboard users' MFA settings. The existing SSO `force_mfa` guard for disabling MFA is preserved.

The RBAC suite now covers both setup and delete MFA paths for namespaced administrators.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
