### PR TITLE
chore(ci): update emqx-qa workflow usage

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -276,4 +276,4 @@ jobs:
         shell: bash
         run: |
           gh --repo emqx/emqx-qa workflow run regression_testing_emqx.yaml \
-            -f froms="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f artifacts="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Backport of #17125 to release-58. The `regression_testing_emqx.yaml` workflow input was renamed from `froms` to `artifacts`; this branch had been failing the QA dispatch step on every push.