### PR TITLE
fix(ds_local): keep meta_worker tick non-periodic

### DIFF
--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_meta_worker.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_meta_worker.erl
@@ -63,10 +63,16 @@ handle_cast(_Cast, S) ->
 handle_info({?MODULE, tick}, S = #s{db = DB}) ->
     Shards = emqx_ds_builtin_local_meta:shards(DB),
     [tick(DB, Shard) || Shard <- Shards],
-    %% Send the same tag the handler matches on; the original
-    %% `tick' atom would fall through to the catchall below and
-    %% silently stop the periodic tick after the first iteration.
-    erlang:send_after(100, self(), {?MODULE, tick}),
+    %% No reschedule: the original send_after delivered a bare `tick'
+    %% atom that did not match this clause, so the timer has been a
+    %% no-op since this module was introduced in 2024-08. Two years of
+    %% production behavior depend on the worker going idle after the
+    %% first tick — making it actually periodic broke
+    %% emqx_ds_builtin_local_SUITE:t_store_batch_fail (meck:unload
+    %% couldn't purge the cover-compiled emqx_ds_storage_layer beam
+    %% while the worker kept calling into it every 100 ms). If the
+    %% storage-layer team wants real periodicity, that's a deliberate
+    %% design change separate from this fix.
     {noreply, S};
 handle_info(_Info, S) ->
     {noreply, S}.


### PR DESCRIPTION
Release version: 5.8.10

## Summary

Follow-up to PR #17228. The periodic-tick portion of that fix made
`erlang:send_after/3` deliver `{?MODULE, tick}` so it would match the
handler clause and the timer would actually fire every 100 ms.

That broke `emqx_ds_builtin_local_SUITE:t_store_batch_fail` under
cover-compiled enterprise CI — caught when syncing forward to
release-510 (PR #17241): `meck:unload` could not purge the
cover-compiled `emqx_ds_storage_layer` beam while the worker was
actively calling into it every 100 ms.

The pre-existing `tick` atom (which falls through to the no-op
catchall and stops the timer after one iteration) is restored. The
badarith guard in `tick/2` — which is the change `t_state_fuzz` on
master needed — is kept.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)