### PR TITLE
fix(mqttsn): handle packets while connecting

### DIFF
--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -1027,6 +1027,12 @@ handle_in(
     AckPkt = ?SN_WILLTOPICRESP_MSG(?SN_RC_ACCEPTED),
     {ok, {outgoing, AckPkt}, Channel#channel{will_msg = NWillMsg}};
 handle_in(
+    ?SN_WILLMSGUPD_MSG(_Payload),
+    Channel = #channel{will_msg = undefined}
+) ->
+    AckPkt = ?SN_WILLMSGRESP_MSG(?SN_RC_NOT_SUPPORTED),
+    {ok, {outgoing, AckPkt}, Channel};
+handle_in(
     ?SN_WILLMSGUPD_MSG(Payload),
     Channel = #channel{will_msg = WillMsg}
 ) ->

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -521,6 +521,11 @@ handle_in(
     ?SLOG(warning, #{msg => "receive_connect_packet_in_connecting_state"}),
     {ok, Channel};
 handle_in(
+    ?SN_DISCONNECT_MSG(_Duration),
+    Channel = #channel{conn_state = connecting}
+) ->
+    handle_out(disconnect, normal, Channel);
+handle_in(
     ?SN_CONNECT_MSG(_Flags, _ProtoId, _Duration, _ClientId),
     Channel = #channel{conn_state = connected}
 ) ->
@@ -554,6 +559,15 @@ handle_in(
     NChannel = Channel#channel{will_msg = WillMsg},
     {ok, {outgoing, ?SN_WILLMSGREQ_MSG()}, NChannel};
 handle_in(
+    ?SN_WILLMSG_MSG(_Payload),
+    Channel = #channel{
+        conn_state = connecting,
+        will_msg = undefined
+    }
+) ->
+    ?SLOG(warning, #{msg => "receive_willmsg_before_willtopic"}),
+    handle_out(disconnect, ?SN_RC_NOT_SUPPORTED, Channel);
+handle_in(
     ?SN_WILLMSG_MSG(Payload),
     Channel = #channel{
         conn_state = connecting,
@@ -567,6 +581,15 @@ handle_in(
         {error, ReasonCode} ->
             handle_out(connack, ReasonCode, Channel)
     end;
+handle_in(
+    Pkt,
+    Channel = #channel{conn_state = connecting}
+) ->
+    ?SLOG(warning, #{
+        msg => "receive_unexpected_packet_in_connecting_state",
+        packet => Pkt
+    }),
+    handle_out(disconnect, ?SN_RC_NOT_SUPPORTED, Channel);
 %% TODO: takeover ???
 handle_in(
     ?SN_CONNECT_MSG(_Flags, _ProtoId, _Duration, ClientId),

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -228,6 +228,42 @@ t_duplicate_connect(_) ->
     ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
     gen_udp:close(Socket).
 
+t_disconnect_during_will_handshake(_) ->
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    send_connect_msg_with_will(Socket, 16#D1CA, <<"C7kauljMB4IdlKbGdf">>),
+    ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+
+    send_disconnect_msg(Socket, 16#45DA),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+    gen_udp:close(Socket).
+
+t_register_during_will_handshake(_) ->
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    send_connect_msg_with_will(Socket, 16#5143, <<"$0P$griMwmaT">>),
+    ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+
+    send_register_msg(Socket, <<"MwjOO">>, 16#5A63),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+    gen_udp:close(Socket).
+
+t_publish_during_will_handshake(_) ->
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    send_connect_msg_with_will(Socket, 16#5143, <<"publish-before-will">>),
+    ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+
+    send_publish_msg_normal_topic(Socket, ?QOS_0, 16#5A64, 1, <<"payload">>),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+    gen_udp:close(Socket).
+
+t_willmsg_before_willtopic(_) ->
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    send_connect_msg_with_will(Socket, 16#5143, <<"willmsg-before-topic">>),
+    ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+
+    send_willmsg_msg(Socket, <<"payload">>),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+    gen_udp:close(Socket).
+
 t_update_not_restart_listener(_) ->
     {ok, Socket} = gen_udp:open(0, [binary]),
     ClientId = ?CLIENTID,

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -1497,6 +1497,20 @@ t_will_test5(_) ->
 
     gen_udp:close(Socket).
 
+t_willmsgupd_without_will_topic(_) ->
+    {ok, Socket} = gen_udp:open(0, [binary]),
+
+    ClientId = <<"willmsgupd-without-will-topic">>,
+    send_connect_msg(Socket, ClientId),
+    ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+
+    send_willmsgupd_msg(Socket, <<"payload">>),
+    ?assertEqual(<<3, ?SN_WILLMSGRESP, ?SN_RC_NOT_SUPPORTED>>, receive_response(Socket)),
+
+    send_disconnect_msg(Socket, undefined),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+    gen_udp:close(Socket).
+
 t_will_case06(_) ->
     QoS = 1,
     Duration = 1,

--- a/changes/ee/fix-17287.en.md
+++ b/changes/ee/fix-17287.en.md
@@ -1,1 +1,1 @@
-Fixed MQTT-SN gateway crashes caused by packets received in unexpected connection or Will states, including `DISCONNECT` during connection setup, `REGISTER` before the Will handshake completes, and `WILLMSGUPD` before a Will topic exists.
+Fixed MQTT-SN clients crash caused by packets received in unexpected connection or Will states, including `DISCONNECT` during connection setup, `REGISTER` before the Will handshake completes, and `WILLMSGUPD` before a Will topic exists.

--- a/changes/ee/fix-17287.en.md
+++ b/changes/ee/fix-17287.en.md
@@ -1,1 +1,1 @@
-Fixed MQTT-SN gateway crashes caused by packets received while a client is still connecting, including `DISCONNECT` during connection setup and `REGISTER` before the Will handshake completes.
+Fixed MQTT-SN gateway crashes caused by packets received in unexpected connection or Will states, including `DISCONNECT` during connection setup, `REGISTER` before the Will handshake completes, and `WILLMSGUPD` before a Will topic exists.

--- a/changes/ee/fix-17287.en.md
+++ b/changes/ee/fix-17287.en.md
@@ -1,0 +1,1 @@
+Fixed MQTT-SN gateway crashes caused by packets received while a client is still connecting, including `DISCONNECT` during connection setup and `REGISTER` before the Will handshake completes.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15287

Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

This PR fixes MQTT-SN gateway crashes caused by packets received in unexpected connection or Will states.

* Handles `DISCONNECT` during the CONNECT/Will handshake as a clean client abort.
* Rejects unexpected MQTT-SN packets during the Will handshake before a session exists, preventing paths such as `REGISTER` from calling `emqx_mqttsn_session:registry(undefined)`.
* Rejects `WILLMSGUPD` when no Will topic/message exists, preventing a `badrecord` crash from updating `undefined` as a message.
* Adds regression coverage for `DISCONNECT`, `REGISTER`, `PUBLISH`, out-of-order `WILLMSG` during the Will handshake, and `WILLMSGUPD` without a Will topic.

Checked locally with targeted MQTT-SN Common Test cases, `erlfmt`, `git diff --check`, and `apps-version-check`.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
