### PR TITLE
fix(s3tables): update parquer to handle empty terminal values (r60)

### DIFF
--- a/apps/emqx_bridge_s3tables/mix.exs
+++ b/apps/emqx_bridge_s3tables/mix.exs
@@ -37,7 +37,7 @@ defmodule EMQXBridgeS3Tables.MixProject do
       {:emqx_connector_aggregator, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_s3, in_umbrella: true},
-      {:parquer, github: "emqx/parquer", tag: "0.1.3", manager: :rebar3},
+      {:parquer, github: "emqx/parquer", tag: "0.1.8", manager: :rebar3},
       :erlcloud,
       :murmerl3
     ])

--- a/changes/ee/fix-17293.en.md
+++ b/changes/ee/fix-17293.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where, when writing a Parquet file with an object containing a required key but with an `undefined`/`null` value, a corrupt file would be written instead of raising an error.


### PR DESCRIPTION
Fixes emqx#17226

See emqx/parquer#7

Release version:
6.0.3, 6.1.2, 6.2.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
