### PR TITLE
fix(authz): expand path to rules before replicating file source

### DIFF
--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.4.8"},
+    {vsn, "0.4.9"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -351,7 +351,12 @@ load_config_from_raw(RawConf0, Opts) ->
     SchemaMod = emqx_conf:schema_module(),
     RawConf1 = emqx_config:upgrade_raw_conf(SchemaMod, RawConf0),
     case check_config(RawConf1, Opts) of
-        {ok, RawConf} ->
+        {ok, RawConfChecked} ->
+            %% If the user supplied a file authz source with `path`, expand it
+            %% to inline `rules` (by reading the file locally) so cluster_rpc
+            %% replication carries the content rather than a node-local path
+            %% that other nodes can't read.
+            RawConf = emqx_authz:maybe_read_files(RawConfChecked),
             case update_cluster_links(cluster, RawConf, Opts) of
                 ok ->
                     %% It has been ensured that the connector is always the first

--- a/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
@@ -89,6 +89,8 @@ init_per_testcase(TC = t_import_on_cluster, Config) ->
     [{cluster, cluster(TC, Config)} | setup(TC, Config)];
 init_per_testcase(TC = t_verify_imported_mnesia_tab_on_cluster, Config) ->
     [{cluster, cluster(TC, Config)} | setup(TC, Config)];
+init_per_testcase(TC = t_load_file_authz_with_path_on_cluster, Config) ->
+    [{cluster, cluster(TC, Config)} | setup(TC, Config)];
 init_per_testcase(t_mnesia_bad_tab_schema, Config) ->
     meck:new(emqx_mgmt_data_backup, [passthrough]),
     meck:expect(TC = emqx_mgmt_data_backup, modules_with_mnesia_tabs_to_backup, 0, [?MODULE]),
@@ -102,6 +104,9 @@ end_per_testcase(t_import_on_cluster, Config) ->
     meck:unload(emqx_mgmt_listeners_conf),
     meck:unload(emqx_gateway_conf);
 end_per_testcase(t_verify_imported_mnesia_tab_on_cluster, Config) ->
+    emqx_cth_cluster:stop(?config(cluster, Config)),
+    cleanup(Config);
+end_per_testcase(t_load_file_authz_with_path_on_cluster, Config) ->
     emqx_cth_cluster:stop(?config(cluster, Config)),
     cleanup(Config);
 end_per_testcase(t_mnesia_bad_tab_schema, Config) ->
@@ -637,6 +642,62 @@ t_verify_imported_mnesia_tab_on_cluster(Config) ->
     %% Give some extra time to replicant to import data...
     timer:sleep(3000),
     ?assertEqual(AllUsers, lists:sort(rpc:call(ReplicantNode, mnesia, dirty_all_keys, [Tab]))).
+
+%% Regression: `emqx ctl conf load` (and the REST `PUT /configs` it backs)
+%% used to ship the user-provided `path` of a file authz source across the
+%% cluster verbatim. Peer nodes had no such file on disk and failed to apply
+%% the change with `failed_to_read_acl_file` / `cluster_rpc_apply_failed`.
+%% The fix expands `path` to inline `rules` (by reading the file locally)
+%% before the config goes through `emqx_conf:update`.
+t_load_file_authz_with_path_on_cluster(Config) ->
+    [Core1, Core2, _Replicant] = ?config(cluster, Config),
+    Rules = <<"{allow, {username, \"alice\"}, all, [\"#\"]}.\n">>,
+    %% Place an ACL file on Core1 only — the bug surfaces precisely because
+    %% the path is node-local.
+    AclPath = ?ON(
+        Core1,
+        begin
+            Tmp = filename:join(emqx:data_dir(), "user_authz_input.acl"),
+            ok = filelib:ensure_dir(Tmp),
+            ok = file:write_file(Tmp, Rules),
+            Tmp
+        end
+    ),
+    HoconBin = iolist_to_binary([
+        "authorization {\n",
+        "  sources = [{ type = file, enable = true, path = \"",
+        AclPath,
+        "\" }]\n",
+        "}\n"
+    ]),
+    ok = ?ON(Core1, emqx_conf_cli:load_config(HoconBin, #{mode => replace, log => none})),
+    %% Each node must have written its own copy of acl.conf locally with the
+    %% rules content read from the initiator-side file.
+    [
+        ?assertMatch(
+            {ok, Rules},
+            ?ON(N, file:read_file(emqx_authz_file:acl_conf_file()))
+        )
+     || N <- [Core1, Core2]
+    ],
+    %% cluster_rpc must be fully synced (both nodes at the same tnx_id) and
+    %% the cluster_rpc_apply_failed alarm must not be active on either node.
+    {atomic, StatusOnCore1} = ?ON(Core1, emqx_cluster_rpc:status()),
+    TnxIds = lists:usort([T || #{tnx_id := T} <- StatusOnCore1]),
+    ?assertMatch([_Single], TnxIds, #{status => StatusOnCore1}),
+    [
+        ?assertEqual(
+            [],
+            [
+                A
+             || A <- ?ON(N, emqx_alarm:get_alarms(activated)),
+                cluster_rpc_apply_failed =:= maps:get(name, A, undefined)
+            ],
+            #{node => N}
+        )
+     || N <- [Core1, Core2]
+    ],
+    ok.
 
 backup_tables() ->
     {<<"mocked_test">>, [data_backup_test]}.

--- a/changes/ee/fix-17345.en.md
+++ b/changes/ee/fix-17345.en.md
@@ -1,0 +1,10 @@
+Fixed a clustered-config replication bug where loading a HOCON config that
+contained a `file`-type authorization source with a `path = ...` (via
+`emqx ctl conf load` or `PUT /api/v5/configs?key=authorization`) could
+leave peer nodes lagging with a `cluster_rpc_apply_failed` /
+`failed_to_read_acl_file` error, because the path referenced a file that
+existed only on the initiator node.
+
+The config sent to the cluster now expands `path` to inline `rules` (by
+reading the file locally) before replication, so each peer writes its own
+copy of the ACL file from the replicated content.


### PR DESCRIPTION
Fixes EMQX-15330

Release version:
5.8.11

## Summary

\`emqx ctl conf load\` and \`PUT /api/v5/configs?key=authorization\` used to ship the user-provided \`path\` of a file authz source across the cluster verbatim. Peer nodes had no such file on disk and failed to apply the change with:

\`\`\`
[critical] msg: failed_to_read_acl_file
[error]    msg: cluster_rpc_apply_failed, result: {error,#{reason => failed_to_read_acl_file, kind => validation_error, matched_type => "authz:file"}}
\`\`\`

The leader's tnx_id advances while peers retry every minute indefinitely; the \`cluster_rpc_apply_failed\` alarm stays activated.

### Fix

Expand \`path\` to inline \`rules\` (by reading the file locally on the initiator) in \`emqx_conf_cli:load_config_from_raw/2\` before the config is handed to \`emqx_conf:update\`. Each peer's \`pre_config_update\` then re-runs \`emqx_authz:maybe_write_source_files/1\`, writing its own local copy of \`acl.conf\` from the replicated content — the same code path the working \`/authorization/sources\` API has always used.

### Why only one site here (vs. two on release-60)

This is a port of #17343 (release-60). On release-60 the data-backup importer had the same bug — its \`validate_cluster_hocon\` result (post-write, path-form) is what got passed to \`do_import_conf\`. On release-58 the importer discards that result and feeds \`do_import_conf\` the original rules-form \`RawConf1\`, so the import path is already correct on this branch. Only the CLI / REST \`/configs\` site needs the fix.

### Test

New cluster CT \`t_load_file_authz_with_path_on_cluster\` in \`emqx_mgmt_data_backup_SUITE\` places an ACL file on Core1 only, loads a HOCON pointing at that path via \`emqx_conf_cli:load_config\`, and asserts both core nodes end up with the same content in their own local \`acl.conf\` and no \`cluster_rpc_apply_failed\` alarm fires. Confirmed to fail without the fix (Core2 gets no acl.conf) and pass with it.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)