### PR TITLE
test(cassandra): generate TLS certs for common tests

### DIFF
--- a/.ci/docker-compose-file/cassandra/cassandra.yaml
+++ b/.ci/docker-compose-file/cassandra/cassandra.yaml
@@ -1047,12 +1047,12 @@ client_encryption_options:
     enabled: true
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
-    keystore: /certs/server.jks
-    keystore_password: my_password
+    keystore: /certs/kafka.keystore.jks
+    keystore_password: password
     require_client_auth: true
     # Set trustore and truststore_password if require_client_auth is true
-    truststore: /certs/truststore.jks
-    truststore_password: my_password
+    truststore: /certs/kafka.truststore.jks
+    truststore_password: password
     # More advanced defaults below:
     protocol: TLS
     store_type: JKS

--- a/.ci/docker-compose-file/cassandra/cassandra_noauth.yaml
+++ b/.ci/docker-compose-file/cassandra/cassandra_noauth.yaml
@@ -1047,12 +1047,12 @@ client_encryption_options:
     enabled: true
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
-    keystore: /certs/server.jks
-    keystore_password: my_password
+    keystore: /certs/kafka.keystore.jks
+    keystore_password: password
     require_client_auth: true
     # Set trustore and truststore_password if require_client_auth is true
-    truststore: /certs/truststore.jks
-    truststore_password: my_password
+    truststore: /certs/kafka.truststore.jks
+    truststore_password: password
     # More advanced defaults below:
     protocol: TLS
     store_type: JKS

--- a/.ci/docker-compose-file/docker-compose-cassandra.yaml
+++ b/.ci/docker-compose-file/docker-compose-cassandra.yaml
@@ -22,15 +22,29 @@ x-cassandra: &cassandra
     - emqx_bridge
 
 services:
+  ssl_cert_gen:
+    # see https://github.com/emqx/docker-images
+    image: ghcr.io/emqx/certgen:latest
+    container_name: ssl_cert_gen
+    user: "${DOCKER_USER:-root}"
+    volumes:
+      - /tmp/emqx-ci/emqx-shared-secret:/var/lib/secret
+
   cassandra_server:
     <<: *cassandra
     container_name: cassandra
+    depends_on:
+      ssl_cert_gen:
+        condition: service_completed_successfully
     volumes:
-      - ./certs:/certs
+      - /tmp/emqx-ci/emqx-shared-secret:/certs:ro
       - ./cassandra/cassandra.yaml:/etc/cassandra/cassandra.yaml
   cassandra_noauth_server:
     <<: *cassandra
     container_name: cassandra_noauth
+    depends_on:
+      ssl_cert_gen:
+        condition: service_completed_successfully
     volumes:
-      - ./certs:/certs
+      - /tmp/emqx-ci/emqx-shared-secret:/certs:ro
       - ./cassandra/cassandra_noauth.yaml:/etc/cassandra/cassandra.yaml

--- a/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
+++ b/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
@@ -49,11 +49,11 @@
 
 %% cert files for client
 -define(CERT_ROOT,
-    filename:join([emqx_common_test_helpers:proj_root(), ".ci", "docker-compose-file", "certs"])
+    os:getenv("CI_SHARED_SECRET_PATH", "/var/lib/secret")
 ).
 
 -define(CAFILE, filename:join(?CERT_ROOT, ["ca.crt"])).
--define(CERTFILE, filename:join(?CERT_ROOT, ["client.pem"])).
+-define(CERTFILE, filename:join(?CERT_ROOT, ["client.crt"])).
 -define(KEYFILE, filename:join(?CERT_ROOT, ["client.key"])).
 
 %% How to run it locally:
@@ -66,7 +66,8 @@
 %%  2. Run use cases with special environment variables
 %%    CASSA_TCP_HOST=127.0.0.1 CASSA_TCP_PORT=19042 \
 %%    CASSA_TLS_HOST=127.0.0.1 CASSA_TLS_PORT=19142 \
-%%    PROXY_HOST=127.0.0.1 ./rebar3 as test ct -c -v --name ct@127.0.0.1 \
+%%    PROXY_HOST=127.0.0.1 CI_SHARED_SECRET_PATH=/tmp/emqx-ci/emqx-shared-secret \
+%%    ./rebar3 as test ct -c -v --name ct@127.0.0.1 \
 %%    --suite apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
 %%
 


### PR DESCRIPTION
Fixes EMQX-9327

Release version:
5.10.4

## Summary

- Target branch is `release-510`.
- Generate Cassandra common-test TLS certificates at runtime through the existing `ghcr.io/emqx/certgen:latest` service instead of mounting the checked-in `.ci/docker-compose-file/certs` directory.
- Mount `/tmp/emqx-ci/emqx-shared-secret` into Cassandra containers and use the generated Kafka keystore/truststore files with the generator password.
- Read Cassandra client TLS files from `CI_SHARED_SECRET_PATH` in `emqx_bridge_cassandra_SUITE`, matching the shared-secret pattern already used by Kafka tests.
- Local checks run: `./scripts/erlfmt -w apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl`, `git diff --check`, YAML parsing for the modified compose/config files, `docker compose ... config`, and `ssl_cert_gen` service execution. Full Cassandra CT was not run because pulling `public.ecr.aws/docker/library/cassandra:3.11` hit `toomanyrequests: Rate exceeded`.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
