### PR TITLE
fix(s3tables): update `parquer` to handle empty terminal values (r510)

### DIFF
--- a/apps/emqx_bridge_s3tables/mix.exs
+++ b/apps/emqx_bridge_s3tables/mix.exs
@@ -32,7 +32,7 @@ defmodule EMQXBridgeS3Tables.MixProject do
       {:emqx_resource, in_umbrella: true},
       {:emqx_connector_aggregator, in_umbrella: true},
       {:emqx_s3, in_umbrella: true},
-      {:parquer, github: "emqx/parquer", tag: "0.1.3", manager: :rebar3},
+      {:parquer, github: "emqx/parquer", tag: "0.1.8", manager: :rebar3},
       UMP.common_dep(:erlcloud),
       UMP.common_dep(:murmerl3),
     ]

--- a/apps/emqx_bridge_s3tables/rebar.config
+++ b/apps/emqx_bridge_s3tables/rebar.config
@@ -13,5 +13,5 @@
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_connector_aggregator, {path, "../../apps/emqx_connector_aggregator"}},
     {emqx_s3, {path, "../../apps/emqx_s3"}},
-    {parquer, {git, "https://github.com/emqx/parquer.git", {tag, "0.1.3"}}}
+    {parquer, {git, "https://github.com/emqx/parquer.git", {tag, "0.1.8"}}}
 ]}.

--- a/changes/ee/fix-17292.en.md
+++ b/changes/ee/fix-17292.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where, when writing a Parquet file with an object containing a required key but with an `undefined`/`null` value, a corrupt file would be written instead of raising an error.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/17226

See https://github.com/emqx/parquer/pull/7

Release version:
5.10.4

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
