### PR TITLE
fix: extend control-character rejection beyond peer cert CN / DN

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -309,6 +309,7 @@ init(
         Zone
     ),
     {NClientInfo, NConnInfo0} = take_conn_info_fields([ws_cookie, peersni], ClientInfo, ConnInfo),
+    ok = validate_clientinfo_string(peersni, maps:get(peersni, NClientInfo, undefined)),
     NConnInfo = maybe_quic_shared_state(NConnInfo0, Opts),
     #channel{
         conninfo = NConnInfo,
@@ -381,6 +382,27 @@ validate_peercert_string(Field, Value, Source) when is_binary(Value) ->
 peercert_source(Peercert) when is_binary(Peercert) -> tls_certificate;
 peercert_source(PP2Info) when is_list(PP2Info) -> proxy_protocol_v2;
 peercert_source(_) -> unknown.
+
+%% Same byte-class check as `validate_peercert_string/3', for binary fields
+%% that flow into `ClientInfo' from the connection layer (currently `peersni',
+%% which comes from the TLS handshake SNI or the PROXY-Protocol v2
+%% `pp2_authority' TLV). On bad bytes, terminate the connection and log a
+%% warning, mirroring how `emqx_frame:validate_utf8/1' rejects MQTT-ingested
+%% UTF-8 strings.
+validate_clientinfo_string(_Field, undefined) ->
+    ok;
+validate_clientinfo_string(Field, Value) when is_binary(Value) ->
+    case emqx_utils:is_mqtt_safe_utf8(Value) of
+        true ->
+            ok;
+        false ->
+            ?SLOG(warning, #{
+                msg => "clientinfo_field_rejected",
+                field => Field,
+                reason => contains_control_characters
+            }),
+            erlang:exit({shutdown, clientinfo_field_invalid})
+    end.
 
 take_conn_info_fields(Fields, ClientInfo, ConnInfo) ->
     lists:foldl(
@@ -2084,16 +2106,30 @@ initialize_client_attrs(Inits, #{clientid := ClientId} = ClientInfo) ->
                     ),
                     Acc;
                 {ok, Value} ->
-                    ?SLOG(
-                        debug,
-                        #{
-                            msg => "client_attr_initialized",
-                            set_as_attr => Name,
-                            attr_value => Value
-                        },
-                        #{clientid => ClientId}
-                    ),
-                    Acc#{client_attrs => Attrs#{Name => Value}};
+                    case emqx_utils:is_mqtt_safe_utf8(Value) of
+                        true ->
+                            ?SLOG(
+                                debug,
+                                #{
+                                    msg => "client_attr_initialized",
+                                    set_as_attr => Name,
+                                    attr_value => Value
+                                },
+                                #{clientid => ClientId}
+                            ),
+                            Acc#{client_attrs => Attrs#{Name => Value}};
+                        false ->
+                            ?SLOG(
+                                warning,
+                                #{
+                                    msg => "client_attr_dropped",
+                                    set_as_attr => Name,
+                                    reason => contains_control_characters
+                                },
+                                #{clientid => ClientId}
+                            ),
+                            Acc
+                    end;
                 {error, Reason} ->
                     ?SLOG(
                         warning,

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -1104,6 +1104,46 @@ t_peercert_pp2_cn_clean_accepted(_) ->
         emqx_channel:info(clientinfo, Channel)
     ).
 
