### PR TITLE
feat: implement security profiles (part I)

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -3,7 +3,6 @@
 %%--------------------------------------------------------------------
 
 -module(emqx_schema).
--feature(maybe_expr, enable).
 
 -dialyzer(no_return).
 -dialyzer(no_match).
@@ -632,7 +631,7 @@ fields("crl_cache") ->
             )}
     ];
 fields("mqtt_tcp_listener") ->
-    mqtt_listener(1883) ++
+    mqtt_listener(mqtt_default_bind_schema(1883)) ++
         [
             {"tcp_backend",
                 sc(
@@ -656,7 +655,7 @@ fields("mqtt_tcp_listener") ->
                 )}
         ];
 fields("mqtt_ssl_listener") ->
-    mqtt_listener(8883) ++
+    mqtt_listener(mqtt_default_bind_schema(8883)) ++
         mqtt_parse_options() ++
         [
             {"tcp_options",
@@ -671,7 +670,7 @@ fields("mqtt_ssl_listener") ->
                 )}
         ];
 fields("mqtt_ws_listener") ->
-    mqtt_listener(8083) ++
+    mqtt_listener(mqtt_default_bind_schema(8083)) ++
         [
             {"tcp_options",
                 sc(
@@ -685,7 +684,7 @@ fields("mqtt_ws_listener") ->
                 )}
         ];
 fields("mqtt_wss_listener") ->
-    mqtt_listener(8084) ++
+    mqtt_listener(mqtt_default_bind_schema(8084)) ++
         [
             {"tcp_options",
                 sc(
@@ -2131,6 +2130,7 @@ base_listener(Bind) ->
                 ip_port(),
                 #{
                     default => Bind,
+                    converter => fun listener_ip_port_converter/2,
                     required => true,
                     desc => ?DESC(base_listener_bind)
                 }
@@ -3811,11 +3811,11 @@ assert_required_field(Conf, Key, ErrorMessage) ->
 
 default_listener(tcp) ->
     #{
-        <<"bind">> => <<"0.0.0.0:1883">>
+        <<"bind">> => mqtt_default_bind_config(1883)
     };
 default_listener(ws) ->
     #{
-        <<"bind">> => <<"0.0.0.0:8083">>,
+        <<"bind">> => mqtt_default_bind_config(8083),
         <<"websocket">> => #{<<"mqtt_path">> => <<"/mqtt">>}
     };
 default_listener(SSLListener) ->
@@ -3828,12 +3828,12 @@ default_listener(SSLListener) ->
     case SSLListener of
         ssl ->
             #{
-                <<"bind">> => <<"0.0.0.0:8883">>,
+                <<"bind">> => mqtt_default_bind_config(8883),
                 <<"ssl_options">> => SslOptions
             };
         wss ->
             #{
-                <<"bind">> => <<"0.0.0.0:8084">>,
+                <<"bind">> => mqtt_default_bind_config(8084),
                 <<"ssl_options">> => SslOptions,
                 <<"websocket">> => #{<<"mqtt_path">> => <<"/mqtt">>}
             }
@@ -4399,6 +4399,41 @@ listeners() ->
                 }
             )}
     ].
+
+mqtt_default_bind_schema(Port) ->
+    case emqx_security_profile:policy(mqtt_default_bind) of
+        any -> Port;
+        loopback -> <<"127.0.0.1:", (integer_to_binary(Port))/binary>>
+    end.
+
+mqtt_default_bind_config(Port) ->
+    PortBin = integer_to_binary(Port),
+    case emqx_security_profile:policy(mqtt_default_bind) of
+        any -> <<"0.0.0.0:", PortBin/binary>>;
+        loopback -> <<"127.0.0.1:", PortBin/binary>>
+    end.
+
+listener_ip_port_converter(Value, Opts) ->
+    case emqx_security_profile:policy(mqtt_default_bind) of
+        any -> Value;
+        loopback -> maybe_add_loopback_converter(Value, Opts)
+    end.
+
+maybe_add_loopback_converter(undefined, _) ->
+    undefined;
+maybe_add_loopback_converter(Port, _) when is_integer(Port) ->
+    PortBin = integer_to_binary(Port),
+    <<"127.0.0.1:", PortBin/binary>>;
+maybe_add_loopback_converter(BindStr, _) when is_binary(BindStr) ->
+    case split_ip_port(BindStr) of
+        {"", Port} ->
+            PortBin = integer_to_binary(Port),
+            <<"127.0.0.1:", PortBin/binary>>;
+        {_MaybeIp, _Port} ->
+            BindStr
+    end;
+maybe_add_loopback_converter(Other, _) ->
+    Other.
 
 mkunion(Field, Schemas) ->
     mkunion(Field, Schemas, none).

--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -81,7 +81,7 @@ clear_profile() ->
 
 cache_profile() ->
     Profile =
-        case getenv_lowcase(?PROFILE_ENV_VAR) of
+        case os:getenv(?PROFILE_ENV_VAR) of
             false ->
                 ?PROFILE_DEFAULT;
             "" ->
