### PR TITLE
fix(redis): support separate sentinel authentication for r6

### DIFF
--- a/.ci/docker-compose-file/docker-compose-redis-sentinel-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-sentinel-tcp.yaml
@@ -25,6 +25,7 @@ services:
     image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
     volumes:
       - ./redis/sentinel-tcp/sentinel-base.conf:/usr/local/etc/redis/sentinel-base.conf
+      - ./redis/sentinel-tcp/users.acl:/usr/local/etc/redis/users.acl
     depends_on:
       - redis-sentinel-master
       - redis-sentinel-slave
@@ -34,6 +35,135 @@ services:
     networks:
       - emqx_bridge
 
+  redis-sentinel-master-noauth:
+    container_name: redis-sentinel-master-noauth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/master-noauth.conf:/usr/local/etc/redis/master-noauth.conf:ro
+    command: redis-server /usr/local/etc/redis/master-noauth.conf
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "PING"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
 
+  redis-sentinel-master-auth:
+    container_name: redis-sentinel-master-auth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/master-auth.conf:/usr/local/etc/redis/master-auth.conf:ro
+      - ./redis/sentinel-auth-matrix/master-users.acl:/usr/local/etc/redis/master-users.acl:ro
+    command: redis-server /usr/local/etc/redis/master-auth.conf
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "redis-cli",
+          "-p",
+          "6379",
+          "--user",
+          "redis_user",
+          "--pass",
+          "redis-password",
+          "--no-auth-warning",
+          "PING"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
+
+  redis-sentinel-noauth-master-noauth:
+    container_name: redis-sentinel-noauth-master-noauth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/sentinel-noauth-master-noauth.conf:/usr/local/etc/redis/sentinel-noauth-master-noauth.conf:ro
+    depends_on:
+      - redis-sentinel-master-noauth
+    command: >
+      bash -c "cp -f /usr/local/etc/redis/sentinel-noauth-master-noauth.conf /tmp/sentinel.conf &&
+               redis-sentinel /tmp/sentinel.conf"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster | grep -q 6379"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
+
+  redis-sentinel-noauth-master-auth:
+    container_name: redis-sentinel-noauth-master-auth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/sentinel-noauth-master-auth.conf:/usr/local/etc/redis/sentinel-noauth-master-auth.conf:ro
+    depends_on:
+      - redis-sentinel-master-auth
+    command: >
+      bash -c "cp -f /usr/local/etc/redis/sentinel-noauth-master-auth.conf /tmp/sentinel.conf &&
+               redis-sentinel /tmp/sentinel.conf"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster | grep -q 6379"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
+
+  redis-sentinel-auth-master-noauth:
+    container_name: redis-sentinel-auth-master-noauth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/sentinel-auth-master-noauth.conf:/usr/local/etc/redis/sentinel-auth-master-noauth.conf:ro
+      - ./redis/sentinel-auth-matrix/sentinel-users.acl:/usr/local/etc/redis/sentinel-users.acl:ro
+    depends_on:
+      - redis-sentinel-master-noauth
+    command: >
+      bash -c "cp -f /usr/local/etc/redis/sentinel-auth-master-noauth.conf /tmp/sentinel.conf &&
+               redis-sentinel /tmp/sentinel.conf"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "redis-cli -p 26379 --user sentinel_user --pass sentinel-password --no-auth-warning SENTINEL get-master-addr-by-name mymaster | grep -q 6379"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
+
+  redis-sentinel-auth-master-auth:
+    container_name: redis-sentinel-auth-master-auth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/sentinel-auth-master-auth.conf:/usr/local/etc/redis/sentinel-auth-master-auth.conf:ro
+      - ./redis/sentinel-auth-matrix/sentinel-users.acl:/usr/local/etc/redis/sentinel-users.acl:ro
+    depends_on:
+      - redis-sentinel-master-auth
+    command: >
+      bash -c "cp -f /usr/local/etc/redis/sentinel-auth-master-auth.conf /tmp/sentinel.conf &&
+               redis-sentinel /tmp/sentinel.conf"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "redis-cli -p 26379 --user sentinel_user --pass sentinel-password --no-auth-warning SENTINEL get-master-addr-by-name mymaster | grep -q 6379"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
 
 

