### PR TITLE
fix(dashboard): set Content-Type to application/json on GET /api/v5/schemas/:name

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_schema_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema_api.erl
@@ -70,7 +70,10 @@ schema("/schemas/:name") ->
 get_schema(get, #{
     bindings := #{name := Name}
 }) ->
-    {200, gen_schema(Name)};
+    %% The body is already a JSON binary; tell minirest the content type
+    %% explicitly so it doesn't fall back to text/plain.
+    Headers = #{<<"content-type">> => <<"application/json">>},
+    {200, Headers, gen_schema(Name)};
 get_schema(get, _) ->
     {400, ?BAD_REQUEST, <<"unknown">>}.
 

--- a/apps/emqx_dashboard/test/emqx_dashboard_schema_api_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_schema_api_SUITE.erl
@@ -14,8 +14,6 @@
 
 -define(SERVER, "http://127.0.0.1:18083/api/v5").
 
--import(emqx_mgmt_api_test_util, [request/2]).
-
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
@@ -36,22 +34,25 @@ end_per_suite(Config) ->
     ok.
 
 t_hotconf(_) ->
-    Url = ?SERVER ++ "/schemas/hotconf",
-    {ok, 200, Body} = request(get, Url),
-    %% assert it's a valid json
-    _ = emqx_utils_json:decode(Body),
-    ok.
+    assert_schema_response("hotconf").
 
 t_actions(_) ->
-    Url = ?SERVER ++ "/schemas/actions",
-    {ok, 200, Body} = request(get, Url),
-    %% assert it's a valid json
-    _ = emqx_utils_json:decode(Body),
-    ok.
+    assert_schema_response("actions").
 
 t_connectors(_) ->
-    Url = ?SERVER ++ "/schemas/connectors",
-    {ok, 200, Body} = request(get, Url),
+    assert_schema_response("connectors").
+
+assert_schema_response(Name) ->
+    Url = ?SERVER ++ "/schemas/" ++ Name,
+    {ok, {{_, 200, _}, Headers, Body}} = request_with_headers(get, Url),
     %% assert it's a valid json
     _ = emqx_utils_json:decode(Body),
+    %% assert minirest reports JSON content-type, not the text/plain fallback
+    ContentType = proplists:get_value("content-type", Headers),
+    ?assertMatch(<<"application/json">>, iolist_to_binary(ContentType)),
     ok.
+
+request_with_headers(Method, Url) ->
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Opts = #{return_all => true, httpc_req_opts => [{body_format, binary}]},
+    emqx_mgmt_api_test_util:request_api(Method, Url, [], AuthHeader, [], Opts).

--- a/changes/ee/fix-17319.en.md
+++ b/changes/ee/fix-17319.en.md
@@ -1,0 +1,4 @@
+`GET /api/v5/schemas/{hotconf,actions,connectors}` now returns the response with
+`Content-Type: application/json`. Previously the response body was valid JSON but
+the header was `text/plain; charset=utf-8`, which broke clients that dispatch on
+the response content type.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

`GET /api/v5/schemas/{hotconf,actions,connectors}` returned a JSON body but advertised `Content-Type: text/plain; charset=utf-8`, breaking clients that dispatch on the response content type.

The handler pre-encodes the body to a JSON binary. minirest's binary encoder sets no response headers, so cowboy falls back to `text/plain`. Switched the handler return to the `{Status, Headers, Body}` 3-tuple form with an explicit `application/json` header, matching the existing pattern in `emqx_mgmt_api_clients:format_msgs_resp/4` (see comment there: "Make sure minirest won't set another content-type for self-encoded JSON response body").

All three sibling routes (`hotconf`, `actions`, `connectors`) share the same handler, so the fix applies to all three. Updated `apps/emqx_dashboard/test/emqx_dashboard_schema_api_SUITE.erl` to assert the response Content-Type header for each route.

Relevant files:
- `apps/emqx_dashboard/src/emqx_dashboard_schema_api.erl`
- `apps/emqx_dashboard/test/emqx_dashboard_schema_api_SUITE.erl`

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)