### PR TITLE
chore(deps): bump jose to 1.11.12

### DIFF
--- a/changes/ee/chore-17246.en.md
+++ b/changes/ee/chore-17246.en.md
@@ -1,0 +1,1 @@
+Upgraded `jose` library from 1.11.10 to 1.11.12, picking up EC and EdDSA key fixes for newer OTP releases.

--- a/mix.exs
+++ b/mix.exs
@@ -227,7 +227,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def common_dep(:jose),
     do:
-      {:jose, github: "potatosalad/erlang-jose", tag: "1.11.10", manager: :rebar3, override: true}
+      {:jose, github: "potatosalad/erlang-jose", tag: "1.11.12", manager: :rebar3, override: true}
 
   def common_dep(:rulesql), do: {:rulesql, github: "emqx/rulesql", tag: "0.2.1"}
 


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

Bump `jose` Erlang/Elixir library from 1.11.10 to 1.11.12.

Highlights from upstream changelog:
- 1.11.11: EC key decode/encode fixes for OTP 28; EdDSA key fixes for OTP 27.1.3+.
- 1.11.12: properly handle `nil` from Elixir maps when encoding with the builtin OTP `json` module; lowered required Elixir version back to 1.13.

No API changes; sanity-checked HS256 / RS256 / ES256 sign+verify round-trips against the rebuilt dep, plus the existing dialyzer/xref static checks.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)