+t_peersni_with_crlf_rejected(_) ->
+    %% `peersni' is sourced from the TLS handshake SNI or, when PROXY-Protocol
+    %% v2 is used, from the `pp2_authority' TLV (attacker-controlled). It must
+    %% pass the same byte-class gate as `cn' / `dn', since `${peersni}' and
+    %% `${client_attrs.tns}' (commonly derived from `peersni') flow into the
+    %% same HTTP authn / authz / bridge template paths.
+    SmuggledSNI = <<"tenant-a\r\nX-Override-Result: allow">>,
+    ConnInfo = (pp2_conn_info(nossl))#{peersni => SmuggledSNI},
+    Opts = #{zone => default, limiter => undefined, listener => {tcp, default}},
+    ?assertExit(
+        {shutdown, clientinfo_field_invalid},
+        emqx_channel:init(ConnInfo, Opts)
+    ).
+
+t_peersni_clean_accepted(_) ->
+    ConnInfo = (pp2_conn_info(nossl))#{peersni => <<"tenant-a.example.com">>},
+    Opts = #{zone => default, limiter => undefined, listener => {tcp, default}},
+    Channel = emqx_channel:init(ConnInfo, Opts),
+    ?assertMatch(
+        #{peersni := <<"tenant-a.example.com">>},
+        emqx_channel:info(clientinfo, Channel)
+    ).
+
+t_client_attrs_with_control_chars_dropped(_) ->
+    %% A `client_attrs_init' Variform expression that ends up producing bytes
+    %% in the C0/C1 control range (e.g. by pulling from a non-strict-mode
+    %% MQTT v5 user property) must be dropped, not propagated to
+    %% `client_attrs', otherwise it would re-introduce the CRLF primitive
+    %% via `${client_attrs.tns}' in HTTP templates.
+    {ok, Good} = emqx_variform:compile(<<"concat(['tenant-a'])">>),
+    {ok, Bad} = emqx_variform:compile(<<"concat(['tenant-a\r\nsmuggled'])">>),
+    Result = emqx_channel:initialize_client_attrs(
+        [
+            #{set_as_attr => <<"good">>, expression => Good},
+            #{set_as_attr => <<"tns">>, expression => Bad}
+        ],
+        #{clientid => <<"c1">>}
+    ),
+    ?assertEqual(#{<<"good">> => <<"tenant-a">>}, maps:get(client_attrs, Result, #{})).
+
 pp2_conn_info(PeerCert) ->
     #{
         socktype => tcp,

--- a/apps/emqx_auth/src/emqx_auth_utils.erl
+++ b/apps/emqx_auth/src/emqx_auth_utils.erl
@@ -312,26 +312,15 @@ validate_headers(Headers) when is_map(Headers) ->
 validate_headers_list([]) ->
     ok;
 validate_headers_list([{Name, Value} | Rest]) ->
-    case header_byte_check(Name) of
+    case emqx_utils:http_header_byte_check(Name) of
         ok ->
-            case header_byte_check(Value) of
+            case emqx_utils:http_header_byte_check(Value) of
                 ok -> validate_headers_list(Rest);
                 {error, Reason} -> {error, {bad_http_header_value, Name, Reason}}
             end;
         {error, Reason} ->
             {error, {bad_http_header_name, Reason}}
     end.
-
-header_byte_check(Bin) when is_binary(Bin) ->
-    header_byte_check_bin(Bin);
-header_byte_check(_NonBin) ->
-    ok.
-
-header_byte_check_bin(<<>>) -> ok;
-header_byte_check_bin(<<0, _/binary>>) -> {error, contains_nul};
-header_byte_check_bin(<<$\r, _/binary>>) -> {error, contains_cr};
-header_byte_check_bin(<<$\n, _/binary>>) -> {error, contains_lf};
-header_byte_check_bin(<<_, Rest/binary>>) -> header_byte_check_bin(Rest).
 
 post_request_content_type(Headers) ->
     proplists:get_value(<<"content-type">>, Headers, ?DEFAULT_HTTP_REQUEST_CONTENT_TYPE).

--- a/apps/emqx_auth/test/emqx_auth_utils_tests.erl
+++ b/apps/emqx_auth/test/emqx_auth_utils_tests.erl
@@ -24,7 +24,7 @@ generate_request_rejects_crlf_in_header_test_() ->
             do_generate(<<"alice\rX-Override-Result: allow">>)
         ),
         ?_assertMatch(
-            {error, {bad_http_header_value, _, contains_nul}},
+            {error, {bad_http_header_value, _, contains_null}},
             do_generate(<<"alice", 0, "X-Override-Result: allow">>)
         )
     ].

--- a/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_http, [
     {description, "EMQX HTTP Bridge and Connector Application"},
-    {vsn, "0.3.9"},
+    {vsn, "0.3.10"},
     {registered, []},
     {applications, [kernel, stdlib, emqx_resource, ehttpc]},
     {env, [

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
@@ -831,15 +831,39 @@ render_request_body(BodyTks, RenderTmplFunc, Msg) ->
     RenderTmplFunc(BodyTks, Msg).
 
 render_headers(HeaderTks, RenderTmplFunc, Msg) ->
-    lists:map(
-        fun({K, V}) ->
-            {
-                render_template_string(K, RenderTmplFunc, Msg),
-                render_template_string(emqx_secret:unwrap(V), RenderTmplFunc, Msg)
-            }
+    lists:filtermap(
+        fun({KTks, VTks}) ->
+            K = render_template_string(KTks, RenderTmplFunc, Msg),
+            V = render_template_string(emqx_secret:unwrap(VTks), RenderTmplFunc, Msg),
+            case safe_http_header(K, V) of
+                true ->
+                    {true, {K, V}};
+                {false, Reason} ->
+                    ?SLOG(warning, #{
+                        msg => "http_header_dropped",
+                        header_name => K,
+                        reason => Reason
+                    }),
+                    false
+            end
         end,
         HeaderTks
     ).
+
+%% Defense-in-depth: a templated header value can interpolate message-level
+%% bytes that originated from an MQTT publisher. Reject CR/LF/NUL so a
+%% malicious payload cannot split the outgoing HTTP request to the bridge
+%% destination.
+safe_http_header(K, V) ->
+    case emqx_utils:http_header_byte_check(K) of
+        ok ->
+            case emqx_utils:http_header_byte_check(V) of
+                ok -> true;
+                {error, Reason} -> {false, Reason}
+            end;
+        {error, Reason} ->
+            {false, Reason}
+    end.
 
 render_template(Template, Msg) ->
     % NOTE: ignoring errors here, missing variables will be rendered as `"undefined"`.
@@ -1043,6 +1067,30 @@ clientid(Msg) -> maps:get(clientid, Msg, undefined).
 
 iolists_equal(L1, L2) ->
     iolist_to_binary(L1) =:= iolist_to_binary(L2).
+
+%% Defense-in-depth: a templated header whose rendered name or value
+%% contains NUL, CR or LF must be dropped, not emitted. An MQTT publisher
+%% could otherwise smuggle headers into the bridge destination via a
+%% template such as `${client_attrs.tns}'.
+drop_unsafe_headers_test() ->
+    Preprocessed = preprocess_request(#{
+        method => <<"post">>,
+        path => <<"/ingest">>,
+        headers => #{
+            <<"content-type">> => <<"application/json">>,
+            <<"x-clean">> => <<"${good}">>,
+            <<"x-tns">> => <<"${tns}">>
+        }
+    }),
+    #{headers := HeadersTemplate} = Preprocessed,
+    Msg = #{
+        <<"good">> => <<"alice">>,
+        <<"tns">> => <<"alice\r\nX-Override: allow">>
+    },
+    Rendered = render_headers(HeadersTemplate, fun render_template/2, Msg),
+    Names = [K || {K, _} <- Rendered],
+    ?assert(lists:member(<<"x-clean">>, Names)),
+    ?assertNot(lists:member(<<"x-tns">>, Names)).
 
 redact_test_() ->
     TestData = #{

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -73,6 +73,7 @@
     foldl_while/3,
     is_restricted_str/1,
     is_mqtt_safe_utf8/1,
+    http_header_byte_check/1,
     interactive_load/1
 ]).
 
@@ -919,6 +920,31 @@ is_mqtt_safe_utf8(<<_H/utf8, Rest/binary>>) ->
     is_mqtt_safe_utf8(Rest);
 is_mqtt_safe_utf8(<<_BadUtf8, _Rest/binary>>) ->
     false.
+
+%% @doc Scan a binary for bytes capable of splitting an HTTP/1.1 request line.
+%% Returns `ok' if the binary is safe to emit as an HTTP header name or value,
+%% otherwise `{error, contains_null | contains_cr | contains_lf}'. Non-binary
+%% inputs are treated as safe; callers that templated something other than a
+%% binary have already failed earlier in a more visible way.
+%%
+%% Implemented with `binary:match/2' (NIF) so the happy path stays cheap; the
+%% per-byte inspection only runs when an offending byte is found.
+-spec http_header_byte_check(binary() | term()) ->
+    ok | {error, contains_null | contains_cr | contains_lf}.
+http_header_byte_check(Bin) when is_binary(Bin) ->
+    case binary:match(Bin, [<<$\r>>, <<$\n>>, <<0>>]) of
+        nomatch ->
+            ok;
+        {Pos, _} ->
+            <<_:Pos/binary, Byte, _/binary>> = Bin,
+            {error, control_byte_to_reason(Byte)}
+    end;
+http_header_byte_check(_NonBin) ->
+    ok.
+
+control_byte_to_reason(0) -> contains_null;
+control_byte_to_reason($\r) -> contains_cr;
+control_byte_to_reason($\n) -> contains_lf.
 
 %% @doc Generate random, printable bytes as an ID.
 %% The first byte is ensured to be a-z or A-Z.

--- a/changes/ee/fix-17322.en.md
+++ b/changes/ee/fix-17322.en.md
@@ -1,0 +1,13 @@
+Extend the byte-class check applied to MQTT clientid / username / password
+to other fields that feed `ClientInfo` and HTTP request templating:
+
+- `peersni` (TLS Server Name Indication; also accepted from the
+  PROXY-Protocol v2 `authority` TLV) is now validated at the connection
+  ingestion boundary. Control characters cause the connection to be
+  rejected and a warning logged.
+- Client attribute values produced by `mqtt.client_attrs_init` Variform
+  expressions are dropped (with a warning) when they contain control
+  characters, so templates such as `${client_attrs.tns}` cannot carry
+  injected bytes downstream.
+- HTTP action / bridge connector header rendering now drops any header
+  whose rendered name or value contains NUL, CR, or LF.


### PR DESCRIPTION
Release version:
5.8.11, 5.10.4

## Summary

Follow-up to #17314 on `release-58` (port of upstream #17315 from `release-60`). That earlier PR rejected control characters in `cn` / `dn` at the peer-cert ingestion boundary. This PR closes three sibling holes through which the same byte class could still flow into HTTP authentication, authorization, and bridge templates.

### Changes

1. **`peersni` validated at ingestion** (`apps/emqx/src/emqx_channel.erl`). `peersni` is set in `ConnInfo` by the TCP / WebSocket / connection layer and is sourced from the TLS handshake SNI or, when PROXY-Protocol v2 is in use, from the `pp2_authority` TLV (attacker-controlled). After `take_conn_info_fields/3` moves it into `ClientInfo`, `init/2` now runs it through `emqx_utils:is_mqtt_safe_utf8/1` and exits the connection with `{shutdown, clientinfo_field_invalid}` on bad bytes — same semantics as the existing `cn` / `dn` check.

2. **`client_attrs` values vetted before being stored** (`apps/emqx/src/emqx_channel.erl`). `initialize_client_attrs/2` evaluates Variform expressions defined in `mqtt.client_attrs_init`. The rendered binaries land in `ClientInfo.client_attrs` and are then exposed to templates as `${client_attrs.<name>}` (the documented `tns` tenant-namespace pattern is one example). Values that contain control bytes are dropped with a warning, not stored — so a template like `${client_attrs.tns}` cannot carry injected bytes into an outbound HTTP header even if the Variform expression pulled bytes from a non-strict-mode MQTT v5 `user_property`. Dropping the attribute (rather than terminating the connection) avoids punishing operators who write complex Variform expressions while still neutralizing the smuggling primitive.

3. **HTTP bridge connector drops unsafe headers** (`apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl`). `render_headers/3` now consults `emqx_utils:http_header_byte_check/1` on each rendered `{name, value}` pair and drops any pair containing NUL / CR / LF. An MQTT publisher could otherwise smuggle headers into the bridge destination through a templated value such as `${payload.something}` or `${client_attrs.tns}`. Dropping the header (rather than failing the request) keeps the bridge buffer worker progressing while preventing the malicious bytes from reaching the wire.

4. **Shared helper in `emqx_utils`**. The header byte-check, previously private to `emqx_auth_utils` (the 5.x location; called `emqx_auth_http_utils` on 6.x), moves to `emqx_utils:http_header_byte_check/1` so both `emqx_auth_utils` and `emqx_bridge_http_connector` use the same implementation. The happy-path scan is backed by `binary:match/2` (NIF). The NUL reason atom is renamed `contains_nul` -> `contains_null` for spelling consistency.

### Tests

- `emqx_channel_SUITE`: `t_peersni_with_crlf_rejected`, `t_peersni_clean_accepted`, `t_client_attrs_with_control_chars_dropped` (all pass).
- `emqx_bridge_http_connector` inline eunit: `drop_unsafe_headers_test`.
- `emqx_auth_utils_tests` updated for the renamed reason atom.

### Backports

Stacked port of upstream #17315 onto `release-58`; same scope as the prior #17314 port. The v5 file layout differs from v6 — the HTTP request generator and its header validator live in `emqx_auth_utils` (v5) rather than `emqx_auth_http_utils` (v6) — so the shared-helper switchover applied there.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)