### PR TITLE
fix: sanitize PROXY-Protocol v2 cert TLVs before they enter client identity

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -339,7 +339,10 @@ set_peercert_infos(NoSSL, ClientInfo, _) when
 ->
     ClientInfo#{username => undefined};
 set_peercert_infos(Peercert, ClientInfo, Zone) ->
-    {DN, CN} = {esockd_peercert:subject(Peercert), esockd_peercert:common_name(Peercert)},
+    DN = esockd_peercert:subject(Peercert),
+    CN = esockd_peercert:common_name(Peercert),
+    ok = validate_peercert_string(dn, DN, Peercert),
+    ok = validate_peercert_string(cn, CN, Peercert),
     PeercetAs = fun(Key) ->
         case get_mqtt_conf(Zone, Key) of
             cn -> CN;
@@ -353,6 +356,31 @@ set_peercert_infos(Peercert, ClientInfo, Zone) ->
     Username = PeercetAs(peer_cert_as_username),
     ClientId = PeercetAs(peer_cert_as_clientid),
     ClientInfo#{username => Username, clientid => ClientId, dn => DN, cn => CN}.
+
+%% Reject control characters (0x00-0x1F, 0x7F-0x9F) in CN / DN. Mirrors the
+%% byte-class check `emqx_frame:validate_utf8/1` applies to MQTT-ingested
+%% clientid/username/password. Closes a CRLF-injection primitive where bytes
+%% sourced from a PROXY-Protocol v2 SSL TLV could be smuggled into outbound
+%% HTTP authn/authz/bridge requests via `${cert_common_name}` / `${cert_subject}`.
+validate_peercert_string(_Field, undefined, _Source) ->
+    ok;
+validate_peercert_string(Field, Value, Source) when is_binary(Value) ->
+    case emqx_utils:is_mqtt_safe_utf8(Value) of
+        true ->
+            ok;
+        false ->
+            ?SLOG(warning, #{
+                msg => "peer_certificate_field_rejected",
+                field => Field,
+                source => peercert_source(Source),
+                reason => contains_control_characters
+            }),
+            erlang:exit({shutdown, peercert_field_invalid})
+    end.
+
+peercert_source(Peercert) when is_binary(Peercert) -> tls_certificate;
+peercert_source(PP2Info) when is_list(PP2Info) -> proxy_protocol_v2;
+peercert_source(_) -> unknown.
 
 take_conn_info_fields(Fields, ClientInfo, ConnInfo) ->
     lists:foldl(

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -1074,6 +1074,47 @@ t_flapping_detect(_) ->
     end,
     meck:unload([emqx_flapping]).
 
+t_peercert_pp2_cn_with_crlf_rejected(_) ->
+    %% PROXY-Protocol v2 surfaces SSL_CN as a raw attacker-controlled binary.
+    %% Bytes that would split an HTTP request line (CR/LF/NUL) or any other
+    %% C0/C1 control character must cause the connection to be rejected,
+    %% mirroring how `emqx_frame:validate_utf8/1` rejects MQTT-ingested
+    %% clientid/username/password.
+    SmuggledCN =
+        <<
+            "admin\r\nX-Forwarded-User: ROOT_VIA_PP2"
+            "\r\nX-Override-Result: allow\r\nX-Bypass: 1"
+        >>,
+    PeerCert = [{pp2_ssl_cn, SmuggledCN}],
+    ConnInfo = pp2_conn_info(PeerCert),
+    Opts = #{zone => default, limiter => undefined, listener => {tcp, default}},
+    ?assertExit(
+        {shutdown, peercert_field_invalid},
+        emqx_channel:init(ConnInfo, Opts)
+    ).
+
+t_peercert_pp2_cn_clean_accepted(_) ->
+    %% Negative control: a well-formed PP2 SSL_CN is still accepted.
+    PeerCert = [{pp2_ssl_cn, <<"alice.example.com">>}],
+    ConnInfo = pp2_conn_info(PeerCert),
+    Opts = #{zone => default, limiter => undefined, listener => {tcp, default}},
+    Channel = emqx_channel:init(ConnInfo, Opts),
+    ?assertMatch(
+        #{cn := <<"alice.example.com">>},
+        emqx_channel:info(clientinfo, Channel)
+    ).
+
+pp2_conn_info(PeerCert) ->
+    #{
+        socktype => tcp,
+        peername => {{127, 0, 0, 1}, 3456},
+        sockname => {{127, 0, 0, 1}, 1883},
+        peercert => PeerCert,
+        peersni => undefined,
+        conn_mod => emqx_connection,
+        sock => self()
+    }.
+
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------

