### PR TITLE
refactor(relup): rename relup mark file to `current`

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -209,8 +209,8 @@ RELUP_DIR="relup"
 BASE_RUNNER_ROOT_DIR="${BASE_RUNNER_ROOT_DIR:-$RUNNER_ROOT_DIR}"
 RELUP_PATH="$RUNNER_ROOT_DIR/$RELUP_DIR"
 
-if [ -f "$RELUP_PATH/version" ]; then
-    TARGET_VSN=$(cat "$RELUP_PATH/version")
+if [ -f "$RELUP_PATH/current" ]; then
+    TARGET_VSN=$(cat "$RELUP_PATH/current")
     export BASE_RUNNER_ROOT_DIR
     ## only print for boot commands to avoid messing the CLI outputs
     if [ "$IS_BOOT_COMMAND" = 'yes' ]; then

--- a/plugins/emqx_relup/README.md
+++ b/plugins/emqx_relup/README.md
@@ -39,12 +39,12 @@ CLI on each node.
 
 5. **Verify the node** before moving on. Two cheap signals:
    - `emqx ctl status` reports the node running.
-   - `cat <RootDir>/relup/version` matches the target version, and
+   - `cat <RootDir>/relup/current` matches the target version, and
      `<RootDir>/relup/<TargetVsn>/` contains `bin/`, `erts-*/`,
      `lib/`, `releases/`.
 
    On the next `emqx start`/`restart`, the `bin/emqx` wrapper
