### PR TITLE
build(mongodb): pin client to v3.1.1

### DIFF
--- a/apps/emqx_mongodb/mix.exs
+++ b/apps/emqx_mongodb/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXMongodb.MixProject do
     UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
-      {:mongodb, github: "emqx/mongodb-erlang", tag: "v3.1.0"}
+      {:mongodb, github: "emqx/mongodb-erlang", tag: "v3.1.1"}
     ])
   end
 end


### PR DESCRIPTION
Picks up emqx/mongodb-erlang v3.1.1: poolboy switched from `comtihon/poolboy` master to `emqx/poolboy` 1.5.2, and the app uses `vsn = git` so versions follow tags. No user-visible behavior change.