### PR TITLE
fix(nodetool): start helper kernel as a hidden node

### DIFF
--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -433,7 +433,9 @@ print_existing_versions(TargetNode) ->
 
 start_distribution(TargetNode, NameTypeArg, Cookie) ->
     MyNode = make_script_node(TargetNode),
-    {ok, _Pid} = net_kernel:start([MyNode, get_name_type(NameTypeArg)]),
+    {ok, _Pid} = net_kernel:start(MyNode, #{
+        name_domain => get_name_type(NameTypeArg), hidden => true
+    }),
     erlang:set_cookie(node(), Cookie),
     case {net_kernel:hidden_connect_node(TargetNode), net_adm:ping(TargetNode)} of
         {true, pong} ->

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -49,7 +49,11 @@ do(Args) ->
         "-name",
         fun(TargetName) ->
             ThisNode = this_node_name(longnames, TargetName),
-            {ok, _} = net_kernel:start([ThisNode, longnames]),
+            %% Start as a hidden node so the broker never sees nodeup/nodedown
+            %% for short-lived ctl invocations.
+            {ok, _} = net_kernel:start(ThisNode, #{
+                name_domain => longnames, hidden => true
+            }),
             put(target_node, nodename(TargetName))
         end
     ),
@@ -58,7 +62,9 @@ do(Args) ->
         "-sname",
         fun(TargetName) ->
             ThisNode = this_node_name(shortnames, TargetName),
-            {ok, _} = net_kernel:start([ThisNode, shortnames]),
+            {ok, _} = net_kernel:start(ThisNode, #{
+                name_domain => shortnames, hidden => true
+            }),
             put(target_node, nodename(TargetName))
         end
     ),
@@ -286,10 +292,10 @@ nodename(Name) ->
     end.
 
 this_node_name(longnames, Name) ->
-    [Node, Host] = re:split(Name, "@", [{return, list}, unicode]),
-    list_to_atom(lists:concat(["remsh_maint_", Node, node_name_suffix_id(), "@", Host]));
-this_node_name(shortnames, Name) ->
-    list_to_atom(lists:concat(["remsh_maint_", Name, node_name_suffix_id()])).
+    [_Node, Host] = re:split(Name, "@", [{return, list}, unicode]),
+    list_to_atom(lists:concat(["remsh", node_name_suffix_id(), "@", Host]));
+this_node_name(shortnames, _Name) ->
+    list_to_atom(lists:concat(["remsh", node_name_suffix_id()])).
 
 %% use the reversed value that from pid mod 1000 as the node name suffix
 node_name_suffix_id() ->

--- a/changes/ee/fix-17220.en.md
+++ b/changes/ee/fix-17220.en.md
@@ -1,0 +1,1 @@
+Avoid `bin/emqx` and `bin/emqx_ctl` invocations from triggering `nodeup`/`nodedown` events on the running broker, which previously surfaced as misleading `cm_registry_node_down` warnings in the broker log. The temporary helper nodes started by these scripts now register as hidden Erlang nodes, as intended.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 5.8.11

## Summary

Backport of #17218 to release-58.

In production we observed noisy warnings of the form:

```
[warning] msg: cm_registry_node_down, pid: <0.6286.0>, node: 'remsh_maint_emqx897@10.111.0.6'
```

### Root cause

`bin/nodetool` starts its local Erlang kernel with `net_kernel:start([Name, longnames])` — i.e. as a regular *published* (visible) node — and only relies on `net_kernel:hidden_connect_node/1` to keep the connection to the broker hidden. Under happy paths this works, but it is fragile: if `hidden_connect_node/1` returns `false` (e.g. brief network race), the surrounding tuple still evaluates `net_adm:ping/1`, which establishes a regular **visible** connection. The broker then fires `nodeup` / `nodedown`, mria notifies subscribers, and `emqx_cm_registry` logs the warning before the script halts.

The OTP version is **not** the cause — same nodetool code path reproduces the warning on OTP 25 (5.4.1), OTP 26 (5.8.10), and OTP 27 (6.0.2).

### Fix

- `bin/nodetool` and `bin/install_upgrade.escript`: start `net_kernel` with `#{name_domain => longnames|shortnames, hidden => true}`. Every connection the helper makes is then bilaterally hidden regardless of which connect API is used. Verified to work on OTP 25/26/27.
- Also shortened the helper node name from `remsh_maint_<NodeName><id>@<host>` to `remsh<id>@<host>` for easier reading in logs and `epmd -names` listings.

### Verification (on emqx-enterprise:5.8.10)

With patched `bin/nodetool` and a probe `net_kernel:monitor_nodes(true, [{node_type, visible}, nodedown_reason])` attached to the broker:

- 5× `emqx ctl status`
- visible-probe events: `[]`
- all-types-probe events: only `node_type=hidden`, with the new `remshNNN@host` names
- broker log: zero `cm_registry_node_down` lines

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)