### PR TITLE
chore: pull amqp_client from Hex instead of rabbitmq-server git subdir

### DIFF
--- a/apps/emqx_bridge_rabbitmq/mix.exs
+++ b/apps/emqx_bridge_rabbitmq/mix.exs
@@ -30,12 +30,7 @@ defmodule EMQXBridgeRabbitmq.MixProject do
 
   def deps() do
     UMP.deps([
-      {:thoas, "1.2.1"},
-      {:credentials_obfuscation, github: "rabbitmq/credentials-obfuscation", tag: "v3.5.0"},
-      {:rabbit_common,
-       github: "rabbitmq/rabbitmq-server", tag: "v4.2.1", subdir: "deps/rabbit_common"},
-      {:amqp_client,
-       github: "rabbitmq/rabbitmq-server", tag: "v4.2.1", subdir: "deps/amqp_client"},
+      {:amqp_client, "4.2.1"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version:
6.1.2, 6.2.0

## Summary

Restore the Hex-package dependency pattern for `amqp_client` / `rabbit_common`. release-60 has used `{:amqp_client, \"4.0.3\"}` from Hex since #df6dba8e6 (Jan 2025); commit 4b4716d943 (\"chore: adapt for OTP 28 changes\", Oct 2025) reverted release-61+ to a sparse subdir of `rabbitmq/rabbitmq-server.git@v4.2.1` because Hex didn't yet have a 4.2.x publish at the time. Hex.pm has had `amqp_client` 4.2.1, 4.2.0, 4.1.6, 4.1.5, 4.1.5-rc.* since 2025-11-06, so the workaround is no longer needed.

Per-CI-job cost saved by switching back to Hex:
- No longer clones the full `rabbitmq/rabbitmq-server.git` tree.
- No longer bootstraps `erlang.mk`'s own `rebar3` + plugin chain (hex_core, bbmustache, cf, erlware_commons, getopt, providers, eunit_formatters, ssl_verify_fun, relx, certifi, …) into `deps/{amqp_client,rabbit_common}/.erlang.mk/rebar3/_build/` once for each of the two deps.

Measured ~21s × 2 ≈ ~42s per slim build in a recent release-61 job log.

## Resolution check

`amqp_client 4.2.1` → `rabbit_common 4.2.1`, `credentials_obfuscation 3.5.0`
`rabbit_common 4.2.1` → `credentials_obfuscation 3.5.0`, `ranch 2.2.0`, `recon 2.5.6`, `thoas 1.2.1`

Top-level `mix.exs` already overrides `ranch` to the emqx fork (`emqx/ranch 2.2.0-emqx-3`), so no version conflict. Locally verified `make` produces a release tree with `lib/amqp_client-4.2.1` (and the transitive Hex deps) and the slim path completes through `==> emqx_bridge_rabbitmq` cleanly.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)