### PR TITLE
chore(deps): bump kafka client deps brod 4.5.4 and wolff 4.1.10

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,10 +2,10 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.1.7"},
+    {wolff, "4.1.10"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
-    {brod, "4.5.2"},
+    {brod, "4.5.4"},
     {snappyer, "1.2.10"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,10 +2,10 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.1.7"},
+    {wolff, "4.1.10"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
-    {brod, "4.5.2"},
+    {brod, "4.5.4"},
     {snappyer, "1.2.10"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,10 +2,10 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.1.7"},
+    {wolff, "4.1.10"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
-    {brod, "4.5.2"},
+    {brod, "4.5.4"},
     {snappyer, "1.2.10"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},

--- a/changes/ee/chore-17301.en.md
+++ b/changes/ee/chore-17301.en.md
@@ -1,0 +1,6 @@
+Upgraded Kafka client libraries: `brod` 4.5.2 → 4.5.4 and `wolff` 4.1.7 → 4.1.10.
+
+This brings the following user-visible fixes to Kafka producer and consumer integrations:
+
+- Fixed a connection race condition during SASL re-authentication that could drop queued produce requests and cause `sync` produce calls to time out.
+- Improved leader-connection reconnection so that stale dead connections are no longer returned right after an idle-timeout disconnect.

--- a/mix.exs
+++ b/mix.exs
@@ -281,13 +281,13 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.1.7"}
+  def common_dep(:wolff), do: {:wolff, "4.1.10"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),
     do: {:kafka_protocol, "4.3.2", override: true}
 
-  def common_dep(:brod), do: {:brod, "4.5.2"}
+  def common_dep(:brod), do: {:brod, "4.5.4"}
   ## TODO: remove `mix.exs` from `wolff` and remove this override
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.10", override: true}


### PR DESCRIPTION
Fixes: https://emqx.atlassian.net/browse/EEC-1152
Release version: 5.8.11, 5.10.4

## Summary

Bumps the Kafka client dependencies for the Kafka, Confluent and Azure Event Hub bridges:

- `brod` 4.5.2 → 4.5.4 ([changelog](https://github.com/kafka4beam/brod/compare/4.5.2...4.5.4))
- `wolff` 4.1.7 → 4.1.10 ([changelog](https://github.com/kafka4beam/wolff/compare/4.1.7...4.1.10))

Notable upstream fixes pulled in:

- wolff: fix queued requests being dropped during SASL re-authentication (causing `sync` produce timeouts).
- wolff: fix stale dead leader connections being returned right after an idle-timeout disconnect.
- brod: fix race during SASL re-authentication.

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)