--- a/.ci/docker-compose-file/docker-compose-redis-sentinel-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-sentinel-tls.yaml
@@ -27,6 +27,7 @@ services:
     image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
     volumes:
       - ./redis/sentinel-tls/sentinel-base.conf:/usr/local/etc/redis/sentinel-base.conf
+      - ./redis/sentinel-tls/users.acl:/usr/local/etc/redis/users.acl
       - ../../apps/emqx/etc/certs:/etc/certs
     depends_on:
       - redis-sentinel-tls-master
@@ -36,7 +37,6 @@ services:
                redis-sentinel /usr/local/etc/redis/sentinel.conf"
     networks:
       - emqx_bridge
-
 
 
 

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-auth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-auth.conf
@@ -1,0 +1,13 @@
+bind :: 0.0.0.0
+port 6379
+aclfile /usr/local/etc/redis/master-users.acl
+
+protected-mode no
+daemonize no
+
+loglevel notice
+logfile ""
+
+always-show-logo no
+save ""
+appendonly no

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-noauth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-noauth.conf
@@ -1,0 +1,12 @@
+bind :: 0.0.0.0
+port 6379
+
+protected-mode no
+daemonize no
+
+loglevel notice
+logfile ""
+
+always-show-logo no
+save ""
+appendonly no

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-users.acl
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-users.acl
@@ -1,0 +1,2 @@
+user default off
+user redis_user on >redis-password ~* &* +@all

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-auth-master-auth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-auth-master-auth.conf
@@ -1,0 +1,15 @@
+bind :: 0.0.0.0
+port 26379
+protected-mode no
+daemonize no
+aclfile /usr/local/etc/redis/sentinel-users.acl
+
+loglevel notice
+logfile ""
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-sentinel-master-auth 6379 1
+sentinel auth-user mymaster redis_user
+sentinel auth-pass mymaster redis-password
+sentinel down-after-milliseconds mymaster 10000
+sentinel failover-timeout mymaster 20000

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-auth-master-noauth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-auth-master-noauth.conf
@@ -1,0 +1,13 @@
+bind :: 0.0.0.0
+port 26379
+protected-mode no
+daemonize no
+aclfile /usr/local/etc/redis/sentinel-users.acl
+
+loglevel notice
+logfile ""
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-sentinel-master-noauth 6379 1
+sentinel down-after-milliseconds mymaster 10000
+sentinel failover-timeout mymaster 20000

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-noauth-master-auth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-noauth-master-auth.conf
@@ -1,0 +1,14 @@
+bind :: 0.0.0.0
+port 26379
+protected-mode no
+daemonize no
+
+loglevel notice
+logfile ""
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-sentinel-master-auth 6379 1
+sentinel auth-user mymaster redis_user
+sentinel auth-pass mymaster redis-password
+sentinel down-after-milliseconds mymaster 10000
+sentinel failover-timeout mymaster 20000

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-noauth-master-noauth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-noauth-master-noauth.conf
@@ -1,0 +1,12 @@
+bind :: 0.0.0.0
+port 26379
+protected-mode no
+daemonize no
+
+loglevel notice
+logfile ""
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-sentinel-master-noauth 6379 1
+sentinel down-after-milliseconds mymaster 10000
+sentinel failover-timeout mymaster 20000

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-users.acl
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-users.acl
@@ -1,0 +1,2 @@
+user default off
+user sentinel_user on >sentinel-password ~* &* +@all

--- a/.ci/docker-compose-file/redis/sentinel-tcp/sentinel-base.conf
+++ b/.ci/docker-compose-file/redis/sentinel-tcp/sentinel-base.conf
@@ -1,5 +1,6 @@
 sentinel resolve-hostnames yes
 bind :: 0.0.0.0
