### PR TITLE
feat(mqtt): enforce strict parser mode by default

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -65,7 +65,7 @@
 -type serialize_opts() :: options().
 
 -define(DEFAULT_OPTIONS, #{
-    strict_mode => false,
+    strict_mode => true,
     max_size => ?MAX_PACKET_SIZE,
     version => ?MQTT_PROTO_V4
 }).

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -4052,7 +4052,7 @@ mqtt_general() ->
             sc(
                 boolean(),
                 #{
-                    default => false,
+                    default => true,
                     desc => ?DESC(mqtt_strict_mode)
                 }
             )},

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -243,6 +243,17 @@ t_init_zones_load_other_schema(Config) when is_list(Config) ->
         emqx_config:get([zones, default])
     ).
 
+t_default_strict_mode_is_true(Config) when is_list(Config) ->
+    emqx_config:erase_all(),
+    %% Given an empty config that does not set mqtt.strict_mode
+    ConfFile = prepare_conf_file(?FUNCTION_NAME, <<"">>, Config),
+    application:set_env(emqx, config_files, [ConfFile]),
+    ?assertEqual(ok, emqx_config:init_load(emqx_schema)),
+    %% Then mqtt.strict_mode defaults to true at the global root
+    ?assertEqual(true, emqx:get_config([mqtt, strict_mode])),
+    %% And it is propagated to the default zone
+    ?assertEqual(true, emqx_config:get([zones, default, mqtt, strict_mode])).
+
 t_init_zones_with_user_defined_default_zone(Config) when is_list(Config) ->
     emqx_config:erase_all(),
     %% Given user defined config for default zone
@@ -514,7 +525,7 @@ zone_global_defaults() ->
                 shared_subscription => true,
                 shared_subscription_strategy => round_robin,
                 shared_subscription_initial_sticky_pick => random,
-                strict_mode => false,
+                strict_mode => true,
                 subscription_message_filter => disable,
                 upgrade_qos => false,
                 use_username_as_clientid => false,

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -197,7 +197,12 @@ t_handle_msg(_) ->
     ?assertMatch(
         {stop, {shutdown, discarded}, _St}, handle_msg({'$gen_call', From, discard}, st())
     ),
-    ?assertMatch({ok, [], _St}, handle_msg({tcp, From, <<"for_testing">>}, st())),
+    %% Strict-mode default surfaces bad header as a frame_error rather than
+    %% buffering the bytes silently.
+    ?assertMatch(
+        {ok, {incoming, {frame_error, bad_frame_header}}, _St},
+        handle_msg({tcp, From, <<"for_testing">>}, st())
+    ),
     ?assertMatch({ok, _St}, handle_msg(for_testing, st())).
 
 t_handle_msg_incoming(_) ->
@@ -293,7 +298,12 @@ t_handle_timeout(_) ->
 
 t_parse_incoming(_) ->
     ?assertMatch({0, [], _NState}, emqx_connection:parse_incoming(<<>>, st())),
