### PR TITLE
fix(redis): support separate sentinel authentication

### DIFF
--- a/.ci/docker-compose-file/docker-compose-redis-sentinel-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-sentinel-tcp.yaml
@@ -35,5 +35,133 @@ services:
     networks:
       - emqx_bridge
 
+  redis-sentinel-master-noauth:
+    container_name: redis-sentinel-master-noauth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/master-noauth.conf:/usr/local/etc/redis/master-noauth.conf:ro
+    command: redis-server /usr/local/etc/redis/master-noauth.conf
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "6379", "PING"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
 
+  redis-sentinel-master-auth:
+    container_name: redis-sentinel-master-auth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/master-auth.conf:/usr/local/etc/redis/master-auth.conf:ro
+      - ./redis/sentinel-auth-matrix/master-users.acl:/usr/local/etc/redis/master-users.acl:ro
+    command: redis-server /usr/local/etc/redis/master-auth.conf
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "redis-cli",
+          "-p",
+          "6379",
+          "--user",
+          "redis_user",
+          "--pass",
+          "redis-password",
+          "--no-auth-warning",
+          "PING"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
 
+  redis-sentinel-noauth-master-noauth:
+    container_name: redis-sentinel-noauth-master-noauth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/sentinel-noauth-master-noauth.conf:/usr/local/etc/redis/sentinel-noauth-master-noauth.conf:ro
+    depends_on:
+      - redis-sentinel-master-noauth
+    command: >
+      bash -c "cp -f /usr/local/etc/redis/sentinel-noauth-master-noauth.conf /tmp/sentinel.conf &&
+               redis-sentinel /tmp/sentinel.conf"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster | grep -q 6379"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
+
+  redis-sentinel-noauth-master-auth:
+    container_name: redis-sentinel-noauth-master-auth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/sentinel-noauth-master-auth.conf:/usr/local/etc/redis/sentinel-noauth-master-auth.conf:ro
+    depends_on:
+      - redis-sentinel-master-auth
+    command: >
+      bash -c "cp -f /usr/local/etc/redis/sentinel-noauth-master-auth.conf /tmp/sentinel.conf &&
+               redis-sentinel /tmp/sentinel.conf"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "redis-cli -p 26379 SENTINEL get-master-addr-by-name mymaster | grep -q 6379"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
+
+  redis-sentinel-auth-master-noauth:
+    container_name: redis-sentinel-auth-master-noauth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/sentinel-auth-master-noauth.conf:/usr/local/etc/redis/sentinel-auth-master-noauth.conf:ro
+      - ./redis/sentinel-auth-matrix/sentinel-users.acl:/usr/local/etc/redis/sentinel-users.acl:ro
+    depends_on:
+      - redis-sentinel-master-noauth
+    command: >
+      bash -c "cp -f /usr/local/etc/redis/sentinel-auth-master-noauth.conf /tmp/sentinel.conf &&
+               redis-sentinel /tmp/sentinel.conf"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "redis-cli -p 26379 --user sentinel_user --pass sentinel-password --no-auth-warning SENTINEL get-master-addr-by-name mymaster | grep -q 6379"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge
+
+  redis-sentinel-auth-master-auth:
+    container_name: redis-sentinel-auth-master-auth
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    volumes:
+      - ./redis/sentinel-auth-matrix/sentinel-auth-master-auth.conf:/usr/local/etc/redis/sentinel-auth-master-auth.conf:ro
+      - ./redis/sentinel-auth-matrix/sentinel-users.acl:/usr/local/etc/redis/sentinel-users.acl:ro
+    depends_on:
+      - redis-sentinel-master-auth
+    command: >
+      bash -c "cp -f /usr/local/etc/redis/sentinel-auth-master-auth.conf /tmp/sentinel.conf &&
+               redis-sentinel /tmp/sentinel.conf"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "redis-cli -p 26379 --user sentinel_user --pass sentinel-password --no-auth-warning SENTINEL get-master-addr-by-name mymaster | grep -q 6379"
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+    networks:
+      - emqx_bridge

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-auth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-auth.conf
@@ -1,0 +1,13 @@
+bind :: 0.0.0.0
+port 6379
+aclfile /usr/local/etc/redis/master-users.acl
+
+protected-mode no
+daemonize no
+
+loglevel notice
+logfile ""
+
+always-show-logo no
+save ""
+appendonly no

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-noauth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-noauth.conf
@@ -1,0 +1,12 @@
+bind :: 0.0.0.0
+port 6379
+
+protected-mode no
+daemonize no
+
+loglevel notice
+logfile ""
+
+always-show-logo no
+save ""
+appendonly no

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-users.acl
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/master-users.acl
@@ -1,0 +1,2 @@
+user default off
+user redis_user on >redis-password ~* &* +@all

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-auth-master-auth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-auth-master-auth.conf
@@ -1,0 +1,15 @@
+bind :: 0.0.0.0
+port 26379
+protected-mode no
+daemonize no
+aclfile /usr/local/etc/redis/sentinel-users.acl
+
+loglevel notice
+logfile ""
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-sentinel-master-auth 6379 1
+sentinel auth-user mymaster redis_user
+sentinel auth-pass mymaster redis-password
+sentinel down-after-milliseconds mymaster 10000
+sentinel failover-timeout mymaster 20000

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-auth-master-noauth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-auth-master-noauth.conf
@@ -1,0 +1,13 @@
+bind :: 0.0.0.0
+port 26379
+protected-mode no
+daemonize no
+aclfile /usr/local/etc/redis/sentinel-users.acl
+
+loglevel notice
+logfile ""
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-sentinel-master-noauth 6379 1
+sentinel down-after-milliseconds mymaster 10000
+sentinel failover-timeout mymaster 20000

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-noauth-master-auth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-noauth-master-auth.conf
@@ -1,0 +1,14 @@
+bind :: 0.0.0.0
+port 26379
+protected-mode no
+daemonize no
+
+loglevel notice
+logfile ""
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-sentinel-master-auth 6379 1
+sentinel auth-user mymaster redis_user
+sentinel auth-pass mymaster redis-password
+sentinel down-after-milliseconds mymaster 10000
+sentinel failover-timeout mymaster 20000

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-noauth-master-noauth.conf
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-noauth-master-noauth.conf
@@ -1,0 +1,12 @@
+bind :: 0.0.0.0
+port 26379
+protected-mode no
+daemonize no
+
+loglevel notice
+logfile ""
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-sentinel-master-noauth 6379 1
+sentinel down-after-milliseconds mymaster 10000
+sentinel failover-timeout mymaster 20000

