### PR TITLE
build: Bump to EMQX otp-28.4.1-3

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -1,7 +1,7 @@
 services:
   kdc:
     hostname: kdc.emqx.net
-    image:  ghcr.io/emqx/emqx-builder/6.1-2:1.19.1-28.4.1-2-ubuntu24.04
+    image:  ghcr.io/emqx/emqx-builder/6.1-4:1.19.1-28.4.1-3-ubuntu24.04
     container_name: kdc.emqx.net
     expose:
       - 88 # kdc

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   erlang:
     hostname: erlang.emqx.net
     container_name: erlang
-    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/6.1-2:1.19.1-28.4.1-2-ubuntu24.04}
+    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/6.1-4:1.19.1-28.4.1-3-ubuntu24.04}
     env_file:
       - credentials.env
       - conf.env

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -59,7 +59,7 @@ on:
       otp_vsn:
         required: false
         type: string
-        default: '28.4.1-2'
+        default: '28.4.1-3'
       elixir_vsn:
         required: false
         type: string
@@ -67,7 +67,7 @@ on:
       builder_vsn:
         required: false
         type: string
-        default: '6.1-2'
+        default: '6.1-4'
 
 permissions:
   contents: read

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-erlang 28.4.1-2
+erlang 28.4.1-3
 elixir 1.19.1-otp-28
 rust 1.88.0

--- a/changes/ee/fix-17198.en.md
+++ b/changes/ee/fix-17198.en.md
@@ -1,0 +1,3 @@
+Bumped OTP version to 28.4.1-3 and builder version to 6.1-4.
+
+Without this change, during EMQX startup, Mria app boot may get stuck if it's not connected to the cluster.

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/6.1-2:1.19.1-28.4.1-2-debian13
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/6.1-4:1.19.1-28.4.1-3-debian13
 ARG RUN_FROM=debian:13-slim
 ARG SOURCE_TYPE=src # tgz
 

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 # https://github.com/emqx/emqx-builder
-export EMQX_BUILDER_VSN=6.1-2
-export OTP_VSN=28.4.1-2
+export EMQX_BUILDER_VSN=6.1-4
+export OTP_VSN=28.4.1-3
 export ELIXIR_VSN=1.19.1
 export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-ubuntu24.04
 export EMQX_DOCKER_BUILD_FROM=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-debian13


### PR DESCRIPTION
Without this change, during EMQX startup, Mria app boot may get stuck if it's not connected to the cluster.

Fixes <issue-or-jira-number>

Release version:
<!-- uncomment for v5:
5.8.10, 5.10.4
-->

6.2.0


## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
