### PR TITLE
fix(cli-trace): handle missing `ruleid` trace filter argument [r510]

### DIFF
--- a/apps/emqx_bridge_dynamo/test/emqx_bridge_dynamo_SUITE.erl
+++ b/apps/emqx_bridge_dynamo/test/emqx_bridge_dynamo_SUITE.erl
@@ -92,10 +92,6 @@ init_per_suite(Config) ->
     [{dynamo_secretfile, SecretFile} | Config].
 
 end_per_suite(_Config) ->
-    emqx_mgmt_api_test_util:end_suite(),
-    ok = emqx_common_test_helpers:stop_apps([
-        emqx_rule_engine, emqx_bridge, emqx_resource, emqx_conf, erlcloud
-    ]),
     ok.
 
 init_per_testcase(TestCase, Config) ->

--- a/apps/emqx_bridge_hstreamdb/test/emqx_bridge_hstreamdb_SUITE.erl
+++ b/apps/emqx_bridge_hstreamdb/test/emqx_bridge_hstreamdb_SUITE.erl
@@ -109,8 +109,6 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    emqx_mgmt_api_test_util:end_suite(),
-    ok = emqx_common_test_helpers:stop_apps([emqx_bridge, emqx_resource, emqx_conf, hstreamdb_erl]),
     ok.
 
 init_per_testcase(t_to_hrecord_failed, Config) ->

--- a/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
+++ b/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
@@ -119,8 +119,6 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    emqx_mgmt_api_test_util:end_suite(),
-    ok = emqx_common_test_helpers:stop_apps([emqx_rule_engine, emqx_bridge, emqx_conf]),
     ok.
 
 init_per_testcase(_Testcase, Config) ->

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -891,6 +891,7 @@ trace_type(Op, Match, "json") -> trace_type(Op, Match, json);
 trace_type("client", ClientId, Formatter) -> {ok, clientid, bin(ClientId), Formatter};
 trace_type("topic", Topic, Formatter) -> {ok, topic, bin(Topic), Formatter};
 trace_type("ip_address", IP, Formatter) -> {ok, ip_address, IP, Formatter};
+trace_type("ruleid", RuleId, Formatter) -> {ok, ruleid, bin(RuleId), Formatter};
 trace_type(_, _, _) -> error.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -21,6 +21,7 @@ init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
             emqx_conf,
+            emqx_modules,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],
@@ -218,7 +219,7 @@ t_trace(_Config) ->
 
 t_traces(_Config) ->
     %% traces list                             # List all cluster traces started
-    emqx_ctl:run_command(["traces", "list"]),
+    0 = emqx_ctl:run_command(["traces", "list"]),
     %% traces start <Name> client <ClientId>   # Traces for a client in cluster
     %% traces start <Name> topic <Topic>       # Traces for a topic in cluster
     %% traces start <Name> ip_address <IPAddr> # Traces for a IP in cluster

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -227,29 +227,40 @@ t_traces(_Config) ->
     ok.
 
 t_traces_client(_Config) ->
-    TraceC = "TraceNameClientID",
-    emqx_ctl:run_command(["traces", "start", TraceC, "client", "ClientID"]),
-    emqx_ctl:run_command(["traces", "stop", TraceC]),
-    emqx_ctl:run_command(["traces", "delete", TraceC]).
+    Name = "TraceNameClientID",
+    ok = emqx_ctl:run_command(["traces", "start", Name, "client", "ClientID"]),
+    1 = emqx_ctl:run_command(["traces", "list"]),
+    ok = emqx_ctl:run_command(["traces", "stop", Name]),
+    ok = emqx_ctl:run_command(["traces", "delete", Name]).
 
 t_traces_client_with_duration(_Config) ->
-    TraceC = "TraceNameClientID",
+    Name = "TraceNameClientID",
     Duration = "1000",
-    emqx_ctl:run_command(["traces", "start", TraceC, "client", "ClientID", Duration]),
-    emqx_ctl:run_command(["traces", "stop", TraceC]),
-    emqx_ctl:run_command(["traces", "delete", TraceC]).
+    ok = emqx_ctl:run_command(["traces", "start", Name, "client", "ClientID", Duration]),
+    1 = emqx_ctl:run_command(["traces", "list"]),
+    ok = emqx_ctl:run_command(["traces", "stop", Name]),
+    ok = emqx_ctl:run_command(["traces", "delete", Name]).
 
 t_traces_topic(_Config) ->
-    TraceT = "TraceNameTopic",
-    emqx_ctl:run_command(["traces", "start", TraceT, "topic", "a/b"]),
-    emqx_ctl:run_command(["traces", "stop", TraceT]),
-    emqx_ctl:run_command(["traces", "delete", TraceT]).
+    Name = "TraceNameTopic",
+    ok = emqx_ctl:run_command(["traces", "start", Name, "topic", "a/b"]),
+    1 = emqx_ctl:run_command(["traces", "list"]),
+    ok = emqx_ctl:run_command(["traces", "stop", Name]),
+    ok = emqx_ctl:run_command(["traces", "delete", Name]).
 
 t_traces_ip(_Config) ->
-    TraceI = "TraceNameIP",
-    emqx_ctl:run_command(["traces", "start", TraceI, "ip_address", "127.0.0.1"]),
-    emqx_ctl:run_command(["traces", "stop", TraceI]),
-    emqx_ctl:run_command(["traces", "delete", TraceI]).
+    Name = "TraceNameIP",
+    ok = emqx_ctl:run_command(["traces", "start", Name, "ip_address", "127.0.0.1"]),
+    1 = emqx_ctl:run_command(["traces", "list"]),
+    ok = emqx_ctl:run_command(["traces", "stop", Name]),
+    ok = emqx_ctl:run_command(["traces", "delete", Name]).
+
+t_traces_rule(_Config) ->
+    Name = "TraceNameRule",
+    ok = emqx_ctl:run_command(["traces", "start", Name, "ruleid", "rule:42"]),
+    1 = emqx_ctl:run_command(["traces", "list"]),
+    ok = emqx_ctl:run_command(["traces", "stop", Name]),
+    ok = emqx_ctl:run_command(["traces", "delete", Name]).
 
 t_listeners(_Config) ->
     %% listeners                      # List listeners


### PR DESCRIPTION
Release version: 5.10.4

## Summary

Backport of #16002.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
