### PR TITLE
feat(mqtt): allow configuring client TCP socket options

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -99,7 +99,8 @@
     validate_tcp_keepalive/1,
     parse_tcp_keepalive/1,
     tcp_keepalive_opts/1,
-    tcp_keepalive_opts/4
+    tcp_keepalive_opts/4,
+    client_tcp_opts_to_proplist/1
 ]).
 
 -export([qos/0]).
@@ -1157,6 +1158,57 @@ fields("tcp_opts") ->
                     default => <<"none">>,
                     desc => ?DESC(fields_tcp_opts_keepalive),
                     validator => fun validate_tcp_keepalive/1
+                }
+            )}
+    ];
+fields("client_tcp_opts") ->
+    [
+        {nodelay,
+            sc(
+                boolean(),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC(fields_client_tcp_opts_nodelay)
+                }
+            )},
+        {sndbuf,
+            sc(
+                bytesize(),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_LOW,
+                    example => <<"4KB">>,
+                    desc => ?DESC(fields_client_tcp_opts_sndbuf)
+                }
+            )},
+        {recbuf,
+            sc(
+                bytesize(),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_LOW,
+                    example => <<"4KB">>,
+                    desc => ?DESC(fields_client_tcp_opts_recbuf)
+                }
+            )},
+        {buffer,
+            sc(
+                bytesize(),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_LOW,
+                    example => <<"4KB">>,
+                    desc => ?DESC(fields_client_tcp_opts_buffer)
+                }
+            )},
+        {keepalive,
+            sc(
+                boolean(),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC(fields_client_tcp_opts_keepalive)
                 }
             )}
     ];
@@ -2332,6 +2384,8 @@ desc("ws_opts") ->
     "WebSocket listener options.";
 desc("tcp_opts") ->
     "TCP listener options.";
+desc("client_tcp_opts") ->
+    ?DESC("client_tcp_opts");
 desc("listener_ssl_opts") ->
     "Socket options for SSL connections.";
 desc("listener_wss_opts") ->
@@ -3193,6 +3247,26 @@ tcp_keepalive_opts({unix, darwin}, Idle, Interval, Probes) ->
     ]};
 tcp_keepalive_opts(OS, _Idle, _Interval, _Probes) ->
     {error, {unsupported_os, OS}}.
