### PR TITLE
Fix cluster sync raw config diff noise

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -852,12 +852,12 @@ print_inconsistent_conf(New = #{}, Old = #{}, Options) ->
         changed := Changed
     } = emqx_utils_maps:diff_maps(New, Old),
     RemovedFmt = "~ts(~w)'s ~s has deleted certain keys, but they are still present on ~ts(~w).~n",
-    print_inconsistent(Removed, RemovedFmt, Options),
+    print_inconsistent(Removed, RemovedFmt, removed, Options),
     AddedFmt = "~ts(~w)'s ~s has new setting, but it has not been applied to ~ts(~w).~n",
-    print_inconsistent(Added, AddedFmt, Options),
+    print_inconsistent(Added, AddedFmt, added, Options),
     ChangedFmt =
         "~ts(~w)'s ~s has been updated, but the changes have not been applied to ~ts(~w).~n",
-    print_inconsistent(Changed, ChangedFmt, Options);
+    print_inconsistent(Changed, ChangedFmt, changed, Options);
 %% authentication rewrite topic_metrics is list(not map).
 print_inconsistent_conf(New, Old, Options) ->
     #{
@@ -873,39 +873,116 @@ print_inconsistent_conf(New, Old, Options) ->
     emqx_ctl:print("~ts:~n", [Target]),
     print_hocon(New).
 
-print_inconsistent(Conf, Fmt, Options) when Conf =/= #{} ->
+print_inconsistent(Conf, Fmt, Kind, Options) when Conf =/= #{} ->
     #{
         key := Key,
         target := {Target, TargetTnxId},
         node := {Node, NodeTnxId}
     } = Options,
