### PR TITLE
test(auth_mnesia): fix 30-min hang in authz_api_mnesia end_per_suite

### DIFF
--- a/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
@@ -40,8 +40,16 @@ init_per_suite(Config) ->
     _ = emqx_common_test_http:create_default_app(),
     [{suite_apps, Apps} | Config].
 end_per_suite(_Config) ->
-    ok = emqx_cth_suite:stop(?config(suite_apps, _Config)),
+    %% Belt-and-suspenders timetrap: emqx_mgmt_auth:delete/1 wraps the
+    %% delete in a mria transaction with no timeout, so calling
+    %% delete_default_app after the apps are stopped causes a 30-minute
+    %% hang waiting for the dead mria shard. The line order below puts
+    %% the delete BEFORE the stop (matching every other api SUITE);
+    %% the 30s timetrap is kept so any future regression fails fast
+    %% instead of blocking the whole CT shard for the full CT default.
+    ct:timetrap({seconds, 30}),
     _ = emqx_common_test_http:delete_default_app(),
+    ok = emqx_cth_suite:stop(?config(suite_apps, _Config)),
     ok.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl` consistently hung 30 min in `end_per_suite` on every run, making the `apps/emqx_auth_mnesia-1_1` CT shard take ~32 min vs 3–9 min for peer CT jobs.

Root cause: the call order in `end_per_suite` was inverted from every other api SUITE in the repo:

```erlang
end_per_suite(_Config) ->
    ok = emqx_cth_suite:stop(...),                   % stops mria
    _ = emqx_common_test_http:delete_default_app().  % calls mria:sync_transaction (infinity timeout) — hangs forever
```

`emqx_common_test_http:delete_default_app/0` → `emqx_mgmt_auth:delete/1` → `mria:sync_transaction(?COMMON_SHARD, ..., infinity)`. After mria is stopped, that call never returns. CT's default 30-min `end_per_suite` timetrap then fires.

Confirmed by instrumenting `emqx_cth_suite:stop_apps/1` to log per-app stop/unload durations: every app stops in <30 ms, and the hang is in the next line of `end_per_suite`.

## Fix

Swap the two lines so the delete happens **before** the apps are stopped — matching the order used in 14 other api SUITEs in the repo (e.g. `emqx_authn_api_mnesia_SUITE.erl:61`). Also keep a short `ct:timetrap({seconds, 30})` as belt-and-suspenders so any future regression fails fast instead of blocking the whole shard.

## Test plan

- [x] Locally, the full auth_mnesia CT shard now runs in **~2 min** (was ~32 min). All 36 cases pass.
- [x] CI: verify the `apps/emqx_auth_mnesia-1_1` job duration drops to a few minutes.