-   detects `relup/version` and execs into the deployed tree (new
+   detects `relup/current` and execs into the deployed tree (new
    ERTS, new bin scripts, new lib). The original `<RootDir>` stays
    the authority for `data/`, `etc/`, `log/`, `plugins/`.
 
@@ -64,7 +64,7 @@ Practical rollback paths:
 
 - **Before the next restart**, if the upgrade succeeded but the new
   code is misbehaving and the data on disk is still compatible with
-  the old release: `rm <RootDir>/relup/version` (and optionally
+  the old release: `rm <RootDir>/relup/current` (and optionally
   `rm -rf <RootDir>/relup/<TargetVsn>/`), then `emqx restart`. The
   wrapper falls back to the original `<RootDir>/bin/emqx` tree.
   This recovers only the *boot path*; live state inside the running

--- a/plugins/emqx_relup/README.md
+++ b/plugins/emqx_relup/README.md
@@ -6,30 +6,12 @@ CLI on each node.
 
 ## Operator workflow
 
-1. **Install the plugin** on every node. The plugin tarball is
-   published per EMQX release at:
+1. **Install the plugin**
+   The plugin tarball is published per EMQX release at:
 
-       https://packages.emqx.io/emqx-plugins/e<EMQX-VSN>/emqx_relup-<PLUGIN-VSN>.tar.gz
+       `https://packages.emqx.io/emqx-plugins/e<EMQX-VSN>/emqx_relup-<PLUGIN-VSN>.tar.gz`
 
-   On each node:
-
-   ```
-   # fetch
-   curl -fLO https://packages.emqx.io/emqx-plugins/e<EMQX-VSN>/emqx_relup-<PLUGIN-VSN>.tar.gz
-
-   # drop into the plugin install dir
-   #   deb/rpm        : /var/lib/emqx/plugins/
-   #   tarball release: <RootDir>/plugins/
-   mv emqx_relup-<PLUGIN-VSN>.tar.gz <plugin-install-dir>/
-
-   # install + enable + start
-   emqx ctl plugins install emqx_relup-<PLUGIN-VSN>
-   emqx ctl plugins enable  emqx_relup-<PLUGIN-VSN>
-   emqx ctl plugins start   emqx_relup-<PLUGIN-VSN>
-   ```
-
-   Verify with `emqx ctl plugins list` — the plugin should show
-   `running`.
+    Install the plugin from the dashboard.
 
 2. **Confirm the upgrade path is supported.**
    `emqx ctl relup list-supported-paths` lists the supported

--- a/plugins/emqx_relup/priv/relup/README.md
+++ b/plugins/emqx_relup/priv/relup/README.md
@@ -121,7 +121,7 @@ healthy cluster is a no-op.
 4. add_patha(<RootDir>/data/patches)             — last step of (3)
 5. eval_post_upgrade_actions: for each entry,
        erlang:apply(get_upgrade_mod(TargetVsn), Func, [FromVsn | Args])
-6. handler writes <RootDir>/relup/version with TargetVsn
+6. handler writes <RootDir>/relup/current with TargetVsn
 ```
 
 Failure semantics:

--- a/plugins/emqx_relup/src/emqx_relup_cli.erl
+++ b/plugins/emqx_relup/src/emqx_relup_cli.erl
@@ -22,7 +22,17 @@ cmd(["list-supported-paths"]) ->
             ]
     end;
 cmd(["status"]) ->
-    emqx_ctl:print("~ts~n", [emqx_relup_main:get_latest_upgrade_status()]);
+    case emqx_relup_main:get_latest_upgrade_status() of
+        idle ->
+            emqx_ctl:print("idle~n");
+        'in-progress' ->
+            emqx_ctl:print("in-progress~n");
+        {hot_upgraded, TargetVsn} ->
+            emqx_ctl:print(
+                "hot-upgraded to ~ts; restart pending to boot the deployed tree~n",
+                [TargetVsn]
+            )
+    end;
 cmd(["logs"]) ->
     case emqx_relup_main:get_all_upgrade_logs() of
         [] ->
@@ -42,8 +52,10 @@ cmd(_) ->
             "`releases/emqx_vars` (`REL_VSN`)."},
         {"relup list-supported-paths", "List the {From, Target} hops the priv catalog supports"},
         {"relup status",
-            "Print 'in-progress' if an upgrade is currently running on this "
-            "node, otherwise 'idle'."},
+            "Print 'in-progress' while an upgrade is running, "
+            "'hot-upgraded to <vsn>' if a previous upgrade is committed and "
+            "the node is awaiting restart to boot the deployed tree, "
+            "otherwise 'idle'."},
         {"relup logs", "Print this node's upgrade history (one row per attempt)."},
         {"relup logs-clear", "Wipe this node's upgrade log table."}
     ]).

--- a/plugins/emqx_relup/src/emqx_relup_cli.erl
+++ b/plugins/emqx_relup/src/emqx_relup_cli.erl
@@ -46,17 +46,21 @@ cmd(["logs-clear"]) ->
 cmd(_) ->
     emqx_ctl:usage([
         {"relup upgrade <TarballPath>",
-            "Upgrade using the EMQX target tarball at <TarballPath>. "
-            "A `<TarballPath>.sha256` sidecar must sit next to it. "
-            "Target version is read from the tarball's "
+            "Upgrade using the EMQX target tarball at <TarballPath>.\n"
+            "A `<TarballPath>.sha256` sidecar must sit next to it.\n"
+            "Target version is read from the tarball's\n"
             "`releases/emqx_vars` (`REL_VSN`)."},
-        {"relup list-supported-paths", "List the {From, Target} hops the priv catalog supports"},
+        {"relup list-supported-paths", "List the {From, Target} hops the priv catalog supports."},
         {"relup status",
-            "Print 'in-progress' while an upgrade is running, "
-            "'hot-upgraded to <vsn>' if a previous upgrade is committed and "
-            "the node is awaiting restart to boot the deployed tree, "
-            "otherwise 'idle'."},
-        {"relup logs", "Print this node's upgrade history (one row per attempt)."},
+            "Print the current upgrade state of this node:\n"
+            "  'idle'                  no upgrade in progress;\n"
+            "  'in-progress'           an upgrade is running right now;\n"
+            "  'hot-upgraded to <vsn>' a previous upgrade has been applied\n"
+            "                          and the node is pending restart to\n"
+            "                          boot from the new version."},
+        {"relup logs",
+            "Print this node's upgrade history,\n"
+            "one row per attempt, oldest first."},
         {"relup logs-clear", "Wipe this node's upgrade log table."}
     ]).
 

--- a/plugins/emqx_relup/src/emqx_relup_cli.erl
+++ b/plugins/emqx_relup/src/emqx_relup_cli.erl
@@ -29,7 +29,7 @@ cmd(["status"]) ->
             emqx_ctl:print("in-progress~n");
         {hot_upgraded, TargetVsn} ->
             emqx_ctl:print(
-                "hot-upgraded to ~ts; restart pending to boot the deployed tree~n",
+                "hot-upgraded to ~ts; pending on restart to boot from the new version~n",
                 [TargetVsn]
             )
     end;

--- a/plugins/emqx_relup/src/emqx_relup_handler.erl
+++ b/plugins/emqx_relup/src/emqx_relup_handler.erl
@@ -30,9 +30,9 @@ list_supported_paths() ->
 
 check_and_unpack(CurrVsn, RootDir, #{tarball := TarFile} = Opts) ->
     try
-        ok = assert_no_upgrade_pending(RootDir),
         {ok, UnpackDir} = unpack_release(TarFile),
         TargetVsn = read_rel_vsn(UnpackDir),
+        ok = assert_no_duplicate_pending(RootDir, TargetVsn),
         ok = assert_not_same_vsn(CurrVsn, TargetVsn),
         ok = check_write_permission(RootDir),
         ok = check_otp_comaptibility(CurrVsn, RootDir, UnpackDir, TargetVsn),
@@ -77,31 +77,42 @@ perform_upgrade(CurrVsn, TargetVsn, RootDir, Opts) ->
 %%==============================================================================
 %% A previous successful upgrade leaves `<RootDir>/relup/current` pointing at
 %% the deployed target. The `bin/emqx` wrapper consumes that marker on the
-%% next start and execs into `<RootDir>/relup/<TargetVsn>/bin/emqx`. Until that
-%% restart happens, `code:root_dir()` still points at the original install and
-%% another upgrade attempt would re-run the same hop (or, worse, plan a hop on
-%% top of stale `emqx_release:version()`). Refuse early.
+%% next start and execs into `<RootDir>/relup/<TargetVsn>/bin/emqx`.
 %%
-%% After the restart, the new `bin/emqx` resolves `code:root_dir()` to the
-%% deploy dir, which has no `relup/current` of its own, so this check passes
-%% and the next hop can be planned from the freshly booted version.
-assert_no_upgrade_pending(RootDir) ->
+%% Chaining another upgrade on top of a pending one is allowed: the operator
+%% may stack hops (e.g. A -> B then B -> C) without restarting between them.
+%% The .relup hop author is responsible for declaring `from_version` to match
+%% whatever base state the node is in (hot-loaded post-A vs freshly booted),
+%% and for writing `code_changes` that handle the chain.
+%%
+%% What we refuse is running the *same* target again: that would re-apply the
+%% same hop's `code_changes` against a VM that's already been migrated by it,
+%% which is almost certainly an operator mistake. The first hop's idempotency
+%% can't be assumed (it may have done `restart_application` etc.). Tell the
+%% operator to restart or remove the marker if they really want a redo.
+assert_no_duplicate_pending(RootDir, TargetVsn) ->
     MarkerFile = filename:join([independent_deploy_root(RootDir), "current"]),
     case file:read_file(MarkerFile) of
         {ok, Bin} ->
             PendingTarget = string:trim(Bin),
-            throw(
-                make_error(upgrade_pending_restart, #{
-                    pending_target => PendingTarget,
-                    marker_file => bin(MarkerFile),
-                    hint =>
-                        <<
-                            "a previous upgrade is deployed and pending node restart; "
-                            "restart the node before another upgrade, or remove "
-                            "the marker file to override"
-                        >>
-                })
-            );
+            TargetBin = bin(TargetVsn),
+            case PendingTarget =:= TargetBin of
+                true ->
+                    throw(
+                        make_error(duplicate_pending_target, #{
+                            pending_target => PendingTarget,
+                            marker_file => bin(MarkerFile),
+                            hint =>
+                                <<
+                                    "this exact target is already deployed and "
+                                    "pending node restart; restart the node, or "
+                                    "remove the marker file to retry"
+                                >>
+                        })
+                    );
+                false ->
+                    ok
+            end;
         {error, enoent} ->
             ok
     end.

--- a/plugins/emqx_relup/src/emqx_relup_handler.erl
+++ b/plugins/emqx_relup/src/emqx_relup_handler.erl
@@ -30,6 +30,7 @@ list_supported_paths() ->
 
 check_and_unpack(CurrVsn, RootDir, #{tarball := TarFile} = Opts) ->
     try
+        ok = assert_no_upgrade_pending(RootDir),
         {ok, UnpackDir} = unpack_release(TarFile),
         TargetVsn = read_rel_vsn(UnpackDir),
         ok = assert_not_same_vsn(CurrVsn, TargetVsn),
@@ -74,6 +75,37 @@ perform_upgrade(CurrVsn, TargetVsn, RootDir, Opts) ->
 %%==============================================================================
 %% Check Upgrade
 %%==============================================================================
+%% A previous successful upgrade leaves `<RootDir>/relup/version` pointing at
+%% the deployed target. The `bin/emqx` wrapper consumes that marker on the
+%% next start and execs into `<RootDir>/relup/<TargetVsn>/bin/emqx`. Until that
+%% restart happens, `code:root_dir()` still points at the original install and
+%% another upgrade attempt would re-run the same hop (or, worse, plan a hop on
+%% top of stale `emqx_release:version()`). Refuse early.
+%%
+%% After the restart, the new `bin/emqx` resolves `code:root_dir()` to the
+%% deploy dir, which has no `relup/version` of its own, so this check passes
+%% and the next hop can be planned from the freshly booted version.
+assert_no_upgrade_pending(RootDir) ->
+    VersionFile = filename:join([independent_deploy_root(RootDir), "version"]),
+    case file:read_file(VersionFile) of
+        {ok, Bin} ->
+            PendingTarget = string:trim(Bin),
+            throw(
+                make_error(upgrade_pending_restart, #{
+                    pending_target => PendingTarget,
+                    version_marker => bin(VersionFile),
+                    hint =>
+                        <<
+                            "a previous upgrade is deployed and pending node restart; "
+                            "restart the node before another upgrade, or remove "
+                            "the version marker file to override"
+                        >>
+                })
+            );
+        {error, enoent} ->
+            ok
+    end.
+
 assert_not_same_vsn(TargetVsn, TargetVsn) ->
     throw(make_error(already_upgraded_to_target_vsn, #{vsn => TargetVsn}));
 assert_not_same_vsn(_CurrVsn, _TargetVsn) ->

--- a/plugins/emqx_relup/src/emqx_relup_handler.erl
+++ b/plugins/emqx_relup/src/emqx_relup_handler.erl
@@ -75,7 +75,7 @@ perform_upgrade(CurrVsn, TargetVsn, RootDir, Opts) ->
 %%==============================================================================
 %% Check Upgrade
 %%==============================================================================
-%% A previous successful upgrade leaves `<RootDir>/relup/version` pointing at
+%% A previous successful upgrade leaves `<RootDir>/relup/current` pointing at
 %% the deployed target. The `bin/emqx` wrapper consumes that marker on the
 %% next start and execs into `<RootDir>/relup/<TargetVsn>/bin/emqx`. Until that
 %% restart happens, `code:root_dir()` still points at the original install and
@@ -83,22 +83,22 @@ perform_upgrade(CurrVsn, TargetVsn, RootDir, Opts) ->
 %% top of stale `emqx_release:version()`). Refuse early.
 %%
 %% After the restart, the new `bin/emqx` resolves `code:root_dir()` to the
-%% deploy dir, which has no `relup/version` of its own, so this check passes
+%% deploy dir, which has no `relup/current` of its own, so this check passes
 %% and the next hop can be planned from the freshly booted version.
 assert_no_upgrade_pending(RootDir) ->
-    VersionFile = filename:join([independent_deploy_root(RootDir), "version"]),
-    case file:read_file(VersionFile) of
+    MarkerFile = filename:join([independent_deploy_root(RootDir), "current"]),
+    case file:read_file(MarkerFile) of
         {ok, Bin} ->
             PendingTarget = string:trim(Bin),
             throw(
                 make_error(upgrade_pending_restart, #{
                     pending_target => PendingTarget,
-                    version_marker => bin(VersionFile),
+                    marker_file => bin(MarkerFile),
                     hint =>
                         <<
                             "a previous upgrade is deployed and pending node restart; "
                             "restart the node before another upgrade, or remove "
-                            "the version marker file to override"
+                            "the marker file to override"
                         >>
                 })
             );
@@ -394,7 +394,7 @@ load_one_relup(File) ->
 %% Permanent Release
 %%==============================================================================
 permanent_upgrade(_CurrVsn, TargetVsn, RootDir, _) ->
-    file:write_file(filename:join([independent_deploy_root(RootDir), "version"]), TargetVsn).
+    file:write_file(filename:join([independent_deploy_root(RootDir), "current"]), TargetVsn).
 
 %%==============================================================================
 %% Eval Relup Instructions

--- a/plugins/emqx_relup/src/emqx_relup_main.erl
+++ b/plugins/emqx_relup/src/emqx_relup_main.erl
@@ -95,10 +95,11 @@ handle_call({upgrade, Opts}, _From, State) ->
     CurrVsn = emqx_release:version(),
     RootDir = code:root_dir(),
     %% target_vsn isn't known until check_and_unpack parses
-    %% releases/emqx_vars from the extracted tarball.
-    Key = log_upgrade_started(CurrVsn, undefined, Opts),
-    Result = do_upgrade(CurrVsn, RootDir, Opts),
-    ok = log_upgrade_result(Key, Result),
+    %% releases/emqx_vars from the extracted tarball; do_upgrade/3
+    %% surfaces it so the log row can be stamped.
+    Key = log_upgrade_started(CurrVsn, Opts),
+    {Result, TargetVsn} = do_upgrade(CurrVsn, RootDir, Opts),
+    ok = log_upgrade_result(Key, Result, TargetVsn),
     {reply, Result, State};
 handle_call(_Request, _From, State) ->
     {reply, ok, State}.
@@ -116,42 +117,46 @@ do_upgrade(CurrVsn, RootDir, Opts) ->
     case emqx_relup_handler:check_and_unpack(CurrVsn, RootDir, Opts) of
         {error, Reason} ->
             ?LOG(error, #{msg => check_upgrade_failed, reason => Reason}),
-            {error, Reason#{stage => check_and_unpack}};
+            {{error, Reason#{stage => check_and_unpack}}, undefined};
         {ok, #{target_vsn := TargetVsn} = Opts1} ->
             ?LOG(notice, #{msg => perform_upgrade, from_vsn => CurrVsn, target_vsn => TargetVsn}),
-            try emqx_relup_handler:perform_upgrade(CurrVsn, TargetVsn, RootDir, Opts1) of
+            Result = do_perform_and_permanent(CurrVsn, TargetVsn, RootDir, Opts1),
+            {Result, TargetVsn}
+    end.
+
+do_perform_and_permanent(CurrVsn, TargetVsn, RootDir, Opts) ->
+    try emqx_relup_handler:perform_upgrade(CurrVsn, TargetVsn, RootDir, Opts) of
+        ok ->
+            case emqx_relup_handler:permanent_upgrade(CurrVsn, TargetVsn, RootDir, Opts) of
                 ok ->
-                    case emqx_relup_handler:permanent_upgrade(CurrVsn, TargetVsn, RootDir, Opts1) of
-                        ok ->
-                            ?LOG(notice, #{
-                                msg => upgrade_complete,
-                                from_vsn => CurrVsn,
-                                target_vsn => TargetVsn
-                            }),
-                            ok;
-                        {error, Reason} ->
-                            ?LOG(error, #{
-                                msg => permanent_upgrade_failed,
-                                reason => Reason,
-                                from_vsn => CurrVsn,
-                                target_vsn => TargetVsn
-                            }),
-                            {error, Reason#{stage => permanent_upgrade}}
-                    end;
+                    ?LOG(notice, #{
+                        msg => upgrade_complete,
+                        from_vsn => CurrVsn,
+                        target_vsn => TargetVsn
+                    }),
+                    ok;
                 {error, Reason} ->
                     ?LOG(error, #{
-                        msg => perform_upgrade_failed,
+                        msg => permanent_upgrade_failed,
                         reason => Reason,
                         from_vsn => CurrVsn,
                         target_vsn => TargetVsn
                     }),
-                    {error, Reason#{stage => perform_upgrade}}
-            catch
-                throw:Reason ->
-                    restart_vm(Reason);
-                Err:Reason:ST ->
-                    restart_vm({Err, Reason, ST})
-            end
+                    {error, Reason#{stage => permanent_upgrade}}
+            end;
+        {error, Reason} ->
+            ?LOG(error, #{
+                msg => perform_upgrade_failed,
+                reason => Reason,
+                from_vsn => CurrVsn,
+                target_vsn => TargetVsn
+            }),
+            {error, Reason#{stage => perform_upgrade}}
+    catch
+        throw:Reason ->
+            restart_vm(Reason);
+        Err:Reason:ST ->
+            restart_vm({Err, Reason, ST})
     end.
 
 restart_vm(Reason) ->
@@ -174,14 +179,31 @@ get_all_upgrade_logs() ->
     lists:map(fun format_upgrade_log/1, ets:tab2list(emqx_relup_log)).
 
 get_latest_upgrade_status() ->
-    case ets:last(emqx_relup_log) of
-        '$end_of_table' ->
-            idle;
-        Key ->
-            case ets:lookup(emqx_relup_log, Key) of
-                [#emqx_relup_log{status = finished}] -> idle;
-                [#emqx_relup_log{status = 'in-progress'}] -> 'in-progress'
+    %% If `<code:root_dir()>/relup/version` exists, an upgrade has been
+    %% committed against this install and the running BEAM has hot-loaded
+    %% the target's modules; a node restart is required to boot the
+    %% deployed tree. Surface that state explicitly so operators don't
+    %% confuse it with `idle`.
+    case read_version_marker() of
+        {ok, TargetVsn} ->
+            {hot_upgraded, TargetVsn};
+        none ->
+            case ets:last(emqx_relup_log) of
+                '$end_of_table' ->
+                    idle;
+                Key ->
+                    case ets:lookup(emqx_relup_log, Key) of
+                        [#emqx_relup_log{status = finished}] -> idle;
+                        [#emqx_relup_log{status = 'in-progress'}] -> 'in-progress'
+                    end
             end
+    end.
+
+read_version_marker() ->
+    Path = filename:join([code:root_dir(), "relup", "version"]),
+    case file:read_file(Path) of
+        {ok, Bin} -> {ok, string:trim(Bin)};
+        {error, _} -> none
     end.
 
 format_upgrade_log(#emqx_relup_log{
@@ -196,43 +218,49 @@ format_upgrade_log(#emqx_relup_log{
     #{
         started_at => maybe_to_rfc3339(StartedAt),
         finished_at => maybe_to_rfc3339(FinishedAt),
-        from_vsn => FromVsn,
-        target_vsn => TargetVsn,
+        from_vsn => maybe_undefined(FromVsn),
+        target_vsn => maybe_undefined(TargetVsn),
         upgrade_opts => Opts,
         status => Status,
-        result => maybe_result(Result)
+        result => maybe_undefined(Result)
     }.
 
 maybe_to_rfc3339(undefined) -> <<>>;
 maybe_to_rfc3339(Int) -> bin(calendar:system_time_to_rfc3339(Int, [{unit, millisecond}])).
 
-maybe_result(undefined) -> <<>>;
-maybe_result(Result) -> Result.
+maybe_undefined(undefined) -> <<>>;
+maybe_undefined(V) -> V.
 
-log_upgrade_started(CurrVsn, TargetVsn, Opts) ->
+log_upgrade_started(CurrVsn, Opts) ->
     Now = erlang:system_time(millisecond),
     ?LOG(notice, #{
-        msg => got_upgrade_request, from_vsn => CurrVsn, target_vsn => TargetVsn, opts => Opts
+        msg => got_upgrade_request, from_vsn => CurrVsn, opts => Opts
     }),
     ok = mnesia:dirty_write(#emqx_relup_log{
         started_at = Now,
         from_vsn = bin(CurrVsn),
-        target_vsn = bin(TargetVsn),
+        target_vsn = undefined,
         upgrade_opts = Opts,
         status = 'in-progress'
     }),
     Now.
 
-log_upgrade_result(Key, Result) ->
+log_upgrade_result(Key, Result, TargetVsn) ->
+    TargetBin =
+        case TargetVsn of
+            undefined -> undefined;
+            _ -> bin(TargetVsn)
+        end,
     case mnesia:dirty_read(emqx_relup_log, Key) of
-        [#emqx_relup_log{from_vsn = FromVsn, target_vsn = TargetVsn} = Log] ->
+        [#emqx_relup_log{from_vsn = FromVsn} = Log] ->
             ?LOG(notice, #{
                 msg => upgrade_finished,
                 from_vsn => FromVsn,
-                target_vsn => TargetVsn,
+                target_vsn => TargetBin,
                 result => Result
             }),
             mnesia:dirty_write(Log#emqx_relup_log{
+                target_vsn = TargetBin,
                 finished_at = erlang:system_time(millisecond),
                 status = finished,
                 result = format_result(Result)

--- a/plugins/emqx_relup/src/emqx_relup_main.erl
+++ b/plugins/emqx_relup/src/emqx_relup_main.erl
@@ -179,12 +179,12 @@ get_all_upgrade_logs() ->
     lists:map(fun format_upgrade_log/1, ets:tab2list(emqx_relup_log)).
 
 get_latest_upgrade_status() ->
-    %% If `<code:root_dir()>/relup/version` exists, an upgrade has been
+    %% If `<code:root_dir()>/relup/current` exists, an upgrade has been
     %% committed against this install and the running BEAM has hot-loaded
     %% the target's modules; a node restart is required to boot the
     %% deployed tree. Surface that state explicitly so operators don't
     %% confuse it with `idle`.
-    case read_version_marker() of
+    case read_current_marker() of
         {ok, TargetVsn} ->
             {hot_upgraded, TargetVsn};
         none ->
@@ -199,8 +199,8 @@ get_latest_upgrade_status() ->
             end
     end.
 
-read_version_marker() ->
-    Path = filename:join([code:root_dir(), "relup", "version"]),
+read_current_marker() ->
+    Path = filename:join([code:root_dir(), "relup", "current"]),
     case file:read_file(Path) of
         {ok, Bin} -> {ok, string:trim(Bin)};
         {error, _} -> none

--- a/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
@@ -198,6 +198,36 @@ t_os_arch_mismatch_rejects(Config) ->
     ),
     ?assertMatch({error, #{err_type := os_arch_mismatch}}, Result).
 
+-doc "An existing `<RootDir>/relup/version` marker means a previous "
+"upgrade has been deployed but the node has not yet restarted into "
+"the new tree. A second upgrade request must be refused with "
+"`upgrade_pending_restart`. The check fires before any tarball work, "
+"so even a perfectly good tarball with a valid sidecar is rejected.".
+t_refuse_when_upgrade_pending_restart(Config) ->
+    RootDir = ?config(root_dir, Config),
+    Tarball = forge_target_tarball(RootDir, ?TARGET_VSN, default_arch()),
+    ok = write_sha256_sidecar(Tarball),
+    _ = write_no_op_relup(?CURR_VSN, ?TARGET_VSN),
+    Marker = filename:join([RootDir, "relup", "version"]),
+    ok = filelib:ensure_dir(Marker),
+    ok = file:write_file(Marker, ?TARGET_VSN),
+    Result = emqx_relup_handler:check_and_unpack(
+        ?CURR_VSN, RootDir, #{tarball => Tarball}
+    ),
+    ?assertMatch(
+        {error, #{
+            err_type := upgrade_pending_restart,
+            pending_target := <<?TARGET_VSN>>
+        }},
+        Result
+    ),
+    %% Once the marker is gone, the same inputs proceed normally.
+    ok = file:delete(Marker),
+    ?assertMatch(
+        {ok, #{target_vsn := ?TARGET_VSN}},
+        emqx_relup_handler:check_and_unpack(?CURR_VSN, RootDir, #{tarball => Tarball})
+    ).
+
 %%==============================================================================
 %% helpers
 %%==============================================================================

--- a/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
@@ -198,12 +198,12 @@ t_os_arch_mismatch_rejects(Config) ->
     ),
     ?assertMatch({error, #{err_type := os_arch_mismatch}}, Result).
 
--doc "An existing `<RootDir>/relup/current` marker means a previous "
-"upgrade has been deployed but the node has not yet restarted into "
-"the new tree. A second upgrade request must be refused with "
-"`upgrade_pending_restart`. The check fires before any tarball work, "
-"so even a perfectly good tarball with a valid sidecar is rejected.".
-t_refuse_when_upgrade_pending_restart(Config) ->
+-doc "An existing `<RootDir>/relup/current` marker pointing at the "
+"same target means the operator is re-running the exact same "
+"upgrade against a VM that's already been migrated by it. Refuse "
+"with `duplicate_pending_target`. Chaining to a different target "
+"is allowed and exercised by `t_chain_relup_from_pending_marker`.".
+t_refuse_duplicate_pending_target(Config) ->
     RootDir = ?config(root_dir, Config),
     Tarball = forge_target_tarball(RootDir, ?TARGET_VSN, default_arch()),
     ok = write_sha256_sidecar(Tarball),
@@ -216,13 +216,33 @@ t_refuse_when_upgrade_pending_restart(Config) ->
     ),
     ?assertMatch(
         {error, #{
-            err_type := upgrade_pending_restart,
+            err_type := duplicate_pending_target,
             pending_target := <<?TARGET_VSN>>
         }},
         Result
     ),
     %% Once the marker is gone, the same inputs proceed normally.
     ok = file:delete(Marker),
+    ?assertMatch(
+        {ok, #{target_vsn := ?TARGET_VSN}},
+        emqx_relup_handler:check_and_unpack(?CURR_VSN, RootDir, #{tarball => Tarball})
+    ).
+
+-doc "A marker pointing at a *different* version than the requested "
+"target means the operator wants to chain another hop on top of "
+"the pending one. The framework allows it; the .relup hop author "
+"is responsible for `from_version` and `code_changes` that match "
+"whatever base state the running node is in.".
+t_chain_relup_from_pending_marker(Config) ->
+    RootDir = ?config(root_dir, Config),
+    Tarball = forge_target_tarball(RootDir, ?TARGET_VSN, default_arch()),
+    ok = write_sha256_sidecar(Tarball),
+    _ = write_no_op_relup(?CURR_VSN, ?TARGET_VSN),
+    %% A pending marker for some unrelated earlier hop must not block
+    %% the new target.
+    Marker = filename:join([RootDir, "relup", "current"]),
+    ok = filelib:ensure_dir(Marker),
+    ok = file:write_file(Marker, "9.9.0-some-earlier-hop"),
     ?assertMatch(
         {ok, #{target_vsn := ?TARGET_VSN}},
         emqx_relup_handler:check_and_unpack(?CURR_VSN, RootDir, #{tarball => Tarball})

--- a/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
@@ -90,7 +90,7 @@ t_round_trip_no_op(Config) ->
     ok = emqx_relup_handler:perform_upgrade(?CURR_VSN, ?TARGET_VSN, RootDir, Opts1),
     ok = emqx_relup_handler:permanent_upgrade(?CURR_VSN, ?TARGET_VSN, RootDir, Opts1),
 
-    Marker = filename:join([RootDir, "relup", "version"]),
+    Marker = filename:join([RootDir, "relup", "current"]),
     ?assertEqual({ok, list_to_binary(?TARGET_VSN)}, file:read_file(Marker)),
     DeployDir = filename:join([RootDir, "relup", ?TARGET_VSN]),
     ?assert(filelib:is_dir(DeployDir), DeployDir ++ " should be a dir"),
@@ -198,7 +198,7 @@ t_os_arch_mismatch_rejects(Config) ->
     ),
     ?assertMatch({error, #{err_type := os_arch_mismatch}}, Result).
 
--doc "An existing `<RootDir>/relup/version` marker means a previous "
+-doc "An existing `<RootDir>/relup/current` marker means a previous "
 "upgrade has been deployed but the node has not yet restarted into "
 "the new tree. A second upgrade request must be refused with "
 "`upgrade_pending_restart`. The check fires before any tarball work, "
@@ -208,7 +208,7 @@ t_refuse_when_upgrade_pending_restart(Config) ->
     Tarball = forge_target_tarball(RootDir, ?TARGET_VSN, default_arch()),
     ok = write_sha256_sidecar(Tarball),
     _ = write_no_op_relup(?CURR_VSN, ?TARGET_VSN),
-    Marker = filename:join([RootDir, "relup", "version"]),
+    Marker = filename:join([RootDir, "relup", "current"]),
     ok = filelib:ensure_dir(Marker),
     ok = file:write_file(Marker, ?TARGET_VSN),
     Result = emqx_relup_handler:check_and_unpack(


### PR DESCRIPTION

Release version: 5.10.4

## Summary

- Rename `version` to `current`
- Refine logging messages
- Refine status report
- Refuse upgrade again (from current to current)
- Allow relup from current to another version (previously rejected)