### PR TITLE
docs: add missed 5.10.4 changelog entries (#17298, #17365)

### DIFF
--- a/changes/e5.10.4.en.md
+++ b/changes/e5.10.4.en.md
@@ -200,6 +200,13 @@
 
 - [#17346](https://github.com/emqx/emqx/pull/17346) Upgraded the RocketMQ client dependency to `v0.7.2` to fix memory growth in async producer requests.
 
+- [#17298](https://github.com/emqx/emqx/pull/17298) Upgraded the `emqtt` MQTT client dependency from `1.14.6` to `1.15.1`.
+
+  This brings the following user-visible improvements to MQTT bridges, MQTT Sources, and other connectors that talk MQTT outbound:
+
+  - Track pingresp timeout from the keepalive timer instead of a separate timer, so pingresp handling stays aligned with the configured `keepalive` interval.
+  - QUIC: after a peer `recv` abort, abort only the send direction instead of tearing down both directions, so pending sends on a half-closed QUIC stream are no longer dropped silently.
+
 ### Clustering
 
 - [#16729](https://github.com/emqx/emqx/pull/16729) Improved recovery time of a cluster after a simultaneous restart of all nodes.
@@ -266,3 +273,5 @@
 - [#17255](https://github.com/emqx/emqx/pull/17255) Improved memory-usage reporting inside containers.
 
   The broker now picks the most constraining memory reading among cgroup v2, cgroup v1, and the host's `/proc/meminfo` (smallest non-zero total wins, larger usage ratio breaks ties). Previously the reading could be misleading in two ways: on containers with a tight cgroup limit, the host view could indicate >70% while the cgroup limit was <10% (or the reverse); and on hosts where a cgroup is mounted with no memory limit set, the cgroup reading could collapse the reported usage ratio to ~0%. Overload-protection thresholds and the `Memory used` metric now reflect the limit that actually constrains the process.
+
+- [#17365](https://github.com/emqx/emqx/pull/17365) Fixed `emqx ctl trace` to accept `ruleid` as a trace filter type. Previously, `emqx ctl trace start <name> ruleid <rule-id> <log-level>` (and the corresponding `trace add ...` form) fell through to a generic error because the `ruleid` filter was missing from the CLI argument parser. The other filter types (`client`, `topic`, `ip_address`) were unaffected.

--- a/changes/ee/fix-17298.en.md
+++ b/changes/ee/fix-17298.en.md
@@ -1,0 +1,6 @@
+Upgraded the `emqtt` MQTT client dependency from `1.14.6` to `1.15.1`.
+
+This brings the following user-visible improvements to MQTT bridges, MQTT Sources, and other connectors that talk MQTT outbound:
+
+- Track pingresp timeout from the keepalive timer instead of a separate timer, so pingresp handling stays aligned with the configured `keepalive` interval.
+- QUIC: after a peer `recv` abort, abort only the send direction instead of tearing down both directions, so pending sends on a half-closed QUIC stream are no longer dropped silently.

--- a/changes/ee/fix-17365.en.md
+++ b/changes/ee/fix-17365.en.md
@@ -1,0 +1,1 @@
+Fixed `emqx ctl trace` to accept `ruleid` as a trace filter type. Previously, `emqx ctl trace start <name> ruleid <rule-id> <log-level>` (and the corresponding `trace add ...` form) fell through to a generic error because the `ruleid` filter was missing from the CLI argument parser. The other filter types (`client`, `topic`, `ip_address`) were unaffected.


### PR DESCRIPTION
Release version: 5.10.4

## Summary

Two PRs landed on `release-510` close to (or just before) the 5.10.4 changelog PR #17168 but didn't carry their own `changes/ee/*` file, so they were missing from `changes/e5.10.4.en.md`. This adds the entries:

- **#17298** `chore: bump emqtt 1.15.1` (merged 2026-05-21). emqtt is the MQTT client used by MQTT bridges, MQTT Sources, and other outbound-MQTT connectors. Tag `1.14.6 -> 1.15.1` brings keepalive-based pingresp timeout tracking and a QUIC half-close fix that are user-visible to bridge users.
- **#17365** `fix(cli-trace): handle missing ruleid trace filter argument` (merged 2026-05-25). `emqx ctl trace start ... ruleid <id> ...` previously fell through to a generic error because the `ruleid` filter was missing from the CLI parser; this is a real user-visible CLI fix.

No source changes; only `changes/ee/fix-17298.en.md`, `changes/ee/fix-17365.en.md`, and the corresponding two entries in `changes/e5.10.4.en.md`.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking