### PR TITLE
feat(clink): expose last disconnect reason in fwd resource health

### DIFF
--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -18,7 +18,7 @@
 -export([connect/1]).
 
 %% emqtt
--export([handle_disconnect/3]).
+-export([handle_disconnect/4]).
 
 -behaviour(emqx_resource).
 -export([
@@ -92,6 +92,7 @@
 -define(ROUTE_DELETE, 100).
 
 -define(AUTO_RECONNECT_INTERVAL_S, 2).
+-define(DISCONNECT_REASON(WorkerId), {disconnect_reason, WorkerId}).
 
 -type cluster_name() :: binary().
 
@@ -275,33 +276,42 @@ classify_error(Reason) ->
     {unrecoverable_error, Reason}.
 
 %% copied from emqx_bridge_mqtt_connector
-on_get_status(_ResourceId, #{pool_name := PoolName} = _State) ->
-    Workers = [Worker || {_Name, Worker} <- ecpool:workers(PoolName)],
+on_get_status(ResourceId, #{pool_name := PoolName} = _State) ->
+    Workers = ecpool:workers(PoolName),
+    DisconnectReasons = last_disconnect_reasons(ResourceId),
     try emqx_utils:pmap(fun get_status/1, Workers, ?HEALTH_CHECK_TIMEOUT) of
         Statuses ->
-            combine_status(Statuses)
+            enrich_status(combine_status(Statuses), DisconnectReasons)
     catch
         exit:timeout ->
             ?status_connecting
     end.
 
-get_status(Worker) ->
+enrich_status(?status_connected, _) ->
+    ?status_connected;
+enrich_status(?status_disconnected, [LastDisconnectReason | _]) ->
+    %% NOTE: Picking only the first one for the sake of simplicity.
+    {?status_disconnected, LastDisconnectReason};
+enrich_status(Status, _) ->
+    Status.
+
+get_status({_Name, Worker}) ->
     case ecpool_worker:client(Worker) of
         {ok, Client} -> status(Client);
-        {error, _} -> disconnected
+        {error, _} -> ?status_disconnected
     end.
 
 status(Pid) ->
     try
         case proplists:get_value(socket, emqtt:info(Pid)) of
             Socket when Socket /= undefined ->
-                connected;
+                ?status_connected;
             undefined ->
-                connecting
+                ?status_disconnected
         end
     catch
         exit:{noproc, _} ->
-            disconnected
+            ?status_disconnected
     end.
 
 combine_status(Statuses) ->
@@ -322,6 +332,7 @@ combine_status(Statuses) ->
 
 connect(Options) ->
     WorkerId = proplists:get_value(ecpool_worker_id, Options),
+    ResourceId = proplists:get_value(name, Options),
     TargetCluster = proplists:get_value(target_cluster, Options),
     ClientOpts0 = #{clientid := ClientId0} = proplists:get_value(client_opts, Options),
     ClientIdBase = emqx_bridge_mqtt_lib:clientid_base([ClientId0, ?MSG_CLIENTID_SUFFIX]),
@@ -329,13 +340,14 @@ connect(Options) ->
     ClientOpts = ClientOpts0#{
         clientid => ClientId,
         msg_handler => #{
-            disconnected => {fun ?MODULE:handle_disconnect/3, [TargetCluster, ClientId]}
+            disconnected => mk_disconnect_handler(ResourceId, WorkerId, ClientId, TargetCluster)
         }
     },
     case emqtt:start_link(ClientOpts) of
         {ok, Pid} ->
             case emqtt:connect(Pid) of
                 {ok, _Props} ->
+                    ok = clear_disconnect_reason(ResourceId, WorkerId),
                     {ok, Pid};
                 Error ->
                     Error
@@ -349,21 +361,27 @@ connect(Options) ->
             Error
     end.
 
+mk_disconnect_handler(ResourceId, WorkerId, ClientId, TargetCluster) ->
+    {fun ?MODULE:handle_disconnect/4, [
+        ResourceId,
+        WorkerId,
+        #{
+            target_cluster => TargetCluster,
+            client_id => ClientId
+        }
+    ]}.
+
 -spec handle_disconnect(
     {disconnected, emqx_types:reason_code(), emqx_types:properties()}
     | {parse_packets_error, _Reason, _ParserState}
     | {connack_error, _Reason :: atom()}
     | connack_timeout
     | _SocketError,
-    emqx_cluster_link_schema:cluster(),
-    emqx_types:clientid()
+    _ResourceId :: resource_id(),
+    _WorkerId :: pos_integer(),
+    #{atom => any()}
 ) -> ok.
-handle_disconnect(Reason, TargetCluster, ClientId) ->
-    Event = #{
-        msg => "cluster_link_forwarding_client_disconnected",
-        target_cluster => TargetCluster,
-        client_id => ClientId
-    },
+handle_disconnect(Reason, ResourceId, WorkerId, EventCtx) ->
     case Reason of
         {disconnected, RC, _Props} ->
             %% NOTE
