### PR TITLE
fix(ds_local): guard meta_worker tick against fresh-shard timestamp

### DIFF
--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_meta_worker.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_meta_worker.erl
@@ -51,7 +51,10 @@ handle_cast(_Cast, S) ->
 handle_info({?MODULE, tick}, S = #s{db = DB}) ->
     Shards = emqx_ds_builtin_local_meta:shards(DB),
     [tick(DB, Shard) || Shard <- Shards],
-    erlang:send_after(100, self(), tick),
+    %% Send the same tag the handler matches on; the original
+    %% `tick' atom would fall through to the catchall below and
+    %% silently stop the periodic tick after the first iteration.
+    erlang:send_after(100, self(), {?MODULE, tick}),
     {noreply, S};
 handle_info(_Info, S) ->
     {noreply, S}.
@@ -69,9 +72,16 @@ terminate(_Reason, _S) ->
 
 tick(DB, Shard) ->
     ShardId = {DB, Shard},
-    Now = max(
-        erlang:system_time(microsecond), emqx_ds_builtin_local_meta:current_timestamp(ShardId) + 1
-    ),
+    SystemNow = erlang:system_time(microsecond),
+    %% On a fresh shard no transaction has been committed yet, so
+    %% `current_timestamp/1' returns `undefined' — guard against the
+    %% `undefined + 1' arithmetic that previously crashed the worker
+    %% on its first tick.
+    Now =
+        case emqx_ds_builtin_local_meta:current_timestamp(ShardId) of
+            undefined -> SystemNow;
+            Latest -> max(SystemNow, Latest + 1)
+        end,
     emqx_ds_builtin_local_meta:set_current_timestamp(ShardId, Now),
     %% @TODO ????
     Events = emqx_ds_storage_layer:handle_event(ShardId, Now, {?MODULE, tick}),


### PR DESCRIPTION
Release version: 5.9.2

## Summary

Backport of the master fix for a latent bug in
`emqx_ds_builtin_local_meta_worker`: `tick/2` reads
`emqx_ds_builtin_local_meta:current_timestamp/1` and adds 1 to it. On a
freshly opened shard with no committed transactions yet,
`current_timestamp/1` returns `undefined` and `undefined + 1` raises
`badarith`. The supervisor restarts the worker, init schedules another
tick, the same crash repeats until `reached_max_restart_intensity`
shuts the timers supervisor down. Caught by
`emqx_persistent_session_ds_SUITE:t_state_fuzz` on master.

While here, fix a second bug in `handle_info/2`: `erlang:send_after/3`
delivered the bare atom `tick`, but the matching clause is on
`{?MODULE, tick}`. Hidden by the badarith — once that's fixed, the
periodic tick would otherwise stop after the first iteration.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)