### PR TITLE
feat(mqtt): add delay_send to client TCP options

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1210,6 +1210,15 @@ fields("client_tcp_opts") ->
                     importance => ?IMPORTANCE_LOW,
                     desc => ?DESC(fields_client_tcp_opts_keepalive)
                 }
+            )},
+        {delay_send,
+            sc(
+                boolean(),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC(fields_client_tcp_opts_delay_send)
+                }
             )}
     ];
 fields("listener_ssl_opts") ->
@@ -3280,6 +3289,7 @@ client_tcp_opts_to_proplist(Map) when is_map(Map) ->
             (recbuf, V, Acc) when is_integer(V) -> [{recbuf, V} | Acc];
             (buffer, V, Acc) when is_integer(V) -> [{buffer, V} | Acc];
             (keepalive, V, Acc) when is_boolean(V) -> [{keepalive, V} | Acc];
+            (delay_send, V, Acc) when is_boolean(V) -> [{delay_send, V} | Acc];
             (_, _, Acc) -> Acc
         end,
         [],

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_schema_tests.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_schema_tests.erl
@@ -311,7 +311,8 @@ schema_test_() ->
                             <<"sndbuf">> => <<"16KB">>,
                             <<"recbuf">> => <<"8KB">>,
                             <<"buffer">> => <<"32KB">>,
-                            <<"keepalive">> => true
+                            <<"keepalive">> => true,
+                            <<"delay_send">> => true
                         }
                     })
                 ),
@@ -321,7 +322,8 @@ schema_test_() ->
                         <<"sndbuf">> := <<"16KB">>,
                         <<"recbuf">> := <<"8KB">>,
                         <<"buffer">> := <<"32KB">>,
-                        <<"keepalive">> := true
+                        <<"keepalive">> := true,
+                        <<"delay_send">> := true
                     },
                     TcpOpts
                 ),
@@ -330,13 +332,15 @@ schema_test_() ->
                     sndbuf => 16384,
                     recbuf => 8192,
                     buffer => 32768,
-                    keepalive => true
+                    keepalive => true,
+                    delay_send => true
                 }),
                 ?assertEqual(true, proplists:get_value(nodelay, Proplist)),
                 ?assertEqual(16384, proplists:get_value(sndbuf, Proplist)),
                 ?assertEqual(8192, proplists:get_value(recbuf, Proplist)),
                 ?assertEqual(32768, proplists:get_value(buffer, Proplist)),
-                ?assertEqual(true, proplists:get_value(keepalive, Proplist))
+                ?assertEqual(true, proplists:get_value(keepalive, Proplist)),
+                ?assertEqual(true, proplists:get_value(delay_send, Proplist))
             end)},
         {"tcp_opts : empty/unset keys are not forwarded",
             ?_test(begin

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_schema_tests.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_schema_tests.erl
@@ -105,7 +105,8 @@ tcp_opts_schema_test_() ->
                         <<"sndbuf">> => <<"16KB">>,
                         <<"recbuf">> => <<"8KB">>,
                         <<"buffer">> => <<"32KB">>,
-                        <<"keepalive">> => false
+                        <<"keepalive">> => false,
+                        <<"delay_send">> => true
                     }
                 })
             ]),
@@ -115,7 +116,8 @@ tcp_opts_schema_test_() ->
                     <<"sndbuf">> := 16384,
                     <<"recbuf">> := 8192,
                     <<"buffer">> := 32768,
-                    <<"keepalive">> := false
+                    <<"keepalive">> := false,
+                    <<"delay_send">> := true
                 },
                 TcpOpts
             ),
@@ -129,7 +131,8 @@ tcp_opts_schema_test_() ->
                         sndbuf => 16384,
                         recbuf => 8192,
                         buffer => 32768,
-                        keepalive => false
+                        keepalive => false,
+                        delay_send => true
                     }
                 },
                 #{tcp_opts := Proplist} = emqx_cluster_link_config:mk_emqtt_options(LinkConf),
@@ -137,7 +140,8 @@ tcp_opts_schema_test_() ->
                 ?assertEqual(16384, proplists:get_value(sndbuf, Proplist)),
                 ?assertEqual(8192, proplists:get_value(recbuf, Proplist)),
                 ?assertEqual(32768, proplists:get_value(buffer, Proplist)),
-                ?assertEqual(false, proplists:get_value(keepalive, Proplist))
+                ?assertEqual(false, proplists:get_value(keepalive, Proplist)),
+                ?assertEqual(true, proplists:get_value(delay_send, Proplist))
             end)
         end)}.
 

--- a/changes/ee/feat-17282.en.md
+++ b/changes/ee/feat-17282.en.md
@@ -1,0 +1,3 @@
+Client TCP options for MQTT bridge connectors and Cluster Link now expose `delay_send`, a `gen_tcp` option that coalesces small writes for better throughput at the cost of a small latency increase. Off by default.
+
+Follow-up to PR #17186.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1122,6 +1122,14 @@ This is the OS-level TCP keepalive probe and is independent of the MQTT-level ke
 fields_client_tcp_opts_keepalive.label:
 """TCP SO_KEEPALIVE"""
 
+fields_client_tcp_opts_delay_send.desc:
+"""When enabled, `gen_tcp` may briefly queue small writes to coalesce them into larger TCP segments.
+Improves throughput for bursty publishers at the cost of a small added latency.
+Default: `false`."""
+
+fields_client_tcp_opts_delay_send.label:
+"""Delay Send"""
+
 sysmon_top_db_username.desc:
 """Username of the PostgreSQL database"""
 

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1124,7 +1124,7 @@ fields_client_tcp_opts_keepalive.label:
 
 fields_client_tcp_opts_delay_send.desc:
 """When enabled, `gen_tcp` may briefly queue small writes to coalesce them into larger TCP segments.
-Improves throughput for bursty publishers at the cost of a small added latency.
+Improves throughput for publishers that send many small messages, at the cost of a small added latency.
 Default: `false`."""
 
 fields_client_tcp_opts_delay_send.label:


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version:
6.0.3, 6.1.1, 6.2.0

## Summary

Follow-up to PR #17186, which introduced shared client-side TCP socket tunables (`nodelay`, `sndbuf`, `recbuf`, `buffer`, `keepalive`) for MQTT bridge connectors and Cluster Link via `emqx_schema:fields("client_tcp_opts")` and the `client_tcp_opts_to_proplist/1` helper.

This PR adds the missing `delay_send` field. `delay_send` is a `gen_tcp` socket option: when enabled, the Erlang VM may briefly queue small writes to coalesce them into larger TCP segments, improving throughput for bursty publishers at the cost of a small added latency. It defaults to `false`, matching the `gen_tcp` default — existing configs are unaffected.

Changes:
- `apps/emqx/src/emqx_schema.erl` — adds `delay_send` to `fields("client_tcp_opts")` and the matching clause in `client_tcp_opts_to_proplist/1`.
- `rel/i18n/emqx_schema.hocon` — i18n entry mirroring the existing `keepalive` field.
- Schema tests in both `emqx_bridge_mqtt_schema_tests` and `emqx_cluster_link_schema_tests` extended to round-trip `delay_send`.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)