### PR TITLE
fix(conf): suppress noisy cluster sync status diffs

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -953,11 +953,32 @@ changed(K, V, Conf) ->
 find_running_confs() ->
     lists:map(
         fun(Node) ->
-            Conf = emqx_conf_proto_v5:get_config(Node, ?global_ns, []),
+            Conf = normalize_running_conf(Node),
             {Node, maps:without(?READONLY_ROOT_KEYS, Conf)}
         end,
         emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI_NAME, 5)
     ).
+
+normalize_running_conf(Node) ->
+    try normalize_running_raw_conf(emqx_conf_proto_v5:get_raw_config(Node, ?global_ns, [])) of
+        Conf ->
+            Conf
+    catch
+        Class:Reason:Stacktrace ->
+            ?SLOG(warning, #{
+                msg => "failed_to_normalize_cluster_sync_status_conf",
+                node => Node,
+                exception => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
+            emqx_conf_proto_v5:get_config(Node, ?global_ns, [])
+    end.
+
+normalize_running_raw_conf(RawConf) ->
+    RawConf1 = fill_defaults(RawConf),
+    {_AppEnvs, Conf} = emqx_config:check_config(emqx_conf:schema_module(), RawConf1),
+    Conf.
 
 print_inconsistent_conf(Keys, Target, Status, AllConfs) ->
     {value, {_, TargetConf}, OtherConfs} = lists:keytake(Target, 1, AllConfs),

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -997,12 +997,12 @@ print_inconsistent_conf(New = #{}, Old = #{}, Options) ->
         changed := Changed
     } = emqx_utils_maps:diff_maps(New, Old),
     RemovedFmt = "~ts(~w)'s ~s has deleted certain keys, but they are still present on ~ts(~w).~n",
-    print_inconsistent(Removed, RemovedFmt, Options),
+    print_inconsistent(Removed, RemovedFmt, removed, Options),
     AddedFmt = "~ts(~w)'s ~s has new setting, but it has not been applied to ~ts(~w).~n",
-    print_inconsistent(Added, AddedFmt, Options),
+    print_inconsistent(Added, AddedFmt, added, Options),
     ChangedFmt =
         "~ts(~w)'s ~s has been updated, but the changes have not been applied to ~ts(~w).~n",
-    print_inconsistent(Changed, ChangedFmt, Options);
+    print_inconsistent(Changed, ChangedFmt, changed, Options);
 %% authentication rewrite topic_metrics is list(not map).
 print_inconsistent_conf(New, Old, Options) ->
     #{
@@ -1018,39 +1018,116 @@ print_inconsistent_conf(New, Old, Options) ->
     emqx_ctl:print("~ts:~n", [Target]),
     print_hocon(New).
 
-print_inconsistent(Conf, Fmt, Options) when Conf =/= #{} ->
+print_inconsistent(Conf, Fmt, Kind, Options) when Conf =/= #{} ->
     #{
         key := Key,
         target := {Target, TargetTxId},
         node := {Node, NodeTxId}
     } = Options,
-    emqx_ctl:warning(Fmt, [Target, TargetTxId, Key, Node, NodeTxId]),
     NodeRawConf = emqx_conf_proto_v5:get_raw_config(Node, ?global_ns, [Key]),
     TargetRawConf = emqx_conf_proto_v5:get_raw_config(Target, ?global_ns, [Key]),
     {NodeConf, TargetConf} =
         maps:fold(
-            fun(SubKey, _, {NewAcc, OldAcc}) ->
-                SubNew0 = maps:get(atom_to_binary(SubKey), NodeRawConf, undefined),
-                SubOld0 = maps:get(atom_to_binary(SubKey), TargetRawConf, undefined),
-                {SubNew1, SubOld1} = remove_identical_value(SubNew0, SubOld0),
-                {NewAcc#{SubKey => SubNew1}, OldAcc#{SubKey => SubOld1}}
+            fun(SubKey, CheckedDiff, {NodeAcc, TargetAcc}) ->
+                RawSubKey = raw_config_key(SubKey),
+                SubNew0 = maps:get(RawSubKey, NodeRawConf, undefined),
+                SubOld0 = maps:get(RawSubKey, TargetRawConf, undefined),
+                {SubNew1, SubOld1} =
+                    remove_identical_config_value(Kind, SubNew0, SubOld0, CheckedDiff),
+                {
+                    maybe_put_config_diff(SubKey, SubNew1, NodeAcc),
+                    maybe_put_config_diff(SubKey, SubOld1, TargetAcc)
+                }
             end,
             {#{}, #{}},
             Conf
         ),
     %% zones.default is a virtual zone. It will be changed when mqtt changes,
     %% so we can't retrieve the raw data for zones.default(always undefined).
-    case TargetConf =:= NodeConf of
-        true -> ok;
-        false -> print_hocon(#{Target => #{Key => TargetConf}, Node => #{Key => NodeConf}})
+    emqx_ctl:warning(Fmt, [Target, TargetTxId, Key, Node, NodeTxId]),
+    case has_config_diff(NodeConf) orelse has_config_diff(TargetConf) of
+        true ->
+            print_hocon(#{Target => #{Key => TargetConf}, Node => #{Key => NodeConf}});
+        false ->
+            ok
     end;
-print_inconsistent(_Conf, _Format, _Options) ->
+print_inconsistent(_Conf, _Format, _Kind, _Options) ->
     ok.
+
+raw_config_key(K) when is_atom(K) ->
+    atom_to_binary(K);
+raw_config_key(K) ->
+    K.
+
+remove_identical_config_value(changed, NodeRaw, TargetRaw, {NodeChecked, TargetChecked}) ->
+    remove_identical_config_values(NodeRaw, TargetRaw, NodeChecked, TargetChecked);
+remove_identical_config_value(_Kind, NodeRaw, TargetRaw, _CheckedDiff) ->
+    remove_identical_value(NodeRaw, TargetRaw).
+
+remove_identical_config_values(NodeRaw, TargetRaw, NodeChecked, TargetChecked) ->
+    {NodeRaw1, TargetRaw1} = remove_identical_value(NodeRaw, TargetRaw),
+    keep_checked_changes(NodeRaw1, TargetRaw1, NodeChecked, TargetChecked).
+
+keep_checked_changes(_NodeRaw, _TargetRaw, SameChecked, SameChecked) ->
+    {undefined, undefined};
+keep_checked_changes(NodeRaw = #{}, TargetRaw = #{}, NodeChecked = #{}, TargetChecked = #{}) ->
+    lists:foldl(
+        fun(K, {NodeAcc, TargetAcc}) ->
+            {NodeV, TargetV} = keep_checked_changes(
+                maps:get(K, NodeRaw, undefined),
+                maps:get(K, TargetRaw, undefined),
+                find_checked_value(K, NodeChecked),
+                find_checked_value(K, TargetChecked)
+            ),
+            {
+                maybe_put_config_diff(K, NodeV, NodeAcc),
+                maybe_put_config_diff(K, TargetV, TargetAcc)
+            }
+        end,
+        {#{}, #{}},
+        lists:usort(maps:keys(NodeRaw) ++ maps:keys(TargetRaw))
+    );
+keep_checked_changes(NodeRaw, TargetRaw, _NodeChecked, _TargetChecked) ->
+    {NodeRaw, TargetRaw}.
+
+find_checked_value(K, Map) when is_map(Map) ->
+    case maps:find(K, Map) of
+        {ok, V} ->
+            V;
+        error ->
+            maps:get(alt_config_key(K), Map, undefined)
+    end.
+
+alt_config_key(K) when is_atom(K) ->
+    atom_to_binary(K);
+alt_config_key(K) when is_binary(K) ->
+    try
+        binary_to_existing_atom(K, utf8)
+    catch
+        _:_ -> K
+    end;
+alt_config_key(K) ->
+    K.
+
+maybe_put_config_diff(K, V, Acc) ->
+    case has_config_diff(V) of
+        true -> Acc#{K => V};
+        false -> Acc
+    end.
+
+has_config_diff(undefined) ->
+    false;
+has_config_diff(Map) when is_map(Map) ->
+    maps:fold(fun(_K, V, Acc) -> Acc orelse has_config_diff(V) end, false, Map);
+has_config_diff(_Value) ->
+    true.
 
 remove_identical_value(New = #{}, Old = #{}) ->
     maps:fold(
         fun(K, NewV, {Acc1, Acc2}) ->
             case maps:find(K, Old) of
+                error ->
+                    {Acc1, Acc2};
                 {ok, NewV} ->
                     {maps:remove(K, Acc1), maps:remove(K, Acc2)};
                 {ok, OldV} ->

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -52,6 +52,21 @@
 
 %% All 'cluster.*' keys, except for 'cluster.link', should also be treated as read-only.
 -define(READONLY_ROOT_KEYS, [rpc, node]).
+%% Generated UI/API metadata should not make status report a runtime config mismatch.
+-define(CLUSTER_SYNC_METADATA_ROOTS, [
+    actions,
+    sources,
+    bridges,
+    <<"actions">>,
+    <<"sources">>,
+    <<"bridges">>
+]).
+-define(CLUSTER_SYNC_TIMESTAMP_KEYS, [
+    created_at,
+    last_modified_at,
+    <<"created_at">>,
+    <<"last_modified_at">>
+]).
 
 -define(OPTIONS, #{rawconf_with_defaults => true, override_to => cluster}).
 
@@ -894,7 +909,8 @@ waiting_for_sync_finish(Sec) ->
             waiting_for_sync_finish(Sec + 1)
     end.
 
-find_lagging(Status, AllConfs) ->
+find_lagging(Status, AllConfs0) ->
+    AllConfs = normalize_cluster_sync_status_confs(AllConfs0),
     case find_highest_node(Status) of
         {same_tnx_id, TxId} ->
             %% check the conf is the same or not
@@ -972,13 +988,96 @@ normalize_running_conf(Node) ->
                 reason => Reason,
                 stacktrace => Stacktrace
             }),
-            emqx_conf_proto_v5:get_config(Node, ?global_ns, [])
+            normalize_cluster_sync_status_conf(emqx_conf_proto_v5:get_config(Node, ?global_ns, []))
     end.
 
 normalize_running_raw_conf(RawConf) ->
     RawConf1 = fill_defaults(RawConf),
     {_AppEnvs, Conf} = emqx_config:check_config(emqx_conf:schema_module(), RawConf1),
+    normalize_cluster_sync_status_conf(Conf).
+
+normalize_cluster_sync_status_confs(AllConfs) ->
+    [
+        {Node, normalize_cluster_sync_status_conf(Conf)}
+     || {Node, Conf} <- AllConfs
+    ].
+
+normalize_cluster_sync_status_conf(Conf) when is_map(Conf) ->
+    Conf1 = lists:foldl(
+        fun(Root, Acc) ->
+            update_if_present(Root, fun drop_named_config_timestamp_metadata/1, Acc)
+        end,
+        Conf,
+        ?CLUSTER_SYNC_METADATA_ROOTS
+    ),
+    update_if_present(
+        <<"rule_engine">>,
+        fun drop_rule_engine_timestamp_metadata/1,
+        update_if_present(rule_engine, fun drop_rule_engine_timestamp_metadata/1, Conf1)
+    );
+normalize_cluster_sync_status_conf(Conf) ->
     Conf.
+
+update_if_present(Key, Fun, Map) when is_map(Map) ->
+    case maps:find(Key, Map) of
+        {ok, Value} ->
+            Map#{Key => Fun(Value)};
+        error ->
+            Map
+    end.
+
+drop_named_config_timestamp_metadata(ConfigsByType) when is_map(ConfigsByType) ->
+    maps:map(
+        fun(_Type, ConfigsByName) ->
+            drop_named_config_timestamp_metadata_by_name(ConfigsByName)
+        end,
+        ConfigsByType
+    );
+drop_named_config_timestamp_metadata(ConfigsByType) ->
+    ConfigsByType.
+
+drop_named_config_timestamp_metadata_by_name(ConfigsByName) when is_map(ConfigsByName) ->
+    maps:map(
+        fun(_Name, Config) ->
+            drop_timestamp_metadata(Config)
+        end,
+        ConfigsByName
+    );
+drop_named_config_timestamp_metadata_by_name(ConfigsByName) ->
+    ConfigsByName.
+
+drop_rule_engine_timestamp_metadata(RuleEngine) when is_map(RuleEngine) ->
+    update_if_present(
+        <<"rules">>,
+        fun drop_rules_timestamp_metadata/1,
+        update_if_present(rules, fun drop_rules_timestamp_metadata/1, RuleEngine)
+    );
+drop_rule_engine_timestamp_metadata(RuleEngine) ->
+    RuleEngine.
+
+drop_rules_timestamp_metadata(Rules) when is_map(Rules) ->
+    maps:map(
+        fun(_RuleId, Rule) ->
+            drop_rule_timestamp_metadata(Rule)
+        end,
+        Rules
+    );
+drop_rules_timestamp_metadata(Rules) ->
+    Rules.
+
+drop_rule_timestamp_metadata(Rule) when is_map(Rule) ->
+    update_if_present(
+        <<"metadata">>,
+        fun drop_timestamp_metadata/1,
+        update_if_present(metadata, fun drop_timestamp_metadata/1, Rule)
+    );
+drop_rule_timestamp_metadata(Rule) ->
+    Rule.
+
+drop_timestamp_metadata(Config) when is_map(Config) ->
+    maps:without(?CLUSTER_SYNC_TIMESTAMP_KEYS, Config);
+drop_timestamp_metadata(Config) ->
+    Config.
 
 print_inconsistent_conf(Keys, Target, Status, AllConfs) ->
     {value, {_, TargetConf}, OtherConfs} = lists:keytake(Target, 1, AllConfs),
@@ -1276,6 +1375,42 @@ find_inconsistent_test() ->
     ?assertEqual(
         {inconsistent_key, 3, [<<"mqtt">>]},
         find_lagging(SameStatus, Confs0)
+    ),
+    ok.
+
+find_lagging_ignores_action_timestamp_metadata_test() ->
+    Status = [
+        #{node => node1, tnx_id => 3},
+        #{node => node2, tnx_id => 3}
+    ],
+    Action = #{
+        connector => <<"test">>,
+        enable => true,
+        parameters => #{topic => <<"testtopic-in">>},
+        created_at => 1779764590042
+    },
+    ConfsWithOnlyTimestampDiff = [
+        {node1, #{actions => #{kafka_producer => #{test => Action#{last_modified_at => 1}}}}},
+        {node2, #{actions => #{kafka_producer => #{test => Action#{last_modified_at => 2}}}}}
+    ],
+    ?assertEqual(
+        {consistent, <<"All configuration synchronized(tnx_id=3) successfully\n">>},
+        find_lagging(Status, ConfsWithOnlyTimestampDiff)
+    ),
+
+    ConfsWithRealActionDiff = [
+        {node1, #{actions => #{kafka_producer => #{test => Action#{last_modified_at => 1}}}}},
+        {node2, #{
+            actions => #{
+                kafka_producer => #{
+                    test => Action#{last_modified_at => 2, parameters => #{topic => <<"other">>}}
+                }
+            }
+        }}
+    ],
+    ?assertEqual(
+        {inconsistent_key, 3, [actions]},
+        find_lagging(Status, ConfsWithRealActionDiff)
     ),
     ok.
 

--- a/apps/emqx_conf/src/proto/emqx_conf_proto_v5.erl
+++ b/apps/emqx_conf/src/proto/emqx_conf_proto_v5.erl
@@ -102,7 +102,8 @@ get_override_config_file(Nodes) ->
 get_hocon_config(Node, Namespace) ->
     rpc:call(Node, emqx_conf_cli, get_config_namespaced, [Namespace]).
 
--spec get_raw_config(node(), maybe_namespace(), update_config_key_path()) -> map() | {badrpc, _}.
+-spec get_raw_config(node(), maybe_namespace(), emqx_utils_maps:config_key_path()) ->
+    map() | {badrpc, _}.
 get_raw_config(Node, Namespace, KeyPath) ->
     rpc:call(Node, emqx, get_raw_namespaced_config, [Namespace, KeyPath]).
 

--- a/apps/emqx_conf/test/emqx_conf_cli_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_cli_tests.erl
@@ -23,6 +23,18 @@ cluster_sync_status_prunes_raw_only_diffs_test_() ->
         end
     end}.
 
+cluster_sync_status_ignores_timestamp_metadata_test_() ->
+    {setup, fun setup_mocks/0, fun teardown_mocks/1, fun(_) ->
+        fun() ->
+            setup_cluster_sync_status_timestamp_metadata_diff(),
+            ?assertEqual(ok, emqx_conf_cli:admins(["status"])),
+            Output = ctl_output(),
+            ?assertNotEqual(nomatch, binary:match(Output, <<"All configuration synchronized">>)),
+            ?assertEqual(nomatch, binary:match(Output, <<"Inconsistent keys">>)),
+            ?assertEqual(nomatch, binary:match(Output, <<"last_modified_at">>))
+        end
+    end}.
+
 setup_mocks() ->
     Modules = [emqx_bpapi, emqx_cluster_rpc, emqx_conf_proto_v5, emqx_ctl, emqx_mgmt_cli],
     lists:foreach(
@@ -35,6 +47,51 @@ teardown_mocks(Modules) ->
     meck:unload(Modules).
 
 setup_cluster_sync_status_raw_diff() ->
+    setup_cluster_sync_status_base(),
+    ok = meck:expect(
+        emqx_conf_proto_v5,
+        get_config,
+        fun
+            (?TARGET_NODE, ?global_ns, []) -> checked_rule_conf(<<"select new">>);
+            (?OTHER_NODE, ?global_ns, []) -> checked_rule_conf(<<"select old">>)
+        end
+    ),
+    ok = meck:expect(
+        emqx_conf_proto_v5,
+        get_raw_config,
+        fun
+            (?TARGET_NODE, ?global_ns, []) ->
+                invalid_raw_conf;
+            (?OTHER_NODE, ?global_ns, []) ->
+                invalid_raw_conf;
+            (?TARGET_NODE, ?global_ns, [rule_engine]) ->
+                raw_rule_conf(#{}, <<"select new">>);
+            (?OTHER_NODE, ?global_ns, [rule_engine]) ->
+                raw_rule_conf(#{<<"enable">> => true}, <<"select old">>)
+        end
+    ),
+    ok.
+
+setup_cluster_sync_status_timestamp_metadata_diff() ->
+    setup_cluster_sync_status_base(),
+    ok = meck:expect(
+        emqx_conf_proto_v5,
+        get_config,
+        fun
+            (?TARGET_NODE, ?global_ns, []) -> checked_action_conf(1);
+            (?OTHER_NODE, ?global_ns, []) -> checked_action_conf(2)
+        end
+    ),
+    ok = meck:expect(
+        emqx_conf_proto_v5,
+        get_raw_config,
+        fun(_Node, ?global_ns, []) ->
+            invalid_raw_conf
+        end
+    ),
+    ok.
+
+setup_cluster_sync_status_base() ->
     ok = meck:expect(
         emqx_cluster_rpc,
         status,
@@ -55,31 +112,9 @@ setup_cluster_sync_status_raw_diff() ->
         nodes_supporting_bpapi_version,
         fun(emqx_conf, 5) -> [?TARGET_NODE, ?OTHER_NODE] end
     ),
-    ok = meck:expect(
-        emqx_conf_proto_v5,
-        get_config,
-        fun
-            (?TARGET_NODE, ?global_ns, []) -> checked_conf(<<"select new">>);
-            (?OTHER_NODE, ?global_ns, []) -> checked_conf(<<"select old">>)
-        end
-    ),
-    ok = meck:expect(
-        emqx_conf_proto_v5,
-        get_raw_config,
-        fun
-            (?TARGET_NODE, ?global_ns, []) ->
-                invalid_raw_conf;
-            (?OTHER_NODE, ?global_ns, []) ->
-                invalid_raw_conf;
-            (?TARGET_NODE, ?global_ns, [rule_engine]) ->
-                raw_conf(#{}, <<"select new">>);
-            (?OTHER_NODE, ?global_ns, [rule_engine]) ->
-                raw_conf(#{<<"enable">> => true}, <<"select old">>)
-        end
-    ),
     ok.
 
-checked_conf(Sql) ->
+checked_rule_conf(Sql) ->
     #{
         rule_engine => #{
             rules => #{
@@ -89,11 +124,26 @@ checked_conf(Sql) ->
         }
     }.
 
-raw_conf(SameRuleRaw, Sql) ->
+raw_rule_conf(SameRuleRaw, Sql) ->
     #{
         <<"rules">> => #{
             <<"same">> => SameRuleRaw,
             <<"changed">> => #{<<"sql">> => Sql}
+        }
+    }.
+
+checked_action_conf(LastModifiedAt) ->
+    #{
+        actions => #{
+            kafka_producer => #{
+                test => #{
+                    connector => <<"test">>,
+                    enable => true,
+                    parameters => #{topic => <<"testtopic-in">>},
+                    created_at => 1779764590042,
+                    last_modified_at => LastModifiedAt
+                }
+            }
         }
     }.
 

--- a/apps/emqx_conf/test/emqx_conf_cli_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_cli_tests.erl
@@ -1,0 +1,108 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_conf_cli_tests).
+
+-include("emqx_conf.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TARGET_NODE, <<"target">>).
+-define(OTHER_NODE, <<"other">>).
+
+cluster_sync_status_prunes_raw_only_diffs_test_() ->
+    {setup, fun setup_mocks/0, fun teardown_mocks/1, fun(_) ->
+        fun() ->
+            setup_cluster_sync_status_raw_diff(),
+            ?assertEqual(ok, emqx_conf_cli:admins(["status"])),
+            Output = ctl_output(),
+            ?assertNotEqual(nomatch, binary:match(Output, <<"changed">>)),
+            ?assertEqual(nomatch, binary:match(Output, <<"same">>)),
+            ?assertEqual(nomatch, binary:match(Output, <<"enable">>))
+        end
+    end}.
+
+setup_mocks() ->
+    Modules = [emqx_bpapi, emqx_cluster_rpc, emqx_conf_proto_v5, emqx_ctl, emqx_mgmt_cli],
+    lists:foreach(
+        fun(Module) -> ok = meck:new(Module, [passthrough, no_link]) end,
+        Modules
+    ),
+    Modules.
+
+teardown_mocks(Modules) ->
+    meck:unload(Modules).
+
+setup_cluster_sync_status_raw_diff() ->
+    ok = meck:expect(
+        emqx_cluster_rpc,
+        status,
+        fun() ->
+            {atomic, [
+                #{node => ?TARGET_NODE, tnx_id => 1},
+                #{node => ?OTHER_NODE, tnx_id => 1}
+            ]}
+        end
+    ),
+    ok = meck:expect(
+        emqx_mgmt_cli,
+        cluster_info,
+        fun() -> #{stopped_nodes => []} end
+    ),
+    ok = meck:expect(
+        emqx_bpapi,
+        nodes_supporting_bpapi_version,
+        fun(emqx_conf, 5) -> [?TARGET_NODE, ?OTHER_NODE] end
+    ),
+    ok = meck:expect(
+        emqx_conf_proto_v5,
+        get_config,
+        fun
+            (?TARGET_NODE, ?global_ns, []) -> checked_conf(<<"select new">>);
+            (?OTHER_NODE, ?global_ns, []) -> checked_conf(<<"select old">>)
+        end
+    ),
+    ok = meck:expect(
+        emqx_conf_proto_v5,
+        get_raw_config,
+        fun
+            (?TARGET_NODE, ?global_ns, [rule_engine]) ->
+                raw_conf(#{}, <<"select new">>);
+            (?OTHER_NODE, ?global_ns, [rule_engine]) ->
+                raw_conf(#{<<"enable">> => true}, <<"select old">>)
+        end
+    ),
+    ok.
+
+checked_conf(Sql) ->
+    #{
+        rule_engine => #{
+            rules => #{
+                <<"same">> => #{enable => true},
+                <<"changed">> => #{sql => Sql}
+            }
+        }
+    }.
+
+raw_conf(SameRuleRaw, Sql) ->
+    #{
+        <<"rules">> => #{
+            <<"same">> => SameRuleRaw,
+            <<"changed">> => #{<<"sql">> => Sql}
+        }
+    }.
+
+ctl_output() ->
+    unicode:characters_to_binary([
+        format_ctl_output(Fun, Args)
+     || {_Pid, {emqx_ctl, Fun, Args}, _Result} <- meck:history(emqx_ctl),
+        Fun =:= print orelse Fun =:= warning
+    ]).
+
+format_ctl_output(_Fun, [Format]) ->
+    Format;
+format_ctl_output(_Fun, [Format, Args]) ->
+    io_lib:format(Format, Args);
+format_ctl_output(_Fun, Args) ->
+    io_lib:format("~p", [Args]).

--- a/apps/emqx_conf/test/emqx_conf_cli_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_cli_tests.erl
@@ -67,6 +67,10 @@ setup_cluster_sync_status_raw_diff() ->
         emqx_conf_proto_v5,
         get_raw_config,
         fun
+            (?TARGET_NODE, ?global_ns, []) ->
+                invalid_raw_conf;
+            (?OTHER_NODE, ?global_ns, []) ->
+                invalid_raw_conf;
             (?TARGET_NODE, ?global_ns, [rule_engine]) ->
                 raw_conf(#{}, <<"select new">>);
             (?OTHER_NODE, ?global_ns, [rule_engine]) ->

--- a/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
@@ -96,6 +96,14 @@ mk_cluster_spec(Opts) ->
 cli_admin(Cmd, Args) ->
     emqx_conf_cli:admins([Cmd | Args]).
 
+assert_same_tnx_id(Nodes) ->
+    Status = status(),
+    ?assertEqual(lists:sort(Nodes), lists:sort([Node || #{node := Node} <- Status])),
+    TnxIds = lists:usort([TnxId || #{tnx_id := TnxId} <- Status]),
+    ?assertMatch([_], TnxIds),
+    [TnxId] = TnxIds,
+    TnxId.
+
 str(X) -> emqx_utils_conv:str(X).
 
 namespace_of(TCConfig) ->
@@ -207,19 +215,11 @@ t_fix(Config) when is_list(Config) ->
 
     %% fix inconsistent_tnx_id_key. tnx_id and key are updated.
     ?ON(Node1, fake_mfa(TxId1 + 1, Node1, {?MODULE, undef, []})),
-    %% 2 -> fake_mfa, 3-> mark_begin_log, 4-> mqtt 5 -> zones
-    TxId2 = 5,
-    ?ON(Node2, begin
+    TnxIdAfterKeyFix = ?ON(Node2, begin
         ok = cli_admin("fix", []),
-        ?assertMatch(
-            [
-                #{node := Node1, tnx_id := TxId2},
-                #{node := Node2, tnx_id := TxId2}
-            ],
-            status(),
-            #{expected_tx_id => TxId2}
-        )
+        ?MODULE:assert_same_tnx_id([Node1, Node2])
     end),
+    ?assert(TnxIdAfterKeyFix > TxId1 + 1),
     ?assertMatch(99, emqx_conf_proto_v5:get_config(Node1, Namespace, [mqtt, max_topic_levels])),
     ?assertMatch(99, emqx_conf_proto_v5:get_config(Node2, Namespace, [mqtt, max_topic_levels])),
 
@@ -227,35 +227,20 @@ t_fix(Config) when is_list(Config) ->
     {ok, _} = ?ON(
         Node1, emqx_conf_proto_v5:update([<<"mqtt">>], #{<<"max_topic_levels">> => 98}, UpdateOpts)
     ),
-    ?ON(Node2, fake_mfa(TxId2 + 2, Node2, {?MODULE, undef1, []})),
-    TxId3 =
-        case Namespace of
-            ?global_ns -> 8;
-            _ -> 9
-        end,
-    ?ON(Node1, begin
+    TnxIdAfterUpdate = ?ON(Node1, ?MODULE:assert_same_tnx_id([Node1, Node2])),
+    FakeTnxId = TnxIdAfterUpdate + 1,
+    ?ON(Node2, fake_mfa(FakeTnxId, Node2, {?MODULE, undef1, []})),
+    TnxIdAfterFastForward = ?ON(Node1, begin
         ok = cli_admin("fix", []),
-        ?assertMatch(
-            [
-                #{node := Node1, tnx_id := TxId3},
-                #{node := Node2, tnx_id := TxId3}
-            ],
-            status(),
-            #{expected_tx_id => TxId3}
-        )
+        ?MODULE:assert_same_tnx_id([Node1, Node2])
     end),
+    ?assert(TnxIdAfterFastForward > FakeTnxId),
     ?assertMatch(98, emqx_conf_proto_v5:get_config(Node1, Namespace, [mqtt, max_topic_levels])),
     ?assertMatch(98, emqx_conf_proto_v5:get_config(Node2, Namespace, [mqtt, max_topic_levels])),
     %% unchanged
     ?ON(Node1, begin
         ok = cli_admin("fix", []),
-        ?assertMatch(
-            {atomic, [
-                #{node := Node1, tnx_id := TxId3},
-                #{node := Node2, tnx_id := TxId3}
-            ]},
-            emqx_cluster_rpc:status()
-        )
+        ?assertEqual(TnxIdAfterFastForward, ?MODULE:assert_same_tnx_id([Node1, Node2]))
     end),
     ok.
 

--- a/apps/emqx_conf/test/emqx_conf_cluster_sync_import_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cluster_sync_import_SUITE.erl
@@ -157,8 +157,7 @@ get_rule_from_map(Rules) ->
         {ok, Rule} ->
             Rule;
         error ->
-            RuleIdAtom = binary_to_existing_atom(?RAW_DIFF_RULE_ID, utf8),
-            maps:get(RuleIdAtom, Rules)
+            maps:get(existing_atom_rule_id(), Rules)
     end.
 
 wait_imported_rule(Node) ->
@@ -172,7 +171,19 @@ wait_imported_rule(Node) ->
 has_imported_rule(Node) ->
     Rules = ?ON(Node, emqx_conf:get([rule_engine, rules])),
     maps:is_key(?RAW_DIFF_RULE_ID, Rules) orelse
-        maps:is_key(binary_to_existing_atom(?RAW_DIFF_RULE_ID, utf8), Rules).
+        has_existing_atom_rule_id(Rules).
+
+existing_atom_rule_id() ->
+    binary_to_existing_atom(?RAW_DIFF_RULE_ID, utf8).
+
+has_existing_atom_rule_id(Rules) ->
+    try existing_atom_rule_id() of
+        RuleIdAtom ->
+            maps:is_key(RuleIdAtom, Rules)
+    catch
+        error:badarg ->
+            false
+    end.
 
 %% Emulate `emqx_conf_app:init_load/1`; the CT cluster helper does not
 %% automatically replay this boot-time sync after a node joins.

--- a/apps/emqx_conf/test/emqx_conf_cluster_sync_import_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cluster_sync_import_SUITE.erl
@@ -1,0 +1,268 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_conf_cluster_sync_import_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+-define(RAW_DIFF_RULE_ID, <<"cluster_sync_raw_diff_rule">>).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+suite() ->
+    [{timetrap, {seconds, 180}}].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+t_status_after_import_then_join_ignores_raw_only_diffs(Config) ->
+    WorkDir = emqx_cth_suite:work_dir(?FUNCTION_NAME, Config),
+    AppSpecs = import_join_app_specs(),
+    ClusterSpec = [
+        {cluster_sync_import1, #{role => core, apps => AppSpecs}},
+        {cluster_sync_import2, #{role => core, apps => AppSpecs}}
+    ],
+    [N1Spec, N2Spec] = emqx_cth_cluster:mk_nodespecs(
+        ClusterSpec,
+        #{
+            work_dir => WorkDir,
+            start_apps_timeout => 60_000
+        }
+    ),
+    [N1, N2] = Nodes = [maps:get(name, N1Spec), maps:get(name, N2Spec)],
+    on_exit(fun() -> emqx_cth_cluster:stop(Nodes) end),
+
+    [N1] = emqx_cth_cluster:start([N1Spec]),
+    BackupFile = make_rule_engine_backup(Config),
+    ImportRes = {ok, #{db_errors => #{}, config_errors => #{}}},
+    ?assertEqual(ImportRes, ?ON(N1, emqx_mgmt_data_backup:import_local(BackupFile))),
+    wait_imported_rule(N1),
+
+    [N2] = emqx_cth_cluster:start([N2Spec]),
+    emulate_emqx_conf_init_load(N2, N1),
+    wait_clustered(Nodes),
+    wait_same_tnx_id(Nodes),
+    wait_imported_rule(N2),
+
+    N1Rule = get_imported_rule(N1, emqx_conf, get, [rule_engine, rules]),
+    N2Rule = get_imported_rule(N2, emqx_conf, get, [rule_engine, rules]),
+    ?assertEqual(N1Rule, N2Rule),
+
+    emulate_sparse_import_raw_conf(N1),
+    N1RawRule = get_imported_rule(N1, emqx_conf, get_raw, [rule_engine, rules]),
+    N2RawRule = get_imported_rule(N2, emqx_conf, get_raw, [rule_engine, rules]),
+    ?assertNotEqual(N1RawRule, N2RawRule),
+
+    Output = capture_cluster_sync_status(N1),
+    ?assertEqual(
+        nomatch,
+        binary:match(Output, <<"has been updated">>),
+        #{output => Output}
+    ),
+    ?assertEqual(
+        nomatch,
+        binary:match(Output, <<"inconsistent keys">>),
+        #{output => Output}
+    ),
+    ?assertNotEqual(
+        nomatch,
+        binary:match(Output, <<"All configuration synchronized">>),
+        #{output => Output}
+    ),
+    ok.
+
+import_join_app_specs() ->
+    [
+        {emqx, #{
+            override_env => [{boot_modules, []}],
+            config => #{
+                listeners => #{
+                    tcp => #{default => <<"marked_for_deletion">>},
+                    ssl => #{default => <<"marked_for_deletion">>},
+                    ws => #{default => <<"marked_for_deletion">>},
+                    wss => #{default => <<"marked_for_deletion">>}
+                }
+            }
+        }},
+        {emqx_conf, #{config => #{}}},
+        emqx_management,
+        emqx_rule_engine
+    ].
+
+make_rule_engine_backup(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    BackupName = filename:join(PrivDir, "cluster-sync-raw-diff-import.tar.gz"),
+    BackupRoot = filename:basename(BackupName, ".tar.gz"),
+    Meta = unicode:characters_to_binary(
+        hocon_pp:do(
+            #{
+                edition => emqx_release:edition(),
+                version => emqx_release:version()
+            },
+            #{}
+        )
+    ),
+    ClusterHocon = unicode:characters_to_binary(hocon_pp:do(rule_engine_import_conf(), #{})),
+    ok = erl_tar:create(
+        BackupName,
+        [
+            {filename:join(BackupRoot, "META.hocon"), Meta},
+            {filename:join(BackupRoot, "cluster.hocon"), ClusterHocon}
+        ],
+        [compressed]
+    ),
+    BackupName.
+
+rule_engine_import_conf() ->
+    #{
+        <<"rule_engine">> => #{
+            <<"rules">> => #{
+                ?RAW_DIFF_RULE_ID => sparse_rule_raw()
+            }
+        }
+    }.
+
+sparse_rule_raw() ->
+    #{
+        <<"description">> => <<"">>,
+        <<"sql">> => <<"SELECT * FROM \"t/#\"">>,
+        <<"actions">> => [
+            #{
+                <<"function">> => <<"republish">>,
+                <<"args">> => #{
+                    <<"topic">> => <<"cluster/sync/${topic}">>
+                }
+            }
+        ]
+    }.
+
+get_imported_rule(Node, Module, Function, Path) ->
+    Rules = ?ON(Node, erlang:apply(Module, Function, [Path])),
+    get_rule_from_map(Rules).
+
+get_rule_from_map(Rules) ->
+    case maps:find(?RAW_DIFF_RULE_ID, Rules) of
+        {ok, Rule} ->
+            Rule;
+        error ->
+            RuleIdAtom = binary_to_existing_atom(?RAW_DIFF_RULE_ID, utf8),
+            maps:get(RuleIdAtom, Rules)
+    end.
+
+wait_imported_rule(Node) ->
+    wait_until(
+        fun() ->
+            has_imported_rule(Node)
+        end,
+        #{action => wait_imported_rule, node => Node}
+    ).
+
+has_imported_rule(Node) ->
+    Rules = ?ON(Node, emqx_conf:get([rule_engine, rules])),
+    maps:is_key(?RAW_DIFF_RULE_ID, Rules) orelse
+        maps:is_key(binary_to_existing_atom(?RAW_DIFF_RULE_ID, utf8), Rules).
+
+%% Emulate `emqx_conf_app:init_load/1`; the CT cluster helper does not
+%% automatically replay this boot-time sync after a node joins.
+emulate_emqx_conf_init_load(NewNode, SeedNode) ->
+    ?ON(SeedNode, ok = emqx_config_backup_manager:flush()),
+    ?ON(NewNode, begin
+        {ok, _TnxId} = emqx_conf_app:sync_cluster_conf(),
+        DataDir = emqx:data_dir(),
+        Path = filename:join([DataDir, "configs", "cluster.hocon"]),
+        {ok, Contents0} = file:read_file(Path),
+        ok = file:write_file(Path, [
+            Contents0,
+            <<"node.cookie = cookie\n">>,
+            <<"node.data_dir = \"">>,
+            DataDir,
+            <<"\"\n">>
+        ]),
+        SchemaMod = emqx_conf:schema_module(),
+        ok = application:stop(emqx_rule_engine),
+        ok = emqx_config:init_load(SchemaMod),
+        ok = application:start(emqx_rule_engine)
+    end).
+
+%% `release-60` may materialize defaults during the import path already.  Keep
+%% the original regression shape by making the importer node retain the sparse
+%% user-provided raw rule while leaving its checked config untouched.
+emulate_sparse_import_raw_conf(Node) ->
+    ?ON(Node, emqx_config:put_raw([rule_engine, rules, ?RAW_DIFF_RULE_ID], sparse_rule_raw())).
+
+wait_clustered(Nodes) ->
+    wait_until(
+        fun() ->
+            lists:all(
+                fun(Node) ->
+                    lists:sort(Nodes) =:= lists:sort(?ON(Node, mria:running_nodes()))
+                end,
+                Nodes
+            )
+        end,
+        #{action => wait_clustered, nodes => Nodes}
+    ).
+
+wait_same_tnx_id(Nodes) ->
+    [Node | _] = Nodes,
+    wait_until(
+        fun() ->
+            case ?ON(Node, emqx_cluster_rpc:status()) of
+                {atomic, Status} ->
+                    TnxIds = lists:usort([TnxId || #{tnx_id := TnxId} <- Status]),
+                    length(TnxIds) =:= 1;
+                _ ->
+                    false
+            end
+        end,
+        #{action => wait_same_tnx_id, nodes => Nodes}
+    ).
+
+wait_until(Fun, Context) ->
+    wait_until(Fun, Context, 30).
+
+wait_until(_Fun, Context, 0) ->
+    error({timeout, Context});
+wait_until(Fun, Context, Retries) ->
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(500),
+            wait_until(Fun, Context, Retries - 1)
+    end.
+
+capture_cluster_sync_status(Node) ->
+    ?ON(Node, begin
+        ok = meck:new(emqx_ctl, [passthrough, no_link]),
+        try
+            ok = emqx_conf_cli:admins(["status"]),
+            History = meck:history(emqx_ctl),
+            unicode:characters_to_binary([
+                format_ctl_output(Fun, Args)
+             || {_Pid, {emqx_ctl, Fun, Args}, _Result} <- History,
+                Fun =:= print orelse Fun =:= warning
+            ])
+        after
+            meck:unload(emqx_ctl)
+        end
+    end).
+
+format_ctl_output(_Fun, [Format]) ->
+    Format;
+format_ctl_output(_Fun, [Format, Args]) ->
+    io_lib:format(Format, Args);
+format_ctl_output(_Fun, Args) ->
+    io_lib:format("~p", [Args]).

--- a/changes/ee/fix-17348.en.md
+++ b/changes/ee/fix-17348.en.md
@@ -6,3 +6,8 @@ The command now suppresses raw-only representation differences that do not corre
 checked configuration changes, while still warning when checked configuration is
 inconsistent. It also avoids crashing when a raw configuration key exists on one node but
 is missing from another node.
+
+It also ignores timestamp-only metadata differences in `created_at` and `last_modified_at`
+for actions, sources, bridges, and rule metadata. Data import or boot-time configuration
+loading can refresh these generated timestamps on only some nodes even when the effective
+runtime configuration is otherwise identical.

--- a/changes/ee/fix-17348.en.md
+++ b/changes/ee/fix-17348.en.md
@@ -1,0 +1,8 @@
+Fixed noisy and misleading `emqx ctl conf cluster_sync status` diagnostics when clustered
+nodes have the same effective checked configuration but different raw configuration
+representations.
+
+The command now suppresses raw-only representation differences that do not correspond to
+checked configuration changes, while still warning when checked configuration is
+inconsistent. It also avoids crashing when a raw configuration key exists on one node but
+is missing from another node.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15291
Fixes https://emqx.atlassian.net/browse/EMQX-15310

Release version:
6.0.3

## Summary

`emqx ctl conf cluster_sync status` can emit noisy and misleading diagnostics when nodes have the same effective checked configuration but different non-runtime representations. Typical cases include sparse imported raw config on one node and boot-time default-materialized raw config on another node, or generated timestamp metadata refreshed on only some nodes.

This PR ports the cluster sync status fixes from #17313 and #17387 to `release-60`.

The `release-60` port now:

* normalizes each running node's raw config through defaults and schema check before status comparison, with a fallback to checked config if raw normalization fails;
* suppresses raw-only representation differences when printing diagnostics so only real checked config changes remain visible;
* ignores timestamp-only `created_at` and `last_modified_at` metadata differences for actions, sources, bridges, and rule metadata;
* keeps the warning when checked config is genuinely inconsistent, even if the pruned raw payload is empty;
* allows the root raw config path in the v5 proto spec used by status normalization.

Regression coverage includes the import-then-join integration test `emqx_conf_cluster_sync_import_SUITE` from #17313, adapted for `release-60` import default materialization, plus focused CLI/EUnit guards for raw diff pruning and timestamp-only metadata differences.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)