### PR TITLE
feat(conf): default node.max_ports to auto

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -79,10 +79,12 @@
 -define(MAX_PORTS_PER_CORE, 64000).
 -define(MAX_PORTS_CORES_CLAMP, 8).
 
-%% Process table is sized as round(?PROCESS_LIMIT_RATIO * +Q). 1.2 leaves some
-%% headroom for non-port-owning processes (supervisors, gen_servers) without
-%% inflating the table to 2x like the historical default did.
--define(PROCESS_LIMIT_RATIO, 1.2).
+%% Process table is sized as ?PROCESS_LIMIT_RATIO * +Q.
+%% 2x is the historical default and is required for TLS/QUIC: each TLS
+%% connection owns 2 Erlang processes (the connection process plus the SSL
+%% handshake/record process), so the process table must scale at 2x the port
+%% table to avoid hitting +P before +Q under a full TLS load.
+-define(PROCESS_LIMIT_RATIO, 2).
 
 %% Don't forget to update `emqx_log_throttler:new_throttler/1` when adding a message that
 %% is throttled on a per-resource basis.
@@ -1311,7 +1313,7 @@ tr_vm_args_max_ports(Conf) ->
 %% would silently cap the process table below what max_ports already promises.
 tr_vm_args_process_limit(Conf) ->
     MaxPorts = resolve_max_ports(conf_get("node.max_ports", Conf, auto)),
-    Derived = round(?PROCESS_LIMIT_RATIO * MaxPorts),
+    Derived = ?PROCESS_LIMIT_RATIO * MaxPorts,
     case conf_get("node.process_limit", Conf, undefined) of
         N when is_integer(N), N > Derived -> N;
         _ -> Derived

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -76,7 +76,11 @@
 %% `node.max_ports = auto' scales linearly with logical_processors_available
 %% up to MAX_PORTS_CORES_CLAMP cores. Above the clamp we fall back to
 %% ?DEFAULT_MAX_PORTS so a large host doesn't end up with an unbounded table.
--define(MAX_PORTS_PER_CORE, 64000).
+%% 65536 == 2^16 -- the VM rounds +Q up to the next power of two anyway, so
+%% using a power-of-two multiplier keeps the configured and effective limits
+%% in sync (no surprise gap between `node.max_ports' and what shows up at
+%% runtime in `erlang:system_info(port_limit)').
+-define(MAX_PORTS_PER_CORE, 65536).
 -define(MAX_PORTS_CORES_CLAMP, 8).
 
 %% Process table is sized as ?PROCESS_LIMIT_RATIO * +Q.

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -76,7 +76,7 @@
 %% `node.max_ports = auto' scales linearly with logical_processors_available
 %% up to MAX_PORTS_CORES_CLAMP cores. Above the clamp we fall back to
 %% ?DEFAULT_MAX_PORTS so a large host doesn't end up with an unbounded table.
--define(MAX_PORTS_PER_CORE, 65536).
+-define(MAX_PORTS_PER_CORE, 6400).
 -define(MAX_PORTS_CORES_CLAMP, 8).
 
 %% Process table is sized as round(?PROCESS_LIMIT_RATIO * +Q). 1.2 leaves some

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -514,6 +514,20 @@ fields("node") ->
                     'readOnly' => true
                 }
             )},
