### PR TITLE
refactor(authn): resolve provider optional-callback dispatch at registration

### DIFF
--- a/apps/emqx_auth/src/emqx_authn/emqx_authn.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn.erl
@@ -12,6 +12,7 @@
     get_enabled_authns/0,
 
     register_provider/2,
+    register_provider/3,
     deregister_provider/1
 ]).
 
@@ -58,6 +59,9 @@ tally_authenticators(#{id := AuthenticatorName}, Acc) ->
 
 register_provider(ProviderType, ProviderModule) ->
     ok = ?AUTHN:register_provider(ProviderType, ProviderModule).
+
+register_provider(ProviderType, ProviderModule, Opts) ->
+    ok = ?AUTHN:register_provider(ProviderType, ProviderModule, Opts).
 
 deregister_provider(ProviderType) ->
     ok = ?AUTHN:deregister_provider(ProviderType).

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
@@ -24,7 +24,12 @@
     provider :: module(),
     enable :: boolean(),
     precondition :: undefined | emqx_variform:compiled(),
-    state :: map()
+    state :: map(),
+    %% Whether this provider implements the optional user-management callbacks
+    %% (add_user, delete_user, update_user, lookup_user, list_users, import_users).
+    %% Declared by the provider at registration via register_provider/3 Opts;
+    %% avoids an erlang:function_exported/3 probe on every dispatch.
+    support_user_operations = false :: boolean()
 }).
 
 -record(chain, {
@@ -47,6 +52,7 @@
 %% Authenticator management APIs
 -export([
     register_provider/2,
+    register_provider/3,
     register_providers/1,
     deregister_provider/1,
     deregister_providers/1,
@@ -114,6 +120,9 @@ end).
 -type position() :: front | rear | {before, authenticator_id()} | {'after', authenticator_id()}.
 -type authn_type() :: atom() | {atom(), atom()}.
 -type provider() :: module().
+-type provider_opts() :: #{support_user_operations => boolean()}.
+-type provider_spec() ::
+    {authn_type(), module()} | {authn_type(), module(), provider_opts()}.
 
 -type chain() :: #{
     name := chain_name(),
@@ -244,17 +253,28 @@ stop() ->
 
 %% @doc Register authentication providers.
 %% A provider is a tuple of `AuthNType' the module which implements
-%% the authenticator callbacks.
+%% the authenticator callbacks. An optional third element carries provider
+%% metadata, currently just `support_user_operations'.
 %% For example, ``[{{'password_based', redis}, emqx_authn_redis}]''
 %% NOTE: Later registered provider may override earlier registered if they
 %% happen to clash the same `AuthNType'.
--spec register_providers([{authn_type(), module()}]) -> ok | {error, term()}.
+-spec register_providers([provider_spec()]) -> ok | {error, term()}.
 register_providers(Providers) ->
-    call({register_providers, Providers}).
+    call({register_providers, [normalize_provider_spec(P) || P <- Providers]}).
 
 -spec register_provider(authn_type(), module()) -> ok.
 register_provider(AuthNType, Provider) ->
-    register_providers([{AuthNType, Provider}]).
+    register_provider(AuthNType, Provider, #{}).
+
+-spec register_provider(authn_type(), module(), provider_opts()) -> ok.
+register_provider(AuthNType, Provider, Opts) ->
+    register_providers([{AuthNType, Provider, Opts}]).
+
+normalize_provider_spec({AuthNType, Module}) ->
+    {AuthNType, Module, #{support_user_operations => false}};
+normalize_provider_spec({AuthNType, Module, Opts}) ->
+    SupportsUserOps = maps:get(support_user_operations, Opts, false),
+    {AuthNType, Module, Opts#{support_user_operations => SupportsUserOps}}.
 
 -spec deregister_providers([authn_type()]) -> ok.
 deregister_providers(AuthNTypes) when is_list(AuthNTypes) ->
@@ -420,18 +440,19 @@ handle_call(
     _From,
     #{providers := Reg0} = State
 ) ->
-    case lists:filter(fun({T, _}) -> maps:is_key(T, Reg0) end, Providers) of
+    case lists:filter(fun({T, _, _}) -> maps:is_key(T, Reg0) end, Providers) of
         [] ->
             Reg = lists:foldl(
-                fun({AuthNType, Module}, Pin) ->
-                    Pin#{AuthNType => Module}
+                fun({AuthNType, Module, Opts}, Pin) ->
+                    Pin#{AuthNType => {Module, Opts}}
                 end,
                 Reg0,
                 Providers
             ),
             reply(ok, State#{providers := Reg}, initialize_authentication);
         Clashes ->
-            reply({error, {authentication_type_clash, Clashes}}, State)
+            ClashSummary = [{T, M} || {T, M, _} <- Clashes],
+            reply({error, {authentication_type_clash, ClashSummary}}, State)
     end;
 handle_call({deregister_providers, AuthNTypes}, _From, #{providers := Providers} = State) ->
     reply(ok, State#{providers := maps:without(AuthNTypes, Providers)});
@@ -944,22 +965,23 @@ do_create_authenticator(AuthenticatorID, Config, Providers) ->
     case maps:get(Type, Providers, undefined) of
         undefined ->
             {error, #{cause => "no_available_provider", type => Type}};
-        Provider ->
-            do_create_authenticator2(AuthenticatorID, Config, Provider)
+        {Provider, Opts} ->
+            do_create_authenticator2(AuthenticatorID, Config, Provider, Opts)
     end.
 
 %% Compile precondition and create authenticator
-do_create_authenticator2(AuthenticatorID, Config, Provider) ->
+do_create_authenticator2(AuthenticatorID, Config, Provider, Opts) ->
     case compile_precondition(Config) of
         {ok, Precondition} ->
-            do_create_authenticator3(AuthenticatorID, Config, Provider, Precondition);
+            do_create_authenticator3(AuthenticatorID, Config, Provider, Opts, Precondition);
         {error, Reason} ->
             {error, #{cause => "bad_precondition_expression", reason => Reason}}
     end.
 
 %% Create authenticator with precondition
-do_create_authenticator3(AuthenticatorID, Config, Provider, Precondition) ->
+do_create_authenticator3(AuthenticatorID, Config, Provider, Opts, Precondition) ->
     #{enable := Enable} = Config,
+    SupportsUserOps = maps:get(support_user_operations, Opts, false),
     try Provider:create(AuthenticatorID, Config) of
         {ok, State} ->
             Authenticator = #authenticator{
@@ -967,7 +989,8 @@ do_create_authenticator3(AuthenticatorID, Config, Provider, Precondition) ->
                 provider = Provider,
                 enable = Enable,
                 state = State,
-                precondition = Precondition
+                precondition = Precondition,
+                support_user_operations = SupportsUserOps
             },
             {ok, Authenticator};
         {error, Reason} ->
@@ -1099,13 +1122,10 @@ call_authenticator(ChainName, AuthenticatorID, Func, Args) ->
             case lists:keyfind(AuthenticatorID, #authenticator.id, Authenticators) of
                 false ->
                     {error, {not_found, {authenticator, AuthenticatorID}}};
+                #authenticator{support_user_operations = false} ->
+                    {error, unsupported_operation};
                 #authenticator{provider = Provider, state = State} ->
-                    case erlang:function_exported(Provider, Func, length(Args) + 1) of
-                        true ->
-                            {ok, erlang:apply(Provider, Func, Args ++ [State])};
-                        false ->
-                            {error, unsupported_operation}
-                    end
+                    {ok, erlang:apply(Provider, Func, Args ++ [State])}
             end
         end,
     with_chain(ChainName, Fun).

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_provider_opts_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_provider_opts_SUITE.erl
@@ -1,0 +1,133 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% Verifies that emqx_authn dispatch consults the
+%% `support_user_operations' flag declared at registration time, instead
+%% of probing `erlang:function_exported/3' on every dispatch.
+%%
+%% This SUITE doubles as the provider fixture: it implements the
+%% mandatory `emqx_authn_provider' callbacks plus one optional callback
+%% (`add_user/2'). Each test case registers it differently (with or
+%% without `support_user_operations') and checks that dispatch matches
+%% the declared capability — not whether `add_user/2' happens to be
+%% exported (it always is).
+
+-module(emqx_authn_provider_opts_SUITE).
+
+-behaviour(emqx_authn_provider).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include("emqx_authn_chains.hrl").
+
+-define(CHAIN, 'mqtt:global').
+-define(BACKEND, built_in_database).
+-define(AUTHN_TYPE, {password_based, ?BACKEND}).
+-define(AUTHENTICATOR_ID, <<"password_based:built_in_database">>).
+
+%%------------------------------------------------------------------------------
+%% emqx_authn_provider callbacks
+%%------------------------------------------------------------------------------
+
+create(_AuthenticatorID, _Config) ->
+    {ok, #{mark => provider_state}}.
+
+update(_Config, _State) ->
+    {ok, #{mark => provider_state}}.
+
+authenticate(#{username := <<"good">>}, _State) ->
+    {ok, #{is_superuser => false}};
+authenticate(_, _State) ->
+    {error, bad_username_or_password}.
+
+destroy(_State) ->
+    ok.
+
+%% Optional callback — always exported. Whether dispatch reaches it is
+%% governed solely by the support_user_operations flag.
+add_user(_UserInfo, _State) ->
+    {ok, #{user_id => <<"u">>, is_superuser => false}}.
+
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [emqx, emqx_conf, emqx_auth],
+        #{work_dir => ?config(priv_dir, Config)}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(apps, Config)),
+    ok.
+
+init_per_testcase(Case, Config) ->
+    Opts = testcase_provider_opts(Case),
+    ok = emqx_authn_chains:register_providers([{?AUTHN_TYPE, ?MODULE, Opts}]),
+    {ok, _} = emqx:update_config(
+        [authentication],
+        {create_authenticator, ?CHAIN, #{
+            <<"mechanism">> => <<"password_based">>,
+            <<"backend">> => <<"built_in_database">>,
+            <<"user_id_type">> => <<"username">>
+        }}
+    ),
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    _ = emqx:update_config(
+        [authentication],
+        {delete_authenticator, ?CHAIN, ?AUTHENTICATOR_ID}
+    ),
+    _ = emqx_authn_chains:deregister_providers([?AUTHN_TYPE]),
+    ok.
+
+testcase_provider_opts(t_user_ops_enabled_dispatches) ->
+    #{support_user_operations => true};
+testcase_provider_opts(_Case) ->
+    #{}.
+
+%%------------------------------------------------------------------------------
+%% Tests
+%%------------------------------------------------------------------------------
+
+%% Provider registered without support_user_operations must short-circuit
+%% with unsupported_operation, even though add_user/2 IS exported. This
+%% proves dispatch consults the flag, not erlang:function_exported/3.
+t_user_ops_disabled_short_circuits(_Config) ->
+    ?assertEqual(
+        {error, unsupported_operation},
+        emqx_authn_chains:add_user(?CHAIN, ?AUTHENTICATOR_ID, #{
+            user_id => <<"u">>, password => <<"p">>
+        })
+    ).
+
+%% Provider registered with support_user_operations => true dispatches
+%% normally.
+t_user_ops_enabled_dispatches(_Config) ->
+    ?assertMatch(
+        {ok, _},
+        emqx_authn_chains:add_user(?CHAIN, ?AUTHENTICATOR_ID, #{
+            user_id => <<"u">>, password => <<"p">>
+        })
+    ).
+
+%% Regression: authenticate/2 is mandatory and is dispatched directly,
+%% so it must work regardless of the support_user_operations flag.
+t_authenticate_dispatches_to_provider(_Config) ->
+    Credential = #{
+        listener => 'tcp:default',
+        protocol => mqtt,
+        username => <<"good">>,
+        password => <<"p">>
+    },
+    ?assertMatch({ok, _}, emqx_access_control:authenticate(Credential)).

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_test_lib.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_test_lib.erl
@@ -61,8 +61,11 @@ client_ssl_cert_opts() ->
     }.
 
 register_fake_providers(ProviderTypes) ->
+    %% The fake provider implements add_user/2 — declare that here so
+    %% emqx_authn_chains dispatches optional callbacks instead of returning
+    %% {error, unsupported_operation}.
     Providers = [
-        {ProviderType, emqx_authn_fake_provider}
+        {ProviderType, emqx_authn_fake_provider, #{support_user_operations => true}}
      || ProviderType <- ProviderTypes
     ],
     emqx_authn_chains:register_providers(Providers).

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_app.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_app.erl
@@ -13,8 +13,12 @@
 start(_StartType, _StartArgs) ->
     {ok, Sup} = emqx_auth_mnesia_sup:start_link(),
     ok = emqx_authz:register_source(?AUTHZ_TYPE, emqx_authz_mnesia),
-    ok = emqx_authn:register_provider(?AUTHN_TYPE_SIMPLE, emqx_authn_mnesia),
-    ok = emqx_authn:register_provider(?AUTHN_TYPE_SCRAM, emqx_authn_scram_mnesia),
+    ok = emqx_authn:register_provider(
+        ?AUTHN_TYPE_SIMPLE, emqx_authn_mnesia, #{support_user_operations => true}
+    ),
+    ok = emqx_authn:register_provider(
+        ?AUTHN_TYPE_SCRAM, emqx_authn_scram_mnesia, #{support_user_operations => true}
+    ),
     {ok, Sup}.
 
 stop(_State) ->

--- a/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
@@ -27,7 +27,8 @@
     delete_user/3,
     update_user/4,
     lookup_user/3,
-    list_users/2
+    list_users/2,
+    import_users/2
 ]).
 
 -export([
@@ -173,6 +174,13 @@ do_destroy(UserGroup) ->
         end,
         mnesia:select(?NS_TAB, all_ns_group_match_spec('_', UserGroup), write)
     ).
+
+%% SCRAM credentials cannot be bulk-imported: salts and stored/server keys
+%% derive from the plaintext password, which is never persisted. The provider
+%% advertises user-management support generally, so we surface the limitation
+%% here rather than letting dispatch crash.
+import_users(_File, _State) ->
+    {error, unsupported_operation}.
 
 add_user(UserInfo, State) ->
     UserInfoRecord = user_info_record(UserInfo, State),


### PR DESCRIPTION
Each authenticator now caches its provider's optional-callback set in the #authenticator{} record when the authenticator is created. emqx_authn_chains:call_authenticator/4 consults that map at dispatch time instead of calling erlang:function_exported/3 on every client login. The provider is force-loaded once during probing so the behaviour is correct under -mode interactive as well as -mode embedded.