### PR TITLE
fix(cm_registry): Handle partial network isolation during cleanup

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {gproc, "1.0.0"},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.14.0"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.24.2"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "1.0.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.5.1"}}},
     {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.6"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.45.3"}}},

--- a/apps/emqx/src/emqx_broker_heal.erl
+++ b/apps/emqx/src/emqx_broker_heal.erl
@@ -26,7 +26,7 @@ Limitations:
 -behaviour(gen_server).
 
 %% API:
--export([start_local/1, on_autoheal/1, consistency_check/0]).
+-export([start_local/1, on_autoheal/1]).
 
 %% behavior callbacks:
 -export([init/1, handle_call/3, handle_continue/2, handle_cast/2, handle_info/2, terminate/2]).
@@ -70,38 +70,6 @@ Start a process that will cause all local channels to renew their registrations 
 -spec start_local({[node()], [[node()]]}) -> ok | {error, _}.
 start_local(_) ->
     emqx_broker_sup:start_heal().
-
--doc """
-Check whether the global registry contains local clients.
-`true` = global registry is consistent.
-
-This check is not precise and is based on heuristics.
-Due to possible race conditions,
-it assumes that the registry is consistent when it contains the majority of local channels.
-""".
--spec consistency_check() -> boolean().
-consistency_check() ->
-    MS = {{'$1', '_'}, [], ['$1']},
-    SampleSize = 1000,
-    case ets:select(?CHAN_TAB, [MS], SampleSize) of
-        '$end_of_table' ->
-            true;
-        {Sample, _Cont} ->
-            {NPresent, NMissing} =
-                lists:foldl(
-                    fun(ClientId, {AccPresent, AccMissing}) ->
-                        case emqx_cm_registry:lookup_all_channels(ClientId) of
-                            [] ->
-                                {AccPresent, AccMissing + 1};
-                            _ ->
-                                {AccPresent + 1, AccMissing}
-                        end
-                    end,
-                    {0, 0},
-                    Sample
-                ),
-            NPresent >= NMissing
-    end.
 
 %%================================================================================
 %% behavior callbacks

--- a/apps/emqx/src/emqx_broker_heal.erl
+++ b/apps/emqx/src/emqx_broker_heal.erl
@@ -26,7 +26,7 @@ Limitations:
 -behaviour(gen_server).
 
 %% API:
--export([start_local/1, on_autoheal/1]).
+-export([start_local/1, on_autoheal/1, consistency_check/0]).
 
 %% behavior callbacks:
 -export([init/1, handle_call/3, handle_continue/2, handle_cast/2, handle_info/2, terminate/2]).
@@ -70,6 +70,38 @@ Start a process that will cause all local channels to renew their registrations 
 -spec start_local({[node()], [[node()]]}) -> ok | {error, _}.
 start_local(_) ->
     emqx_broker_sup:start_heal().
+
+-doc """
+Check whether the global registry contains local clients.
+`true` = global registry is consistent.
+
+This check is not precise and is based on heuristics.
+Due to possible race conditions,
+it assumes that the registry is consistent when it contains the majority of local channels.
+""".
+-spec consistency_check() -> boolean().
+consistency_check() ->
+    MS = {{'$1', '_'}, [], ['$1']},
+    SampleSize = 1000,
+    case ets:select(?CHAN_TAB, [MS], SampleSize) of
+        '$end_of_table' ->
+            true;
+        {Sample, _Cont} ->
+            {NPresent, NMissing} =
+                lists:foldl(
+                    fun(ClientId, {AccPresent, AccMissing}) ->
+                        case emqx_cm_registry:lookup_all_channels(ClientId) of
+                            [] ->
+                                {AccPresent, AccMissing + 1};
+                            _ ->
+                                {AccPresent + 1, AccMissing}
+                        end
+                    end,
+                    {0, 0},
+                    Sample
+                ),
+            NPresent >= NMissing
+    end.
 
 %%================================================================================
 %% behavior callbacks

--- a/apps/emqx/src/emqx_cm_registry.erl
+++ b/apps/emqx/src/emqx_cm_registry.erl
@@ -209,7 +209,7 @@ handle_info({membership, _Event}, State) ->
     {noreply, State};
 handle_info(#mria_replica_status_update{status = Status}, State) ->
     ?tp(info, cm_registry_shard_up, #{}),
-    maybe_trigger_heal(is_enabled(), Status),
+    _ = maybe_trigger_heal(is_enabled(), Status),
     {noreply, State};
 handle_info(Info, State) ->
     ?SLOG(error, #{msg => "unexpected_info", info => Info}),

--- a/apps/emqx/src/emqx_cm_registry.erl
+++ b/apps/emqx/src/emqx_cm_registry.erl
@@ -185,7 +185,7 @@ init([]) ->
         ]}
     ]),
     ok = mria_rlog:wait_for_shards([?CM_SHARD], infinity),
