### PR TITLE
fix(config): name the file when cluster.hocon save fails

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -1003,10 +1003,10 @@ save_configs(AppEnvs, Conf, RawConf, OverrideConf, Opts) ->
         ok ->
             save_to_app_env(AppEnvs),
             save_to_config_map(Conf, RawConf);
-        {error, #{filename := Filename, reason := Reason}} ->
+        {error, #{filename := FileName, reason := Reason}} ->
             throw(#{
                 msg => failed_to_save_conf_file,
-                filename => Filename,
+                filename => FileName,
                 reason => Reason
             })
     end.

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -999,9 +999,17 @@ save_configs(AppEnvs, Conf, RawConf, OverrideConf, Opts) ->
     %% We first try to save to files, because saving to files is more error prone
     %% than saving into memory.
     HasDeprecatedFile = has_deprecated_file(),
-    ok = save_to_override_conf(HasDeprecatedFile, OverrideConf, Opts),
-    save_to_app_env(AppEnvs),
-    save_to_config_map(Conf, RawConf).
+    case save_to_override_conf(HasDeprecatedFile, OverrideConf, Opts) of
+        ok ->
+            save_to_app_env(AppEnvs),
+            save_to_config_map(Conf, RawConf);
+        {error, #{filename := Filename, reason := Reason}} ->
+            throw(#{
+                msg => failed_to_save_conf_file,
+                filename => Filename,
+                reason => Reason
+            })
+    end.
 
 save_configs_namespaced(Namespace, RootKeyAtom, Conf, RawConf, ClusterRPCOpts, Opts) when
     is_binary(Namespace)
@@ -1052,7 +1060,8 @@ save_to_config_map(Conf, RawConf) ->
     ?MODULE:put(Conf),
     ?MODULE:put_raw(RawConf).
 
--spec save_to_override_conf(boolean(), raw_config(), update_opts()) -> ok | {error, term()}.
+-spec save_to_override_conf(boolean(), raw_config(), update_opts()) ->
+    ok | {error, #{filename := file:filename(), reason := term()}}.
 save_to_override_conf(_HasDeprecatedFile, undefined, _) ->
     ok;
 save_to_override_conf(true = _HasDeprecatedFile, RawConf, Opts) ->

--- a/apps/emqx/src/emqx_config_backup_manager.erl
+++ b/apps/emqx/src/emqx_config_backup_manager.erl
@@ -50,26 +50,30 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec backup_and_write(file:filename(), iodata()) -> ok.
+-spec backup_and_write(file:filename(), iodata()) ->
+    ok | {error, #{filename := file:filename(), reason := term()}}.
 backup_and_write(DestFilename, NewContents) ->
-    %% this may fail, but we don't care
-    %% e.g. read-only file system
     _ = filelib:ensure_dir(DestFilename),
     TmpFilename = DestFilename ++ ".tmp",
     case file:write_file(TmpFilename, NewContents) of
         ok ->
             backup_and_replace(DestFilename, TmpFilename);
         {error, Reason} ->
-            ?SLOG(error, #{
-                msg => "failed_to_save_conf_file",
-                hint =>
-                    "The updated cluster config is not saved on this node, please check the file system.",
-                filename => TmpFilename,
-                reason => Reason
-            }),
-            %% e.g. read-only, it's not the end of the world
-            ok
+            log_save_error(TmpFilename, Reason),
+            {error, #{filename => DestFilename, reason => Reason}}
     end.
+
+log_save_error(Filename, Reason) ->
+    ?SLOG(error, #{
+        msg => "failed_to_save_conf_file",
+        hint =>
+            "The updated cluster config is not saved on this node, please check the file system. "
+            "Common causes: the file or its directory is read-only, owned by another user, "
+            "is a Docker bind-mount of a single file (rename returns ebusy), "
+            "or the file has the immutable attribute set (rename returns eperm).",
+        filename => Filename,
+        reason => Reason
+    }).
 
 %%------------------------------------------------------------------------------
 %% Internal API
@@ -141,10 +145,10 @@ backup_and_replace(DestFilename, TmpFilename) ->
     case file:read_file(DestFilename) of
         {ok, OriginalContents} ->
             gen_server:cast(?MODULE, #backup{filename = DestFilename, contents = OriginalContents}),
-            ok = file:rename(TmpFilename, DestFilename);
+            do_rename(TmpFilename, DestFilename);
         {error, enoent} ->
             %% not created yet
-            ok = file:rename(TmpFilename, DestFilename);
+            do_rename(TmpFilename, DestFilename);
         {error, Reason} ->
             ?SLOG(warning, #{
                 msg => "failed_to_read_current_conf_file",
@@ -152,6 +156,16 @@ backup_and_replace(DestFilename, TmpFilename) ->
                 reason => Reason
             }),
             ok
+    end.
+
+do_rename(TmpFilename, DestFilename) ->
+    case file:rename(TmpFilename, DestFilename) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            log_save_error(DestFilename, Reason),
+            _ = file:delete(TmpFilename),
+            {error, #{filename => DestFilename, reason => Reason}}
     end.
 
 dump_backup(DestFilename, OldContents) ->

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -182,6 +182,31 @@ t_cluster_hocon_backup(C) when is_list(C) ->
     ),
     ok.
 
+t_cluster_hocon_save_failure({'end', _C}) ->
+    Dir = "backup-test-fail-dir",
+    Dest = filename:join(Dir, "data.hocon"),
+    _ = file:change_mode(Dir, 8#0755),
+    _ = file:delete(Dest),
+    _ = file:delete(Dest ++ ".tmp"),
+    _ = file:del_dir(Dir),
+    ok;
+t_cluster_hocon_save_failure(C) when is_list(C) ->
+    Dir = "backup-test-fail-dir",
+    ok = file:make_dir(Dir),
+    Dest = filename:join(Dir, "data.hocon"),
+    ok = file:write_file(Dest, <<"old">>),
+    %% Make the directory read-only so writing the .tmp file fails with eacces.
+    ok = file:change_mode(Dir, 8#0555),
+    try
+        Result = emqx_config:backup_and_write(Dest, <<"new">>),
+        ?assertMatch({error, #{filename := Dest, reason := eacces}}, Result),
+        %% original file untouched
+        ?assertEqual({ok, <<"old">>}, file:read_file(Dest))
+    after
+        ok = file:change_mode(Dir, 8#0755)
+    end,
+    ok.
+
 t_init_load_emqx_schema(Config) when is_list(Config) ->
     emqx_config:erase_all(),
     %% Given empty config file

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -183,28 +183,19 @@ t_cluster_hocon_backup(C) when is_list(C) ->
     ok.
 
 t_cluster_hocon_save_failure({'end', _C}) ->
-    Dir = "backup-test-fail-dir",
-    Dest = filename:join(Dir, "data.hocon"),
-    _ = file:change_mode(Dir, 8#0755),
-    _ = file:delete(Dest),
-    _ = file:delete(Dest ++ ".tmp"),
-    _ = file:del_dir(Dir),
+    _ = file:delete("backup-test-blocker"),
     ok;
 t_cluster_hocon_save_failure(C) when is_list(C) ->
-    Dir = "backup-test-fail-dir",
-    ok = file:make_dir(Dir),
-    Dest = filename:join(Dir, "data.hocon"),
-    ok = file:write_file(Dest, <<"old">>),
-    %% Make the directory read-only so writing the .tmp file fails with eacces.
-    ok = file:change_mode(Dir, 8#0555),
-    try
-        Result = emqx_config:backup_and_write(Dest, <<"new">>),
-        ?assertMatch({error, #{filename := Dest, reason := eacces}}, Result),
-        %% original file untouched
-        ?assertEqual({ok, <<"old">>}, file:read_file(Dest))
-    after
-        ok = file:change_mode(Dir, 8#0755)
-    end,
+    %% Force a save failure deterministically without depending on user perms
+    %% (CI runs as root, which ignores chmod). We use a regular file as the
+    %% would-be parent directory of the destination, so file:write_file/2 of the
+    %% .tmp file fails with enotdir.
+    Blocker = "backup-test-blocker",
+    ok = file:write_file(Blocker, <<>>),
+    Dest = filename:join(Blocker, "data.hocon"),
+    Result = emqx_config:backup_and_write(Dest, <<"new">>),
+    ?assertMatch({error, #{filename := Dest, reason := enotdir}}, Result),
+    ok = file:delete(Blocker),
     ok.
 
 t_init_load_emqx_schema(Config) when is_list(Config) ->

--- a/changes/ee/fix-17227.en.md
+++ b/changes/ee/fix-17227.en.md
@@ -1,0 +1,19 @@
+Cluster config file save errors now name the file and the underlying reason.
+
+When `cluster.hocon` (or its directory) is read-only, immutable, or otherwise
+unwritable (e.g. mounted read-only into a container), changing config via the
+dashboard or REST API previously returned an opaque HTTP 400 with body
+`{config_update_crashed,{badmatch,{error,ebusy}}}` and only logged a badmatch
+crash that did not name the file.
+
+The error now:
+
+- Logs `failed_to_save_conf_file` with the actual file path and reason
+  (`eacces`, `eperm`, `ebusy`, ...) plus a hint listing common operator-side
+  causes.
+- Returns a structured HTTP 400 body that names both the file and the reason,
+  so the cause is visible in the dashboard without digging through node logs.
+
+Previously, when only the temporary file write failed (e.g. read-only directory),
+the API silently returned HTTP 200 even though the change was not persisted to
+disk. The API now correctly reports failure in this case as well.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version:
6.0.3, 6.1.1, 6.2.0

## Summary

When `cluster.hocon` (or its directory) is read-only, immutable, or otherwise
unwritable — read-only filesystem, file owned by root, single-file Docker
bind-mount, `chattr +i`, etc. — saving a config change via the dashboard or
REST API previously returned an opaque HTTP 400 with body
`{config_update_crashed,{badmatch,{error,ebusy}}}` and only logged a badmatch
crash that did not name the file. Operators had to trace through the badmatch
stacktrace to figure out which file was unwritable.

This PR makes the failure self-explanatory:

- `apps/emqx/src/emqx_config_backup_manager.erl`: replace the hard
  `ok = file:rename(...)` match with a case clause; on failure log the file
  path + posix reason via a structured `failed_to_save_conf_file` error and
  return `{error, #{filename, reason}}`. The hint enumerates the common
  operator-side causes (read-only directory, single-file Docker bind-mount,
  immutable attribute). The temporary file is also cleaned up on failure.
- `apps/emqx/src/emqx_config.erl`: `save_configs/5` now throws a structured
  map on file save failure; `safe_handle_update_request` catches the throw
  and returns `{error, Reason}` so the API renders a clean 400 body that
  names both the file and the reason.
- The previously-silent failure of the temporary-file write (e.g. read-only
  directory) is also now surfaced — it used to return HTTP 200 even though
  the change was not persisted to disk.
- New regression test `t_cluster_hocon_save_failure` in
  `apps/emqx/test/emqx_config_SUITE.erl`.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)