### PR TITLE
fix(docker): avoid empty node host on lookup failure

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -78,13 +78,13 @@ jobs:
         run: ./scripts/shellcheck.sh
       - name: Run shell tests
         run: scripts/shelltest/run_tests.sh
-      - name: Run pytest find-apps tests
+      - name: Run pytest script tests
         run: |
           python3 -m venv venv
           source venv/bin/activate
           pip install --upgrade pip
           pip install pytest
-          pytest scripts/test/test_find_apps.py -v
+          pytest scripts/test/test_find_apps.py scripts/test/test_docker_entrypoint.py -v
       - name: Check workflow files
         env:
           ACTIONLINT_VSN: 1.6.25

--- a/changes/ee/fix-17311.en.md
+++ b/changes/ee/fix-17311.en.md
@@ -1,0 +1,1 @@
+Fixed Docker startup when the container hostname cannot be resolved. The entrypoint now falls back to the interface IP address before auto-generating the node name, and fails with a clear error if no node host can be determined.

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -12,7 +12,18 @@ shopt -s nullglob
 
 ## Local IP address setting
 
-LOCAL_IP=$(hostname -i | grep -oE '((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])' | head -n 1)
+IP_REGEX='((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])'
+LOCAL_IP=$(hostname -i 2>/dev/null | grep -oE "$IP_REGEX" | head -n 1)
+if [[ -z "$LOCAL_IP" ]]; then
+    LOCAL_IP=$(hostname -I 2>/dev/null | grep -oE "$IP_REGEX" | head -n 1)
+fi
+
+ensure_local_ip() {
+    if [[ -z "$LOCAL_IP" ]]; then
+        echo "ERROR: Failed to determine EMQX node host. Set EMQX_NODE__NAME or EMQX_HOST." >&2
+        exit 1
+    fi
+}
 
 export EMQX_NAME="${EMQX_NAME:-emqx}"
 
@@ -29,14 +40,17 @@ if [[ -z "${EMQX_NODE_NAME:-}" ]] && [[ -z "${EMQX_NODE__NAME:-}" ]]; then
         elif [[ "$EMQX_CLUSTER__DISCOVERY_STRATEGY" == "k8s" ]] && \
             [[ "$EMQX_CLUSTER__K8S__ADDRESS_TYPE" == "dns" ]] && \
             [[ -n "$EMQX_CLUSTER__K8S__NAMESPACE" ]]; then
+                ensure_local_ip
                 EMQX_CLUSTER__K8S__SUFFIX=${EMQX_CLUSTER__K8S__SUFFIX:-"pod.cluster.local"}
                 EMQX_HOST="${LOCAL_IP//./-}.$EMQX_CLUSTER__K8S__NAMESPACE.$EMQX_CLUSTER__K8S__SUFFIX"
         elif [[ "$EMQX_CLUSTER__DISCOVERY_STRATEGY" == "k8s" ]] && \
             [[ "$EMQX_CLUSTER__K8S__ADDRESS_TYPE" == 'hostname' ]] && \
             [[ -n "$EMQX_CLUSTER__K8S__NAMESPACE" ]]; then
+                ensure_local_ip
                 EMQX_CLUSTER__K8S__SUFFIX=${EMQX_CLUSTER__K8S__SUFFIX:-'svc.cluster.local'}
                 EMQX_HOST=$(grep -h "^$LOCAL_IP" /etc/hosts | grep -o "$(hostname).*.$EMQX_CLUSTER__K8S__NAMESPACE.$EMQX_CLUSTER__K8S__SUFFIX")
         else
+            ensure_local_ip
             EMQX_HOST="$LOCAL_IP"
         fi
         export EMQX_HOST

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -18,10 +18,20 @@ if [[ -z "$LOCAL_IP" ]]; then
     LOCAL_IP=$(hostname -I 2>/dev/null | grep -oE "$IP_REGEX" | head -n 1)
 fi
 
+failed_to_determine_node_host() {
+    echo "ERROR: Failed to determine EMQX node host. Set EMQX_NODE_NAME, EMQX_NODE__NAME, or EMQX_HOST." >&2
+    exit 1
+}
+
 ensure_local_ip() {
     if [[ -z "$LOCAL_IP" ]]; then
-        echo "ERROR: Failed to determine EMQX node host. Set EMQX_NODE__NAME or EMQX_HOST." >&2
-        exit 1
+        failed_to_determine_node_host
+    fi
+}
+
+ensure_emqx_host() {
+    if [[ -z "${EMQX_HOST:-}" ]]; then
+        failed_to_determine_node_host
     fi
 }
 
@@ -48,11 +58,12 @@ if [[ -z "${EMQX_NODE_NAME:-}" ]] && [[ -z "${EMQX_NODE__NAME:-}" ]]; then
             [[ -n "$EMQX_CLUSTER__K8S__NAMESPACE" ]]; then
                 ensure_local_ip
                 EMQX_CLUSTER__K8S__SUFFIX=${EMQX_CLUSTER__K8S__SUFFIX:-'svc.cluster.local'}
-                EMQX_HOST=$(grep -h "^$LOCAL_IP" /etc/hosts | grep -o "$(hostname).*.$EMQX_CLUSTER__K8S__NAMESPACE.$EMQX_CLUSTER__K8S__SUFFIX")
+                EMQX_HOST=$(grep -h "^$LOCAL_IP" /etc/hosts | grep -o "$(hostname).*.$EMQX_CLUSTER__K8S__NAMESPACE.$EMQX_CLUSTER__K8S__SUFFIX" || true)
         else
             ensure_local_ip
             EMQX_HOST="$LOCAL_IP"
         fi
