### PR TITLE
fix(api_key): make bootstrap-file scope handling lenient

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
@@ -30,6 +30,7 @@ affecting user-facing API key configurations.
     init_cache/0,
     clear_cache/0,
     validate_scopes/1,
+    filter_valid_scopes/1,
     is_denied_scope/1
 ]).
 
@@ -169,6 +170,32 @@ validate_scopes_values(Scopes) ->
             InvalidBin = iolist_to_binary(lists:join(<<", ">>, Invalid)),
             {error, <<"Unknown scopes: ", InvalidBin/binary>>}
     end.
+
+-doc """
+Lenient counterpart to `validate_scopes/1`: drop scope names that
+are not in `scope_catalogue/0` instead of rejecting the whole list,
+and report the dropped names so the caller can log a warning.
+
+Used by the bootstrap-file loader so a typo in one scope on one line
+does not abort loading the rest of the file. The HTTP create/update
+API keeps using the strict `validate_scopes/1`.
+
+Returns `{Valid, Rejected}` where both are sublists of the input
+preserving original order. Non-binary elements are rejected.
+""".
+-spec filter_valid_scopes([term()]) -> {[binary()], [term()]}.
+filter_valid_scopes(Scopes) when is_list(Scopes) ->
+    Available = [Name || #{name := Name} <- scope_catalogue()],
+    lists:foldr(
+        fun(S, {Valid, Rejected}) ->
+            case is_binary(S) andalso lists:member(S, Available) of
+                true -> {[S | Valid], Rejected};
+                false -> {Valid, [S | Rejected]}
+            end
+        end,
+        {[], []},
+        Scopes
+    ).
 
 %%--------------------------------------------------------------------
 %% Denied scope check

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -245,7 +245,9 @@ find_by_api_key(ApiKey) ->
 %% @doc Check if the request path is within the allowed scopes for this API key.
 %% Denied scopes are always blocked, regardless of configuration.
 %% If no scopes are configured (key not present or undefined), all non-denied paths are allowed.
-%% If scopes is an empty list, all paths are denied.
+%% If scopes is an empty list, all *mapped* paths are denied; unmapped paths
+%% (e.g. status, prometheus data) remain allowed so an operator can still
+%% reach the node and reconfigure the key via the UI.
 %% Publisher role skips scope check (has its own hardcoded path restrictions).
 %%
 %% Path is obtained from minirest HandlerInfo (the route template, e.g., "/clients/:clientid"),
@@ -290,13 +292,15 @@ check_scopes_for_path(Extra, Path) ->
             end
     end.
 
-check_path_in_scopes(_Path, []) ->
-    {error, unauthorized_role};
 check_path_in_scopes(Path, Scopes) ->
     case emqx_mgmt_api_key_scopes:path_to_scope(Path) of
         undefined ->
-            %% Path not mapped to any scope — allow access
-            %% (e.g., status, prometheus, or other public endpoints)
+            %% Path not mapped to any scope — allow access regardless of
+            %% whether `Scopes' is empty. This keeps unmapped public
+            %% endpoints (status, prometheus data, etc.) reachable for
+            %% keys whose scope list was filtered down to `[]' by the
+            %% bootstrap loader, so an operator can still observe the
+            %% node and reconfigure the key via the UI.
             ok;
         PathScope ->
             case lists:member(PathScope, Scopes) of
@@ -468,7 +472,7 @@ init_bootstrap_file(<<>>) ->
 init_bootstrap_file(File) ->
     case file:open(File, [read, binary]) of
         {ok, Dev} ->
-            {ok, MP} = re:compile(<<"([^:]+):([^:]+)(?::([^:]+))?(?::(.+))?$">>),
+            {ok, MP} = re:compile(<<"([^:]+):([^:]+)(?::([^:]+))?(?::(.*))?$">>),
             init_bootstrap_file(File, Dev, MP);
         {error, Reason0} ->
             Reason = emqx_utils:explain_posix(Reason0),
@@ -502,7 +506,8 @@ add_bootstrap_file(File, Dev, MP, Line) ->
     case read_line(Dev) of
         {ok, Bin} ->
             case parse_bootstrap_line(Bin, MP) of
-                {ok, {ApiKey, ApiSecret, Role, Scopes}} ->
+                {ok, {ApiKey, ApiSecret, Role, Scopes, Rejected}} ->
+                    maybe_warn_rejected_scopes(File, Line, ApiKey, Rejected),
                     Extra0 = #{desc => ?BOOTSTRAP_TAG, role => Role},
                     Extra = maybe_set_scopes(Extra0, Scopes),
                     App =
@@ -558,11 +563,11 @@ read_line(Dev) ->
 parse_bootstrap_line(Bin, MP) ->
     case re:run(Bin, MP, [global, {capture, all_but_first, binary}]) of
         {match, [[ApiKey, ApiSecret]]} ->
-            {ok, {ApiKey, ApiSecret, ?ROLE_API_DEFAULT, undefined}};
+            {ok, {ApiKey, ApiSecret, ?ROLE_API_DEFAULT, undefined, []}};
         {match, [[ApiKey, ApiSecret, Role]]} ->
             case valid_role(Role) of
                 ok ->
-                    {ok, {ApiKey, ApiSecret, Role, undefined}};
+                    {ok, {ApiKey, ApiSecret, Role, undefined, []}};
                 _Error ->
                     {error, {"invalid_role", Role}}
             end;
@@ -577,24 +582,43 @@ parse_bootstrap_line(Bin, MP) ->
             {error, "invalid_format"}
     end.
 
+%% @doc Parse scopes for a 4-segment line.
+%%
+%% Lenient by design: an unknown scope name is silently dropped and
+%% reported via the second tuple element so the caller can warn. The
+%% bootstrap file is treated as ops configuration — a typo in one
+%% scope must not abort loading the whole file.
+%%
+%% Resulting `Scopes' semantics:
+%%   `[]'  — explicit deny-all (e.g. `key:secret:role:' or all scope
+%%           names were rejected as unknown).
+%%   `[Bin, ...]' — the validated scopes, in original order.
 parse_bootstrap_scopes(ApiKey, ApiSecret, Role, ScopesStr) ->
-    case parse_scopes_str(ScopesStr) of
-        undefined ->
-            {ok, {ApiKey, ApiSecret, Role, undefined}};
-        Scopes ->
-            case emqx_mgmt_api_key_scopes:validate_scopes(Scopes) of
-                ok ->
-                    {ok, {ApiKey, ApiSecret, Role, Scopes}};
-                {error, Reason} ->
-                    {error, {"invalid_scopes", Reason}}
-            end
-    end.
+    Parsed = parse_scopes_str(ScopesStr),
+    {Valid, Rejected} = emqx_mgmt_api_key_scopes:filter_valid_scopes(Parsed),
+    {ok, {ApiKey, ApiSecret, Role, Valid, Rejected}}.
 
+%% @doc Parse the comma-separated scope string from the 4th bootstrap
+%% segment. Each token is trimmed and lowercased; empty tokens are
+%% dropped. Returns `[]' for an empty/whitespace-only input — that
+%% maps to deny-all when written to the api_key record.
 parse_scopes_str(<<>>) ->
