### PR TITLE
fix(takeover): refresh channel stats after session replay

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1615,7 +1615,9 @@ handle_info(continue, Channel) ->
             %% Session timers are not restored here, so there's a tiny chance that
             %% the session becomes stuck, when it already has no place to track new
             %% messages.
-            {ok, Outgoing, NChannel2}
+            %% Refresh chan-info / chan-stats so the dashboard and REST API
+            %% reflect post-replay inflight immediately, not on the next stats tick.
+            {ok, Outgoing ++ [?REPLY_EVENT(updated)], NChannel2}
     end;
 handle_info({subscribe, TopicFilters}, Channel) ->
     ?EXT_TRACE_BROKER_SUBSCRIBE(

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -53,7 +53,8 @@ tc_v5_only() ->
         t_takeover_session_then_abnormal_disconnect,
         t_takeover_session_then_abnormal_disconnect_2,
         t_disconnected_at_before_connected_at_on_takeover,
-        t_disconnected_at_before_connected_at_on_discard
+        t_disconnected_at_before_connected_at_on_discard,
+        t_chan_info_refreshed_after_takeover_replay
     ].
 
 init_per_suite(Config) ->
@@ -917,6 +918,124 @@ t_ongoing_takeover(Config) ->
 
 %% t_takover_in_cluster(_) ->
 %%     todo.
