### PR TITLE
test(auth_mnesia): fix 30-min hang in authz_api_mnesia end_per_suite

### DIFF
--- a/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
@@ -40,8 +40,16 @@ init_per_suite(Config) ->
     _ = emqx_common_test_http:create_default_app(),
     [{suite_apps, Apps} | Config].
 end_per_suite(_Config) ->
-    ok = emqx_cth_suite:stop(?config(suite_apps, _Config)),
+    %% Belt-and-suspenders timetrap: emqx_mgmt_auth:delete/1 wraps the
+    %% delete in a mria transaction with no timeout, so calling
+    %% delete_default_app after the apps are stopped causes a 30-minute
+    %% hang waiting for the dead mria shard. The line order below puts
+    %% the delete BEFORE the stop (matching every other api SUITE);
+    %% the 30s timetrap is kept so any future regression fails fast
+    %% instead of blocking the whole CT shard for the full CT default.
+    ct:timetrap({seconds, 30}),
     _ = emqx_common_test_http:delete_default_app(),
+    ok = emqx_cth_suite:stop(?config(suite_apps, _Config)),
     ok.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl:end_per_suite` calls `emqx_cth_suite:stop` first, then `emqx_common_test_http:delete_default_app`. `delete_default_app` wraps `emqx_mgmt_auth:delete/1`, which calls `mria:sync_transaction/3` with the default `infinity` timeout. After `emqx_cth_suite:stop` shuts mria down, that `sync_transaction` never returns and the suite hangs for the full CT default 30-minute `end_per_suite` timetrap on every run — making the whole `apps/emqx_auth_mnesia-1_1` CT shard take ~32 min vs 3–9 min for peer CT jobs.

Every other api SUITE in the repo does the calls in the opposite order. Same root cause as #17312 (release-60). Diagnosed and verified locally on release-60: after the swap, the shard runs in ~2 min instead of ~32 min.

## Fix

Swap the two lines so `delete_default_app` runs **before** `emqx_cth_suite:stop`, and keep a short `ct:timetrap({seconds, 30})` as belt-and-suspenders so any future regression fails fast.

## Test plan

- [ ] CI: `apps/emqx_auth_mnesia-1_1` job duration drops from ~32 min to a few minutes.