### PR TITLE
fix(redis): support sentinel password auth

### DIFF
--- a/.ci/docker-compose-file/docker-compose-redis-sentinel-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-sentinel-tcp.yaml
@@ -25,6 +25,7 @@ services:
     image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
     volumes:
       - ./redis/sentinel-tcp/sentinel-base.conf:/usr/local/etc/redis/sentinel-base.conf
+      - ./redis/sentinel-tcp/users.acl:/usr/local/etc/redis/users.acl
     depends_on:
       - redis-sentinel-master
       - redis-sentinel-slave
@@ -33,7 +34,6 @@ services:
                redis-sentinel /usr/local/etc/redis/sentinel.conf"
     networks:
       - emqx_bridge
-
 
 
 

--- a/.ci/docker-compose-file/docker-compose-redis-sentinel-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-sentinel-tls.yaml
@@ -27,6 +27,7 @@ services:
     image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
     volumes:
       - ./redis/sentinel-tls/sentinel-base.conf:/usr/local/etc/redis/sentinel-base.conf
+      - ./redis/sentinel-tls/users.acl:/usr/local/etc/redis/users.acl
       - ../../apps/emqx/etc/certs:/etc/certs
     depends_on:
       - redis-sentinel-tls-master
@@ -36,7 +37,6 @@ services:
                redis-sentinel /usr/local/etc/redis/sentinel.conf"
     networks:
       - emqx_bridge
-
 
 
 

--- a/.ci/docker-compose-file/redis/sentinel-tcp/sentinel-base.conf
+++ b/.ci/docker-compose-file/redis/sentinel-tcp/sentinel-base.conf
@@ -1,5 +1,6 @@
 sentinel resolve-hostnames yes
 bind :: 0.0.0.0
+aclfile /usr/local/etc/redis/users.acl
 
 sentinel monitor mytcpmaster redis-sentinel-master 6379 1
 sentinel auth-pass mytcpmaster public

--- a/.ci/docker-compose-file/redis/sentinel-tls/sentinel-base.conf
+++ b/.ci/docker-compose-file/redis/sentinel-tls/sentinel-base.conf
@@ -7,6 +7,7 @@ tls-cert-file /etc/certs/cert.pem
 tls-key-file /etc/certs/key.pem
 tls-ca-cert-file /etc/certs/cacert.pem
 tls-auth-clients no
+aclfile /usr/local/etc/redis/users.acl
 
 sentinel monitor mytlsmaster redis-sentinel-tls-master 6389 1
 sentinel auth-pass mytlsmaster public

--- a/apps/emqx_bridge_redis/test/emqx_bridge_v2_redis_SUITE.erl
+++ b/apps/emqx_bridge_redis/test/emqx_bridge_v2_redis_SUITE.erl
@@ -345,7 +345,15 @@ t_on_get_status_no_username_pass(Config0) when is_list(Config0) ->
                 single ->
                     ?assertMatch([_ | _], ?of_kind(emqx_redis_auth_required_error, Trace));
                 sentinel ->
-                    ?assertMatch([_ | _], ?of_kind(emqx_redis_auth_required_error, Trace));
+                    ?assertEqual([], ?of_kind(emqx_redis_auth_required_error, Trace)),
+                    SentinelDiscoveryErrors = [
+                        Event
+                     || #{error := Error} = Event <- ?of_kind(resource_activate_alarm, Trace),
+                        is_binary(Error),
+                        binary:match(Error, <<"start_pool_failed">>) =/= nomatch,
+                        binary:match(Error, <<"sentinel_unreachable">>) =/= nomatch
+                    ],
+                    ?assertMatch([_ | _], SentinelDiscoveryErrors);
                 cluster ->
                     ok
             end

