### PR TITLE
ci: run cover-to-cobertura.escript in compile mode

### DIFF
--- a/scripts/cover-to-cobertura.escript
+++ b/scripts/cover-to-cobertura.escript
@@ -1,5 +1,4 @@
 #!/usr/bin/env escript
-%%! -mode(compile)
 %%
 %% Convert a directory of .coverdata files into a single Cobertura XML report.
 %%
@@ -21,6 +20,8 @@
 %% larger compressed payload. Each entry is one of:
 %%   {file, Module, BeamPath}
 %%   {#bump{module=M, function=F, arity=A, clause=C, line=L}, Count}
+
+-mode(compile).
 
 -record(bump, {module = '_', function = '_', arity = '_', clause = '_', line = '_'}).
 -record(opts, {


### PR DESCRIPTION
Follow-up to #17341.

The `%%! -mode(compile)` on the shell-args line is ignored — escript only recognises `-mode(compile).` as a module attribute. Without it the script runs in interpret mode, and `fun read_file/2` passed to `lists:foldl/3` blows up at call time:

```
{undef,[{erl_eval,read_file,2,[]}, ...]}
```