+        {"schedulers",
+            sc(
+                hoconsc:union([auto, pos_integer()]),
+                #{
+                    %% `mapping' is intentionally omitted: the translation
+                    %% `tr_vm_args_schedulers/1' below resolves `auto' to the
+                    %% number of logical processors available and emits the
+                    %% final `N:N' string into `vm_args.+S'.
+                    desc => ?DESC(schedulers),
+                    default => auto,
+                    importance => ?IMPORTANCE_LOW,
+                    'readOnly' => true
+                }
+            )},
         {"dist_buffer_size",
             sc(
                 range(1, 2097151),
@@ -1313,13 +1327,18 @@ translation("vm_args") ->
 %% `logical_processors_available' reflects sched_getaffinity (and therefore
 %% the cgroup) on Linux; falls back to the static `logical_processors' count
 %% on platforms where the runtime can't determine availability.
-tr_vm_args_schedulers(_Conf) ->
-    N =
-        case erlang:system_info(logical_processors_available) of
-            X when is_integer(X), X >= 1 -> X;
-            _ -> erlang:system_info(logical_processors)
-        end,
+%% A user-specified `node.schedulers' overrides the auto-detected value.
+tr_vm_args_schedulers(Conf) ->
+    N = resolve_schedulers(conf_get("node.schedulers", Conf, auto)),
     integer_to_list(N) ++ ":" ++ integer_to_list(N).
+
+resolve_schedulers(auto) ->
+    case erlang:system_info(logical_processors_available) of
+        X when is_integer(X), X >= 1 -> X;
+        _ -> erlang:system_info(logical_processors)
+    end;
+resolve_schedulers(N) when is_integer(N), N >= 1 ->
+    N.
 
 tr_vm_args_max_ports(Conf) ->
     resolve_max_ports(conf_get("node.max_ports", Conf, auto)).

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -76,7 +76,7 @@
 %% `node.max_ports = auto' scales linearly with logical_processors_available
 %% up to MAX_PORTS_CORES_CLAMP cores. Above the clamp we fall back to
 %% ?DEFAULT_MAX_PORTS so a large host doesn't end up with an unbounded table.
--define(MAX_PORTS_PER_CORE, 6400).
+-define(MAX_PORTS_PER_CORE, 64000).
 -define(MAX_PORTS_CORES_CLAMP, 8).
 
 %% Process table is sized as round(?PROCESS_LIMIT_RATIO * +Q). 1.2 leaves some

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -1300,9 +1300,26 @@ translation("vm_args") ->
     [
         {"+Q", fun tr_vm_args_max_ports/1},
         {"+P", fun tr_vm_args_process_limit/1},
+        {"+S", fun tr_vm_args_schedulers/1},
         {"-kernel inet_dist_use_interface", fun tr_vm_args_dist_bind_address/1},
         {"-kernel inet_dist_connect_options", fun tr_kernel_inet_dist_connect_options/1}
     ].
+
+%% Cap +S at the number of logical processors actually available to the VM.
+%% BEAM's default is one scheduler per host CPU regardless of cgroup CPU set,
+%% so a 20-core host running emqx in a `--cpuset-cpus=0-7' container would
+%% otherwise spawn 20 scheduler OS threads where only 8 can run in parallel,
+%% wasting ~MB-per-scheduler of stack/heap overhead with no throughput gain.
+%% `logical_processors_available' reflects sched_getaffinity (and therefore
+%% the cgroup) on Linux; falls back to the static `logical_processors' count
+%% on platforms where the runtime can't determine availability.
+tr_vm_args_schedulers(_Conf) ->
+    N =
+        case erlang:system_info(logical_processors_available) of
+            X when is_integer(X), X >= 1 -> X;
+            _ -> erlang:system_info(logical_processors)
+        end,
+    integer_to_list(N) ++ ":" ++ integer_to_list(N).
 
 tr_vm_args_max_ports(Conf) ->
     resolve_max_ports(conf_get("node.max_ports", Conf, auto)).

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -68,8 +68,21 @@
     emqx_mgmt_api_key_schema
 ]).
 
-%% 1 million default ports counter
+%% Fallback used when `node.max_ports' is `auto' and the host has more than
+%% MAX_PORTS_CORES_CLAMP logical processors available (or the runtime cannot
+%% report a CPU count). Matches the historical fixed default of 1 million.
 -define(DEFAULT_MAX_PORTS, 1024 * 1024).
+
+%% `node.max_ports = auto' scales linearly with logical_processors_available
+%% up to MAX_PORTS_CORES_CLAMP cores. Above the clamp we fall back to
+%% ?DEFAULT_MAX_PORTS so a large host doesn't end up with an unbounded table.
+-define(MAX_PORTS_PER_CORE, 65536).
+-define(MAX_PORTS_CORES_CLAMP, 8).
+
+%% Process table is sized as round(?PROCESS_LIMIT_RATIO * +Q). 1.2 leaves some
+%% headroom for non-port-owning processes (supervisors, gen_servers) without
+%% inflating the table to 2x like the historical default did.
+-define(PROCESS_LIMIT_RATIO, 1.2).
 
 %% Don't forget to update `emqx_log_throttler:new_throttler/1` when adding a message that
 %% is throttled on a per-resource basis.
@@ -479,22 +492,22 @@ fields("node") ->
             sc(
                 range(1024, 134217727),
                 #{
-                    %% deprecated make sure it's disappeared in raw_conf user(HTTP API)
-                    %% but still in vm.args via translation/1
-                    %% ProcessLimit is always equal to MaxPort * 2 when translation/1.
-                    deprecated => {since, "5.1"},
                     desc => ?DESC(process_limit),
+                    %% Hidden so to infer from max_ports
                     importance => ?IMPORTANCE_HIDDEN,
                     'readOnly' => true
                 }
             )},
         {"max_ports",
             sc(
-                range(1024, 134217727),
+                hoconsc:union([auto, range(1024, 134217727)]),
                 #{
-                    mapping => "vm_args.+Q",
+                    %% `mapping' is intentionally omitted: the translation
+                    %% `tr_vm_args_max_ports/1' below resolves `auto' to the
+                    %% per-core value and emits the final integer into
+                    %% `vm_args.+Q'.
                     desc => ?DESC(max_ports),
-                    default => ?DEFAULT_MAX_PORTS,
+                    default => auto,
                     importance => ?IMPORTANCE_HIGH,
                     'readOnly' => true
                 }
@@ -1283,13 +1296,40 @@ translation("prometheus") ->
     ];
 translation("vm_args") ->
     [
+        {"+Q", fun tr_vm_args_max_ports/1},
         {"+P", fun tr_vm_args_process_limit/1},
         {"-kernel inet_dist_use_interface", fun tr_vm_args_dist_bind_address/1},
         {"-kernel inet_dist_connect_options", fun tr_kernel_inet_dist_connect_options/1}
     ].
 
+tr_vm_args_max_ports(Conf) ->
+    resolve_max_ports(conf_get("node.max_ports", Conf, auto)).
+
+%% `+P' is normally derived from `+Q' (max_ports) so users don't have to
+%% think about it. The hidden `node.process_limit' override is honored only
+%% when it's strictly larger than the derived value -- a smaller user value
+%% would silently cap the process table below what max_ports already promises.
 tr_vm_args_process_limit(Conf) ->
-    2 * conf_get("node.max_ports", Conf, ?DEFAULT_MAX_PORTS).
+    MaxPorts = resolve_max_ports(conf_get("node.max_ports", Conf, auto)),
+    Derived = round(?PROCESS_LIMIT_RATIO * MaxPorts),
+    case conf_get("node.process_limit", Conf, undefined) of
+        N when is_integer(N), N > Derived -> N;
+        _ -> Derived
+    end.
+
+%% Resolve `node.max_ports' to an integer suitable for `+Q'.
+%% `auto' -> per-core formula clamped at ?MAX_PORTS_CORES_CLAMP cores;
+%% above the clamp (or when the runtime cannot report a CPU count) we use
+%% ?DEFAULT_MAX_PORTS so very large hosts keep the historical default.
+resolve_max_ports(auto) ->
+    case erlang:system_info(logical_processors_available) of
+        Cores when is_integer(Cores), Cores >= 1, Cores =< ?MAX_PORTS_CORES_CLAMP ->
+            Cores * ?MAX_PORTS_PER_CORE;
+        _ ->
+            ?DEFAULT_MAX_PORTS
+    end;
+resolve_max_ports(N) when is_integer(N) ->
+    N.
 
 tr_vm_args_dist_bind_address(Conf) ->
     %% Try accessing via node first (like max_ports does)

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -35,7 +35,10 @@ array_nodes_test() ->
             ProcLimit = proplists:get_value('+P', VMArgs),
             MaxPort = proplists:get_value('+Q', VMArgs),
             ?assertEqual(2048, MaxPort),
-            ?assertEqual(MaxPort * 2, ProcLimit),
+            %% node.process_limit = 10240 in BASE_CONF overrides the derived
+            %% 2 * max_ports = 4096 because the override is honored only when
+            %% strictly larger than the derived value.
+            ?assertEqual(10240, ProcLimit),
 
             ClusterDiscovery = proplists:get_value(
                 cluster_discovery, proplists:get_value(ekka, ConfList)

--- a/changes/ee/breaking-17267.en.md
+++ b/changes/ee/breaking-17267.en.md
@@ -1,6 +1,6 @@
-The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM port limit (`+Q`) with the number of logical CPU cores: 64000 ports per core for up to 8 cores, and 1048576 (the historical fixed default) above that. Explicit integer values are still accepted.
+The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM port limit (`+Q`) with the number of logical CPU cores: 65536 ports per core for up to 8 cores, and 1048576 (the historical fixed default) above that. Explicit integer values are still accepted.
 
-This is a behavior change for nodes upgraded from earlier versions where `max_ports` defaulted to a fixed 1048576: hosts with 8 or fewer CPU cores will now boot with a smaller port table. Setups that rely on accepting more than `cores * 64000` connections must set `node.max_ports` explicitly (and restart the node) before upgrading.
+This is a behavior change for nodes upgraded from earlier versions where `max_ports` defaulted to a fixed 1048576: hosts with 8 or fewer CPU cores will now boot with a smaller port table. Setups that rely on accepting more than `cores * 65536` connections must set `node.max_ports` explicitly (and restart the node) before upgrading.
 
 The hidden `node.process_limit` setting is reinstated as an override: when set to a value larger than the derived limit (`2 * max_ports`), it is respected; smaller values are ignored so the process table never under-sizes the port table.
 

--- a/changes/ee/breaking-17267.en.md
+++ b/changes/ee/breaking-17267.en.md
@@ -3,3 +3,5 @@ The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM p
 This is a behavior change for nodes upgraded from earlier versions where `max_ports` defaulted to a fixed 1048576: hosts with 8 or fewer CPU cores will now boot with a smaller port table. Setups that rely on accepting more than `cores * 64000` connections must set `node.max_ports` explicitly (and restart the node) before upgrading.
 
 The hidden `node.process_limit` setting is reinstated as an override: when set to a value larger than the derived limit (`2 * max_ports`), it is respected; smaller values are ignored so the process table never under-sizes the port table.
+
+A new `node.schedulers` setting (default `auto`) controls the Erlang scheduler count (`+S`). With `auto`, the count is capped at the number of logical processors actually available to the VM (`sched_getaffinity` on Linux), so containers limited via `--cpuset-cpus` or Kubernetes CPU requests no longer spawn scheduler OS threads they cannot run in parallel. Set it to a positive integer to override the auto-detected value.

--- a/changes/ee/breaking-17267.en.md
+++ b/changes/ee/breaking-17267.en.md
@@ -1,0 +1,5 @@
+The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM port limit (`+Q`) with the number of logical CPU cores: 64000 ports per core for up to 8 cores, and 1048576 (the historical fixed default) above that. Explicit integer values are still accepted.
+
+This is a behavior change for nodes upgraded from earlier versions where `max_ports` defaulted to a fixed 1048576: hosts with 8 or fewer CPU cores will now boot with a smaller port table. Setups that rely on accepting more than `cores * 64000` connections must set `node.max_ports` explicitly (and restart the node) before upgrading.
+
+The hidden `node.process_limit` setting is reinstated as an override: when set to a value larger than the derived limit (`2 * max_ports`), it is respected; smaller values are ignored so the process table never under-sizes the port table.

--- a/changes/ee/feat-17267.en.md
+++ b/changes/ee/feat-17267.en.md
@@ -1,3 +1,0 @@
-The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM port limit (`+Q`) with the number of logical CPU cores: 64000 ports per core for up to 8 cores, and 1048576 (the historical fixed default) above that. Explicit integer values are still accepted.
-
-The Erlang process limit (`+P`) is now derived as `round(1.2 * max_ports)` instead of the previous `2 * max_ports`, reducing memory used by the process table on small deployments. The hidden `node.process_limit` setting is reinstated as an override: when set to a value larger than the derived limit, it is respected; smaller values are ignored so the process table never under-sizes the port table.

--- a/changes/ee/feat-17267.en.md
+++ b/changes/ee/feat-17267.en.md
@@ -1,3 +1,3 @@
-The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM port limit (`+Q`) with the number of logical CPU cores: 65536 ports per core for up to 8 cores, and 1048576 (the historical fixed default) above that. Explicit integer values are still accepted.
+The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM port limit (`+Q`) with the number of logical CPU cores: 6400 ports per core for up to 8 cores, and 1048576 (the historical fixed default) above that. Explicit integer values are still accepted.
 
 The Erlang process limit (`+P`) is now derived as `round(1.2 * max_ports)` instead of the previous `2 * max_ports`, reducing memory used by the process table on small deployments. The hidden `node.process_limit` setting is reinstated as an override: when set to a value larger than the derived limit, it is respected; smaller values are ignored so the process table never under-sizes the port table.

--- a/changes/ee/feat-17267.en.md
+++ b/changes/ee/feat-17267.en.md
@@ -1,3 +1,3 @@
-The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM port limit (`+Q`) with the number of logical CPU cores: 6400 ports per core for up to 8 cores, and 1048576 (the historical fixed default) above that. Explicit integer values are still accepted.
+The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM port limit (`+Q`) with the number of logical CPU cores: 64000 ports per core for up to 8 cores, and 1048576 (the historical fixed default) above that. Explicit integer values are still accepted.
 
 The Erlang process limit (`+P`) is now derived as `round(1.2 * max_ports)` instead of the previous `2 * max_ports`, reducing memory used by the process table on small deployments. The hidden `node.process_limit` setting is reinstated as an override: when set to a value larger than the derived limit, it is respected; smaller values are ignored so the process table never under-sizes the port table.

--- a/changes/ee/feat-17267.en.md
+++ b/changes/ee/feat-17267.en.md
@@ -1,0 +1,3 @@
+The `node.max_ports` config now defaults to `auto`, which scales the Erlang VM port limit (`+Q`) with the number of logical CPU cores: 65536 ports per core for up to 8 cores, and 1048576 (the historical fixed default) above that. Explicit integer values are still accepted.
+
+The Erlang process limit (`+P`) is now derived as `round(1.2 * max_ports)` instead of the previous `2 * max_ports`, reducing memory used by the process table on small deployments. The hidden `node.process_limit` setting is reinstated as an override: when set to a value larger than the derived limit, it is respected; smaller values are ignored so the process table never under-sizes the port table.

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -552,7 +552,7 @@ max_ports.desc: """~
   Specifies the maximum number of simultaneously open ports (files, sockets, etc.) allowed by this Erlang system.
 
   When set to `auto` (the default), EMQX scales the limit with the number of
-  logical CPUs available, using 64000 ports per core up to 8 cores. Hosts with
+  logical CPUs available, using 65536 ports per core up to 8 cores. Hosts with
   more than 8 cores fall back to a fixed limit of 1048576 ports.
 
   Note: The actual limit chosen by the runtime may be larger than the number configured here.

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -552,7 +552,7 @@ max_ports.desc: """~
   Specifies the maximum number of simultaneously open ports (files, sockets, etc.) allowed by this Erlang system.
 
   When set to `auto` (the default), EMQX scales the limit with the number of
-  logical CPUs available, using 65536 ports per core up to 8 cores. Hosts with
+  logical CPUs available, using 6400 ports per core up to 8 cores. Hosts with
   more than 8 cores fall back to a fixed limit of 1048576 ports.
 
   Note: The actual limit chosen by the runtime may be larger than the number configured here.

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -576,6 +576,22 @@ process_limit.desc: """~
 process_limit.label:
 """Erlang Process Limit"""
 
+schedulers.desc: """~
+  Translated to the `+S` flag of the Erlang VM, sets both the total and
+  online scheduler count.
+
+  When set to `auto` (the default), EMQX uses the number of logical
+  processors actually available to the VM (`sched_getaffinity` on Linux),
+  so a container limited via `--cpuset-cpus` or k8s CPU requests does not
+  spawn scheduler OS threads it cannot run in parallel.
+
+  Set this to a positive integer to override the auto-detected value.
+  Useful when you want to reserve CPU headroom for non-EMQX work on the
+  same host, or to cap schedulers below the available CPU count.~"""
+
+schedulers.label:
+"""Erlang Schedulers"""
+
 desc_log_rotation.desc:
 """By default, the logs are stored in `./log` directory (for installation from zip file) or in `/var/log/emqx` (for binary installation).<br/>
 This section of the configuration controls the number of files kept for each log handler."""

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -552,7 +552,7 @@ max_ports.desc: """~
   Specifies the maximum number of simultaneously open ports (files, sockets, etc.) allowed by this Erlang system.
 
   When set to `auto` (the default), EMQX scales the limit with the number of
-  logical CPUs available, using 6400 ports per core up to 8 cores. Hosts with
+  logical CPUs available, using 64000 ports per core up to 8 cores. Hosts with
   more than 8 cores fall back to a fixed limit of 1048576 ports.
 
   Note: The actual limit chosen by the runtime may be larger than the number configured here.

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -558,7 +558,7 @@ max_ports.desc: """~
   Note: The actual limit chosen by the runtime may be larger than the number configured here.
   In most cases, the VM rounds the value up to the next power of two for internal efficiency.
 
-  EMQX automatically sets the Erlang process limit (`+P` flag) to 1.2x this value, so users only need to configure `max_ports`.
+  EMQX automatically sets the Erlang process limit (`+P` flag) to 2x this value, so users only need to configure `max_ports`. The 2x ratio accommodates TLS/QUIC connections, which each use two Erlang processes.
   The corresponding `+P` flag controls the maximum number of Erlang processes.
 
   The effective values can be observed from the dashboard node monitoring tab.~"""
@@ -568,7 +568,7 @@ max_ports.label:
 
 process_limit.desc: """~
   Override for the Erlang `+P` (maximum number of processes) flag.
-  By default, EMQX derives this from `max_ports` (1.2x), which is appropriate
+  By default, EMQX derives this from `max_ports` (2x), which is appropriate
   for the great majority of workloads. This setting is honored only when it is
   strictly greater than the derived value; a smaller value is ignored so that
   the process table never under-sizes the port table.~"""

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -549,18 +549,32 @@ cluster_autoclean.label:
 
 max_ports.desc: """~
   Translated to the `+Q` flag of the Erlang VM.
-  Specifies the maximum number of simultaneously open ports (files, sockets, etc.) allowed by this Erlang system.  
+  Specifies the maximum number of simultaneously open ports (files, sockets, etc.) allowed by this Erlang system.
+
+  When set to `auto` (the default), EMQX scales the limit with the number of
+  logical CPUs available, using 65536 ports per core up to 8 cores. Hosts with
+  more than 8 cores fall back to a fixed limit of 1048576 ports.
 
   Note: The actual limit chosen by the runtime may be larger than the number configured here.
   In most cases, the VM rounds the value up to the next power of two for internal efficiency.
 
-  EMQX automatically sets the Erlang process limit (`+P` flag) to twice this value, so users only need to configure `max_ports`.
+  EMQX automatically sets the Erlang process limit (`+P` flag) to 1.2x this value, so users only need to configure `max_ports`.
   The corresponding `+P` flag controls the maximum number of Erlang processes.
 
   The effective values can be observed from the dashboard node monitoring tab.~"""
 
 max_ports.label:
 """Erlang Port and Process Limit"""
+
+process_limit.desc: """~
+  Override for the Erlang `+P` (maximum number of processes) flag.
+  By default, EMQX derives this from `max_ports` (1.2x), which is appropriate
+  for the great majority of workloads. This setting is honored only when it is
+  strictly greater than the derived value; a smaller value is ignored so that
+  the process table never under-sizes the port table.~"""
+
+process_limit.label:
+"""Erlang Process Limit"""
 
 desc_log_rotation.desc:
 """By default, the logs are stored in `./log` directory (for installation from zip file) or in `/var/log/emqx` (for binary installation).<br/>


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 6.3.0

## Summary

- `node.max_ports` schema changed from a fixed integer to `union(auto, range(1024, 134217727))`, with default `auto`.
- `auto` resolves to `cores * 65536` for hosts with up to 8 logical CPUs (via `tr_vm_args_max_ports/1`), falling back to the historical `1048576` for larger hosts. 65536 is 2^16, the next power of two the VM would round up to anyway, so the configured and effective `+Q` match.
- `+P` (Erlang process limit) is derived as `2 * max_ports` to leave headroom for TLS/QUIC workloads where one connection can spawn multiple processes.
- The hidden `node.process_limit` setting is no longer deprecated; it is reinstated as an override that wins only when strictly larger than the derived value (smaller user values are ignored to keep the process table from under-sizing the port table).
- New `node.schedulers` setting (default `auto`) caps `+S` at `logical_processors_available`, so a container limited via `--cpuset-cpus` or k8s CPU requests doesn't spawn scheduler OS threads it can't run in parallel. A user-specified positive integer overrides the auto-detected value.

Most files touched:
- `apps/emqx_conf/src/emqx_conf_schema.erl` — schema + translation
- `rel/i18n/emqx_conf_schema.hocon` — `max_ports`/`process_limit`/`schedulers` descriptions

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)