### PR TITLE
fix(rule engine): correct return type when there are no rules

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -1663,7 +1663,7 @@ get_namespace_from_message(#message{}) ->
 get_rules_for_topic(Message = #message{topic = Topic}) ->
     case emqx_rule_engine:get_rules_for_topic(Topic) of
         [] ->
-            ok;
+            [];
         EnrichedRules0 ->
             LimitSelectsInNamespace = emqx_rule_engine_config:get_limit_selects_in_namespace(),
             case LimitSelectsInNamespace of


### PR DESCRIPTION
Bug introduced by https://github.com/emqx/emqx/pull/17157 , unreleased

Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