+aclfile /usr/local/etc/redis/users.acl
 
 sentinel monitor mytcpmaster redis-sentinel-master 6379 1
 sentinel auth-pass mytcpmaster public

--- a/.ci/docker-compose-file/redis/sentinel-tls/sentinel-base.conf
+++ b/.ci/docker-compose-file/redis/sentinel-tls/sentinel-base.conf
@@ -7,6 +7,7 @@ tls-cert-file /etc/certs/cert.pem
 tls-key-file /etc/certs/key.pem
 tls-ca-cert-file /etc/certs/cacert.pem
 tls-auth-clients no
+aclfile /usr/local/etc/redis/users.acl
 
 sentinel monitor mytlsmaster redis-sentinel-tls-master 6389 1
 sentinel auth-pass mytlsmaster public

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
@@ -238,6 +238,8 @@ connector_parameter(sentinel) ->
         sentinel => <<"myredismaster">>,
         pool_size => 8,
         database => 1,
+        sentinel_username => <<"sentinel_user">>,
+        sentinel_password => <<"******">>,
         username => <<"test">>,
         password => <<"******">>
     }.

--- a/apps/emqx_bridge_redis/test/emqx_bridge_redis_SUITE.erl
+++ b/apps/emqx_bridge_redis/test/emqx_bridge_redis_SUITE.erl
@@ -173,7 +173,8 @@ type_specific_connector_config_of(TCConfig) ->
                 <<"parameters">> => #{
                     <<"redis_type">> => <<"sentinel">>,
                     <<"servers">> => <<"redis-sentinel:26379">>,
-                    <<"sentinel">> => <<"mytcpmaster">>
+                    <<"sentinel">> => <<"mytcpmaster">>,
+                    <<"sentinel_password">> => <<"public">>
                 }
             };
         {?sentinel, ?tls} ->
@@ -181,7 +182,8 @@ type_specific_connector_config_of(TCConfig) ->
                 <<"parameters">> => #{
                     <<"redis_type">> => <<"sentinel">>,
                     <<"servers">> => <<"redis-sentinel-tls:26380">>,
-                    <<"sentinel">> => <<"mytlsmaster">>
+                    <<"sentinel">> => <<"mytlsmaster">>,
+                    <<"sentinel_password">> => <<"public">>
                 },
                 <<"ssl">> => enabled_ssl_opts(TCConfig)
             };

--- a/apps/emqx_redis/mix.exs
+++ b/apps/emqx_redis/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXRedis.MixProject do
   def project do
     [
       app: :emqx_redis,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),
@@ -25,7 +25,7 @@ defmodule EMQXRedis.MixProject do
     UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
-      {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.8.10"}
+      {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.8.12"}
     ])
   end
 end

--- a/apps/emqx_redis/src/emqx_redis.erl
+++ b/apps/emqx_redis/src/emqx_redis.erl
@@ -78,7 +78,10 @@ fields(redis_sentinel_connector) ->
             type => string(),
             required => true,
             desc => ?DESC("sentinel_desc")
-        }}
+        }},
+        {sentinel_username, fun sentinel_username/1},
+        {sentinel_password,
+            emqx_connector_schema_lib:password_field(#{desc => ?DESC("sentinel_password")})}
     ] ++ redis_fields().
 
 server() ->
@@ -129,7 +132,7 @@ on_start(InstId, Config0) ->
             {options, Options},
             {pool_size, PoolSize},
             {auto_reconnect, ?AUTO_RECONNECT_INTERVAL}
-        ] ++ database(Config),
+        ] ++ sentinel_auth(Config) ++ database(Config),
 
     State = #{pool_name => InstId, type => Type},
     ok = emqx_resource:allocate_resource(InstId, ?MODULE, type, Type),
@@ -346,3 +349,16 @@ redis_fields() ->
         }},
         {auto_reconnect, fun emqx_connector_schema_lib:auto_reconnect/1}
     ].