@@ -377,20 +395,43 @@ handle_disconnect(Reason, TargetCluster, ClientId) ->
                     ?RC_SESSION_TAKEN_OVER -> info;
                     _ -> warning
                 end,
-            ?SLOG(Level, Event#{
-                cause => "broker_disconnect",
+            Info = #{
+                cause => broker_disconnect,
                 reason => emqx_reason_codes:name(RC),
                 reason_code => RC
-            });
-        {parse_packets_error, Reason, _ParserState} ->
-            ?SLOG(warning, Event#{cause => "malformed_packet", reason => Reason});
-        {connack_error, _} ->
-            ok;
+            },
+            report_disconnect(ResourceId, WorkerId, Level, EventCtx, Info);
+        {parse_packets_error, ParserReason, _ParserState} ->
+            Info = #{cause => malformed_packet, reason => ParserReason},
+            report_disconnect(ResourceId, WorkerId, warning, EventCtx, Info);
+        {connack_error, RCName} ->
+            Info = #{cause => broker_connect_refused, reason => RCName},
+            report_disconnect(ResourceId, WorkerId, Info);
         connack_timeout ->
-            ok;
+            Info = #{cause => broker_connect_timeout},
+            report_disconnect(ResourceId, WorkerId, Info);
         SocketError ->
