### PR TITLE
feat(plugins): TTL and sha256-pinning for install allowlist + zip-slip fix

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -78,6 +78,7 @@
 {emqx_plugins,1}.
 {emqx_plugins,2}.
 {emqx_plugins,3}.
+{emqx_plugins,4}.
 {emqx_prometheus,1}.
 {emqx_prometheus,2}.
 {emqx_resource,1}.

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -558,7 +558,9 @@ upload_install(post, #{}) ->
 install_package_on_nodes(NameVsn, Bin) ->
     case emqx_plugins:is_allowed_installation(NameVsn, Bin) of
         ok ->
-            do_install_package_on_nodes(NameVsn, Bin);
+            Result = do_install_package_on_nodes(NameVsn, Bin),
+            ok = forget_allow_after_install(NameVsn, Result),
+            Result;
         {error, not_allowed} ->
             Msg = iolist_to_binary([
                 <<"Package is not allowed installation;">>,
@@ -576,6 +578,17 @@ install_package_on_nodes(NameVsn, Bin) ->
             ]),
             {403, #{code => 'FORBIDDEN', message => Msg}}
     end.
+
+%% On a successful HTTP install, immediately revoke the cluster-wide allow
+%% entry so the same grant cannot be reused for a subsequent (potentially
+%% different) upload. On failure, leave the entry in place so the operator
+%% can retry without having to re-issue `emqx ctl plugins allow'.
+forget_allow_after_install(NameVsn, {204}) ->
+    Nodes = emqx:running_nodes(),
+    _ = emqx_plugins_proto_v3:disallow_installation(Nodes, NameVsn),
+    ok;
+forget_allow_after_install(_NameVsn, _Other) ->
+    ok.
 
 do_install_package_on_nodes(NameVsn, Bin) ->
     %% TODO: handle bad nodes

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -556,16 +556,23 @@ upload_install(post, #{}) ->
     }}.
 
 install_package_on_nodes(NameVsn, Bin) ->
-    case emqx_plugins:is_allowed_installation(NameVsn) of
-        true ->
+    case emqx_plugins:is_allowed_installation(NameVsn, Bin) of
+        ok ->
             do_install_package_on_nodes(NameVsn, Bin);
-        false ->
+        {error, not_allowed} ->
             Msg = iolist_to_binary([
                 <<"Package is not allowed installation;">>,
                 <<" first allow it to be installed by running:">>,
                 <<" `emqx ctl plugins allow ">>,
                 NameVsn,
                 <<"`">>
+            ]),
+            {403, #{code => 'FORBIDDEN', message => Msg}};
+        {error, sha256_mismatch} ->
+            Msg = iolist_to_binary([
+                <<"Package sha256 does not match the value bound by `emqx ctl plugins allow ">>,
+                NameVsn,
+                <<" sha256:...`">>
             ]),
             {403, #{code => 'FORBIDDEN', message => Msg}}
     end.

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -490,6 +490,15 @@ plugins(["describe", NameVsn]) ->
     emqx_plugins_cli:describe(NameVsn, fun emqx_ctl:print/2);
 plugins(["allow", NameVsn]) ->
     emqx_plugins_cli:allow_installation(NameVsn, fun emqx_ctl:print/2);
+plugins(["allow", NameVsn, "sha256:" ++ Hex]) ->
+    case parse_sha256_hex(Hex) of
+        {ok, Sha256} ->
+            emqx_plugins_cli:allow_installation(NameVsn, Sha256, fun emqx_ctl:print/2);
+        error ->
+            emqx_ctl:print(
+                "sha256 must be 64 lowercase hex characters, e.g. sha256:abc...~n"
+            )
+    end;
 plugins(["disallow", NameVsn]) ->
     emqx_plugins_cli:disallow_installation(NameVsn, fun emqx_ctl:print/2);
 plugins(["install", NameVsn]) ->
@@ -518,8 +527,11 @@ plugins(_) ->
             {"plugins <command> [Name-Vsn]", "e.g. 'start emqx_plugin_template-5.0-rc.1'"},
             {"plugins list", "List all installed plugins"},
             {"plugins describe  Name-Vsn", "Describe an installed plugins"},
-            {"plugins allow     Name-Vsn",
-                "Allows installation of a plugin in the cluster from Dashboard or API"},
+            {"plugins allow     Name-Vsn [sha256:HEX]",
+                "Allows installation of a plugin in the cluster from Dashboard or API.\n"
+                "The grant expires 5 minutes after issue.\n"
+                "If sha256:HEX (64 lowercase hex chars) is given, the upload bytes\n"
+                "must hash to that value or the install is rejected."},
             {"plugins disallow  Name-Vsn",
                 "Disallows installation of a plugin in the cluster from Dashboard or API"},
             {"plugins install   Name-Vsn",
@@ -542,6 +554,14 @@ plugins(_) ->
                 "     plugins enable bar-0.2.0 before foo-0.1.0"}
         ]
     ).