--- a/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-users.acl
+++ b/.ci/docker-compose-file/redis/sentinel-auth-matrix/sentinel-users.acl
@@ -1,0 +1,2 @@
+user default off
+user sentinel_user on >sentinel-password ~* &* +@all

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_redis, [
     {description, "EMQX Enterprise Redis Bridge"},
-    {vsn, "0.1.11"},
+    {vsn, "0.1.12"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis.erl
@@ -58,7 +58,9 @@ values("sentinel", post) ->
         servers => [<<"127.0.0.1:26379">>],
         redis_type => sentinel,
         sentinel => <<"mymaster">>,
-        database => 1
+        database => 1,
+        sentinel_username => <<"sentinel_user">>,
+        sentinel_password => <<"******">>
     },
     values(common, "sentinel", SpecificOpts);
 values("cluster", post) ->

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
@@ -242,6 +242,8 @@ connector_parameter(sentinel) ->
         sentinel => <<"myredismaster">>,
         pool_size => 8,
         database => 1,
+        sentinel_username => <<"sentinel_user">>,
+        sentinel_password => <<"******">>,
         username => <<"test">>,
         password => <<"******">>
     }.

--- a/apps/emqx_bridge_redis/test/emqx_bridge_redis_SUITE.erl
+++ b/apps/emqx_bridge_redis/test/emqx_bridge_redis_SUITE.erl
@@ -582,12 +582,14 @@ redis_connect_configs() ->
             tcp => #{
                 <<"servers">> => <<"redis-sentinel:26379">>,
                 <<"redis_type">> => <<"sentinel">>,