--- a/apps/emqx_redis/mix.exs
+++ b/apps/emqx_redis/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXRedis.MixProject do
     [
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
-      {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.8.10"}
+      {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.8.11"}
     ]
   end
 end

--- a/apps/emqx_redis/rebar.config
+++ b/apps/emqx_redis/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     %% NOTE: mind ecpool version when updating eredis_cluster version
-    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.8.10"}}},
+    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.8.11"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.

--- a/apps/emqx_redis/test/emqx_redis_SUITE.erl
+++ b/apps/emqx_redis/test/emqx_redis_SUITE.erl
@@ -98,6 +98,21 @@ t_sentinel_lifecycle(_Config) ->
         [<<"PING">>]
     ).
 
+t_sentinel_password_auth(_Config) ->
+    ResourceId = <<"emqx_redis_SUITE_sentinel_password_auth">>,
+    {ok, #{config := CheckedConfig}} =
+        emqx_resource:check_config(?REDIS_RESOURCE_MOD, redis_config_sentinel()),
+    {ok, #{status := connected}} = emqx_resource:create_local(
+        ResourceId,
+        ?CONNECTOR_RESOURCE_GROUP,
+        ?REDIS_RESOURCE_MOD,
+        CheckedConfig,
+        #{}
+    ),
+    ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+    ?assertEqual({ok, <<"PONG">>}, emqx_resource:query(ResourceId, {cmd, [<<"PING">>]})),
+    ?assertEqual(ok, emqx_resource:remove_local(ResourceId)).
+
 perform_lifecycle_check(ResourceId, InitialConfig, RedisCommand) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(?REDIS_RESOURCE_MOD, InitialConfig),

--- a/changes/ee/fix-17248.en.md
+++ b/changes/ee/fix-17248.en.md
@@ -1,0 +1,1 @@
+Fixed Redis Sentinel connections failing when Sentinel itself requires password authentication.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15277

Release version: 5.10

## Summary

This PR updates the Redis connector dependency on `eredis_cluster` to `0.8.11`. That release depends on `eredis` `1.2.17`, which passes top-level Redis credentials into the Sentinel connection options used by `eredis_sentinel`. EMQX no longer needs a direct `eredis` override in `apps/emqx_redis`.

Previously, Redis Sentinel mode could authenticate to the Redis master with the configured password, but the Sentinel connection itself did not receive that password. When Sentinel was configured to require client authentication, the connector could not discover the master.

The Redis Sentinel TCP/TLS test fixtures now load the same ACL file used by Redis nodes, so Sentinel itself requires authentication. A Common Test case creates a Redis Sentinel resource through `emqx_resource`, verifies the resource becomes connected, and executes `PING` through the discovered Redis master.

The bridge Redis v2 status test now asserts the authenticated Sentinel fixture fails at Sentinel discovery when credentials are omitted: no Redis master `NOAUTH` trace is emitted, and resource activation reports `start_pool_failed` with `sentinel_unreachable`.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

## Test Plan

- `BUILD_WITHOUT_QUIC=1 ./rebar3 upgrade eredis_cluster`
- `mix deps.update eredis_cluster`
- `./scripts/erlfmt -c apps/emqx_bridge_redis/test/emqx_bridge_v2_redis_SUITE.erl`
- `DOCKER_CT_RUNNER_IMAGE=ghcr.io/emqx/emqx-builder/6.0-9:1.18.3-27.3.4.2-6-ubuntu24.04 docker compose --env-file .ci/docker-compose-file/.env -f .ci/docker-compose-file/docker-compose.yaml -f .ci/docker-compose-file/docker-compose-redis-single-tcp.yaml -f .ci/docker-compose-file/docker-compose-redis-sentinel-tcp.yaml up --wait --pull never`
- `docker exec redis-sentinel redis-cli -p 26379 sentinel get-master-addr-by-name mytcpmaster` returned `NOAUTH Authentication required.`
- `docker exec redis-sentinel redis-cli -p 26379 --user test_user -a test_passwd --no-auth-warning sentinel get-master-addr-by-name mytcpmaster` returned the Sentinel master address.
- `docker exec -e IS_CI=yes -e BUILD_WITHOUT_QUIC=1 erlang bash -lc 'cd /emqx && ./rebar3 ct -v --readable=true --name test@127.0.0.1 --suite apps/emqx_redis/test/emqx_redis_SUITE.erl --case t_sentinel_password_auth'` passed with `1 ok, 0 failed`.
- `DOCKER_CT_RUNNER_IMAGE=ghcr.io/emqx/emqx-builder/6.1-4:1.18.3-27.3.4.2-8-ubuntu24.04 MONGO_TAG=5 MYSQL_TAG=8 PGSQL_TAG=13 REDIS_TAG=7.0 INFLUXDB_TAG=2.5.0 TDENGINE_TAG=3.0.2.4 OPENTS_TAG=9aa7f88 SUITEGROUP=1_1 ENABLE_COVER_COMPILE=1 CT_COVER_EXPORT_PREFIX=emqx-enterprise-sg1_1 ./scripts/ct/run.sh --ci --app apps/emqx_bridge_redis --keep-up` passed: `emqx_bridge_redis_SUITE` `67 ok, 0 failed, 12 skipped`; `emqx_bridge_v2_redis_SUITE` `18 ok, 0 failed`.
- `BEFORE_REF=ce/release-510 AFTER_REF=HEAD ./scripts/check-changes-filename-pattern.sh`