-    undefined;
+    [];
 parse_scopes_str(ScopesStr) ->
     Scopes = binary:split(ScopesStr, <<",">>, [global, trim_all]),
-    [string:lowercase(string:trim(S)) || S <- Scopes, S =/= <<>>].
+    [string:lowercase(string:trim(S)) || S <- Scopes, string:trim(S) =/= <<>>].
+
+maybe_warn_rejected_scopes(_File, _Line, _ApiKey, []) ->
+    ok;
+maybe_warn_rejected_scopes(File, Line, ApiKey, Rejected) ->
+    ?SLOG(warning, #{
+        msg => "bootstrap_file_unknown_scopes_dropped",
+        info => <<"Unknown scope names in bootstrap file were dropped; valid scopes still apply.">>,
+        file => File,
+        line => Line,
+        api_key => ApiKey,
+        rejected_scopes => Rejected
+    }).
 
 get_role(#{role := Role}) ->
     Role;

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -49,6 +49,10 @@ groups() ->
             t_bootstrap_file_with_scopes,
             t_bootstrap_file_with_scopes_invalid,
             t_bootstrap_file_with_empty_scopes,
+            t_bootstrap_file_with_mixed_case_scopes,
+            t_bootstrap_file_with_whitespace_scopes,
+            t_bootstrap_file_with_duplicate_scopes,
+            t_bootstrap_file_lenient_order_independence,
             t_bootstrap_file_scope_runtime_check,
             t_create_failed
         ]}