-                <<"sentinel">> => <<"mytcpmaster">>
+                <<"sentinel">> => <<"mytcpmaster">>,
+                <<"sentinel_password">> => <<"public">>
             },
             tls => #{
                 <<"servers">> => <<"redis-sentinel-tls:26380">>,
                 <<"redis_type">> => <<"sentinel">>,
                 <<"sentinel">> => <<"mytlsmaster">>,
+                <<"sentinel_password">> => <<"public">>,
                 <<"ssl">> => redis_connect_ssl_opts(redis_sentinel)
             }
         },

--- a/apps/emqx_bridge_redis/test/emqx_bridge_v2_redis_SUITE.erl
+++ b/apps/emqx_bridge_redis/test/emqx_bridge_v2_redis_SUITE.erl
@@ -191,6 +191,8 @@ per_type_connector_config(sentinel) ->
                 <<"database">> => <<"0">>,
                 <<"servers">> => <<"redis-sentinel:26379">>,
                 <<"sentinel">> => <<"mytcpmaster">>,
+                <<"sentinel_username">> => <<"test_user">>,
+                <<"sentinel_password">> => <<"test_passwd">>,
                 <<"redis_type">> => <<"sentinel">>
             }
     };
@@ -345,15 +347,7 @@ t_on_get_status_no_username_pass(Config0) when is_list(Config0) ->
                 single ->
                     ?assertMatch([_ | _], ?of_kind(emqx_redis_auth_required_error, Trace));
                 sentinel ->
-                    ?assertEqual([], ?of_kind(emqx_redis_auth_required_error, Trace)),
-                    SentinelDiscoveryErrors = [
-                        Event
-                     || #{error := Error} = Event <- ?of_kind(resource_activate_alarm, Trace),
-                        is_binary(Error),
-                        binary:match(Error, <<"start_pool_failed">>) =/= nomatch,
-                        binary:match(Error, <<"sentinel_unreachable">>) =/= nomatch
-                    ],
-                    ?assertMatch([_ | _], SentinelDiscoveryErrors);
+                    ?assertMatch([_ | _], ?of_kind(emqx_redis_auth_required_error, Trace));
                 cluster ->
                     ok
             end

--- a/apps/emqx_redis/mix.exs
+++ b/apps/emqx_redis/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXRedis.MixProject do
     [
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
-      {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.8.11"}
+      {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.8.12"}
     ]
   end
 end

--- a/apps/emqx_redis/rebar.config
+++ b/apps/emqx_redis/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     %% NOTE: mind ecpool version when updating eredis_cluster version
-    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.8.11"}}},
+    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.8.12"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.

--- a/apps/emqx_redis/src/emqx_redis.app.src
+++ b/apps/emqx_redis/src/emqx_redis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_redis, [
     {description, "EMQX Redis Database Connector"},
-    {vsn, "0.1.9"},
+    {vsn, "0.1.10"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_redis/src/emqx_redis.erl
+++ b/apps/emqx_redis/src/emqx_redis.erl
@@ -78,7 +78,10 @@ fields(redis_sentinel_connector) ->
             type => string(),
             required => true,
             desc => ?DESC("sentinel_desc")
-        }}
+        }},
+        {sentinel_username, fun sentinel_username/1},
+        {sentinel_password,
+            emqx_connector_schema_lib:password_field(#{desc => ?DESC("sentinel_password")})}
     ] ++ redis_fields().
 
 server() ->
@@ -129,7 +132,7 @@ on_start(InstId, Config0) ->
             {options, Options},
             {pool_size, PoolSize},
             {auto_reconnect, ?AUTO_RECONNECT_INTERVAL}
-        ] ++ database(Config),
+        ] ++ sentinel_auth(Config) ++ database(Config),
 
     State = #{pool_name => InstId, type => Type},
     ok = emqx_resource:allocate_resource(InstId, ?MODULE, type, Type),