+
+sentinel_username(type) -> binary();
+sentinel_username(desc) -> ?DESC("sentinel_username");
+sentinel_username(required) -> false;
+sentinel_username(_) -> undefined.
+
+sentinel_auth(#{redis_type := sentinel} = Config) ->
+    [
+        {sentinel_username, maps:get(sentinel_username, Config, undefined)},
+        {sentinel_password, maps:get(sentinel_password, Config, "")}
+    ];
+sentinel_auth(_) ->
+    [].

--- a/apps/emqx_redis/test/emqx_redis_SUITE.erl
+++ b/apps/emqx_redis/test/emqx_redis_SUITE.erl
@@ -17,6 +17,10 @@
 -define(REDIS_SINGLE_PORT, 6379).
 -define(REDIS_SENTINEL_HOST, "redis-sentinel").
 -define(REDIS_SENTINEL_PORT, 26379).
+-define(REDIS_SENTINEL_S_NO_AUTH_M_AUTH_HOST, "redis-sentinel-noauth-master-auth").
+-define(REDIS_SENTINEL_S_AUTH_M_AUTH_HOST, "redis-sentinel-auth-master-auth").
+-define(REDIS_SENTINEL_S_NO_AUTH_M_NO_AUTH_HOST, "redis-sentinel-noauth-master-noauth").
+-define(REDIS_SENTINEL_S_AUTH_M_NO_AUTH_HOST, "redis-sentinel-auth-master-noauth").
 -define(REDIS_CLUSTER_HOST, "redis-cluster-1").
 -define(REDIS_CLUSTER_PORT, 6379).
 -define(REDIS_RESOURCE_MOD, emqx_redis).
@@ -62,7 +66,11 @@ wait_for_redis(Checks) ->
         emqx_common_test_helpers:is_all_tcp_servers_available(
             [
                 {?REDIS_SINGLE_HOST, ?REDIS_SINGLE_PORT},
-                {?REDIS_SENTINEL_HOST, ?REDIS_SENTINEL_PORT}
+                {?REDIS_SENTINEL_HOST, ?REDIS_SENTINEL_PORT},
+                {?REDIS_SENTINEL_S_NO_AUTH_M_AUTH_HOST, ?REDIS_SENTINEL_PORT},
+                {?REDIS_SENTINEL_S_AUTH_M_AUTH_HOST, ?REDIS_SENTINEL_PORT},
+                {?REDIS_SENTINEL_S_NO_AUTH_M_NO_AUTH_HOST, ?REDIS_SENTINEL_PORT},
+                {?REDIS_SENTINEL_S_AUTH_M_NO_AUTH_HOST, ?REDIS_SENTINEL_PORT}
             ]
         )
     of
@@ -97,6 +105,53 @@ t_sentinel_lifecycle(_Config) ->
         redis_config_sentinel(),
         [<<"PING">>]
     ).