+
+-doc """
+Regression test: after a session takeover triggers a replay, the
+?CHAN_INFO_TAB snapshot read by the dashboard and REST API must
+reflect the post-replay inflight, not the (zero) pre-replay value.
+
+Pre-fix, the snapshot would stay stale until the next 15s stats_timer
+tick. Post-fix, REPLY_EVENT(updated) appended to the channel's
+`continue' reply refreshes the snapshot immediately.
+""".
+t_chan_info_refreshed_after_takeover_replay(Config) ->
+    case ?config(persistence_enabled, Config) of
+        true ->
+            {skip, "Classic session only — DS path has its own stats model"};
+        _ ->
+            do_chan_info_refreshed_after_takeover_replay(Config)
+    end.
+
+do_chan_info_refreshed_after_takeover_replay(_Config) ->
+    process_flag(trap_exit, true),
+    ClientId = iolist_to_binary([
+        atom_to_binary(?FUNCTION_NAME),
+        "-",
+        integer_to_binary(erlang:unique_integer([positive]))
+    ]),
+    Topic = <<ClientId/binary, "/t">>,
+    NMsgs = 3,
+    ClientOpts = [
+        {proto_ver, v5},
+        {clean_start, false},
+        {properties, #{'Session-Expiry-Interval' => 60}}
+    ],
+
+    %% GIVEN: client A subscribes, then disconnects leaving session alive.
+    {ok, ClientA} = emqtt:start_link([{clientid, ClientId} | ClientOpts]),
+    {ok, _} = emqtt:connect(ClientA),
+    {ok, _, [?QOS_1]} = emqtt:subscribe(ClientA, Topic, ?QOS_1),
+    [OldChanPid] = emqx_cm:lookup_channels(ClientId),
+    ok = emqtt:disconnect(ClientA),
+
+    %% AND: publish NMsgs messages so they queue in the offline session.
+    {ok, Publisher} = emqtt:start_link([{proto_ver, v5}, {clean_start, true}]),
+    {ok, _} = emqtt:connect(Publisher),
+    lists:foreach(
+        fun(I) ->
+            {ok, _} = emqtt:publish(
+                Publisher, Topic, integer_to_binary(I), ?QOS_1
+            )
+        end,
+        lists:seq(1, NMsgs)
+    ),
+    ok = emqtt:disconnect(Publisher),
+
+    %% WHEN: client B reconnects with same clientid -> takeover + replay.
+    %% auto_ack=false keeps the replayed messages in inflight long enough
+    %% to observe via emqx_cm:get_chan_stats/2.
+    {ok, ClientB} = emqtt:start_link([
+        {clientid, ClientId},
+        {auto_ack, false}
+        | ClientOpts
+    ]),
+    {ok, _} = emqtt:connect(ClientB),
+
+    %% Wait for takeover: the channel pid should change.
+    true = wait_until(
+        fun() ->
+            case emqx_cm:lookup_channels(ClientId) of
+                [Pid] when Pid =/= OldChanPid -> true;
+                _ -> false
+            end
+        end,
+        2000
+    ),
+    [ChanPid] = emqx_cm:lookup_channels(ClientId),
+
+    %% THEN: chan-info stats reflect the *post-replay* state — messages
+    %% moved from mqueue into inflight — well before the 15s stats_timer
+    %% would tick. Pre-fix, the snapshot is taken on `{event, connected}'
+    %% (before the deferred replay), so it shows inflight_cnt=0 and
+    %% mqueue_len=NMsgs. Post-fix, REPLY_EVENT(updated) fires after the
+    %% replay, refreshing the snapshot to inflight_cnt=NMsgs, mqueue_len=0.
+    PollTimeout = 5_000,
+    Result = wait_until(
+        fun() ->
+            case emqx_cm:get_chan_stats(ClientId, ChanPid) of
+                Stats when is_list(Stats) ->
+                    Inflight = proplists:get_value(inflight_cnt, Stats, 0),
+                    Inflight >= NMsgs;
+                _ ->
+                    false
+            end
+        end,
+        PollTimeout
+    ),
+    ?assertEqual(
+        true,
+        Result,
+        {chan_stats_not_refreshed_post_replay, emqx_cm:get_chan_stats(ClientId, ChanPid)}
+    ),
+
+    catch emqtt:stop(ClientB),
+    ok.
+
+%% End t_chan_info_refreshed_after_takeover_replay helpers --------------
+
+wait_until(Fun, Timeout) ->
+    wait_until(Fun, Timeout, 50).
+
+wait_until(_Fun, Timeout, _Step) when Timeout =< 0 ->
+    false;
+wait_until(Fun, Timeout, Step) ->
+    case Fun() of
+        true ->
+            true;
+        false ->
+            timer:sleep(Step),
+            wait_until(Fun, Timeout - Step, Step)
+    end.
 
 %%--------------------------------------------------------------------
 %% Commands

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -53,8 +53,7 @@ tc_v5_only() ->
         t_takeover_session_then_abnormal_disconnect,
         t_takeover_session_then_abnormal_disconnect_2,
         t_disconnected_at_before_connected_at_on_takeover,
-        t_disconnected_at_before_connected_at_on_discard,
-        t_chan_info_refreshed_after_takeover_replay
+        t_disconnected_at_before_connected_at_on_discard
     ].
 
 init_per_suite(Config) ->
@@ -931,7 +930,8 @@ t_chan_info_refreshed_after_takeover_replay(Config) ->
             do_chan_info_refreshed_after_takeover_replay(Config)
     end.
 
-do_chan_info_refreshed_after_takeover_replay(_Config) ->
+do_chan_info_refreshed_after_takeover_replay(Config) ->
+    MqttVer = ?config(mqtt_vsn, Config),
     ClientId = iolist_to_binary([
         atom_to_binary(?FUNCTION_NAME),
         "-",
@@ -940,9 +940,9 @@ do_chan_info_refreshed_after_takeover_replay(_Config) ->
     Topic = <<ClientId/binary, "/t">>,
     NMsgs = 3,
     ClientOpts = [
-        {proto_ver, v5},
-        {clean_start, false},
-        {properties, #{'Session-Expiry-Interval' => 60}}
+        {proto_ver, MqttVer},
+        {clean_start, false}
+        | [{properties, #{'Session-Expiry-Interval' => 60}} || v5 == MqttVer]
     ],
 
     %% GIVEN: client A subscribes, then disconnects leaving session alive.
@@ -953,7 +953,7 @@ do_chan_info_refreshed_after_takeover_replay(_Config) ->
     ok = emqtt:disconnect(ClientA),
 
     %% AND: publish NMsgs messages so they queue in the offline session.
-    {ok, Publisher} = emqtt:start_link([{proto_ver, v5}, {clean_start, true}]),
+    {ok, Publisher} = emqtt:start_link([{proto_ver, MqttVer}, {clean_start, true}]),
     {ok, _} = emqtt:connect(Publisher),
     lists:foreach(
         fun(I) ->

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -937,7 +937,6 @@ t_chan_info_refreshed_after_takeover_replay(Config) ->
     end.
 
 do_chan_info_refreshed_after_takeover_replay(_Config) ->
-    process_flag(trap_exit, true),
     ClientId = iolist_to_binary([
         atom_to_binary(?FUNCTION_NAME),
         "-",

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -920,18 +920,13 @@ t_ongoing_takeover(Config) ->
 %%     todo.
 
 -doc """
-Regression test: after a session takeover triggers a replay, the
-?CHAN_INFO_TAB snapshot read by the dashboard and REST API must
-reflect the post-replay inflight, not the (zero) pre-replay value.
-
-Pre-fix, the snapshot would stay stale until the next 15s stats_timer
-tick. Post-fix, REPLY_EVENT(updated) appended to the channel's
-`continue' reply refreshes the snapshot immediately.
+Regression test: chan-info stats reflect post-replay state after
+session takeover (instead of waiting up to 15s for the stats_timer).
 """.
 t_chan_info_refreshed_after_takeover_replay(Config) ->
     case ?config(persistence_enabled, Config) of
         true ->
-            {skip, "Classic session only — DS path has its own stats model"};
+            {skip, "Classic session only — DS uses seqno_q*/n_streams stats"};
         _ ->
             do_chan_info_refreshed_after_takeover_replay(Config)
     end.
@@ -980,61 +975,26 @@ do_chan_info_refreshed_after_takeover_replay(_Config) ->
     ]),
     {ok, _} = emqtt:connect(ClientB),
 
-    %% Wait for takeover: the channel pid should change.
-    true = wait_until(
-        fun() ->
-            case emqx_cm:lookup_channels(ClientId) of
-                [Pid] when Pid =/= OldChanPid -> true;
-                _ -> false
-            end
-        end,
-        2000
-    ),
-    [ChanPid] = emqx_cm:lookup_channels(ClientId),
-
-    %% THEN: chan-info stats reflect the *post-replay* state — messages
-    %% moved from mqueue into inflight — well before the 15s stats_timer
-    %% would tick. Pre-fix, the snapshot is taken on `{event, connected}'
-    %% (before the deferred replay), so it shows inflight_cnt=0 and
-    %% mqueue_len=NMsgs. Post-fix, REPLY_EVENT(updated) fires after the
-    %% replay, refreshing the snapshot to inflight_cnt=NMsgs, mqueue_len=0.
-    PollTimeout = 5_000,
-    Result = wait_until(
-        fun() ->
-            case emqx_cm:get_chan_stats(ClientId, ChanPid) of
-                Stats when is_list(Stats) ->
-                    Inflight = proplists:get_value(inflight_cnt, Stats, 0),
-                    Inflight >= NMsgs;
-                _ ->
-                    false
-            end
-        end,
-        PollTimeout
-    ),
-    ?assertEqual(
-        true,
-        Result,
-        {chan_stats_not_refreshed_post_replay, emqx_cm:get_chan_stats(ClientId, ChanPid)}
+    %% THEN: chan-info stats reflect the post-replay inflight well before
+    %% the 15s stats_timer would tick. Comfort margin: 50ms x 100 = 5s.
+    ?retry(
+        50,
+        100,
+        begin
+            [ChanPid] = [
+                Pid
+             || Pid <- emqx_cm:lookup_channels(ClientId), Pid =/= OldChanPid
+            ],
+            ?assertMatch(
+                #{inflight_cnt := N} when N >= NMsgs,
+                maps:from_list(emqx_cm:get_chan_stats(ClientId, ChanPid)),
+                chan_stats_not_refreshed_post_replay
+            )
+        end
     ),
 
     catch emqtt:stop(ClientB),
     ok.
-
-%% End t_chan_info_refreshed_after_takeover_replay helpers --------------
-
-wait_until(Fun, Timeout) ->
-    wait_until(Fun, Timeout, 50).
-
-wait_until(_Fun, Timeout, _Step) when Timeout =< 0 ->
-    false;
-wait_until(Fun, Timeout, Step) ->
-    case Fun() of
-        true ->
-            true;
-        false ->
-            timer:sleep(Step),
-            wait_until(Fun, Timeout - Step, Step)
-    end.
 
 %%--------------------------------------------------------------------
 %% Commands

--- a/changes/ee/fix-17383.en.md
+++ b/changes/ee/fix-17383.en.md
@@ -1,0 +1,1 @@
+After a session takeover, the channel info reflected by the dashboard and REST API (`mqueue_len`, `inflight_cnt`) now updates immediately after the takeover replay completes, rather than waiting for the next 15-second stats refresh tick.


### PR DESCRIPTION
Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

After a session takeover, the dashboard's client view and REST API
`mqueue_len` / `inflight_cnt` were stale for up to 15 seconds (the
default `mqtt.idle_timeout` / stats-timer interval).

### Root cause

Commit 9c43e0ae15 ("feat(chan): allow return `continue` to
short-circuit control flow back", first shipped in `e5.9.0`) deferred
the takeover replay to a `continue` reply that runs **after** the
`{event, connected}` reply. Consequently `?CHAN_INFO_TAB` was
populated on `{event, connected}` with the pre-replay session
snapshot (`inflight_cnt=0`, `mqueue_len=N`). The actual replay then
moved the N messages from mqueue to inflight, but no event fired to
refresh `?CHAN_INFO_TAB` — so the snapshot stayed stale until the
15s `stats_timer` ticked.

### Fix

Append `?REPLY_EVENT(updated)` to the replies returned from
`emqx_channel:handle_info(continue, _)` post-replay. The catch-all
`handle_msg({event, _Other}, ...)` clause in every connection module
(`emqx_socket_connection`, `emqx_connection`, `emqx_ws_connection`)
already calls `emqx_cm:set_chan_info/2` + `emqx_cm:set_chan_stats/2`,
so this naturally refreshes the snapshot for all listener types.

The same fix path is exercised by both classic (`emqx_session_mem`)
and persistent (`emqx_persistent_session_ds`) takeover, since they
share `emqx_session:replay/3` dispatch.

### Test

`apps/emqx/test/emqx_takeover_SUITE.erl::t_chan_info_refreshed_after_takeover_replay`
reproduces the scenario (client A subscribes & disconnects, N
messages publish into the offline session, client B reconnects with
`clean_start=0` & `auto_ack=false`) and asserts that
`inflight_cnt` reflects N within 5 s — comfortably under the 15 s
stats-timer interval. Verified to fail without the fix
(`inflight_cnt=0` in the polled snapshot) and pass with it.

### Notes

The same regression exists on `release-59` (v5.10) and `release-510`
(v5.11) and should be ported in a follow-up.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)