### PR TITLE
fix(clink): silence disconnects from forwarding emqtt clients

### DIFF
--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -17,6 +17,9 @@
 %% ecpool
 -export([connect/1]).
 
+%% emqtt
+-export([handle_disconnect/1]).
+
 -behaviour(emqx_resource).
 -export([
     callback_mode/0,
@@ -172,7 +175,7 @@ on_start(ResourceId, #{pool_size := PoolSize} = ClusterConf) ->
         {pool_size, PoolSize},
         {pool_type, hash},
         {auto_reconnect, ?AUTO_RECONNECT_INTERVAL_S},
-        {client_opts, emqtt_client_opts(?MSG_CLIENTID_SUFFIX, ClusterConf)}
+        {client_opts, emqx_cluster_link_config:mk_emqtt_options(ClusterConf)}
     ],
     ok = emqx_resource:allocate_resource(ResourceId, ?MODULE, pool_name, PoolName),
     case emqx_resource_pool:start(PoolName, ?MODULE, Options) of
@@ -317,11 +320,17 @@ combine_status(Statuses) ->
 %%--------------------------------------------------------------------
 
 connect(Options) ->
-    WorkerIdBin = integer_to_binary(proplists:get_value(ecpool_worker_id, Options)),
-    #{clientid := ClientId} = ClientOpts = proplists:get_value(client_opts, Options),
-    ClientId1 = <<ClientId/binary, ":", WorkerIdBin/binary>>,
-    ClientOpts1 = ClientOpts#{clientid => ClientId1},
-    case emqtt:start_link(ClientOpts1) of
+    WorkerId = proplists:get_value(ecpool_worker_id, Options),
+    ClientOpts0 = #{clientid := ClientId0} = proplists:get_value(client_opts, Options),
+    ClientIdBase = emqx_bridge_mqtt_lib:clientid_base([ClientId0, ?MSG_CLIENTID_SUFFIX]),
+    ClientId = iolist_to_binary([ClientIdBase, $:, integer_to_binary(WorkerId)]),
+    ClientOpts = ClientOpts0#{
+        clientid => ClientId,
+        msg_handler => #{
+            disconnected => {fun ?MODULE:handle_disconnect/1, []}
+        }
+    },
+    case emqtt:start_link(ClientOpts) of
         {ok, Pid} ->
             case emqtt:connect(Pid) of
                 {ok, _Props} ->
@@ -337,6 +346,10 @@ connect(Options) ->
             }),
             Error
     end.
+
+-spec handle_disconnect({disconnected, emqx_types:reason_code(), emqx_types:properties()}) -> ok.
+handle_disconnect(_Reason) ->
+    ok.
 
 %%--------------------------------------------------------------------
 %% Protocol
