### PR TITLE
build(docker): harden runtime image and ship static curl

### DIFF
--- a/changes/ee/fix-17276.en.md
+++ b/changes/ee/fix-17276.en.md
@@ -1,0 +1,12 @@
+Hardened the official EMQX docker image to clear image-scanner findings:
+
+- Applied Debian security upgrades during the runtime image build, so the
+  image picks up the latest patched `libssl3t64`.
+- Removed the unused `libgnutls30t64` package. EMQX talks TLS via OpenSSL
+  through Erlang/OTP and never links GnuTLS, so it was only present as a
+  transitive dependency of `curl` and showed up in scanner reports.
+- Replaced the Debian `curl` package — which would have transitively
+  re-introduced `libgnutls30t64` via `librtmp1` — with a statically-linked
+  `curl` binary from <https://github.com/stunnel/static-curl> (OpenSSL,
+  HTTP/2, HTTP/3; no RTMP, no GnuTLS). Container healthchecks that call
+  `curl` continue to work unchanged.

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -2,6 +2,30 @@ ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.6-2:1.15.7-26.2.5.14-1-debian13
 ARG RUN_FROM=debian:13-slim
 ARG SOURCE_TYPE=src # tgz
 
+# Fetch a self-contained `curl` binary from stunnel/static-curl. Debian's stock
+# curl drags libgnutls30t64 in via librtmp1 (libcurl4t64 -> librtmp1 -> gnutls),
+# which is what makes scanners flag the four GnuTLS CVEs even though EMQX
+# itself never links GnuTLS. The static binary is built with OpenSSL and no
+# RTMP, so we get `curl` back without re-introducing GnuTLS. This stage is
+# discarded after the COPY in the runtime stage; only the verified binary
+# ships in the final image. Based on BUILD_FROM (the emqx-builder image)
+# because it already ships curl + xz + tar; no apt-install needed.
+FROM ${BUILD_FROM} AS curl_static
+ARG TARGETARCH
+ARG CURL_STATIC_VERSION=8.20.0
+RUN set -eu; \
+    case "${TARGETARCH}" in \
+        amd64) curl_arch=x86_64; curl_sha=3cf20eb1bca2726d74a39fcda2b758a08a23a3dce73ad6f3f468d7e4d49d215b ;; \
+        arm64) curl_arch=aarch64; curl_sha=061b624119f128038bdfa96f975980d6c35ed502130c4825d59b3143efeafa0e ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH} for stunnel/static-curl" >&2; exit 1 ;; \
+    esac; \
+    f="curl-linux-${curl_arch}-glibc-${CURL_STATIC_VERSION}.tar.xz"; \
+    curl -fsSL -o "/tmp/${f}" "https://github.com/stunnel/static-curl/releases/download/${CURL_STATIC_VERSION}/${f}"; \
+    echo "${curl_sha}  /tmp/${f}" | sha256sum -c -; \
+    tar -xJf "/tmp/${f}" -C /tmp curl; \
+    install -m 0755 /tmp/curl /usr/local/bin/curl; \
+    /usr/local/bin/curl --version
+
 FROM ${BUILD_FROM} AS builder_src
 ONBUILD COPY . /emqx
 
@@ -47,10 +71,18 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
 COPY deploy/docker/docker-entrypoint.sh /usr/bin/
+COPY --from=curl_static /usr/local/bin/curl /usr/bin/curl
 
 RUN set -eu; \
+    export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
-    apt-get install -y --no-install-recommends ca-certificates procps curl $(echo "${EXTRA_DEPS}" | tr ',' ' '); \
+    apt-get upgrade -y; \
+    apt-get install -y --no-install-recommends ca-certificates procps $(echo "${EXTRA_DEPS}" | tr ',' ' '); \
+    if dpkg-query -s libgnutls30t64 >/dev/null 2>&1; then \
+        apt-get remove --purge -y libgnutls30t64; \
+        apt-get autoremove --purge -y; \
+    fi; \
+    apt-get clean; \
     rm -rf /var/lib/apt/lists/*; \
     groupadd -r -g 1000 emqx; \
     useradd -r -m -u 1000 -g emqx emqx;


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 5.8.10

## Summary

Port of #17271 to release-58. Hardens the runtime stage of the official EMQX docker image so it passes customer image-scanner checks:

- `apt-get upgrade` is run in the runtime stage so the image picks up the latest Debian security patches.
- `libgnutls30t64` is purged. EMQX talks TLS via OpenSSL through Erlang/OTP and never links GnuTLS, so it was only present as a transitive dependency of `curl` and showed up as a scanner finding. The removal is guarded with `dpkg-query` so a future base image that doesn't ship the package will not break the build.
- `curl` is replaced by a pinned, SHA256-verified statically-linked binary from [stunnel/static-curl](https://github.com/stunnel/static-curl) 8.20.0 (OpenSSL build, HTTP/2 + HTTP/3, no librtmp, no GnuTLS). The fetch happens in a discardable `curl_static` build stage based on `BUILD_FROM` because the emqx-builder image already ships `curl`, `xz` and `tar`; only the verified binary is copied into the runtime image. Container healthchecks that call `curl` continue to work unchanged.

Relevant file: `deploy/docker/Dockerfile`.

Verified locally by building `emqx-enterprise:5.8.10-ge1e5f53c` for amd64, booting it, running `debsecan --suite trixie` against installed packages, and confirming `curl http://localhost:18083/api/v5/status` returns HTTP 200 from inside the container.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)