--- a/apps/emqx_auth/src/emqx_auth.app.src
+++ b/apps/emqx_auth/src/emqx_auth.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth, [
     {description, "EMQX Authentication and authorization"},
-    {vsn, "0.4.6"},
+    {vsn, "0.4.7"},
     {modules, []},
     {registered, [emqx_auth_sup]},
     {applications, [

--- a/apps/emqx_auth/src/emqx_auth_utils.erl
+++ b/apps/emqx_auth/src/emqx_auth_utils.erl
@@ -276,22 +276,62 @@ generate_request(
     Path = render_urlencoded_str(BasePathTemplate, Values),
     Query = render_deep_for_url(BaseQueryTemplate, Values),
     Headers = emqx_auth_utils:render_deep_for_raw(Headers0, Values),
-    case Method of
-        get ->
-            Body = render_deep_for_url(BodyTemplate, Values),
-            NPath = append_query(Path, Query, Body),
-            {ok, {NPath, Headers}};
-        _ ->
-            try
-                ContentType = post_request_content_type(Headers),
-                Body = serialize_body(ContentType, BodyTemplate, Values),
-                NPathQuery = append_query(Path, Query),
-                {ok, {NPathQuery, Headers, Body}}
-            catch
-                error:{encode_error, _} = Reason ->
-                    {error, Reason}
-            end
+    case validate_headers(Headers) of
+        ok ->
+            case Method of
+                get ->
+                    Body = render_deep_for_url(BodyTemplate, Values),
+                    NPath = append_query(Path, Query, Body),
+                    {ok, {NPath, Headers}};
+                _ ->
+                    try
+                        ContentType = post_request_content_type(Headers),
+                        Body = serialize_body(ContentType, BodyTemplate, Values),
+                        NPathQuery = append_query(Path, Query),
+                        {ok, {NPathQuery, Headers, Body}}
+                    catch
+                        error:{encode_error, _} = Reason ->
+                            {error, Reason}
+                    end
+            end;
+        {error, _} = Error ->
+            Error
     end.
+
+%% Defense-in-depth: reject HTTP header names/values that contain bytes
+%% capable of splitting the request line (NUL, CR, LF). Header templates may
+%% interpolate variables that originated from outside the broker (e.g.
+%% ${cert_common_name} from a PROXY-Protocol v2 SSL TLV, ${peerhost}, or
+%% client-attribute computations). The primary mitigation rejects PP2 cert
+%% TLVs with control bytes at ingestion time; this is a second wall.
+validate_headers(Headers) when is_list(Headers) ->
+    validate_headers_list(Headers);
+validate_headers(Headers) when is_map(Headers) ->
+    validate_headers_list(maps:to_list(Headers)).
+
+validate_headers_list([]) ->
+    ok;
+validate_headers_list([{Name, Value} | Rest]) ->
+    case header_byte_check(Name) of
+        ok ->
+            case header_byte_check(Value) of
+                ok -> validate_headers_list(Rest);
+                {error, Reason} -> {error, {bad_http_header_value, Name, Reason}}
+            end;
+        {error, Reason} ->
+            {error, {bad_http_header_name, Reason}}
+    end.
+
+header_byte_check(Bin) when is_binary(Bin) ->
+    header_byte_check_bin(Bin);
+header_byte_check(_NonBin) ->
+    ok.
+
+header_byte_check_bin(<<>>) -> ok;
+header_byte_check_bin(<<0, _/binary>>) -> {error, contains_nul};
+header_byte_check_bin(<<$\r, _/binary>>) -> {error, contains_cr};
+header_byte_check_bin(<<$\n, _/binary>>) -> {error, contains_lf};
+header_byte_check_bin(<<_, Rest/binary>>) -> header_byte_check_bin(Rest).
 
 post_request_content_type(Headers) ->
     proplists:get_value(<<"content-type">>, Headers, ?DEFAULT_HTTP_REQUEST_CONTENT_TYPE).

--- a/apps/emqx_auth/test/emqx_auth_utils_tests.erl
+++ b/apps/emqx_auth/test/emqx_auth_utils_tests.erl
@@ -1,0 +1,55 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_auth_utils_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Defense-in-depth: even if some new render path bypasses the PP2 ingestion
+%% sanitizer, the HTTP request generator must reject header values containing
+%% bytes that would split the request line.
+generate_request_rejects_crlf_in_header_test_() ->
+    [
+        ?_assertMatch(
+            {error, {bad_http_header_value, _, contains_cr}},
+            do_generate(<<"alice\r\nX-Override-Result: allow">>)
+        ),
+        ?_assertMatch(
+            {error, {bad_http_header_value, _, contains_lf}},
+            do_generate(<<"alice\nX-Override-Result: allow">>)
+        ),
+        ?_assertMatch(
+            {error, {bad_http_header_value, _, contains_cr}},
+            do_generate(<<"alice\rX-Override-Result: allow">>)
+        ),
+        ?_assertMatch(
+            {error, {bad_http_header_value, _, contains_nul}},
+            do_generate(<<"alice", 0, "X-Override-Result: allow">>)
+        )
+    ].
+
+generate_request_accepts_clean_header_test() ->
+    ?assertMatch(
+        {ok, _},
+        do_generate(<<"alice.example.com">>)
+    ).
+
+do_generate(CN) ->
+    HeadersTpl = emqx_authn_utils:parse_deep(
+        maps:to_list(#{
+            <<"content-type">> => <<"application/json">>,
+            <<"x-cert-cn">> => <<"${cert_common_name}">>
+        })
+    ),
+    BodyTpl = emqx_authn_utils:parse_deep(#{}),
+    QueryTpl = emqx_authn_utils:parse_deep([]),
+    PathTpl = emqx_authn_utils:parse_str(<<"/auth">>),
+    State = #{
+        method => post,
+        headers => HeadersTpl,
+        body_template => BodyTpl,
+        base_path_template => PathTpl,
+        base_query_template => QueryTpl
+    },
+    emqx_auth_utils:generate_request(State, #{cert_common_name => CN}).

--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.5.2"},
+    {vsn, "5.5.3"},
     {modules, [
         emqx_utils,
         emqx_utils_api,

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -72,6 +72,7 @@
     ntoa/1,
     foldl_while/3,
     is_restricted_str/1,
+    is_mqtt_safe_utf8/1,
     interactive_load/1
 ]).
 
@@ -899,6 +900,25 @@ ntoa(IP) ->
 is_restricted_str(String) ->
     RE = <<"^[A-Za-z0-9]+[A-Za-z0-9-_]*$">>,
     match =:= re:run(String, RE, [{capture, none}]).
+
+%% @doc Validate that a binary is a well-formed UTF-8 string with no characters
+%% in the ranges 0x00-0x1F (C0 controls) or 0x7F-0x9F (DEL + C1 controls).
+%% This is the same byte-class check `emqx_frame:validate_utf8/1` applies to
+%% MQTT-ingested clientid/username/password and is used to vet bytes that flow
+%% into the same `ClientInfo` map from non-MQTT sources (e.g. PROXY-Protocol
+%% v2 SSL TLVs).
+-spec is_mqtt_safe_utf8(binary()) -> boolean().
+is_mqtt_safe_utf8(<<>>) ->
+    true;
+is_mqtt_safe_utf8(<<H/utf8, _Rest/binary>>) when
+    H >= 16#00, H =< 16#1F;
+    H >= 16#7F, H =< 16#9F
+->
+    false;
+is_mqtt_safe_utf8(<<_H/utf8, Rest/binary>>) ->
+    is_mqtt_safe_utf8(Rest);
+is_mqtt_safe_utf8(<<_BadUtf8, _Rest/binary>>) ->
+    false.
 
 %% @doc Generate random, printable bytes as an ID.
 %% The first byte is ensured to be a-z or A-Z.

--- a/changes/ee/fix-17314.en.md
+++ b/changes/ee/fix-17314.en.md
@@ -1,0 +1,11 @@
+Sanitize PROXY-Protocol v2 SSL Common Name / Subject before they enter
+client identity. When a listener is configured with `proxy_protocol = true`,
+the broker now rejects connections whose PROXY-Protocol SSL TLV bytes contain
+ASCII control characters (the same byte class already rejected on MQTT-ingested
+clientid/username/password). This blocks attacker-controlled bytes from being
+smuggled into outbound HTTP authentication, authorization, or rule-engine
+header values via `${cert_common_name}` and `${cert_subject}` templates.
+
+As an additional defense layer, the HTTP authentication and authorization
+clients now refuse to send a request when a rendered header name or value
+contains a CR, LF, or NUL byte.


### PR DESCRIPTION
Release version:
5.8.11, 5.10.4

## Summary

When a listener has `proxy_protocol = true`, the SSL_CN / SSL_SUBJECT sub-TLVs of an incoming PROXY-Protocol v2 frame are attacker-controlled bytes. Those bytes were copied verbatim into `ClientInfo#{cn, dn}` and surfaced as the `${cert_common_name}` / `${cert_subject}` template variables.

An operator who follows the documented pattern of forwarding mTLS identity from an upstream L4 load balancer (TLS terminated upstream, identity carried in PP2) and uses `${cert_common_name}` or `${cert_subject}` in an `emqx_auth_http` / `emqx_authz_http` header template was exposed to CRLF injection — a CR/LF in the TLV split the outgoing HTTP request to the auth backend and let an attacker smuggle headers that could coerce an `allow` decision.

This is the same byte class EMQX already rejects on MQTT-ingested clientid / username / password via `emqx_frame:validate_utf8/1` (`strict_mode = true` by default). The PROXY-Protocol ingestion path skipped that check — asymmetric validation.

### Mitigation

1. **Primary**: validate CN / DN at the peer-cert ingestion boundary in `emqx_channel:set_peercert_infos/3`. Bytes in the ranges `0x00-0x1F` or `0x7F-0x9F` cause the connection to be rejected before any MQTT packet is parsed and a warning is logged (`peer_certificate_field_rejected`). This matches the existing MQTT-validation semantics and shields all downstream consumers — including `emqx_auth_http`, `emqx_authz_http`, and HTTP bridges/actions templated from `clientinfo.cn` — since the offending bytes never enter `ClientInfo` in the first place.

2. **Defense in depth**: `emqx_auth_utils:generate_request/2` now refuses to emit a request when a rendered header name or value contains CR, LF, or NUL, regardless of where the bytes came from. If a future render path forgets to sanitize, this second wall still prevents request smuggling. The check is intentionally narrow (just the bytes that split a request line) so it does not change behavior for clean templates that interpolate UTF-8 or other variables such as `${username}`.

### Files

- `apps/emqx_utils/src/emqx_utils.erl` — new `is_mqtt_safe_utf8/1` helper.
- `apps/emqx/src/emqx_channel.erl` — validate CN / DN in `set_peercert_infos/3`.
- `apps/emqx_auth/src/emqx_auth_utils.erl` — reject CR/LF/NUL in rendered HTTP header name/value pairs (`generate_request/2`).
- Tests: `apps/emqx/test/emqx_channel_SUITE.erl` and `apps/emqx_auth/test/emqx_auth_utils_tests.erl`.

### Backports

Port of the v6 fix on `release-60`. The same vulnerability is present on the 5.x line; this PR targets `release-58`. The v5 file layout differs from v6 — the HTTP request generator lives in `emqx_auth_utils` (v5) rather than `emqx_auth_http_utils` (v6) — so the defense-in-depth hook landed in the equivalent v5 module.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)