### PR TITLE
fix(scopes): unify API key and dashboard user scope response as tri-state contract

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -144,7 +144,29 @@ add_user(Username, Password, Role, Desc) when is_binary(Username), is_binary(Pas
     end.
 
 do_add_user(Username, Password, Role, Desc) ->
-    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun add_user_/4, [Username, Password, Role, Desc]),
+    do_add_user(Username, Password, Role, Desc, undefined).
+
+%% @doc Internal admin/SSO-user creation entry point.
+%%
+%% `InitialScopes' controls what ends up in the persisted `extra' map's
+%% `scopes' key BEFORE any later `set_user_scopes/2' call:
+%%
+%%   * `undefined' (default, 4-arg version) - no scopes key is written; the
+%%     caller is expected to materialise scopes afterwards (e.g. the API POST
+%%     handler does `maybe_set_user_scopes/2' with role-default scopes).
+%%     This keeps the read-modify-write path of `emqx_dashboard_api' unchanged.
+%%
+%%   * `[binary(), ...]' (5-arg version) - the listed scopes are written
+%%     into the record atomically inside the same mria transaction as the
+%%     row insertion. This is used by paths that do NOT have a follow-up
+%%     `set_user_scopes' step (SSO auto-provisioning, default-admin bootstrap)
+%%     so a new row never appears with a missing scopes key.
+do_add_user(Username, Password, Role, Desc, InitialScopes) ->
+    Res = mria:sync_transaction(
+        ?DASHBOARD_SHARD,
+        fun add_user_/5,
+        [Username, Password, Role, Desc, InitialScopes]
+    ),
     return(Res).
 
 get_mfa_enabled_state(Username) ->
@@ -557,15 +579,17 @@ force_add_user(Username, Password, Role, Desc) ->
     end.
 
 %% @private
-add_user_(Username, Password, Role, Desc) ->
+add_user_(Username, Password, Role, Desc, InitialScopes) ->
     case mnesia:wread({?ADMIN, Username}) of
         [] ->
+            Extra0 = #{password_ts => erlang:system_time(second)},
+            Extra = maybe_seed_initial_scopes(Extra0, InitialScopes),
             Admin = #?ADMIN{
                 username = Username,
                 pwdhash = hash(Password),
                 role = Role,
                 description = Desc,
-                extra = #{password_ts => erlang:system_time(second)}
+                extra = Extra
             },
             mnesia:write(Admin),
             ?SLOG(info, #{msg => "dashboard_sso_user_added", username => Username, role => Role}),
@@ -579,6 +603,14 @@ add_user_(Username, Password, Role, Desc) ->
             }),
             mnesia:abort(?USERNAME_ALREADY_EXISTS_ERROR)
     end.
+
+%% Materialise initial scopes inside the same mria transaction as the row
+%% insertion. `undefined' leaves the extra map untouched so the existing
+%% read-modify-write contract of API POST handlers is preserved.
+maybe_seed_initial_scopes(Extra, undefined) ->
+    Extra;
+maybe_seed_initial_scopes(Extra, Scopes) when is_list(Scopes) ->
+    Extra#{scopes => Scopes}.
 
 -spec remove_user(dashboard_username()) -> {ok, any()} | {error, any()}.
 remove_user(Username) ->
@@ -978,8 +1010,18 @@ add_default_user(Username, Password) ->
 
 do_add_default_user(Username, Password) ->
     maybe