+
+t_sentinel_password_auth(_Config) ->
+    ResourceId = <<"emqx_redis_SUITE_sentinel_password_auth">>,
+    {ok, #{config := CheckedConfig}} =
+        emqx_resource:check_config(?REDIS_RESOURCE_MOD, redis_config_sentinel()),
+    {ok, #{status := connected}} = emqx_resource:create_local(
+        ResourceId,
+        ?CONNECTOR_RESOURCE_GROUP,
+        ?REDIS_RESOURCE_MOD,
+        CheckedConfig,
+        #{spawn_buffer_workers => true}
+    ),
+    ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+    ?assertEqual({ok, <<"PONG">>}, emqx_resource:query(ResourceId, {cmd, [<<"PING">>]})),
+    ?assertEqual(ok, emqx_resource:remove_local(ResourceId)).
+
+t_sentinel_auth_master_noauth_sentinel_noauth(_Config) ->
+    run_sentinel_auth_matrix_case(#{
+        name => master_noauth_sentinel_noauth,
+        host => ?REDIS_SENTINEL_S_NO_AUTH_M_NO_AUTH_HOST,
+        redis_auth => none,
+        sentinel_auth => none
+    }).
+
+t_sentinel_auth_master_auth_sentinel_noauth(_Config) ->
+    run_sentinel_auth_matrix_case(#{
+        name => master_auth_sentinel_noauth,
+        host => ?REDIS_SENTINEL_S_NO_AUTH_M_AUTH_HOST,
+        redis_auth => password,
+        sentinel_auth => none
+    }).
+
+t_sentinel_auth_master_noauth_sentinel_auth(_Config) ->
+    run_sentinel_auth_matrix_case(#{
+        name => master_noauth_sentinel_auth,
+        host => ?REDIS_SENTINEL_S_AUTH_M_NO_AUTH_HOST,
+        redis_auth => none,
+        sentinel_auth => password
+    }).
+
+t_sentinel_auth_master_auth_sentinel_auth(_Config) ->
+    run_sentinel_auth_matrix_case(#{
+        name => master_auth_sentinel_auth,
+        host => ?REDIS_SENTINEL_S_AUTH_M_AUTH_HOST,
+        redis_auth => password,
+        sentinel_auth => password
+    }).
 
 perform_lifecycle_check(ResourceId, InitialConfig, RedisCommand) ->
     {ok, #{config := CheckedConfig}} =
@@ -199,6 +254,76 @@ redis_config_cluster() ->
 redis_config_sentinel() ->
     redis_config_base("sentinel", "servers").
 
+redis_config_sentinel_auth_matrix(Host, RedisAuth, SentinelAuth) ->
+    RawConfig = list_to_binary(
+        io_lib:format(
+            "" ++
+                "\n" ++
+                "    auto_reconnect = true\n" ++
+                "    pool_size = 1\n" ++
+                "    redis_type = sentinel\n" ++
+                "    sentinel = mymaster\n" ++
+                "    database = 0\n" ++
+                "    servers = \"~s:~b\"\n" ++
+                "~s" ++
+                "~s",
+            [
+                Host,
+                ?REDIS_SENTINEL_PORT,
+                redis_auth_config(RedisAuth),
+                sentinel_auth_config(SentinelAuth)
+            ]
+        )
+    ),
+    {ok, Config} = hocon:binary(RawConfig),
+    #{<<"config">> => Config}.
+
+redis_auth_config(none) ->
+    "";
+redis_auth_config(password) ->
+    "" ++
+        "    username = \"redis_user\"\n" ++
+        "    password = \"redis-password\"\n".
+
+sentinel_auth_config(none) ->
+    "";
+sentinel_auth_config(password) ->
+    "" ++
+        "    sentinel_username = \"sentinel_user\"\n" ++
+        "    sentinel_password = \"sentinel-password\"\n".
+
+run_sentinel_auth_matrix_case(#{
+    name := Name,
+    host := Host,
+    redis_auth := RedisAuth,
+    sentinel_auth := SentinelAuth
+}) ->
+    ResourceId = iolist_to_binary(["emqx_redis_SUITE_", atom_to_binary(Name)]),
+    Config = redis_config_sentinel_auth_matrix(Host, RedisAuth, SentinelAuth),
+    {ok, #{config := CheckedConfig}} = emqx_resource:check_config(?REDIS_RESOURCE_MOD, Config),
+    try
+        {ok, #{status := connected}} = emqx_resource:create_local(
+            ResourceId,
+            ?CONNECTOR_RESOURCE_GROUP,
+            ?REDIS_RESOURCE_MOD,
+            CheckedConfig,
+            #{spawn_buffer_workers => true}
+        ),
+        Key = atom_to_binary(Name),
+        Value = <<"ok">>,
+        ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+        ?assertEqual(
+            {ok, <<"OK">>},
+            emqx_resource:query(ResourceId, {cmd, [<<"SET">>, Key, Value]})
+        ),
+        ?assertEqual(
+            {ok, Value},
+            emqx_resource:query(ResourceId, {cmd, [<<"GET">>, Key]})
+        )
+    after
+        catch emqx_resource:remove_local(ResourceId)
+    end.
+
 -define(REDIS_CONFIG_BASE(MaybeSentinel, MaybeDatabase),
     "" ++
         "\n" ++
@@ -219,7 +344,10 @@ redis_config_base(Type, ServerKey) ->
         "sentinel" ->
             Host = ?REDIS_SENTINEL_HOST,
             Port = ?REDIS_SENTINEL_PORT,
-            MaybeSentinel = "    sentinel = mytcpmaster\n",
+            MaybeSentinel =
+                "    sentinel = mytcpmaster\n" ++
+                    "    sentinel_username = test_user\n" ++
+                    "    sentinel_password = test_passwd\n",
             MaybeDatabase = "    database = 1\n";
         "single" ->
             Host = ?REDIS_SINGLE_HOST,

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -56,6 +56,9 @@ is_sensitive_key(<<"secret_key">>) -> true;
 is_sensitive_key(security_token) -> true;
 is_sensitive_key("security_token") -> true;
 is_sensitive_key(<<"security_token">>) -> true;
+is_sensitive_key(sentinel_password) -> true;
+is_sensitive_key("sentinel_password") -> true;
+is_sensitive_key(<<"sentinel_password">>) -> true;
 is_sensitive_key(sp_private_key) -> true;
 is_sensitive_key(<<"sp_private_key">>) -> true;
 is_sensitive_key(private_key_password) -> true;
@@ -290,6 +293,7 @@ redact_test_() ->
         secret_key,
         secret_access_key,
         security_token,
+        sentinel_password,
         token,
         bind_password
     ],

--- a/apps/emqx_utils/test/emqx_utils_redact_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_redact_tests.erl
@@ -75,6 +75,12 @@ redact_wrapped_secret_test() ->
         })
     ).
 
