### PR TITLE
fix: clarify namespace change guard

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -572,9 +572,13 @@ update_user_(Username, Role, Desc, Extra) ->
                 end,
             NewNamespace = maps:get(?namespace, NewExtra, ?global_ns),
             PreviousNamespace = maps:get(?namespace, OldExtra, ?global_ns),
-            maybe
-                true ?= PreviousNamespace /= NewNamespace,
-                mnesia:abort(<<"changing_namespace_is_forbidden">>)
+            case PreviousNamespace /= NewNamespace of
+                true ->
+                    %% Namespace is part of the RBAC boundary.  Require delete/recreate
+                    %% instead of moving an existing user (and its tokens) across scopes.
+                    mnesia:abort(<<"changing_namespace_is_forbidden">>);
+                false ->
+                    ok
             end,
             mnesia:write(Admin#?ADMIN{role = Role, description = Desc, extra = NewExtra}),
             {

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -188,9 +188,13 @@ do_update(Name, Enable, ExpiredAt, Desc, #{?role := Role, ?namespace := Namespac
         [App0 = #?APP{enable = Enable0, extra = Extra0}] ->
             #{desc := Desc0} = Extra1 = normalize_extra(Extra0),
             PreviousNamespace = maps:get(?namespace, Extra1, ?global_ns),
-            maybe
-                true ?= PreviousNamespace /= Namespace,
-                mnesia:abort(<<"changing_namespace_is_forbidden">>)
+            case PreviousNamespace /= Namespace of
+                true ->
+                    %% Namespace is part of the RBAC boundary.  Require delete/recreate
+                    %% instead of moving an existing API key across scopes.
+                    mnesia:abort(<<"changing_namespace_is_forbidden">>);
+                false ->
+                    ok
             end,
             Extra2 = emqx_utils_maps:put_if(
                 Extra1#{?role => Role, desc => ensure_not_undefined(Desc, Desc0)},


### PR DESCRIPTION
## Summary
- replace one-armed maybe guards with explicit namespace-change checks
- document why namespace moves are rejected for dashboard users and API keys

## Testing
- ./rebar3 as test compile
- git diff --check

Internal-only readability/comment refactor; no user-facing behavior change.