### PR TITLE
feat(mgmt): support --scopes for CLI-managed API keys

### DIFF
--- a/apps/emqx/test/emqx_common_test_http.erl
+++ b/apps/emqx/test/emqx_common_test_http.erl
@@ -82,7 +82,7 @@ create_default_app() ->
     Now = erlang:system_time(second),
     ExpiredAt = Now + timer:minutes(10),
     case
-        emqx_mgmt_auth:create(
+        emqx_mgmt_auth:create_with_key(
             ?DEFAULT_APP_ID,
             ?DEFAULT_APP_KEY,
             ?DEFAULT_APP_SECRET,

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -481,7 +481,7 @@ ensure_namespaced_api_key(Opts) ->
             viewer ->
                 <<"ns:", Namespace/binary, "::viewer">>
         end,
-    Res = emqx_mgmt_auth:create(
+    Res = emqx_mgmt_auth:create_with_key(
         Name,
         APIKey,
         APISecret,

--- a/apps/emqx_dashboard/src/emqx_dashboard_cli.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_cli.erl
@@ -97,7 +97,8 @@ api_keys(_) ->
             {"api_keys show --name <Name>", "Show API key details"},
             {
                 "api_keys add --name <Name> [--api-secret <Secret>]\n"
-                "[--valid-days <infinity|days>] [--role <Role>] [--desc <Desc>]",
+                "[--valid-days <infinity|days>] [--role <Role>] [--desc <Desc>]\n"
+                "[--scopes <scope1,scope2,...>]",
                 "Create API key"
             },
             {"api_keys enable --name <Name>", "Enable API key"},
@@ -123,22 +124,41 @@ add_api_key(Opts) ->
     Desc = maps:get("--desc", Opts, default_api_key_desc()),
     Role = maps:get("--role", Opts, ?ROLE_API_DEFAULT),
     ExpiredAt = maps:get("--valid-days", Opts, infinity),
-    case maps:find("--api-secret", Opts) of
-        {ok, ApiSecret} ->
-            case emqx_mgmt_auth:create(Name, ApiSecret, true, ExpiredAt, Desc, Role) of
-                {ok, APIKey} ->
-                    print_json(api_key_public_info(APIKey));
-                {error, Reason} ->
-                    print_json_error(Reason)
+    Scopes = maps:get("--scopes", Opts, undefined),
+    case validate_scopes(Scopes) of
+        ok ->
+            case maps:find("--api-secret", Opts) of
+                {ok, ApiSecret} ->
+                    case
+                        emqx_mgmt_auth:create_with_secret(
+                            Name, ApiSecret, true, ExpiredAt, Desc, Role, Scopes
+                        )
+                    of
+                        {ok, APIKey} ->
+                            print_json(api_key_public_info(APIKey));
+                        {error, Reason} ->
+                            print_json_error(Reason)
+                    end;
+                error ->
+                    case
+                        emqx_mgmt_auth:create(
+                            Name, true, ExpiredAt, Desc, Role, Scopes
+                        )
+                    of
+                        {ok, APIKey} ->
+                            print_json(api_key_create_info(APIKey));
+                        {error, Reason} ->
+                            print_json_error(Reason)
+                    end
             end;
-        error ->
-            case emqx_mgmt_auth:create(Name, true, ExpiredAt, Desc, Role) of
-                {ok, APIKey} ->
-                    print_json(api_key_create_info(APIKey));
-                {error, Reason} ->
-                    print_json_error(Reason)
-            end
+        {error, Reason} ->
+            print_json_error(Reason)
     end.
+
+validate_scopes(undefined) ->
+    ok;
+validate_scopes(Scopes) when is_list(Scopes) ->
+    emqx_mgmt_api_key_scopes:validate_scopes(Scopes).
 
 delete_api_key(Name) ->
     case emqx_mgmt_auth:delete(Name) of
@@ -192,7 +212,12 @@ parse_api_key_add_args(Args) ->
                 {ok, _Name} ->
                     case
                         ensure_allowed_opts(Opts, [
-                            "--name", "--desc", "--role", "--api-secret", "--valid-days"
+                            "--name",
+                            "--desc",
+                            "--role",
+                            "--api-secret",
+                            "--valid-days",
+                            "--scopes"
                         ])
                     of
                         ok -> {ok, Opts};
@@ -225,6 +250,8 @@ do_collect_api_key_args(["--valid-days", Days | Rest], Acc) ->
         {error, _} = Error ->
             Error
     end;
+do_collect_api_key_args(["--scopes", Scopes | Rest], Acc) ->
+    do_collect_api_key_args(Rest, Acc#{"--scopes" => parse_scopes(Scopes)});
 do_collect_api_key_args([Option], _Acc) ->
     case lists:prefix("--", Option) of
         true ->
@@ -242,6 +269,9 @@ ensure_allowed_opts(Opts, Allowed) ->
         [Unknown | _] ->
             {error, iolist_to_binary(io_lib:format("unknown option: ~ts", [Unknown]))}
     end.
+
+parse_scopes(Scopes) ->
+    [bin(string:trim(S)) || S <- string:split(Scopes, ",", all), S =/= ""].
 
 parse_valid_days("infinity") ->
     {ok, infinity};

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -438,7 +438,48 @@ t_cli(_Config) ->
         ])
     ),
     ?assertMatch(#{<<"error">> := _}, json(iolist_to_binary(BadValidDaysError))),
-    ?assertMatch({error, not_found}, emqx_mgmt_auth:read(<<"test-key-4">>)).
+    ?assertMatch({error, not_found}, emqx_mgmt_auth:read(<<"test-key-4">>)),
+    %% --scopes: valid list is stored on the app record, both with and without --api-secret.
+    ?CAPTURE(
+        emqx_dashboard_cli:api_keys([
+            "add",
+            "--name",
+            "test-key-scoped",
+            "--scopes",
+            "connections,publish"
+        ])
+    ),
+    ?assertMatch(
+        {ok, #{scopes := [<<"connections">>, <<"publish">>]}},
+        emqx_mgmt_auth:read(<<"test-key-scoped">>)
+    ),
+    ?CAPTURE(
+        emqx_dashboard_cli:api_keys([
+            "add",
+            "--name",
+            "test-key-scoped-with-secret",
+            "--api-secret",
+            binary_to_list(Secret),
+            "--scopes",
+            "monitoring"
+        ])
+    ),
+    ?assertMatch(
+        {ok, #{scopes := [<<"monitoring">>]}},
+        emqx_mgmt_auth:read(<<"test-key-scoped-with-secret">>)
+    ),
+    %% --scopes: unknown scope is rejected and no key is created.
+    {ok, [BadScopeError]} = ?CAPTURE(
+        emqx_dashboard_cli:api_keys([
+            "add",
+            "--name",
+            "test-key-bad-scope",
+            "--scopes",
+            "connections,nonexistent"
+        ])
+    ),
+    ?assertMatch(#{<<"error">> := _}, json(iolist_to_binary(BadScopeError))),
+    ?assertMatch({error, not_found}, emqx_mgmt_auth:read(<<"test-key-bad-scope">>)).
 
 t_lookup_by_username_jwt(_Config) ->
     User = bin(["user-", integer_to_list(random_num())]),

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -27,7 +27,10 @@
 -export([
     create/5,
     create/6,
-    create/7,
+    create_with_secret/6,
+    create_with_secret/7,
+    create_with_key/7,
+    create_with_key/8,
     read/1,
     update/5,
     update/6,
@@ -54,7 +57,6 @@
 ]).
 
 -ifdef(TEST).
--export([create/8]).
 -export([trans/2, force_create_app/1]).
 -export([init_bootstrap_file/1]).
 -endif.
@@ -131,34 +133,39 @@ try_init_bootstrap_file() ->
             ok
     end.
 
+%% Three public entry points, one purpose each:
+%%
+%%   create/{5,6}             — REST API: auto-generate both ApiKey and ApiSecret.
+%%   create_with_secret/{6,7} — Dashboard CLI when user provides --api-secret;
+%%                              auto-generate ApiKey only.
+%%   create_with_key/{7,8}    — Tests / bootstrap: caller provides both
+%%                              ApiKey and ApiSecret explicitly.
+%%
+%% Each function has exactly one signature shape; no guard-based dispatch
+%% on positional arguments.
 create(Name, Enable, ExpiredAt, Desc, Role) ->
     create(Name, Enable, ExpiredAt, Desc, Role, undefined).
 
-%% Two 6-arity clauses coexist via guards:
-%% 1. CLI variant (release-60 legacy): (Name, ApiSecret, Enable, ExpiredAt, Desc, Role)
-%%    - ApiSecret is a binary of >= 32 bytes.
-%% 2. REST-API variant (scope-aware):  (Name, Enable, ExpiredAt, Desc, Role, Scopes)
-%%    - Enable is a boolean and Scopes is a list or undefined.
-create(Name, ApiSecret, Enable, ExpiredAt, Desc, Role) when
+create(Name, Enable, ExpiredAt, Desc, Role, Scopes) ->
+    ApiKey = generate_unique_api_key(),
+    ApiSecret = generate_api_secret(),
+    create_with_key(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role, Scopes).
+
+create_with_secret(Name, ApiSecret, Enable, ExpiredAt, Desc, Role) ->
+    create_with_secret(Name, ApiSecret, Enable, ExpiredAt, Desc, Role, undefined).
+
+create_with_secret(Name, ApiSecret, Enable, ExpiredAt, Desc, Role, Scopes) when
     is_binary(ApiSecret) andalso byte_size(ApiSecret) >= 32
 ->
     ApiKey = generate_unique_api_key(),
-    create(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role, undefined);
-create(_Name, ApiSecret, _Enable, _ExpiredAt, _Desc, _Role) when
-    is_binary(ApiSecret)
-->
-    {error, <<"api_secret_too_short">>};
-create(Name, Enable, ExpiredAt, Desc, Role, Scopes) when
-    is_boolean(Enable) andalso (is_list(Scopes) orelse Scopes =:= undefined)
-->
-    ApiKey = generate_unique_api_key(),
-    ApiSecret = generate_api_secret(),
-    create(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role, Scopes).
+    create_with_key(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role, Scopes);
+create_with_secret(_Name, _ApiSecret, _Enable, _ExpiredAt, _Desc, _Role, _Scopes) ->
+    {error, <<"api_secret_too_short">>}.
 
-create(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role) ->
-    create(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role, undefined).
+create_with_key(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role) ->
+    create_with_key(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role, undefined).
 
-create(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role, Scopes) ->
+create_with_key(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role, Scopes) ->
     case mnesia:table_info(?APP, size) < 100 of
         true -> create_app(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role, Scopes);
         false -> {error, "Maximum number of ApiKeys reached."}

--- a/changes/ee/feat-17178.en.md
+++ b/changes/ee/feat-17178.en.md
@@ -1,0 +1,1 @@
+The `emqx ctl api_keys add` CLI command now accepts a `--scopes <scope1,scope2,...>` option, matching the scope-based permission control already supported by the REST API.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version:
6.0.3

## Summary

Mirror the scope-based permission control already supported by the REST API (`POST /api_key`) in the `emqx ctl api_keys add` CLI command.

- Add `--scopes <scope1,scope2,...>` option to `api_keys add`. Comma-separated, optional.
- Scopes are validated up-front via `emqx_mgmt_api_key_scopes:validate_scopes/1`; unknown scopes are rejected before the key is created.
- Add a new 7-arity `emqx_mgmt_auth:create/7` CLI variant `(Name, ApiSecret, Enable, ExpiredAt, Desc, Role, Scopes)` to thread scopes through the `--api-secret` path; the `--api-secret`-less path reuses the existing scope-aware `create/6` REST-API variant.
- Existing test coverage in `t_cli/1` extended: scopes stored on the app record (with and without `--api-secret`), and unknown-scope rejection.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)