### PR TITLE
test: optimize Datalayers bridge CT suite

### DIFF
--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -609,6 +609,8 @@ t_wss_update_opts(Config) ->
                 ok;
             {ws_upgrade_failed, {error, closed}} ->
                 ok;
+            {ws_upgrade_failed, {error, einval}} ->
+                ok;
             _ ->
                 error({unexpected_error, CertReqErr})
         end,

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -1898,8 +1898,10 @@ t_rule_test_trace(Config, Opts) ->
             #{sequence => Sequence}
         )
     end),
+    RuleTraceRetryInterval = maps:get(rule_trace_retry_interval, Opts, 1_000),
+    RuleTraceRetryAttempts = maps:get(rule_trace_retry_attempts, Opts, 10),
     ?tpal("checking logs"),
-    ?retry(1_000, 10, AssertLogFn(TraceName)),
+    ?retry(RuleTraceRetryInterval, RuleTraceRetryAttempts, AssertLogFn(TraceName)),
     ?tpal("logs ok"),
     {204, _} = stop_rule_test_trace(TraceName),
 
@@ -2018,7 +2020,11 @@ t_rule_test_trace(Config, Opts) ->
             ct:pal("trigger test trace response (with error):\n  ~p", [TriggerTestRespErr]),
             _Context4 = PostTestFn(Context3),
             ?tpal("waiting for fallback action test logs"),
-            ?retry(1_000, 10, AssertFallbackLogFn(TraceNameErr))
+            ?retry(
+                RuleTraceRetryInterval,
+                RuleTraceRetryAttempts,
+                AssertFallbackLogFn(TraceNameErr)
+            )
         end
     ),
     {204, _} = stop_rule_test_trace(TraceNameErr),

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
@@ -15,32 +15,50 @@
 %%------------------------------------------------------------------------------
 
 all() ->
-    [
-        {group, with_batch},
-        {group, without_batch}
-    ].
+    [{group, Group} || {Group, _Cases} <- matrix_cases()].
 
 groups() ->
-    TCs = emqx_common_test_helpers:all(?MODULE),
+    [{Group, Cases} || {Group, Cases} <- matrix_cases()].
+
+matrix_cases() ->
     [
-        {with_batch, [
-            {group, sync_query},
-            {group, async_query}
-        ]},
-        {without_batch, [
-            {group, sync_query},
-            {group, async_query}
-        ]},
-        {sync_query, [
-            {group, apiv1_tcp},
-            {group, apiv1_tls}
-        ]},
-        {async_query, [
-            {group, apiv1_tcp},
-            {group, apiv1_tls}
-        ]},
-        {apiv1_tcp, TCs},
-        {apiv1_tls, TCs}
+        {without_batch_sync_apiv1_tcp, representative_cases()},
+        {with_batch_sync_apiv1_tcp, batch_cases()},
+        {without_batch_async_apiv1_tcp, async_cases()},
+        {with_batch_async_apiv1_tcp, lists:usort(batch_cases() ++ async_cases())},
+        {without_batch_sync_apiv1_tls, tls_cases()}
+    ].
+
+representative_cases() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+batch_cases() ->
+    [
+        t_start_ok,
+        t_boolean_variants,
+        t_bad_timestamp,
+        t_missing_field,
+        t_write_failure
+    ].
+
+async_cases() ->
+    [
+        t_start_ok,
+        t_boolean_variants,
+        t_bad_timestamp,
+        t_missing_field,
+        t_write_failure,
+        t_authentication_error_on_send_message
+    ].
+
+tls_cases() ->
+    [
+        t_start_ok,
+        t_get_status,
+        t_create_disconnected,
+        t_authentication_error,
+        t_authentication_error_on_get_status,
+        t_authentication_error_on_send_message
     ].
 
 init_per_suite(Config) ->
@@ -49,7 +67,23 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_group(DatalayersType, Config0) when
+init_per_group(Group, Config0) ->
+    {BatchSize, QueryMode, DatalayersType} = matrix_group_config(Group),
+    Config = [{batch_size, BatchSize}, {query_mode, QueryMode} | Config0],
+    init_datalayers_group(DatalayersType, Config).
+
+matrix_group_config(without_batch_sync_apiv1_tcp) ->
+    {1, sync, apiv1_tcp};
+matrix_group_config(with_batch_sync_apiv1_tcp) ->
+    {100, sync, apiv1_tcp};
+matrix_group_config(without_batch_async_apiv1_tcp) ->
+    {1, async, apiv1_tcp};
+matrix_group_config(with_batch_async_apiv1_tcp) ->
+    {100, async, apiv1_tcp};
+matrix_group_config(without_batch_sync_apiv1_tls) ->
+    {1, sync, apiv1_tls}.
+
+init_datalayers_group(DatalayersType, Config0) when
     DatalayersType =:= apiv1_tcp;
     DatalayersType =:= apiv1_tls
 ->
@@ -141,22 +175,9 @@ init_per_group(DatalayersType, Config0) when
             NewConfig;
         false ->
             {skip, no_datalayers}
