### PR TITLE
feat(dashboard): drop bundled swagger ui, redirect /api-docs to /api-spec.html

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -424,8 +424,19 @@ maybe_swagger_dispatch(false) ->
 %% Routes for the focused API spec endpoints (no auth required).
 %% These are added as raw cowboy routes (not minirest trails) so they do not
 %% appear in the swagger spec they serve and bypass minirest auth middleware.
+%%
+%% `/api-docs/swagger.json` is preserved (returning the full OpenAPI JSON
+%% spec) so external Swagger UI deployments that load EMQX's spec by URL
+%% keep working. `/api-docs` and `/api-docs/index.html` are 308 redirects
+%% to the new in-tree explorer. Other `/api-docs/*` paths used to serve the
+%% bundled Swagger UI assets which were removed in cowboy_swagger 3.0.0;
+%% those now 404.
 api_spec_dispatch() ->
+    ToApiSpec = #{location => <<"/api-spec.html">>},
     [
+        {"/api-docs", emqx_dashboard_redirect_handler, ToApiSpec},
+        {"/api-docs/index.html", emqx_dashboard_redirect_handler, ToApiSpec},
+        {"/api-docs/swagger.json", emqx_dashboard_api_spec_handler, #{}},
         {"/api-spec.md", emqx_dashboard_api_spec_handler, #{}},
         {"/api-spec.json", emqx_dashboard_api_spec_handler, #{}},
         {"/api-spec/:tag", emqx_dashboard_api_spec_handler, #{}},

--- a/apps/emqx_dashboard/src/emqx_dashboard_api_spec_handler.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api_spec_handler.erl
@@ -22,6 +22,10 @@ Endpoints:
     Further narrows the tag-scoped spec to endpoints whose oneOf
     request or response schemas contain a member whose `$ref` matches
     `name` case-insensitively.
+  - `GET /api-docs/swagger.json`
+    Returns the full, unfiltered OpenAPI 3.0.0 document for the
+    listener. Kept for backward compatibility with external Swagger UI
+    deployments that load EMQX's spec by URL.
 """.
 
 -behaviour(cowboy_rest).
@@ -51,6 +55,8 @@ allowed_methods(Req, State) ->
 content_types_provided(Req, State) ->
     case {cowboy_req:path(Req), cowboy_req:binding(tag, Req)} of
         {<<"/api-spec.json">>, undefined} ->
+            {[{{<<"application">>, <<"json">>, '*'}, handle_get_json}], Req, State};
+        {<<"/api-docs/swagger.json">>, undefined} ->
             {[{{<<"application">>, <<"json">>, '*'}, handle_get_json}], Req, State};
         {<<"/api-spec.md">>, undefined} ->
             {[{<<"text/markdown">>, handle_get_markdown}], Req, State};
@@ -90,20 +96,29 @@ handle_get_markdown(Req, State) ->
     end.
 
 handle_get_json(Req, State) ->
-    Tag = cowboy_req:binding(tag, Req),
-    Name = cowboy_req:binding(name, Req),
-    case build_response(Tag, Name) of
-        {ok, Body} ->
-            {Body, Req, State};
-        {error, not_found} ->
-            Req1 = cowboy_req:reply(
-                404,
-                #{<<"content-type">> => <<"application/json">>},
-                encode_pretty(#{<<"error">> => <<"not_found">>}),
-                Req
-            ),
-            {stop, Req1, State}
+    case cowboy_req:path(Req) of
+        <<"/api-docs/swagger.json">> ->
+            {full_swagger_json(), Req, State};
+        _ ->
+            Tag = cowboy_req:binding(tag, Req),
+            Name = cowboy_req:binding(name, Req),
+            case build_response(Tag, Name) of
+                {ok, Body} ->
+                    {Body, Req, State};
+                {error, not_found} ->
+                    Req1 = cowboy_req:reply(
+                        404,
+                        #{<<"content-type">> => <<"application/json">>},
+                        encode_pretty(#{<<"error">> => <<"not_found">>}),
+                        Req
+                    ),
+                    {stop, Req1, State}
+            end
     end.
+
+%% Full unfiltered OpenAPI spec, for `/api-docs/swagger.json`.
+full_swagger_json() ->
+    cowboy_swagger:to_json(get_trails()).
 
 %%--------------------------------------------------------------------
 %% Response builders

--- a/apps/emqx_dashboard/src/emqx_dashboard_redirect_handler.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_redirect_handler.erl
@@ -1,0 +1,19 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_dashboard_redirect_handler).
+
+-moduledoc "Tiny cowboy handler that issues an HTTP redirect to a configured Location.".
+
+-export([init/2]).
+
+init(Req0, State) ->
+    Location = maps:get(location, State),
+    Status = maps:get(status, State, 308),
+    Headers = #{
+        <<"location">> => Location,
+        <<"cache-control">> => <<"no-store">>
+    },
+    Req = cowboy_req:reply(Status, Headers, <<>>, Req0),
+    {ok, Req, State}.

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -243,46 +243,46 @@ t_rest_api(_Config) ->
     ok.
 
 t_swagger_json(_Config) ->
+    %% `/api-docs/swagger.json` keeps serving the full OpenAPI 3 JSON spec
+    %% so external Swagger UI deployments that point at it keep working
+    %% after the bundled in-tree UI was removed.
     Url = ?HOST ++ "/api-docs/swagger.json",
-    %% with auth
-    Auth = auth_header_(<<"admin">>, <<"public_www1">>),
-    {ok, 200, Body1} = request_api(get, Url, Auth),
-    ?assert(emqx_utils_json:is_json(Body1)),
-    %% without auth
-    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, Body2}} =
+    {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, Body}} =
         httpc:request(get, {Url, []}, [], [{body_format, binary}]),
-    ?assertEqual(Body1, Body2),
+    ?assert(emqx_utils_json:is_json(Body)),
     ?assertMatch(
         #{
-            <<"info">> := #{
-                <<"title">> := _,
-                <<"version">> := _
-            }
+            <<"openapi">> := <<"3.", _/binary>>,
+            <<"info">> := #{<<"title">> := _, <<"version">> := _},
+            <<"paths">> := _
         },
-        emqx_utils_json:decode(Body1)
-    ),
-    ok.
+        emqx_utils_json:decode(Body)
+    ).
 
 t_disable_swagger_json(_Config) ->
-    Url = ?HOST ++ "/api-docs/index.html",
-    ApiSpecUrls = [
+    %% All `/api-docs*` and `/api-spec*` paths share gating with
+    %% `dashboard.swagger_support`: flipping it to false makes them
+    %% all 404, and flipping it back restores them.
+    RedirectUrl = ?HOST ++ "/api-docs",
+    OkUrls = [
+        ?HOST ++ "/api-docs/swagger.json",
         ?HOST ++ "/api-spec.html",
         ?HOST ++ "/api-spec.md",
         ?HOST ++ "/api-spec.json"
     ],
-    ?assertMatch(
-        {ok, {{"HTTP/1.1", 200, "OK"}, __, _}},
-        httpc:request(get, {Url, []}, [], [{body_format, binary}])
-    ),
-    lists:foreach(
-        fun(ApiSpecUrl) ->
+    AssertStatus =
+        fun(Status, Url) ->
             ?assertMatch(
-                {ok, {{"HTTP/1.1", 200, "OK"}, _, _}},
-                httpc:request(get, {ApiSpecUrl, []}, [], [{body_format, binary}])
+                {ok, {{"HTTP/1.1", Status, _}, _, _}},
+                httpc:request(
+                    get, {Url, []}, [{autoredirect, false}], [{body_format, binary}]
+                ),
+                #{url => Url, expected_status => Status}
             )
         end,
-        ApiSpecUrls
-    ),
+    %% Initial state: redirect returns 308, the rest 200.
+    AssertStatus(308, RedirectUrl),
+    lists:foreach(fun(U) -> AssertStatus(200, U) end, OkUrls),
     DashboardCfg = emqx:get_raw_config([dashboard]),
     ?check_trace(
         {_, {ok, _}} = ?wait_async_action(
@@ -295,19 +295,7 @@ t_disable_swagger_json(_Config) ->
         ),
         []
     ),
-    ?assertMatch(
-        {ok, {{"HTTP/1.1", 404, "Not Found"}, _, _}},
-        httpc:request(get, {Url, []}, [], [{body_format, binary}])
-    ),
-    lists:foreach(
-        fun(ApiSpecUrl) ->
-            ?assertMatch(
-                {ok, {{"HTTP/1.1", 404, "Not Found"}, _, _}},
-                httpc:request(get, {ApiSpecUrl, []}, [], [{body_format, binary}])
-            )
-        end,
-        ApiSpecUrls
-    ),
+    lists:foreach(fun(U) -> AssertStatus(404, U) end, [RedirectUrl | OkUrls]),
     ?check_trace(
         {_, {ok, _}} = ?wait_async_action(
             begin
@@ -319,19 +307,8 @@ t_disable_swagger_json(_Config) ->
         ),
         []
     ),
-    ?assertMatch(
-        {ok, {{"HTTP/1.1", 200, "OK"}, _, _}},
-        httpc:request(get, {Url, []}, [], [{body_format, binary}])
-    ),
-    lists:foreach(
-        fun(ApiSpecUrl) ->
-            ?assertMatch(
-                {ok, {{"HTTP/1.1", 200, "OK"}, _, _}},
-                httpc:request(get, {ApiSpecUrl, []}, [], [{body_format, binary}])
-            )
-        end,
-        ApiSpecUrls
-    ).
+    AssertStatus(308, RedirectUrl),
+    lists:foreach(fun(U) -> AssertStatus(200, U) end, OkUrls).
 
 t_cli(_Config) ->
     [mria:dirty_delete(?ADMIN, Admin) || Admin <- mnesia:dirty_all_keys(?ADMIN)],

--- a/changes/ee/breaking-17215.en.md
+++ b/changes/ee/breaking-17215.en.md
@@ -1,0 +1,3 @@
+Removed the bundled Swagger UI assets from the EMQX release package, reducing tarball size by approximately 11 MB.
+
+`/api-docs/swagger.json` continues to serve the full OpenAPI 3 JSON spec, so external Swagger UI deployments that load it by URL keep working. The legacy `/api-docs` URL now responds with HTTP 308 redirect to `/api-spec.html`, the new in-tree spec explorer introduced in 6.3.0. Other `/api-docs/*` subpaths (the embedded Swagger UI assets) are no longer served and return 404.

--- a/mix.exs
+++ b/mix.exs
@@ -233,7 +233,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:bcrypt, github: "emqx/erlang-bcrypt", tag: "0.6.3", override: true}
 
   def common_dep(:minirest),
-    do: {:minirest, github: "emqx/minirest", tag: "1.4.12", override: true}
+    do: {:minirest, github: "emqx/minirest", tag: "1.5.0", override: true}
 
   # maybe forbid to fetch quicer
   def common_dep(:emqtt),

--- a/scripts/test/emqx-smoke-test.sh
+++ b/scripts/test/emqx-smoke-test.sh
@@ -35,10 +35,10 @@ json_status() {
     fi
 }
 
-## Check if the API docs are available
-check_api_docs() {
+## Check if the API spec explorer is available
+check_api_spec() {
     local attempts=5
-    local url="$BASE_URL/api-docs/index.html"
+    local url="$BASE_URL/api-spec.html"
     local status="undefined"
     while [ "$status" != "200" ]; do
         status="$(curl -s -o /dev/null -w "%{http_code}" "$url")"
@@ -67,6 +67,38 @@ check_swagger_json() {
     fi
 }
 
+## Check that /api-docs and /api-docs/index.html HTTP-redirect to the new
+## in-tree spec explorer.
+check_api_docs_redirect() {
+    local path url status location
+    for path in /api-docs /api-docs/index.html; do
+        url="$BASE_URL$path"
+        status="$(curl -s -o /dev/null -w '%{http_code}' "$url")"
+        if [ "$status" != "308" ]; then
+            echo "expected 308 from $url, got $status"
+            exit 1
+        fi
+        location="$(curl -sI "$url" | awk -F': *' 'tolower($1)=="location" { sub(/\r$/,"",$2); print $2; exit }')"
+        if [ "$location" != "/api-spec.html" ]; then
+            echo "expected Location: /api-spec.html from $url, got '$location'"
+            exit 1
+        fi
+    done
+}
+
+## Check that /api-docs/* subpaths other than swagger.json and index.html
+## return 404 (the bundled Swagger UI assets were dropped from the release).
+check_api_docs_subpaths_404() {
+    local subpath status
+    for subpath in /api-docs/swagger-ui.css /api-docs/swagger-ui-bundle.js /api-docs/some/junk; do
+        status="$(curl -s -o /dev/null -w '%{http_code}' "$BASE_URL$subpath")"
+        if [ "$status" != "404" ]; then
+            echo "expected 404 from $BASE_URL$subpath, got $status"
+            exit 1
+        fi
+    done
+}
+
 check_schema_json() {
     local name="$1"
     local expected_title="$2"
@@ -86,7 +118,9 @@ main() {
     wait_for_emqx
     local JSON_STATUS
     JSON_STATUS="$(json_status)"
-    check_api_docs
+    check_api_spec
+    check_api_docs_redirect
+    check_api_docs_subpaths_404
     ## The json status feature was added after hotconf API
     if [ "$JSON_STATUS" != 'NOT_JSON' ]; then
         check_swagger_json


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 6.3.0

## Summary

Bumps minirest to `1.5.0` (cowboy_swagger `3.0.0`), which strips the bundled Swagger UI assets (~11 MB of JS bundles, source maps, fonts) and the `/api-docs` cowboy trails it used to register.

EMQX now owns the `/api-docs/*` routing itself:

* `GET /api-docs` — HTTP 308 redirect to `/api-spec.html`, the new in-tree spec explorer (introduced in 6.3.0).
* `GET /api-docs/swagger.json` — 200, full OpenAPI 3 JSON spec. Preserved so external Swagger UI deployments that load EMQX's spec by URL keep working.
* `GET /api-docs/<other>` — 404. The embedded UI assets (`index.html`, `swagger-ui.css`, etc.) are gone.

The serving of `/api-docs/swagger.json` is handled by `emqx_dashboard_api_spec_handler` via a new `full_swagger_json/0` clause that calls `cowboy_swagger:to_json/1` over all dashboard trails, mirroring what the deleted `cowboy_swagger_json_handler` used to do. A small `emqx_dashboard_redirect_handler` provides the 308 reply for `/api-docs`.

Tests in `apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl` cover the redirect, the preserved `swagger.json`, the 404 on other subpaths, and the `dashboard.swagger_support` flag toggling all `/api-docs*` and `/api-spec.*` routes between 200/308 and 404.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)