### PR TITLE
test(mqtt): de-flake t_message_expiry_interval

### DIFF
--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -115,7 +115,9 @@ message_expiry_interval_exipred(CPublish, CControl, QoS) ->
     after 1000 ->
         ct:fail(should_receive_publish)
     end,
-    ct:sleep(1100),
+    %% Sleep well past Message-Expiry-Interval (1s) with wide margin so the
+    %% wall-clock-based expiry check at session resume is not racy on slow CI.
+    ct:sleep(2000),
 
     %% resume the session for Client-Verify
     {ok, CVerify} = emqtt:start_link([


### PR DESCRIPTION
## Summary

`t_message_expiry_interval` was flaky on slow CI runners — `should_have_expired` would fire because the broker still delivered the queued message when `Client-Verify` resumed.

`emqx_message:is_expired/2` compares `erlang:system_time(millisecond) - CreatedAt` against `timer:seconds(Interval)`. With `Message-Expiry-Interval => 1` (1000 ms) and `ct:sleep(1100)` the test had only a 100 ms margin — enough to be eaten by scheduler jitter or an NTP nudge on heavy GHA hosts, leaving elapsed ≤ 1000 ms at session-resume dequeue and the message still considered live.

Bump the sleep to 2000 ms so the margin (≈1 s) absorbs realistic CI clock noise. No production change.

## Test plan

- [x] `make apps/emqx-ct SUITES=apps/emqx/test/emqx_mqtt_SUITE.erl CASES=t_message_expiry_interval` ×15 (all pass; the lone "fail" in my loop was an unrelated port-1883 init_per_suite skip from a parallel full-suite run)
- [x] Full `emqx_mqtt_SUITE` (6/6 pass)
- [x] `make fmt-diff`, `./scripts/elvis-check.sh`