### PR TITLE
feat(dashboard): require authentication for OpenAPI spec endpoints

### DIFF
--- a/apps/emqx_dashboard/priv/api-spec.html
+++ b/apps/emqx_dashboard/priv/api-spec.html
@@ -903,6 +903,72 @@
       border-color: var(--color-primary);
     }
 
+    .auth-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.55);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 50;
+    }
+
+    .auth-overlay.is-open {
+      display: flex;
+    }
+
+    .auth-dialog {
+      background: var(--color-bg-content);
+      border: 1px solid var(--color-border-primary);
+      border-radius: var(--radius-sm);
+      padding: 20px;
+      width: min(380px, calc(100vw - 32px));
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
+    }
+
+    .auth-dialog h3 {
+      margin: 0 0 6px 0;
+      font-size: 16px;
+    }
+
+    .auth-dialog p {
+      margin: 0 0 14px 0;
+      font-size: 12px;
+      color: var(--color-text-secondary);
+    }
+
+    .auth-dialog label {
+      display: block;
+      font-size: 12px;
+      color: var(--color-text-secondary);
+      margin-bottom: 4px;
+    }
+
+    .auth-dialog input {
+      width: 100%;
+      padding: 8px 10px;
+      margin-bottom: 12px;
+      border: 1px solid var(--color-border-primary);
+      border-radius: var(--radius-sm);
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--color-text-primary);
+      font-size: 13px;
+      box-sizing: border-box;
+    }
+
+    .auth-dialog .auth-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+
+    .auth-dialog .auth-error {
+      color: #ffc9c9;
+      font-size: 12px;
+      margin-bottom: 10px;
+      min-height: 14px;
+    }
+
     @media (max-width: 1100px) {
       .layout {
         grid-template-columns: 1fr;
@@ -972,11 +1038,27 @@
         </div>
       </div>
       <div class="actions">
+        <button class="btn" id="btn-logout" title="Sign out of the API spec session" hidden>Sign out</button>
         <button class="btn" id="btn-theme" title="Toggle light/dark theme">Dark</button>
         <span class="pill" id="scope-pill">Scope: index</span>
         <span class="status"><span class="dot"></span><span id="status-text">Ready</span></span>
       </div>
     </header>
+
+    <div class="auth-overlay" id="auth-overlay" role="dialog" aria-modal="true" aria-labelledby="auth-title">
+      <form class="auth-dialog" id="auth-form" autocomplete="off">
+        <h3 id="auth-title">Sign in to view the spec</h3>
+        <p id="auth-hint">Use your dashboard username and password. Credentials are scoped to this browser session.</p>
+        <div class="auth-error" id="auth-error"></div>
+        <label for="auth-username">Username</label>
+        <input id="auth-username" name="username" type="text" autocomplete="username" required />
+        <label for="auth-password">Password</label>
+        <input id="auth-password" name="password" type="password" autocomplete="current-password" required />
+        <div class="auth-actions">
+          <button type="submit" class="btn btn-primary" id="auth-submit">Sign in</button>
+        </div>
+      </form>
+    </div>
 
     <div class="layout">
       <aside class="sidebar">
@@ -1042,7 +1124,19 @@
       btnReload: document.getElementById('btn-reload'),
       btnCopyUrl: document.getElementById('btn-copy-url'),
       btnTheme: document.getElementById('btn-theme'),
+      btnLogout: document.getElementById('btn-logout'),
+      authOverlay: document.getElementById('auth-overlay'),
+      authForm: document.getElementById('auth-form'),
+      authUsername: document.getElementById('auth-username'),
+      authPassword: document.getElementById('auth-password'),
+      authError: document.getElementById('auth-error'),
+      authHint: document.getElementById('auth-hint'),
+      authSubmit: document.getElementById('auth-submit'),
     };
+
+    let signedInUsername = '';
+    let sessionToken = '';
+    let pendingAuthAction = null;
 
     init();
 
@@ -1092,6 +1186,99 @@
         const next = current === 'dark' ? 'light' : 'dark';
         setTheme(next);
       });