+redact_sentinel_password_test() ->
+    ?assertEqual(
+        #{sentinel_password => <<"******">>},
+        redact(#{sentinel_password => <<"sentinel-password">>})
+    ).
+
 deobfuscate_file_path_secrets_test_() ->
     Original1 = #{foo => #{bar => #{headers => #{"authorization" => "file://a"}}}},
     Original2 = #{foo => #{bar => #{headers => #{"authorization" => "a"}}}},

--- a/changes/ee/fix-17250.en.md
+++ b/changes/ee/fix-17250.en.md
@@ -1,0 +1,1 @@
+Fixed Redis Sentinel connectors to support separate authentication settings for Redis data nodes and Sentinel nodes.

--- a/rel/i18n/emqx_redis.hocon
+++ b/rel/i18n/emqx_redis.hocon
@@ -24,6 +24,18 @@ sentinel_desc.desc:
 sentinel_desc.label:
 """Cluster Name"""
 
+sentinel_password.desc:
+"""Password used to authenticate with Redis Sentinel. Leave it unset when Sentinel does not require authentication."""
+
+sentinel_password.label:
+"""Sentinel Password"""
+
+sentinel_username.desc:
+"""Username used to authenticate with Redis Sentinel. Leave it unset when Sentinel does not require ACL username authentication."""
+
+sentinel_username.label:
+"""Sentinel Username"""
+
 server.desc:
 """The IPv4 or IPv6 address or the hostname to connect to.<br/>
 A host entry has the following form: `Host[:Port]`.<br/>


### PR DESCRIPTION
Backports #17248 and the follow-up separate Sentinel authentication changes from #17256.

Fix https://emqx.atlassian.net/browse/EMQX-15277

Release version:
6.0.3

## Summary

This updates Redis Sentinel connectors on release-60 so Sentinel authentication can be configured separately from Redis data-node authentication.

* Upgrade `eredis_cluster` to `0.8.12`, which supports separate Sentinel credentials during master discovery.
* Add `sentinel_username` and `sentinel_password` schema fields for Redis Sentinel connectors, including i18n and example config coverage.
* Add Sentinel auth-matrix CT fixtures and Redis CT coverage for all master/Sentinel auth combinations.
* Redact `sentinel_password` and cover it in redaction tests.
* Keep Redis bridge Sentinel tests aligned with the new separate Sentinel credential path.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking