### PR TITLE
feat: support config distribution port listen options for perf tunings

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -42,7 +42,9 @@
 
 -define(DEFAULT_NODE_NAME, <<"emqx@127.0.0.1">>).
 
--define(DEFAULT_KERNEL_INET_DIST_CONNECT_OPTIONS, <<"[{buffer,1048576}]">>).
+-define(DEFAULT_KERNEL_INET_DIST_OPTIONS, <<"[{buffer,1048576}]">>).
+-define(DEFAULT_KERNEL_INET_DIST_CONNECT_OPTIONS, ?DEFAULT_KERNEL_INET_DIST_OPTIONS).
+-define(DEFAULT_KERNEL_INET_DIST_LISTEN_OPTIONS, ?DEFAULT_KERNEL_INET_DIST_OPTIONS).
 
 %% Static apps which merge their configs into the merged emqx.conf
 %% The list can not be made a dynamic read at run-time as it is used
@@ -505,6 +507,16 @@ fields("node") ->
                     default => 8192,
                     importance => ?IMPORTANCE_LOW,
                     'readOnly' => true
+                }
+            )},
+        {"dist_listen_options",
+            sc(
+                binary(),
+                #{
+                    desc => ?DESC(dist_listen_options),
+                    default => ?DEFAULT_KERNEL_INET_DIST_LISTEN_OPTIONS,
+                    importance => ?IMPORTANCE_LOW,
+                    'readOnly' => false
                 }
             )},
         {"dist_connect_options",
@@ -1271,7 +1283,8 @@ translation("prometheus") ->
 translation("vm_args") ->
     [
         {"+P", fun tr_vm_args_process_limit/1},
-        {"-kernel inet_dist_connect_options", fun tr_kernel_inet_dist_connect_options/1}
+        {"-kernel inet_dist_connect_options", fun tr_kernel_inet_dist_connect_options/1},
+        {"-kernel inet_dist_listen_options", fun tr_kernel_inet_dist_listen_options/1}
     ].
 
 tr_vm_args_process_limit(Conf) ->
@@ -1279,6 +1292,10 @@ tr_vm_args_process_limit(Conf) ->
 
 tr_kernel_inet_dist_connect_options(Conf) ->
     Val = conf_get("node.dist_connect_options", Conf, [?DEFAULT_KERNEL_INET_DIST_CONNECT_OPTIONS]),
+    lists:flatten(io_lib:format("~0p", [Val])).
+
+tr_kernel_inet_dist_listen_options(Conf) ->
+    Val = conf_get("node.dist_listen_options", Conf, [?DEFAULT_KERNEL_INET_DIST_CONNECT_OPTIONS]),
     lists:flatten(io_lib:format("~0p", [Val])).
 
 tr_prometheus_collectors(Conf) ->

--- a/changes/ee/perf-17181.en.md
+++ b/changes/ee/perf-17181.en.md
@@ -1,0 +1,3 @@
+Added support for configuring Erlang inet port listen options for the distribution port, with a default `buffer` size of 1 MB.
+
+See also #17152

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -91,6 +91,14 @@ dist_buffer_size.desc:
 dist_buffer_size.label:
 """Erlang's dist buffer size(KB)"""
 
+dist_listen_options.desc:
+"""Erlang's distribution listener port options for performance tuning.
+Defines a list of extra socket options to be used when opening the listening socket for a distributed Erlang node.
+See https://www.erlang.org/doc/apps/kernel/gen_tcp.html#listen/2"""
+
+dist_listen_options.label:
+"""Erlang's distribution listener port options"""
+
 dist_connect_options.desc:
 """Erlang's distribution port connect options for performance tuning.
 Defines a list of extra socket options to be used when connecting to other distributed Erlang nodes.


### PR DESCRIPTION
Fixes [EMQX-15239](https://emqx.atlassian.net/browse/EMQX-15239)

follow up for  #17152 which was for the client and this is for the listener.

Release version:
<!-- uncomment for v5:
5.8.10, 5.10.4
-->

6.0.3, 6.1.2, 6.2.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-15239]: https://emqx.atlassian.net/browse/EMQX-15239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