+
+%% @doc Convert a `client_tcp_opts' HOCON map (with possibly missing keys) into
+%% a proplist suitable as `gen_tcp:connect/3' options. Only set keys are
+%% forwarded so unset fields keep their `gen_tcp' defaults.
+-spec client_tcp_opts_to_proplist(map() | undefined) -> [gen_tcp:connect_option()].
+client_tcp_opts_to_proplist(undefined) ->
+    [];
+client_tcp_opts_to_proplist(Map) when is_map(Map) ->
+    maps:fold(
+        fun
+            (nodelay, V, Acc) when is_boolean(V) -> [{nodelay, V} | Acc];
+            (sndbuf, V, Acc) when is_integer(V) -> [{sndbuf, V} | Acc];
+            (recbuf, V, Acc) when is_integer(V) -> [{recbuf, V} | Acc];
+            (buffer, V, Acc) when is_integer(V) -> [{buffer, V} | Acc];
+            (keepalive, V, Acc) when is_boolean(V) -> [{keepalive, V} | Acc];
+            (_, _, Acc) -> Acc
+        end,
+        [],
+        Map
+    ).
 
 validate_tcp_keepalive(Value) ->
     case unicode:characters_to_binary(Value) of

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -612,12 +612,14 @@ mk_ecpool_client_opts(
         namespace := Namespace
     } =
         emqx_connector_resource:parse_connector_id(ConnResId, #{atom_name => false}),
+    TcpOpts = emqx_schema:client_tcp_opts_to_proplist(maps:get(tcp_opts, Config, #{})),
     Options#{
         hosts => [HostPort],
         clientid => clientid(Namespace, Name, Config),
         connect_timeout => ConnectTimeoutS,
         keepalive => ms_to_s(KeepAlive),
         force_ping => true,
+        tcp_opts => TcpOpts,
         ssl => EnableSsl,
         ssl_opts => maps:to_list(maps:remove(enable, Ssl))
     }.

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
@@ -149,6 +149,15 @@ fields("server_configs") ->
                     default => 32,
                     desc => ?DESC("max_inflight")
                 }
+            )},
+        {tcp_opts,
+            mk(
+                hoconsc:ref(emqx_schema, "client_tcp_opts"),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC("tcp_opts")
+                }
             )}
     ] ++ emqx_connector_schema_lib:ssl_fields();
 fields("ingress") ->

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_schema_tests.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_schema_tests.erl
@@ -301,5 +301,48 @@ schema_test_() ->
                         ]
                     })
                 )
-            )}
+            )},
+        {"tcp_opts : parse and convert to proplist",
+            ?_test(begin
+                #{<<"tcp_opts">> := TcpOpts} = parse_and_check_connector(
+                    connector_config(#{
+                        <<"tcp_opts">> => #{
+                            <<"nodelay">> => true,
+                            <<"sndbuf">> => <<"16KB">>,
+                            <<"recbuf">> => <<"8KB">>,
+                            <<"buffer">> => <<"32KB">>,
+                            <<"keepalive">> => true
+                        }
+                    })
+                ),
+                ?assertMatch(
+                    #{
+                        <<"nodelay">> := true,
+                        <<"sndbuf">> := <<"16KB">>,
+                        <<"recbuf">> := <<"8KB">>,
+                        <<"buffer">> := <<"32KB">>,
+                        <<"keepalive">> := true
+                    },
+                    TcpOpts
+                ),
+                Proplist = emqx_schema:client_tcp_opts_to_proplist(#{
+                    nodelay => true,
+                    sndbuf => 16384,
+                    recbuf => 8192,
+                    buffer => 32768,
+                    keepalive => true
+                }),
+                ?assertEqual(true, proplists:get_value(nodelay, Proplist)),
+                ?assertEqual(16384, proplists:get_value(sndbuf, Proplist)),
+                ?assertEqual(8192, proplists:get_value(recbuf, Proplist)),
+                ?assertEqual(32768, proplists:get_value(buffer, Proplist)),
+                ?assertEqual(true, proplists:get_value(keepalive, Proplist))
+            end)},
+        {"tcp_opts : empty/unset keys are not forwarded",
+            ?_test(begin
+                ?assertEqual([], emqx_schema:client_tcp_opts_to_proplist(#{})),
+                ?assertEqual([], emqx_schema:client_tcp_opts_to_proplist(undefined)),
+                Partial = emqx_schema:client_tcp_opts_to_proplist(#{nodelay => false}),
+                ?assertEqual([{nodelay, false}], Partial)
+            end)}
     ].

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
@@ -148,11 +148,13 @@ mk_emqtt_options(#{server := Server, ssl := #{enable := EnableSsl} = Ssl} = Link
     ClientId = maps:get(clientid, LinkConf, cluster()),
     #{hostname := Host, port := Port} = emqx_schema:parse_server(Server, ?MQTT_HOST_OPTS),
     Opts = maps:with([username, retry_interval, max_inflight], LinkConf),
+    TcpOpts = emqx_schema:client_tcp_opts_to_proplist(maps:get(tcp_opts, LinkConf, #{})),
     Opts1 = Opts#{
         host => Host,
         port => Port,
         clientid => ClientId,
         proto_ver => v5,
+        tcp_opts => TcpOpts,
         ssl => EnableSsl,
         ssl_opts => maps:to_list(maps:remove(enable, Ssl))
     },

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
@@ -110,6 +110,15 @@ fields("link") ->
                     desc => ?DESC("max_inflight")
                 }
             )},
+        {tcp_opts,
+            ?HOCON(
+                ?R_REF(emqx_schema, "client_tcp_opts"),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC("tcp_opts")
+                }
+            )},
         {resource_opts,
             ?HOCON(
                 ?R_REF(?MODULE, "creation_opts"),

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_schema_tests.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_schema_tests.erl
@@ -94,3 +94,83 @@ special_topics_test_() ->
                 })
             ])
         )}.
+
+tcp_opts_schema_test_() ->
+    {"tcp_opts: schema parses and is forwarded to emqtt options",
+        ?_test(begin
+            [#{<<"tcp_opts">> := TcpOpts}] = parse_and_check([
+                link(<<"link1">>, #{
+                    <<"tcp_opts">> => #{
+                        <<"nodelay">> => true,
+                        <<"sndbuf">> => <<"16KB">>,
+                        <<"recbuf">> => <<"8KB">>,
+                        <<"buffer">> => <<"32KB">>,
+                        <<"keepalive">> => false
+                    }
+                })
+            ]),
+            ?assertMatch(
+                #{
+                    <<"nodelay">> := true,
+                    <<"sndbuf">> := 16384,
+                    <<"recbuf">> := 8192,
+                    <<"buffer">> := 32768,
+                    <<"keepalive">> := false
+                },
+                TcpOpts
+            ),
+            with_cluster_name(fun() ->
+                LinkConf = #{
+                    server => <<"127.0.0.1:1883">>,
+                    clientid => <<"linkclientid">>,
+                    ssl => #{enable => false},
+                    tcp_opts => #{
+                        nodelay => true,
+                        sndbuf => 16384,
+                        recbuf => 8192,
+                        buffer => 32768,
+                        keepalive => false
+                    }
+                },
+                #{tcp_opts := Proplist} = emqx_cluster_link_config:mk_emqtt_options(LinkConf),
+                ?assertEqual(true, proplists:get_value(nodelay, Proplist)),
+                ?assertEqual(16384, proplists:get_value(sndbuf, Proplist)),
+                ?assertEqual(8192, proplists:get_value(recbuf, Proplist)),
+                ?assertEqual(32768, proplists:get_value(buffer, Proplist)),
+                ?assertEqual(false, proplists:get_value(keepalive, Proplist))
+            end)
+        end)}.
+
+tcp_opts_default_test_() ->
+    {"tcp_opts: when unset, mk_emqtt_options forwards an empty proplist",
+        ?_test(
+            with_cluster_name(fun() ->
+                LinkConf = #{
+                    server => <<"127.0.0.1:1883">>,
+                    clientid => <<"linkclientid">>,
+                    ssl => #{enable => false}
+                },
+                #{tcp_opts := Proplist} = emqx_cluster_link_config:mk_emqtt_options(LinkConf),
+                ?assertEqual([], Proplist)
+            end)
+        )}.
+
+with_cluster_name(Fun) ->
+    %% `emqx_cluster_link_config:mk_emqtt_options/1' falls back on `cluster()' as a
+    %% default value for clientid; that lookup needs `[cluster, name]' to exist in
+    %% `emqx_config'.  Stub it with a dummy value for the duration of the test.
+    Prior =
+        try
+            {ok, emqx_config:get([cluster, name])}
+        catch
+            _:_ -> undefined
+        end,
+    emqx_config:put([cluster, name], 'test@nohost'),
+    try
+        Fun()
+    after
+        case Prior of
+            {ok, V} -> emqx_config:put([cluster, name], V);
+            _ -> ok
+        end
+    end.

