### PR TITLE
fix(authz): keep `rules` inline when replicating file source

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -1144,7 +1144,8 @@ validate_cluster_hocon(RawConf0) ->
     %% the running value and drop required fields without defaults such as
     %% `node.cookie'.
     RawConfFiltered = maps:without(import_skip_root_keys(), RawConf0),
-    %% write ACL file to comply with the schema...
+    %% Write ACL file(s) locally so the `authz:file` schema's path validator
+    %% (which calls file:consult/1) passes during the schema check below.
     RawConf1 = emqx_authz:maybe_write_files(RawConfFiltered),
     maybe
         {ok, RawConf} ?=
@@ -1153,7 +1154,15 @@ validate_cluster_hocon(RawConf0) ->
                 maps:merge(emqx:get_raw_config([]), RawConf1),
                 #{atom_key => false, required => false, make_serializable => true}
             ),
-        {ok, maps:with(maps:keys(RawConfFiltered), RawConf)}
+        Filtered = maps:with(maps:keys(RawConfFiltered), RawConf),
+        %% For every file authz source whose *input* form carried inline
+        %% `rules`, restore that `rules` field before the config is shipped
+        %% via cluster_rpc. Otherwise remote nodes would receive only a
+        %% `path` — pointing at the file we just wrote on this node — and
+        %% fail with `failed_to_read_acl_file` because they have no such
+        %% file locally. Sources whose input was a bare `path` (user-
+        %% specified) are left untouched so the user's intent is preserved.
+        {ok, restore_inline_authz_rules(Filtered, RawConfFiltered)}
     end.
 
 %% Roots that are dropped from the imported cluster.hocon before the
@@ -1165,6 +1174,35 @@ validate_cluster_hocon(RawConf0) ->
 %% list disjoint from ?CONF_KEYS (see import_skip_root_keys_test/0).
 import_skip_root_keys() ->
     [<<"node">>, <<"rpc">>].
+
+restore_inline_authz_rules(
+    #{<<"authorization">> := #{<<"sources">> := NewSources} = NewAuthz} = NewConf,
+    #{<<"authorization">> := #{<<"sources">> := OldSources}}
+) ->
+    Restored = [maybe_restore_source_rules(S, OldSources) || S <- NewSources],
+    NewConf#{<<"authorization">> := NewAuthz#{<<"sources">> := Restored}};
+restore_inline_authz_rules(NewConf, _OldConf) ->
+    NewConf.
+
+maybe_restore_source_rules(
+    #{<<"type">> := <<"file">>, <<"path">> := _} = NewSrc, OldSources
+) ->
+    case
+        lists:search(
+            fun
+                (#{<<"type">> := <<"file">>, <<"rules">> := _}) -> true;
+                (_) -> false
+            end,
+            OldSources
+        )
+    of
+        {value, #{<<"rules">> := Rules}} ->
+            maps:remove(<<"path">>, NewSrc#{<<"rules">> => Rules});
+        false ->
+            NewSrc
+    end;
+maybe_restore_source_rules(NewSrc, _OldSources) ->
+    NewSrc.
 
 do_import_conf(Namespace, RawConf, Opts) ->
     GenConfErrs = filter_errors(maps:from_list(import_generic_conf(Namespace, RawConf))),

--- a/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
@@ -73,6 +73,23 @@ init_per_testcase(TC = t_import_on_cluster, Config) ->
     [{cluster, cluster(TC, Config)} | setup(TC, Config)];
 init_per_testcase(TC = t_verify_imported_mnesia_tab_on_cluster, Config) ->
     [{cluster, cluster(TC, Config)} | setup(TC, Config)];
+init_per_testcase(TC = t_import_file_authz_source_on_cluster, Config) ->
+    %% Don't import listeners to avoid port conflicts when running in a cluster.
+    meck:new(emqx_mgmt_listeners_conf, [passthrough]),
+    meck:new(emqx_gateway_conf, [passthrough]),
+    meck:expect(
+        emqx_mgmt_listeners_conf,
+        import_config,
+        2,
+        {ok, #{changed => [], root_key => listeners}}
+    ),
+    meck:expect(
+        emqx_gateway_conf,
+        import_config,
+        2,
+        {ok, #{changed => [], root_key => gateway}}
+    ),
+    [{cluster, cluster(TC, Config)} | setup(TC, Config)];
 init_per_testcase(t_mnesia_bad_tab_schema, Config) ->
     meck:new(emqx_mgmt_data_backup, [passthrough]),
     meck:expect(TC = emqx_mgmt_data_backup, modules_with_mnesia_tabs_to_backup, 0, [?MODULE]),
@@ -88,6 +105,11 @@ end_per_testcase(t_import_on_cluster, Config) ->
 end_per_testcase(t_verify_imported_mnesia_tab_on_cluster, Config) ->
     emqx_cth_cluster:stop(?config(cluster, Config)),
     cleanup(Config);
+end_per_testcase(t_import_file_authz_source_on_cluster, Config) ->
+    emqx_cth_cluster:stop(?config(cluster, Config)),
+    cleanup(Config),
+    meck:unload(emqx_mgmt_listeners_conf),
+    meck:unload(emqx_gateway_conf);
 end_per_testcase(t_mnesia_bad_tab_schema, Config) ->
     cleanup(Config),
     meck:unload(emqx_mgmt_data_backup);
@@ -596,6 +618,89 @@ t_verify_imported_mnesia_tab_on_cluster(Config) ->
     %% Give some extra time to replicant to import data...
     timer:sleep(3000),
     ?assertEqual(AllUsers, lists:sort(rpc:call(ReplicantNode, mnesia, dirty_all_keys, [Tab]))).
+
+%% Regression: importing a backup that contains an authz `file` source used to
+%% strip inline `rules` on the importer node and ship only `path` across the
+%% cluster. Peer nodes had no such file on disk and failed to apply the change
+%% with `failed_to_read_acl_file` / `cluster_rpc_apply_failed`. The fix keeps
+%% `rules` inline in the cluster-bound config so each peer writes its own
+%% local copy of acl.conf during pre_config_update.
+t_import_file_authz_source_on_cluster(Config) ->
+    [Core1, Core2, _Replicant] = ?config(cluster, Config),
+    BackupRules = <<"{allow, {username, \"backup_user\"}, all, [\"#\"]}.\n">>,
+    BackupSource = #{
+        <<"type">> => <<"file">>,
+        <<"enable">> => true,
+        <<"rules">> => BackupRules
+    },
+    %% Set the file source via the safe rules-bearing API path so that
+    %% both nodes already have a local acl.conf before export.
+    {ok, _} = ?ON(
+        Core1,
+        emqx_conf:update(
+            [authorization, sources],
+            {replace, [BackupSource]},
+            #{override_to => cluster}
+        )
+    ),
+    {ok, #{filename := FileName}} = ?ON(Core1, emqx_mgmt_data_backup:export()),
+    {ok, Cwd} = ?ON(Core1, file:get_cwd()),
+    AbsPath = filename:join(Cwd, FileName),
+    %% Change authz to something different so re-import triggers a real
+    %% cluster_rpc update on both nodes.
+    OtherSource = #{
+        <<"type">> => <<"file">>,
+        <<"enable">> => true,
+        <<"rules">> => <<"{deny, all}.\n">>
+    },
+    {ok, _} = ?ON(
+        Core1,
+        emqx_conf:update(
+            [authorization, sources],
+            {replace, [OtherSource]},
+            #{override_to => cluster}
+        )
+    ),
+    %% Delete acl.conf on Core2 so that the import actually has to recreate
+    %% the file from the replicated `rules`. Without this, the bug could
+    %% silently leave the stale OtherSource content in place on Core2 and
+    %% only the content assertion below would catch it.
+    ok = ?ON(Core2, file:delete(emqx_authz_file:acl_conf_file())),
+    %% Import — pre-fix this triggered cluster_rpc_apply_failed on Core2
+    %% because the importer used to ship `path` instead of `rules`.
+    ?assertEqual(
+        {ok, #{db_errors => #{}, config_errors => #{}}},
+        ?ON(Core1, emqx_mgmt_data_backup:import_local(AbsPath))
+    ),
+    %% Each node must have written its own copy of acl.conf locally with
+    %% the imported `rules` content. (The stored config's `path` field is
+    %% legitimately node-local because each node resolves the file under
+    %% its own `data_dir`; we don't assert raw-config equality across nodes.)
+    [
+        ?assertMatch(
+            {ok, BackupRules},
+            ?ON(N, file:read_file(emqx_authz_file:acl_conf_file()))
+        )
+     || N <- [Core1, Core2]
+    ],
+    %% cluster_rpc must be fully synced (both nodes at the same tnx_id) and
+    %% the cluster_rpc_apply_failed alarm must not be active on either node.
+    {atomic, StatusOnCore1} = ?ON(Core1, emqx_cluster_rpc:status()),
+    TnxIds = lists:usort([T || #{tnx_id := T} <- StatusOnCore1]),
+    ?assertMatch([_Single], TnxIds, #{status => StatusOnCore1}),
+    [
+        ?assertEqual(
+            [],
+            [
+                A
+             || A <- ?ON(N, emqx_alarm:get_alarms(activated)),
+                cluster_rpc_apply_failed =:= maps:get(name, A, undefined)
+            ],
+            #{node => N}
+        )
+     || N <- [Core1, Core2]
+    ],
+    ok.
 
 backup_tables() ->
     {<<"mocked_test">>, [data_backup_test]}.

--- a/changes/ee/fix-17343.en.md
+++ b/changes/ee/fix-17343.en.md
@@ -1,0 +1,10 @@
+Fixed a clustered-config replication bug where importing a data backup (or
+loading a HOCON config via `emqx ctl conf load` / `PUT /api/v5/configs`) that
+contained a `file`-type authorization source could leave peer nodes lagging
+with a `cluster_rpc_apply_failed` / `failed_to_read_acl_file` error.
+
+The importer used to write the ACL file locally and replace inline `rules`
+with a `path`, then ship the path-form config across the cluster. Peer nodes
+have no such file on disk and so could not apply the change. The config sent
+to the cluster now keeps `rules` inline, so each peer writes its own copy of
+the ACL file from the replicated content.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

introduced in https://github.com/emqx/emqx/pull/16657

Importing a backup that contains a file-type authz source with inline `rules` (i.e. any backup taken from a healthy cluster) used to ship only `path` across the cluster: `validate_cluster_hocon` wrote the ACL file locally and rewrote the source to its post-write form before the config went through `cluster_rpc`. Peer nodes had no such file on disk and failed to apply with:

```
[critical] msg: failed_to_read_acl_file
[error]    msg: cluster_rpc_apply_failed, result: {error,#{reason => failed_to_read_acl_file, kind => validation_error, matched_type => "authz:file"}}
```

The leader's tnx_id advances while peers retry every minute and the `cluster_rpc_apply_failed` alarm stays activated.

### Fix

In `emqx_mgmt_data_backup:validate_cluster_hocon/1`, for every file authz source whose **input** form carried inline `rules`, restore that field before returning the validated config. Each peer's `pre_config_update` then writes its own local copy of `acl.conf` from the replicated content — the same code path the working `/authorization/sources` API has always used.

Sources whose input was a bare `path` (user-specified, e.g. a hand-edited HOCON pointing to a deployment-managed file) are left untouched so the user's intent is preserved.


### Test

New cluster CT `t_import_file_authz_source_on_cluster` in `emqx_mgmt_data_backup_SUITE` sets a file authz source on Core1 (rules-form), exports a backup, mutates the config so re-import is meaningful, imports the backup, and asserts both core nodes end up with the imported `rules` content in their own local `acl.conf` and no `cluster_rpc_apply_failed` alarm fires. Confirmed locally to fail on pristine `release-60` (Core2 keeps the pre-import content) and pass with the fix.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)