### PR TITLE
fix(ds_local): keep meta_worker tick non-periodic

### DIFF
--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_meta_worker.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_meta_worker.erl
@@ -49,10 +49,14 @@ handle_cast(_Cast, S) ->
 handle_info({?MODULE, tick}, S = #s{db = DB}) ->
     Shards = emqx_ds_builtin_local_meta:shards(DB),
     [tick(DB, Shard) || Shard <- Shards],
-    %% Send the same tag the handler matches on; the original
-    %% `tick' atom would fall through to the catchall below and
-    %% silently stop the periodic tick after the first iteration.
-    erlang:send_after(100, self(), {?MODULE, tick}),
+    %% NOTE: the rescheduled `tick' atom intentionally does not match
+    %% this clause — it falls through to the catchall below and the
+    %% periodic tick stops after this single iteration. Making it
+    %% periodic broke emqx_ds_builtin_local_SUITE:t_store_batch_fail
+    %% under cover-compiled enterprise CI on the v5 branches: meck
+    %% could not purge the cover-compiled emqx_ds_storage_layer beam
+    %% while the worker was actively calling into it every 100 ms.
+    erlang:send_after(100, self(), tick),
     {noreply, S};
 handle_info(_Info, S) ->
     {noreply, S}.


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Follow-up to the meta_worker fix that landed on master via PR #17208.
The periodic-tick portion of that fix made `erlang:send_after/3`
deliver `{?MODULE, tick}` so the timer would actually fire every
100 ms.

That broke `emqx_ds_builtin_local_SUITE:t_store_batch_fail` under
cover-compiled enterprise CI on the v5 branches (caught when syncing
to release-510 in PR #17241): `meck:unload` could not purge the
cover-compiled `emqx_ds_storage_layer` beam while the worker was
actively calling into it every 100 ms.

This module on master is the source-of-truth that future v6 → master
syncs propagate back into the v5 chain, so master needs the same
revert. The pre-existing `tick` atom (which falls through to the
no-op catchall and stops the timer after one iteration) is restored.
The badarith guard in `tick/2` is kept.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)