--- a/changes/ee/feat-17170.en.md
+++ b/changes/ee/feat-17170.en.md
@@ -1,0 +1,1 @@
+Added `tcp_opts` (`nodelay`, `sndbuf`, `recbuf`, `buffer`, `keepalive`) to the MQTT bridge connector and Cluster Link configurations, so the outbound MQTT client TCP socket can be tuned per connection. Unset fields keep the operating system / `gen_tcp` defaults.

--- a/rel/i18n/emqx_bridge_mqtt_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_mqtt_connector_schema.hocon
@@ -146,6 +146,13 @@ max_inflight.desc:
 max_inflight.label:
 """Max Inflight Message"""
 
+tcp_opts.desc:
+"""TCP socket options for the outbound MQTT client connection.
+All fields are optional; unset fields keep the OS / `gen_tcp` defaults."""
+
+tcp_opts.label:
+"""TCP Options"""
+
 mode.desc:
 """The mode of the MQTT Bridge.<br/>
 - cluster_shareload: create an MQTT connection on each node in the emqx cluster.<br/>

--- a/rel/i18n/emqx_cluster_link_schema.hocon
+++ b/rel/i18n/emqx_cluster_link_schema.hocon
@@ -51,6 +51,13 @@ max_inflight.desc:
 max_inflight.label:
 """Max Inflight Message"""
 
+tcp_opts.desc:
+"""TCP socket options for the outbound cluster link MQTT connection.
+All fields are optional; unset fields keep the OS / `gen_tcp` defaults."""
+
+tcp_opts.label:
+"""TCP Options"""
+
 retry_interval.label: "Retry Interval"
 retry_interval.desc: "Delay for the MQTT bridge to retry sending the QoS1/QoS2 messages in case of ACK not received."
 

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1083,6 +1083,45 @@ Default: 'none', Set to 'none' to use OS default keepalive settings (still activ
 fields_tcp_opts_keepalive.label:
 """TCP keepalive options"""
 
+client_tcp_opts.desc:
+"""TCP socket options for outbound MQTT client connections.
+All fields are optional; unset fields keep the operating system or `gen_tcp` defaults."""
+
+client_tcp_opts.label:
+"""Client TCP Options"""
+
+fields_client_tcp_opts_nodelay.desc:
+"""The `TCP_NODELAY` flag for the outbound TCP connection.
+When set to `true`, data is sent immediately, regardless of size."""
+
+fields_client_tcp_opts_nodelay.label:
+"""No Delay"""
+
+fields_client_tcp_opts_sndbuf.desc:
+"""The TCP send buffer (OS kernel) size for the outbound MQTT connection."""
+
+fields_client_tcp_opts_sndbuf.label:
+"""TCP Send Buffer"""
+
+fields_client_tcp_opts_recbuf.desc:
+"""The TCP receive buffer (OS kernel) size for the outbound MQTT connection."""
+
+fields_client_tcp_opts_recbuf.label:
+"""TCP Receive Buffer"""
+
+fields_client_tcp_opts_buffer.desc:
+"""The size of the user-space buffer used by the Erlang VM for the outbound MQTT connection."""
+
+fields_client_tcp_opts_buffer.label:
+"""User-space Buffer"""
+
+fields_client_tcp_opts_keepalive.desc:
+"""Enable the TCP `SO_KEEPALIVE` socket option for the outbound MQTT connection.
+This is the OS-level TCP keepalive probe and is independent of the MQTT-level keepalive."""
+
+fields_client_tcp_opts_keepalive.label:
+"""TCP SO_KEEPALIVE"""
+
 sysmon_top_db_username.desc:
 """Username of the PostgreSQL database"""
 


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

Adds a new optional `tcp_opts` field on the MQTT bridge connector and on each Cluster Link, exposing client-side TCP socket tunables (`nodelay`, `sndbuf`, `recbuf`, `buffer`, `keepalive`) for the outbound `emqtt` connections.

The schema lives in a new shared struct `emqx_schema:fields("client_tcp_opts")` so both call sites use the same definition (it is intentionally **not** the existing listener-side `tcp_opts` struct, which has server-only fields like `backlog`, `reuseaddr`, etc.). A small helper `emqx_schema:client_tcp_opts_to_proplist/1` converts the HOCON map into a `gen_tcp` proplist; only keys the user explicitly set are forwarded, so unset fields keep the OS / `gen_tcp` defaults.

Wiring:
- `emqx_bridge_mqtt_connector:mk_ecpool_client_opts/2` — `tcp_opts` joins the whitelist and is forwarded to `emqtt`.
- `emqx_cluster_link_config:mk_emqtt_options/1` — same forwarding for cluster link clients.

The new `keepalive` is the gen_tcp `SO_KEEPALIVE` socket option, distinct from MQTT-level keepalive.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)