+        ensure_emqx_host
         export EMQX_HOST
     fi
     export EMQX_NODE_NAME="$EMQX_NAME@$EMQX_HOST"

--- a/scripts/test/test_docker_entrypoint.py
+++ b/scripts/test/test_docker_entrypoint.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Pytest tests for EMQX Docker entrypoint behavior.
+
+Usage:
+    pytest scripts/test/test_docker_entrypoint.py -v
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def run_entrypoint_with_hostname(tmp_path, hostname_script):
+    workspace_root = Path(__file__).parent.parent.parent
+    entrypoint = workspace_root / "deploy" / "docker" / "docker-entrypoint.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    hostname = fake_bin / "hostname"
+    hostname.write_text(hostname_script)
+    hostname.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    for name in [
+        "EMQX_HOST",
+        "EMQX_NAME",
+        "EMQX_NODE_NAME",
+        "EMQX_NODE__NAME",
+        "EMQX_CLUSTER__DISCOVERY_STRATEGY",
+        "EMQX_CLUSTER__DNS__RECORD_TYPE",
+        "EMQX_CLUSTER__K8S__ADDRESS_TYPE",
+        "EMQX_CLUSTER__K8S__NAMESPACE",
+    ]:
+        env.pop(name, None)
+
+    return subprocess.run(
+        [str(entrypoint), "env"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_entrypoint_falls_back_to_interface_ip_when_hostname_resolution_fails(tmp_path):
+    result = run_entrypoint_with_hostname(
+        tmp_path,
+        """#!/usr/bin/env bash
+if [ "$1" = "-i" ]; then
+  echo "hostname: Temporary failure in name resolution" >&2
+  exit 1
+fi
+if [ "$1" = "-I" ]; then
+  echo "172.17.0.2 10.0.0.3"
+  exit 0
+fi
+echo "emqx-container"
+""",
+    )
+
+    assert result.returncode == 0
+    assert "EMQX_HOST=172.17.0.2" in result.stdout
+    assert "EMQX_NODE_NAME=emqx@172.17.0.2" in result.stdout
+
+
+def test_entrypoint_fails_when_node_host_cannot_be_determined(tmp_path):
+    result = run_entrypoint_with_hostname(
+        tmp_path,
+        """#!/usr/bin/env bash
+if [ "$1" = "-i" ] || [ "$1" = "-I" ]; then
+  echo "hostname: Temporary failure in name resolution" >&2
+  exit 1
+fi
+echo "emqx-container"
+""",
+    )
+
+    assert result.returncode != 0
+    assert "Failed to determine EMQX node host" in result.stderr
+    assert "EMQX_NODE_NAME=emqx@" not in result.stdout

--- a/scripts/test/test_docker_entrypoint.py
+++ b/scripts/test/test_docker_entrypoint.py
@@ -11,7 +11,7 @@ import subprocess
 from pathlib import Path
 
 
-def run_entrypoint_with_hostname(tmp_path, hostname_script):
+def run_entrypoint_with_hostname(tmp_path, hostname_script, extra_env=None):
     workspace_root = Path(__file__).parent.parent.parent
     entrypoint = workspace_root / "deploy" / "docker" / "docker-entrypoint.sh"
     fake_bin = tmp_path / "bin"
@@ -33,6 +33,8 @@ def run_entrypoint_with_hostname(tmp_path, hostname_script):
         "EMQX_CLUSTER__K8S__NAMESPACE",
     ]:
         env.pop(name, None)
+    if extra_env:
+        env.update(extra_env)
 
     return subprocess.run(
         [str(entrypoint), "env"],
@@ -78,4 +80,32 @@ echo "emqx-container"
 
     assert result.returncode != 0
     assert "Failed to determine EMQX node host" in result.stderr
+    assert "EMQX_NODE_NAME" in result.stderr
+    assert "EMQX_NODE_NAME=emqx@" not in result.stdout
+
+
+def test_entrypoint_reports_clear_error_when_k8s_hostname_lookup_is_missing(tmp_path):
+    result = run_entrypoint_with_hostname(
+        tmp_path,
+        """#!/usr/bin/env bash
+if [ "$1" = "-i" ]; then
+  echo "203.0.113.45"
+  exit 0
+fi
+if [ "$1" = "-I" ]; then
+  echo "203.0.113.45"
+  exit 0
+fi
+echo "emqx-container"
+""",
+        {
+            "EMQX_CLUSTER__DISCOVERY_STRATEGY": "k8s",
+            "EMQX_CLUSTER__K8S__ADDRESS_TYPE": "hostname",
+            "EMQX_CLUSTER__K8S__NAMESPACE": "default",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "Failed to determine EMQX node host" in result.stderr
+    assert "EMQX_NODE_NAME" in result.stderr
     assert "EMQX_NODE_NAME=emqx@" not in result.stdout


### PR DESCRIPTION
Fixes emqx/emqx-customer-support#1

Release version:
6.0.3

## Summary

The Docker entrypoint previously derived the automatic node host only from `hostname -i`. In container environments where the hostname cannot be resolved, that command can return no IPv4 address, causing the entrypoint to export an invalid node name such as `emqx@`. Erlang distribution then fails during `net_kernel` startup with `nodistribution`.

This change keeps the existing `hostname -i` behavior for normal environments, falls back to the first IPv4 address reported by `hostname -I` when hostname resolution fails, and exits with a clear error if no local IP can be determined while auto-generating the node name. Explicit `EMQX_NODE_NAME`, `EMQX_NODE__NAME`, or `EMQX_HOST` settings keep their current precedence.

A lightweight pytest regression covers the fallback path and the empty-host guard, and the PR entrypoint workflow now runs that test with the existing script pytest checks.

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
