### PR TITLE
fix timescale bad float param error

### DIFF
--- a/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
+++ b/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
@@ -277,6 +277,13 @@ connect_and_get_payload(TCConfig) ->
     ok = epgsql:close(Conn),
     Result.
 
+connect_and_count_rows(TCConfig) ->
+    SQL = <<"SELECT count(*) FROM mqtt_test">>,
+    Conn = connect_direct_pgsql(TCConfig),
+    {ok, _, [{Result}]} = epgsql:squery(Conn, SQL),
+    ok = epgsql:close(Conn),
+    Result.
+
 full_matrix() ->
     [
         [Conn, Sync, Batch]
@@ -876,6 +883,58 @@ t_bad_datetime_param(TCConfig) ->
             #{?snk_kind := "postgres_bad_param_error"}
         )
     ),
+    ok.
+
+%% Checks that furnishing `epgsql' a binary string for a float column results in a
+%% pretty error instead of a connection process crash.
+t_bad_float_param() ->
+    [{matrix, true}].
+t_bad_float_param(matrix) ->
+    [[?timescale, ?sync, ?without_batch]];
+t_bad_float_param(TCConfig) ->
+    Conn = connect_direct_pgsql(TCConfig),
+    {ok, _, _} = epgsql:squery(Conn, <<"ALTER TABLE mqtt_test ADD COLUMN temp FLOAT">>),
+    ok = epgsql:close(Conn),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{
+            <<"sql">> => <<
+                "INSERT INTO mqtt_test(payload, temp) "
+                "VALUES (${payload}, ${temp})"
+            >>
+        }
+    }),
+    #{topic := RuleTopic} =
+        simple_create_rule_api(
+            <<"select payload, payload.temp as temp from \"${t}\" ">>,
+            TCConfig
+        ),
+    Payload = <<"{\"temp\":\"27.1\"}">>,
+    C = start_client(),
+    ?assertMatch(
+        {_,
+            {ok, #{
+                context := #{
+                    reason := bad_param,
+                    type := float8,
+                    index := 1,
+                    value := <<"27.1">>
+                }
+            }}},
+        ?wait_async_action(
+            emqtt:publish(C, RuleTopic, Payload),
+            #{?snk_kind := "postgres_bad_param_error"}
+        )
+    ),
+    ActionId = emqx_bridge_v2_testlib:resource_id(TCConfig),
+    ?assertEqual(1, emqx_resource_metrics:matched_get(ActionId)),
+    ?retry(
+        _Sleep = 200,
+        _Attempts = 10,
+        ?assertEqual(1, emqx_resource_metrics:failed_get(ActionId))
+    ),
+    ?assertEqual(0, emqx_resource_metrics:success_get(ActionId)),
+    ?assertEqual(<<"0">>, connect_and_count_rows(TCConfig)),
     ok.
 
 %% Checks that we trigger a full reconnection if the health check times out, by declaring

--- a/changes/ee/fix-17216.en.md
+++ b/changes/ee/fix-17216.en.md
@@ -1,0 +1,1 @@
+Fixed Timescale/PostgreSQL actions to report a structured bad parameter error instead of crashing the database connection process when a quoted JSON numeric string is mapped to a `FLOAT` column.

--- a/mix.exs
+++ b/mix.exs
@@ -214,7 +214,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ra), do: {:ra, github: "emqx/ra", tag: "v2.16.13-emqx-2", override: true}
 
   # in conflict by emqx_connector and system_monitor
-  def common_dep(:epgsql), do: {:epgsql, github: "emqx/epgsql", tag: "4.7.1.4", override: true}
+  def common_dep(:epgsql), do: {:epgsql, github: "emqx/epgsql", tag: "4.7.1.5", override: true}
   def common_dep(:sasl_auth), do: {:sasl_auth, "2.3.3", override: true}
   def common_dep(:gen_rpc), do: {:gen_rpc, github: "emqx/gen_rpc", tag: "3.5.1", override: true}
 


### PR DESCRIPTION
Fixes EMQX-12083

Jira: https://emqx.atlassian.net/browse/EMQX-12083

Release version:
6.0.3

## Summary

This PR updates the EMQX epgsql dependency from `4.7.1.4` to `4.7.1.5` (https://github.com/emqx/epgsql/pull/13), which includes the driver-side fix for bad float parameters. With the updated driver, quoted JSON numeric strings sent to PostgreSQL/Timescale `FLOAT` columns are returned as structured `bad_param` errors instead of crashing the epgsql connection process with `function_clause`.

It also adds a Timescale regression test in `emqx_bridge_pgsql_SUITE` for the original case: payload `{"temp":"27.1"}` mapped into a `FLOAT` column. The test verifies that the action emits the `postgres_bad_param_error` trace, increments action metrics as `matched=1`, `failed=1`, `success=0`, and does not insert the invalid row.

No EMQX runtime logic change is needed beyond consuming the fixed epgsql tag. The existing PostgreSQL connector error handling already maps `bad_param` into an unrecoverable action error and logs the structured context correctly.

Validation:

```bash
git diff --check
docker exec -e PROFILE=emqx-enterprise -e CASES=t_bad_float_param -e PKG_VSN=6.0.2 -i erlang bash -lc 'MIX_ENV=emqx-enterprise-test mix deps.get && make apps/emqx_bridge_pgsql-ct'
```

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
