### PR TITLE
fix(mongodb): treat call timeout as recoverable (r58)

### DIFF
--- a/apps/emqx_bridge_mongodb/test/emqx_bridge_v2_mongodb_SUITE.erl
+++ b/apps/emqx_bridge_mongodb/test/emqx_bridge_v2_mongodb_SUITE.erl
@@ -263,6 +263,21 @@ delete_action_api(Config) ->
         ?config(action_name, Config)
     ).
 
+get_poolboy_pids() ->
+    [
+        Pid
+     || Pid <- processes(),
+        case proc_lib:initial_call(Pid) of
+            {poolboy, _, _} -> true;
+            _ -> false
+        end
+    ].
+
+find_all(Config) ->
+    #{<<"collection">> := Collection} = ?config(action_config, Config),
+    ResourceID = emqx_bridge_v2_testlib:resource_id(Config),
+    emqx_resource:simple_sync_query(ResourceID, {find, Collection, #{}, #{}}).
+
 %%------------------------------------------------------------------------------
 %% Testcases
 %%------------------------------------------------------------------------------
@@ -370,5 +385,38 @@ t_timeout_during_connector_health_check(Config0) ->
             ?assertEqual([], ?of_kind("remove_channel_failed", Trace)),
             ok
         end
+    ),
+    ok.
+
+%% Checks that we treat poolboy call timeouts (checking out connections) as recoverable
+%% errors.
+t_call_timeout(TCConfig) ->
+    {201, _} = create_bridge_api(TCConfig, #{}),
+    RuleTopic = <<"t/poolboy/timeout">>,
+    {ok, _} = emqx_bridge_v2_testlib:create_rule_and_action_http(
+        ?ACTION_TYPE, RuleTopic, TCConfig
+    ),
+    Payload = integer_to_binary(erlang:unique_integer()),
+    Pids = get_poolboy_pids(),
+    try
+        lists:foreach(fun sys:suspend/1, Pids),
+        {_, {ok, _}} = ?wait_async_action(
+            emqx:publish(emqx_message:make(RuleTopic, Payload)),
+            #{?snk_kind := "mongo_insert_call_timeout"},
+            15_000
+        ),
+        ok
+    after
+        lists:foreach(fun sys:resume/1, Pids)
+    end,
+    %% eventually should work
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            {ok, [#{<<"payload">> := Payload}]},
+            find_all(TCConfig),
+            #{payload => Payload}
+        )
     ),
     ok.

--- a/apps/emqx_bridge_mongodb/test/emqx_bridge_v2_mongodb_SUITE.erl
+++ b/apps/emqx_bridge_mongodb/test/emqx_bridge_v2_mongodb_SUITE.erl
@@ -179,7 +179,7 @@ action_config(Name, ConnectorId) ->
             <<"enable">> => true,
             <<"connector">> => ConnectorId,
             <<"parameters">> =>
-                #{},
+                #{<<"collection">> => Name},
             <<"local_topic">> => <<"t/mongo">>,
             <<"resource_opts">> => #{
                 <<"batch_size">> => 1,
@@ -262,6 +262,21 @@ delete_action_api(Config) ->
         ?ACTION_TYPE,
         ?config(action_name, Config)
     ).
+
+get_poolboy_pids() ->
+    [
+        Pid
+     || Pid <- processes(),
+        case proc_lib:initial_call(Pid) of
+            {poolboy, _, _} -> true;
+            _ -> false
+        end
+    ].
+
+find_all(Config) ->
+    #{<<"parameters">> := #{<<"collection">> := Collection}} = ?config(action_config, Config),
+    ResourceID = emqx_bridge_v2_testlib:resource_id(Config),
+    emqx_resource:simple_sync_query(ResourceID, {find, Collection, #{}, #{}}).
 
 %%------------------------------------------------------------------------------
 %% Testcases
@@ -370,5 +385,53 @@ t_timeout_during_connector_health_check(Config0) ->
             ?assertEqual([], ?of_kind("remove_channel_failed", Trace)),
             ok
         end
+    ),
+    ok.
+
+%% Checks that we treat poolboy call timeouts (checking out connections) as recoverable
+%% errors.
+t_call_timeout(TCConfig0) ->
+    Overrides = #{<<"resource_opts">> => #{<<"health_check_interval">> => <<"700ms">>}},
+    TCConfig = emqx_bridge_v2_testlib:proplist_update(
+        TCConfig0,
+        connector_config,
+        fun(Cfg) ->
+            emqx_utils_maps:deep_merge(Cfg, Overrides)
+        end
+    ),
+    {201, _} = create_bridge_api(TCConfig, #{
+        <<"resource_opts">> => #{
+            <<"health_check_interval">> => <<"700ms">>,
+            <<"resume_interval">> => <<"700ms">>
+        }
+    }),
+    RuleTopic = <<"t/poolboy/timeout">>,
+    {ok, _} = emqx_bridge_v2_testlib:create_rule_and_action_http(
+        ?ACTION_TYPE, RuleTopic, TCConfig
+    ),
+    Payload = integer_to_binary(erlang:unique_integer()),
+    Pids = get_poolboy_pids(),
+    try
+        lists:foreach(fun sys:suspend/1, Pids),
+        ct:pal("sending message"),
+        {_, {ok, _}} = ?wait_async_action(
+            spawn(fun() -> emqx:publish(emqx_message:make(RuleTopic, Payload)) end),
+            #{?snk_kind := "mongo_insert_call_timeout"},
+            15_000
+        ),
+        ct:pal("sent message"),
+        ok
+    after
+        lists:foreach(fun(P) -> catch sys:resume(P) end, Pids)
+    end,
+    %% eventually should work
+    ?retry(
+        500,
+        10,
+        ?assertMatch(
+            {ok, [#{<<"payload">> := Payload}]},
+            find_all(TCConfig),
+            #{payload => Payload}
+        )
     ),
     ok.

--- a/apps/emqx_mongodb/src/emqx_mongodb.app.src
+++ b/apps/emqx_mongodb/src/emqx_mongodb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_mongodb, [
     {description, "EMQX MongoDB Connector"},
-    {vsn, "0.1.10"},
+    {vsn, "0.1.11"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_mongodb/src/emqx_mongodb.erl
+++ b/apps/emqx_mongodb/src/emqx_mongodb.erl
@@ -262,6 +262,17 @@ on_query(
             {error, Reason};
         {error, ecpool_empty} ->
             {error, {recoverable_error, ecpool_empty}};
+        {error, {timeout, _}} ->
+            ?tp("mongo_insert_call_timeout", #{}),
+            ?SLOG(warning, #{
+                msg => "mongodb_connector_pool_checkout_timeout",
+                action => insert,
+                pid => self(),
+                connector => InstId
+            }),
+            {error, {recoverable_error, worker_call_timeout}};
+        {error, Error} ->
+            {error, {unrecoverable_error, Error}};
         {{true, _Info}, _Document} ->
             ok
     end;
@@ -302,6 +313,14 @@ on_select_query(
             case Reason of
                 ecpool_empty ->
                     {error, {recoverable_error, Reason}};
+                {timeout, _} ->
+                    ?SLOG(warning, #{
+                        msg => "mongodb_connector_pool_checkout_timeout",
+                        action => Action,
+                        pid => self(),
+                        connector => InstId
+                    }),
+                    {error, {recoverable_error, worker_call_timeout}};
                 _ ->
                     {error, Reason}
             end;

--- a/changes/ee/fix-17179.en.md
+++ b/changes/ee/fix-17179.en.md
@@ -1,0 +1,7 @@
+Fixed an issue where, under heavy load, a timed out call to a MongoDB process would be interpreted as an unrecoverable error and wouldn't be retried.  Now, the message will be retried on such events.
+
+On such events, logs like the following would be printed:
+
+```
+{"stacktrace":["{emqx_mongodb,on_query,3,[{file,\"emqx_mongodb.erl\"},{line,236}]}","{emqx_resource_buffer_worker,apply_query_fun,9,[{file,\"emqx_resource_buffer_worker.erl\"},{line,1514}]}","{emqx_resource_buffer_worker,call_query2,8,[{file,\"emqx_resource_buffer_worker.erl\"},{line,1355}]}","{emqx_resource_buffer_worker,do_flush,2,[{file,\"emqx_resource_buffer_worker.erl\"},{line,768}]}","{gen_statem,loop_state_callback,11,[{file,\"gen_statem.erl\"},{line,3735}]}","{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,329}]}"],"request":"...","name":"call_query","id":"action:mongodb:xxx:connector:mongodb:xxx","error":"{error,{case_clause,{error,{timeout,{gen_server,call,[<0.215642180.3>,{checkout,#Ref<0.2539918795.141557761.165483>,true},5000]}}}}}"}...
+```


### PR DESCRIPTION
Port of #17180 

Fixes https://emqx.atlassian.net/browse/EMQX-15250

```
{"stacktrace":["{emqx_mongodb,on_query,3,[{file,\"emqx_mongodb.erl\"},{line,236}]}","{emqx_resource_buffer_worker,apply_query_fun,9,[{file,\"emqx_resource_buffer_worker.erl\"},{line,1514}]}","{emqx_resource_buffer_worker,call_query2,8,[{file,\"emqx_resource_buffer_worker.erl\"},{line,1355}]}","{emqx_resource_buffer_worker,do_flush,2,[{file,\"emqx_resource_buffer_worker.erl\"},{line,768}]}","{gen_statem,loop_state_callback,11,[{file,\"gen_statem.erl\"},{line,3735}]}","{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,329}]}"],"request":"...","name":"call_query","id":"action:mongodb:xxx:connector:mongodb:xxx","error":"{error,{case_clause,{error,{timeout,{gen_server,call,[<0.215642180.3>,{checkout,#Ref<0.2539918795.141557761.165483>,true},5000]}}}}}"}...
```

Release version:
5.8.10, 5.10.4

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
