### PR TITLE
fix(mqttsn): handle duplicate CONNECT without crashing the connection process

### DIFF
--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -524,7 +524,8 @@ handle_in(
     ?SN_CONNECT_MSG(_Flags, _ProtoId, _Duration, _ClientId),
     Channel = #channel{conn_state = connected}
 ) ->
-    {error, unexpected_connect, Channel};
+    ?SLOG(warning, #{msg => "receive_connect_packet_in_connected_state"}),
+    handle_out(disconnect, ?SN_RC_NOT_SUPPORTED, Channel);
 handle_in(
     ?SN_WILLTOPIC_EMPTY_MSG,
     Channel = #channel{conn_state = connecting}

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -212,6 +212,22 @@ t_connect(_) ->
     ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
     gen_udp:close(Socket).
 
+-doc """
+A connected MQTT-SN client sending a second CONNECT from the same UDP source
+port must be rejected with a DISCONNECT, not crash the connection process.
+Regression test for the case_clause in emqx_gateway_conn:with_channel/3 when
+emqx_mqttsn_channel returned {error, unexpected_connect, _}.
+""".
+t_duplicate_connect(_) ->
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    send_connect_msg(Socket, <<"client_id_dup_connect">>),
+    ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+
+    %% second CONNECT from the same source port must not crash the gateway
+    send_connect_msg(Socket, <<"client_id_dup_connect">>),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+    gen_udp:close(Socket).
+
 t_update_not_restart_listener(_) ->
     {ok, Socket} = gen_udp:open(0, [binary]),
     ClientId = ?CLIENTID,

--- a/changes/ee/fix-17258.en.md
+++ b/changes/ee/fix-17258.en.md
@@ -1,0 +1,4 @@
+Fixed an issue in the MQTT-SN gateway where a connected client sending a
+second CONNECT packet on the same session would crash its connection
+process. The gateway now responds with a DISCONNECT and closes the session
+gracefully.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

A second CONNECT received on an already-connected MQTT-SN session caused
the connection process to exit with a `case_clause`. The channel returned
`{error, unexpected_connect, Channel}` from
`emqx_mqttsn_channel:handle_in/2` (`conn_state = connected`), but
`emqx_gateway_conn:with_channel/3` has no matching clause for that shape,
so the process crashed and the client's session was lost.

This change makes the channel react like the regular MQTT channel: log a
warning and call `handle_out(disconnect, ?SN_RC_NOT_SUPPORTED, Channel)`,
which sends an `SN_DISCONNECT` and shuts the session down via the normal
`{close, Reason}` path.

Scope is intentionally narrow:
* `apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl` — replace the
  unhandled `{error, ...}` return with `handle_out(disconnect, ...)`.
* `apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl` — new
  `t_duplicate_connect` regression test: two CONNECTs on one UDP socket,
  expect `SN_DISCONNECT` and no crash.

Note: per-peer UDP processes are tracked by `esockd_udp` (linked, not
supervised with a restart spec), so this crash does not contribute to any
OTP restart-intensity budget — but it still kills the targeted client's
session and produces noisy crash logs, which is the behaviour the fix
addresses. `emqx_stomp_channel.erl:430` has the same `{error, unexpected_connect, _}`
shape; left for a separate change.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)