@@ -100,11 +100,3 @@ cache_profile() ->
         end,
     _ = persistent_term:put(?PT_KEY, Profile),
     Profile.
-
-getenv_lowcase(Var) ->
-    case os:getenv(Var) of
-        false ->
-            false;
-        Value ->
-            string:lowercase(Value)
-    end.

--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -1,0 +1,110 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_security_profile).
+
+-moduledoc """
+This module manages the security profile of EMQX, which can be either "legacy" or
+"hardened".
+
+NOTE: this module may be called without the EMQX application started,
+e.g. in schema validation code.
+""".
+
+-define(PT_KEY, {?MODULE, profile}).
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
+
+%% Change to hardened in v7.0
+-define(PROFILE_DEFAULT, legacy).
+
+-export([profile/0, policy/1, clear_profile/0]).
+
+%---------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+-doc """
+Returns a value depending on the current security profile.
+
+Use this function only for introspection/logging purposes.
+Do not rely on security profile values directly in the code logic,
+use `emqx_security_profile:policy/1` instead.
+""".
+-spec profile() -> legacy | hardened.
+profile() ->
+    case persistent_term:get(?PT_KEY, undefined) of
+        undefined ->
+            cache_profile();
+        Profile ->
+            Profile
+    end.
+
+-doc """
+Returns policy depending on the current security profile.
+""".
+-spec policy
+    (mqtt_default_bind) -> loopback | any;
+    (dashboard_http_default_bind) -> loopback | any;
+    (authn_not_configured) -> allow | deny;
+    (dashboard_unchanged_default_credentials) -> allow | deny.
+policy(mqtt_default_bind) ->
+    case profile() of
+        legacy -> any;
+        hardened -> loopback
+    end;
+policy(dashboard_http_default_bind) ->
+    case profile() of
+        legacy -> any;
+        hardened -> loopback
+    end;
+policy(authn_not_configured) ->
+    case profile() of
+        legacy -> allow;
+        hardened -> deny
+    end;
+policy(dashboard_unchanged_default_credentials) ->
+    case profile() of
+        legacy -> allow;
+        hardened -> deny
+    end.
+
+-doc """
+Clears the cached security profile. This function is intended for testing purposes only.
+""".
+clear_profile() ->
+    persistent_term:erase(?PT_KEY).
+
+%%---------------------------------------------------------------------
+%% Internal functions
+%%---------------------------------------------------------------------
+
+cache_profile() ->
+    Profile =
+        case getenv_lowcase(?PROFILE_ENV_VAR) of
+            false ->
+                ?PROFILE_DEFAULT;
+            "" ->
+                ?PROFILE_DEFAULT;
+            "legacy" ->
+                legacy;
+            "hardened" ->
+                hardened;
+            Other ->
+                Message = io_lib:format(
+                    "Invalid security profile(~p) value: ~p. "
+                    "Valid values are: `legacy', `hardened', or empty (defaulting to ~p).",
+                    [?PROFILE_ENV_VAR, Other, ?PROFILE_DEFAULT]
+                ),
+                exit({invalid_security_profile, iolist_to_binary(Message)})
+        end,
+    _ = persistent_term:put(?PT_KEY, Profile),
+    Profile.
+
+getenv_lowcase(Var) ->
+    case os:getenv(Var) of
+        false ->
+            false;
+        Value ->
+            string:lowercase(Value)
+    end.

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -113,3 +113,8 @@ t_hardened(_) ->
     ?assertEqual({{127, 0, 0, 1}, 8883}, emqx:get_config([listeners, ssl, default, bind])),
     ?assertEqual({{127, 0, 0, 1}, 8083}, emqx:get_config([listeners, ws, default, bind])),
     ?assertEqual({{127, 0, 0, 1}, 8084}, emqx:get_config([listeners, wss, default, bind])).