@@ -343,3 +346,16 @@ redis_fields() ->
         }},
         {auto_reconnect, fun emqx_connector_schema_lib:auto_reconnect/1}
     ].
+
+sentinel_username(type) -> binary();
+sentinel_username(desc) -> ?DESC("sentinel_username");
+sentinel_username(required) -> false;
+sentinel_username(_) -> undefined.
+
+sentinel_auth(#{redis_type := sentinel} = Config) ->
+    [
+        {sentinel_username, maps:get(sentinel_username, Config, undefined)},
+        {sentinel_password, maps:get(sentinel_password, Config, "")}
+    ];
+sentinel_auth(_) ->
+    [].

--- a/apps/emqx_redis/test/emqx_redis_SUITE.erl
+++ b/apps/emqx_redis/test/emqx_redis_SUITE.erl
@@ -17,6 +17,10 @@
 -define(REDIS_SINGLE_PORT, 6379).
 -define(REDIS_SENTINEL_HOST, "redis-sentinel").
 -define(REDIS_SENTINEL_PORT, 26379).
+-define(REDIS_SENTINEL_S_NO_AUTH_M_AUTH_HOST, "redis-sentinel-noauth-master-auth").
+-define(REDIS_SENTINEL_S_AUTH_M_AUTH_HOST, "redis-sentinel-auth-master-auth").
+-define(REDIS_SENTINEL_S_NO_AUTH_M_NO_AUTH_HOST, "redis-sentinel-noauth-master-noauth").
+-define(REDIS_SENTINEL_S_AUTH_M_NO_AUTH_HOST, "redis-sentinel-auth-master-noauth").
 -define(REDIS_CLUSTER_HOST, "redis-cluster-1").
 -define(REDIS_CLUSTER_PORT, 6379).
 -define(REDIS_RESOURCE_MOD, emqx_redis).
@@ -62,7 +66,11 @@ wait_for_redis(Checks) ->
         emqx_common_test_helpers:is_all_tcp_servers_available(
             [
                 {?REDIS_SINGLE_HOST, ?REDIS_SINGLE_PORT},
-                {?REDIS_SENTINEL_HOST, ?REDIS_SENTINEL_PORT}
+                {?REDIS_SENTINEL_HOST, ?REDIS_SENTINEL_PORT},
+                {?REDIS_SENTINEL_S_NO_AUTH_M_AUTH_HOST, ?REDIS_SENTINEL_PORT},
+                {?REDIS_SENTINEL_S_AUTH_M_AUTH_HOST, ?REDIS_SENTINEL_PORT},
+                {?REDIS_SENTINEL_S_NO_AUTH_M_NO_AUTH_HOST, ?REDIS_SENTINEL_PORT},
+                {?REDIS_SENTINEL_S_AUTH_M_NO_AUTH_HOST, ?REDIS_SENTINEL_PORT}
             ]
         )
     of
@@ -112,6 +120,38 @@ t_sentinel_password_auth(_Config) ->
     ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
     ?assertEqual({ok, <<"PONG">>}, emqx_resource:query(ResourceId, {cmd, [<<"PING">>]})),
     ?assertEqual(ok, emqx_resource:remove_local(ResourceId)).
+
+t_sentinel_auth_master_noauth_sentinel_noauth(_Config) ->
+    run_sentinel_auth_matrix_case(#{
+        name => master_noauth_sentinel_noauth,
+        host => ?REDIS_SENTINEL_S_NO_AUTH_M_NO_AUTH_HOST,
+        redis_auth => none,
+        sentinel_auth => none
+    }).
+
+t_sentinel_auth_master_auth_sentinel_noauth(_Config) ->
+    run_sentinel_auth_matrix_case(#{
+        name => master_auth_sentinel_noauth,
+        host => ?REDIS_SENTINEL_S_NO_AUTH_M_AUTH_HOST,
+        redis_auth => password,
+        sentinel_auth => none
+    }).
+
+t_sentinel_auth_master_noauth_sentinel_auth(_Config) ->
+    run_sentinel_auth_matrix_case(#{
+        name => master_noauth_sentinel_auth,
+        host => ?REDIS_SENTINEL_S_AUTH_M_NO_AUTH_HOST,
+        redis_auth => none,
+        sentinel_auth => password
+    }).
+
+t_sentinel_auth_master_auth_sentinel_auth(_Config) ->
+    run_sentinel_auth_matrix_case(#{
+        name => master_auth_sentinel_auth,
+        host => ?REDIS_SENTINEL_S_AUTH_M_AUTH_HOST,
+        redis_auth => password,
+        sentinel_auth => password
+    }).
 
 perform_lifecycle_check(ResourceId, InitialConfig, RedisCommand) ->
     {ok, #{config := CheckedConfig}} =
@@ -214,6 +254,76 @@ redis_config_cluster() ->
 redis_config_sentinel() ->
     redis_config_base("sentinel", "servers").
 
+redis_config_sentinel_auth_matrix(Host, RedisAuth, SentinelAuth) ->
+    RawConfig = list_to_binary(
+        io_lib:format(
+            "" ++
+                "\n" ++
+                "    auto_reconnect = true\n" ++
+                "    pool_size = 1\n" ++
+                "    redis_type = sentinel\n" ++
+                "    sentinel = mymaster\n" ++
+                "    database = 0\n" ++
+                "    servers = \"~s:~b\"\n" ++
+                "~s" ++
+                "~s",
+            [
+                Host,
+                ?REDIS_SENTINEL_PORT,
+                redis_auth_config(RedisAuth),
+                sentinel_auth_config(SentinelAuth)
+            ]
+        )
+    ),
+    {ok, Config} = hocon:binary(RawConfig),
+    #{<<"config">> => Config}.
+
+redis_auth_config(none) ->
+    "";
+redis_auth_config(password) ->
+    "" ++
+        "    username = \"redis_user\"\n" ++
+        "    password = \"redis-password\"\n".
+
+sentinel_auth_config(none) ->
+    "";
+sentinel_auth_config(password) ->
+    "" ++
+        "    sentinel_username = \"sentinel_user\"\n" ++
+        "    sentinel_password = \"sentinel-password\"\n".
+
+run_sentinel_auth_matrix_case(#{
+    name := Name,
+    host := Host,
+    redis_auth := RedisAuth,
+    sentinel_auth := SentinelAuth
+}) ->
+    ResourceId = iolist_to_binary(["emqx_redis_SUITE_", atom_to_binary(Name)]),
+    Config = redis_config_sentinel_auth_matrix(Host, RedisAuth, SentinelAuth),
+    {ok, #{config := CheckedConfig}} = emqx_resource:check_config(?REDIS_RESOURCE_MOD, Config),
+    try
+        {ok, #{status := connected}} = emqx_resource:create_local(
+            ResourceId,
+            ?CONNECTOR_RESOURCE_GROUP,
+            ?REDIS_RESOURCE_MOD,
+            CheckedConfig,
+            #{spawn_buffer_workers => true}
+        ),
+        Key = atom_to_binary(Name),
+        Value = <<"ok">>,
+        ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+        ?assertEqual(
+            {ok, <<"OK">>},
+            emqx_resource:query(ResourceId, {cmd, [<<"SET">>, Key, Value]})
+        ),
+        ?assertEqual(
+            {ok, Value},
+            emqx_resource:query(ResourceId, {cmd, [<<"GET">>, Key]})
+        )
+    after
+        catch emqx_resource:remove_local(ResourceId)
+    end.
+
 -define(REDIS_CONFIG_BASE(MaybeSentinel, MaybeDatabase),
     "" ++
         "\n" ++
@@ -234,7 +344,10 @@ redis_config_base(Type, ServerKey) ->
         "sentinel" ->
             Host = ?REDIS_SENTINEL_HOST,
             Port = ?REDIS_SENTINEL_PORT,
-            MaybeSentinel = "    sentinel = mytcpmaster\n",
+            MaybeSentinel =
+                "    sentinel = mytcpmaster\n" ++
+                    "    sentinel_username = test_user\n" ++
+                    "    sentinel_password = test_passwd\n",
             MaybeDatabase = "    database = 1\n";
         "single" ->
             Host = ?REDIS_SINGLE_HOST,

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -56,6 +56,9 @@ is_sensitive_key(<<"secret_key">>) -> true;
 is_sensitive_key(security_token) -> true;
 is_sensitive_key("security_token") -> true;
 is_sensitive_key(<<"security_token">>) -> true;
+is_sensitive_key(sentinel_password) -> true;
+is_sensitive_key("sentinel_password") -> true;
+is_sensitive_key(<<"sentinel_password">>) -> true;
 is_sensitive_key(sp_private_key) -> true;
 is_sensitive_key(<<"sp_private_key">>) -> true;
 is_sensitive_key(private_key_password) -> true;
@@ -290,6 +293,7 @@ redact_test_() ->
         secret_key,
         secret_access_key,
         security_token,
+        sentinel_password,
         token,
         bind_password
     ],

--- a/apps/emqx_utils/test/emqx_utils_redact_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_redact_tests.erl
@@ -75,6 +75,12 @@ redact_wrapped_secret_test() ->
         })
     ).
 