@@ -495,12 +508,3 @@ decode_payload(Payload) ->
 forward(ClusterName, #delivery{message = #message{topic = Topic} = Msg}) ->
     QueryOpts = #{pick_key => Topic},
     emqx_resource:query(?MSG_RES_ID(ClusterName), Msg, QueryOpts).
-
-%%--------------------------------------------------------------------
-%% Internal functions
-%%--------------------------------------------------------------------
-
-emqtt_client_opts(ClientIdSuffix, ClusterConf) ->
-    #{clientid := BaseClientId} = Opts = emqx_cluster_link_config:mk_emqtt_options(ClusterConf),
-    ClientId = emqx_bridge_mqtt_lib:clientid_base([BaseClientId, ClientIdSuffix]),
-    Opts#{clientid => ClientId}.

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -18,7 +18,7 @@
 -export([connect/1]).
 
 %% emqtt
--export([handle_disconnect/1]).
+-export([handle_disconnect/3]).
 
 -behaviour(emqx_resource).
 -export([
@@ -168,13 +168,14 @@ callback_mode() -> async_if_possible.
 resource_type() ->
     cluster_link_mqtt.
 
-on_start(ResourceId, #{pool_size := PoolSize} = ClusterConf) ->
+on_start(ResourceId, #{name := ClusterName, pool_size := PoolSize} = ClusterConf) ->
     PoolName = ResourceId,
     Options = [
         {name, PoolName},
         {pool_size, PoolSize},
         {pool_type, hash},
         {auto_reconnect, ?AUTO_RECONNECT_INTERVAL_S},
+        {target_cluster, ClusterName},
         {client_opts, emqx_cluster_link_config:mk_emqtt_options(ClusterConf)}
     ],
     ok = emqx_resource:allocate_resource(ResourceId, ?MODULE, pool_name, PoolName),
@@ -321,13 +322,14 @@ combine_status(Statuses) ->
 
 connect(Options) ->
     WorkerId = proplists:get_value(ecpool_worker_id, Options),
+    TargetCluster = proplists:get_value(target_cluster, Options),
     ClientOpts0 = #{clientid := ClientId0} = proplists:get_value(client_opts, Options),
     ClientIdBase = emqx_bridge_mqtt_lib:clientid_base([ClientId0, ?MSG_CLIENTID_SUFFIX]),
     ClientId = iolist_to_binary([ClientIdBase, $:, integer_to_binary(WorkerId)]),
     ClientOpts = ClientOpts0#{
         clientid => ClientId,
         msg_handler => #{
-            disconnected => {fun ?MODULE:handle_disconnect/1, []}
+            disconnected => {fun ?MODULE:handle_disconnect/3, [TargetCluster, ClientId]}
         }
     },
     case emqtt:start_link(ClientOpts) of
@@ -347,9 +349,48 @@ connect(Options) ->
             Error
     end.
 
--spec handle_disconnect({disconnected, emqx_types:reason_code(), emqx_types:properties()}) -> ok.
-handle_disconnect(_Reason) ->
-    ok.
+-spec handle_disconnect(
+    {disconnected, emqx_types:reason_code(), emqx_types:properties()}
+    | {parse_packets_error, _Reason, _ParserState}
+    | {connack_error, _Reason :: atom()}
+    | connack_timeout
+    | _SocketError,
+    emqx_cluster_link_schema:cluster(),
+    emqx_types:clientid()
+) -> ok.
+handle_disconnect(Reason, TargetCluster, ClientId) ->
+    Event = #{
+        msg => "cluster_link_forwarding_client_disconnected",
+        target_cluster => TargetCluster,
+        client_id => ClientId
+    },
+    case Reason of
+        {disconnected, RC, _Props} ->
+            %% NOTE
+            %% Emit warning if RC hints at misconfiguration or integration issues.
+            Level =
+                case RC of
+                    ?RC_SUCCESS -> info;
+                    ?RC_SERVER_BUSY -> info;
+                    ?RC_SERVER_UNAVAILABLE -> info;
+                    ?RC_SERVER_SHUTTING_DOWN -> info;
+                    ?RC_SESSION_TAKEN_OVER -> info;
+                    _ -> warning
+                end,
+            ?SLOG(Level, Event#{
+                cause => "broker_disconnect",
+                reason => emqx_reason_codes:name(RC),
+                reason_code => RC
+            });
+        {parse_packets_error, Reason, _ParserState} ->
+            ?SLOG(warning, Event#{cause => "malformed_packet", reason => Reason});
+        {connack_error, _} ->
+            ok;
+        connack_timeout ->
+            ok;
+        SocketError ->
+            ?SLOG(info, Event#{cause => "socket_error", reason => SocketError})
+    end.
 
 %%--------------------------------------------------------------------
 %% Protocol

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_SUITE.erl
@@ -12,8 +12,6 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--define(ON(NODE, DO), erpc:call(NODE, fun() -> DO end)).
-
 %%
 
 suite() -> [{timetrap, {minutes, 1}}].

--- a/changes/ee/fix-17214.en.md
+++ b/changes/ee/fix-17214.en.md
@@ -1,0 +1,4 @@
+Removed error-level logging of harmless disconnect events from Cluster Link message forwarding MQTT clients. Events similar to this one should no longer appear in the error logs:
+```
+2026-05-06T03:00:48.738654+00:00 [error] [PoolWorker] unexpected info: {disconnected,141,#{}}
+```

--- a/changes/ee/fix-17214.en.md
+++ b/changes/ee/fix-17214.en.md
@@ -1,4 +1,4 @@
-Removed error-level logging of harmless disconnect events from Cluster Link message forwarding MQTT clients. Events similar to this one should no longer appear in the error logs:
+Removed cryptic error-level logging of disconnect events from Cluster Link message forwarding MQTT clients, in favor of more user-friendly messages with enough context for troubleshooting. Events similar to this one should no longer appear in the error logs:
 ```
 2026-05-06T03:00:48.738654+00:00 [error] [PoolWorker] unexpected info: {disconnected,141,#{}}
 ```


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.0

## Summary

This PR helps to avoid following errors from appering in the node logs. These are effectively false negatives as Cluster Link tolerate occasional disconnects.
```
2026-05-06T03:00:48.738654+00:00 [error] [PoolWorker] unexpected info: {disconnected,141,#{}}
```

## PR Checklist

- [ ] The changes are covered with new or existing tests
    Verified manually.
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible