### PR TITLE
feat(packaging): expose /opt/emqx symlinks on rpm/deb installs

### DIFF
--- a/changes/ee/feat-17335.en.md
+++ b/changes/ee/feat-17335.en.md
@@ -1,0 +1,1 @@
+After installation from an RPM or DEB package, the directory `/opt/emqx` is created and populated with convenience symlinks (`bin`, `data`, `etc`, `lib`, `log`, `plugins`, `releases`, `erts-*`) pointing at the scattered FHS paths used by the package. Operators can now use the same `/opt/emqx/...` paths as in the official Docker image, regardless of how EMQX was installed.

--- a/deploy/packages/deb/debian/postinst
+++ b/deploy/packages/deb/debian/postinst
@@ -35,6 +35,20 @@ chmod -R 0755 /usr/lib/emqx/bin
 ln -s /usr/lib/emqx/bin/emqx /usr/bin/emqx
 ln -s /usr/lib/emqx/bin/emqx_ctl /usr/bin/emqx_ctl
 
+# Expose the scattered FHS layout under /opt/emqx so paths match the docker image.
+mkdir -p /opt/emqx
+ln -sfn /usr/lib/emqx/bin      /opt/emqx/bin
+ln -sfn /var/lib/emqx          /opt/emqx/data
+ln -sfn /etc/emqx              /opt/emqx/etc
+ln -sfn /usr/lib/emqx/lib      /opt/emqx/lib
+ln -sfn /var/log/emqx          /opt/emqx/log
+ln -sfn /usr/lib/emqx/plugins  /opt/emqx/plugins
+ln -sfn /usr/lib/emqx/releases /opt/emqx/releases
+for erts in /usr/lib/emqx/erts-*; do
+    [ -d "$erts" ] || continue
+    ln -sfn "$erts" "/opt/emqx/$(basename "$erts")"
+done
+
 if systemctl status --no-pager; then
     systemctl enable emqx;
 else

--- a/deploy/packages/deb/debian/postrm
+++ b/deploy/packages/deb/debian/postrm
@@ -19,11 +19,26 @@
 
 set -e
 
+# Remove the /opt/emqx convenience symlinks installed by postinst.
+# Only touch symlinks we own, so anything the user dropped into /opt/emqx is left alone.
+cleanup_opt_emqx() {
+    [ -d /opt/emqx ] || return 0
+    for entry in /opt/emqx/bin /opt/emqx/data /opt/emqx/etc /opt/emqx/lib \
+                 /opt/emqx/log /opt/emqx/plugins /opt/emqx/releases \
+                 /opt/emqx/erts-*; do
+        if [ -L "$entry" ]; then
+            rm -f "$entry"
+        fi
+    done
+    rmdir /opt/emqx 2>/dev/null || true
+}
+
 case "$1" in
     purge)
         # force kill all processes owned by emqx, if any
         pkill -9 -u emqx || true
         rm -f /etc/default/emqx
+        cleanup_opt_emqx
 
         if [ -d /var/lib/emqx ]; then
                 rm -r /var/lib/emqx
@@ -66,6 +81,7 @@ case "$1" in
     remove)
         rm /usr/bin/emqx
         rm /usr/bin/emqx_ctl
+        cleanup_opt_emqx
     ;;
 
     upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/deploy/packages/rpm/emqx.spec
+++ b/deploy/packages/rpm/emqx.spec
@@ -82,6 +82,20 @@ fi
 systemctl enable %{_name}.service
 chown -R %{_user}:%{_group} %{_lib_home}
 
+# Expose the scattered FHS layout under /opt/%{_name} so paths match the docker image.
+mkdir -p /opt/%{_name}
+ln -sfn %{_lib_home}/bin      /opt/%{_name}/bin
+ln -sfn %{_var_home}          /opt/%{_name}/data
+ln -sfn %{_conf_dir}          /opt/%{_name}/etc
+ln -sfn %{_lib_home}/lib      /opt/%{_name}/lib
+ln -sfn %{_log_dir}           /opt/%{_name}/log
+ln -sfn %{_lib_home}/plugins  /opt/%{_name}/plugins
+ln -sfn %{_lib_home}/releases /opt/%{_name}/releases
+for erts in %{_lib_home}/erts-*; do
+    [ -d "$erts" ] || continue
+    ln -sfn "$erts" "/opt/%{_name}/$(basename "$erts")"
+done
+
 %preun
 %{_preun_addition}
 # Only on uninstall, not upgrades
@@ -95,6 +109,16 @@ exit 0
 %postun
 if [ $1 = 0 ]; then
    rm -rf %{_lib_home}
+   if [ -d /opt/%{_name} ]; then
+       for entry in /opt/%{_name}/bin /opt/%{_name}/data /opt/%{_name}/etc \
+                    /opt/%{_name}/lib /opt/%{_name}/log /opt/%{_name}/plugins \
+                    /opt/%{_name}/releases /opt/%{_name}/erts-*; do
+           if [ -L "$entry" ]; then
+               rm -f "$entry"
+           fi
+       done
+       rmdir /opt/%{_name} 2>/dev/null || true
+   fi
 fi
 exit 0
 


### PR DESCRIPTION
Release version: 6.3.0

## Summary

After installing EMQX from an RPM or DEB package, the directory `/opt/emqx` is now created and populated with convenience symlinks that point at the scattered FHS paths used by the package layout:

| Symlink | Target |
|---|---|
| `/opt/emqx/bin` | `/usr/lib/emqx/bin` |
| `/opt/emqx/data` | `/var/lib/emqx` |
| `/opt/emqx/etc` | `/etc/emqx` |
| `/opt/emqx/lib` | `/usr/lib/emqx/lib` |
| `/opt/emqx/log` | `/var/log/emqx` |
| `/opt/emqx/plugins` | `/usr/lib/emqx/plugins` |
| `/opt/emqx/releases` | `/usr/lib/emqx/releases` |
| `/opt/emqx/erts-<vsn>` | `/usr/lib/emqx/erts-<vsn>` |

This mirrors the directory layout of the official Docker image, where `/opt/emqx` is the broker's home and all subdirectories live underneath it. Operators, scripts, and documentation can now use the same `/opt/emqx/...` paths regardless of how EMQX was installed.

On uninstall, the symlinks are removed and `/opt/emqx` itself is removed only if empty (anything an operator dropped into `/opt/emqx` is preserved).

### Files changed

- `deploy/packages/deb/debian/postinst` — create symlinks (idempotent via `ln -sfn`, also runs on upgrade)
- `deploy/packages/deb/debian/postrm` — clean up on both `remove` and `purge`
- `deploy/packages/rpm/emqx.spec` — same logic in `%post` (idempotent on upgrade) and `%postun` (cleanup only on uninstall, not upgrade)

### Test plan

- Built `emqx-enterprise` DEB on Ubuntu 20.04 and installed it inside a fresh `ubuntu:20.04` container: all 8 symlinks present and resolving, `/opt/emqx/bin/emqx` executable, `/opt/emqx/etc/emqx.conf` reachable.
- Verified that `apt-get remove` and `apt-get purge` both clean up `/opt/emqx` (no dangling symlinks left).
- RPM spec changes mirror the DEB postinst/postrm shell logic exactly; CI's el7/el8/el9/amzn2023 install path will exercise it.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)