### PR TITLE
feat(prometheus): expose VM uptime and max FDs ulimit

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -199,7 +199,9 @@ vm_stats() ->
             {mnesia_tm_mailbox_size, vm_stats('mnesia.tm.mailbox.size')},
             {broker_pool_max_mailbox_size, vm_stats('broker.pool.max.mailbox.size')},
             {total_memory, MemTotal},
-            {used_memory, erlang:round(MemTotal * MemUsedRatio)}
+            {used_memory, erlang:round(MemTotal * MemUsedRatio)},
+            {uptime, emqx_sys:uptime()},
+            {max_fds, esockd:ulimit()}
         ].
 
 cpu_stats() ->

--- a/apps/emqx_opentelemetry/src/emqx_otel_metrics.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_metrics.erl
@@ -99,7 +99,7 @@ create_metric_views() ->
     Meter = opentelemetry_experimental:get_meter(),
     StatsGauge = emqx_stats:getstats(),
     create_gauge(Meter, StatsGauge, fun ?MODULE:get_stats_gauge/1),
-    VmGauge = lists:map(fun({K, V}) -> {normalize_name(K), V} end, emqx_mgmt:vm_stats()),
+    VmGauge = [{KN, V} || {K, V} <- emqx_mgmt:vm_stats(), KN <- [normalize_name(K)], is_atom(KN)],
     create_gauge(Meter, VmGauge, fun ?MODULE:get_vm_gauge/1),
     ClusterGauge = [{'node.running', 0}, {'node.stopped', 0}],
     create_gauge(Meter, ClusterGauge, fun ?MODULE:get_cluster_gauge/1),
@@ -257,8 +257,8 @@ normalize_name(total_memory) ->
     'total.memory';
 normalize_name(used_memory) ->
     'used.memory';
-normalize_name(Name) ->
-    list_to_existing_atom(lists:flatten(string:replace(atom_to_list(Name), "_", ".", all))).
+normalize_name(_) ->
+    {error, unknown}.
 
 assert_started({ok, _Pid}) -> ok;
 assert_started({ok, _Pid, _Info}) -> ok;

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -416,6 +416,8 @@ emqx_collect(K = emqx_delayed_max, D) -> gauge_metrics(?MG(K, D));
 emqx_collect(K = emqx_vm_cpu_use, D) -> gauge_metrics(?MG(K, D));
 emqx_collect(K = emqx_vm_cpu_idle, D) -> gauge_metrics(?MG(K, D));
 emqx_collect(K = emqx_vm_run_queue, D) -> gauge_metrics(?MG(K, D));
+emqx_collect(K = emqx_vm_uptime_ms, D) -> gauge_metrics(?MG(K, D));
+emqx_collect(K = emqx_vm_max_fds, D) -> gauge_metrics(?MG(K, D));
 emqx_collect(K = emqx_vm_process_messages_in_queues, D) -> gauge_metrics(?MG(K, D));
 emqx_collect(K = emqx_vm_total_memory, D) -> gauge_metrics(?MG(K, D));
 emqx_collect(K = emqx_vm_used_memory, D) -> gauge_metrics(?MG(K, D));
@@ -689,6 +691,8 @@ vm_metric_meta() ->
         {emqx_vm_cpu_use, gauge, 'cpu_use'},
         {emqx_vm_cpu_idle, gauge, 'cpu_idle'},
         {emqx_vm_run_queue, gauge, 'run_queue'},
+        {emqx_vm_uptime_ms, gauge, 'uptime'},
+        {emqx_vm_max_fds, gauge, 'max_fds'},
         {emqx_vm_process_messages_in_queues, gauge, 'process_total_messages'},
         {emqx_vm_total_memory, gauge, 'total_memory'},
         {emqx_vm_used_memory, gauge, 'used_memory'},

--- a/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
@@ -345,6 +345,8 @@ metric_meta(<<"emqx_subscriptions_shared_max">>) -> ?meta(0, 0, 0);
 metric_meta(<<"emqx_vm_cpu_use">>) -> ?meta(0, 1, 1);
 metric_meta(<<"emqx_vm_cpu_idle">>) -> ?meta(0, 1, 1);
 metric_meta(<<"emqx_vm_run_queue">>) -> ?meta(0, 1, 1);
+metric_meta(<<"emqx_vm_uptime_ms">>) -> ?meta(0, 1, 1);
+metric_meta(<<"emqx_vm_max_fds">>) -> ?meta(0, 1, 1);
 metric_meta(<<"emqx_vm_process_messages_in_queues">>) -> ?meta(0, 1, 1);
 metric_meta(<<"emqx_vm_total_memory">>) -> ?meta(0, 1, 1);
 metric_meta(<<"emqx_vm_used_memory">>) -> ?meta(0, 1, 1);
@@ -558,6 +560,8 @@ assert_json_data__metrics(M, ?PROM_DATA_MODE__NODE) ->
             emqx_vm_cpu_use := _,
             emqx_vm_cpu_idle := _,
             emqx_vm_run_queue := _,
+            emqx_vm_uptime_ms := _,
+            emqx_vm_max_fds := _,
             emqx_vm_process_messages_in_queues := _,
             emqx_vm_total_memory := _,
             emqx_vm_used_memory := _

--- a/changes/ee/feat-17329.en.md
+++ b/changes/ee/feat-17329.en.md
@@ -1,0 +1,4 @@
+Added two node-wide gauge metrics to the `/api/v5/prometheus/stats` endpoint:
+
+* `emqx_vm_uptime_ms` reports the EMQX node uptime in milliseconds.
+* `emqx_vm_max_fds` reports the maximum number of file descriptors available to the node.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.0

## Summary

This PR adds a couple of metrics currently provided by `emqx-reporter` for older releases.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible