### PR TITLE
Update RocketMQ client to v0.7.2

### DIFF
--- a/apps/emqx_bridge_rocketmq/mix.exs
+++ b/apps/emqx_bridge_rocketmq/mix.exs
@@ -23,7 +23,7 @@ defmodule EMQXBridgeRocketmq.MixProject do
 
   def deps() do
     [
-      {:rocketmq, github: "emqx/rocketmq-client-erl", tag: "v0.6.1"},
+      {:rocketmq, github: "emqx/rocketmq-client-erl", tag: "v0.7.2"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}

--- a/apps/emqx_bridge_rocketmq/rebar.config
+++ b/apps/emqx_bridge_rocketmq/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {rocketmq, {git, "https://github.com/emqx/rocketmq-client-erl.git", {tag, "v0.7.1"}}},
+    {rocketmq, {git, "https://github.com/emqx/rocketmq-client-erl.git", {tag, "v0.7.2"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_rocketmq/test/emqx_bridge_rocketmq_SUITE.erl
+++ b/apps/emqx_bridge_rocketmq/test/emqx_bridge_rocketmq_SUITE.erl
@@ -29,17 +29,21 @@ all() ->
     [
         {group, async},
         {group, sync},
+        {group, async_producer},
         {group, acl}
     ].
 
 groups() ->
-    TCs = emqx_common_test_helpers:all(?MODULE) -- [t_acl_deny],
+    TCs =
+        emqx_common_test_helpers:all(?MODULE) --
+            [t_acl_deny, t_async_producer_cleans_completed_requests],
     BatchingGroups = [{group, with_batch}, {group, without_batch}],
     [
         {async, BatchingGroups},
         {sync, BatchingGroups},
         {with_batch, TCs},
         {without_batch, TCs},
+        {async_producer, [t_async_producer_cleans_completed_requests]},
         {acl, [t_acl_deny]}
     ].
 
@@ -53,13 +57,18 @@ init_per_group(with_batch, Config0) ->
 init_per_group(without_batch, Config0) ->
     Config = [{batch_size, 1} | Config0],
     common_init(Config);
+init_per_group(async_producer, Config0) ->
+    Config = [{batch_size, ?BATCH_SIZE}, {query_mode, async} | Config0],
+    common_init(Config);
 init_per_group(acl, Config0) ->
     Config = [{batch_size, 1}, {query_mode, sync} | Config0],
     common_init(Config);
 init_per_group(_Group, Config) ->
     Config.
 
-end_per_group(Group, Config) when Group =:= with_batch; Group =:= without_batch ->
+end_per_group(Group, Config) when
+    Group =:= with_batch; Group =:= without_batch; Group =:= async_producer
+->
     ProxyHost = ?config(proxy_host, Config),
     ProxyPort = ?config(proxy_port, Config),
     Apps = ?config(apps, Config),
@@ -442,6 +451,56 @@ t_simple_query(Config) ->
     ?assertEqual(ok, Result),
     ok.
 
+t_async_producer_cleans_completed_requests(Config) ->
+    Host = ?GET_CONFIG(host, Config),
+    Port = ?GET_CONFIG(port, Config),
+    Parent = self(),
+    ClientId = unique_atom("rocketmq_async_client"),
+    ProducerName = unique_atom("rocketmq_async_producer"),
+    Topic = list_to_binary(?TOPIC),
+    ProducerGroup = iolist_to_binary([atom_to_binary(ClientId, utf8), <<"_">>, Topic]),
+    ACLInfo = #{
+        access_key => <<?ACCESS_KEY>>,
+        secret_key => <<?SECRET_KEY>>
+    },
+    ProducerOpts = #{
+        batch_size => ?BATCH_SIZE,
+        callback => fun(Result, CallbackTopic, BatchLen) ->
+            Parent ! {rocketmq_async_callback, Result, CallbackTopic, BatchLen}
+        end,
+        name => ProducerName,
+        ref_topic_route_interval => 3000,
+        acl_info => ACLInfo
+    },
+    {ok, _ClientPid} = rocketmq:ensure_supervised_client(ClientId, [{Host, Port}], #{
+        acl_info => ACLInfo
+    }),
+    try
+        {ok, Producers} =
+            rocketmq:ensure_supervised_producers(ClientId, ProducerGroup, Topic, ProducerOpts),
+        try
+            ok = rocketmq:send(Producers, ?PAYLOAD),
+            receive
+                {rocketmq_async_callback, ok, Topic, 1} ->
+                    ok;
+                {rocketmq_async_callback, Result, CallbackTopic, BatchLen} ->
+                    ct:fail(#{
+                        reason => unexpected_async_callback,
+                        result => Result,
+                        topic => CallbackTopic,
+                        batch_len => BatchLen
+                    })
+            after 10000 ->
+                ct:fail(async_callback_timeout)
+            end,
+            wait_until_request_count(Producers, 0, 50)
+        after
+            _ = rocketmq:stop_and_delete_supervised_producers(Producers)
+        end
+    after
+        _ = rocketmq:stop_and_delete_supervised_client(ClientId)
+    end.
+
 t_acl_deny(Config0) ->
     RocketCfg = ?GET_CONFIG(rocketmq_config, Config0),
     RocketCfg2 = RocketCfg#{<<"topic">> := ?DENY_TOPIC},
@@ -467,3 +526,28 @@ t_acl_deny(Config0) ->
         end
     ),
     ok.
+
+unique_atom(Prefix) ->
+    list_to_atom(Prefix ++ "_" ++ integer_to_list(erlang:unique_integer([positive]))).
+
+wait_until_request_count(Producers, Expected, Attempts) ->
+    case producer_request_count(Producers) of
+        Expected ->
+            ok;
+        _Count when Attempts > 0 ->
+            timer:sleep(100),
+            wait_until_request_count(Producers, Expected, Attempts - 1);
+        Count ->
+            ?assertEqual(Expected, Count)
+    end.
+
+producer_request_count(#{workers := WorkersTab}) ->
+    lists:sum([
+        producer_request_count(ProducerPid)
+     || {_Index, _BrokerName, _QueueSeqNum, ProducerPid, _BrokerAddrs} <- ets:tab2list(WorkersTab),
+        is_pid(ProducerPid)
+    ]);
+producer_request_count(ProducerPid) ->
+    {_StateName, ProducerState} = sys:get_state(ProducerPid),
+    Requests = element(14, ProducerState),
+    map_size(Requests).

--- a/changes/ee/fix-17346.en.md
+++ b/changes/ee/fix-17346.en.md
@@ -1,0 +1,1 @@
+Upgraded the RocketMQ client dependency to `v0.7.2` to fix memory growth in async producer requests.


### PR DESCRIPTION
Fixes none

Release version: e5.10.4

https://github.com/emqx/rocketmq-client-erl/pull/38

## Summary

This PR updates the RocketMQ client used by the RocketMQ bridge to `v0.7.2`.

The dependency update pulls in the upstream fix for async producer request cleanup. In the affected client versions, completed async batch requests were left in the producer request map after the response callback ran, which could cause memory growth for async producer usage.

The RocketMQ bridge itself still uses sync query paths, but this release branch carries the affected dependency. A dedicated Common Test group now exercises the dependency's async `rocketmq:send/2` path against the RocketMQ integration test environment and verifies that completed request entries are removed.

Validation:

- With `v0.7.1`, the new `async_producer` case failed with `expected: 0, got: 1`.
- With `v0.7.2`, `GROUPS=async_producer make apps/emqx_bridge_rocketmq-ct` passed.
- With `v0.7.2`, `make apps/emqx_bridge_rocketmq-ct` passed with `30 ok, 0 failed`.

## PR Checklist

- ~For internal contributor: there is a jira ticket to track this change~
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

No schema changes.
