### PR TITLE
build(refactor): move `parquer` dep to root `mix.exs`

### DIFF
--- a/apps/emqx_bridge_s3tables/mix.exs
+++ b/apps/emqx_bridge_s3tables/mix.exs
@@ -37,7 +37,7 @@ defmodule EMQXBridgeS3Tables.MixProject do
       {:emqx_connector_aggregator, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_s3, in_umbrella: true},
-      {:parquer, github: "emqx/parquer", tag: "0.1.8", manager: :rebar3},
+      :parquer,
       :erlcloud,
       :murmerl3
     ])

--- a/mix.exs
+++ b/mix.exs
@@ -312,6 +312,9 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:optvar),
     do: {:optvar, override: true, git: "https://github.com/emqx/optvar", tag: "1.0.5"}
 
+  def common_dep(:parquer),
+    do: {:parquer, github: "emqx/parquer", tag: "0.1.8", manager: :rebar3}
+
   def common_dep(:thrift),
     do: {:thrift, github: "emqx/thrift.erl", tag: "0.1.4", override: true}
 


### PR DESCRIPTION
Even though `parquer` is solely used by the s3tables bridge in 6.0.x, it's used by more apps in later versions.  Syncing `release-60` to `release-61` could fail to correctly update its version at the root `mix.exs` file.  Therefore, we move it to be a `common_dep` clause in the root mix file to facilitate syncing between branches.