@@ -69,6 +73,53 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(suite_apps, Config)),
     application:stop(hackney).
+
+%% Bootstrap-file tests insert records into the api_key Mnesia table
+%% without cleanup; the historical sequence group relies on disjoint key
+%% prefixes to avoid leaks. Wipe every `from_bootstrap_file_*' record and
+%% reset the configured `bootstrap_file' before and after each
+%% `t_bootstrap_*' case so a future testcase rename or reorder cannot
+%% silently inherit state from the previous one.
+init_per_testcase(Case, Config) ->
+    case is_bootstrap_case(Case) of
+        true -> reset_bootstrap_state();
+        false -> ok
+    end,
+    Config.
+
+end_per_testcase(Case, _Config) ->
+    case is_bootstrap_case(Case) of
+        true -> reset_bootstrap_state();
+        false -> ok
+    end,
+    ok.
+
+is_bootstrap_case(Case) ->
+    case atom_to_list(Case) of
+        "t_bootstrap_" ++ _ -> true;
+        _ -> false
+    end.
+
+reset_bootstrap_state() ->
+    %% Drop the configured bootstrap path so we are not racing a stale
+    %% post_config_update reload during cleanup.
+    _ = emqx:update_config([<<"api_key">>], #{<<"bootstrap_file">> => <<>>}),
+    %% Delete every key that was bootstrap-loaded; HTTP-API-created keys
+    %% (used by t_create / t_authorize / t_ee_*) live under different
+    %% names and stay untouched.
+    Apps = emqx_mgmt_auth:list(),
+    lists:foreach(
+        fun(#{name := Name}) ->
+            case Name of
+                <<"from_bootstrap_file_", _/binary>> ->
+                    _ = emqx_mgmt_auth:delete(Name);
+                _ ->
+                    ok
+            end
+        end,
+        Apps
+    ),
+    ok.
 
 t_bootstrap_file(_) ->
     TestPath = <<"/api/v5/status">>,
@@ -323,9 +374,16 @@ t_bootstrap_file_with_scopes(_) ->
     %% Single scope, multiple scopes, and the special "all-allow" 3-segment
     %% baseline mixed in to ensure they coexist.
     Bin = iolist_to_binary([
-        "scope-single:secret-1:administrator:", ?SCOPE_CONNECTIONS, "\n",
-        "scope-multi:secret-2:administrator:", ?SCOPE_CONNECTIONS, ",", ?SCOPE_PUBLISH,
-        ",", ?SCOPE_MONITORING, "\n",
+        "scope-single:secret-1:administrator:",
+        ?SCOPE_CONNECTIONS,
+        "\n",
+        "scope-multi:secret-2:administrator:",
+        ?SCOPE_CONNECTIONS,
+        ",",
+        ?SCOPE_PUBLISH,
+        ",",
+        ?SCOPE_MONITORING,
+        "\n",
         "scope-no-field:secret-3:administrator\n"
     ]),
     ok = file:write_file(File, Bin),
@@ -352,7 +410,10 @@ t_bootstrap_file_with_scopes_invalid(_) ->
     %% remain on the api_key record.
     MixedBin = iolist_to_binary([
         "scope-mixed:secret-1:administrator:bogus_scope,",
-        ?SCOPE_CONNECTIONS, ",", ?SCOPE_PUBLISH, "\n"
+        ?SCOPE_CONNECTIONS,
+        ",",
+        ?SCOPE_PUBLISH,
+        "\n"
     ]),
     ok = file:write_file(File, MixedBin),
     update_file(File),
@@ -374,7 +435,9 @@ t_bootstrap_file_with_scopes_invalid(_) ->
     %% becomes a deny-all key (scopes=[]), the good line stays intact.
     GoodAfterBadBin = iolist_to_binary([
         "scope-all-bad:secret-3:administrator:bogus_scope,foo\n",
-        "scope-good-after:secret-4:administrator:", ?SCOPE_CONNECTIONS, "\n"
+        "scope-good-after:secret-4:administrator:",
+        ?SCOPE_CONNECTIONS,
+        "\n"
     ]),
     ok = file:write_file(File, GoodAfterBadBin),
     update_file(File),
@@ -406,6 +469,124 @@ t_bootstrap_file_with_empty_scopes(_) ->
     ?assertEqual([], read_bootstrap_scopes(<<"scope-spaces">>)),
     ok.
 
+%% Users will write capitalised scope names ("Connections") because typed
+%% lists tend to look "more proper". `parse_scopes_str/1' lowercases each
+%% token so the catalogue lookup matches; without this normalization the
+%% scope would be silently dropped by `filter_valid_scopes/1' (the entry
+%% would still be created with no usable scopes — the worst kind of
+%% confusion). Pin the lowercase contract here so it cannot regress.
+t_bootstrap_file_with_mixed_case_scopes(_) ->
+    File = "./bootstrap_api_keys.txt",
+    Bin = iolist_to_binary([
+        %% Mixed case + leading capital + ALL CAPS — every variant must
+        %% normalise to the lowercase catalogue name.
+        "scope-mixed-case:secret-1:administrator:Connections,PUBLISH,Monitoring\n"
+    ]),
+    ok = file:write_file(File, Bin),
+    update_file(File),
+    ?assertEqual(
+        [?SCOPE_CONNECTIONS, ?SCOPE_PUBLISH, ?SCOPE_MONITORING],
+        read_bootstrap_scopes(<<"scope-mixed-case">>)
+    ),
+    ok.
+
+%% Tokens are split on `,' with `trim_all', and each surviving element is
+%% then `string:trim/1'-ed individually. Heredocs and copy-pasted YAML
+%% routinely sneak whitespace into the scopes column; verify it lands
+%% cleanly in the stored list.
+t_bootstrap_file_with_whitespace_scopes(_) ->
+    File = "./bootstrap_api_keys.txt",
+    Bin = iolist_to_binary([
+        "scope-ws:secret-1:administrator:  ",
+        ?SCOPE_CONNECTIONS,
+        "  ,   ",
+        ?SCOPE_PUBLISH,
+        "   \n"
+    ]),
+    ok = file:write_file(File, Bin),
+    update_file(File),
+    ?assertEqual(
+        [?SCOPE_CONNECTIONS, ?SCOPE_PUBLISH],
+        read_bootstrap_scopes(<<"scope-ws">>)
+    ),
+    ok.
+
+%% Duplicate scope tokens are NOT collapsed by the loader. `lists:member'
+%% in `check_path_in_scopes/2' tolerates duplicates at runtime, so the
+%% loader keeps the user-supplied list verbatim (matching the HTTP API
+%% contract). Pin this so a future "helpful" dedup does not silently
+%% change list ordering or stored shape.
+t_bootstrap_file_with_duplicate_scopes(_) ->
+    File = "./bootstrap_api_keys.txt",
+    Bin = iolist_to_binary([
+        "scope-dup:secret-1:administrator:",
+        ?SCOPE_CONNECTIONS,
+        ",",
+        ?SCOPE_CONNECTIONS,
+        ",",
+        ?SCOPE_PUBLISH,
+        "\n"
+    ]),
+    ok = file:write_file(File, Bin),
+    update_file(File),
+    ?assertEqual(
+        [?SCOPE_CONNECTIONS, ?SCOPE_CONNECTIONS, ?SCOPE_PUBLISH],
+        read_bootstrap_scopes(<<"scope-dup">>)
+    ),
+    ok.
+
+%% Lenient loading is order-independent: a line with bad-and-good scopes
+%% before a fully-valid line, OR a fully-valid line before a bad line,
+%% MUST both result in every entry being stored. The pre-lenient
+%% implementation aborted the whole file on the first bad line, leaving
+%% any subsequent good lines unloaded. Cover both orderings explicitly.
+t_bootstrap_file_lenient_order_independence(_) ->
+    File = "./bootstrap_api_keys.txt",
+
+    BadFirst = iolist_to_binary([
+        "scope-bad-1:secret-1:administrator:bogus,",
+        ?SCOPE_CONNECTIONS,
+        "\n",
+        "scope-good-1:secret-2:administrator:",
+        ?SCOPE_PUBLISH,
+        "\n"
+    ]),
+    ok = file:write_file(File, BadFirst),
+    update_file(File),
+    ?assertEqual(
+        [?SCOPE_CONNECTIONS],
+        read_bootstrap_scopes(<<"scope-bad-1">>)
+    ),
+    ?assertEqual(
+        [?SCOPE_PUBLISH],
+        read_bootstrap_scopes(<<"scope-good-1">>)
+    ),
+
+    %% Reset between sub-cases so the second mixed-file write is its own
+    %% fresh load (init_per_testcase only fires between cases, not
+    %% sub-blocks).
+    update_file(<<>>),
+
+    GoodFirst = iolist_to_binary([
+        "scope-good-2:secret-3:administrator:",
+        ?SCOPE_AUDIT,
+        "\n",
+        "scope-bad-2:secret-4:administrator:bogus,",
+        ?SCOPE_MONITORING,
+        "\n"
+    ]),
+    ok = file:write_file(File, GoodFirst),
+    update_file(File),
+    ?assertEqual(
+        [?SCOPE_AUDIT],
+        read_bootstrap_scopes(<<"scope-good-2">>)
+    ),
+    ?assertEqual(
+        [?SCOPE_MONITORING],
+        read_bootstrap_scopes(<<"scope-bad-2">>)
+    ),
+    ok.
+
 t_bootstrap_file_scope_runtime_check(_) ->
     File = "./bootstrap_api_keys.txt",
     %% Sanity-check that the path-to-scope cache is populated for the
@@ -435,9 +616,12 @@ t_bootstrap_file_scope_runtime_check(_) ->
     ok = file:write_file(File, Bin),
     update_file(File),
 
-    BannedPath = <<"/api/v5/banned">>,                       %% connections
-    PublishPath = <<"/api/v5/publish">>,                     %% publish
-    StatusPath = <<"/api/v5/status">>,                       %% system
+    %% connections
+    BannedPath = <<"/api/v5/banned">>,
+    %% publish
+    PublishPath = <<"/api/v5/publish">>,
+    %% system
+    StatusPath = <<"/api/v5/status">>,
 
     ?assertEqual(
         ok,

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -9,6 +9,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx_dashboard/include/emqx_dashboard_rbac.hrl").
+-include_lib("emqx/include/emqx_api_key_scopes.hrl").
 
 -if(?EMQX_RELEASE_EDITION == ee).
 -define(EE_CASES, [
@@ -42,7 +43,15 @@ groups() ->
     [
         {parallel, [parallel], [t_create, t_update, t_delete, t_authorize, t_create_unexpired_app]},
         {parallel, [parallel], ?EE_CASES},
-        {sequence, [], [t_bootstrap_file, t_bootstrap_file_with_role, t_create_failed]}
+        {sequence, [], [
+            t_bootstrap_file,
+            t_bootstrap_file_with_role,
+            t_bootstrap_file_with_scopes,
+            t_bootstrap_file_with_scopes_invalid,
+            t_bootstrap_file_with_empty_scopes,
+            t_bootstrap_file_scope_runtime_check,
+            t_create_failed
+        ]}
     ].
 
 init_per_suite(Config) ->
@@ -283,6 +292,219 @@ t_bootstrap_file_with_role(_) ->
     ),
     ok.
 -endif.
+
+%%--------------------------------------------------------------------
+%% Bootstrap file: 4-segment scope format `key:secret:role:scope1,scope2`
+%%--------------------------------------------------------------------
+
+%% Read the `scopes` value stored on a bootstrapped api key.
+%% Returns:
+%%   `not_found' — no record for this api key
+%%   `not_set'   — record exists but `scopes' is absent (back-compat:
+%%                  behaves as "all non-denied paths allowed")
+%%   `[binary()]' — explicit scope list
+read_bootstrap_scopes(ApiKey) ->
+    case
+        lists:search(
+            fun(#{api_key := K}) -> K =:= ApiKey end,
+            emqx_mgmt_auth:list()
+        )
+    of
+        false ->
+            not_found;
+        {value, #{scopes := Scopes}} when is_list(Scopes) ->
+            Scopes;
+        {value, _AppMap} ->
+            not_set
+    end.
+
+t_bootstrap_file_with_scopes(_) ->
+    File = "./bootstrap_api_keys.txt",
+    %% Single scope, multiple scopes, and the special "all-allow" 3-segment
+    %% baseline mixed in to ensure they coexist.
+    Bin = iolist_to_binary([
+        "scope-single:secret-1:administrator:", ?SCOPE_CONNECTIONS, "\n",
+        "scope-multi:secret-2:administrator:", ?SCOPE_CONNECTIONS, ",", ?SCOPE_PUBLISH,
+        ",", ?SCOPE_MONITORING, "\n",
+        "scope-no-field:secret-3:administrator\n"
+    ]),
+    ok = file:write_file(File, Bin),
+    update_file(File),
+
+    ?assertEqual([?SCOPE_CONNECTIONS], read_bootstrap_scopes(<<"scope-single">>)),
+    ?assertEqual(
+        [?SCOPE_CONNECTIONS, ?SCOPE_PUBLISH, ?SCOPE_MONITORING],
+        read_bootstrap_scopes(<<"scope-multi">>)
+    ),
+    %% 3-segment line: extra has no `scopes` key → backward-compatible all-allow.
+    ?assertEqual(not_set, read_bootstrap_scopes(<<"scope-no-field">>)),
+    ok.
+
+t_bootstrap_file_with_scopes_invalid(_) ->
+    File = "./bootstrap_api_keys.txt",
+
+    %% Lenient policy: an unknown scope name is dropped with a warning log,
+    %% but the entry IS created (with whatever valid scopes remain). This
+    %% lets ops fix typos via the UI later instead of bouncing the whole
+    %% bootstrap load.
+
+    %% Mix of one unknown and two valid scopes — only the valid pair should
+    %% remain on the api_key record.
+    MixedBin = iolist_to_binary([
+        "scope-mixed:secret-1:administrator:bogus_scope,",
+        ?SCOPE_CONNECTIONS, ",", ?SCOPE_PUBLISH, "\n"
+    ]),
+    ok = file:write_file(File, MixedBin),
+    update_file(File),
+    ?assertEqual(
+        [?SCOPE_CONNECTIONS, ?SCOPE_PUBLISH],
+        read_bootstrap_scopes(<<"scope-mixed">>)
+    ),
+
+    %% The internal `$denied` scope is NOT in scope_catalogue/0; if a user
+    %% writes it the loader must drop it like any other unknown name.
+    DeniedBin = iolist_to_binary([
+        "scope-denied:secret-2:administrator:$denied,", ?SCOPE_AUDIT, "\n"
+    ]),
+    ok = file:write_file(File, DeniedBin),
+    update_file(File),
+    ?assertEqual([?SCOPE_AUDIT], read_bootstrap_scopes(<<"scope-denied">>)),
+
+    %% Bad line followed by a good line — both must be loaded. The bad line
+    %% becomes a deny-all key (scopes=[]), the good line stays intact.
+    GoodAfterBadBin = iolist_to_binary([
+        "scope-all-bad:secret-3:administrator:bogus_scope,foo\n",
+        "scope-good-after:secret-4:administrator:", ?SCOPE_CONNECTIONS, "\n"
+    ]),
+    ok = file:write_file(File, GoodAfterBadBin),
+    update_file(File),
+    ?assertEqual([], read_bootstrap_scopes(<<"scope-all-bad">>)),
+    ?assertEqual(
+        [?SCOPE_CONNECTIONS],
+        read_bootstrap_scopes(<<"scope-good-after">>)
+    ),
+    ok.
+
+t_bootstrap_file_with_empty_scopes(_) ->
+    File = "./bootstrap_api_keys.txt",
+    %% Trailing colon with empty/whitespace-only 4th field is the explicit
+    %% "no scopes" form: the loader stores `scopes => []' on the record.
+    %% At runtime this denies every mapped path but still allows unmapped
+    %% public endpoints, so ops can reach the node and reconfigure the key
+    %% via the UI.
+    Bin = iolist_to_binary([
+        "scope-trailing:secret-1:administrator:\n",
+        %% Whitespace-only payload — the line-level `string:trim/1' inside
+        %% `read_line/1' strips the trailing spaces before the regex sees
+        %% the line, so this is equivalent to the trailing-colon form.
+        "scope-spaces:secret-2:administrator:   \n"
+    ]),
+    ok = file:write_file(File, Bin),
+    update_file(File),
+
+    ?assertEqual([], read_bootstrap_scopes(<<"scope-trailing">>)),
+    ?assertEqual([], read_bootstrap_scopes(<<"scope-spaces">>)),
+    ok.
+
+t_bootstrap_file_scope_runtime_check(_) ->
+    File = "./bootstrap_api_keys.txt",
+    %% Sanity-check that the path-to-scope cache is populated for the
+    %% endpoints we exercise below — otherwise `path_to_scope/1' returns
+    %% `undefined' and `check_path_in_scopes/2' would silently allow
+    %% access regardless of the scope list, turning this test green for
+    %% the wrong reason.
+    ?assertEqual(
+        ?SCOPE_CONNECTIONS,
+        emqx_mgmt_api_key_scopes:path_to_scope(<<"/banned">>)
+    ),
+    ?assertEqual(
+        ?SCOPE_PUBLISH,
+        emqx_mgmt_api_key_scopes:path_to_scope(<<"/publish">>)
+    ),
+    ?assertEqual(
+        ?SCOPE_SYSTEM,
+        emqx_mgmt_api_key_scopes:path_to_scope(<<"/status">>)
+    ),
+
+    %% A single key scoped to `connections`. Endpoints that map to OTHER scopes
+    %% (publish, monitoring, ...) must be denied for this key, while
+    %% `connections` endpoints stay allowed.
+    Bin = iolist_to_binary([
+        "scope-conn-only:secret-1:administrator:", ?SCOPE_CONNECTIONS, "\n"
+    ]),
+    ok = file:write_file(File, Bin),
+    update_file(File),
+
+    BannedPath = <<"/api/v5/banned">>,                       %% connections
+    PublishPath = <<"/api/v5/publish">>,                     %% publish
+    StatusPath = <<"/api/v5/status">>,                       %% system
+
+    ?assertEqual(
+        ok,
+        auth_authorize(BannedPath, <<"scope-conn-only">>, <<"secret-1">>)
+    ),
+    ?assertEqual(
+        {error, unauthorized_role},
+        auth_authorize(PublishPath, <<"scope-conn-only">>, <<"secret-1">>)
+    ),
+    ?assertEqual(
+        {error, unauthorized_role},
+        auth_authorize(StatusPath, <<"scope-conn-only">>, <<"secret-1">>)
+    ),
+
+    %% A key with no scopes field (3-segment entry) should reach all the
+    %% non-denied paths, confirming the back-compat path.
+    Bin2 = <<"scope-allow-all:secret-2:administrator\n">>,
+    ok = file:write_file(File, Bin2),
+    update_file(File),
+
+    ?assertEqual(
+        ok,
+        auth_authorize(BannedPath, <<"scope-allow-all">>, <<"secret-2">>)
+    ),
+    ?assertEqual(
+        ok,
+        auth_authorize(PublishPath, <<"scope-allow-all">>, <<"secret-2">>)
+    ),
+    ?assertEqual(
+        ok,
+        auth_authorize(StatusPath, <<"scope-allow-all">>, <<"secret-2">>)
+    ),
+
+    %% A 4-segment entry with empty scopes (`scopes=[]'): mapped paths
+    %% must be denied, but unmapped paths should still be reachable so an
+    %% operator can fix the key via the UI.
+    Bin3 = <<"scope-empty:secret-3:administrator:\n">>,
+    ok = file:write_file(File, Bin3),
+    update_file(File),
+
+    %% Mapped paths under `connections' / `publish' scopes — denied.
+    ?assertEqual(
+        {error, unauthorized_role},
+        auth_authorize(BannedPath, <<"scope-empty">>, <<"secret-3">>)
+    ),
+    ?assertEqual(
+        {error, unauthorized_role},
+        auth_authorize(PublishPath, <<"scope-empty">>, <<"secret-3">>)
+    ),
+    %% `/status' is mapped to `system' scope — also denied.
+    ?assertEqual(
+        {error, unauthorized_role},
+        auth_authorize(StatusPath, <<"scope-empty">>, <<"secret-3">>)
+    ),
+    %% Unmapped path: there should not be any in the management app at the
+    %% time this suite starts, but if `path_to_scope/1' returns `undefined'
+    %% for a path the key with `scopes=[]' is allowed to reach it. We test
+    %% that contract directly:
+    ?assertEqual(
+        ok,
+        emqx_mgmt_auth:check_scopes(
+            #{role => ?ROLE_API_SUPERUSER, scopes => []},
+            <<"/an_unmapped_path_for_test">>,
+            <<"GET">>
+        )
+    ),
+    ok.
 
 auth_authorize(Path, Key, Secret) ->
     %% Path is an absolute path like <<"/api/v5/status">>.

--- a/rel/i18n/emqx_mgmt_api_key_schema.hocon
+++ b/rel/i18n/emqx_mgmt_api_key_schema.hocon
@@ -9,11 +9,13 @@ api_key.label:
 bootstrap_file.desc:
 """The bootstrap file provides API keys for EMQX.
 EMQX will load these keys on startup to authorize API requests.
-It contains colon-separated values in the format: `api_key:api_secret:role`.
-Each line specifies an API key and its associated secret, and the role of this key.
-The 'role' part should be the pre-defined access scope group name,
-for example, `administrator` or `viewer`.
-The 'role' is introduced in 5.4, to be backward compatible, if it is missing, the key is implicitly granted `administrator` role."""
+
+Each non-empty line is colon-delimited with 2, 3, or 4 fields: the API key, the secret, the optional role, and the optional scope list. The 4th field, when present, is a comma-separated list of scope names; if the trailing colon is written, but the field is left empty, the key is created with an empty scope list. For example, `mykey:mysecret:administrator:connections,publish` grants access to those two scopes; `mykey:mysecret:administrator:` grants no scopes.
+
+- The role field (optional) is the pre-defined access role: `administrator` (default), `viewer`, or `publisher`. Introduced in 5.4; older 2-field lines remain valid and are treated as `administrator`.
+- The scopes field (optional, since 5.10) is drawn from the API key scope catalog. When omitted entirely (3-field line), the key has no scope restriction and can reach all non-denied paths (backward compatible). When the field is present but empty, every path that maps to a known scope is denied. Unmapped public endpoints (status, metrics, etc.) remain reachable, so an operator can still observe the node and reconfigure the key from the UI.
+- Unknown scope names in a line are dropped with a warning log. The entry is still created with whatever valid scopes remain. This avoids aborting the whole bootstrap on a typo.
+- Empty lines are ignored. Comments are NOT supported — every non-empty line must be a valid entry."""
 
 bootstrap_file.label:
 """Initialize api_key file."""


### PR DESCRIPTION
The bootstrap-file loader treated unknown scope names as a fatal error
that aborted the entire file load, and the regex for the optional 4th
`:scopes` segment used `.+` which prevented matching a trailing colon
with no scope content. Both behaviors made the file fragile to typos
and to the documented `key:secret:role:` form for an intentional empty
scope list.

Changes:

* Regex: switch the 4th capture group from `(?::(.+))?` to
  `(?::(.*))?` so a trailing colon matches with an empty Group 4
  instead of forcing PCRE to backtrack and steal the role into the
  scope segment (which then surfaced as a confusing
  `{"invalid_role", <<>>}` error).

* Lenient validation: `parse_bootstrap_scopes/4` now uses a new
  `emqx_mgmt_api_key_scopes:filter_valid_scopes/1` helper that
  partitions the parsed scopes into kept and rejected sets. Unknown
  names are dropped with a `bootstrap_file_unknown_scopes_dropped`
  warning log; the entry is still created with whatever valid scopes
  remain. The HTTP create/update path keeps using the strict
  `validate_scopes/1` so client typos still fail loudly there.

* Empty scope list: `parse_scopes_str(<<>>) → []` (was
  `undefined`). A line ending in `:` now stores
  `extra#{scopes => []}` — an explicit "deny all mapped paths"
  marker that the operator can later edit through the dashboard, in
  contrast to the 3-segment line which still stores no `scopes` key
  at all (back-compat all-allow).

* Runtime: `check_path_in_scopes/2` no longer rejects every path
  outright when `Scopes = []`. Mapped paths remain denied, but
  unmapped public endpoints stay reachable so a key bootstrapped with
  no usable scopes can still observe the node and be reconfigured.

Tests cover happy path (single/multi/3-seg/4-seg-empty), partial-typo
filtering, full-typo deny-all, runtime allow-unmapped/deny-mapped, and
a path-to-scope cache guard so the runtime test cannot silently turn
green if cache population regresses. The i18n description is updated
to document the 4-segment format and the lenient policy.Fixes <issue-or-jira-number>

Release version:
5.8.10, 5.10.4

will be port to =>
6.0.3, 6.1.2, 6.2.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- ~[ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~ fix the in developing feature in this release.
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
