### PR TITLE
ci: include plugin .sha256 sidecars in S3 upload

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -95,7 +95,9 @@ jobs:
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "plugins"
-        path: _build/plugins/*.tar.gz
+        path: |
+          _build/plugins/*.tar.gz
+          _build/plugins/*.sha256
         retention-days: 7
 
   mac:

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -42,7 +42,9 @@ jobs:
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "plugins"
-        path: _build/plugins/*.tar.gz
+        path: |
+          _build/plugins/*.tar.gz
+          _build/plugins/*.sha256
         retention-days: 7
         compression-level: 0
 

--- a/changes/ee/fix-17252.en.md
+++ b/changes/ee/fix-17252.en.md
@@ -1,0 +1,1 @@
+Publish `.sha256` checksum sidecars alongside plugin packages on the official download site, so users can verify the integrity of downloaded plugin archives.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 6.0.3

## Summary

Plugin packages built in `_build/plugins/` include both `*.tar.gz` archives and their `*.sha256` checksum sidecars (generated by the `mix emqx.plugin` task). The `actions/upload-artifact` step in `build_packages.yaml` and `build_slim_packages.yaml` was globbing only `*.tar.gz`, so the `.sha256` sidecars were dropped before the `packages` job downloaded the artifact and ran `aws s3 cp --recursive packages/plugins …`. End users on the official download CDN therefore had no checksum file to verify plugin archives against.

This change widens the artifact `path:` to a multi-line list including `_build/plugins/*.sha256`, so the sidecars survive into S3 and the CDN.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)