+
+      els.authForm.addEventListener('submit', onAuthSubmit);
+      els.btnLogout.addEventListener('click', onLogout);
+    }
+
+    function openAuthDialog(retry) {
+      pendingAuthAction = retry || null;
+      els.authError.textContent = '';
+      els.authOverlay.classList.add('is-open');
+      els.authPassword.value = '';
+      setTimeout(() => els.authUsername.focus(), 0);
+    }
+
+    function closeAuthDialog() {
+      els.authOverlay.classList.remove('is-open');
+    }
+
+    async function onAuthSubmit(e) {
+      e.preventDefault();
+      const username = els.authUsername.value.trim();
+      const password = els.authPassword.value;
+      if (!username || !password) return;
+      els.authError.textContent = '';
+      els.authSubmit.disabled = true;
+      try {
+        const res = await fetch('/api/v5/login', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify({ username, password }),
+        });
+        let body = null;
+        try { body = await res.json(); } catch (_err) { body = null; }
+        if (!res.ok) {
+          let msg = `Sign-in failed (HTTP ${res.status}).`;
+          if (body && body.message) msg = body.message;
+          els.authError.textContent = msg;
+          return;
+        }
+        if (!body || !body.token) {
+          els.authError.textContent = 'Sign-in succeeded but no token was returned.';
+          return;
+        }
+        signedInUsername = username;
+        sessionToken = body.token;
+        setSessionCookie(body.token);
+        els.btnLogout.hidden = false;
+        closeAuthDialog();
+        const retry = pendingAuthAction;
+        pendingAuthAction = null;
+        if (retry) {
+          retry();
+        } else {
+          loadIndex();
+        }
+      } catch (err) {
+        els.authError.textContent = String(err.message || err);
+      } finally {
+        els.authSubmit.disabled = false;
+      }
+    }
+
+    async function onLogout() {
+      try {
+        await fetch('/api/v5/logout', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer ' + sessionToken,
+          },
+          body: JSON.stringify({ username: signedInUsername }),
+        });
+      } catch (_err) {
+        // Even if the call fails, fall through and prompt for credentials again.
+      }
+      clearSessionCookie();
+      signedInUsername = '';
+      sessionToken = '';
+      els.btnLogout.hidden = true;
+      state.indexData = null;
+      state.specData = null;
+      openAuthDialog(() => loadIndex());
+    }
+
+    function setSessionCookie(token) {
+      const secure = location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie = `emqx_auth=${encodeURIComponent(token)}; Path=/; SameSite=Strict${secure}`;
+    }
+
+    function clearSessionCookie() {
+      const secure = location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie = `emqx_auth=; Path=/; Max-Age=0; SameSite=Strict${secure}`;
     }
 
     function initTheme() {
@@ -1162,7 +1349,27 @@
     }
 
     async function fetchJson(url) {
-      const res = await fetch(url, { headers: { Accept: 'application/json' } });
+      const res = await fetch(url, {
+        credentials: 'same-origin',
+        headers: { Accept: 'application/json' },
+      });
+      if (res.status === 401) {
+        let hint = 'Authentication required. Sign in to view the spec.';
+        try {
+          const body = await res.json();
+          const desc = body && body.info && body.info.description;
+          if (desc) hint = desc;
+        } catch (_err) {
+          // fall through with the default hint
+        }
+        els.authHint.textContent = hint;
+        signedInUsername = '';
+        els.btnLogout.hidden = true;
+        openAuthDialog(null);
+        const err = new Error(hint);
+        err.status = 401;
+        throw err;
+      }
       if (!res.ok) {
         let body = '';
         try {

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -414,21 +414,20 @@ static_dispatch(SwaggerSupport) ->
         maybe_swagger_dispatch(SwaggerSupport).
 
 maybe_swagger_dispatch(true) ->
-    [
-        {"/api-spec.html", cowboy_static, {priv_file, emqx_dashboard, "api-spec.html"}}
-        | api_spec_dispatch()
-    ];
+    api_spec_dispatch();
 maybe_swagger_dispatch(false) ->
     [].
 
-%% Routes for the focused API spec endpoints (no auth required).
+%% Routes for the focused API spec endpoints.
 %% These are added as raw cowboy routes (not minirest trails) so they do not
-%% appear in the swagger spec they serve and bypass minirest auth middleware.
+%% appear in the swagger spec they serve. They bypass minirest auth middleware
+%% and instead enforce authentication inside the handler itself, returning a
+%% minimal OpenAPI document (or markdown equivalent) on 401.
 %%
 %% `/api-docs/swagger.json` is preserved (returning the full OpenAPI JSON
 %% spec) so external Swagger UI deployments that load EMQX's spec by URL
 %% keep working. `/api-docs` and `/api-docs/index.html` are 308 redirects
-%% to the new in-tree explorer. Other `/api-docs/*` paths used to serve the
+%% to the in-tree explorer. Other `/api-docs/*` paths used to serve the
 %% bundled Swagger UI assets which were removed in cowboy_swagger 3.0.0;
 %% those now 404.
 api_spec_dispatch() ->
@@ -437,6 +436,7 @@ api_spec_dispatch() ->
         {"/api-docs", emqx_dashboard_redirect_handler, ToApiSpec},
         {"/api-docs/index.html", emqx_dashboard_redirect_handler, ToApiSpec},
         {"/api-docs/swagger.json", emqx_dashboard_api_spec_handler, #{}},
+        {"/api-spec.html", emqx_dashboard_api_spec_handler, #{}},
         {"/api-spec.md", emqx_dashboard_api_spec_handler, #{}},
         {"/api-spec.json", emqx_dashboard_api_spec_handler, #{}},
         {"/api-spec/:tag", emqx_dashboard_api_spec_handler, #{}},

--- a/apps/emqx_dashboard/src/emqx_dashboard_api_spec_handler.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api_spec_handler.erl
@@ -7,6 +7,13 @@
 -moduledoc """
 Cowboy REST handler that serves focused, AI-consumable API specs.
 
+All endpoints require authentication (basic with API key/secret, bearer
+JWT from `POST /api/v5/login`, or the dashboard's `emqx_auth` session
+cookie). Unauthenticated requests get a 401 with a minimal but valid
+OpenAPI document (or its markdown equivalent for `/api-spec.md`) that
+points the caller at how to authenticate. The `WWW-Authenticate` header
+lists the supported schemes per RFC 7235 §4.1.
+
 Endpoints:
 
   - `GET /api-spec.md`
@@ -30,6 +37,14 @@ Endpoints:
 
 -behaviour(cowboy_rest).
 
+%% Same caveat as `emqx_dashboard:authorize/2`: `emqx_mgmt_auth:authorize/4`
+%% and `emqx_dashboard_admin:verify_token/3` have success typings dialyzer
+%% can't see through (the scope-check helper is marked `no_return`), so the
+%% `{ok, _} -> ok` clauses here look unreachable and the bearer branch
+%% looks like it never returns. Silence both warning classes on the auth
+%% helpers and their caller.
+-dialyzer({nowarn_function, [init/2, authenticate/1, verify_bearer/2]}).
+
 -export([
     init/2,
     allowed_methods/2,
@@ -37,8 +52,19 @@ Endpoints:
     resource_exists/2,
     handle_get/2,
     handle_get_markdown/2,
-    handle_get_json/2
+    handle_get_json/2,
+    handle_get_html/2
 ]).
+
+-define(WWW_AUTHENTICATE_FULL,
+    <<"Basic realm=\"emqx-dashboard\", Bearer realm=\"emqx-dashboard\"">>
+).
+%% Browsers pop up their native HTTP Basic dialog when they see a `Basic`
+%% challenge on a 401 to a top-level navigation. For `/api-spec.html` we
+%% want the in-page sign-in widget to handle the flow instead, so the HTML
+%% 401 advertises only `Bearer` — RFC 7235 still requires the header to be
+%% present, but browsers have no native UI for `Bearer` and skip the popup.
+-define(WWW_AUTHENTICATE_BEARER, <<"Bearer realm=\"emqx-dashboard\"">>).
 
 %%--------------------------------------------------------------------
 %% Cowboy REST callbacks
@@ -46,7 +72,13 @@ Endpoints:
 
 -doc "Initialize the Cowboy REST handler state.".
 init(Req, Opts) ->
-    {cowboy_rest, Req, Opts}.
+    case authenticate(Req) of
+        ok ->
+            {cowboy_rest, Req, Opts};
+        unauthorized ->
+            Req1 = reply_unauthorized(Req),
+            {ok, Req1, Opts}
+    end.
 
 -doc "Advertise GET as the only supported HTTP method.".
 allowed_methods(Req, State) ->
@@ -54,6 +86,8 @@ allowed_methods(Req, State) ->
 
 content_types_provided(Req, State) ->
     case {cowboy_req:path(Req), cowboy_req:binding(tag, Req)} of
+        {<<"/api-spec.html">>, undefined} ->
+            {[{<<"text/html">>, handle_get_html}], Req, State};
         {<<"/api-spec.json">>, undefined} ->
             {[{{<<"application">>, <<"json">>, '*'}, handle_get_json}], Req, State};
         {<<"/api-docs/swagger.json">>, undefined} ->
@@ -87,6 +121,21 @@ resource_exists(Req, State) ->
 handle_get(Req, State) ->
     handle_get_json(Req, State).
 
+handle_get_html(Req, State) ->
+    HtmlPath = filename:join(code:priv_dir(emqx_dashboard), "api-spec.html"),
+    case file:read_file(HtmlPath) of
+        {ok, Body} ->
+            {Body, Req, State};
+        {error, _Reason} ->
+            Req1 = cowboy_req:reply(
+                500,
+                #{<<"content-type">> => <<"text/plain">>},
+                <<"api-spec.html unavailable">>,
+                Req
+            ),
+            {stop, Req1, State}
+    end.
+
 handle_get_markdown(Req, State) ->
     case {cowboy_req:path(Req), cowboy_req:binding(tag, Req)} of
         {<<"/api-spec.md">>, undefined} ->
@@ -119,6 +168,216 @@ handle_get_json(Req, State) ->
 %% Full unfiltered OpenAPI spec, for `/api-docs/swagger.json`.
 full_swagger_json() ->
     cowboy_swagger:to_json(get_trails()).
+
+%%--------------------------------------------------------------------
+%% Authentication gate
+%%--------------------------------------------------------------------
+
+%% Accept a request only if the caller presents a valid API key (Basic),
+%% bearer token, or the dashboard's `emqx_auth` session cookie. Spec
+%% browsing is a read-only operation and does not depend on the API
+%% key's role / scope assignment, but we reuse the same primitives that
+%% guard the rest of the dashboard so the credential checks stay in one
+%% place.
+authenticate(Req) ->
+    case cowboy_req:parse_header(<<"authorization">>, Req) of
+        {basic, Username, Password} ->
+            case emqx_mgmt_auth:authorize(handler_info(Req), Req, Username, Password) of
+                {ok, _ActorContext} -> ok;
+                _ -> unauthorized
+            end;
+        {bearer, Token} ->
+            verify_bearer(Req, Token);
+        _ ->
+            authenticate_via_cookie(Req)
+    end.
+
+authenticate_via_cookie(Req) ->
+    case cowboy_req:match_cookies([{emqx_auth, [], undefined}], Req) of
+        #{emqx_auth := Token} when is_binary(Token), Token =/= <<>> ->
+            verify_bearer(Req, Token);
+        _ ->
+            unauthorized
+    end.
+
+verify_bearer(Req, Token) ->
+    case emqx_dashboard_admin:verify_token(Req, handler_info(Req), Token) of
+        {ok, _ActorContext} -> ok;
+        _ -> unauthorized
+    end.
+
+%% Synthetic HandlerInfo for the auth primitives. The path is the route
+%% pattern rather than the request URL so `emqx_mgmt_auth:check_scopes/2`
+%% treats it as an unmapped path (allow). The module/function are real so
+%% dialyzer can see them.
+handler_info(Req) ->
+    #{
+        module => ?MODULE,
+        function => handle_get,
+        method => 'GET',
+        path => binary_to_list(cowboy_req:path(Req))
+    }.
+
+reply_unauthorized(Req) ->
+    Path = cowboy_req:path(Req),
+    {ContentType, Body} = unauthorized_body(Path),
+    Headers = #{
+        <<"content-type">> => ContentType,
+        <<"www-authenticate">> => www_authenticate(Path)
+    },
+    cowboy_req:reply(401, Headers, Body, Req).
+
+www_authenticate(<<"/api-spec.html">>) -> ?WWW_AUTHENTICATE_BEARER;
+www_authenticate(_) -> ?WWW_AUTHENTICATE_FULL.
+
+unauthorized_body(<<"/api-spec.md">>) ->
+    {<<"text/markdown; charset=utf-8">>, unauthorized_markdown()};
+unauthorized_body(<<"/api-spec.html">>) ->
+    {<<"text/html; charset=utf-8">>, unauthorized_html()};
+unauthorized_body(_) ->
+    {<<"application/json">>, encode_pretty(unauthorized_openapi_doc())}.
+
+unauthorized_openapi_doc() ->
+    Version = release_version(),
+    #{
+        <<"openapi">> => <<"3.0.0">>,
+        <<"info">> => #{
+            <<"title">> => api_title(),
+            <<"version">> => Version,
+            <<"description">> =>
+                <<
+                    "Authenticate via one of the security schemes to retrieve the "
+                    "full specification, or create an API key in the dashboard."
+                >>
+        },
+        <<"servers">> => [#{<<"url">> => server_url()}],
+        <<"components">> => #{
+            <<"securitySchemes">> => #{
+                <<"basicAuth">> => #{
+                    <<"type">> => <<"http">>,
+                    <<"scheme">> => <<"basic">>,
+                    <<"description">> =>
+                        <<
+                            "API key as username and API secret as password. "
+                            "Manage keys in the dashboard or via "
+                            "'emqx ctl api_keys'."
+                        >>
+                },
+                <<"bearerAuth">> => #{
+                    <<"type">> => <<"http">>,
+                    <<"scheme">> => <<"bearer">>,
+                    <<"description">> =>
+                        <<"JWT obtained from POST /api/v5/login.">>
+                }
+            }
+        },
+        <<"security">> => [
+            #{<<"basicAuth">> => []},
+            #{<<"bearerAuth">> => []}
+        ],
+        <<"paths">> => #{
+            <<"/login">> => #{
+                <<"post">> => #{
+                    <<"summary">> => <<"Obtain a bearer token.">>,
+                    <<"tags">> => [<<"Authentication">>],
+                    <<"security">> => [],
+                    <<"responses">> => #{
+                        <<"200">> => #{
+                            <<"description">> =>
+                                <<"Bearer token returned in the response body.">>
+                        }
+                    }
+                }
+            },
+            <<"/status">> => #{
+                <<"get">> => #{
+                    <<"summary">> => <<"Broker health check.">>,
+                    <<"tags">> => [<<"Status">>],
+                    <<"security">> => [],
+                    <<"responses">> => #{
+                        <<"200">> => #{
+                            <<"description">> =>
+                                <<"Plain-text 'emqx is running' when the broker is up.">>
+                        }
+                    }
+                }
+            }
+        }
+    }.
+
+unauthorized_html() ->
+    Title = api_title(),
+    <<
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        "<title>",
+        Title/binary,
+        " - Sign in</title>"
+        "<meta name=\"robots\" content=\"noindex,nofollow\">"
+        "<style>"
+        "body{font:14px system-ui,sans-serif;background:#0e1116;color:#e6e6e6;"
+        "display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}"
+        "form{background:#161b22;border:1px solid #2a313a;border-radius:8px;"
+        "padding:24px;width:min(360px,calc(100vw - 32px))}"
+        "h1{margin:0 0 6px;font-size:16px}"
+        "p{margin:0 0 16px;color:#9aa4ae;font-size:12px}"
+        "label{display:block;font-size:12px;color:#9aa4ae;margin-bottom:4px}"
+        "input{width:100%;padding:8px 10px;margin-bottom:12px;border:1px solid #2a313a;"
+        "border-radius:6px;background:#0e1116;color:#e6e6e6;font-size:13px;box-sizing:border-box}"
+        "button{width:100%;padding:9px 12px;border:0;border-radius:6px;"
+        "background:#3b82f6;color:#fff;font-size:13px;cursor:pointer}"
+        "button:disabled{opacity:.6;cursor:not-allowed}"
+        ".err{color:#ffb4b4;font-size:12px;margin-bottom:10px;min-height:14px}"
+        "</style></head><body>"
+        "<form id=\"f\" autocomplete=\"off\">"
+        "<h1>Sign in to view the API specification</h1>"
+        "<p>Authenticate to access the in-tree API spec explorer.</p>"
+        "<div class=\"err\" id=\"e\"></div>"
+        "<label for=\"u\">Username</label>"
+        "<input id=\"u\" name=\"username\" autocomplete=\"username\" required>"
+        "<label for=\"p\">Password</label>"
+        "<input id=\"p\" name=\"password\" type=\"password\" autocomplete=\"current-password\" required>"
+        "<button id=\"b\" type=\"submit\">Sign in</button>"
+        "</form>"
+        "<script>"
+        "var f=document.getElementById('f'),e=document.getElementById('e'),b=document.getElementById('b');"
+        "f.addEventListener('submit',async function(ev){ev.preventDefault();e.textContent='';b.disabled=true;"
+        "try{var r=await fetch('/api/v5/login',{method:'POST',credentials:'same-origin',"
+        "headers:{'Content-Type':'application/json',Accept:'application/json'},"
+        "body:JSON.stringify({username:f.username.value.trim(),password:f.password.value})});"
+        "var body=null;try{body=await r.json()}catch(_){body=null}"
+        "if(!r.ok){e.textContent=(body&&body.message)||('Sign-in failed (HTTP '+r.status+').');return}"
+        "if(!body||!body.token){e.textContent='Sign-in succeeded but no token was returned.';return}"
+        "var sec=location.protocol==='https:'?'; Secure':'';"
+        "document.cookie='emqx_auth='+encodeURIComponent(body.token)+'; Path=/; SameSite=Strict'+sec;"
+        "location.reload()}catch(err){e.textContent=String(err.message||err)}finally{b.disabled=false}});"
+        "</script>"
+        "</body></html>"
+    >>.
+
+unauthorized_markdown() ->
+    Lines = [
+        <<"# ", (api_title())/binary, " - Authentication Required\n\n">>,
+        <<
+            "Authenticate via one of the security schemes to retrieve the full "
+            "specification, or create an API key in the dashboard.\n\n"
+        >>,
+        <<"## Authentication\n\n">>,
+        <<"- API key: `Authorization: Basic base64(api_key:api_secret)`\n">>,
+        <<"- Bearer token: `POST /api/v5/login`, then `Authorization: Bearer <token>`\n\n">>,
+        <<"## Public endpoints\n\n">>,
+        <<"- `POST /api/v5/login` - interactive login (returns a bearer token).\n">>,
+        <<"- `GET  /api/v5/status` - broker health check.\n">>
+    ],
+    unicode:characters_to_binary(Lines).
+
+api_title() ->
+    iolist_to_binary([emqx_release:description(), " API"]).
+
+release_version() ->
+    iolist_to_binary(emqx_release:version()).
+
+server_url() ->
+    iolist_to_binary(emqx_dashboard_swagger:base_path()).
 
 %%--------------------------------------------------------------------
 %% Response builders
@@ -198,7 +457,7 @@ overview_sections() ->
 
 auth_help_lines() ->
     [
-        <<"Most `/api/v5/*` endpoints require authentication, even on localhost.">>,
+        <<"All `/api/v5/*` endpoints require authentication, even on localhost.">>,
         <<"- API key: `Authorization: Basic base64(api_key:api_secret)`.">>,
         <<"  * Command to add API keys: `emqx ctl api_keys ...`">>,
         <<
@@ -208,7 +467,11 @@ auth_help_lines() ->
         <<"- Bearer token: `POST /api/v5/login`, then `Authorization: Bearer <token>`.">>,
         <<"  * Request body: `{ \"username\": \"admin\", \"password\": \"...\" }`">>,
         <<"  * Command to add new user: `emqx ctl admins add <Username> <Password> <Description> <Role>`">>,
-        <<"Note: `/api-spec.md`, `/api-spec.json` and `/api-spec.html` do not require authentication.">>
+        <<
+            "The `/api-spec.md`, `/api-spec.json`, `/api-spec/...` and `/api-docs/swagger.json` "
+            "endpoints also require authentication; unauthenticated requests receive a minimal "
+            "OpenAPI document describing how to authenticate."
+        >>
     ].
 
 drilldown_help_lines() ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_api_spec_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_api_spec_SUITE.erl
@@ -35,6 +35,78 @@ end_per_suite(Config) ->
 %% Test cases
 %%--------------------------------------------------------------------
 
+-doc "Verify unauthenticated GET requests return 401 with a minimal but valid "
+"OpenAPI JSON document and the WWW-Authenticate header.".
+t_unauthenticated_json_stub(_Config) ->
+    lists:foreach(
+        fun(Path) ->
+            {401, Headers, RawBody} = do_get_raw(Path, []),
+            WwwAuth = proplists:get_value("www-authenticate", Headers, ""),
+            ?assert(
+                string:find(string:lowercase(WwwAuth), "basic") =/= nomatch,
+                #{path => Path, header => WwwAuth}
+            ),
+            ?assert(
+                string:find(string:lowercase(WwwAuth), "bearer") =/= nomatch,
+                #{path => Path, header => WwwAuth}
+            ),
+            ContentType = proplists:get_value("content-type", Headers, ""),
+            ?assert(
+                string:find(list_to_binary(ContentType), <<"application/json">>) =/= nomatch,
+                #{path => Path, content_type => ContentType}
+            ),
+            Body = emqx_utils_json:decode(list_to_binary(RawBody)),
+            ?assertMatch(#{<<"openapi">> := <<"3.0.0">>}, Body),
+            ?assertMatch(
+                #{<<"info">> := #{<<"description">> := _, <<"title">> := _, <<"version">> := _}},
+                Body
+            ),
+            ?assertMatch(
+                #{
+                    <<"components">> := #{
+                        <<"securitySchemes">> := #{
+                            <<"basicAuth">> := _,
+                            <<"bearerAuth">> := _
+                        }
+                    }
+                },
+                Body
+            ),
+            Paths = maps:get(<<"paths">>, Body),
+            ?assert(maps:is_key(<<"/login">>, Paths), #{path => Path, paths => Paths}),
+            ?assert(maps:is_key(<<"/status">>, Paths), #{path => Path, paths => Paths})
+        end,
+        [
+            "/api-spec.json",
+            "/api-docs/swagger.json",
+            "/api-spec/status",
+            "/api-spec/status/something"
+        ]
+    ).
+
+-doc "Verify unauthenticated GET /api-spec.md returns 401 with markdown body and "
+"the WWW-Authenticate header.".
+t_unauthenticated_markdown_stub(_Config) ->
+    {401, Headers, RawBody} = do_get_raw("/api-spec.md", []),
+    WwwAuth = proplists:get_value("www-authenticate", Headers, ""),
+    ?assert(string:find(string:lowercase(WwwAuth), "basic") =/= nomatch),
+    ?assert(string:find(string:lowercase(WwwAuth), "bearer") =/= nomatch),
+    ContentType = proplists:get_value("content-type", Headers, ""),
+    ?assert(
+        string:find(list_to_binary(ContentType), <<"text/markdown">>) =/= nomatch,
+        #{content_type => ContentType}
+    ),
+    BodyBin = list_to_binary(RawBody),
+    ?assert(string:find(BodyBin, <<"Authentication Required">>) =/= nomatch),
+    ?assert(string:find(BodyBin, <<"POST /api/v5/login">>) =/= nomatch).
+
+-doc "Verify an invalid bearer token also produces the 401 stub.".
+t_unauthenticated_invalid_bearer(_Config) ->
+    BadAuth = {"Authorization", "Bearer not-a-valid-token"},
+    {401, _Headers, RawBody} = do_get_raw("/api-spec.json", [BadAuth]),
+    Body = emqx_utils_json:decode(list_to_binary(RawBody)),
+    ?assertMatch(#{<<"openapi">> := <<"3.0.0">>}, Body).
+
 -doc "Verify /api-spec.md returns markdown with expected content-type and body.".
 t_index_markdown(_Config) ->
     {200, Headers, Body} = do_get_raw("/api-spec.md"),
@@ -85,12 +157,33 @@ t_index_json(_Config) ->
         ]
     ).
 
--doc "Verify api-spec.html exists in priv dir and contains the expected title.".
+-doc "Verify authenticated /api-spec.html serves the full explorer page and "
+"unauthenticated requests get a 401 with a tiny login HTML.".
 t_api_spec_html(_Config) ->
-    HtmlPath = filename:join([code:priv_dir(emqx_dashboard), "api-spec.html"]),
-    ?assertMatch({ok, _}, file:read_file_info(HtmlPath)),
-    {ok, Body} = file:read_file(HtmlPath),
-    ?assert(string:find(Body, <<"EMQX API Spec Explorer">>) =/= nomatch).
+    {200, Headers, Body} = do_get_raw("/api-spec.html"),
+    ContentType = proplists:get_value("content-type", Headers, ""),
+    ?assert(string:find(list_to_binary(ContentType), <<"text/html">>) =/= nomatch),
+    BodyBin = list_to_binary(Body),
+    ?assert(string:find(BodyBin, <<"EMQX API Spec Explorer">>) =/= nomatch),
+    {401, StubHeaders, StubBody} = do_get_raw("/api-spec.html", []),
+    StubContentType = proplists:get_value("content-type", StubHeaders, ""),
+    ?assert(string:find(list_to_binary(StubContentType), <<"text/html">>) =/= nomatch),
+    %% The HTML 401 must NOT advertise Basic, so browsers skip the native
+    %% popup and let our in-page widget handle sign-in.
+    StubWww = proplists:get_value("www-authenticate", StubHeaders, ""),
+    ?assertEqual(
+        nomatch,
+        string:find(string:lowercase(StubWww), "basic"),
+        #{header => StubWww}
+    ),
+    ?assert(
+        string:find(string:lowercase(StubWww), "bearer") =/= nomatch,
+        #{header => StubWww}
+    ),
+    StubBin = list_to_binary(StubBody),
+    ?assert(string:find(StubBin, <<"Sign in">>) =/= nomatch),
+    %% Stub must not include the full explorer markup.
+    ?assertEqual(nomatch, string:find(StubBin, <<"EMQX API Spec Explorer">>)).
 
 -doc "Verify /api-spec/:tag returns a valid OpenAPI 3.0.0 doc with correctly tagged paths.".
 t_tag_spec(_Config) ->
@@ -301,17 +394,23 @@ t_drilldown_no_full_union_fallback(_Config) ->
 %%--------------------------------------------------------------------
 
 do_get_raw(Path) ->
+    do_get_raw(Path, [auth_header()]).
+
+do_get_raw(Path, Headers) ->
     Url = ?HOST ++ Path,
-    case httpc:request(get, {Url, []}, [], []) of
-        {ok, {{_, Code, _}, Headers, RawBody}} ->
-            {Code, Headers, RawBody};
+    case httpc:request(get, {Url, Headers}, [], []) of
+        {ok, {{_, Code, _}, RespHeaders, RawBody}} ->
+            {Code, RespHeaders, RawBody};
         {error, Reason} ->
             error({http_request_failed, Reason})
     end.
 
 do_get(Path) ->
+    do_get(Path, [auth_header()]).
+
+do_get(Path, Headers) ->
     Url = ?HOST ++ Path,
-    case httpc:request(get, {Url, []}, [], []) of
+    case httpc:request(get, {Url, Headers}, [], []) of
         {ok, {{_, Code, _}, _Headers, RawBody}} ->
             Body =
                 try
@@ -323,6 +422,9 @@ do_get(Path) ->
         {error, Reason} ->
             error({http_request_failed, Reason})
     end.
+
+auth_header() ->
+    emqx_common_test_http:default_auth_header().
 
 assert_openapi_shape(Spec) ->
     ?assertMatch(#{<<"openapi">> := <<"3.0.0">>}, Spec),

--- a/changes/ee/feat-17375.en.md
+++ b/changes/ee/feat-17375.en.md
@@ -1,0 +1,13 @@
+The OpenAPI specification endpoints now require authentication by default.
+This covers `GET /api-docs/swagger.json`, `GET /api-spec.json`,
+`GET /api-spec.md`, and `GET /api-spec/:tag[/:name]`.
+
+Unauthenticated requests receive a 401 with a `WWW-Authenticate` header and a
+minimal but valid OpenAPI document (or its markdown equivalent for
+`/api-spec.md`) that lists the supported security schemes and the public
+bootstrap endpoints (`POST /api/v5/login`, `GET /api/v5/status`), so callers
+can discover how to authenticate without the dashboard exposing its full API
+surface anonymously.
+
+The dashboard's `api-spec.html` explorer continues to load anonymously and
+fetches the spec with the existing session cookie or token.

--- a/scripts/test/emqx-smoke-test.sh
+++ b/scripts/test/emqx-smoke-test.sh
@@ -7,6 +7,34 @@ set -euo pipefail
 HOST=$1
 PORT=$2
 BASE_URL="http://$HOST:$PORT"
+ADMIN_USER="${EMQX_SMOKE_USER:-admin}"
+ADMIN_PASSWORD="${EMQX_SMOKE_PASSWORD:-public}"
+ADMIN_TOKEN=""
+
+## Login to the dashboard and cache a bearer token. The spec endpoints
+## require authentication; this lets the rest of the script call them.
+login() {
+    local attempts=10
+    local resp token
+    while [ $attempts -gt 0 ]; do
+        resp="$(curl -s -X POST "$BASE_URL/api/v5/login" \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASSWORD\"}" || true)"
+        token="$(echo "$resp" | jq -r '.token // empty' 2>/dev/null || true)"
+        if [ -n "$token" ]; then
+            ADMIN_TOKEN="$token"
+            return 0
+        fi
+        sleep 1
+        attempts=$((attempts-1))
+    done
+    echo "failed to login as $ADMIN_USER at $BASE_URL/api/v5/login: $resp"
+    exit 1
+}
+
+auth_curl() {
+    curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$@"
+}
 
 ## Check if EMQX is responding
 wait_for_emqx() {
@@ -35,30 +63,35 @@ json_status() {
     fi
 }
 
-## Check if the API spec explorer is available
+## Check that /api-spec.html is gated by authentication and serves the
+## explorer to authenticated callers.
 check_api_spec() {
-    local attempts=5
     local url="$BASE_URL/api-spec.html"
-    local status="undefined"
-    while [ "$status" != "200" ]; do
-        status="$(curl -s -o /dev/null -w "%{http_code}" "$url")"
-        if [ "$status" != "200" ]; then
-            if [ $attempts -eq 0 ]; then
-                echo "emqx return non-200 responses($status) on $url"
-                exit 1
-            fi
-            sleep 1
-            attempts=$((attempts-1))
-        fi
-    done
+    local anon_status authed_status
+    anon_status="$(curl -s -o /dev/null -w '%{http_code}' "$url")"
+    if [ "$anon_status" != "401" ]; then
+        echo "expected 401 from anonymous GET $url, got $anon_status"
+        exit 1
+    fi
+    authed_status="$(auth_curl -o /dev/null -w '%{http_code}' "$url")"
+    if [ "$authed_status" != "200" ]; then
+        echo "expected 200 from authenticated GET $url, got $authed_status"
+        exit 1
+    fi
 }
 
-## Check if the swagger.json contains hidden fields
-## fail if it does
+## Check that swagger.json requires authentication and that the
+## authenticated response does not contain hidden fields.
 check_swagger_json() {
     local url="$BASE_URL/api-docs/swagger.json"
-    ## assert swagger.json is valid json
-    JSON="$(curl -s "$url")"
+    local anon_status
+    anon_status="$(curl -s -o /dev/null -w '%{http_code}' "$url")"
+    if [ "$anon_status" != "401" ]; then
+        echo "expected 401 from anonymous GET $url, got $anon_status"
+        exit 1
+    fi
+    ## assert authenticated swagger.json is valid json
+    JSON="$(auth_curl "$url")"
     echo "$JSON" | jq . >/dev/null
     ## assert swagger.json does not contain trie_compaction (which is a hidden field)
     if echo "$JSON" | grep -q trie_compaction; then
@@ -116,6 +149,7 @@ check_schema_json() {
 
 main() {
     wait_for_emqx
+    login
     local JSON_STATUS
     JSON_STATUS="$(json_status)"
     check_api_spec


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 6.3.0

## Summary

Until now `/api-docs/swagger.json` and the `/api-spec.{json,md}` /
`/api-spec/:tag[/:name]` endpoints were served anonymously. Customer security
scanners flag this as exposed API documentation. This PR gates the spec data
endpoints inside `emqx_dashboard_api_spec_handler` so unauthenticated callers
receive a `401` with:

- a `WWW-Authenticate` header listing the supported schemes (`Basic`, `Bearer`)
  per RFC 7235 §4.1
- a body whose shape matches the requested format: a minimal but valid
  OpenAPI 3.0.0 document for the JSON endpoints, or a short markdown
  equivalent for `/api-spec.md`. The stub lists `components.securitySchemes`
  and the two public bootstrap paths (`POST /api/v5/login`,
  `GET /api/v5/status`) so a fresh client (or Swagger UI) can discover how
  to authenticate.

Authenticated callers (basic auth with API key/secret, bearer JWT from
`POST /api/v5/login`, or the dashboard's `emqx_auth` session cookie) see the
full spec exactly as before.

The HTML explorer at `/api-spec.html` and the `/api-docs[/index.html]`
redirects stay public so users can still reach the auth UI; the explorer
sends the existing session cookie and surfaces a clearer message on `401`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/feat-17375.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)