### PR TITLE
fix(api): hide release version from unauthenticated /status response

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_status.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_status.erl
@@ -130,19 +130,12 @@ do_get_status(AppStatus, <<"json">>) ->
     BrokerStatus = broker_status(),
     emqx_utils_json:encode(#{
         node_name => atom_to_binary(node(), utf8),
-        rel_vsn => vsn(),
         broker_status => atom_to_binary(BrokerStatus),
         app_status => atom_to_binary(AppStatus)
     });
 do_get_status(AppStatus, _) ->
     BrokerStatus = broker_status(),
     io_lib:format("Node ~ts is ~ts~nemqx is ~ts", [node(), BrokerStatus, AppStatus]).
-
-vsn() ->
-    iolist_to_binary([
-        emqx_release:edition_vsn_prefix(),
-        emqx_release:version()
-    ]).
 
 broker_status() ->
     case emqx:is_running() of

--- a/apps/emqx_management/test/emqx_mgmt_api_status_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_status_SUITE.erl
@@ -214,10 +214,13 @@ t_status_json_format(Config) ->
         body => no_body
     }),
     ?assertEqual(200, StatusCode),
+    Decoded = emqx_utils_json:decode(Resp),
     ?assertMatch(
         #{<<"app_status">> := <<"running">>},
-        emqx_utils_json:decode(Resp)
+        Decoded
     ),
+    %% rel_vsn must not be exposed (unauthenticated endpoint).
+    ?assertNot(maps:is_key(<<"rel_vsn">>, Decoded)),
     ok.
 
 t_status_bad_format_qs(Config) ->

--- a/changes/ee/fix-17188.en.md
+++ b/changes/ee/fix-17188.en.md
@@ -1,0 +1,1 @@
+Removed the EMQX release version (`rel_vsn`) from the unauthenticated `GET /status?format=json` response to avoid disclosing the broker version to unauthenticated callers. The version remains available via the authenticated node-info APIs.

--- a/scripts/test/emqx-smoke-test.sh
+++ b/scripts/test/emqx-smoke-test.sh
@@ -22,7 +22,8 @@ wait_for_emqx() {
     done
 }
 
-## Get the JSON format status which is jq friendly and includes a version string
+## Get the JSON format status (used as a feature probe -- the JSON format was
+## introduced after the hotconf and bridges schema API).
 json_status() {
     local url="${BASE_URL}/status?format=json"
     local resp

--- a/scripts/ui-tests/dashboard_test.py
+++ b/scripts/ui-tests/dashboard_test.py
@@ -95,22 +95,24 @@ def test_log(driver, dashboard_url):
     label = driver.find_element(By.XPATH, "//div[@id='app']//form//label[contains(., 'Time Offset')]")
     assert driver.find_elements(By.ID, label.get_attribute("for"))
 
-def fetch_version_info(dashboard_url):
-    status_url = urljoin(dashboard_url, "/status?format=json")
-    response = requests.get(status_url)
-    response.raise_for_status()
-    return response.json()
-
-def parse_version(version_str):
-    prefix_major, minor, _ = version_str.split('.', 2)
-    prefix = prefix_major[:1]
-    major = prefix_major[1:]
-    return prefix, major + '.' + minor
-
-def fetch_version(url):
-    info = fetch_version_info(url)
-    version_str = info['rel_vsn']
-    return parse_version(version_str)
+def fetch_version(dashboard_url):
+    # /status no longer exposes the broker version (it's an unauthenticated
+    # endpoint), so use the authenticated /api/v5/nodes endpoint instead.
+    password = os.getenv("EMQX_DASHBOARD__DEFAULT_PASSWORD", "admin")
+    login_resp = requests.post(
+        urljoin(dashboard_url, "/api/v5/login"),
+        json={"username": "admin", "password": password},
+    )
+    login_resp.raise_for_status()
+    token = login_resp.json()["token"]
+    nodes_resp = requests.get(
+        urljoin(dashboard_url, "/api/v5/nodes"),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    nodes_resp.raise_for_status()
+    version_str = nodes_resp.json()[0]["version"]
+    major, minor, _ = version_str.split(".", 2)
+    return major + "." + minor
 
 def test_docs_link(driver, dashboard_url):
     login(driver, dashboard_url)
@@ -127,9 +129,7 @@ def test_docs_link(driver, dashboard_url):
         raise AssertionError("Cannot find the help link")
     driver.execute_script("arguments[0].click();", link_help)
 
-    prefix, emqx_version = fetch_version(dashboard_url)
-    # it's v5.x in the url
-    emqx_version = 'v' + emqx_version
+    emqx_version = 'v' + fetch_version(dashboard_url)
 
     docs_base_url = "https://docs.emqx.com/en/emqx"
 


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version:
5.8.11, 5.10.4

## Summary

`GET /status?format=json` is mounted with `security => []` (both at `/status` for cowboy LB health checks and at `/api/v5/status` for swagger), so it answers anyone who can reach the dashboard port. The JSON body included a `rel_vsn` field with the broker edition + release version, leaking that fingerprint without authentication. This PR drops the field; the version remains available via the authenticated `/api/v5/nodes` APIs.

Touched modules:
- `apps/emqx_management/src/emqx_mgmt_api_status.erl` — remove `rel_vsn => vsn()` from the JSON response and the now-unused `vsn/0` helper.
- `apps/emqx_management/test/emqx_mgmt_api_status_SUITE.erl` — `t_status_json_format` now also asserts `rel_vsn` is absent.

The `text` format response is unchanged (it never carried the version).

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)