### PR TITLE
ci(test): consolidate sensitive-tables import tests and split mgmt CT

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -243,24 +243,19 @@ t_export_api_key_omits_sensitive_tables(Config) ->
     end,
     ok.
 
-%% API keys must be rejected with 403 when importing a backup that contains
-%% sensitive mnesia tables.
-t_import_api_key_blocks_sensitive_tables(Config) ->
-    ApiAuth = ?config(auth, Config),
-    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
-    ?assertEqual(ok, upload_backup(?NODE1_PORT, ApiAuth, UploadFile)),
-    {Status, Body} = import_backup_full(?NODE1_PORT, ApiAuth, ?UPLOAD_CE_BACKUP),
-    ?assertEqual(403, Status),
-    ?assertMatch(#{<<"code">> := <<"FORBIDDEN">>}, Body),
-    ok.
-
-%% Dashboard bearer-token (JWT) callers can import backups that include the
-%% sensitive mnesia tables. The API-key restriction must not regress them.
-t_import_dashboard_token_allows_sensitive_tables(Config) ->
+%% API keys are rejected with 403 when importing a backup that contains
+%% sensitive mnesia tables; dashboard bearer-token (JWT) callers must still
+%% be allowed. Both checks share one cluster to keep CT runtime down.
+t_import_sensitive_tables_auth_split(Config) ->
     ApiAuth = ?config(auth, Config),
     DashboardAuth = ?config(dashboard_auth, Config),
     UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
     ?assertEqual(ok, upload_backup(?NODE1_PORT, ApiAuth, UploadFile)),
+    %% API key path: blocked.
+    {Status, Body} = import_backup_full(?NODE1_PORT, ApiAuth, ?UPLOAD_CE_BACKUP),
+    ?assertEqual(403, Status),
+    ?assertMatch(#{<<"code">> := <<"FORBIDDEN">>}, Body),
+    %% Dashboard bearer-token path: allowed.
     ?assertMatch({ok, _}, import_backup(?NODE1_PORT, DashboardAuth, ?UPLOAD_CE_BACKUP)),
     ok.
 
@@ -569,8 +564,7 @@ test_case_specific_apps_spec(TC) when
     TC =:= t_import_ee_backup;
     TC =:= t_upload_ce_backup;
     TC =:= t_import_ce_backup;
-    TC =:= t_import_api_key_blocks_sensitive_tables;
-    TC =:= t_import_dashboard_token_allows_sensitive_tables
+    TC =:= t_import_sensitive_tables_auth_split
 ->
     [
         emqx_auth,

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -246,8 +246,8 @@ matrix() {
                 entries+=("$(format_app_entry "$app" 1 emqx-enterprise "$runner")")
                 ;;
             apps/emqx_management)
-                entries+=("$(format_app_entry "$app" 1 emqx "$runner")")
-                entries+=("$(format_app_entry "$app" 1 emqx-enterprise "$runner")")
+                entries+=("$(format_app_entry "$app" 2 emqx "$runner")")
+                entries+=("$(format_app_entry "$app" 2 emqx-enterprise "$runner")")
                 ;;
             apps/emqx_auth_http)
                 entries+=("$(format_app_entry "$app" 1 emqx "$runner")")


### PR DESCRIPTION
Backport of ccbd5218a60312a3c88ec12d1689f1b4149a0542 from release-59.

- Merge `t_import_api_key_blocks_sensitive_tables` and `t_import_dashboard_token_allows_sensitive_tables` into one test sharing a single 3-node cluster.
- Split `apps/emqx_management` CT into 2 suite groups so the heavy data_backup suites get their own runner.

Conflict in `scripts/find-apps.sh` resolved by keeping release-58's matrix structure and bumping `apps/emqx_management` from 1 to 2 groups for both `emqx` and `emqx-enterprise` profiles.