+
+parse_sha256_hex(Hex) when length(Hex) =:= 64 ->
+    case re:run(Hex, "^[0-9a-f]{64}$", [{capture, none}]) of
+        match -> {ok, list_to_binary(Hex)};
+        nomatch -> error
+    end;
+parse_sha256_hex(_) ->
+    error.
 
 %%--------------------------------------------------------------------
 %% @doc vm command

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -130,7 +130,7 @@ t_install_plugin_sha256_match(_Config) ->
     Sha = binary_to_list(binary:encode_hex(crypto:hash(sha256, Bin), lowercase)),
     ok = allow_installation(NameVsn, Sha),
     ok = install_plugin(PackagePath),
-    {ok, _} = describe_plugin(NameVsn),
+    ?assertMatch(#{<<"name">> := <<"my_emqx_plugin">>}, describe_plugin(NameVsn)),
     {ok, []} = uninstall_plugin(NameVsn),
     ok.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -121,6 +121,32 @@ t_plugins(_Config) ->
     ?assertMatch({ok, {{_, 403, _}, _, _}}, install_plugin(PackagePath)),
     ok.
 
+t_install_plugin_sha256_match(_Config) ->
+    PackagePath = get_demo_plugin_package(),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ok = emqx_plugins:delete_package(NameVsn),
+    {ok, Bin} = file:read_file(PackagePath),
+    Sha = binary_to_list(binary:encode_hex(crypto:hash(sha256, Bin), lowercase)),
+    ok = allow_installation(NameVsn, Sha),
+    ok = install_plugin(PackagePath),
+    {ok, _} = describe_plugin(NameVsn),
+    {ok, []} = uninstall_plugin(NameVsn),
+    ok.
+
+t_install_plugin_sha256_mismatch(_Config) ->
+    PackagePath = get_demo_plugin_package(),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ok = emqx_plugins:delete_package(NameVsn),
+    %% Bind a hash that intentionally doesn't match the file bytes.
+    BogusSha = string:copies("a", 64),
+    ok = allow_installation(NameVsn, BogusSha),
+    ?assertMatch({ok, {{_, 403, _}, _, _}}, install_plugin(PackagePath)),
+    %% Clean up the leftover allow entry so other cases aren't affected.
+    ok = disallow_installation(NameVsn),
+    ok.
+
 t_uninstall_conflicting_version_keeps_old_running(_Config) ->
     #{package := OldPackagePath} = get_demo_plugin_package(#{
         shdir => "./",
@@ -623,6 +649,9 @@ get_host_and_auth(Config) when is_list(Config) ->
 
 allow_installation(NameVsn) ->
     emqx_ctl:run_command(["plugins", "allow", NameVsn]).
+
+allow_installation(NameVsn, Sha256Hex) ->
+    emqx_ctl:run_command(["plugins", "allow", NameVsn, "sha256:" ++ Sha256Hex]).
 
 disallow_installation(NameVsn) ->
     emqx_ctl:run_command(["plugins", "disallow", NameVsn]).

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -25,8 +25,11 @@
 %% Package operations
 -export([
     allow_installation/1,
+    allow_installation/2,
     forget_allowed_installation/1,
     is_allowed_installation/1,
+    is_allowed_installation/2,
+    allow_ttl_ms/0,
 
     ensure_installed/0,
     ensure_installed/1,
@@ -102,6 +105,11 @@
 
 -define(allowed_installations, allowed_installations).
 
+%% Default TTL for an `allow_installation' grant.
+%% After this many milliseconds the entry is treated as expired and is purged
+%% lazily on the next allow/check/forget call.
+-define(ALLOW_TTL_MS, timer:minutes(5)).
+
 %%--------------------------------------------------------------------
 %% APIs
 %%--------------------------------------------------------------------
@@ -159,28 +167,94 @@ handle_api_call(Plugin0, Request, Timeout) ->
 %% We could use `application:set_env', but the typespec for it makes dialyzer sad when it
 %% seems a non-atom key...
 -spec allow_installation(binary() | string()) -> ok.
-allow_installation(NameVsn0) ->
+allow_installation(NameVsn) ->
+    allow_installation(NameVsn, undefined).
+
+%% @doc Allow installation of `NameVsn'. The entry expires after `allow_ttl_ms/0'
+%% milliseconds. When `Sha256' is a 64-char lowercase hex binary, the upload
+%% bytes must hash to the same value to be accepted; when `undefined', any
+%% bytes named `NameVsn.tar.gz' are accepted (legacy behavior).
+-spec allow_installation(binary() | string(), binary() | undefined) -> ok.
+allow_installation(NameVsn0, Sha256) when Sha256 =:= undefined; is_binary(Sha256) ->
     NameVsn = bin(NameVsn0),
+    Entry = #{
+        expires_at => erlang:monotonic_time(millisecond) + allow_ttl_ms(),
+        sha256 => Sha256
+    },
     Allowed0 = application:get_env(?APP, ?allowed_installations, #{}),
-    Allowed = Allowed0#{NameVsn => true},
+    Allowed = (prune_expired(Allowed0))#{NameVsn => Entry},
     application:set_env(?APP, ?allowed_installations, Allowed),
     ok.
 
 %% Note: this is only used for the HTTP API.
+%% Returns true iff a non-expired allow entry exists for `NameVsn'.
+%% Does NOT check sha256 binding — use `is_allowed_installation/2' to verify
+%% the upload bytes against the stored hash.
 -spec is_allowed_installation(binary() | string()) -> boolean().
 is_allowed_installation(NameVsn0) ->
     NameVsn = bin(NameVsn0),
-    Allowed = application:get_env(?APP, ?allowed_installations, #{}),
-    maps:get(NameVsn, Allowed, false).
+    Allowed = prune_and_store(application:get_env(?APP, ?allowed_installations, #{})),
+    maps:is_key(NameVsn, Allowed).
+
+%% @doc Check that `NameVsn' is allowed and that `Bin' matches the bound
+%% sha256 (if any). Returns:
+%%   ok                          - allowed and (hash matches or no hash bound)
+%%   {error, not_allowed}        - no non-expired entry exists
+%%   {error, sha256_mismatch}    - entry has a sha256 that doesn't match `Bin'
+-spec is_allowed_installation(binary() | string(), binary()) ->
+    ok | {error, not_allowed | sha256_mismatch}.
+is_allowed_installation(NameVsn0, Bin) when is_binary(Bin) ->
+    NameVsn = bin(NameVsn0),
+    Allowed = prune_and_store(application:get_env(?APP, ?allowed_installations, #{})),
+    case maps:find(NameVsn, Allowed) of
+        error ->
+            {error, not_allowed};
+        {ok, #{sha256 := undefined}} ->
+            ok;
+        {ok, #{sha256 := Expected}} when is_binary(Expected) ->
+            Got = binary:encode_hex(crypto:hash(sha256, Bin), lowercase),
+            case Got =:= Expected of
+                true -> ok;
+                false -> {error, sha256_mismatch}
+            end
+    end.
 
 %% Note: this is only used for the HTTP API.
 -spec forget_allowed_installation(binary() | string()) -> ok.
 forget_allowed_installation(NameVsn0) ->
     NameVsn = bin(NameVsn0),
     Allowed0 = application:get_env(?APP, ?allowed_installations, #{}),
-    Allowed = maps:remove(NameVsn, Allowed0),
+    Allowed = maps:remove(NameVsn, prune_expired(Allowed0)),
     application:set_env(?APP, ?allowed_installations, Allowed),
     ok.
+
+%% @doc TTL applied to new `allow_installation' entries. The default of 5
+%% minutes can be overridden via `application:set_env(emqx_plugins,
+%% allow_ttl_ms, Ms)' — primarily for tests.
+-spec allow_ttl_ms() -> pos_integer().
+allow_ttl_ms() ->
+    application:get_env(?APP, allow_ttl_ms, ?ALLOW_TTL_MS).
+
+prune_and_store(Allowed0) ->
+    case prune_expired(Allowed0) of
+        Allowed0 ->
+            Allowed0;
+        Pruned ->
+            application:set_env(?APP, ?allowed_installations, Pruned),
+            Pruned
+    end.
+
+prune_expired(Allowed) ->
+    Now = erlang:monotonic_time(millisecond),
+    maps:filter(
+        fun
+            (_K, #{expires_at := ExpiresAt}) -> ExpiresAt > Now;
+            %% Defensive: drop legacy/unknown entries (e.g. left over after a
+            %% hot beam upgrade from a version that stored `true').
+            (_K, _V) -> false
+        end,
+        Allowed
+    ).
 
 %%--------------------------------------------------------------------
 %% Package operations

--- a/apps/emqx_plugins/src/emqx_plugins_cli.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_cli.erl
@@ -15,6 +15,7 @@
     ensure_disabled/2,
     ensure_enabled/3,
     allow_installation/2,
+    allow_installation/3,
     disallow_installation/2
 ]).
 
@@ -47,33 +48,55 @@ describe(NameVsn, LogFun) ->
     end.
 
 allow_installation(NameVsn, LogFun) ->
+    allow_installation(NameVsn, undefined, LogFun).
+
+allow_installation(NameVsn, Sha256, LogFun) ->
     try emqx_plugins_utils:parse_name_vsn(NameVsn) of
         {_AppName, _Vsn} ->
-            do_allow_installation(NameVsn, LogFun)
+            do_allow_installation(NameVsn, Sha256, LogFun)
     catch
         error:bad_name_vsn ->
             ?PRINT({error, bad_name_vsn}, LogFun)
     end.
 
-do_allow_installation(NameVsn, LogFun) ->
+do_allow_installation(NameVsn, undefined, LogFun) ->
+    %% No sha256 binding — use proto v3 to remain compatible with older nodes
+    %% in a rolling upgrade.
     Nodes = nodes_supporting_bpapi_version(3),
     Results = emqx_plugins_proto_v3:allow_installation(Nodes, NameVsn),
+    print_allow_result(Nodes, Results, NameVsn, LogFun);
+do_allow_installation(NameVsn, Sha256, LogFun) when is_binary(Sha256) ->
+    %% sha256 binding — needs every running node on proto v4 so the binding is
+    %% enforced everywhere. Refuse rather than silently allow on old nodes.
+    Running = emqx:running_nodes(),
+    V4Nodes = nodes_supporting_bpapi_version(4),
+    case Running -- V4Nodes of
+        [] ->
+            Results = emqx_plugins_proto_v4:allow_installation(V4Nodes, NameVsn, Sha256),
+            print_allow_result(V4Nodes, Results, NameVsn, LogFun);
+        Missing ->
+            Reason = #{
+                hint => <<"sha256 binding requires all nodes to be upgraded">>,
+                nodes_missing_v4 => Missing
+            },
+            ?PRINT({error, Reason}, LogFun)
+    end.
+
+print_allow_result(Nodes, Results, NameVsn, LogFun) ->
     Errors =
         lists:filter(
             fun
-                ({_Node, {ok, ok}}) ->
-                    false;
-                ({_Node, _Error}) ->
-                    true
+                ({_Node, {ok, ok}}) -> false;
+                ({_Node, _}) -> true
             end,
             lists:zip(Nodes, Results)
         ),
     Result =
         case Errors of
-            [] -> ok;
+            [] -> {ok, #{expires_in_ms => emqx_plugins:allow_ttl_ms()}};
             _ -> {error, maps:from_list(Errors)}
         end,
-    ?PRINT(Result, LogFun).
+    print(NameVsn, Result, LogFun, allow_installation).
 
 disallow_installation(NameVsn, LogFun) ->
     try emqx_plugins_utils:parse_name_vsn(NameVsn) of
@@ -140,6 +163,8 @@ print(NameVsn, Res, LogFun, Action) ->
         case Res of
             ok ->
                 Obj#{result => ok};
+            {ok, Extra} when is_map(Extra) ->
+                maps:merge(Obj#{result => ok}, Extra);
             {error, Reason} ->
                 Obj#{
                     result => not_ok,

--- a/apps/emqx_plugins/src/emqx_plugins_fs.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_fs.erl
@@ -179,13 +179,19 @@ install_from_local_tar(NameVsn, InstallValidator) ->
     TarGz = tar_file_path(NameVsn),
     case erl_tar:extract(TarGz, [compressed, memory]) of
         {ok, TarContent} ->
-            ok = write_tar_file_content(install_dir(), TarContent),
-            case InstallValidator() of
+            case write_tar_file_content(install_dir(), TarContent) of
                 ok ->
-                    ok;
+                    case InstallValidator() of
+                        ok ->
+                            ok;
+                        {error, Reason} ->
+                            ?SLOG(warning, #{
+                                msg => "failed_to_read_after_install", reason => Reason
+                            }),
+                            ok = delete_tar_file_content(install_dir(), TarContent),
+                            {error, Reason}
+                    end;
                 {error, Reason} ->
-                    ?SLOG(warning, #{msg => "failed_to_read_after_install", reason => Reason}),
-                    ok = delete_tar_file_content(install_dir(), TarContent),
                     {error, Reason}
             end;
         {error, {_, enoent}} ->
@@ -353,16 +359,30 @@ create_tar(NameVsn, TarGzName) ->
     end.
 
 write_tar_file_content(BaseDir, TarContent) ->
-    lists:foreach(
-        fun({Name, Bin}) ->
-            Filename = filename:join(BaseDir, Name),
-            ok = filelib:ensure_dir(Filename),
-            ok = file:write_file(Filename, Bin)
-        end,
-        TarContent
-    ).
+    %% Validate every entry up front. A single zip-slip entry must not
+    %% leave half-written legitimate entries behind on disk.
+    case unsafe_entries(BaseDir, TarContent) of
+        [] ->
+            lists:foreach(
+                fun({Name, Bin}) ->
+                    Filename = filename:join(BaseDir, Name),
+                    ok = filelib:ensure_dir(Filename),
+                    ok = file:write_file(Filename, Bin)
+                end,
+                TarContent
+            );
+        [_ | _] = Unsafe ->
+            {error, #{
+                msg => "unsafe_tar_entry_path",
+                hint => "tar entries must stay under the install dir",
+                entries => Unsafe
+            }}
+    end.
 
 delete_tar_file_content(BaseDir, TarContent) ->
+    %% Defense in depth: never follow a tar entry path that escapes
+    %% BaseDir, even on the cleanup path.
+    SafeEntries = [E || {Name, _} = E <- TarContent, is_safe_entry(BaseDir, Name)],
     lists:foreach(
         fun({Name, _}) ->
             Filename = filename:join(BaseDir, Name),
@@ -372,8 +392,17 @@ delete_tar_file_content(BaseDir, TarContent) ->
                 ok ?= file:del_dir_r(TopDirOrFile)
             end
         end,
-        TarContent
+        SafeEntries
     ).
+
+unsafe_entries(BaseDir, TarContent) ->
+    [Name || {Name, _} <- TarContent, not is_safe_entry(BaseDir, Name)].
+
+is_safe_entry(BaseDir, Name) ->
+    case filelib:safe_relative_path(Name, BaseDir) of
+        unsafe -> false;
+        _ -> true
+    end.
 
 top_dir(BaseDir0, DirOrFile) ->
     BaseDir = normalize_dir(BaseDir0),
@@ -438,5 +467,17 @@ top_dir_test_() ->
         ?_assertMatch(
             {error, {out_of_bounds, _}}, top_dir("/base", filename:join(["/", "foo", "bar"]))
         )
+    ].
+
+is_safe_entry_test_() ->
+    %% Use cwd as a real existing directory; safe_relative_path/2 needs that.
+    {ok, Cwd} = file:get_cwd(),
+    [
+        ?_assert(is_safe_entry(Cwd, "evil-1.0.0/release.json")),
+        ?_assert(is_safe_entry(Cwd, "deep/nested/path.txt")),
+        ?_assertNot(is_safe_entry(Cwd, "../escape")),
+        ?_assertNot(is_safe_entry(Cwd, "../../../tmp/pwned")),
+        ?_assertNot(is_safe_entry(Cwd, "evil/../../../tmp/pwned")),
+        ?_assertNot(is_safe_entry(Cwd, "/abs/path"))
     ].
 -endif.

--- a/apps/emqx_plugins/src/proto/emqx_plugins_proto_v4.erl
+++ b/apps/emqx_plugins/src/proto/emqx_plugins_proto_v4.erl
@@ -1,0 +1,42 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_plugins_proto_v4).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+
+    allow_installation/3,
+    disallow_installation/2
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+-define(TIMEOUT, 25_000).
+
+introduced_in() ->
+    "6.0.3".
+
+-spec allow_installation([node()], binary() | string(), binary() | undefined) ->
+    emqx_rpc:erpc_multicall(ok | {error, term()}).
+allow_installation(Nodes, NameVsn, Sha256) ->
+    erpc:multicall(Nodes, emqx_plugins, allow_installation, [NameVsn, Sha256], ?TIMEOUT).
+
+-spec disallow_installation([node()], binary() | string()) ->
+    emqx_rpc:erpc_multicall(ok | {error, term()}).
+disallow_installation(Nodes, NameVsn) ->
+    erpc:multicall(Nodes, emqx_plugins, forget_allowed_installation, [NameVsn], ?TIMEOUT).

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -1213,3 +1213,115 @@ ensure_state(NameVsn, Position, Enabled) ->
 bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
 bin(L) when is_list(L) -> unicode:characters_to_binary(L, utf8);
 bin(B) when is_binary(B) -> B.
+
+%%--------------------------------------------------------------------
+%% allow_installation TTL + sha256 binding
+%%--------------------------------------------------------------------
+
+%% Allow entry expires after the configured TTL and is purged on the next access.
+t_allow_ttl_expires({init, Config}) ->
+    application:set_env(emqx_plugins, allow_ttl_ms, 50),
+    Config;
+t_allow_ttl_expires({'end', _Config}) ->
+    application:unset_env(emqx_plugins, allow_ttl_ms),
+    application:unset_env(emqx_plugins, allowed_installations),
+    ok;
+t_allow_ttl_expires(_Config) ->
+    NameVsn = <<"foo-1.0.0">>,
+    ok = emqx_plugins:allow_installation(NameVsn),
+    ?assert(emqx_plugins:is_allowed_installation(NameVsn)),
+    timer:sleep(150),
+    ?assertNot(emqx_plugins:is_allowed_installation(NameVsn)),
+    %% Lazy purge: the entry should be gone from the env after the read.
+    Allowed = application:get_env(emqx_plugins, allowed_installations, #{}),
+    ?assertEqual(#{}, Allowed),
+    ok.
+
+%% is_allowed_installation/2 accepts bytes whose sha256 matches the bound hash.
+t_allow_sha256_match({init, Config}) ->
+    Config;
+t_allow_sha256_match({'end', _Config}) ->
+    application:unset_env(emqx_plugins, allowed_installations),
+    ok;
+t_allow_sha256_match(_Config) ->
+    NameVsn = <<"foo-1.0.0">>,
+    Bin = <<"hello world">>,
+    Sha = binary:encode_hex(crypto:hash(sha256, Bin), lowercase),
+    ok = emqx_plugins:allow_installation(NameVsn, Sha),
+    ?assertEqual(ok, emqx_plugins:is_allowed_installation(NameVsn, Bin)),
+    ok.
+
+%% is_allowed_installation/2 rejects bytes whose sha256 does not match.
+t_allow_sha256_mismatch({init, Config}) ->
+    Config;
+t_allow_sha256_mismatch({'end', _Config}) ->
+    application:unset_env(emqx_plugins, allowed_installations),
+    ok;
+t_allow_sha256_mismatch(_Config) ->
+    NameVsn = <<"foo-1.0.0">>,
+    Allowed = <<"hello world">>,
+    Tampered = <<"goodbye world">>,
+    Sha = binary:encode_hex(crypto:hash(sha256, Allowed), lowercase),
+    ok = emqx_plugins:allow_installation(NameVsn, Sha),
+    ?assertEqual(
+        {error, sha256_mismatch},
+        emqx_plugins:is_allowed_installation(NameVsn, Tampered)
+    ),
+    ?assertEqual(
+        {error, not_allowed},
+        emqx_plugins:is_allowed_installation(<<"other-1.0.0">>, Allowed)
+    ),
+    ok.
+
+%% When no sha256 is bound, is_allowed_installation/2 accepts any bytes (legacy path).
+t_allow_sha256_undefined_accepts_any({init, Config}) ->
+    Config;
+t_allow_sha256_undefined_accepts_any({'end', _Config}) ->
+    application:unset_env(emqx_plugins, allowed_installations),
+    ok;
+t_allow_sha256_undefined_accepts_any(_Config) ->
+    NameVsn = <<"foo-1.0.0">>,
+    ok = emqx_plugins:allow_installation(NameVsn),
+    ?assertEqual(ok, emqx_plugins:is_allowed_installation(NameVsn, <<"any bytes">>)),
+    ?assertEqual(ok, emqx_plugins:is_allowed_installation(NameVsn, <<"other bytes">>)),
+    ok.
+
+%% A tar entry whose name escapes the install dir (../../../tmp/pwned) must be
+%% rejected, and no part of the tarball may land on disk outside the install dir.
+t_tar_path_traversal({init, Config}) ->
+    InstallDir = ?config(install_dir, Config),
+    NameVsn = "evil-1.0.0",
+    %% Mimic the PoC from the spec: one legitimate entry plus a traversal entry.
+    LegitEntry = filename:join(NameVsn, "release.json"),
+    EvilTarget = filename:join(
+        "/tmp", "pwned-by-emqx-zipslip-" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    EvilEntry = "../../../../tmp/" ++ filename:basename(EvilTarget),
+    TarGz = filename:join(InstallDir, NameVsn ++ ".tar.gz"),
+    ok = erl_tar:create(
+        TarGz,
+        [
+            {LegitEntry, <<"{}">>},
+            {EvilEntry, <<"pwned\n">>}
+        ],
+        [compressed]
+    ),
+    [{tar_gz, TarGz}, {name_vsn, NameVsn}, {evil_target, EvilTarget} | Config];
+t_tar_path_traversal({'end', Config}) ->
+    %% Be paranoid in case the test failed and the file actually got written.
+    file:delete(?config(evil_target, Config)),
+    ok = emqx_plugins:delete_package(?config(name_vsn, Config));
+t_tar_path_traversal(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    EvilTarget = ?config(evil_target, Config),
+    %% Pre-condition: the target must not exist before install.
+    ?assertEqual({error, enoent}, file:read_file_info(EvilTarget)),
+    ?assertMatch(
+        {error, #{msg := "unsafe_tar_entry_path"}},
+        emqx_plugins:ensure_installed(NameVsn)
+    ),
+    %% Post-condition: the malicious file must NOT have been written.
+    ?assertEqual({error, enoent}, file:read_file_info(EvilTarget)),
+    %% And no plugin dir should have been created either.
+    ?assertEqual({error, enoent}, file:read_file_info(emqx_plugins_fs:plugin_dir(NameVsn))),
+    ok.

--- a/changes/ee/feat-17201.en.md
+++ b/changes/ee/feat-17201.en.md
@@ -1,0 +1,3 @@
+Plugin install allowlist entries (`emqx ctl plugins allow <name-vsn>`) now expire 5 minutes after they are issued, and may be pinned to a SHA-256 hash of the package.
+
+`emqx ctl plugins allow <name-vsn> sha256:<HEX>` accepts a 64-character lowercase hex digest; uploads whose contents do not hash to that value are rejected with `403 Forbidden`. The previous behavior of accepting any payload named `<name-vsn>.tar.gz` is preserved when the optional `sha256:` argument is omitted.

--- a/changes/ee/feat-17201.en.md
+++ b/changes/ee/feat-17201.en.md
@@ -1,3 +1,5 @@
 Plugin install allowlist entries (`emqx ctl plugins allow <name-vsn>`) now expire 5 minutes after they are issued, and may be pinned to a SHA-256 hash of the package.
 
 `emqx ctl plugins allow <name-vsn> sha256:<HEX>` accepts a 64-character lowercase hex digest; uploads whose contents do not hash to that value are rejected with `403 Forbidden`. The previous behavior of accepting any payload named `<name-vsn>.tar.gz` is preserved when the optional `sha256:` argument is omitted.
+
+A successful install via the HTTP plugin install endpoint (and the dashboard upload that wraps it) immediately revokes the allow entry cluster-wide, so the same grant cannot be reused for a subsequent (potentially different) tarball.

--- a/changes/ee/fix-17201.en.md
+++ b/changes/ee/fix-17201.en.md
@@ -1,0 +1,1 @@
+Fixed a path-traversal vulnerability in the plugin install endpoint. A tarball whose entry name contained `..` segments could cause file writes outside the plugin install directory. The install path now refuses to extract any tarball whose entries would escape the install directory.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 6.0.3, 6.1.2, 6.2.1

Port of #17200 (release-58) to release-60, plus the auto-revoke follow-up that's parallel to #17202 on release-58.

## Summary

Three changes to the plugin install path:

- **Allowlist TTL + optional sha256 pinning** (`feat-17201`): `emqx ctl plugins allow <name-vsn>` entries now expire 5 minutes after issue. An optional `sha256:<HEX>` argument pins the allowlist entry to a specific package digest; uploads whose contents do not match are rejected with `403 Forbidden`. Existing behavior (no pinning) is preserved when the `sha256:` argument is omitted.
- **Auto-revoke on successful install** (also `feat-17201`): a successful HTTP install immediately calls `disallow_installation` cluster-wide, so the same grant cannot be reused for a subsequent (potentially different) tarball. The TTL still applies as a backstop; this closes the common-path window down to "single successful upload" instead of 5 minutes.
- **Zip-slip fix on install** (`fix-17201`): a tarball whose entry name contained `..` segments could write files outside the plugin install directory. The install path now refuses to extract any entry that would escape the install directory.

The release-60 plugin code was refactored relative to release-58, so this is a manual port rather than a cherry-pick. The TTL/sha256 logic in `emqx_plugins.erl` and the CLI/API plumbing are line-for-line equivalent; the zip-slip safety check was applied to `emqx_plugins_fs.erl` (which is where `write_tar_file_content` / `delete_tar_file_content` live in v6).

New BPAPI proto module `emqx_plugins_proto_v4` carries the sha256 argument across the cluster; the existing `/1` (no-hash) path keeps using v3 so rolling upgrades remain safe.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)