+
+t_uppercase_profile_rejected(_) ->
+    os:putenv(?PROFILE_ENV_VAR, "HARDENED"),
+    emqx_security_profile:clear_profile(),
+    ?assertExit({invalid_security_profile, _}, emqx_security_profile:profile()).

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -1,0 +1,115 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_security_profile_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    WorkDir = emqx_cth_suite:work_dir(Config),
+    Apps = emqx_cth_suite:start(
+        [emqx],
+        #{work_dir => WorkDir}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    ok = emqx_cth_suite:stop(?config(apps, Config)).
+
+init_per_testcase(t_legacy, Config) ->
+    os:putenv(?PROFILE_ENV_VAR, "legacy"),
+    emqx_security_profile:clear_profile(),
+    Config;
+init_per_testcase(t_hardened, Config) ->
+    os:putenv(?PROFILE_ENV_VAR, "hardened"),
+    emqx_security_profile:clear_profile(),
+    Config;
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(_, _Config) ->
+    os:unsetenv(?PROFILE_ENV_VAR),
+    emqx_security_profile:clear_profile(),
+    ok.
+
+t_legacy(_) ->
+    {ok, _} = emqx:update_config([listeners], #{}),
+
+    %% verify the mode itself
+    ?assertEqual(legacy, emqx_security_profile:profile()),
+
+    %% Full defaults
+    ?assertEqual({{0, 0, 0, 0}, 1883}, emqx:get_config([listeners, tcp, default, bind])),
+    ?assertEqual({{0, 0, 0, 0}, 8883}, emqx:get_config([listeners, ssl, default, bind])),
+    ?assertEqual({{0, 0, 0, 0}, 8083}, emqx:get_config([listeners, ws, default, bind])),
+    ?assertEqual({{0, 0, 0, 0}, 8084}, emqx:get_config([listeners, wss, default, bind])),
+
+    %% Default bind values - only port values for legacy profile behavior
+    {ok, _} = emqx:update_config([listeners], #{
+        <<"tcp">> => #{<<"default">> => #{}},
+        <<"ssl">> => #{<<"default">> => #{}},
+        <<"ws">> => #{<<"default">> => #{}},
+        <<"wss">> => #{<<"default">> => #{}}
+    }),
+    ?assertEqual(1883, emqx:get_config([listeners, tcp, default, bind])),
+    ?assertEqual(8883, emqx:get_config([listeners, ssl, default, bind])),
+    ?assertEqual(8083, emqx:get_config([listeners, ws, default, bind])),
+    ?assertEqual(8084, emqx:get_config([listeners, wss, default, bind])),
+
+    %% Port values as bind values - no change for legacy profile behavior
+    {ok, _} = emqx:update_config([listeners], #{
+        <<"tcp">> => #{<<"default">> => #{<<"bind">> => 1883}},
+        <<"ssl">> => #{<<"default">> => #{<<"bind">> => 8883}},
+        <<"ws">> => #{<<"default">> => #{<<"bind">> => 8083}},
+        <<"wss">> => #{<<"default">> => #{<<"bind">> => 8084}}
+    }),
+    ?assertEqual(1883, emqx:get_config([listeners, tcp, default, bind])),
+    ?assertEqual(8883, emqx:get_config([listeners, ssl, default, bind])),
+    ?assertEqual(8083, emqx:get_config([listeners, ws, default, bind])),
+    ?assertEqual(8084, emqx:get_config([listeners, wss, default, bind])).
+
+t_hardened(_) ->
+    {ok, _} = emqx:update_config([listeners], #{}),
+
+    %% verify the mode itself
+    ?assertEqual(hardened, emqx_security_profile:profile()),
+
+    %% Full defaults are secure in hardened profile
+    ?assertEqual({{127, 0, 0, 1}, 1883}, emqx:get_config([listeners, tcp, default, bind])),
+    ?assertEqual({{127, 0, 0, 1}, 8883}, emqx:get_config([listeners, ssl, default, bind])),
+    ?assertEqual({{127, 0, 0, 1}, 8083}, emqx:get_config([listeners, ws, default, bind])),
+    ?assertEqual({{127, 0, 0, 1}, 8084}, emqx:get_config([listeners, wss, default, bind])),
+
+    %% Default bind values, port + loopback should be used for hardened profile behavior
+    {ok, _} = emqx:update_config([listeners], #{
+        <<"tcp">> => #{<<"default">> => #{}},
+        <<"ssl">> => #{<<"default">> => #{}},
+        <<"ws">> => #{<<"default">> => #{}},
+        <<"wss">> => #{<<"default">> => #{}}
+    }),
+    ?assertEqual({{127, 0, 0, 1}, 1883}, emqx:get_config([listeners, tcp, default, bind])),
+    ?assertEqual({{127, 0, 0, 1}, 8883}, emqx:get_config([listeners, ssl, default, bind])),
+    ?assertEqual({{127, 0, 0, 1}, 8083}, emqx:get_config([listeners, ws, default, bind])),
+    ?assertEqual({{127, 0, 0, 1}, 8084}, emqx:get_config([listeners, wss, default, bind])),
+
+    %% Port values as bind values, loopback should still be applied in hardened profile behavior
+    {ok, _} = emqx:update_config([listeners], #{
+        <<"tcp">> => #{<<"default">> => #{<<"bind">> => 1883}},
+        <<"ssl">> => #{<<"default">> => #{<<"bind">> => 8883}},
+        <<"ws">> => #{<<"default">> => #{<<"bind">> => 8083}},
+        <<"wss">> => #{<<"default">> => #{<<"bind">> => 8084}}
+    }),
+    ?assertEqual({{127, 0, 0, 1}, 1883}, emqx:get_config([listeners, tcp, default, bind])),
+    ?assertEqual({{127, 0, 0, 1}, 8883}, emqx:get_config([listeners, ssl, default, bind])),
+    ?assertEqual({{127, 0, 0, 1}, 8083}, emqx:get_config([listeners, ws, default, bind])),
+    ?assertEqual({{127, 0, 0, 1}, 8084}, emqx:get_config([listeners, wss, default, bind])).

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
@@ -169,20 +169,32 @@ authenticate(#{listener := Listener, protocol := Protocol} = Credential, _AuthRe
         {ok, ChainName, Authenticators} ->
             case get_enabled(Authenticators) of
                 [] ->
-                    %% Empty chain means allowed anonymous access.
-                    %% Further authentication hooks may still forbid the access.
+                    %% Empty chain means allowed anonymous access for legacy security profile,
+                    %% and forbidden access for hardened security profile.
+                    %%
+                    %% Further authentication hooks may override this result
                     %% We return
                     %% {
                     %%   ok, %% to tell the hooks that we want to set a new AuthResult acc
-                    %%   ok %% the actual new AuthResult acc
+                    %%   ok | {error, not_authorized} %% the actual new AuthResult acc
                     %% }
-                    ?TRACE_RESULT("authentication_result", {ok, ok}, empty_chain);
+                    Result =
+                        case emqx_security_profile:policy(authn_not_configured) of
+                            allow -> ok;
+                            deny -> {error, not_authorized}
+                        end,
+                    ?TRACE_RESULT("authentication_result", {ok, Result}, empty_chain);
                 NAuthenticators ->
                     Result = do_authenticate(ChainName, NAuthenticators, Credential),
                     ?TRACE_RESULT("authentication_result", Result, chain_result)
             end;
         none ->
-            ?TRACE_RESULT("authentication_result", {ok, ok}, no_chain);
+            Result =
+                case emqx_security_profile:policy(authn_not_configured) of
+                    allow -> ok;
+                    deny -> {error, not_authorized}
+                end,
+            ?TRACE_RESULT("authentication_result", {ok, Result}, no_chain);
         no_table ->
             %% This basically means that authn app crashed or stopped or being restarted.
             ?TRACE_RESULT("authentication_result", {ok, {error, not_authorized}}, no_chain_table)

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
@@ -24,6 +24,7 @@
 ).
 -define(CONF_ROOT, ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_ATOM).
 -define(NOT_SUPERUSER, #{is_superuser => false}).
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 -define(assertAuthSuccessForUser(User),
     ?assertMatch(
@@ -571,9 +572,81 @@ t_combine_authn_and_callback({'end', Config}) ->
     ?AUTHN:deregister_provider(?config(authn_type)),
     ok.
 
+t_authn_not_configured_missing_chain({'init', Config}) ->
+    Config;
+t_authn_not_configured_missing_chain(Config) when is_list(Config) ->
+    ok = cleanup_authn_not_configured_chains(),
+    ClientInfo = authn_not_configured_clientinfo(),
+
+    with_profile("legacy", fun() ->
+        ?assertMatch({ok, _}, emqx_access_control:authenticate(ClientInfo))
+    end),
+    with_profile("hardened", fun() ->
+        ?assertEqual({error, not_authorized}, emqx_access_control:authenticate(ClientInfo))
+    end),
+    ok;
+t_authn_not_configured_missing_chain({'end', _Config}) ->
+    ok = cleanup_authn_not_configured_chains(),
+    clear_security_profile().
+
+t_authn_not_configured_empty_chain({'init', Config}) ->
+    Config;
+t_authn_not_configured_empty_chain(Config) when is_list(Config) ->
+    ListenerID = 'tcp:default',
+    AuthNType = {password_based, built_in_database},
+    ok = cleanup_authn_not_configured_chains(),
+    register_provider(AuthNType, ?MODULE),
+    AuthenticatorConfig = #{
+        mechanism => password_based,
+        backend => built_in_database,
+        enable => false
+    },
+    {ok, _} = ?AUTHN:create_authenticator(ListenerID, AuthenticatorConfig),
+    ClientInfo = authn_not_configured_clientinfo(),
+
+    with_profile("legacy", fun() ->
+        ?assertMatch({ok, _}, emqx_access_control:authenticate(ClientInfo))
+    end),
+    with_profile("hardened", fun() ->
+        ?assertEqual({error, not_authorized}, emqx_access_control:authenticate(ClientInfo))
+    end),
+    ok;
+t_authn_not_configured_empty_chain({'end', _Config}) ->
+    ok = cleanup_authn_not_configured_chains(),
+    ok = ?AUTHN:deregister_provider({password_based, built_in_database}),
+    clear_security_profile().
+
 %%=================================================================================
 %% Helpers fns
 %%=================================================================================
+
+authn_not_configured_clientinfo() ->
+    #{
+        zone => default,
+        listener => 'tcp:default',
+        protocol => mqtt,
+        username => <<"bad">>,
+        password => <<"any">>
+    }.
+
+with_profile(Profile, Fun) ->
+    os:putenv(?PROFILE_ENV_VAR, Profile),
+    emqx_security_profile:clear_profile(),
+    try
+        Fun()
+    after
+        clear_security_profile()
+    end.
+
+clear_security_profile() ->
+    os:unsetenv(?PROFILE_ENV_VAR),
+    emqx_security_profile:clear_profile(),
+    ok.
+
+cleanup_authn_not_configured_chains() ->
+    _ = ?AUTHN:delete_chain('tcp:default'),
+    _ = ?AUTHN:delete_chain('mqtt:global'),
+    ok.
 
 hook(Priority) ->
     ok = emqx_hooks:put(

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_sources_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_sources_SUITE.erl
@@ -99,9 +99,7 @@ init_per_suite(Config) ->
     meck:expect(
         emqx_authz_file,
         acl_conf_file,
-        fun() ->
-            emqx_common_test_helpers:deps_path(emqx_auth, "etc/acl.conf")
-        end
+        fun() -> acl_conf_path() end
     ),
     ACLConfPath = acl_conf_path(),
     {ok, ACLConfBackup} = file:read_file(ACLConfPath),

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -205,7 +205,7 @@ listeners(Listeners) ->
             ({_Protocol, #{bind := 0}}) ->
                 false;
             ({Protocol, Conf = #{}}) ->
-                {Conf1, Bind} = ip_port(Conf),
+                {Conf1, Bind} = ip_port(Protocol, Conf),
                 {true, {
                     listener_name(Protocol),
                     Protocol,
@@ -220,11 +220,29 @@ listeners(Listeners) ->
 list_listeners() ->
     listeners(listeners()).
 
-ip_port(Opts) -> ip_port(maps:take(bind, Opts), Opts).
+%% http
+ip_port(http = _Protocol, #{bind := Port} = Opts) when is_integer(Port) ->
+    case emqx_security_profile:policy(dashboard_http_default_bind) of
+        any ->
+            {maps:without([bind], Opts#{port => Port}), Port};
+        loopback ->
+            IP = loopback_ip(Opts),
+            {maps:without([bind], Opts#{port => Port, ip => IP}), {IP, Port}}
+    end;
+ip_port(http = _Protocol, #{bind := {IP, Port} = Bind} = Opts) ->
+    {maps:without([bind], Opts#{port => Port, ip => IP}), Bind};
+ip_port(http = Protocol, Opts) ->
+    ip_port(Protocol, Opts#{bind => 18083});
+%% https
+ip_port(https = _Protocol, #{bind := Port} = Opts) when is_integer(Port) ->
+    {maps:without([bind], Opts#{port => Port}), Port};
+ip_port(https = _Protocol, #{bind := {IP, Port} = Bind} = Opts) ->
+    {maps:without([bind], Opts#{port => Port, ip => IP}), Bind};
+ip_port(https = Protocol, Opts) ->
+    ip_port(Protocol, Opts#{bind => 18084}).
 
-ip_port(error, Opts) -> {Opts#{port => 18083}, 18083};
-ip_port({Port, Opts}, _) when is_integer(Port) -> {Opts#{port => Port}, Port};
-ip_port({{IP, Port}, Opts}, _) -> {Opts#{port => Port, ip => IP}, {IP, Port}}.
+loopback_ip(#{inet6 := true}) -> {0, 0, 0, 0, 0, 0, 0, 1};
+loopback_ip(_Opts) -> {127, 0, 0, 1}.
 
 ranch_opts(Options) ->
     Keys = [

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -92,6 +92,7 @@
 -type role() :: binary().
 
 -define(USERNAME_ALREADY_EXISTS_ERROR, <<"username_already_exists">>).
+-define(INSECURE_DEFAULT_PASSWORD, <<"public">>).
 
 %%--------------------------------------------------------------------
 %% Mnesia bootstrap
@@ -774,16 +775,22 @@ check(Username, Password, MfaToken) ->
         [#?ADMIN{pwdhash = PwdHash} = User] ->
             IsPwdOk = (ok =:= verify_hash(Password, PwdHash)),
             MfaVerifyResult = verify_mfa_token(Username, MfaToken, IsPwdOk),
-            check_mfa_pwd(MfaVerifyResult, IsPwdOk, User);
+            maybe
+                ok ?= check_mfa_pwd(MfaVerifyResult, IsPwdOk),
+                ok ?= check_unchanged_default_credentials(Password),
+                {ok, User}
+            else
+                Error -> Error
+            end;
         [] ->
             {error, <<"username_not_found">>}
     end.
 
-check_mfa_pwd(ok, true, User) ->
-    {ok, User};
-check_mfa_pwd(ok, false, _User) ->
+check_mfa_pwd(ok, true) ->
+    ok;
+check_mfa_pwd(ok, false) ->
     {error, <<"password_error">>};
-check_mfa_pwd({error, MfaError}, IsPwdOk, _User) ->
+check_mfa_pwd({error, MfaError}, IsPwdOk) ->
     %% MFA error
     case emqx_dashboard_mfa:is_need_setup_error(MfaError) of
         true when not IsPwdOk ->
@@ -798,6 +805,21 @@ check_mfa_pwd({error, MfaError}, IsPwdOk, _User) ->
             %% - MFA is setup, but token is NOT provided
             %% - MFA is setup, but bad token prvoided
             {error, MfaError}
+    end.
+
+check_unchanged_default_credentials(Password) ->
+    %% NOTE
+    %% This intentionally triggers if the username was changed but the password is still the standard default.
+    case Password =:= ?INSECURE_DEFAULT_PASSWORD of
+        true ->
+            case emqx_security_profile:policy(dashboard_unchanged_default_credentials) of
+                allow ->
+                    ok;
+                deny ->
+                    {error, <<"default_credentials_not_changed">>}
+            end;
+        false ->
+            ok
     end.
 
 verify_mfa_token(_Username, ?TRUSTED_MFA_TOKEN, _IsPwdOk) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -279,6 +279,13 @@ login(post, #{body := Params}) ->
             format_login_failed_error(R)
     end.
 
+format_login_failed_error(<<"default_credentials_not_changed">>) ->
+    {401, ?BAD_USERNAME_OR_PWD,
+        ~b"""
+    Default admin password must be changed before login is allowed.
+    Run: emqx ctl admins passwd admin <a-strong-password>.
+    Or configure: dashboard.default_password = "<a-strong-password>".
+    """};
 format_login_failed_error(Reason) ->
     maybe
         {is_mfa_error, false} ?= {is_mfa_error, emqx_dashboard_mfa:is_mfa_error(Reason)},

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -27,6 +27,7 @@
 
 -define(BASE_PATH, "/api/v5").
 -define(CAPTURE(Expr), emqx_common_test_helpers:capture_io_format(fun() -> Expr end)).
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 -define(OVERVIEWS, [
     "alarms",
@@ -60,6 +61,15 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     emqx_cth_suite:stop(?config(suite_apps, Config)).
+
+init_per_test_case(_, Config) ->
+    Config.
+
+end_per_test_case(t_default_public_password_login_security_profile, _Config) ->
+    clear_security_profile(),
+    mnesia:clear_table(?ADMIN);
+end_per_test_case(_Case, _Config) ->
+    ok.
 
 t_overview(_) ->
     mnesia:clear_table(?ADMIN),
@@ -192,6 +202,36 @@ t_admin_delete_default_username(_TCConfig) ->
     ok = application:start(emqx_dashboard),
     ?assertMatch([_], emqx_dashboard_admin:admin_users()),
     ok.
+
+t_default_public_password_login_security_profile(_TCConfig) ->
+    mnesia:clear_table(?ADMIN),
+    Username = <<"someuser">>,
+    PublicPassword = <<"public">>,
+    ok = emqx_dashboard_admin:force_add_user(
+        Username, PublicPassword, ?ROLE_SUPERUSER, <<"public password test">>, #{}
+    ),
+
+    with_security_profile("legacy", fun() ->
+        ?assertMatch(
+            {ok, {{_, 200, _}, _, _}},
+            login_api(Username, PublicPassword)
+        )
+    end),
+
+    with_security_profile("hardened", fun() ->
+        {ok, {{_, 401, _}, _, Body}} = login_api(Username, PublicPassword),
+        #{
+            <<"code">> := <<"BAD_USERNAME_OR_PWD">>,
+            <<"message">> := Message
+        } = json(Body),
+        ?assertNotEqual(
+            nomatch,
+            binary:match(
+                Message,
+                <<"Default admin password must be changed before login is allowed.">>
+            )
+        )
+    end).
 
 t_rest_api(_Config) ->
     mnesia:clear_table(?ADMIN),
@@ -558,6 +598,29 @@ auth_header_() ->
 auth_header_(Username, Password) ->
     {ok, #{token := Token}} = emqx_dashboard_admin:sign_token(Username, Password),
     {"Authorization", "Bearer " ++ binary_to_list(Token)}.
+
+login_api(Username, Password) ->
+    Body = emqx_utils_json:encode(#{username => Username, password => Password}),
+    httpc:request(
+        post,
+        {?HOST ++ filename:join([?BASE_PATH, "login"]), [], "application/json", Body},
+        [],
+        [{body_format, binary}]
+    ).
+
+with_security_profile(Profile, Fun) ->
+    os:putenv(?PROFILE_ENV_VAR, Profile),
+    emqx_security_profile:clear_profile(),
+    try
+        Fun()
+    after
+        clear_security_profile()
+    end.
+
+clear_security_profile() ->
+    os:unsetenv(?PROFILE_ENV_VAR),
+    emqx_security_profile:clear_profile(),
+    ok.
 
 api_path(Parts) ->
     ?HOST ++ filename:join([?BASE_PATH | Parts]).

--- a/apps/emqx_dashboard/test/emqx_dashboard_listener_config_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_listener_config_SUITE.erl
@@ -11,23 +11,26 @@
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
+
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
-init_per_suite(Config) ->
+init_per_testcase(TestCase, Config) ->
     Apps = emqx_cth_suite:start(
         [
             emqx_conf,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],
-        #{work_dir => emqx_cth_suite:work_dir(Config)}
+        #{work_dir => emqx_cth_suite:work_dir(TestCase, Config)}
     ),
     [{apps, Apps} | Config].
 
-end_per_suite(Config) ->
+end_per_testcase(_TestCase, Config) ->
     Apps = ?config(apps, Config),
     emqx_cth_suite:stop(Apps),
+    clear_security_profile(),
     ok.
 
 t_change_i18n_lang(_Config) ->
@@ -40,6 +43,43 @@ t_change_i18n_lang(_Config) ->
         []
     ).
 
+t_http_default_bind_security_profile(_Config) ->
+    ok = assert_http_default_bind("legacy", false, 18083, inet),
+    ok = assert_http_default_bind("legacy", true, 18083, inet6),
+    ok = assert_http_default_bind("hardened", false, {{127, 0, 0, 1}, 18083}, inet),
+    ok = assert_http_default_bind("hardened", true, {{0, 0, 0, 0, 0, 0, 0, 1}, 18083}, inet6).
+
 change_i18n_lang(Lang) ->
     {ok, _} = emqx_conf:update([dashboard], {change_i18n_lang, Lang}, #{}),
+    ok.
+
+assert_http_default_bind(Profile, Inet6, ExpectedBind, ExpectedInetOpt) ->
+    set_security_profile(Profile),
+    {ok, _} = emqx:update_config([dashboard, listeners], #{
+        <<"http">> => #{
+            <<"enable">> => true,
+            <<"bind">> => 18083,
+            <<"inet6">> => Inet6,
+            <<"ipv6_v6only">> => false
+        }
+    }),
+    [Listener] = emqx_dashboard:list_listeners(),
+    ?assertMatch(
+        {'http:dashboard', http, ExpectedBind, _RanchOpts, _ProtoOpts},
+        Listener
+    ),
+    {'http:dashboard', http, ExpectedBind, RanchOpts, _ProtoOpts} = Listener,
+    SocketOpts = maps:get(socket_opts, RanchOpts),
+    ?assert(lists:member(ExpectedInetOpt, SocketOpts)),
+    ?assertEqual(false, lists:keymember(bind, 1, SocketOpts)),
+    ok.
+
+set_security_profile(Profile) ->
+    os:putenv(?PROFILE_ENV_VAR, Profile),
+    emqx_security_profile:clear_profile(),
+    ok.
+
+clear_security_profile() ->
+    os:unsetenv(?PROFILE_ENV_VAR),
+    emqx_security_profile:clear_profile(),
     ok.

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -42,6 +42,12 @@
 post_boot() ->
     ok = ensure_apps_started(),
     ok = print_vsn(),
+    ?SLOG(info, #{
+        msg => "emqx_is_running",
+        description => emqx_app:get_description(),
+        release => emqx_app:get_release(),
+        security_profile => emqx_security_profile:profile()
+    }),
     ok = start_autocluster(),
     ignore.
 

--- a/bin/emqx
+++ b/bin/emqx
@@ -254,6 +254,16 @@ case "${COMMAND}" in
         ;;
 esac
 
+# Will be set to hardened since v7
+export EMQX_SECURITY_PROFILE="${EMQX_SECURITY_PROFILE:-legacy}"
+
+if [[ "$IS_BOOT_COMMAND" = 'yes' ]]; then
+    if ! [[ "${EMQX_SECURITY_PROFILE,,}" =~ ^(legacy|hardened)?$ ]]; then
+        logerr "Invalid security profile: $EMQX_SECURITY_PROFILE. Valid values are: legacy, hardened, or empty (defaulting to legacy)."
+        exit 1
+    fi
+fi
+
 RELUP_DIR="relup"
 BASE_RUNNER_ROOT_DIR="${BASE_RUNNER_ROOT_DIR:-$RUNNER_ROOT_DIR}"
 RELUP_PATH="$RUNNER_ROOT_DIR/$RELUP_DIR"
@@ -1026,11 +1036,17 @@ fi
 [ -z "$COOKIE" ] && COOKIE="$COOKIE_IN_USE"
 [ -z "$COOKIE" ] && COOKIE="$EMQX_DEFAULT_ERLANG_COOKIE"
 
+# Frequently used sample cookie value for testing, not recommended for production use
+EMQX_SAMPLE_ERLANG_COOKIE="emqxsecretcookie"
+
 maybe_warn_default_cookie() {
-    if [ $IS_BOOT_COMMAND = 'yes' ] && [ "$COOKIE" = "$EMQX_DEFAULT_ERLANG_COOKIE" ]; then
+    if [[ "$IS_BOOT_COMMAND" = 'yes' && ("$COOKIE" = "$EMQX_DEFAULT_ERLANG_COOKIE" || "$COOKIE" = "$EMQX_SAMPLE_ERLANG_COOKIE") ]]; then
         logwarn "Default (insecure) Erlang cookie is in use."
         logwarn "Configure node.cookie in $EMQX_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE__COOKIE"
         logwarn "NOTE: Use the same cookie for all nodes in the cluster."
+        if [ "$EMQX_SECURITY_PROFILE" != "legacy" ]; then
+            die "Cannot continue with default cookie and EMQX_SECURITY_PROFILE set to '$EMQX_SECURITY_PROFILE'."
+        fi
     fi
 }
 

--- a/bin/emqx
+++ b/bin/emqx
@@ -258,8 +258,8 @@ esac
 export EMQX_SECURITY_PROFILE="${EMQX_SECURITY_PROFILE:-legacy}"
 
 if [[ "$IS_BOOT_COMMAND" = 'yes' ]]; then
-    if ! [[ "${EMQX_SECURITY_PROFILE,,}" =~ ^(legacy|hardened)?$ ]]; then
-        logerr "Invalid security profile: $EMQX_SECURITY_PROFILE. Valid values are: legacy, hardened, or empty (defaulting to legacy)."
+    if [ "$EMQX_SECURITY_PROFILE" != 'legacy' ] && [ "$EMQX_SECURITY_PROFILE" != 'hardened' ]; then
+        logerr "Invalid security profile: $EMQX_SECURITY_PROFILE. Valid values are: legacy, hardened."
         exit 1
     fi
 fi

--- a/changes/ee/security-17301.en.md
+++ b/changes/ee/security-17301.en.md
@@ -1,0 +1,11 @@
+Added `EMQX_SECURITY_PROFILE` environment variable support to provide graceful transiton from legacy defaults to more secure defaults in EMQX 7.
+With `EMQX_SECURITY_PROFILE` set to `legacy` (default in EMQX 6 and earlier), the behavior is unchanged.
+With `EMQX_SECURITY_PROFILE` set to `hardened`, the following changes are made:
+
+- Reject insecure Erlang cookies.
+- Bind MQTT and WebSocket listeners to loopback by default or when bind host is ommitted.
+- Bind the default HTTP Dashboard listener to loopback by default or when bind host is ommitted.
+- Reject Dashboard login with the default `public` password.
+- Deny MQTT anonimous access when no authentication backends are configured.
+
+In EMQX 7, the default value of `EMQX_SECURITY_PROFILE` will be `hardened`. To achieve previous default behavior, setting `EMQX_SECURITY_PROFILE` to `legacy` explicitly will be required.

--- a/scripts/test/test_emqx_boot.py
+++ b/scripts/test/test_emqx_boot.py
@@ -40,6 +40,18 @@ def emqx_rel_path(profile):
     return rel_path
 
 
+def run_emqx_console(emqx_bin_path, env_overrides, timeout=10):
+    env = os.environ.copy()
+    env.update(env_overrides)
+    return subprocess.run(
+        [str(emqx_bin_path), "console"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout
+    )
+
+
 def test_profile_defaults_to_emqx_enterprise():
     """Test that PROFILE defaults to emqx-enterprise when not set."""
     # This test verifies the default behavior
@@ -63,6 +75,35 @@ def test_emqx_boot_with_invalid_node_name(emqx_bin_path):
     # The command should fail and output should contain error message
     output = result.stdout + result.stderr
     assert "ERROR: Invalid node name," in output or result.returncode != 0
+
+
+def test_hardened_rejects_insecure_cookie(emqx_bin_path):
+    """Test that hardened profile rejects known insecure Erlang cookies."""
+    for cookie in ["emqx50elixir", "emqxsecretcookie"]:
+        result = run_emqx_console(
+            emqx_bin_path,
+            {
+                "EMQX_SECURITY_PROFILE": "hardened",
+                "EMQX_NODE__COOKIE": cookie,
+            },
+        )
+        output = result.stdout + result.stderr
+        assert result.returncode != 0, f"Expected EMQX to reject cookie {cookie}"
+        assert "Cannot continue with default cookie" in output
+        assert "EMQX_SECURITY_PROFILE" in output
+
+
+def test_invalid_security_profile_fails_fast(emqx_bin_path):
+    """Test that malformed EMQX_SECURITY_PROFILE fails before boot."""
+    result = run_emqx_console(
+        emqx_bin_path,
+        {"EMQX_SECURITY_PROFILE": "not-a-profile"},
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Invalid security profile" in output
+    assert "legacy" in output
+    assert "hardened" in output
 
 
 def test_corrupted_cluster_override_conf(emqx_bin_path, emqx_rel_path):

--- a/scripts/test/test_emqx_boot.py
+++ b/scripts/test/test_emqx_boot.py
@@ -93,11 +93,12 @@ def test_hardened_rejects_insecure_cookie(emqx_bin_path):
         assert "EMQX_SECURITY_PROFILE" in output
 
 
-def test_invalid_security_profile_fails_fast(emqx_bin_path):
+@pytest.mark.parametrize("security_profile", ["not-a-profile", "HARDENED"])
+def test_invalid_security_profile_fails_fast(emqx_bin_path, security_profile):
     """Test that malformed EMQX_SECURITY_PROFILE fails before boot."""
     result = run_emqx_console(
         emqx_bin_path,
-        {"EMQX_SECURITY_PROFILE": "not-a-profile"},
+        {"EMQX_SECURITY_PROFILE": security_profile},
     )
     output = result.stdout + result.stderr
     assert result.returncode != 0


### PR DESCRIPTION
First part of https://github.com/emqx/eip/blob/main/active/0036-support-environment-variable-emqx-security-profile.md (everything but acf.conf changes, see https://github.com/emqx/eip/pull/106)

Release version: 6.3

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