+        %% Seed the default admin with its role-default scopes so the very
+        %% first node bootstrap of a fresh cluster yields a default admin
+        %% that already carries scopes — never the legacy `<<"unset">>'
+        %% sentinel.
         {error, ?USERNAME_ALREADY_EXISTS_ERROR} ?=
-            do_add_user(Username, Password, ?ROLE_SUPERUSER, <<"administrator">>),
+            do_add_user(
+                Username,
+                Password,
+                ?ROLE_SUPERUSER,
+                <<"administrator">>,
+                role_default_scopes(?ROLE_SUPERUSER)
+            ),
         %% race condition: multiple nodes booting at the same time?
         {ok, default_user_exists}
     end.
@@ -1013,7 +1055,13 @@ add_sso_user(Backend, Username0, Role, Desc) when is_binary(Username0) ->
     case legal_role(Role) of
         ok ->
             Username = ?SSO_USERNAME(Backend, Username0),
-            do_add_user(Username, <<>>, Role, Desc);
+            %% SSO auto-provisioning has no follow-up `set_user_scopes' step
+            %% (LDAP / OIDC / SAML `ensure_user_exists' callers just call
+            %% `add_sso_user' and stop). Seed the role default into the
+            %% same mria transaction so a fresh SSO row never appears in
+            %% the "no scopes key" state — that state is reserved for legacy
+            %% records upgraded from versions before the scope feature shipped.
+            do_add_user(Username, <<>>, Role, Desc, role_default_scopes(Role));
         {error, _} = Error ->
             Error
     end.

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -757,8 +757,21 @@ to_external_user(UserRecord) ->
     flatten_username(maps:merge(Base, ee_user_extra(UserRecord))).
 
 -if(?EMQX_RELEASE_EDITION == ee).
-ee_user_extra(UserRecord) ->
-    #{scopes => effective_scopes_of_admin(UserRecord)}.
+%% @doc Surface raw scope state with a tri-state contract:
+%%   - `[]`            : explicit deny-all
+%%   - `[binary(), …]` : explicit allow-list
+%%   - `null`          : not set; authorization falls back to role default
+%%                       (administrator/viewer: generic + login-only scopes;
+%%                       publisher: hard-coded `/publish*`)
+%% Authorization keeps using {@link effective_scopes_of_admin/1} which still
+%% expands the role default. The API surface intentionally does not expose the
+%% expanded list so that read-modify-write does not sediment role-default into
+%% an explicit scope list.
+ee_user_extra(#?ADMIN{username = Username}) ->
+    case scopes_of(Username) of
+        undefined -> #{scopes => null};
+        Scopes when is_list(Scopes) -> #{scopes => Scopes}
+    end.
 -else.
 ee_user_extra(_UserRecord) ->
     #{}.

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -46,6 +46,7 @@
     scopes_of/1,
     effective_scopes_of/1,
     effective_scopes_of_admin/1,
+    role_default_scopes/1,
     set_user_scopes/2,
     all_users/0,
     admin_users/0,
@@ -760,16 +761,24 @@ to_external_user(UserRecord) ->
 %% @doc Surface raw scope state with a tri-state contract:
 %%   - `[]`            : explicit deny-all
 %%   - `[binary(), …]` : explicit allow-list
-%%   - `null`          : not set; authorization falls back to role default
-%%                       (administrator/viewer: generic + login-only scopes;
-%%                       publisher: hard-coded `/publish*`)
+%%   - `<<"unset">>`   : the persisted record has no `scopes' field at all (legacy
+%%                       upgrade artefact from before #17235 landed).  The runtime
+%%                       authorization path falls back to role default:
+%%                       administrator -> generic + login-only scopes;
+%%                       viewer        -> generic scopes;
+%%                       publisher     -> hard-coded `/publish*'.
+%%                       Newly created users never end up in this state: the POST
+%%                       and SSO-provisioning paths both materialize role-default
+%%                       scopes at creation time.
 %% Authorization keeps using {@link effective_scopes_of_admin/1} which still
-%% expands the role default. The API surface intentionally does not expose the
-%% expanded list so that read-modify-write does not sediment role-default into
-%% an explicit scope list.
+%% expands the role default for legacy records.  The API surface intentionally
+%% does not expose the expanded list so that read-modify-write does not sediment
+%% role-default into an explicit scope list.  `<<"unset">>' is a stable string
+%% sentinel (not JSON `null') so HTTP/JSON intermediaries cannot conflate it with
+%% `field missing' or `field cleared'.
 ee_user_extra(#?ADMIN{username = Username}) ->
     case scopes_of(Username) of
-        undefined -> #{scopes => null};
+        undefined -> #{scopes => <<"unset">>};
         Scopes when is_list(Scopes) -> #{scopes => Scopes}
     end.
 -else.

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -130,7 +130,7 @@ schema("/users") ->
             tags => [<<"Dashboard">>],
             desc => ?DESC(create_user_api),
             security => [#{'bearerAuth' => []}],
-            'requestBody' => fields([username, password, role, description, scopes]),
+            'requestBody' => fields([username, password, role, description, scopes_request]),
             responses => #{
                 200 => user_fields()
             }
@@ -162,7 +162,7 @@ schema("/users/:username") ->
             tags => [<<"Dashboard">>],
             desc => ?DESC(update_user_api),
             parameters => sso_parameters(fields([username_in_path])),
-            'requestBody' => fields([role, description, scopes]),
+            'requestBody' => fields([role, description, scopes_request]),
             responses => #{
                 200 => user_fields(),
                 400 => emqx_dashboard_swagger:error_codes(
@@ -237,7 +237,7 @@ fields(List) ->
     [field(Key) || Key <- List, field_filter(Key)].
 
 user_fields() ->
-    fields([username, role, description, backend, scopes]) ++ ee_user_fields().
+    fields([username, role, description, backend, scopes_response]) ++ ee_user_fields().
 
 ee_user_fields() ->
     [
@@ -291,10 +291,24 @@ field(new_pwd) ->
 field(role) ->
     {role,
         mk(binary(), #{desc => ?DESC(role), default => ?ROLE_DEFAULT, example => ?ROLE_DEFAULT})};
-field(scopes) ->
+field(scopes_request) ->
     {scopes,
         mk(hoconsc:array(binary()), #{
-            desc => ?DESC(user_scopes),
+            desc => ?DESC(user_scopes_request),
+            required => false,
+            example => [?SCOPE_USER_MGMT, ?SCOPE_MFA_MGMT]
+        })};
+field(scopes_response) ->
+    %% Response shape: `scopes' MAY be the binary sentinel <<"unset">> in
+    %% addition to the array-of-binaries form. This sentinel surfaces only
+    %% for legacy records that survived an upgrade from a release where
+    %% the dashboard-user scopes feature did not exist (#17235). The POST
+    %% and SSO-provisioning paths both materialize role-default scopes at
+    %% creation time, so no fresh user will ever appear with
+    %% `scopes => <<"unset">>'.
+    {scopes,
+        mk(hoconsc:union([unset, hoconsc:array(binary())]), #{
+            desc => ?DESC(user_scopes_response),
             required => false,
             example => [?SCOPE_USER_MGMT, ?SCOPE_MFA_MGMT]
         })};
@@ -369,7 +383,12 @@ users(post, #{body := Params}) ->
     Role = maps:get(<<"role">>, Params, ?ROLE_DEFAULT),
     Username = maps:get(<<"username">>, Params),
     Password = maps:get(<<"password">>, Params),
-    Scopes = maps:get(<<"scopes">>, Params, undefined),
+    %% Materialize role defaults when the client omitted `scopes' entirely.
+    %% Explicit `[]' (deny-all) and explicit lists pass through unchanged.
+    %% After this PR `<<"unset">>' in a GET response is reserved for legacy
+    %% records that survived an upgrade; no creation path stores `undefined'.
+    RawScopes = maps:get(<<"scopes">>, Params, undefined),
+    Scopes = effective_scopes_on_create(Role, RawScopes),
     case ?EMPTY(Username) orelse ?EMPTY(Password) of
         true ->
             {400, ?BAD_REQUEST, <<"Username or password undefined">>};
@@ -619,6 +638,28 @@ register_unsuccessful_login(_, _) ->
 %%     mfa_management is intentionally allowed for any role — non-
 %%     admin holders can self-exempt their own MFA but cannot manage
 %%     other users' MFA (handler-level enforcement).
+%% @doc Resolve the role-default scopes that should be materialized into
+%% the persisted record when the caller did not explicitly supply a
+%% scope list (POST without `scopes', SSO auto-provisioning).
+%%
+%% After this PR, `undefined' is never written into mnesia by any
+%% creation path; the `<<"unset">>' state in the GET response is only
+%% possible for records that survived an upgrade from a release where
+%% the dashboard-user scopes feature did not exist (#17235).
+%%
+%%   * administrator -> `?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES'
+%%   * viewer        -> `?GENERIC_SCOPES'
+%%
+%% Explicit `[]' (deny-all) and explicit lists pass through unchanged.
+effective_scopes_on_create(Role, undefined) ->
+    emqx_dashboard_admin:role_default_scopes(Role);
+effective_scopes_on_create(_Role, Scopes) when is_list(Scopes) ->
+    Scopes;
+effective_scopes_on_create(_Role, Other) ->
+    %% Any non-list, non-undefined value is left as-is; downstream
+    %% validation will reject it with the appropriate 400.
+    Other.
+
 validate_login_user_scopes(_Role, undefined) ->
     ok;
 validate_login_user_scopes(_Role, Scopes) when not is_list(Scopes) ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -48,13 +48,24 @@
     end
 ).
 
+%% common_test enumerates test cases via Mod:all/0 — without it
+%% `export_all' alone resolves to an empty case list and the suite
+%% silently runs zero cases.
+all() ->
+    ?EE_ONLY(emqx_common_test_helpers:all(?MODULE), []).
+
 %% The dashboard's default admin user (created by `do_add_default_user'
 %% at boot) used to land in the legacy "no scopes key" state, which
 %% would surface in API responses as the `<<"unset">>' sentinel.
 %% C3 seeds the administrator role default at row insertion time so a
 %% fresh default-admin is indistinguishable from one created via a POST
 %% that omits the `scopes' field.
+%%
+%% `init_per_testcase' clears the admin table to give every case full
+%% control of `admin_override'.  Re-run the same code path the boot
+%% sequence takes so the assertion exercises the real seeding helper.
 t_default_admin_seeded_with_role_default_scopes(_Config) ->
+    {ok, _} = emqx_dashboard_admin:add_default_user(),
     Username = emqx_dashboard_admin:default_username(),
     ?assertEqual(
         ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES,

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -133,8 +133,10 @@ t_post_users_response_includes_scopes(_Config) ->
     ?assertEqual(?ROLE_SUPERUSER, maps:get(<<"role">>, Resp)).
 
 %% Response from POST /users without an explicit `scopes' field
-%% projects the role-default. Admin (?ROLE_SUPERUSER) default is the
-%% full 14-scope list.
+%% materialises the role-default scope list (administrator -> 10 common
+%% + 4 login-only = 14 scopes). The legacy `<<"unset">>' sentinel is
+%% reserved for records that survived an upgrade without scopes
+%% (pre-#17235); fresh POSTs never produce that state.
 t_post_users_response_role_default_scopes_when_not_set(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
@@ -148,25 +150,17 @@ t_post_users_response_role_default_scopes_when_not_set(_Config) ->
         post, api_path(["users"]), auth_header(Token), Body
     ),
     Resp = emqx_utils_json:decode(RespBody),
-    %% Tri-state contract: `scopes' is always present; `null' means
-    %% "not explicitly set, fall back to role default". The response
-    %% deliberately does NOT project the expanded effective list; that
-    %% would let a dashboard read-modify-write silently sediment the
-    %% role default into an explicit scope list.
-    ?assertEqual(null, maps:get(<<"scopes">>, Resp)),
-    %% Role-default expansion still happens at the authorization layer;
-    %% verify it directly via the internal API.
-    EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(<<"no_scopes">>),
+    %% Response carries the materialised admin defaults (10 common + 4 login-only).
     CommonNames = [N || #{name := N} <- emqx_scope_catalog:common_scope_catalog()],
     LoginOnlyNames = [N || #{name := N} <- emqx_scope_catalog:admin_only_scope_catalog()],
-    lists:foreach(
-        fun(N) -> ?assert(lists:member(N, EffectiveScopes)) end,
-        CommonNames ++ LoginOnlyNames
-    ),
-    ?assertEqual(length(CommonNames) + length(LoginOnlyNames), length(EffectiveScopes)).
+    ExpectedScopes = lists:sort(CommonNames ++ LoginOnlyNames),
+    ?assertEqual(ExpectedScopes, lists:sort(maps:get(<<"scopes">>, Resp))),
+    %% Materialisation is real (persisted to mnesia), not a response-only
+    %% projection — `effective_scopes_of/1' returns the same list.
+    EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(<<"no_scopes">>),
+    ?assertEqual(ExpectedScopes, lists:sort(EffectiveScopes)).
 
-%% Viewer default = common scopes only (no login-only).
-%% Viewer default = the common scopes, no login-only ones.
+%% Viewer default = the 10 common scopes, no login-only ones.
 t_post_users_response_viewer_default_scopes(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
@@ -180,14 +174,72 @@ t_post_users_response_viewer_default_scopes(_Config) ->
         post, api_path(["users"]), auth_header(Token), Body
     ),
     Resp = emqx_utils_json:decode(RespBody),
-    %% Same tri-state contract — viewer with no explicit scopes also surfaces `null'.
-    ?assertEqual(null, maps:get(<<"scopes">>, Resp)),
-    %% Role-default expansion verified via the internal API.
-    EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(<<"viewer_no_scopes">>),
+    %% Response carries the materialised viewer defaults (10 common, no login-only).
     CommonNames = [N || #{name := N} <- emqx_scope_catalog:common_scope_catalog()],
-    ?assertEqual(length(CommonNames), length(EffectiveScopes)),
-    ?assertNot(lists:member(?SCOPE_USER_MGMT, EffectiveScopes)),
-    ?assertNot(lists:member(?SCOPE_MFA_MGMT, EffectiveScopes)).
+    ExpectedScopes = lists:sort(CommonNames),
+    ?assertEqual(ExpectedScopes, lists:sort(maps:get(<<"scopes">>, Resp))),
+    %% Viewer never gets login-only scopes via the role default.
+    ?assertNot(lists:member(?SCOPE_USER_MGMT, maps:get(<<"scopes">>, Resp))),
+    ?assertNot(lists:member(?SCOPE_MFA_MGMT, maps:get(<<"scopes">>, Resp))),
+    %% Confirm persisted state matches.
+    EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(<<"viewer_no_scopes">>),
+    ?assertEqual(ExpectedScopes, lists:sort(EffectiveScopes)).
+
+%% POST without an explicit `scopes' field materialises the role-default
+%% scope list and persists it (it is not merely a response-time
+%% projection). This is what distinguishes a freshly-created user
+%% from a legacy upgraded one.
+t_post_users_materialises_default_scopes(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    Body = #{
+        <<"username">> => <<"materialise_admin">>,
+        <<"password">> => test_password(),
+        <<"role">> => ?ROLE_SUPERUSER,
+        <<"description">> => <<"test">>
+    },
+    {ok, 200, _RespBody} = request_api(
+        post, api_path(["users"]), auth_header(Token), Body
+    ),
+    %% Verify the raw mnesia extra map carries `scopes' (not absence,
+    %% which would be the legacy state).
+    [Admin] = mnesia:dirty_read(?ADMIN, <<"materialise_admin">>),
+    Extra = element(6, Admin),
+    ?assert(is_map(Extra)),
+    ?assert(maps:is_key(scopes, Extra)),
+    %% Persisted list equals the role default.
+    CommonNames = [N || #{name := N} <- emqx_scope_catalog:common_scope_catalog()],
+    LoginOnlyNames = [N || #{name := N} <- emqx_scope_catalog:admin_only_scope_catalog()],
+    ExpectedScopes = lists:sort(CommonNames ++ LoginOnlyNames),
+    ?assertEqual(ExpectedScopes, lists:sort(maps:get(scopes, Extra))).
+
+%% Records created before the user scopes feature shipped have no
+%% `scopes' key in their extra map. Such legacy records still need
+%% a sensible response — the contract is to surface the binary
+%% sentinel `<<"unset">>'. We simulate this by writing a record
+%% directly into mnesia with a stripped extra map.
+t_legacy_record_shows_unset_sentinel(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    %% Create via the API then mutate mnesia to drop the scopes key.
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"legacy_user">>, test_password(), ?ROLE_SUPERUSER, "u"
+    ),
+    {ok, _} = emqx_dashboard_admin:set_user_scopes(
+        <<"legacy_user">>, [?SCOPE_USER_MGMT]
+    ),
+    [Record0] = mnesia:dirty_read(?ADMIN, <<"legacy_user">>),
+    Extra0 = element(6, Record0),
+    ExtraNoScopes = maps:remove(scopes, Extra0),
+    Record1 = setelement(6, Record0, ExtraNoScopes),
+    ok = mnesia:dirty_write(?ADMIN, Record1),
+    %% Read it back through the API and verify the sentinel surfaces.
+    {ok, 200, RespBody} = request_api(
+        get, api_path(["users"]), auth_header(Token), []
+    ),
+    Resp = emqx_utils_json:decode(RespBody),
+    [LegacyEntry] = [E || E <- Resp, maps:get(<<"username">>, E) =:= <<"legacy_user">>],
+    ?assertEqual(<<"unset">>, maps:get(<<"scopes">>, LegacyEntry)).
 
 %% Response from PUT /users/:name must reflect the updated scopes.
 t_put_users_response_includes_updated_scopes(_Config) ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -148,18 +148,22 @@ t_post_users_response_role_default_scopes_when_not_set(_Config) ->
         post, api_path(["users"]), auth_header(Token), Body
     ),
     Resp = emqx_utils_json:decode(RespBody),
-    ScopesOut = maps:get(<<"scopes">>, Resp),
-    ?assert(is_list(ScopesOut)),
-    %% Admin default contains every login-only scope plus every
-    %% common scope — assert membership rather than exact equality
-    %% to avoid coupling to catalog ordering or count.
+    %% Tri-state contract: `scopes' is always present; `null' means
+    %% "not explicitly set, fall back to role default". The response
+    %% deliberately does NOT project the expanded effective list; that
+    %% would let a dashboard read-modify-write silently sediment the
+    %% role default into an explicit scope list.
+    ?assertEqual(null, maps:get(<<"scopes">>, Resp)),
+    %% Role-default expansion still happens at the authorization layer;
+    %% verify it directly via the internal API.
+    EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(<<"no_scopes">>),
     CommonNames = [N || #{name := N} <- emqx_scope_catalog:common_scope_catalog()],
     LoginOnlyNames = [N || #{name := N} <- emqx_scope_catalog:admin_only_scope_catalog()],
     lists:foreach(
-        fun(N) -> ?assert(lists:member(N, ScopesOut)) end,
+        fun(N) -> ?assert(lists:member(N, EffectiveScopes)) end,
         CommonNames ++ LoginOnlyNames
     ),
-    ?assertEqual(length(CommonNames) + length(LoginOnlyNames), length(ScopesOut)).
+    ?assertEqual(length(CommonNames) + length(LoginOnlyNames), length(EffectiveScopes)).
 
 %% Viewer default = common scopes only (no login-only).
 %% Viewer default = the common scopes, no login-only ones.
@@ -176,12 +180,14 @@ t_post_users_response_viewer_default_scopes(_Config) ->
         post, api_path(["users"]), auth_header(Token), Body
     ),
     Resp = emqx_utils_json:decode(RespBody),
-    ScopesOut = maps:get(<<"scopes">>, Resp),
-    ?assert(is_list(ScopesOut)),
+    %% Same tri-state contract — viewer with no explicit scopes also surfaces `null'.
+    ?assertEqual(null, maps:get(<<"scopes">>, Resp)),
+    %% Role-default expansion verified via the internal API.
+    EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(<<"viewer_no_scopes">>),
     CommonNames = [N || #{name := N} <- emqx_scope_catalog:common_scope_catalog()],
-    ?assertEqual(length(CommonNames), length(ScopesOut)),
-    ?assertNot(lists:member(?SCOPE_USER_MGMT, ScopesOut)),
-    ?assertNot(lists:member(?SCOPE_MFA_MGMT, ScopesOut)).
+    ?assertEqual(length(CommonNames), length(EffectiveScopes)),
+    ?assertNot(lists:member(?SCOPE_USER_MGMT, EffectiveScopes)),
+    ?assertNot(lists:member(?SCOPE_MFA_MGMT, EffectiveScopes)).
 
 %% Response from PUT /users/:name must reflect the updated scopes.
 t_put_users_response_includes_updated_scopes(_Config) ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -48,8 +48,18 @@
     end
 ).
 
-all() ->
-    ?EE_ONLY(emqx_common_test_helpers:all(?MODULE), []).
+%% The dashboard's default admin user (created by `do_add_default_user'
+%% at boot) used to land in the legacy "no scopes key" state, which
+%% would surface in API responses as the `<<"unset">>' sentinel.
+%% C3 seeds the administrator role default at row insertion time so a
+%% fresh default-admin is indistinguishable from one created via a POST
+%% that omits the `scopes' field.
+t_default_admin_seeded_with_role_default_scopes(_Config) ->
+    Username = emqx_dashboard_admin:default_username(),
+    ?assertEqual(
+        ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES,
+        emqx_dashboard_admin:scopes_of(Username)
+    ).
 
 init_per_suite(Config) ->
     ?EE_ONLY(

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
@@ -93,10 +93,12 @@ init_users() ->
 %% role default at insertion time, so a fresh SSO user is
 %% indistinguishable from one that listed its scopes explicitly.
 t_add_sso_user_seeds_role_default_scopes({init, Config}) ->
-    init_users(),
     Config;
 t_add_sso_user_seeds_role_default_scopes({'end', _Config}) ->
-    mnesia:clear_table(?ADMIN),
+    %% Do not clear the admin table here: init_users/0 is invoked once
+    %% from init_per_suite and shared with every other testcase. Clearing
+    %% it would leave subsequent cases without an SSO row to look up
+    %% (manifesting as `username_not_found' on set_mfa_state).
     ok;
 t_add_sso_user_seeds_role_default_scopes(_Config) ->
     SsoUser1 = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
 -include("../../emqx_dashboard/include/emqx_dashboard.hrl").
 
 -define(HOST, "http://127.0.0.1:18083").
@@ -78,6 +79,36 @@ init_users() ->
     %% Create SSO users directly via add_sso_user
     {ok, _} = emqx_dashboard_admin:add_sso_user(?SSO_BACKEND, ?SSO_USER, ?ROLE_VIEWER, <<>>),
     {ok, _} = emqx_dashboard_admin:add_sso_user(?SSO_BACKEND, ?SSO_USER2, ?ROLE_VIEWER, <<>>),
+    ok.
+
+%%====================================================================
+%% Regression: SSO auto-provisioning seeds role-default scopes
+%%====================================================================
+
+%% SSO `ensure_user_exists' callers (LDAP, OIDC, SAML) call
+%% `add_sso_user/4' once per first-login and never run a follow-up
+%% `set_user_scopes' step. Before C3 a fresh SSO row would land in the
+%% legacy "no scopes key" state, surfacing in API responses as the
+%% `<<"unset">>' sentinel. After C3 the row is seeded with the viewer
+%% role default at insertion time, so a fresh SSO user is
+%% indistinguishable from one that listed its scopes explicitly.
+t_add_sso_user_seeds_role_default_scopes({init, Config}) ->
+    init_users(),
+    Config;
+t_add_sso_user_seeds_role_default_scopes({'end', _Config}) ->
+    mnesia:clear_table(?ADMIN),
+    ok;
+t_add_sso_user_seeds_role_default_scopes(_Config) ->
+    SsoUser1 = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    ?assertEqual(
+        ?GENERIC_SCOPES,
+        emqx_dashboard_admin:scopes_of(SsoUser1)
+    ),
+    SsoUser2 = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER2),
+    ?assertEqual(
+        ?GENERIC_SCOPES,
+        emqx_dashboard_admin:scopes_of(SsoUser2)
+    ),
     ok.
 
 %%====================================================================

--- a/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
@@ -50,7 +50,7 @@ schema("/api_key") ->
             tags => ?TAGS,
             security => [#{'bearerAuth' => []}],
             responses => #{
-                200 => delete([api_secret], fields(app))
+                200 => delete([api_secret], fields(app_response))
             }
         },
         post => #{
@@ -59,7 +59,7 @@ schema("/api_key") ->
             security => [#{'bearerAuth' => []}],
             'requestBody' => delete([created_at, api_key, api_secret], fields(app)),
             responses => #{
-                200 => hoconsc:ref(app),
+                200 => hoconsc:ref(app_response),
                 400 => emqx_dashboard_swagger:error_codes(['BAD_REQUEST'])
             }
         }
@@ -72,7 +72,7 @@ schema("/api_key/:name") ->
             tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             responses => #{
-                200 => delete([api_secret], fields(app)),
+                200 => delete([api_secret], fields(app_response)),
                 404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'])
             }
         },
@@ -82,7 +82,7 @@ schema("/api_key/:name") ->
             parameters => [hoconsc:ref(name)],
             'requestBody' => delete([created_at, api_key, api_secret, name], fields(app)),
             responses => #{
-                200 => delete([api_secret], fields(app)),
+                200 => delete([api_secret], fields(app_response)),
                 404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'])
             }
         },
@@ -177,7 +177,91 @@ fields(app) ->
             hoconsc:mk(
                 hoconsc:array(binary()),
                 #{
-                    desc => ?DESC(api_key_scopes),
+                    desc => ?DESC(api_key_scopes_request),
+                    required => false,
+                    example => [<<"clients">>, <<"rules">>]
+                }
+            )}
+    ] ++ app_extend_fields();
+%% Response shape: `scopes' MAY be the binary sentinel <<"unset">> in addition
+%% to the array-of-binaries form. This sentinel surfaces only for legacy
+%% records that survived an upgrade from a release where the scopes feature
+%% did not exist; the POST / bootstrap / SSO-provisioning paths all
+%% materialize role-default scopes at creation time, so no fresh record will
+%% ever appear with `scopes => <<"unset">>'.
+%%
+%% Listed explicitly (rather than overriding via `lists:keystore') so that the
+%% OpenAPI spec reads as a self-contained response schema and reviewers do not
+%% have to mentally diff `fields(app)' against `fields(app_response)'.
+fields(app_response) ->
+    [
+        {name,
+            hoconsc:mk(
+                binary(),
+                #{
+                    desc => "Unique and format by [a-zA-Z0-9-_]",
+                    validator => fun ?MODULE:validate_name/1,
+                    example => <<"EMQX-API-KEY-1">>
+                }
+            )},
+        {api_key,
+            hoconsc:mk(
+                binary(),
+                #{
+                    desc => "" "TODO:uses HMAC-SHA256 for signing." "",
+                    example => <<"a4697a5c75a769f6">>
+                }
+            )},
+        {api_secret,
+            hoconsc:mk(
+                binary(),
+                #{
+                    desc =>
+                        ""
+                        "An API secret is a simple encrypted string that identifies"
+                        ""
+                        ""
+                        "an application without any principal."
+                        ""
+                        ""
+                        "They are useful for accessing public data anonymously,"
+                        ""
+                        ""
+                        "and are used to associate API requests."
+                        "",
+                    example => <<"MzAyMjk3ODMwMDk0NjIzOTUxNjcwNzQ0NzQ3MTE2NDYyMDI">>
+                }
+            )},
+        {expired_at,
+            hoconsc:mk(
+                hoconsc:union([infinity, emqx_utils_calendar:epoch_second()]),
+                #{
+                    desc => "No longer valid datetime",
+                    example => <<"2021-12-05T02:01:34.186Z">>,
+                    required => false,
+                    default => infinity
+                }
+            )},
+        {created_at,
+            hoconsc:mk(
+                emqx_utils_calendar:epoch_second(),
+                #{
+                    desc => "ApiKey create datetime",
+                    example => <<"2021-12-01T00:00:00.000Z">>
+                }
+            )},
+        {desc,
+            hoconsc:mk(
+                binary(),
+                #{example => <<"Note">>, required => false}
+            )},
+        {enable, hoconsc:mk(boolean(), #{desc => "Enable/Disable", required => false})},
+        {expired, hoconsc:mk(boolean(), #{desc => "Expired", required => false})},
+        {scopes,
+            hoconsc:mk(
+                hoconsc:union([unset, hoconsc:array(binary())]),
+                #{
+                    desc => ?DESC(api_key_scopes_response),
                     required => false,
                     example => [<<"clients">>, <<"rules">>]
                 }
@@ -257,7 +341,12 @@ api_key(post, #{body := App}) ->
     ExpiredAt = ensure_expired_at(App),
     Desc = unicode:characters_to_binary(Desc0, unicode),
     Role = maps:get(<<"role">>, App, ?ROLE_API_DEFAULT),
-    Scopes = maps:get(<<"scopes">>, App, undefined),
+    %% Materialize role defaults when the client omitted `scopes' entirely.
+    %% Explicit `[]' (deny-all) and explicit lists pass through unchanged.
+    %% After this PR `<<"unset">>' in a GET response is reserved for legacy
+    %% records that survived an upgrade; no creation path stores `undefined'.
+    RawScopes = maps:get(<<"scopes">>, App, undefined),
+    Scopes = emqx_mgmt_auth:effective_scopes_on_create(Role, RawScopes),
     case validate_scopes(Role, Scopes) of
         ok ->
             case emqx_mgmt_auth:create(Name, Enable, ExpiredAt, Desc, Role, Scopes) of

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -352,10 +352,18 @@ to_map(#?APP{
     },
     maybe_add_scopes(Base, Extra).
 
+%% @doc Surface raw scope state to the API consumer with a tri-state contract:
+%%   - `[]`            : explicit deny-all (only `security => []` paths reachable)
+%%   - `[binary(), …]` : explicit allow-list
+%%   - `null`          : not set; authorization falls back to role default (allow-all
+%%                       for administrator/viewer, hard-coded `/publish*` for publisher)
+%% This intentionally exposes the persisted shape rather than an effective list so
+%% that the dashboard read-modify-write cycle cannot silently sediment role-default
+%% into an explicit list.
 maybe_add_scopes(Map, #{scopes := Scopes}) when is_list(Scopes) ->
     Map#{scopes => Scopes};
 maybe_add_scopes(Map, _) ->
-    Map.
+    Map#{scopes => null}.
 
 is_expired(undefined) -> false;
 is_expired(ExpiredTime) -> ExpiredTime < erlang:system_time(second).

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -42,6 +42,12 @@
     do_force_create_app/1
 ]).
 
+%% Helpers for materializing role-default scopes at record-creation time.
+%% Used by the POST handler, the bootstrap-file loader, and the SSO
+%% user-provisioning path so that `<<"unset">>' in a GET response can be
+%% interpreted unambiguously as "record predates the scopes feature".
+-export([role_default_scopes/1, effective_scopes_on_create/2]).
+
 -ifdef(TEST).
 -export([create/8]).
 -export([trans/2, force_create_app/1]).
@@ -331,6 +337,35 @@ maybe_set_scopes(Extra, undefined) ->
 maybe_set_scopes(Extra, Scopes) when is_list(Scopes) ->
     Extra#{scopes => Scopes}.
 
+%% @doc Resolve the role-default scopes that should be materialized into
+%% the persisted record when the caller did not explicitly supply a scope
+%% list (POST without `scopes', 2-/3-segment bootstrap line).
+%%
+%% After this PR, `undefined' is never written into mnesia by any creation
+%% path; the `<<"unset">>' state in the GET response is only possible for
+%% records that survived an upgrade from a release where the scopes
+%% feature did not exist.
+%%
+%%   * administrator / viewer -> `?GENERIC_SCOPES' (10 management scopes,
+%%     no login-only scopes — those are reserved for dashboard users).
+%%   * publisher              -> `[<<"publish">>]' (the only scope the
+%%     publisher role is ever permitted to hold; runtime RBAC also
+%%     hard-restricts publisher to `/publish*' regardless of the stored
+%%     scope list).
+role_default_scopes(?ROLE_API_PUBLISHER) ->
+    [?SCOPE_PUBLISH];
+role_default_scopes(_Role) ->
+    ?GENERIC_SCOPES.
+
+%% @doc Convenience wrapper for the request-handling layer: if the
+%% caller supplied no scopes, materialize the role default; otherwise
+%% pass the explicit value through unchanged (including the empty list
+%% which means explicit deny-all).
+effective_scopes_on_create(Role, undefined) ->
+    role_default_scopes(Role);
+effective_scopes_on_create(_Role, Scopes) when is_list(Scopes) ->
+    Scopes.
+
 ensure_not_undefined(undefined, Old) -> Old;
 ensure_not_undefined(New, _Old) -> New.
 
@@ -355,15 +390,23 @@ to_map(#?APP{
 %% @doc Surface raw scope state to the API consumer with a tri-state contract:
 %%   - `[]`            : explicit deny-all (only `security => []` paths reachable)
 %%   - `[binary(), …]` : explicit allow-list
-%%   - `null`          : not set; authorization falls back to role default (allow-all
-%%                       for administrator/viewer, hard-coded `/publish*` for publisher)
+%%   - `<<"unset">>`   : the persisted record has no `scopes' field at all (legacy
+%%                       upgrade artefact from before #16942 landed). The runtime
+%%                       authorization path falls back to role-default behaviour
+%%                       (allow-all-mapped-paths for administrator/viewer,
+%%                       hard-coded `/publish*' for publisher).  Newly created
+%%                       records never end up in this state: the POST / bootstrap
+%%                       / SSO-provisioning paths all materialize role-default
+%%                       scopes at creation time.
 %% This intentionally exposes the persisted shape rather than an effective list so
 %% that the dashboard read-modify-write cycle cannot silently sediment role-default
-%% into an explicit list.
+%% into an explicit list.  The `<<"unset">>' binary is a stable string sentinel
+%% (not JSON `null') so the consumer cannot confuse it with `field missing' or
+%% `field cleared' — both of which can happen in HTTP/JSON intermediaries.
 maybe_add_scopes(Map, #{scopes := Scopes}) when is_list(Scopes) ->
     Map#{scopes => Scopes};
 maybe_add_scopes(Map, _) ->
-    Map#{scopes => null}.
+    Map#{scopes => <<"unset">>}.
 
 is_expired(undefined) -> false;
 is_expired(ExpiredTime) -> ExpiredTime < erlang:system_time(second).

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -615,11 +615,18 @@ read_line(Dev) ->
 parse_bootstrap_line(Bin, MP) ->
     case re:run(Bin, MP, [global, {capture, all_but_first, binary}]) of
         {match, [[ApiKey, ApiSecret]]} ->
-            {ok, {ApiKey, ApiSecret, ?ROLE_API_DEFAULT, undefined, []}};
+            %% 2-segment `key:secret' lines have no scope column. Materialise
+            %% the role default at parse time so the persisted record is on
+            %% the same footing as a POST that omitted `scopes': only legacy
+            %% records that survived an upgrade can produce `<<"unset">>'.
+            Role = ?ROLE_API_DEFAULT,
+            {ok, {ApiKey, ApiSecret, Role, role_default_scopes(Role), []}};
         {match, [[ApiKey, ApiSecret, Role]]} ->
             case valid_role(Role) of
                 ok ->
-                    {ok, {ApiKey, ApiSecret, Role, undefined, []}};
+                    %% 3-segment `key:secret:role' lines: same rationale as
+                    %% the 2-segment case.
+                    {ok, {ApiKey, ApiSecret, Role, role_default_scopes(Role), []}};
                 _Error ->
                     {error, {"invalid_role", Role}}
             end;

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -70,6 +70,8 @@ groups() ->
             t_bootstrap_file_lenient_order_independence,
             t_bootstrap_file_scope_runtime_check,
             t_bootstrap_file_publisher_only_publish_scope,
+            t_bootstrap_file_2_segment_seeds_default_scopes,
+            t_bootstrap_file_3_segment_publisher_seeds_publish_scope,
             t_create_failed
         ]}
     ].
@@ -381,6 +383,12 @@ read_bootstrap_scopes(ApiKey) ->
             not_found;
         {value, #{scopes := Scopes}} when is_list(Scopes) ->
             Scopes;
+        {value, #{scopes := <<"unset">>}} ->
+            %% Legacy upgrade artefact - extra map has no `scopes' key.
+            %% Fresh records (any segment count) materialise role-default
+            %% scopes at parse time, so this branch is only reachable in
+            %% upgrade scenarios.
+            unset;
         {value, _AppMap} ->
             not_set
     end.
@@ -410,8 +418,10 @@ t_bootstrap_file_with_scopes(_) ->
         [?SCOPE_CONNECTIONS, ?SCOPE_PUBLISH, ?SCOPE_MONITORING],
         read_bootstrap_scopes(<<"scope-multi">>)
     ),
-    %% 3-segment line: extra has no `scopes` key → backward-compatible all-allow.
-    ?assertEqual(not_set, read_bootstrap_scopes(<<"scope-no-field">>)),
+    %% 3-segment line: parser materialises role-default scopes (administrator
+    %% → GENERIC_SCOPES). The persisted extra map now carries an explicit
+    %% scope list, never the `<<"unset">>' sentinel.
+    ?assertEqual(?GENERIC_SCOPES, read_bootstrap_scopes(<<"scope-no-field">>)),
     ok.
 
 t_bootstrap_file_with_scopes_invalid(_) ->
@@ -803,6 +813,38 @@ t_bootstrap_file_publisher_only_publish_scope(_) ->
     ?assertEqual(
         [?SCOPE_CONNECTIONS, ?SCOPE_PUBLISH, ?SCOPE_MONITORING],
         read_bootstrap_scopes(<<"from_bootstrap_file_admin_full">>)
+    ),
+    ok.
+
+%% 2-segment `key:secret' bootstrap lines have no role and no scope column.
+%% The parser defaults the role to `?ROLE_API_DEFAULT' (administrator) and
+%% materialises that role's default scope list at parse time. The persisted
+%% record carries an explicit scope list — never the legacy `<<"unset">>'
+%% sentinel — so a fresh `key:secret' bootstrap key behaves identically to
+%% a POST that omits the `scopes' field.
+t_bootstrap_file_2_segment_seeds_default_scopes(_) ->
+    File = "./bootstrap_api_keys.txt",
+    Bin = <<"from_bootstrap_file_2seg:secret-2seg\n">>,
+    ok = file:write_file(File, Bin),
+    update_file(File),
+    ?assertEqual(
+        ?GENERIC_SCOPES,
+        read_bootstrap_scopes(<<"from_bootstrap_file_2seg">>)
+    ),
+    ok.
+
+%% 3-segment `key:secret:publisher' lines materialise the publisher
+%% role default — a single `publish' scope — so the record can be served
+%% via the management API without falling back to the `<<"unset">>'
+%% sentinel and without exposing the publisher to non-publish endpoints.
+t_bootstrap_file_3_segment_publisher_seeds_publish_scope(_) ->
+    File = "./bootstrap_api_keys.txt",
+    Bin = <<"from_bootstrap_file_3seg_pub:secret-3seg:publisher\n">>,
+    ok = file:write_file(File, Bin),
+    update_file(File),
+    ?assertEqual(
+        [?SCOPE_PUBLISH],
+        read_bootstrap_scopes(<<"from_bootstrap_file_3seg_pub">>)
     ),
     ok.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -487,7 +487,9 @@ t_api_create_with_scopes(_Config) ->
 t_api_update_scopes(_Config) ->
     Name = <<"SCOPES-API-UPDATE">>,
     {ok, Created} = create_app(Name),
-    ?assertEqual(false, maps:is_key(<<"scopes">>, Created)),
+    %% Tri-state contract: response always carries `scopes' key; `null'
+    %% means "not set, fall back to role default".
+    ?assertEqual(null, maps:get(<<"scopes">>, Created)),
     %% Update with scopes
     {ok, Updated1} = update_app(Name, #{scopes => [?SCOPE_CONNECTIONS]}),
     ?assertMatch(#{<<"scopes">> := [?SCOPE_CONNECTIONS]}, Updated1),

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -52,7 +52,9 @@ groups() ->
         {api_tests, [parallel], [
             t_api_list_scopes,
             t_api_create_with_scopes,
-            t_api_update_scopes
+            t_api_update_scopes,
+            t_api_post_materialises_default_scopes,
+            t_api_legacy_record_shows_unset_sentinel
         ]}
     ].
 
@@ -487,10 +489,16 @@ t_api_create_with_scopes(_Config) ->
 t_api_update_scopes(_Config) ->
     Name = <<"SCOPES-API-UPDATE">>,
     {ok, Created} = create_app(Name),
-    %% Tri-state contract: response always carries `scopes' key; `null'
-    %% means "not set, fall back to role default".
-    ?assertEqual(null, maps:get(<<"scopes">>, Created)),
-    %% Update with scopes
+    %% POST without `scopes' now materialises the role-default scope list
+    %% (administrator -> the 10 common management scopes). The legacy
+    %% `<<"unset">>' sentinel is reserved for records that pre-date the
+    %% scopes feature and was thus upgraded without a scopes field.
+    DefaultAdminScopes = lists:sort(?GENERIC_SCOPES),
+    ?assertEqual(
+        DefaultAdminScopes,
+        lists:sort(maps:get(<<"scopes">>, Created))
+    ),
+    %% Update with scopes overwrites the materialised default.
     {ok, Updated1} = update_app(Name, #{scopes => [?SCOPE_CONNECTIONS]}),
     ?assertMatch(#{<<"scopes">> := [?SCOPE_CONNECTIONS]}, Updated1),
     %% Update to multiple scopes
@@ -499,9 +507,62 @@ t_api_update_scopes(_Config) ->
         lists:sort([?SCOPE_CONNECTIONS, ?SCOPE_PUBLISH]),
         lists:sort(maps:get(<<"scopes">>, Updated2))
     ),
-    %% Update to empty scopes
+    %% Update to empty scopes (explicit deny-all)
     {ok, Updated3} = update_app(Name, #{scopes => []}),
     ?assertMatch(#{<<"scopes">> := []}, Updated3),
+    delete_app(Name).
+
+%% POST without an explicit `scopes' field materialises the role-default
+%% scope list and persists it (it is not merely a response-time
+%% projection). This is what distinguishes a freshly-created key
+%% from a legacy upgraded one.
+t_api_post_materialises_default_scopes(_Config) ->
+    Name = <<"SCOPES-API-MATERIALISE">>,
+    {ok, Created} = create_app(Name),
+    %% Response carries the materialised admin defaults.
+    DefaultAdminScopes = lists:sort(?GENERIC_SCOPES),
+    ?assertEqual(
+        DefaultAdminScopes,
+        lists:sort(maps:get(<<"scopes">>, Created))
+    ),
+    %% Persisted state matches — `scopes' really is in the extra map,
+    %% not synthesised at response time. Read raw mnesia row directly.
+    [Record] = mnesia:dirty_read(emqx_app, Name),
+    %% Record is #emqx_app{name, api_key, api_secret_hash, enable, expired_at,
+    %%                    extra, created_at}. The `extra' field is at index 6
+    %% (1=record_name, 2=name, ...). We avoid hard-coding the index by using
+    %% emqx_mgmt_auth's normalisation helper via lookup.
+    {ok, MapForm} = emqx_mgmt_auth:read(Name),
+    %% to_map projects materialised scopes verbatim — no sentinel.
+    ?assertEqual(
+        DefaultAdminScopes,
+        lists:sort(maps:get(<<"scopes">>, MapForm))
+    ),
+    %% Defensive: also assert the raw extra map carries `scopes' (not
+    %% the absence of the key, which would have been the legacy state).
+    Extra = element(6, Record),
+    ?assert(is_map(Extra)),
+    ?assert(maps:is_key(scopes, Extra)),
+    delete_app(Name).
+
+%% Records created before the scopes feature shipped have no `scopes'
+%% key in their extra map. Such legacy records still need a sensible
+%% response — the contract is to surface the binary sentinel
+%% `<<"unset">>'. We simulate this by writing a record directly into
+%% mnesia with a stripped extra map.
+t_api_legacy_record_shows_unset_sentinel(_Config) ->
+    Name = <<"SCOPES-API-LEGACY">>,
+    %% First create a normal record via the API so we get a valid record
+    %% layout, then mutate its extra to remove the scopes key.
+    {ok, _} = create_app(Name),
+    [Record0] = mnesia:dirty_read(emqx_app, Name),
+    Extra0 = element(6, Record0),
+    ExtraNoScopes = maps:remove(scopes, Extra0),
+    Record1 = setelement(6, Record0, ExtraNoScopes),
+    ok = mnesia:dirty_write(emqx_app, Record1),
+    %% Now read it back through the API and verify the sentinel surfaces.
+    {ok, ReadBack} = read_app(Name),
+    ?assertEqual(<<"unset">>, maps:get(<<"scopes">>, ReadBack)),
     delete_app(Name).
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -534,9 +534,12 @@ t_api_post_materialises_default_scopes(_Config) ->
     %% emqx_mgmt_auth's normalisation helper via lookup.
     {ok, MapForm} = emqx_mgmt_auth:read(Name),
     %% to_map projects materialised scopes verbatim — no sentinel.
+    %% MapForm is the internal atom-keyed shape (read/1 returns the raw
+    %% to_map/1 projection, before the API layer converts keys to
+    %% binaries for the JSON response).
     ?assertEqual(
         DefaultAdminScopes,
-        lists:sort(maps:get(<<"scopes">>, MapForm))
+        lists:sort(maps:get(scopes, MapForm))
     ),
     %% Defensive: also assert the raw extra map carries `scopes' (not
     %% the absence of the key, which would have been the legacy state).

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -89,10 +89,17 @@ list_user_scopes_api.desc:
 
 Returned to any authenticated login user — the endpoint exists to populate the dashboard UI's scope selector and does not itself require a specific scope."""
 
-user_scopes.desc:
+user_scopes_request.desc:
 """Dashboard user scopes — a fine-grained access list applied on top of role.
 
-When the field is absent, the user falls back to role-based access. An empty list denies all paths mapped to a known scope (unmapped paths still allowed).
+When omitted on creation, the server materializes the role default — administrator gets all management scopes plus the four login-only scopes; viewer gets all management scopes; publisher (where applicable) gets the `publish` scope only. Send an explicit empty list `[]` to create a deny-all user (only anonymous endpoints such as `/status` remain reachable).
+
+Login users may hold any of the API key catalog scopes plus the four login-only scopes: `user_management`, `mfa_management`, `sso_management`, `api_key_management`. Of these four, three are administrator-only (`user_management`, `sso_management`, `api_key_management`); `mfa_management` may also be assigned to non-administrator users — for non-admin holders it acts as a self-exemption key allowing the user to bypass force_mfa and admin_required locks on their own MFA only."""
+
+user_scopes_response.desc:
+"""Dashboard user scopes — a fine-grained access list applied on top of role.
+
+The literal string `unset` is a legacy-only sentinel surfaced for records that survived an upgrade from a release where the dashboard-user scopes feature did not exist; the runtime falls back to role default for such records and a client should treat them as "no explicit scope policy yet". An empty list `[]` means deny-all (only anonymous endpoints such as `/status` remain reachable).
 
 Login users may hold any of the API key catalog scopes plus the four login-only scopes: `user_management`, `mfa_management`, `sso_management`, `api_key_management`. Of these four, three are administrator-only (`user_management`, `sso_management`, `api_key_management`); `mfa_management` may also be assigned to non-administrator users — for non-admin holders it acts as a self-exemption key allowing the user to bypass force_mfa and admin_required locks on their own MFA only."""
 

--- a/rel/i18n/emqx_mgmt_api_api_keys.hocon
+++ b/rel/i18n/emqx_mgmt_api_api_keys.hocon
@@ -38,10 +38,15 @@ api_key_scopes_list.desc:
 api_key_scopes_list.label:
 """List API key scopes"""
 
-api_key_scopes.desc:
-"""List of scope names to restrict this API key's access. Each scope is a stable functional category (e.g., connections, publish, monitoring). If not set or undefined, the key has access to all APIs. An empty list means no API access."""
-api_key_scopes.label:
-"""API key scopes"""
+api_key_scopes_request.desc:
+"""List of scope names to grant this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). When omitted on creation, the server materializes the role default — administrator/viewer get all management scopes, publisher gets `publish` only. Send an explicit empty list `[]` to create a deny-all key (only anonymous endpoints such as `/status` remain reachable)."""
+api_key_scopes_request.label:
+"""API key scopes (request)"""
+
+api_key_scopes_response.desc:
+"""List of scope names granted to this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). The literal string `unset` is a legacy-only sentinel surfaced for records that survived an upgrade from a release where the scopes feature did not exist; the runtime falls back to role default for such records and a client should treat them as "no explicit scope policy yet". An empty list `[]` means deny-all (only anonymous endpoints such as `/status` remain reachable)."""
+api_key_scopes_response.label:
+"""API key scopes (response)"""
 
 scope_info_name.desc:
 """Scope name — a stable identifier for a functional category of API endpoints."""


### PR DESCRIPTION
Release version: 5.10.4

## Summary

Two unreleased features on `release-510` chose **inconsistent** ways
to project the `scopes` field in their GET response:

- API key scopes (#16942) — omitted the field whenever no explicit
  scopes were set, even though `extra` had no `scopes` key.
- Dashboard user scopes (#17235) — always expanded the role default
  into a concrete 10-or-14-item list whenever no explicit scopes
  were set.

Both behaviours surface the same persisted shape (`extra` with or
without a `scopes` key, or with `scopes => []` / `scopes => [list]`)
but project it differently, which means:

1. The frontend has to special-case two different shapes for the
   same UX concept.
2. The user form's read-modify-write cycle silently sediments role
   default into an explicit list: read the user → form prefills with
   the 10 or 14 effective scopes → save the form unchanged → the
   user is now pinned to that list and will no longer track future
   role-default evolution.

This PR aligns both responses on a single tri-state contract and
makes the "no scopes" state observable only for genuine legacy
upgrade artefacts.

### Tri-state contract

| persisted state              | response `scopes`     |
|------------------------------|-----------------------|
| `extra` has no `scopes` key  | `<<"unset">>` (string)|
| `extra => #{scopes => []}`   | `[]`                  |
| `extra => #{scopes => List}` | `List`                |

The `<<"unset">>` literal is reserved for **records persisted before
#16942 / #17235 landed** that survive an upgrade without ever being
touched by POST, PUT, bootstrap, SSO provisioning, or default-admin
first-boot. Fresh records always carry an explicit `scopes` list.

### Why `<<"unset">>` instead of `null`

`null` is too overloaded in JSON ("missing", "explicitly cleared",
"unknown") and is awkward in dashboard frontends that strictly type
`scopes` as `string[]`. A dedicated string sentinel is unambiguous
and easy to surface to operators (e.g. "this record predates the
scopes feature — review and assign explicit scopes").

The unified response shape `[]` / `["scope", ...]` / `"unset"` is
declared by a dedicated `fields(app_response)` schema for API keys
and a `field(scopes_response)` callback for dashboard users so the
OpenAPI spec accurately reflects the runtime shape (request bodies
still require a plain `array(binary())`, not a union).

### How fresh records avoid `<<"unset">>`

Each creation path materialises role-default scopes at insertion
time so the persisted record is always self-contained:

- **API key POST** (`/api_key`) — `effective_scopes_on_create/2`
  expands `undefined` to `role_default_scopes(Role)`:
    - administrator / viewer → `?GENERIC_SCOPES` (10 management
      scopes, no login-only)
    - publisher → `[<<"publish">>]`
- **Dashboard user POST** (`/users`) — same expansion:
    - administrator → `?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES` (14)
    - viewer → `?GENERIC_SCOPES` (10)
- **Bootstrap loader** — 2-segment (`key:secret`) and 3-segment
  (`key:secret:role`) lines now seed role-default scopes. The
  4-segment form is unchanged.
- **SSO provisioning** — `add_sso_user/4` (called by every SSO
  backend's `ensure_user_exists`) seeds `role_default_scopes(?ROLE_VIEWER)`
  at insertion time. No follow-up call needed.
- **Default admin first-boot** — `do_add_default_user/2` seeds the
  14-scope admin default.

PUT semantics are unchanged: omitted `scopes` still preserves the
persisted state (partial update), explicit `[]` still means deny-all,
explicit list still overwrites.

### Authorization is unchanged

`emqx_mgmt_auth:check_scopes/2` and
`emqx_dashboard_admin:effective_scopes_of_admin/1` still treat a
missing `scopes` key as "role default". The role-default expansion
that previously happened at projection time now happens at insertion
time, so by the time RBAC reads the row there is nothing left to
expand. Same effective decision, different point in the pipeline.

## Commits

- `d43a0f7d21` `fix(scopes): unify API key and dashboard user scope response as tri-state contract`
- `009c4169b0` `fix(scopes): materialise role-default scopes on creation and adopt "unset" sentinel`
- `f287a90944` `fix(scopes): seed role-default scopes for bootstrap, SSO, and default admin`

## Tests

Recompiled all four sources plus four CT SUITEs against OTP 27.
Notable additions:

  - `t_api_post_materialises_default_scopes` /
    `t_post_users_materialises_default_scopes` — verify the mnesia
    row actually carries the seeded list (not just the response).
  - `t_api_legacy_record_shows_unset_sentinel` /
    `t_legacy_record_shows_unset_sentinel` — manually delete the
    `scopes` key from a freshly created row and confirm the
    `<<"unset">>` sentinel is still reachable.
  - `t_bootstrap_file_2_segment_seeds_default_scopes` /
    `t_bootstrap_file_3_segment_publisher_seeds_publish_scope` —
    cover the two new bootstrap paths.
  - `t_default_admin_seeded_with_role_default_scopes` — first-boot
    admin gets the 14-scope admin default.
  - `t_add_sso_user_seeds_role_default_scopes` — fresh SSO viewer
    gets the 10-scope viewer default.

## Frontend impact

The response shape change is documented in
`FRONTEND-scope-changes.md` in the task tree; the frontend PR will
land in `emqx-dashboard5`.

## Why no changelog and no app vsn bump

Both #16942 (API key scopes) and #17235 (dashboard user scopes)
landed on `release-510` after `5.10.3` shipped, so they are not in
any stable release yet. Aligning their response contracts **during**
the same release development cycle, before any stable build exposes
the asymmetry to end users, doesn't require a changelog (the parent
PRs' changelogs cover the user-facing surface) and doesn't require
an app vsn bump (`scripts/apps-version-check.sh` only checks against
the previous release tag, and `emqx_management` / `emqx_dashboard`
were already bumped in the parent PRs).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log: N/A — intra-release-cycle alignment of two
      unreleased features; parent PRs' changelogs cover the
      user-facing surface.
- [x] Schema changes are backward compatible or intentionally
      breaking (intentionally breaks the response shape of two
      unreleased features only; described above).
