### PR TITLE
ci: probe host disk + docker around build_slim_packages

### DIFF
--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -30,6 +30,8 @@ jobs:
       run: |
         source env.sh
         echo "BUILDER=$EMQX_DOCKER_BUILD_FROM" >> "$GITHUB_OUTPUT"
+    - name: probe host disk + docker (before build)
+      run: ./scripts/runner-resource-probe.sh "before plugins build"
     - name: build plugins in builder
       env:
         BUILDER: ${{ steps.env.outputs.BUILDER }}
@@ -39,6 +41,9 @@ jobs:
           -w /emqx \
           "$BUILDER" \
           bash -lc "git config --global --add safe.directory /emqx && make emqx-enterprise-compile && make plugins"
+    - name: probe host disk + docker (after build)
+      if: always()
+      run: ./scripts/runner-resource-probe.sh "after plugins build"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "plugins"
@@ -68,12 +73,20 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
+    - name: probe host disk + docker (before tgz)
+      run: ./scripts/runner-resource-probe.sh "before tgz ${{ matrix.arch }}"
     - name: build tgz
       run: |
         ./scripts/buildx.sh --profile $PROFILE --pkgtype tgz --arch $ARCH
+    - name: probe host disk + docker (before pkg)
+      if: always()
+      run: ./scripts/runner-resource-probe.sh "before pkg ${{ matrix.arch }}"
     - name: build pkg
       run: |
         ./scripts/buildx.sh --profile $PROFILE --pkgtype pkg --arch $ARCH
+    - name: probe host disk + docker (after pkg)
+      if: always()
+      run: ./scripts/runner-resource-probe.sh "after pkg ${{ matrix.arch }}"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "${{ matrix.profile }}-${{ matrix.arch }}"

--- a/scripts/runner-resource-probe.sh
+++ b/scripts/runner-resource-probe.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+## Diagnostic probe for the CI runner host.
+##
+## Captures disk usage, docker image accumulation, and memory to help diagnose
+## "self-hosted runner lost communication" failures that have hit jobs across
+## the build_slim_packages / run_test_cases matrix.
+##
+## Usage: runner-resource-probe.sh "<label>"
+##   The label is echoed alongside each section so successive probes in the
+##   same job (before/after a build step) are easy to correlate.
+
+set -uo pipefail
+
+label="${1:-unlabeled}"
+ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+echo "==== probe [$label] $ts ===="
+
+echo "---- df -hT (all mounts) ----"
+df -hT 2>&1 || true
+
+echo "---- docker system df ----"
+docker system df 2>&1 || true
+
+echo "---- docker images (count + per-image size) ----"
+echo "image count: $(docker images -q 2>/dev/null | wc -l)"
+docker images --format '{{.Size}}\t{{.Repository}}:{{.Tag}}' 2>&1 | sort -rh | head -30 || true
+
+echo "---- docker / containerd data roots ----"
+docker_root=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null)
+containerd_root=$(sudo containerd config dump 2>/dev/null | awk -F'"' '/^root = / { print $2; exit }')
+containerd_root="${containerd_root:-/var/lib/containerd}"
+for d in "$docker_root" "$containerd_root"; do
+  [ -z "$d" ] && continue
+  echo "## $d (parent fs: $(df -hT "$d" 2>/dev/null | tail -1))"
+  sudo du -sh "$d"/* 2>/dev/null | sort -rh | head -10 \
+    || du -sh "$d" 2>/dev/null \
+    || echo "(no permission to du $d)"
+done
+
+echo "---- free -m ----"
+free -m 2>&1 || true
+
+echo "---- /proc/meminfo (top) ----"
+head -10 /proc/meminfo 2>&1 || true
+
+echo "---- uptime ----"
+uptime 2>&1 || true
+
+echo "==== end probe [$label] ===="


### PR DESCRIPTION
## Summary

Recurring `self-hosted runner lost communication` failures on `build_slim_packages` (and related jobs) are still unexplained:
- In-container build peaks at ~1.8 GiB on a CI-matched 2 vCPU / 7 GiB cgroup, so it isn't builder OOM.
- One round of probing confirmed runners are ephemeral (uptime 0 at job start), docker storage lives on `/data` (xfs, 60 GiB), and root sits at a constant 66% throughout — so the "docker image accumulation fills root" theory is also out.

That leaves AWS spot reclamation / runner-host transients as the working guess. Re-enable the resource probe on the `build_slim_packages` matrix only and let it ride for a few days; when the next batch of lost-comm failures lands we'll have enough host-state snapshots to spot a pattern.

`scripts/runner-resource-probe.sh` dumps `df -hT`, `docker system df`, top docker images, `/var/lib/docker` breakdown, `free -m`, `/proc/meminfo`, and `uptime`. It runs:
- `plugins-linux-amd64`: before + after the build (`if: always()`)
- `linux` matrix: before tgz + before pkg + after pkg (each `if: always()` so failure runs still capture state)

CI-only. No production code touched.