-    end;
-init_per_group(sync_query, Config) ->
-    [{query_mode, sync} | Config];
-init_per_group(async_query, Config) ->
-    [{query_mode, async} | Config];
-init_per_group(with_batch, Config) ->
-    [{batch_size, 100} | Config];
-init_per_group(without_batch, Config) ->
-    [{batch_size, 1} | Config];
-init_per_group(_Group, Config) ->
-    Config.
+    end.
 
-end_per_group(Group, Config) when
-    Group =:= apiv1_tcp;
-    Group =:= apiv1_tls
-->
+end_per_group(_Group, Config) ->
     Apps = ?config(apps, Config),
     ProxyHost = ?config(proxy_host, Config),
     ProxyPort = ?config(proxy_port, Config),
@@ -164,8 +185,6 @@ end_per_group(Group, Config) when
     emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
     ehttpc_sup:stop_pool(EHttpcPoolName),
     emqx_cth_suite:stop(Apps),
-    ok;
-end_per_group(_Group, _Config) ->
     ok.
 
 init_per_testcase(_Testcase, Config) ->
@@ -403,6 +422,22 @@ assert_persisted_data(ClientId, Expected, PersistedData) ->
     ),
     ok.
 
+wait_until_persisted_data(Table, ClientId, Expected, Config) ->
+    wait_until_persisted_data(Table, ClientId, Expected, Config, _Attempts = 20).
+
+wait_until_persisted_data(Table, ClientId, Expected, Config, Attempts) ->
+    try
+        PersistedData = query_by_clientid(Table, ClientId, Config),
+        assert_persisted_data(ClientId, Expected, PersistedData),
+        PersistedData
+    catch
+        Class:Reason:Stacktrace when Attempts =:= 1 ->
+            erlang:raise(Class, Reason, Stacktrace);
+        _Class:_Reason:_Stacktrace ->
+            ct:sleep(100),
+            wait_until_persisted_data(Table, ClientId, Expected, Config, Attempts - 1)
+    end.
+
 connector_id(Config) ->
     Name = ?config(connector_name, Config),
     emqx_connector_resource:resource_id(<<"datalayers">>, Name).
@@ -444,8 +479,6 @@ t_start_ok(Config) ->
                 sync ->
                     ?assertMatch({ok, 204, _}, send_message(Config, SentData))
             end,
-            ct:sleep(1500),
-            PersistedData = query_by_clientid(Table, ClientId, Config),
             Expected = #{
                 bool => true,
                 int_value => -123,
@@ -453,7 +486,7 @@ t_start_ok(Config) ->
                 float_value => 24.5,
                 payload => emqx_utils_json:encode(Payload)
             },
-            assert_persisted_data(ClientId, Expected, PersistedData),
+            wait_until_persisted_data(Table, ClientId, Expected, Config),
             ok
         end,
         fun(Trace0) ->
@@ -616,8 +649,6 @@ t_const_timestamp(Config) ->
         sync ->
             ?assertMatch({ok, 204, _}, send_message(Config, SentData))
     end,
-    ct:sleep(1500),
-    PersistedData = query_by_clientid(<<"mqtt">>, ClientId, Config),
     Expected = #{
         foo => 123,
         foo1 => 123.0,
@@ -630,7 +661,7 @@ t_const_timestamp(Config) ->
         baz3 => <<"au">>,
         baz4 => <<"1u">>
     },
-    assert_persisted_data(ClientId, Expected, PersistedData),
+    PersistedData = wait_until_persisted_data(<<"mqtt">>, ClientId, Expected, Config),
     TimeReturned0 = maps:get(<<"time">>, PersistedData),
     TimeReturned = pad_zero(TimeReturned0),
     ?assertEqual(TsStr, TimeReturned).
@@ -686,15 +717,13 @@ t_boolean_variants(Config) ->
                 async ->
                     ?assertMatch(ok, send_message(Config, SentData))
             end,
-            ct:sleep(1500),
-            PersistedData = query_by_clientid(Table, ClientId, Config),
             Expected = #{
                 bool => Translation,
                 int_value => -123,
                 uint_value => 123,
                 payload => emqx_utils_json:encode(Payload)
             },
-            assert_persisted_data(ClientId, Expected, PersistedData),
+            wait_until_persisted_data(Table, ClientId, Expected, Config),
             ok
         end,
         BoolVariants
@@ -746,11 +775,8 @@ t_any_num_as_float(Config) ->
         async ->
             ?assertMatch(ok, send_message(Config, SentData))
     end,
-    %% sleep is still need even in sync mode, or we would get an empty result sometimes
-    ct:sleep(1500),
-    PersistedData = query_by_clientid(<<"mqtt">>, ClientId, Config),
     Expected = #{float_no_dp => 123.0, float_dp => 123.0},
-    assert_persisted_data(ClientId, Expected, PersistedData),
+    PersistedData = wait_until_persisted_data(<<"mqtt">>, ClientId, Expected, Config),
     TimeReturned0 = maps:get(<<"time">>, PersistedData),
     TimeReturned = pad_zero(TimeReturned0),
     ?assertEqual(TsStr, TimeReturned).
@@ -800,11 +826,8 @@ t_tag_set_use_literal_value(Config) ->
         async ->
             ?assertMatch(ok, send_message(Config, SentData))
     end,