-    emqx_ctl:warning(Fmt, [Target, TargetTnxId, Key, Node, NodeTnxId]),
     NodeRawConf = emqx_conf_proto_v4:get_raw_config(Node, [Key]),
     TargetRawConf = emqx_conf_proto_v4:get_raw_config(Target, [Key]),
     {NodeConf, TargetConf} =
         maps:fold(
-            fun(SubKey, _, {NewAcc, OldAcc}) ->
-                SubNew0 = maps:get(atom_to_binary(SubKey), NodeRawConf, undefined),
-                SubOld0 = maps:get(atom_to_binary(SubKey), TargetRawConf, undefined),
-                {SubNew1, SubOld1} = remove_identical_value(SubNew0, SubOld0),
-                {NewAcc#{SubKey => SubNew1}, OldAcc#{SubKey => SubOld1}}
+            fun(SubKey, CheckedDiff, {NodeAcc, TargetAcc}) ->
+                RawSubKey = raw_config_key(SubKey),
+                SubNew0 = maps:get(RawSubKey, NodeRawConf, undefined),
+                SubOld0 = maps:get(RawSubKey, TargetRawConf, undefined),
+                {SubNew1, SubOld1} =
+                    remove_identical_config_value(Kind, SubNew0, SubOld0, CheckedDiff),
+                {
+                    maybe_put_config_diff(SubKey, SubNew1, NodeAcc),
+                    maybe_put_config_diff(SubKey, SubOld1, TargetAcc)
+                }
             end,
             {#{}, #{}},
             Conf
         ),
     %% zones.default is a virtual zone. It will be changed when mqtt changes,
     %% so we can't retrieve the raw data for zones.default(always undefined).
-    case TargetConf =:= NodeConf of
-        true -> ok;
-        false -> print_hocon(#{Target => #{Key => TargetConf}, Node => #{Key => NodeConf}})
+    emqx_ctl:warning(Fmt, [Target, TargetTnxId, Key, Node, NodeTnxId]),
+    case has_config_diff(NodeConf) orelse has_config_diff(TargetConf) of
+        true ->
+            print_hocon(#{Target => #{Key => TargetConf}, Node => #{Key => NodeConf}});
+        false ->
+            ok
     end;
-print_inconsistent(_Conf, _Format, _Options) ->
+print_inconsistent(_Conf, _Format, _Kind, _Options) ->
     ok.
+
+raw_config_key(K) when is_atom(K) ->
+    atom_to_binary(K);
+raw_config_key(K) ->
+    K.
+
+remove_identical_config_value(changed, NodeRaw, TargetRaw, {NodeChecked, TargetChecked}) ->
+    remove_identical_config_values(NodeRaw, TargetRaw, NodeChecked, TargetChecked);
+remove_identical_config_value(_Kind, NodeRaw, TargetRaw, _CheckedDiff) ->
+    remove_identical_value(NodeRaw, TargetRaw).
+
+remove_identical_config_values(NodeRaw, TargetRaw, NodeChecked, TargetChecked) ->
+    {NodeRaw1, TargetRaw1} = remove_identical_value(NodeRaw, TargetRaw),
+    keep_checked_changes(NodeRaw1, TargetRaw1, NodeChecked, TargetChecked).
+
+keep_checked_changes(_NodeRaw, _TargetRaw, SameChecked, SameChecked) ->
+    {undefined, undefined};
+keep_checked_changes(NodeRaw = #{}, TargetRaw = #{}, NodeChecked = #{}, TargetChecked = #{}) ->
+    lists:foldl(
+        fun(K, {NodeAcc, TargetAcc}) ->
+            {NodeV, TargetV} = keep_checked_changes(
+                maps:get(K, NodeRaw, undefined),
+                maps:get(K, TargetRaw, undefined),
+                find_checked_value(K, NodeChecked),
+                find_checked_value(K, TargetChecked)
+            ),
+            {
+                maybe_put_config_diff(K, NodeV, NodeAcc),
+                maybe_put_config_diff(K, TargetV, TargetAcc)
+            }
+        end,
+        {#{}, #{}},
+        lists:usort(maps:keys(NodeRaw) ++ maps:keys(TargetRaw))
+    );
+keep_checked_changes(NodeRaw, TargetRaw, _NodeChecked, _TargetChecked) ->
+    {NodeRaw, TargetRaw}.
+
+find_checked_value(K, Map) when is_map(Map) ->
+    case maps:find(K, Map) of
+        {ok, V} ->
+            V;
+        error ->
+            maps:get(alt_config_key(K), Map, undefined)
+    end.
+
+alt_config_key(K) when is_atom(K) ->
+    atom_to_binary(K);
+alt_config_key(K) when is_binary(K) ->
+    try
+        binary_to_existing_atom(K, utf8)
+    catch
+        _:_ -> K
+    end;
+alt_config_key(K) ->
+    K.
+
+maybe_put_config_diff(K, V, Acc) ->
+    case has_config_diff(V) of
+        true -> Acc#{K => V};
+        false -> Acc
+    end.
+
+has_config_diff(undefined) ->
+    false;
+has_config_diff(Map) when is_map(Map) ->
+    maps:fold(fun(_K, V, Acc) -> Acc orelse has_config_diff(V) end, false, Map);
+has_config_diff(_Value) ->
+    true.
 
 remove_identical_value(New = #{}, Old = #{}) ->
     maps:fold(
         fun(K, NewV, {Acc1, Acc2}) ->
             case maps:find(K, Old) of
+                error ->
+                    {Acc1, Acc2};
                 {ok, NewV} ->
                     {maps:remove(K, Acc1), maps:remove(K, Acc2)};
                 {ok, OldV} ->
@@ -971,5 +1048,93 @@ find_inconsistent_test() ->
         find_lagging(SameStatus, Confs0)
     ),
     ok.
+
+remove_identical_value_missing_key_test() ->
+    ?assertEqual(
+        {#{<<"present">> => true}, #{}},
+        remove_identical_value(#{<<"present">> => true}, #{})
+    ),
+    ?assertEqual(
+        {#{<<"outer">> => #{<<"present">> => true}}, #{<<"outer">> => #{}}},
+        remove_identical_value(
+            #{<<"outer">> => #{<<"present">> => true}},
+            #{<<"outer">> => #{}}
+        )
+    ).
+
+remove_raw_only_diff_with_same_checked_value_test() ->
+    NodeRaw = #{
+        <<"rules">> => #{
+            <<"same">> => #{<<"enable">> => true},
+            <<"changed">> => #{<<"sql">> => <<"select old">>}
+        }
+    },
+    TargetRaw = #{
+        <<"rules">> => #{
+            <<"same">> => #{},
+            <<"changed">> => #{<<"sql">> => <<"select new">>}
+        }
+    },
+    NodeChecked = #{
+        rules => #{
+            <<"same">> => #{enable => true},
+            <<"changed">> => #{sql => <<"select old">>}
+        }
+    },
+    TargetChecked = #{
+        rules => #{
+            <<"same">> => #{enable => true},
+            <<"changed">> => #{sql => <<"select new">>}
+        }
+    },
+    ?assertEqual(
+        {
+            #{<<"rules">> => #{<<"changed">> => #{<<"sql">> => <<"select old">>}}},
+            #{<<"rules">> => #{<<"changed">> => #{<<"sql">> => <<"select new">>}}}
+        },
+        remove_identical_config_values(NodeRaw, TargetRaw, NodeChecked, TargetChecked)
+    ).
+
+print_warning_when_checked_diff_has_no_raw_payload_test() ->
+    ok = meck:new(emqx_conf_proto_v4, [passthrough, no_link]),
+    ok = meck:new(emqx_ctl, [passthrough, no_link]),
+    Self = self(),
+    try
+        ok = meck:expect(
+            emqx_conf_proto_v4,
+            get_raw_config,
+            fun
+                (node, [zones]) -> #{};
+                (target, [zones]) -> #{}
+            end
+        ),
+        ok = meck:expect(
+            emqx_ctl,
+            warning,
+            fun(Fmt, Args) ->
+                Self ! {warning, Fmt, Args},
+                ok
+            end
+        ),
+        print_inconsistent(
+            #{default => {#{enable => true}, #{enable => false}}},
+            "warning~n",
+            changed,
+            #{
+                key => zones,
+                node => {node, 1},
+                target => {target, 2}
+            }
+        ),
+        ?assert(
+            receive
+                {warning, "warning~n", [target, 2, zones, node, 1]} -> true
+            after 0 ->
+                false
+            end
+        )
+    after
+        meck:unload([emqx_conf_proto_v4, emqx_ctl])
+    end.
 
 -endif.

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -808,11 +808,16 @@ changed(K, V, Conf) ->
 find_running_confs() ->
     lists:map(
         fun(Node) ->
-            Conf = emqx_conf_proto_v4:get_config(Node, []),
+            Conf = normalize_running_conf(emqx_conf_proto_v4:get_raw_config(Node, [])),
             {Node, maps:without(?READONLY_ROOT_KEYS, Conf)}
         end,
         mria:running_nodes()
     ).
+
+normalize_running_conf(RawConf) ->
+    RawConf1 = fill_defaults(RawConf),
+    {_AppEnvs, Conf} = emqx_config:check_config(emqx_conf:schema_module(), RawConf1),
+    Conf.
 
 print_inconsistent_conf(Keys, Target, Status, AllConfs) ->
     {value, {_, TargetConf}, OtherConfs} = lists:keytake(Target, 1, AllConfs),

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -808,13 +808,29 @@ changed(K, V, Conf) ->
 find_running_confs() ->
     lists:map(
         fun(Node) ->
-            Conf = normalize_running_conf(emqx_conf_proto_v4:get_raw_config(Node, [])),
+            Conf = normalize_running_conf(Node),
             {Node, maps:without(?READONLY_ROOT_KEYS, Conf)}
         end,
         mria:running_nodes()
     ).
 
-normalize_running_conf(RawConf) ->
+normalize_running_conf(Node) ->
+    try normalize_running_raw_conf(emqx_conf_proto_v4:get_raw_config(Node, [])) of
+        Conf ->
+            Conf
+    catch
+        Class:Reason:Stacktrace ->
+            ?SLOG(warning, #{
+                msg => "failed_to_normalize_cluster_sync_status_conf",
+                node => Node,
+                exception => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
+            emqx_conf_proto_v4:get_config(Node, [])
+    end.
+
+normalize_running_raw_conf(RawConf) ->
     RawConf1 = fill_defaults(RawConf),
     {_AppEnvs, Conf} = emqx_config:check_config(emqx_conf:schema_module(), RawConf1),
     Conf.
@@ -1053,6 +1069,25 @@ find_inconsistent_test() ->
         find_lagging(SameStatus, Confs0)
     ),
     ok.
+
+normalize_running_conf_falls_back_to_checked_config_test() ->
+    FallbackConf = #{mqtt => #{max_topic_levels => 128}},
+    ok = meck:new(emqx_conf_proto_v4, [passthrough, no_link]),
+    try
+        ok = meck:expect(
+            emqx_conf_proto_v4,
+            get_raw_config,
+            fun(node, []) -> invalid_raw_conf end
+        ),
+        ok = meck:expect(
+            emqx_conf_proto_v4,
+            get_config,
+            fun(node, []) -> FallbackConf end
+        ),
+        ?assertEqual(FallbackConf, normalize_running_conf(node))
+    after
+        meck:unload(emqx_conf_proto_v4)
+    end.
 
 remove_identical_value_missing_key_test() ->
     ?assertEqual(

--- a/apps/emqx_conf/src/proto/emqx_conf_proto_v4.erl
+++ b/apps/emqx_conf/src/proto/emqx_conf_proto_v4.erl
@@ -103,7 +103,7 @@ get_override_config_file(Nodes) ->
 get_hocon_config(Node) ->
     rpc:call(Node, emqx_conf_cli, get_config, []).
 
--spec get_raw_config(node(), update_config_key_path()) -> map() | {badrpc, _}.
+-spec get_raw_config(node(), emqx_utils_maps:config_key_path()) -> map() | {badrpc, _}.
 get_raw_config(Node, KeyPath) ->
     rpc:call(Node, emqx, get_raw_config, [KeyPath]).
 

--- a/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
@@ -70,17 +70,13 @@ t_fix(Config) ->
 
     %% fix inconsistent_tnx_id_key. tnx_id and key are updated.
     ?ON(Node1, fake_mfa(2, Node1, {?MODULE, undef, []})),
-    %% 2 -> fake_mfa, 3-> mark_begin_log, 4-> mqtt 5 -> zones
-    ?ON(Node2, begin
+    %% The exact tnx_id depends on whether the fix produces follow-up
+    %% default/virtual config updates, so assert the sync contract instead.
+    TnxIdAfterKeyFix = ?ON(Node2, begin
         ok = emqx_conf_cli:admins(["fix"]),
-        ?assertMatch(
-            {atomic, [
-                #{node := Node1, tnx_id := 5},
-                #{node := Node2, tnx_id := 5}
-            ]},
-            emqx_cluster_rpc:status()
-        )
+        ?MODULE:assert_same_tnx_id([Node1, Node2])
     end),
+    ?assert(TnxIdAfterKeyFix > 2),
     ?assertMatch(99, emqx_conf_proto_v4:get_config(Node1, [mqtt, max_topic_levels])),
     ?assertMatch(99, emqx_conf_proto_v4:get_config(Node2, [mqtt, max_topic_levels])),
 
@@ -88,31 +84,30 @@ t_fix(Config) ->
     {ok, _} = ?ON(
         Node1, emqx_conf_proto_v4:update([<<"mqtt">>], #{<<"max_topic_levels">> => 98}, #{})
     ),
-    ?ON(Node2, fake_mfa(7, Node2, {?MODULE, undef1, []})),
-    ?ON(Node1, begin
+    TnxIdAfterUpdate = ?ON(Node1, ?MODULE:assert_same_tnx_id([Node1, Node2])),
+    FakeTnxId = TnxIdAfterUpdate + 1,
+    ?ON(Node2, fake_mfa(FakeTnxId, Node2, {?MODULE, undef1, []})),
+    TnxIdAfterFastForward = ?ON(Node1, begin
         ok = emqx_conf_cli:admins(["fix"]),
-        ?assertMatch(
-            {atomic, [
-                #{node := Node1, tnx_id := 8},
-                #{node := Node2, tnx_id := 8}
-            ]},
-            emqx_cluster_rpc:status()
-        )
+        ?MODULE:assert_same_tnx_id([Node1, Node2])
     end),
+    ?assert(TnxIdAfterFastForward > FakeTnxId),
     ?assertMatch(98, emqx_conf_proto_v4:get_config(Node1, [mqtt, max_topic_levels])),
     ?assertMatch(98, emqx_conf_proto_v4:get_config(Node2, [mqtt, max_topic_levels])),
     %% unchanged
     ?ON(Node1, begin
         ok = emqx_conf_cli:admins(["fix"]),
-        ?assertMatch(
-            {atomic, [
-                #{node := Node1, tnx_id := 8},
-                #{node := Node2, tnx_id := 8}
-            ]},
-            emqx_cluster_rpc:status()
-        )
+        ?assertEqual(TnxIdAfterFastForward, ?MODULE:assert_same_tnx_id([Node1, Node2]))
     end),
     ok.
+
+assert_same_tnx_id(Nodes) ->
+    {atomic, Status} = emqx_cluster_rpc:status(),
+    ?assertEqual(lists:sort(Nodes), lists:sort([Node || #{node := Node} <- Status])),
+    TnxIds = lists:usort([TnxId || #{tnx_id := TnxId} <- Status]),
+    ?assertMatch([_], TnxIds),
+    [TnxId] = TnxIds,
+    TnxId.
 
 fake_mfa(TnxId, Node, MFA) ->
     Func = fun() ->

--- a/apps/emqx_conf/test/emqx_conf_cluster_sync_import_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cluster_sync_import_SUITE.erl
@@ -1,0 +1,258 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_conf_cluster_sync_import_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+-define(RAW_DIFF_RULE_ID, <<"cluster_sync_raw_diff_rule">>).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+suite() ->
+    [{timetrap, {seconds, 180}}].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+t_status_after_import_then_join_ignores_raw_only_diffs(Config) ->
+    WorkDir = emqx_cth_suite:work_dir(?FUNCTION_NAME, Config),
+    AppSpecs = import_join_app_specs(),
+    ClusterSpec = [
+        {cluster_sync_import1, #{role => core, apps => AppSpecs}},
+        {cluster_sync_import2, #{role => core, apps => AppSpecs}}
+    ],
+    [N1Spec, N2Spec] = emqx_cth_cluster:mk_nodespecs(
+        ClusterSpec,
+        #{
+            work_dir => WorkDir,
+            start_apps_timeout => 60_000
+        }
+    ),
+    [N1, N2] = Nodes = [maps:get(name, N1Spec), maps:get(name, N2Spec)],
+    on_exit(fun() -> emqx_cth_cluster:stop(Nodes) end),
+
+    [N1] = emqx_cth_cluster:start([N1Spec]),
+    BackupFile = make_rule_engine_backup(Config),
+    ImportRes = {ok, #{db_errors => #{}, config_errors => #{}}},
+    ?assertEqual(ImportRes, ?ON(N1, emqx_mgmt_data_backup:import_local(BackupFile))),
+    wait_imported_rule(N1),
+
+    [N2] = emqx_cth_cluster:start([N2Spec]),
+    emulate_emqx_conf_init_load(N2, N1),
+    wait_clustered(Nodes),
+    wait_same_tnx_id(Nodes),
+    wait_imported_rule(N2),
+
+    N1Rule = get_imported_rule(N1, emqx_conf, get, [rule_engine, rules]),
+    N2Rule = get_imported_rule(N2, emqx_conf, get, [rule_engine, rules]),
+    ?assertEqual(N1Rule, N2Rule),
+
+    N1RawRule = get_imported_rule(N1, emqx_conf, get_raw, [rule_engine, rules]),
+    N2RawRule = get_imported_rule(N2, emqx_conf, get_raw, [rule_engine, rules]),
+    ?assertNotEqual(N1RawRule, N2RawRule),
+
+    Output = capture_cluster_sync_status(N1),
+    ?assertEqual(
+        nomatch,
+        binary:match(Output, <<"has been updated">>),
+        #{output => Output}
+    ),
+    ?assertEqual(
+        nomatch,
+        binary:match(Output, <<"inconsistent keys">>),
+        #{output => Output}
+    ),
+    ?assertNotEqual(
+        nomatch,
+        binary:match(Output, <<"All configuration synchronized">>),
+        #{output => Output}
+    ),
+    ok.
+
+import_join_app_specs() ->
+    [
+        {emqx, #{
+            override_env => [{boot_modules, []}],
+            config => #{
+                listeners => #{
+                    tcp => #{default => <<"marked_for_deletion">>},
+                    ssl => #{default => <<"marked_for_deletion">>},
+                    ws => #{default => <<"marked_for_deletion">>},
+                    wss => #{default => <<"marked_for_deletion">>}
+                }
+            }
+        }},
+        {emqx_conf, #{config => #{}}},
+        emqx_management,
+        emqx_rule_engine
+    ].
+
+make_rule_engine_backup(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    BackupName = filename:join(PrivDir, "cluster-sync-raw-diff-import.tar.gz"),
+    BackupRoot = filename:basename(BackupName, ".tar.gz"),
+    Meta = unicode:characters_to_binary(
+        hocon_pp:do(
+            #{
+                edition => emqx_release:edition(),
+                version => emqx_release:version()
+            },
+            #{}
+        )
+    ),
+    ClusterHocon = unicode:characters_to_binary(hocon_pp:do(rule_engine_import_conf(), #{})),
+    ok = erl_tar:create(
+        BackupName,
+        [
+            {filename:join(BackupRoot, "META.hocon"), Meta},
+            {filename:join(BackupRoot, "cluster.hocon"), ClusterHocon}
+        ],
+        [compressed]
+    ),
+    BackupName.
+
+rule_engine_import_conf() ->
+    #{
+        <<"rule_engine">> => #{
+            <<"rules">> => #{
+                ?RAW_DIFF_RULE_ID => #{
+                    <<"description">> => <<"">>,
+                    <<"sql">> => <<"SELECT * FROM \"t/#\"">>,
+                    <<"actions">> => [
+                        #{
+                            <<"function">> => <<"republish">>,
+                            <<"args">> => #{
+                                <<"topic">> => <<"cluster/sync/${topic}">>
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }.
+
+get_imported_rule(Node, Module, Function, Path) ->
+    Rules = ?ON(Node, erlang:apply(Module, Function, [Path])),
+    get_rule_from_map(Rules).
+
+get_rule_from_map(Rules) ->
+    case maps:find(?RAW_DIFF_RULE_ID, Rules) of
+        {ok, Rule} ->
+            Rule;
+        error ->
+            RuleIdAtom = binary_to_existing_atom(?RAW_DIFF_RULE_ID, utf8),
+            maps:get(RuleIdAtom, Rules)
+    end.
+
+wait_imported_rule(Node) ->
+    wait_until(
+        fun() ->
+            has_imported_rule(Node)
+        end,
+        #{action => wait_imported_rule, node => Node}
+    ).
+
+has_imported_rule(Node) ->
+    Rules = ?ON(Node, emqx_conf:get([rule_engine, rules])),
+    maps:is_key(?RAW_DIFF_RULE_ID, Rules) orelse
+        maps:is_key(binary_to_existing_atom(?RAW_DIFF_RULE_ID, utf8), Rules).
+
+%% Emulate `emqx_conf_app:init_load/1`; the CT cluster helper does not
+%% automatically replay this boot-time sync after a node joins.
+emulate_emqx_conf_init_load(NewNode, SeedNode) ->
+    ?ON(SeedNode, ok = emqx_config_backup_manager:flush()),
+    ?ON(NewNode, begin
+        {ok, _TnxId} = emqx_conf_app:sync_cluster_conf(),
+        DataDir = emqx:data_dir(),
+        Path = filename:join([DataDir, "configs", "cluster.hocon"]),
+        {ok, Contents0} = file:read_file(Path),
+        ok = file:write_file(Path, [
+            Contents0,
+            <<"node.cookie = cookie\n">>,
+            <<"node.data_dir = \"">>,
+            DataDir,
+            <<"\"\n">>
+        ]),
+        SchemaMod = emqx_conf:schema_module(),
+        ok = application:stop(emqx_rule_engine),
+        ok = emqx_config:init_load(SchemaMod),
+        ok = application:start(emqx_rule_engine)
+    end).
+
+wait_clustered(Nodes) ->
+    wait_until(
+        fun() ->
+            lists:all(
+                fun(Node) ->
+                    lists:sort(Nodes) =:= lists:sort(?ON(Node, mria:running_nodes()))
+                end,
+                Nodes
+            )
+        end,
+        #{action => wait_clustered, nodes => Nodes}
+    ).
+
+wait_same_tnx_id(Nodes) ->
+    [Node | _] = Nodes,
+    wait_until(
+        fun() ->
+            case ?ON(Node, emqx_cluster_rpc:status()) of
+                {atomic, Status} ->
+                    TnxIds = lists:usort([TnxId || #{tnx_id := TnxId} <- Status]),
+                    length(TnxIds) =:= 1;
+                _ ->
+                    false
+            end
+        end,
+        #{action => wait_same_tnx_id, nodes => Nodes}
+    ).
+
+wait_until(Fun, Context) ->
+    wait_until(Fun, Context, 30).
+
+wait_until(_Fun, Context, 0) ->
+    error({timeout, Context});
+wait_until(Fun, Context, Retries) ->
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(500),
+            wait_until(Fun, Context, Retries - 1)
+    end.
+
+capture_cluster_sync_status(Node) ->
+    ?ON(Node, begin
+        ok = meck:new(emqx_ctl, [passthrough, no_link]),
+        try
+            ok = emqx_conf_cli:admins(["status"]),
+            History = meck:history(emqx_ctl),
+            unicode:characters_to_binary([
+                format_ctl_output(Fun, Args)
+             || {_Pid, {emqx_ctl, Fun, Args}, _Result} <- History,
+                Fun =:= print orelse Fun =:= warning
+            ])
+        after
+            meck:unload(emqx_ctl)
+        end
+    end).
+
+format_ctl_output(_Fun, [Format]) ->
+    Format;
+format_ctl_output(_Fun, [Format, Args]) ->
+    io_lib:format(Format, Args);
+format_ctl_output(_Fun, Args) ->
+    io_lib:format("~p", [Args]).

--- a/changes/ee/fix-17313.en.md
+++ b/changes/ee/fix-17313.en.md
@@ -1,0 +1,8 @@
+Fixed noisy and misleading `emqx ctl conf cluster_sync status` diagnostics when
+clustered nodes have the same effective checked configuration but different raw
+configuration representations.
+
+The command now suppresses raw-only representation differences that do not
+correspond to checked configuration changes, while still warning when checked
+configuration is inconsistent. It also avoids crashing when a raw configuration
+key exists on one node but is missing from another node.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15291

Release version: 5.10

## Summary

### Problem details

`conf cluster_sync status` could report many inconsistent keys even when all nodes had the same effective running configuration and the same cluster transaction id.

The false positives were caused by comparing raw configuration maps directly. Raw configuration in EMQX is the unparsed, untranslated representation kept by the configuration subsystem, and it is not guaranteed to be canonical across different loading paths.

One reproducible path is:

1. Start one core node.
2. Import a backup containing cluster configuration, for example a rule with a republish action.
3. Start another core node and let it join the cluster.
4. Run `conf cluster_sync status`.

The first node applies the imported configuration through the online update/import path. Its raw config keeps the sparse user-provided representation, such as a republish action with only `topic` under `args`.

The joining node first syncs `cluster.hocon` from an existing core node and then loads it through the boot-time `emqx_config:init_load/1` path. That path fills schema defaults into the runtime raw config. As a result, the same rule can contain materialized default fields on the joining node, for example `enable`, `name`, `qos`, `retain`, `payload`, `mqtt_properties`, `user_properties`, and `direct_dispatch`.

Both raw representations translate to the same checked config, so the nodes are effectively synchronized. However, the old status command compared those raw/default representation differences as if they were real cluster-sync inconsistencies. This also affected other default/materialized roots observed in the Jira investigation, such as `actions`, `license`, and `rule_engine`.

### Fix approach

This PR changes `conf cluster_sync status` to compare normalized effective configuration instead of raw maps directly.

For each running node, the command now fetches raw config, fills defaults, and validates it through the schema to obtain the checked configuration used by EMQX at runtime. The consistency decision is made from that normalized checked config, so semantically equivalent raw representations no longer produce false inconsistent-key reports.

For diagnostic output, the command still fetches raw config for the affected root key, but it prunes the raw payload using the checked-config diff before printing. This keeps useful raw details for real changes while suppressing raw-only differences such as omitted defaults or materialized defaults.

The warning itself is still emitted whenever the checked config reports a real difference, even when the corresponding raw payload is unavailable or pruned empty, such as virtual/default entries like `zones.default`. The HOCON payload is printed only when there is meaningful raw diff to show.

The change also fixes the original crash in raw diff pruning when a nested key exists on one node but is missing on the other.

## Testing

- `BUILD_WITHOUT_QUIC=1 ERL_FLAGS='-kernel prevent_overlapping_partitions false' ./rebar3 ct --name 'test@127.0.0.1' -v --readable=true --suite apps/emqx_conf/test/emqx_conf_cluster_sync_import_SUITE.erl --case t_status_after_import_then_join_ignores_raw_only_diffs`
- `BUILD_WITHOUT_QUIC=1 BUILD_WITHOUT_ROCKSDB=1 ./rebar3 eunit --module=emqx_conf_cli`
- `git diff --check`
- `BEFORE_REF=$(git merge-base HEAD ce/release-510) AFTER_REF=HEAD ./scripts/check-changes-filename-pattern.sh`

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
