### PR TITLE
fix(mgmt): block api key from leaking or restoring dashboard accounts via data backup

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
@@ -228,7 +228,8 @@ field_filename(IsRequired, Meta) ->
 
 data_export(post, #{body := Params0} = Req) ->
     Namespace = emqx_dashboard:get_namespace(Req),
-    Params = emqx_utils_maps:put_if(Params0, <<"namespace">>, Namespace, is_binary(Namespace)),
+    Params1 = emqx_utils_maps:put_if(Params0, <<"namespace">>, Namespace, is_binary(Namespace)),
+    Params = maybe_filter_export_params(Params1, auth_meta(Req)),
     maybe
         ok ?= emqx_mgmt_data_backup:validate_export_root_keys(Params),
         {ok, Opts} ?= emqx_mgmt_data_backup:parse_export_request(Params),
@@ -262,34 +263,51 @@ data_import(post, #{body := #{<<"filename">> := Filename} = Body} = Req) ->
         {error, Msg} ->
             {400, #{code => ?BAD_REQUEST, message => Msg}};
         FileNode ->
-            CoreNode = core_node(FileNode),
-            Opts = emqx_utils_maps:put_if(#{}, namespace, Namespace, is_binary(Namespace)),
-            Res = emqx_mgmt_data_backup_proto_v2:import_file(
-                CoreNode,
-                FileNode,
-                Filename,
-                Opts,
-                infinity
-            ),
-            case Res of
-                {ok, #{db_errors := DbErrs, config_errors := ConfErrs}} ->
-                    case DbErrs =:= #{} andalso ConfErrs =:= #{} of
-                        true ->
-                            {204};
-                        false ->
-                            Msg = format_import_errors(DbErrs, ConfErrs),
-                            {400, #{code => ?BAD_REQUEST, message => Msg}}
-                    end;
-                {badrpc, Reason} ->
-                    {500, #{
-                        code => ?SERVICE_UNAVAILABLE(Reason),
+            case check_no_sensitive_tables(Filename, auth_meta(Req)) of
+                {forbidden, Sets} ->
+                    SensMsg = iolist_to_binary([
+                        <<"API key import refused: backup contains restricted tables: ">>,
+                        lists:join(<<", ">>, Sets)
+                    ]),
+                    {403, #{code => 'FORBIDDEN', message => SensMsg}};
+                {peek_error, Reason} ->
+                    {400, #{
+                        code => ?BAD_REQUEST,
                         message => emqx_mgmt_data_backup:format_error(Reason)
                     }};
-                {error, Reason} ->
-                    {400, #{
-                        code => ?BAD_REQUEST, message => emqx_mgmt_data_backup:format_error(Reason)
-                    }}
+                ok ->
+                    do_data_import(FileNode, Filename, Namespace)
             end
+    end.
+
+do_data_import(FileNode, Filename, Namespace) ->
+    CoreNode = core_node(FileNode),
+    Opts = emqx_utils_maps:put_if(#{}, namespace, Namespace, is_binary(Namespace)),
+    Res = emqx_mgmt_data_backup_proto_v2:import_file(
+        CoreNode,
+        FileNode,
+        Filename,
+        Opts,
+        infinity
+    ),
+    case Res of
+        {ok, #{db_errors := DbErrs, config_errors := ConfErrs}} ->
+            case DbErrs =:= #{} andalso ConfErrs =:= #{} of
+                true ->
+                    {204};
+                false ->
+                    Msg = format_import_errors(DbErrs, ConfErrs),
+                    {400, #{code => ?BAD_REQUEST, message => Msg}}
+            end;
+        {badrpc, Reason} ->
+            {500, #{
+                code => ?SERVICE_UNAVAILABLE(Reason),
+                message => emqx_mgmt_data_backup:format_error(Reason)
+            }};
+        {error, Reason} ->
+            {400, #{
+                code => ?BAD_REQUEST, message => emqx_mgmt_data_backup:format_error(Reason)
+            }}
     end.
 
 format_import_errors(DbErrs, ConfErrs) ->
@@ -366,6 +384,46 @@ data_file_by_name(Method, #{bindings := #{filename := Filename}, query_string :=
 %%------------------------------------------------------------------------------
 %% Internal functions
 %%------------------------------------------------------------------------------
+
+auth_meta(#{auth_meta := AuthMeta}) -> AuthMeta;
+auth_meta(_) -> #{}.
+
+is_api_key_caller(#{auth_type := api_key}) -> true;
+is_api_key_caller(_) -> false.
+
+%% API key callers must not export tables that hold dashboard accounts or
+%% API keys themselves. Force-filter the requested table sets accordingly.
+%% Dashboard JWT callers are unaffected.
+maybe_filter_export_params(Params, AuthMeta) ->
+    case is_api_key_caller(AuthMeta) of
+        true -> filter_sensitive_table_sets(Params);
+        false -> Params
+    end.
+
+filter_sensitive_table_sets(Params) ->
+    Sensitive = emqx_mgmt_data_backup:sensitive_table_set_names(),
+    Allowed =
+        case maps:find(<<"table_sets">>, Params) of
+            {ok, Requested} -> Requested -- Sensitive;
+            error -> emqx_mgmt_data_backup:all_table_set_names() -- Sensitive
+        end,
+    Params#{<<"table_sets">> => Allowed}.
+
+%% Peek the local file. If the file lives on a different node (caller passed
+%% `node' in the body), the local peek returns `{error, not_found}' and the
+%% handler reports a 400 -- API-key callers must upload to the same node where
+%% they import.
+check_no_sensitive_tables(Filename, AuthMeta) ->
+    case is_api_key_caller(AuthMeta) of
+        false ->
+            ok;
+        true ->
+            case emqx_mgmt_data_backup:peek_sensitive_table_sets(Filename) of
+                {ok, []} -> ok;
+                {ok, Sets} -> {forbidden, Sets};
+                {error, Reason} -> {peek_error, Reason}
+            end
+    end.
 
 get_or_delete_file(get, Filename, Node) ->
     emqx_mgmt_data_backup_proto_v1:read_file(Node, Filename, infinity);

--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -29,7 +29,9 @@
     delete_file/1,
     list_files/0,
     format_conf_errors/1,
-    format_db_errors/1
+    format_db_errors/1,
+    sensitive_table_set_names/0,
+    peek_sensitive_table_sets/1
 ]).
 
 -export([default_validate_mnesia_backup/1]).
@@ -195,6 +197,74 @@ build_all_table_set_names() ->
             Mods
         )
     ).
+
+%% Table sets that contain credentials/identities an API key must never be able
+%% to read or write through data backup, mirroring the `?SCOPE_DENIED' guard
+%% on /users and /api_key endpoints.
+-spec sensitive_table_set_names() -> [binary()].
+sensitive_table_set_names() ->
+    [<<"dashboard_users">>, <<"api_keys">>].
+
+%% Inspect a previously-uploaded backup file and return which sensitive table
+%% sets are present in it. Used by the HTTP handler to reject API-key-driven
+%% imports of backups containing dashboard_users / api_keys data.
+-spec peek_sensitive_table_sets(file:filename_all()) ->
+    {ok, [binary()]} | {error, _}.
+peek_sensitive_table_sets(Filename) ->
+    maybe
+        {ok, FilePath} ?= backup_path(Filename),
+        ok ?= validate_file_exists(FilePath),
+        {ok, Entries} ?= tar_table(FilePath),
+        {ok, sensitive_sets_in_entries(Entries)}
+    end.
+
+tar_table(FilePath) ->
+    case erl_tar:table(FilePath, [compressed]) of
+        {ok, _} = Ok -> Ok;
+        {error, Reason} -> {error, {bad_backup_file, Reason}}
+    end.
+
+sensitive_sets_in_entries(Entries) ->
+    SensitiveTabMap = sensitive_tab_to_set_map(),
+    lists:usort(
+        lists:filtermap(
+            fun(Path) -> match_sensitive_entry(Path, SensitiveTabMap) end,
+            Entries
+        )
+    ).
+
+%% #{<<"emqx_admin">> => <<"dashboard_users">>, <<"emqx_app">> => <<"api_keys">>}
+sensitive_tab_to_set_map() ->
+    Mapping = table_set_to_tables_mapping(),
+    Sensitive = sensitive_table_set_names(),
+    maps:fold(
+        fun(SetName, Tabs, Acc) ->
+            case lists:member(SetName, Sensitive) of
+                true ->
+                    lists:foldl(
+                        fun(Tab, A2) -> A2#{atom_to_binary(Tab, utf8) => SetName} end,
+                        Acc,
+                        Tabs
+                    );
+                false ->
+                    Acc
+            end
+        end,
+        #{},
+        Mapping
+    ).
+
+%% Tar entries are paths like "<base>/mnesia/<atom_to_list(TabName)>".
+match_sensitive_entry(Path, SensitiveTabMap) ->
+    case lists:reverse(filename:split(str(Path))) of
+        [TabName, ?BACKUP_MNESIA_DIR | _] ->
+            case maps:find(list_to_binary(TabName), SensitiveTabMap) of
+                {ok, SetName} -> {true, SetName};
+                error -> false
+            end;
+        _ ->
+            false
+    end.
 
 validate_export_root_keys(Params) ->
     RootKeys0 = maps:get(<<"root_keys">>, Params, []),
@@ -406,6 +476,8 @@ format_error({unsupported_version, ImportVersion}) ->
     );
 format_error({already_exists, BackupFilename}) ->
     str(io_lib:format("Backup file \"~s\" already exists", [BackupFilename]));
+format_error({bad_backup_file, Reason}) ->
+    str(io_lib:format("Bad backup file: ~p", [Reason]));
 format_error(Reason) ->
     Reason.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -21,6 +21,8 @@
 -define(UPLOAD_CE_BACKUP, "emqx-export-upload-ce.tar.gz").
 -define(BAD_UPLOAD_BACKUP, "emqx-export-bad-upload.tar.gz").
 -define(BAD_IMPORT_BACKUP, "emqx-export-bad-file.tar.gz").
+-define(DASHBOARD_USER, <<"admin_for_test">>).
+-define(DASHBOARD_PASS, <<"public_for_test_1">>).
 -define(backup_path(_Config_, _BackupName_),
     filename:join(?config(data_dir, _Config_), _BackupName_)
 ).
@@ -305,11 +307,76 @@ t_exhook_backup(Config) ->
     ?ON(N1, emqx_ctl:run_command(["data", "import", Filepath])),
     ok.
 
+%% API keys must not be able to export tables that hold dashboard accounts or
+%% API keys themselves.
+t_export_api_key_omits_sensitive_tables(Config) ->
+    ApiAuth = ?config(auth, Config),
+    {200, #{<<"filename">> := Filename, <<"node">> := NodeBin}} =
+        export_backup2(?NODE1_PORT, ApiAuth, #{}),
+    Node = binary_to_atom(NodeBin, utf8),
+    {ok, BinContents} = ?ON(
+        Node, emqx_mgmt_data_backup:read_file(unicode:characters_to_binary(Filename))
+    ),
+    {ok, TmpFile} = write_tmp_tar(BinContents),
+    try
+        {ok, Entries} = erl_tar:table(TmpFile, [compressed]),
+        SensitiveTabs = ["mnesia/emqx_admin", "mnesia/emqx_app"],
+        FoundSensitive = [
+            E
+         || E <- Entries,
+            S <- SensitiveTabs,
+            string:find(E, S) =/= nomatch
+        ],
+        ?assertEqual(
+            [],
+            FoundSensitive,
+            "API-key export must not contain dashboard_users / api_keys mnesia tables"
+        )
+    after
+        file:delete(TmpFile)
+    end,
+    ok.
+
+%% API keys must be rejected with 403 when importing a backup that contains
+%% sensitive mnesia tables.
+t_import_api_key_blocks_sensitive_tables(Config) ->
+    ApiAuth = ?config(auth, Config),
+    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
+    ?assertEqual(ok, upload_backup(?NODE1_PORT, ApiAuth, UploadFile)),
+    {Status, Body} = import_backup_full(?NODE1_PORT, ApiAuth, ?UPLOAD_CE_BACKUP),
+    ?assertEqual(403, Status),
+    ?assertMatch(#{<<"code">> := <<"FORBIDDEN">>}, Body),
+    ok.
+
+%% Dashboard bearer-token (JWT) callers can import backups that include the
+%% sensitive mnesia tables. The API-key restriction must not regress them.
+t_import_dashboard_token_allows_sensitive_tables(Config) ->
+    ApiAuth = ?config(auth, Config),
+    DashboardAuth = ?config(dashboard_auth, Config),
+    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
+    ?assertEqual(ok, upload_backup(?NODE1_PORT, ApiAuth, UploadFile)),
+    ?assertMatch({ok, _}, import_backup(?NODE1_PORT, DashboardAuth, ?UPLOAD_CE_BACKUP)),
+    ok.
+
+write_tmp_tar(Bin) ->
+    Path = filename:join([
+        "/tmp",
+        "emqx-test-export-" ++ integer_to_list(erlang:unique_integer([positive])) ++ ".tar.gz"
+    ]),
+    ok = file:write_file(Path, Bin),
+    {ok, Path}.
+
+import_backup_full(NodeApiPort, Auth, BackupName) ->
+    Path = emqx_mgmt_api_test_util:api_path(?api_base_url(NodeApiPort), ["data", "import"]),
+    Body = #{<<"filename">> => unicode:characters_to_binary(BackupName)},
+    emqx_mgmt_api_test_util:simple_request(post, Path, Body, Auth).
+
 do_init_per_testcase(TC, Config) ->
     Cluster = [Core1, _Core2, Repl] = cluster(TC, Config),
     Auth = auth_header(Core1),
+    DashboardAuth = dashboard_auth_header(Core1),
     ok = wait_for_auth_replication(Repl),
-    [{auth, Auth}, {cluster, Cluster} | Config].
+    [{auth, Auth}, {dashboard_auth, DashboardAuth}, {cluster, Cluster} | Config].
 
 test_file_op(Method, Config) ->
     Auth = ?config(auth, Config),
@@ -400,6 +467,9 @@ upload_backup_test(Config, BackupName) ->
 
 import_backup_test(Config, BackupName) ->
     Auth = ?config(auth, Config),
+    %% Fixtures contain sensitive mnesia tables (emqx_admin, emqx_app);
+    %% importing them is only allowed via dashboard bearer-token auth, not API key.
+    DashboardAuth = ?config(dashboard_auth, Config),
     UploadFile = ?backup_path(Config, BackupName),
     BadImportFile = ?backup_path(Config, ?BAD_IMPORT_BACKUP),
 
@@ -409,17 +479,19 @@ import_backup_test(Config, BackupName) ->
     ?assertEqual(ok, upload_backup(?NODE2_PORT, Auth, BadImportFile)),
 
     %% Replicant node must be able to import the file by doing rpc to a core node
-    ?assertMatch({ok, _}, import_backup(?NODE3_PORT, Auth, BackupName)),
+    ?assertMatch({ok, _}, import_backup(?NODE3_PORT, DashboardAuth, BackupName)),
 
     [N1, N2, N3] = ?config(cluster, Config),
 
-    ?assertMatch({ok, _}, import_backup(?NODE3_PORT, Auth, BackupName)),
+    ?assertMatch({ok, _}, import_backup(?NODE3_PORT, DashboardAuth, BackupName)),
 
-    ?assertMatch({ok, _}, import_backup(?NODE1_PORT, Auth, BackupName, N3)),
+    ?assertMatch({ok, _}, import_backup(?NODE1_PORT, DashboardAuth, BackupName, N3)),
     %% Now this node must also have the file locally
-    ?assertMatch({ok, _}, import_backup(?NODE1_PORT, Auth, BackupName, N1)),
+    ?assertMatch({ok, _}, import_backup(?NODE1_PORT, DashboardAuth, BackupName, N1)),
 
-    ?assertMatch({error, {_, 400, _}}, import_backup(?NODE2_PORT, Auth, ?BAD_IMPORT_BACKUP, N2)).
+    ?assertMatch(
+        {error, {_, 400, _}}, import_backup(?NODE2_PORT, DashboardAuth, ?BAD_IMPORT_BACKUP, N2)
+    ).
 
 assert_second_call(get, Res) ->
     ?assertMatch({ok, _}, Res);
@@ -538,6 +610,15 @@ auth_header(Node) ->
     {ok, API} = erpc:call(Node, emqx_common_test_http, create_default_app, []),
     emqx_common_test_http:auth_header(API).
 
+dashboard_auth_header(Node) ->
+    User = ?DASHBOARD_USER,
+    Pass = ?DASHBOARD_PASS,
+    _ = erpc:call(Node, emqx_dashboard_admin, add_user, [
+        User, Pass, <<"administrator">>, <<"data backup test admin">>
+    ]),
+    {ok, #{token := Token}} = erpc:call(Node, emqx_dashboard_admin, sign_token, [User, Pass]),
+    {"Authorization", "Bearer " ++ binary_to_list(Token)}.
+
 wait_for_auth_replication(ReplNode) ->
     wait_for_auth_replication(ReplNode, 100).
 
@@ -588,7 +669,9 @@ test_case_specific_apps_spec(TC) when
     TC =:= t_upload_ee_backup;
     TC =:= t_import_ee_backup;
     TC =:= t_upload_ce_backup;
-    TC =:= t_import_ce_backup
+    TC =:= t_import_ce_backup;
+    TC =:= t_import_api_key_blocks_sensitive_tables;
+    TC =:= t_import_dashboard_token_allows_sensitive_tables
 ->
     [
         emqx_auth,

--- a/changes/ee/fix-17173.en.md
+++ b/changes/ee/fix-17173.en.md
@@ -1,0 +1,7 @@
+Restrict API keys from exporting or importing dashboard accounts and API keys via the data backup endpoints.
+
+`POST /data/export` called with an API key now silently omits the `dashboard_users` and `api_keys` mnesia table sets from the resulting archive. `POST /data/import` called with an API key now returns `403 FORBIDDEN` when the uploaded backup contains either of those table sets.
+
+Dashboard bearer-token (login) callers are unaffected and continue to be able to back up and restore the full database, including dashboard users and API keys.
+
+This closes a privilege-escalation gap where an API key holder could read or write dashboard login credentials and API key records — material that the existing `/users` and `/api_key` endpoints already deny to API keys — by going through the data backup endpoints instead.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 6.0.4

## Summary

Port #17169 to release-60.

API keys with the `system` scope could previously call `POST /data/export` and `POST /data/import` to read or write the `dashboard_users` and `api_keys` mnesia table sets. That bypassed the existing `?SCOPE_DENIED` guard on `/users` and `/api_key`: a system-scoped API key could export the cluster, edit the tarball, and re-import it to install crafted dashboard accounts or new super-admin API keys.

This PR adds two narrow guards keyed on the caller's `auth_type`:

- `POST /data/export`: when called via API key, the `dashboard_users` and `api_keys` table sets are silently filtered out of the resulting archive (also when the caller explicitly listed them in `table_sets`).
- `POST /data/import`: when called via API key, the uploaded tarball is inspected locally; if it contains either sensitive table set, the request is rejected with `403 FORBIDDEN`. API-key callers must therefore upload and import on the same node.

Dashboard bearer-token (JWT login) callers are **unaffected** and continue to be able to back up and restore the full database, including dashboard users and API keys. The new test `t_import_dashboard_token_allows_sensitive_tables` pins this regression contract.

**Most relevant files:**
- `apps/emqx_management/src/emqx_mgmt_api_data_backup.erl` — branches on the `auth_meta` map populated by `emqx_dashboard:authorize/2`.
- `apps/emqx_management/src/emqx_mgmt_data_backup.erl` — new `sensitive_table_set_names/0` and `peek_sensitive_table_sets/1` helpers.

**Tests** (`apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl`):
- `t_export_api_key_omits_sensitive_tables` — API-key export's archive must not contain `mnesia/emqx_admin` or `mnesia/emqx_app`.
- `t_import_api_key_blocks_sensitive_tables` — API-key import of a tarball containing those tables returns `403 FORBIDDEN`.
- `t_import_dashboard_token_allows_sensitive_tables` — same tarball imports successfully via dashboard bearer token.

Existing import tests use fixtures that contain `emqx_admin`/`emqx_app`; they have been switched to dashboard bearer-token auth so they continue to verify the full-import path.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)