-    %% sleep is still need even in sync mode, or we would get an empty result sometimes
-    ct:sleep(1500),
-    PersistedData = query_by_clientid(<<"mqtt">>, ClientId, Config),
     Expected = #{field_key1 => 100.1, field_key2 => 100, field_key3 => 123.4},
-    assert_persisted_data(ClientId, Expected, PersistedData),
+    PersistedData = wait_until_persisted_data(<<"mqtt">>, ClientId, Expected, Config),
     TimeReturned0 = maps:get(<<"time">>, PersistedData),
     TimeReturned = pad_zero(TimeReturned0),
     ?assertEqual(TsStr, TimeReturned).
@@ -992,7 +1015,9 @@ t_write_failure(Config) ->
     ProxyPort = ?config(proxy_port, Config),
     ProxyHost = ?config(proxy_host, Config),
     QueryMode = ?config(query_mode, Config),
-    {ok, _} = create_bridge(Config),
+    {ok, _} = create_bridge(Config, #{
+        <<"resource_opts">> => #{<<"request_ttl">> => <<"500ms">>}
+    }),
     ClientId = emqx_guid:to_hexstr(emqx_guid:gen()),
     Payload = #{
         int_key => -123,
@@ -1234,5 +1259,8 @@ t_authentication_error_on_send_message(Config0) ->
     ok.
 
 t_rule_test_trace(Config) ->
-    Opts = #{},
+    Opts = #{
+        rule_trace_retry_interval => 100,
+        rule_trace_retry_attempts => 100
+    },
     emqx_bridge_v2_testlib:t_rule_test_trace(Config, Opts).

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -2269,12 +2269,13 @@ t_cluster_subscription(Config) ->
             on_exit(fun() -> catch emqtt:stop(C1) end),
             {ok, _} = emqtt:connect(C1),
             {ok, _, [2]} = emqtt:subscribe(C1, MQTTTopic, 2),
+            emqx_cth_cluster:sync_routes(Nodes),
 
             Payload = emqx_guid:to_hexstr(emqx_guid:gen()),
             Messages = [#{<<"data">> => Payload}],
             pubsub_publish(Config, PubSubTopic, Messages),
 
-            ?assertMatch({ok, _Published}, receive_published()),
+            ?assertMatch({ok, _Published}, receive_published(#{timeout => 60_000})),
 
             ok
         end,

--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_SUITE.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_SUITE.erl
@@ -261,7 +261,7 @@ t_explicit_session_takeover(Config) ->
     ok = rpc:call(Node1, emqx_eviction_agent, disable, [test_eviction]),
 
     {ok, C1} = emqtt_connect_for_publish(Port1),
-    emqtt:publish(C1, <<"t1">>, <<"MessageToEvictedSession1">>),
+    {ok, _} = emqtt:publish(C1, <<"t1">>, <<"MessageToEvictedSession1">>, qos1),
     ok = emqtt:disconnect(C1),
 
     ok = rpc:call(Node1, emqx_eviction_agent, enable, [test_eviction, undefined]),
@@ -286,9 +286,11 @@ t_explicit_session_takeover(Config) ->
 
     ok = rpc:call(Node1, emqx_eviction_agent, disable, [test_eviction]),
 
+    emqx_cth_cluster:sync_routes([Node1, Node2]),
+
     %% Session is on Node2, but we connect to Node1
     {ok, C2} = emqtt_connect_for_publish(Port1),
-    emqtt:publish(C2, <<"t1">>, <<"MessageToEvictedSession2">>),
+    {ok, _} = emqtt:publish(C2, <<"t1">>, <<"MessageToEvictedSession2">>, qos1),
     ok = emqtt:disconnect(C2),
 
     ct:sleep(100),
@@ -553,7 +555,7 @@ assert_receive_publish([#{payload := Msg, topic := Topic} | Rest]) ->
             topic := Topic
         }} ->
             assert_receive_publish(Rest)
-    after 1000 ->
+    after 5000 ->
         ?assert(false, "Message `" ++ binary_to_list(Msg) ++ "` is lost")
     end.
 


### PR DESCRIPTION
Release version:
5.10.4

## Summary

- Optimized `emqx_bridge_datalayers_SUITE` runtime by replacing fixed persistence sleeps with polling and using a shorter timeout for the write-failure path.
- Reduced the Datalayers CT matrix from 160 repeated executions to 43 targeted executions: one full TCP/sync/no-batch representative group plus focused batch, async, batch+async, and TLS coverage.
- Made rule-test trace log polling configurable in `emqx_bridge_v2_testlib`; Datalayers uses a shorter polling interval while other suites keep the default behavior.
- Hardened the flaky CT cases seen in PR CI: eviction-agent session takeover now waits for route convergence and QoS1 publish, WSS certificate-required accepts the observed socket race, and GCP Pub/Sub cluster subscription waits for route propagation before publish.
- Local Datalayers CT changed from `160 tests, real 121.97s, internal 105.064s` to `43 tests, real 51.18s, internal 33.473s`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (not required: test-only change)
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary) (not applicable: no schema changes)