-            ?SLOG(info, Event#{cause => "socket_error", reason => SocketError})
+            Info = #{cause => socket_error, reason => SocketError},
+            report_disconnect(ResourceId, WorkerId, info, EventCtx, Info)
     end.
+
+report_disconnect(ResourceId, WorkerId, Info) ->
+    clear_disconnect_reason(ResourceId, WorkerId),
+    emqx_resource:allocate_resource(ResourceId, ?MODULE, ?DISCONNECT_REASON(WorkerId), Info).
+
+report_disconnect(ResourceId, WorkerId, Level, EventCtx, Info) ->
+    ?SLOG(
+        Level,
+        maps:merge(EventCtx#{msg => "cluster_link_forwarding_client_disconnected"}, Info)
+    ),
+    report_disconnect(ResourceId, WorkerId, Info).
+
+last_disconnect_reasons(ResourceId) ->
+    Allocated = emqx_resource:get_allocated_resources_list(ResourceId),
+    [Reason || {_ResourceId, ?DISCONNECT_REASON(_), Reason} <- Allocated].
+
+clear_disconnect_reason(ResourceId, WorkerId) ->
+    emqx_resource:deallocate_resource(ResourceId, ?DISCONNECT_REASON(WorkerId)).
 
 %%--------------------------------------------------------------------
 %% Protocol

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_SUITE.erl
@@ -7,10 +7,13 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx_utils/include/emqx_message.hrl").
 
 -compile(export_all).
 -compile(nowarn_export_all).
+
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
 
 %%
 
@@ -180,6 +183,98 @@ test_message_forwarding(SubType, Config) ->
             ok = emqtt:stop(TargetC2)
         end,
         []
+    ).
+
+t_message_forwarding_disconnect_reason_reported('init', Config) ->
+    ok = snabbkaffe:start_trace(),
+    SourceName = fmt("~p_s", [?FUNCTION_NAME]),
+    TargetName = fmt("~p_t", [?FUNCTION_NAME]),
+    TargetSpec = emqx_cluster_link_cth:mk_cluster(2, TargetName, 1, Config),
+    TargetNodes = emqx_cth_cluster:start(TargetSpec),
+    SourceLink = emqx_cluster_link_cth:mk_link_conf_to(TargetNodes, #{
+        <<"topics">> => [],
+        <<"resource_opts">> => #{<<"health_check_interval">> => 100}
+    }),
+    SourceNodespec = #{
+        apps => [
+            {emqx_conf, merge_conf(#{cluster => #{links => [SourceLink]}}, conf_log())}
+        ]
+    },
+    SourceSpec = emqx_cluster_link_cth:mk_cluster(1, SourceName, [SourceNodespec], Config),
+    SourceNodes = emqx_cth_cluster:start(SourceSpec),
+    [
+        {target_name, TargetName},
+        {source_name, SourceName},
+        {target_nodes, TargetNodes},
+        {source_nodes, SourceNodes}
+        | Config
+    ];
+t_message_forwarding_disconnect_reason_reported('end', Config) ->
+    ok = snabbkaffe:stop(),
+    ok = emqx_cth_cluster:stop(?config(source_nodes, Config)),
+    ok = emqx_cth_cluster:stop(?config(target_nodes, Config)).
+
+t_message_forwarding_disconnect_reason_reported(Config) ->
+    TargetName = ?config(target_name, Config),
+    [TargetNode] = ?config(target_nodes, Config),
+    [SourceNode] = ?config(source_nodes, Config),
+    %% 1. Wait and verify message forwarding resource is connected.
+    ResourceId = emqx_cluster_link_mqtt:resource_id(TargetName),
+    ?retry(
+        500,
+        10,
+        ?assertMatch(
+            {ok, _, #{status := connected}},
+            ?ON(SourceNode, emqx_resource:get_instance(ResourceId))
+        )
+    ),
+    %% 2. Repeatedly kick clients after the MQTT resource is up.
+    %% Disconnect reason should be reported through the emqtt disconnect handler.
+    _Kicker = ?ON(
+        TargetNode,
+        erlang:spawn(fun Loop() ->
+            lists:foreach(fun emqx_cm:kick_session/1, emqx_cm:all_client_ids()),
+            timer:sleep(100),
+            Loop()
+        end)
+    ),
+    %% 3. Verify reason is propagated to the resource status.
+    ?retry(
+        500,
+        5,
+        ?assertMatch(
+            {ok, _, #{
+                status := disconnected,
+                error := #{
+                    cause := broker_disconnect,
+                    reason := administrative_action,
+                    reason_code := ?RC_ADMINISTRATIVE_ACTION
+                }
+            }},
+            ?ON(SourceNode, emqx_resource:get_instance(ResourceId))
+        )
+    ),
+    %% 4. Verify reason is propagated to the alarm details.
+    ?retry(
+        500,
+        5,
+        begin
+            Alarms = ?ON(SourceNode, emqx_alarm:get_alarms(activated)),
+            ResourceAlarms = [
+                Alarm
+             || Alarm = #{details := #{resource_id := RId, reason := resource_down}} <- Alarms,
+                RId =:= ResourceId
+            ],
+            ?assertEqual(
+                [
+                    Alarm
+                 || Alarm = #{message := Message} <- ResourceAlarms,
+                    binary:match(Message, <<"broker_disconnect">>) =/= nomatch,
+                    binary:match(Message, <<"administrative_action">>) =/= nomatch
+                ],
+                ResourceAlarms
+            )
+        end
     ).
 
 t_target_extrouting_gc('init', Config) ->

--- a/changes/ee/feat-17221.en.md
+++ b/changes/ee/feat-17221.en.md
@@ -1,0 +1,3 @@
+Improved Cluster Linking diagnostics for MQTT message forwarding.
+
+When message forwarding connections experience connectivity issues, the link resource status and respective alarms now include the disconnect reason, making configuration problems easier to identify.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.0

## Summary

This PR tries to slightly improve Cluster Link observability: disconnect events from `emqtt` are now used to enrich resource status details and, consequently, alarm messages.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible

