### PR TITLE
fix(redis): validate sentinel auth in dry run

### DIFF
--- a/apps/emqx_redis/src/emqx_redis.erl
+++ b/apps/emqx_redis/src/emqx_redis.erl
@@ -34,6 +34,7 @@
 -define(REDIS_HOST_OPTIONS, #{
     default_port => ?REDIS_DEFAULT_PORT
 }).
+-define(SENTINEL_VALIDATION_CLIENT, sentinel_validation_client).
 
 %%=====================================================================
 namespace() -> "redis".
@@ -137,24 +138,104 @@ on_start(InstId, Config0) ->
     State = #{pool_name => InstId, type => Type},
     ok = emqx_resource:allocate_resource(InstId, ?MODULE, type, Type),
     ok = emqx_resource:allocate_resource(InstId, ?MODULE, pool_name, InstId),
-    case Type of
-        cluster ->
-            case eredis_cluster:start_pool(InstId, Opts) of
-                {ok, _} ->
-                    {ok, State};
-                {ok, _, _} ->
-                    {ok, State};
-                {error, Reason} ->
-                    {error, Reason}
-            end;
-        _ ->
-            case emqx_resource_pool:start(InstId, ?MODULE, Opts) of
-                ok ->
-                    {ok, State};
-                {error, Reason} ->
-                    {error, Reason}
-            end
+    case validate_sentinel_connection(Type, InstId, Config, Options) of
+        ok ->
+            do_start(Type, InstId, Opts, State);
+        {error, Reason} ->
+            {error, Reason}
     end.
+
+do_start(cluster, InstId, Opts, State) ->
+    case eredis_cluster:start_pool(InstId, Opts) of
+        {ok, _} ->
+            {ok, State};
+        {ok, _, _} ->
+            {ok, State};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+do_start(_Type, InstId, Opts, State) ->
+    case emqx_resource_pool:start(InstId, ?MODULE, Opts) of
+        ok ->
+            {ok, State};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+validate_sentinel_connection(sentinel, InstId, Config, Options) ->
+    Servers = servers(Config),
+    Sentinel = maps:get(sentinel, Config),
+    SentinelOptions = sentinel_client_options(Config, Options),
+    validate_sentinel_servers(InstId, Servers, Sentinel, SentinelOptions, []);
+validate_sentinel_connection(_Type, _InstId, _Config, _Options) ->
+    ok.
+
+validate_sentinel_servers(_InstId, [], _Sentinel, _Options, Errors) ->
+    {error, {sentinel_error, sentinel_error_reason(Errors)}};
+validate_sentinel_servers(InstId, [{Host, Port} | Rest], Sentinel, Options, Errors) ->
+    case eredis_sentinel_client:start_link(Host, Port, Options) of
+        {ok, Pid} ->
+            ok = emqx_resource:allocate_resource(InstId, ?MODULE, ?SENTINEL_VALIDATION_CLIENT, Pid),
+            try query_sentinel_master(Pid, Sentinel) of
+                {ok, _} ->
+                    ok;
+                {error, Reason} ->
+                    validate_sentinel_servers(InstId, Rest, Sentinel, Options, [Reason | Errors])
+            after
+                ok = cleanup_sentinel_validation_client(InstId, Pid)
+            end;
+        {error, Reason} ->
+            validate_sentinel_servers(InstId, Rest, Sentinel, Options, [Reason | Errors])
+    end.
+
+sentinel_error_reason([Reason | _]) ->
+    Reason;
+sentinel_error_reason([]) ->
+    sentinel_unreachable.
+
+query_sentinel_master(Pid, Sentinel) ->
+    Command = ["SENTINEL", "get-master-addr-by-name", Sentinel],
+    try sentinel_master_response(eredis:q(Pid, Command)) of
+        Result ->
+            Result
+    catch
+        _:_ ->
+            {error, sentinel_unreachable}
+    end.
+
+sentinel_master_response({ok, [_HostBin, PortBin]}) when is_binary(PortBin) ->
+    _ = binary_to_integer(PortBin),
+    {ok, connected};
+sentinel_master_response({ok, undefined}) ->
+    {error, sentinel_master_unknown};
+sentinel_master_response({error, <<"IDONTKNOW", _Rest/binary>>}) ->
+    {error, sentinel_master_unreachable};
+sentinel_master_response({error, Reason}) ->
+    {error, Reason};
+sentinel_master_response(_) ->
+    {error, sentinel_unreachable}.
+
+sentinel_client_options(Config, Options) ->
+    Options0 = lists:keydelete(sentinel, 1, Options),
+    Options1 = prepend_option(password, maps:get(sentinel_password, Config, ""), Options0),
+    prepend_option(username, maps:get(sentinel_username, Config, undefined), Options1).
+
+prepend_option(_Key, undefined, Options) ->
+    Options;
+prepend_option(Key, Value, Options) ->
+    [{Key, Value} | lists:keydelete(Key, 1, Options)].
+
+cleanup_sentinel_validation_client(InstId, Pid) ->
+    ok = stop_sentinel_validation_client(Pid),
+    ok = emqx_resource:deallocate_resource(InstId, ?SENTINEL_VALIDATION_CLIENT).
+
+stop_sentinel_validation_client(#{?SENTINEL_VALIDATION_CLIENT := Pid}) ->
+    stop_sentinel_validation_client(Pid);
+stop_sentinel_validation_client(Pid) when is_pid(Pid) ->
+    eredis_sentinel_client:stop(Pid),
+    ok;
+stop_sentinel_validation_client(_Resources) ->
+    ok.
 
 ssl_options(SSL = #{enable := true}) ->
     [
@@ -169,8 +250,10 @@ on_stop(InstId, _State) ->
         msg => "stopping_redis_connector",
         connector => InstId
     }),
+    Resources = emqx_resource:get_allocated_resources(InstId),
+    ok = stop_sentinel_validation_client(Resources),
     Res =
-        case emqx_resource:get_allocated_resources(InstId) of
+        case Resources of
             #{pool_name := PoolName, type := cluster} ->
                 case eredis_cluster:stop_pool(PoolName) of
                     {error, not_found} -> ok;

--- a/apps/emqx_redis/test/emqx_redis_SUITE.erl
+++ b/apps/emqx_redis/test/emqx_redis_SUITE.erl
@@ -153,6 +153,43 @@ t_sentinel_auth_master_auth_sentinel_auth(_Config) ->
         sentinel_auth => password
     }).
 
+t_sentinel_dry_run_rejects_stale_sentinel_auth(_Config) ->
+    ResourceId = <<"emqx_redis_SUITE_sentinel_dry_run_auth">>,
+    GoodConfig = redis_config_sentinel_auth_matrix(
+        ?REDIS_SENTINEL_S_AUTH_M_NO_AUTH_HOST,
+        none,
+        password
+    ),
+    BadConfig = redis_config_sentinel_auth_matrix(
+        ?REDIS_SENTINEL_S_AUTH_M_NO_AUTH_HOST,
+        none,
+        wrong_username
+    ),
+    {ok, #{config := GoodCheckedConfig}} =
+        emqx_resource:check_config(?REDIS_RESOURCE_MOD, GoodConfig),
+    {ok, #{config := BadCheckedConfig}} =
+        emqx_resource:check_config(?REDIS_RESOURCE_MOD, BadConfig),
+    try
+        {ok, #{status := connected}} = emqx_resource:create_local(
+            ResourceId,
+            ?CONNECTOR_RESOURCE_GROUP,
+            ?REDIS_RESOURCE_MOD,
+            GoodCheckedConfig,
+            #{spawn_buffer_workers => true}
+        ),
+        ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+        ?assertMatch(
+            {error, {sentinel_error, #{type := authentication_error}}},
+            emqx_resource:create_dry_run_local(
+                <<"emqx_redis_SUITE_sentinel_dry_run_wrong_auth">>,
+                ?REDIS_RESOURCE_MOD,
+                BadCheckedConfig
+            )
+        )
+    after
+        catch emqx_resource:remove_local(ResourceId)
+    end.
+
 perform_lifecycle_check(ResourceId, InitialConfig, RedisCommand) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(?REDIS_RESOURCE_MOD, InitialConfig),
@@ -290,6 +327,10 @@ sentinel_auth_config(none) ->
 sentinel_auth_config(password) ->
     "" ++
         "    sentinel_username = \"sentinel_user\"\n" ++
+        "    sentinel_password = \"sentinel-password\"\n";
+sentinel_auth_config(wrong_username) ->
+    "" ++
+        "    sentinel_username = \"wrong_sentinel_user\"\n" ++
         "    sentinel_password = \"sentinel-password\"\n".
 
 run_sentinel_auth_matrix_case(#{


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15308

Release version:
6.0.3

## Summary

This backports #17366 to `release-60`.

Redis Sentinel dry runs could reuse the process-global `eredis_sentinel` discovery process started by an existing connector with valid Sentinel credentials. If a user then probed the same Sentinel with an invalid `sentinel_username`, the dry run could report success even though saving or reconnecting the connector failed with `WRONGPASS`.

This change validates Sentinel discovery with the current connector config before starting the Redis pool. It opens a short-lived `eredis_sentinel_client`, runs `SENTINEL get-master-addr-by-name`, and cleans up the validation client on success, failure, and connector stop. A regression test first creates a valid Sentinel-auth connector, then dry-runs invalid Sentinel credentials and expects an authentication error.

Checked with `mix compile`, `emqx_redis_SUITE`, the new regression case, `erlfmt`, `apps-version-check`, and `git diff --check`. No changelog is added because this is a follow-up/backport for behavior introduced by Redis Sentinel auth support and is covered by the existing release note. There are no schema changes.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- ~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