-    maybe_subscribe_replica_events(),
+    _ = maybe_subscribe_replica_events(),
     ok = ekka:monitor(membership),
     {ok, #{}}.
 
@@ -208,7 +208,7 @@ handle_info({membership, {node, down, Node}}, State) ->
 handle_info({membership, _Event}, State) ->
     {noreply, State};
 handle_info(#mria_replica_status_update{status = Status}, State) ->
-    ?tp(debug, cm_registry_shard_up, #{}),
+    ?tp(info, cm_registry_shard_up, #{}),
     maybe_trigger_heal(is_enabled(), Status),
     {noreply, State};
 handle_info(Info, State) ->
@@ -355,10 +355,15 @@ maybe_subscribe_replica_events() ->
     end.
 
 maybe_trigger_heal(true, normal) ->
+    ?tp(warning, healing, #{c => emqx_broker_heal:consistency_check(), n => node()}),
     %% Shard re-bootstrapped. Check if my clents still exist in the
     %% registry:
-    emqx_broker_heal:consistency_check() orelse
-        emqx_broker_sup:start_heal(),
-    ok;
-maybe_trigger_heal(_, _) ->
+    case emqx_broker_heal:consistency_check() of
+        false ->
+            %% Inconsistent:
+            emqx_broker_sup:start_heal();
+        true ->
+            ok
+    end;
+maybe_trigger_heal(_Enabled, _Status) ->
     ok.

--- a/apps/emqx/src/emqx_cm_registry.erl
+++ b/apps/emqx/src/emqx_cm_registry.erl
@@ -355,15 +355,6 @@ maybe_subscribe_replica_events() ->
     end.
 
 maybe_trigger_heal(true, normal) ->
-    ?tp(warning, healing, #{c => emqx_broker_heal:consistency_check(), n => node()}),
-    %% Shard re-bootstrapped. Check if my clents still exist in the
-    %% registry:
-    case emqx_broker_heal:consistency_check() of
-        false ->
-            %% Inconsistent:
-            emqx_broker_sup:start_heal();
-        true ->
-            ok
-    end;
+    emqx_broker_sup:start_heal();
 maybe_trigger_heal(_Enabled, _Status) ->
     ok.

--- a/apps/emqx/src/emqx_cm_registry.erl
+++ b/apps/emqx/src/emqx_cm_registry.erl
@@ -49,6 +49,7 @@
 -include("emqx_cm.hrl").
 -include("logger.hrl").
 -include("types.hrl").
+-include_lib("mria/include/mria.hrl").
 
 -define(REGISTRY, ?MODULE).
 -define(NODE_DOWN_CLEANUP_LOCK, {?MODULE, cleanup_down}).
@@ -184,6 +185,7 @@ init([]) ->
         ]}
     ]),
     ok = mria_rlog:wait_for_shards([?CM_SHARD], infinity),
+    maybe_subscribe_replica_events(),
     ok = ekka:monitor(membership),
     {ok, #{}}.
 
@@ -205,6 +207,10 @@ handle_info({membership, {node, down, Node}}, State) ->
     {noreply, State};
 handle_info({membership, _Event}, State) ->
     {noreply, State};
+handle_info(#mria_replica_status_update{status = Status}, State) ->
+    ?tp(debug, cm_registry_shard_up, #{}),
+    maybe_trigger_heal(is_enabled(), Status),
+    {noreply, State};
 handle_info(Info, State) ->
     ?SLOG(error, #{msg => "unexpected_info", info => Info}),
     {noreply, State}.
@@ -220,12 +226,21 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 
 cleanup_channels(Node) ->
-    global:trans(
-        {?NODE_DOWN_CLEANUP_LOCK, self()},
-        fun() ->
-            mria:transaction(?CM_SHARD, fun ?MODULE:do_cleanup_channels/1, [Node])
-        end
-    ).
+    case can_run_cleanup(Node) of
+        true ->
+            global:trans(
+                {?NODE_DOWN_CLEANUP_LOCK, self()},
+                fun() ->
+                    ?SLOG(warning, #{
+                        msg => "cleaning up clients connected to disconnected node", node => Node
+                    }),
+                    mria:transaction(?CM_SHARD, fun ?MODULE:do_cleanup_channels/1, [Node])
+                end
+            ),
+            ok;
+        false ->
+            ok
+    end.
 
 do_cleanup_channels(Node) ->
     Pat = [
@@ -313,3 +328,37 @@ fold_hist(F, List) ->
 -spec retain_duration() -> non_neg_integer().
 retain_duration() ->
     emqx:get_config([broker, session_history_retain]).
+
+%% Check if channel cleanup procedure should run:
+can_run_cleanup(Node) ->
+    case mria_rlog:role() of
+        replicant ->
+            %% We don't trust replicants:
+            false;
+        _ ->
+            %% Consult other cores whether they see the node:
+            case mria:is_peer_alive(Node) of
+                {ok, false} ->
+                    true;
+                _ ->
+                    false
+            end
+    end.
+
+%% On replicants we want to monitor mria events
+maybe_subscribe_replica_events() ->
+    case mria_rlog:role() of
+        replicant ->
+            mria:subscribe_replica_events(?CM_SHARD, self());
+        _ ->
+            ok
+    end.
+
+maybe_trigger_heal(true, normal) ->
+    %% Shard re-bootstrapped. Check if my clents still exist in the
+    %% registry:
+    emqx_broker_heal:consistency_check() orelse
+        emqx_broker_sup:start_heal(),
+    ok;
+maybe_trigger_heal(_, _) ->
+    ok.

--- a/apps/emqx/test/emqx_broker_heal_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_heal_SUITE.erl
@@ -6,6 +6,8 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+-include("emqx.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include("emqx_cm.hrl").
@@ -34,7 +36,7 @@ end_per_testcase(_, Config) ->
 %% process. It emulates loss of client information that occurs after
 %% network partition is healed, then it triggers the heal and verifies
 %% that clients restore their information.
-t_renew_client_regs_on_heal(Config) ->
+t_heal_on_core_partition(Config) ->
     Cluster = proplists:get_value(cluster, Config),
     [N1 | Rest] = Nodes = emqx_cth_cluster:start(Cluster),
     Clients = [
@@ -72,3 +74,126 @@ t_renew_client_regs_on_heal(Config) ->
     ),
     [emqtt:stop(Conn) || Conn <- Clients],
     Config.
+
+%% This testcase verifies functioning of `emqx_broker_heal:consistency_check' function.
+t_consistency_check(Config) ->
+    Cluster = proplists:get_value(cluster, Config),
+    NClients = 10,
+    [_, _, R1, _] = emqx_cth_cluster:start(Cluster),
+    %% No clients. Consistency check should pass:
+    ?assertEqual(
+        true,
+        erpc:call(R1, emqx_broker_heal, consistency_check, [])
+    ),
+    %% Connect a number of clients to R1:
+    Clients = [
+        element(
+            2,
+            emqtt:start_link(
+                [{port, emqx_cth_cluster:get_tcp_mqtt_port(R1)}]
+            )
+        )
+     || _ <- lists:seq(1, NClients)
+    ],
+    [{ok, _} = emqtt:connect(Conn) || Conn <- Clients],
+    ct:sleep(100),
+    ?assertEqual(
+        NClients,
+        erpc:call(R1, emqx_cm_registry, table_size, [])
+    ),
+    %% Consistency check should return `true':
+    ?assertEqual(
+        true,
+        erpc:call(R1, emqx_broker_heal, consistency_check, [])
+    ),
+    %% Delete channels from the registry, consistency check should detect that:
+    ?assertEqual(
+        {atomic, ok},
+        erpc:call(R1, mria, clear_table, [?CHAN_REG_TAB])
+    ),
+    ct:sleep(100),
+    ?assertEqual(
+        false,
+        erpc:call(R1, emqx_broker_heal, consistency_check, [])
+    ),
+    [emqtt:stop(Conn) || Conn <- Clients],
+    Config.
+
+%% This testcase verifies that replicants attempt to heal channel registry after mria re-bootstrap.
+t_heal_on_replicant_bootstrap(Config) ->
+    ?check_trace(
+        #{timetrap => 30_000},
+        begin
+            Cluster = proplists:get_value(cluster, Config),
+            NClients = 10,
+            [C1, C2, R1, _] = Nodes = emqx_cth_cluster:start(Cluster),
+            #{shards_in_sync := Shards} = erpc:call(R1, mria_rlog, status, []),
+            erpc:call(
+                R1,
+                fun() ->
+                    %% Tune mria for faster reconnects:
+                    application:set_env(mria, rlog_lb_update_timeout, 10),
+                    application:set_env(mria, rlog_lb_update_timeout, 100)
+                end
+            ),
+            %% Connect a number of clients to R1:
+            Clients = [
+                element(
+                    2,
+                    emqtt:start_link(
+                        [{port, emqx_cth_cluster:get_tcp_mqtt_port(R1)}]
+                    )
+                )
+             || _ <- lists:seq(1, NClients)
+            ],
+            [{ok, _} = emqtt:connect(Conn) || Conn <- Clients],
+            ct:sleep(1_000),
+            ?assertEqual(
+                [{ok, NClients}, {ok, NClients}, {ok, NClients}, {ok, NClients}],
+                erpc:multicall(Nodes, emqx_cm_registry, table_size, [])
+            ),
+            %% Shut down mria upstream on the cores:
+            [
+                ?assertMatch(
+                    ok,
+                    erpc:call(N, supervisor, terminate_child, [mria_sup, mria_rlog_sup])
+                )
+             || N <- [C1, C2]
+            ],
+            %% While the upstream is down, clear the table to imitate registry cleanup logic:
+            ?assertEqual(
+                {atomic, ok},
+                erpc:call(C1, mria, clear_table, [?CHAN_REG_TAB])
+            ),
+            ?assertEqual(
+                0,
+                erpc:call(C1, emqx_cm_registry, table_size, [])
+            ),
+            %% Restart replication. R1 should re-boostrap, execute
+            %% consistency check, and repair the registry:
+            [
+                erpc:call(
+                    N,
+                    fun() ->
+                        ?assertMatch(
+                            {ok, _},
+                            erpc:call(N, supervisor, restart_child, [mria_sup, mria_rlog_sup])
+                        ),
+                        ok = mria_rlog:wait_for_shards(Shards, 5_000)
+                    end
+                )
+             || N <- [C1, C2]
+            ],
+            ?retry(
+                1_000,
+                10,
+                ?assertEqual(
+                    [{ok, NClients}, {ok, NClients}, {ok, NClients}, {ok, NClients}],
+                    erpc:multicall(Nodes, emqx_cm_registry, table_size, [])
+                )
+            ),
+            [emqtt:stop(Conn) || Conn <- Clients],
+            Config
+        end,
+        []
+    ).

--- a/apps/emqx/test/emqx_broker_heal_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_heal_SUITE.erl
@@ -75,50 +75,6 @@ t_heal_on_core_partition(Config) ->
     [emqtt:stop(Conn) || Conn <- Clients],
     Config.
 
-%% This testcase verifies functioning of `emqx_broker_heal:consistency_check' function.
-t_consistency_check(Config) ->
-    Cluster = proplists:get_value(cluster, Config),
-    NClients = 10,
-    [_, _, R1, _] = emqx_cth_cluster:start(Cluster),
-    %% No clients. Consistency check should pass:
-    ?assertEqual(
-        true,
-        erpc:call(R1, emqx_broker_heal, consistency_check, [])
-    ),
-    %% Connect a number of clients to R1:
-    Clients = [
-        element(
-            2,
-            emqtt:start_link(
-                [{port, emqx_cth_cluster:get_tcp_mqtt_port(R1)}]
-            )
-        )
-     || _ <- lists:seq(1, NClients)
-    ],
-    [{ok, _} = emqtt:connect(Conn) || Conn <- Clients],
-    ct:sleep(100),
-    ?assertEqual(
-        NClients,
-        erpc:call(R1, emqx_cm_registry, table_size, [])
-    ),
-    %% Consistency check should return `true':
-    ?assertEqual(
-        true,
-        erpc:call(R1, emqx_broker_heal, consistency_check, [])
-    ),
-    %% Delete channels from the registry, consistency check should detect that:
-    ?assertEqual(
-        {atomic, ok},
-        erpc:call(R1, mria, clear_table, [?CHAN_REG_TAB])
-    ),
-    ct:sleep(100),
-    ?assertEqual(
-        false,
-        erpc:call(R1, emqx_broker_heal, consistency_check, [])
-    ),
-    [emqtt:stop(Conn) || Conn <- Clients],
-    Config.
-
 %% This testcase verifies that replicants attempt to heal channel registry after mria re-bootstrap.
 t_heal_on_replicant_bootstrap(Config) ->
     ?check_trace(

--- a/apps/emqx/test/emqx_cm_registry_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_registry_SUITE.erl
@@ -53,26 +53,38 @@ t_register_unregister_channel(_) ->
     ?assertEqual([], emqx_cm_registry:lookup_channels(ClientId)).
 
 t_cleanup_channels_mnesia_down(_) ->
-    ClientId = <<"clientid">>,
-    ClientId2 = <<"clientid2">>,
-    emqx_cm_registry:register_channel(ClientId),
-    emqx_cm_registry:register_channel(ClientId2),
-    ?assertEqual([self()], emqx_cm_registry:lookup_channels(ClientId)),
-    emqx_cm_registry ! {membership, {mnesia, down, node()}},
-    ct:sleep(100),
-    ?assertEqual([], emqx_cm_registry:lookup_channels(ClientId)),
-    ?assertEqual([], emqx_cm_registry:lookup_channels(ClientId2)).
+    try
+        meck:new(mria, [passthrough, no_history]),
+        meck:expect(mria, is_peer_alive, fun(_) -> {ok, false} end),
+        ClientId = <<"clientid">>,
+        ClientId2 = <<"clientid2">>,
+        emqx_cm_registry:register_channel(ClientId),
+        emqx_cm_registry:register_channel(ClientId2),
+        ?assertEqual([self()], emqx_cm_registry:lookup_channels(ClientId)),
+        emqx_cm_registry ! {membership, {mnesia, down, node()}},
+        ct:sleep(100),
+        ?assertEqual([], emqx_cm_registry:lookup_channels(ClientId)),
+        ?assertEqual([], emqx_cm_registry:lookup_channels(ClientId2))
+    after
+        meck:unload(mria)
+    end.
 
 t_cleanup_channels_node_down(_) ->
-    ClientId = <<"clientid">>,
-    ClientId2 = <<"clientid2">>,
-    emqx_cm_registry:register_channel(ClientId),
-    emqx_cm_registry:register_channel(ClientId2),
-    ?assertEqual([self()], emqx_cm_registry:lookup_channels(ClientId)),
-    emqx_cm_registry ! {membership, {node, down, node()}},
-    ct:sleep(100),
-    ?assertEqual([], emqx_cm_registry:lookup_channels(ClientId)),
-    ?assertEqual([], emqx_cm_registry:lookup_channels(ClientId2)).
+    try
+        meck:new(mria, [passthrough, no_history]),
+        meck:expect(mria, is_peer_alive, fun(_) -> {ok, false} end),
+        ClientId = <<"clientid">>,
+        ClientId2 = <<"clientid2">>,
+        emqx_cm_registry:register_channel(ClientId),
+        emqx_cm_registry:register_channel(ClientId2),
+        ?assertEqual([self()], emqx_cm_registry:lookup_channels(ClientId)),
+        emqx_cm_registry ! {membership, {node, down, node()}},
+        ct:sleep(100),
+        ?assertEqual([], emqx_cm_registry:lookup_channels(ClientId)),
+        ?assertEqual([], emqx_cm_registry:lookup_channels(ClientId2))
+    after
+        meck:unload(mria)
+    end.
 
 t_cm_registry(_) ->
     Children = supervisor:which_children(emqx_cm_sup),

--- a/changes/ee/fix-17382.en.md
+++ b/changes/ee/fix-17382.en.md
@@ -1,0 +1,1 @@
+Fix corruption of global channel registry that may occur when cluster experiences a network partition.

--- a/mix.exs
+++ b/mix.exs
@@ -188,7 +188,7 @@ defmodule EMQXUmbrella.MixProject do
     end
   end
 
-  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.24.2", override: true}
+  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.0", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.14.0", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.3", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -92,7 +92,7 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.14.0"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-10"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.24.2"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "1.0.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.5.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.7.2"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.11"}}},


### PR DESCRIPTION
Fixes [EMQX-15260](https://emqx.atlassian.net/browse/EMQX-15260)

Release version:
5.10.4

## Summary

1. Put more safeguards before triggering channel registry cleanup on behalf of nodes that are left.
2. Trigger registry heal procedure when replicant nodes detect bootstrap of the registry shard.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-15260]: https://emqx.atlassian.net/browse/EMQX-15260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