-    ?assertMatch({0, [], _NState}, emqx_connection:parse_incoming(<<"for_testing">>, st())),
+    %% Strict-mode default rejects garbage with a bad header; lenient parser
+    %% would have buffered as partial bytes.
+    ?assertMatch(
+        {0, [{frame_error, bad_frame_header}], _NState},
+        emqx_connection:parse_incoming(<<"for_testing">>, st())
+    ),
     %% SUBSCRIBE with remaining_len=0 in idle state:
     %% parser throws zero_remaining_len, enriched with protocol hints
     ?assertMatch(

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -323,6 +323,25 @@ t_parse_incoming(_) ->
         {0, [{frame_error, #{cause := zero_remaining_len}}], _NState},
         emqx_connection:parse_incoming(<<16#10, 16#00>>, st(#{}, #{conn_state => idle}))
     ),
+    %% v3.1.1 CONNECT with password flag set but no username flag.
+    %% Strict parser rejects per [MQTT-3.1.2-22]; operator-facing reason
+    %% (also logged at info level by parse_incoming/2) is invalid_password_flag.
+    ?assertMatch(
+        {0,
+            [
+                {frame_error, #{
+                    cause := invalid_password_flag,
+                    proto_ver := 4,
+                    proto_name := <<"MQTT">>,
+                    packet_type := 'CONNECT'
+                }}
+            ],
+            _NState},
+        emqx_connection:parse_incoming(
+            <<16#10, 19, 0, 4, "MQTT", 4, 16#42, 0, 60, 0, 2, "a1", 0, 3, "aaa">>,
+            st(#{}, #{conn_state => idle})
+        )
+    ),
     %% bad_subqos in connected state: no enrichment
     ?assertMatch(
         {0, [{frame_error, bad_subqos}], _NState},

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -38,6 +38,7 @@ groups() ->
             t_parse_frame_too_large,
             t_parse_frame_malformed_variable_byte_integer,
             t_parse_malformed_utf8_string,
+            t_default_parse_state_is_strict,
             t_parse_bad_v5_publish_packet,
             t_guess_first_packet_protocol
         ]},
@@ -139,7 +140,9 @@ t_parse_frame_too_large(_) ->
     ?assertEqual(Packet, parse_serialize(Packet, #{max_size => 2048, version => ?MQTT_PROTO_V4})).
 
 t_parse_frame_malformed_variable_byte_integer(_) ->
-    MalformedPayload = <<<<16#80>> || _ <- lists:seq(1, 6)>>,
+    %% PUBLISH(QoS 0) fixed header byte followed by a malformed remaining
+    %% length where every byte has the continuation bit set.
+    MalformedPayload = iolist_to_binary([<<?PUBLISH:4, 0:1, 0:2, 0:1>> | lists:duplicate(6, 16#80)]),
     ParseState = emqx_frame:initial_parse_state(#{}),
     ?ASSERT_FRAME_THROW(
         malformed_variable_byte_integer,
@@ -158,6 +161,24 @@ t_parse_malformed_utf8_string(_) ->
             98, 108, 105, 99>>,
     ParseState = emqx_frame:initial_parse_state(#{strict_mode => true}),
     ?ASSERT_FRAME_THROW(utf8_string_invalid, emqx_frame:parse(MalformedPacket, ParseState)).
+
+%% Verifies that `initial_parse_state/0` (no options) defaults to strict mode,
+%% so a CONNECT with an invalid-UTF-8 client ID is rejected out of the box.
+t_default_parse_state_is_strict(_) ->
+    %% MQTT v4 CONNECT, clientid contains a control char (0x01) which is
+    %% not a valid MQTT UTF-8 string per [MQTT-1.5.4-3].
+    BadClientIdConnect =
+        <<16, 13, 0, 4, 77, 81, 84, 84, 4, 2, 0, 60, 0, 1, 16#01>>,
+    ?ASSERT_FRAME_THROW(
+        #{cause := utf8_string_invalid},
+        emqx_frame:parse(BadClientIdConnect, emqx_frame:initial_parse_state())
+    ),
+    %% Sanity-check: in lenient mode the same packet parses successfully.
+    LenientParseState = emqx_frame:initial_parse_state(#{strict_mode => false}),
+    ?assertMatch(
+        {_, <<>>, _},
+        emqx_frame:parse(BadClientIdConnect, LenientParseState)
+    ).
 
 %% Case found by fuzzying with defensics.
 t_parse_bad_v5_publish_packet(_) ->
@@ -812,10 +833,12 @@ t_serialize_parse_auth_v5(_) ->
     ).
 
 t_parse_invalid_remaining_len(_) ->
+    %% Valid CONNECT fixed header byte (?CONNECT:4 + zeroed flags) followed
+    %% by a zero remaining-length byte.
     ?assertException(
         throw,
         {frame_parse_error, #{cause := zero_remaining_len}},
-        emqx_frame:parse(<<?CONNECT, 0>>)
+        emqx_frame:parse(<<?CONNECT:4, 0:4, 0>>)
     ).
 
 t_parse_malformed_properties(_) ->
@@ -921,9 +944,10 @@ t_invalid_password_flag(_) ->
     ConnectFlags = <<2#0100:4, 2#0010:4>>,
     ConnectBin =
         <<16, 17, 0, 4, 77, 81, 84, 84, 4, ConnectFlags/binary, 0, 60, 0, 2, 97, 49, 0, 1, 97>>,
+    LenientParseState = emqx_frame:initial_parse_state(#{strict_mode => false}),
     ?assertMatch(
         {_, _, _},
-        emqx_frame:parse(ConnectBin)
+        emqx_frame:parse(ConnectBin, LenientParseState)
     ),
 
     StrictModeParseState = emqx_frame:initial_parse_state(#{strict_mode => true}),

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -417,9 +417,11 @@ t_parse_incoming_order(_) ->
     ?assertEqual([Packet1, Packet2], Packets1).
 
 t_parse_incoming_frame_error(_) ->
+    %% Strict-mode default rejects the reserved/invalid header outright,
+    %% before per-packet parsing has a chance to surface `malformed_packet`.
     {Packets, _St} = ?ws_conn:parse_incoming(<<3, 2, 1, 0>>, [], st()),
     ?assertMatch(
-        [{frame_error, #{header_type := _, cause := malformed_packet}}],
+        [{frame_error, bad_frame_header}],
         Packets
     ).
 

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_SUITE.erl
@@ -108,6 +108,7 @@ t_will_message_connection_denied(Config) when is_list(Config) ->
 
     {ok, Subscriber} = emqtt:start_link([
         {clientid, <<"subscriber">>},
+        {username, <<"u">>},
         {password, <<"p">>}
     ]),
     {ok, _} = emqtt:connect(Subscriber),

--- a/changes/ee/breaking-17185.en.md
+++ b/changes/ee/breaking-17185.en.md
@@ -1,0 +1,1 @@
+The MQTT parser now runs in strict mode by default. Malformed packets (invalid UTF-8 in client ID or topic, reserved-bit violations, and other protocol-level violations) cause the offending client to be disconnected instead of being silently accepted. To restore the previous lenient behavior, set `mqtt.strict_mode = false` (globally or per-zone).

--- a/changes/ee/breaking-17185.en.md
+++ b/changes/ee/breaking-17185.en.md
@@ -1,1 +1,12 @@
-The MQTT parser now runs in strict mode by default. Malformed packets (invalid UTF-8 in client ID or topic, reserved-bit violations, and other protocol-level violations) cause the offending client to be disconnected instead of being silently accepted. To restore the previous lenient behavior, set `mqtt.strict_mode = false` (globally or per-zone).
+The MQTT parser now runs in strict mode by default. To restore the previous lenient behavior, set `mqtt.strict_mode = false` (globally or per-zone).
+
+In strict mode, the broker validates incoming MQTT packets against the protocol specification and disconnects clients that send malformed packets. The validations enforced only in strict mode are:
+
+- **Fixed-header flags.** Reserved DUP/QoS/RETAIN bits must be zero for non-PUBLISH packets, and PUBREL/SUBSCRIBE/UNSUBSCRIBE must use QoS=1 (`bad_frame_header`).
+- **CONNECT reserved bit** must be zero (`reserved_connect_flag`).
+- **CONNECT Will flag consistency**: Will Flag=0 requires Will QoS=0 and Will Retain=0; Will Flag=1 requires Will QoS in {0,1,2} (`invalid_will_qos`, `invalid_will_retain`).
+- **CONNECT Password/Username flags (MQTT 3.1.1 only).** If Username Flag=0, Password Flag must also be 0, per `[MQTT-3.1.2-22]` (`invalid_password_flag`). MQTT 5.0 lifts this constraint and is unaffected.
+- **UTF-8 strings** (proto name, client ID, topic, username, password, will topic, MQTT 5 string properties) must be valid UTF-8 and must not contain control characters U+0000–U+001F or U+007F–U+009F (`utf8_string_invalid`).
+- **Packet identifiers** must be non-zero where required (PUBLISH QoS>0, PUBACK/REC/REL/COMP, SUBSCRIBE/SUBACK, UNSUBSCRIBE/UNSUBACK) (`bad_packet_id`).
+
+When a client violates one of these checks, the broker logs an `info`-level entry with `msg=frame_parse_error` and a structured `reason` (e.g. `cause=invalid_password_flag`, `proto_ver`, `received_prefix`, …) for troubleshooting. For MQTT 5.0 connections the broker also responds with CONNACK/DISCONNECT carrying reason code `0x81 Malformed Packet` before closing; for MQTT 3.1/3.1.1 the connection is silently closed (no CONNACK reason code is defined for malformed packets in those versions).

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1236,7 +1236,8 @@ fields_mqtt_quic_listener_maximum_mtu.label:
 
 mqtt_strict_mode.desc:
 """Whether to parse MQTT messages in strict mode.
-In strict mode, invalid utf8 strings in for example client ID, topic name, etc. will cause the client to be disconnected."""
+In strict mode, invalid UTF-8 strings (in client ID, topic name, etc.), reserved bits, and other malformed packet structure cause the offending client to be disconnected.
+Defaults to `true` since release 6.3 — set to `false` to restore the older lenient behavior for compatibility with nonconforming clients."""
 
 mqtt_strict_mode.label:
 """Strict Mode"""


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/17159

Release version: 6.3.0

## Summary

Flips the default of `mqtt.strict_mode` from `false` to `true` so EMQX rejects malformed MQTT packets out of the box (invalid UTF-8 in client ID / topic, reserved-bit violations, bad packet IDs, etc.) instead of silently accepting them.

- `apps/emqx/src/emqx_schema.erl`: `mqtt.strict_mode` default → `true`.
- `apps/emqx/src/emqx_frame.erl`: parser-internal `?DEFAULT_OPTIONS` `strict_mode` → `true`, aligning the macro with the schema for any `initial_parse_state/0` caller that does not pass an explicit option.
- `rel/i18n/emqx_schema.hocon`: description updated to reflect the new default and the migration knob (`mqtt.strict_mode = false`).

This is a breaking behavior change: clients that today send malformed packets will be disconnected on the new default. Operators who need the older behavior for non-conformant clients can set `mqtt.strict_mode = false` globally or per-zone (per-listener through the listener's zone).

A handful of tests were updated to be explicit about strict_mode where they had been implicitly relying on the lenient default. Two new CTs cover the new default: `t_default_parse_state_is_strict` (frame-level) and `t_default_strict_mode_is_true` (schema/zone propagation).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)