+redact_sentinel_password_test() ->
+    ?assertEqual(
+        #{sentinel_password => <<"******">>},
+        redact(#{sentinel_password => <<"sentinel-password">>})
+    ).
+
 deobfuscate_file_path_secrets_test_() ->
     Original1 = #{foo => #{bar => #{headers => #{"authorization" => "file://a"}}}},
     Original2 = #{foo => #{bar => #{headers => #{"authorization" => "a"}}}},

--- a/changes/ee/fix-17248.en.md
+++ b/changes/ee/fix-17248.en.md
@@ -1,1 +1,0 @@
-Fixed Redis Sentinel connections failing when Sentinel itself requires password authentication.

--- a/changes/ee/fix-17256.en.md
+++ b/changes/ee/fix-17256.en.md
@@ -1,0 +1,1 @@
+Fixed Redis Sentinel connectors to support separate authentication settings for Redis data nodes and Sentinel nodes.

--- a/rel/i18n/emqx_redis.hocon
+++ b/rel/i18n/emqx_redis.hocon
@@ -24,6 +24,18 @@ sentinel_desc.desc:
 sentinel_desc.label:
 """Cluster Name"""
 
+sentinel_password.desc:
+"""Password used to authenticate with Redis Sentinel. Leave it unset when Sentinel does not require authentication."""
+
+sentinel_password.label:
+"""Sentinel Password"""
+
+sentinel_username.desc:
+"""Username used to authenticate with Redis Sentinel. Leave it unset when Sentinel does not require ACL username authentication."""
+
+sentinel_username.label:
+"""Sentinel Username"""
+
 server.desc:
 """The IPv4 or IPv6 address or the hostname to connect to.<br/>
 A host entry has the following form: `Host[:Port]`.<br/>


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15277

Release version: 5.10

## Summary

This PR updates `eredis_cluster` to `0.8.12` and adds separate Redis Sentinel authentication settings for Redis connectors.

Redis data nodes and Redis Sentinel nodes can use independent authentication. The previous release-510 change reused Redis data-node credentials for Sentinel discovery, which only worked when both sides shared the same credentials and could fail when Redis required a password but Sentinel did not, or when Sentinel used a different password.

The connector schema now exposes `sentinel_username` and `sentinel_password` for Sentinel mode. `emqx_redis` passes those settings to the driver separately from the Redis data-node `username` and `password`, without fallback between the two credential sets. This preserves all four deployment combinations: neither side authenticated, only Redis authenticated, only Sentinel authenticated, and both authenticated with independent credentials.

The Redis integration fixtures were extended to cover all four Redis/Sentinel authentication combinations with real Sentinel discovery and Redis `SET`/`GET` operations. `sentinel_password` is also treated as a sensitive field for redaction.

This PR also removes the obsolete `changes/ee/fix-17248.en.md` changelog entry from the earlier incorrect PR, leaving only `changes/ee/fix-17256.en.md` for the final user-visible fix.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)