### PR TITLE
test: optimize Datalayers bridge CT suite

### DIFF
--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -608,6 +608,8 @@ t_wss_update_opts(Config) ->
                 ok;
             {ws_upgrade_failed, {error, closed}} ->
                 ok;
+            {ws_upgrade_failed, {error, einval}} ->
+                ok;
             _ ->
                 error({unexpected_error, CertReqErr})
         end,

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -2263,8 +2263,10 @@ t_rule_test_trace(Config, Opts) ->
             #{sequence => Sequence}
         )
     end),
+    RuleTraceRetryInterval = maps:get(rule_trace_retry_interval, Opts, 1_000),
+    RuleTraceRetryAttempts = maps:get(rule_trace_retry_attempts, Opts, 10),
     ?tpal("checking logs"),
-    ?retry(1_000, 10, AssertLogFn(TraceName)),
+    ?retry(RuleTraceRetryInterval, RuleTraceRetryAttempts, AssertLogFn(TraceName)),
     ?tpal("logs ok"),
     {204, _} = stop_rule_test_trace(TraceName),
 
@@ -2383,7 +2385,11 @@ t_rule_test_trace(Config, Opts) ->
             ct:pal("trigger test trace response (with error):\n  ~p", [TriggerTestRespErr]),
             _Context4 = PostTestFn(Context3),
             ?tpal("waiting for fallback action test logs"),
-            ?retry(1_000, 10, AssertFallbackLogFn(TraceNameErr))
+            ?retry(
+                RuleTraceRetryInterval,
+                RuleTraceRetryAttempts,
+                AssertFallbackLogFn(TraceNameErr)
+            )
         end
     ),
     {204, _} = stop_rule_test_trace(TraceNameErr),

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
@@ -18,32 +18,50 @@
 -import(emqx_common_test_helpers, [on_exit/1]).
 
 all() ->
-    [
-        {group, with_batch},
-        {group, without_batch}
-    ].
+    [{group, Group} || {Group, _Cases} <- matrix_cases()].
 
 groups() ->
-    TCs = emqx_common_test_helpers:all(?MODULE),
+    [{Group, Cases} || {Group, Cases} <- matrix_cases()].
+
+matrix_cases() ->
     [
-        {with_batch, [
-            {group, sync_query},
-            {group, async_query}
-        ]},
-        {without_batch, [
-            {group, sync_query},
-            {group, async_query}
-        ]},
-        {sync_query, [
-            {group, apiv1_http},
-            {group, apiv1_https}
-        ]},
-        {async_query, [
-            {group, apiv1_http},
-            {group, apiv1_https}
-        ]},
-        {apiv1_http, TCs},
-        {apiv1_https, TCs}
+        {without_batch_sync_apiv1_http, representative_cases()},
+        {with_batch_sync_apiv1_http, batch_cases()},
+        {without_batch_async_apiv1_http, async_cases()},
+        {with_batch_async_apiv1_http, lists:usort(batch_cases() ++ async_cases())},
+        {without_batch_sync_apiv1_https, https_cases()}
+    ].
+
+representative_cases() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+batch_cases() ->
+    [
+        t_start_ok,
+        t_boolean_variants,
+        t_bad_timestamp,
+        t_missing_field,
+        t_write_failure
+    ].
+
+async_cases() ->
+    [
+        t_start_ok,
+        t_boolean_variants,
+        t_bad_timestamp,
+        t_missing_field,
+        t_write_failure,
+        t_authentication_error_on_send_message
+    ].
+
+https_cases() ->
+    [
+        t_start_ok,
+        t_get_status,
+        t_create_disconnected,
+        t_authentication_error,
+        t_authentication_error_on_get_status,
+        t_authentication_error_on_send_message
     ].
 
 init_per_suite(Config) ->
@@ -52,7 +70,23 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_group(DatalayersType, Config0) when
+init_per_group(Group, Config0) ->
+    {BatchSize, QueryMode, DatalayersType} = matrix_group_config(Group),
+    Config = [{batch_size, BatchSize}, {query_mode, QueryMode} | Config0],
+    init_datalayers_group(DatalayersType, Config).
+
+matrix_group_config(without_batch_sync_apiv1_http) ->
+    {1, sync, apiv1_http};
+matrix_group_config(with_batch_sync_apiv1_http) ->
+    {100, sync, apiv1_http};
+matrix_group_config(without_batch_async_apiv1_http) ->
+    {1, async, apiv1_http};
+matrix_group_config(with_batch_async_apiv1_http) ->
+    {100, async, apiv1_http};
+matrix_group_config(without_batch_sync_apiv1_https) ->
+    {1, sync, apiv1_https}.
+
+init_datalayers_group(DatalayersType, Config0) when
     DatalayersType =:= apiv1_http;
     DatalayersType =:= apiv1_https
 ->
@@ -144,22 +178,9 @@ init_per_group(DatalayersType, Config0) when
             NewConfig;
         false ->
             {skip, no_datalayers}
-    end;
-init_per_group(sync_query, Config) ->
-    [{query_mode, sync} | Config];
-init_per_group(async_query, Config) ->
-    [{query_mode, async} | Config];
-init_per_group(with_batch, Config) ->
-    [{batch_size, 100} | Config];
-init_per_group(without_batch, Config) ->
-    [{batch_size, 1} | Config];
-init_per_group(_Group, Config) ->
-    Config.
+    end.
 
-end_per_group(Group, Config) when
-    Group =:= apiv1_http;
-    Group =:= apiv1_https
-->
+end_per_group(_Group, Config) ->
     Apps = ?config(apps, Config),
     ProxyHost = ?config(proxy_host, Config),
     ProxyPort = ?config(proxy_port, Config),
@@ -167,8 +188,6 @@ end_per_group(Group, Config) when
     emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
     ehttpc_sup:stop_pool(EHttpcPoolName),
     emqx_cth_suite:stop(Apps),
-    ok;
-end_per_group(_Group, _Config) ->
     ok.
 
 init_per_testcase(_Testcase, Config) ->
@@ -407,6 +426,22 @@ assert_persisted_data(ClientId, Expected, PersistedData) ->
     ),
     ok.
 
+wait_until_persisted_data(Table, ClientId, Expected, Config) ->
+    wait_until_persisted_data(Table, ClientId, Expected, Config, _Attempts = 20).
+
+wait_until_persisted_data(Table, ClientId, Expected, Config, Attempts) ->
+    try
+        PersistedData = query_by_clientid(Table, ClientId, Config),
+        assert_persisted_data(ClientId, Expected, PersistedData),
+        PersistedData
+    catch
+        Class:Reason:Stacktrace when Attempts =:= 1 ->
+            erlang:raise(Class, Reason, Stacktrace);
+        _Class:_Reason:_Stacktrace ->
+            ct:sleep(100),
+            wait_until_persisted_data(Table, ClientId, Expected, Config, Attempts - 1)
+    end.
+
 connector_id(Config) ->
     emqx_bridge_v2_testlib:connector_resource_id(Config).
 
@@ -598,7 +633,7 @@ t_const_timestamp(Config) ->
     Const = (Const0 div 100) * 100 + 1,
     ConstBin = integer_to_binary(Const),
     TsStr = iolist_to_binary(
-        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, 0}])
+        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, "Z"}])
     ),
     ?assertMatch(
         {ok, _},
@@ -637,13 +672,22 @@ t_const_timestamp(Config) ->
         baz3 => <<"au">>,
         baz4 => <<"1u">>
     },
-    ?retry(200, 10, begin
-        PersistedData = query_by_clientid(<<"mqtt">>, ClientId, Config),
-        assert_persisted_data(ClientId, Expected, PersistedData),
-        TimeReturned = maps:get(<<"time">>, PersistedData),
-        ?assertEqual(TsStr, TimeReturned)
-    end),
-    ok.
+    PersistedData = wait_until_persisted_data(<<"mqtt">>, ClientId, Expected, Config),
+    TimeReturned0 = maps:get(<<"time">>, PersistedData),
+    TimeReturned = pad_zero(TimeReturned0),
+    ?assertEqual(TsStr, TimeReturned).
+
+%% influxdb returns timestamps without trailing zeros such as
+%% "2023-02-28T17:21:51.63678163Z"
+%% while the standard should be
+%% "2023-02-28T17:21:51.636781630Z"
+pad_zero(BinTs) ->
+    StrTs = binary_to_list(BinTs),
+    [Nano | Rest] = lists:reverse(string:tokens(StrTs, ".")),
+    [$Z | NanoNum] = lists:reverse(Nano),
+    Padding = lists:duplicate(10 - length(Nano), $0),
+    NewNano = lists:reverse(NanoNum) ++ Padding ++ "Z",
+    iolist_to_binary(string:join(lists:reverse([NewNano | Rest]), ".")).
 
 %% XXX: this case need:
 %% [ts_engine.schemaless]
@@ -688,15 +732,13 @@ t_boolean_variants(Config) ->
                 async ->
                     ?assertMatch(ok, send_message(Config, SentData))
             end,
-            ct:sleep(2000),
-            PersistedData = query_by_clientid(Table, ClientId, Config),
             Expected = #{
                 bool => Translation,
                 int_value => -123,
                 uint_value => 123,
                 payload => emqx_utils_json:encode(Payload)
             },
-            assert_persisted_data(ClientId, Expected, PersistedData),
+            wait_until_persisted_data(Table, ClientId, Expected, Config),
             ok
         end,
         BoolVariants
@@ -708,7 +750,7 @@ t_any_num_as_float(Config) ->
     Const = erlang:system_time(nanosecond),
     ConstBin = integer_to_binary(Const),
     TsStr = iolist_to_binary(
-        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, 0}])
+        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, "Z"}])
     ),
     ?assertMatch(
         {ok, _},
@@ -748,14 +790,11 @@ t_any_num_as_float(Config) ->
         async ->
             ?assertMatch(ok, send_message(Config, SentData))
     end,
-    ?retry(200, 10, begin
-        PersistedData = query_by_clientid(<<"mqtt">>, ClientId, Config),
-        Expected = #{float_no_dp => 123.0, float_dp => 123.0},
-        assert_persisted_data(ClientId, Expected, PersistedData),
-        TimeReturned = maps:get(<<"time">>, PersistedData),
-        ?assertEqual(TsStr, TimeReturned)
-    end),
-    ok.
+    Expected = #{float_no_dp => 123.0, float_dp => 123.0},
+    PersistedData = wait_until_persisted_data(<<"mqtt">>, ClientId, Expected, Config),
+    TimeReturned0 = maps:get(<<"time">>, PersistedData),
+    TimeReturned = pad_zero(TimeReturned0),
+    ?assertEqual(TsStr, TimeReturned).
 
 t_tag_set_use_literal_value(Config) ->
     Table = atom_to_binary(?FUNCTION_NAME),
@@ -763,7 +802,7 @@ t_tag_set_use_literal_value(Config) ->
     Const = erlang:system_time(nanosecond),
     ConstBin = integer_to_binary(Const),
     TsStr = iolist_to_binary(
-        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, 0}])
+        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, "Z"}])
     ),
     ?assertMatch(
         {ok, _},
@@ -804,12 +843,10 @@ t_tag_set_use_literal_value(Config) ->
         async ->
             ?assertMatch(ok, send_message(Config, SentData))
     end,
-    %% sleep is still need even in sync mode, or we would get an empty result sometimes
-    ct:sleep(1500),
-    PersistedData = query_by_clientid(Table, ClientId, Config),
     Expected = #{field_key1 => 100.1, field_key2 => 100, field_key3 => 123.4},
-    assert_persisted_data(ClientId, Expected, PersistedData),
-    TimeReturned = maps:get(<<"time">>, PersistedData),
+    PersistedData = wait_until_persisted_data(Table, ClientId, Expected, Config),
+    TimeReturned0 = maps:get(<<"time">>, PersistedData),
+    TimeReturned = pad_zero(TimeReturned0),
     ?assertEqual(TsStr, TimeReturned).
 
 t_bad_timestamp(Config) ->
@@ -996,7 +1033,9 @@ t_write_failure(Config) ->
     ProxyPort = ?config(proxy_port, Config),
     ProxyHost = ?config(proxy_host, Config),
     QueryMode = ?config(query_mode, Config),
-    {ok, _} = create_bridge(Config),
+    {ok, _} = create_bridge(Config, #{
+        <<"resource_opts">> => #{<<"request_ttl">> => <<"500ms">>}
+    }),
     ClientId = random_clientid_(),
     Payload = #{
         int_key => -123,
@@ -1243,7 +1282,10 @@ t_authentication_error_on_send_message(Config0) ->
     ok.
 
 t_rule_test_trace(Config) ->
-    Opts = #{},
+    Opts = #{
+        rule_trace_retry_interval => 100,
+        rule_trace_retry_attempts => 100
+    },
     emqx_bridge_v2_testlib:t_rule_test_trace(Config, Opts).
 
 random_clientid_() ->

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
@@ -633,7 +633,7 @@ t_const_timestamp(Config) ->
     Const = (Const0 div 100) * 100 + 1,
     ConstBin = integer_to_binary(Const),
     TsStr = iolist_to_binary(
-        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, "Z"}])
+        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, 0}])
     ),
     ?assertMatch(
         {ok, _},
@@ -677,17 +677,32 @@ t_const_timestamp(Config) ->
     TimeReturned = pad_zero(TimeReturned0),
     ?assertEqual(TsStr, TimeReturned).
 
-%% influxdb returns timestamps without trailing zeros such as
-%% "2023-02-28T17:21:51.63678163Z"
+%% Datalayers may return timestamps without trailing zeros such as
+%% "2023-02-28T17:21:51.63678163+00:00"
 %% while the standard should be
-%% "2023-02-28T17:21:51.636781630Z"
+%% "2023-02-28T17:21:51.636781630+00:00"
 pad_zero(BinTs) ->
-    StrTs = binary_to_list(BinTs),
-    [Nano | Rest] = lists:reverse(string:tokens(StrTs, ".")),
-    [$Z | NanoNum] = lists:reverse(Nano),
-    Padding = lists:duplicate(10 - length(Nano), $0),
-    NewNano = lists:reverse(NanoNum) ++ Padding ++ "Z",
-    iolist_to_binary(string:join(lists:reverse([NewNano | Rest]), ".")).
+    case binary:split(BinTs, <<".">>) of
+        [Prefix, FractionWithOffset] ->
+            {Fraction, Offset} = split_fraction_offset(FractionWithOffset),
+            Padding =
+                case 9 - byte_size(Fraction) of
+                    N when N > 0 -> binary:copy(<<"0">>, N);
+                    _ -> <<>>
+                end,
+            <<Prefix/binary, ".", Fraction/binary, Padding/binary, Offset/binary>>;
+        [BinTs] ->
+            BinTs
+    end.
+
+split_fraction_offset(FractionWithOffset) ->
+    case binary:match(FractionWithOffset, [<<"Z">>, <<"+">>, <<"-">>]) of
+        {Pos, _Len} ->
+            <<Fraction:Pos/binary, Offset/binary>> = FractionWithOffset,
+            {Fraction, Offset};
+        nomatch ->
+            {FractionWithOffset, <<>>}
+    end.
 
 %% XXX: this case need:
 %% [ts_engine.schemaless]
@@ -750,7 +765,7 @@ t_any_num_as_float(Config) ->
     Const = erlang:system_time(nanosecond),
     ConstBin = integer_to_binary(Const),
     TsStr = iolist_to_binary(
-        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, "Z"}])
+        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, 0}])
     ),
     ?assertMatch(
         {ok, _},
@@ -802,7 +817,7 @@ t_tag_set_use_literal_value(Config) ->
     Const = erlang:system_time(nanosecond),
     ConstBin = integer_to_binary(Const),
     TsStr = iolist_to_binary(
-        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, "Z"}])
+        calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, 0}])
     ),
     ?assertMatch(
         {ok, _},

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -2064,12 +2064,13 @@ t_cluster_subscription(TCConfig) when is_list(TCConfig) ->
             on_exit(fun() -> catch emqtt:stop(C1) end),
             {ok, _} = emqtt:connect(C1),
             {ok, _, [2]} = emqtt:subscribe(C1, RepublishTopic, 2),
+            emqx_cth_cluster:sync_routes(Nodes),
 
             Payload = emqx_guid:to_hexstr(emqx_guid:gen()),
             Messages = [#{<<"data">> => Payload}],
             pubsub_publish(TCConfig, PubSubTopic, Messages),
 
-            ?assertMatch({ok, _Published}, receive_published()),
+            ?assertMatch({ok, _Published}, receive_published(#{timeout => 60_000})),
 
             ok
         end,

--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_SUITE.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_SUITE.erl
@@ -262,7 +262,7 @@ t_explicit_session_takeover(Config) ->
     ok = rpc:call(Node1, emqx_eviction_agent, disable, [test_eviction]),
 
     {ok, C1} = emqtt_connect_for_publish(Port1),
-    emqtt:publish(C1, <<"t1">>, <<"MessageToEvictedSession1">>),
+    {ok, _} = emqtt:publish(C1, <<"t1">>, <<"MessageToEvictedSession1">>, qos1),
     ok = emqtt:disconnect(C1),
 
     ok = rpc:call(Node1, emqx_eviction_agent, enable, [test_eviction, undefined]),
@@ -288,9 +288,11 @@ t_explicit_session_takeover(Config) ->
     ok = rpc:call(Node1, emqx_eviction_agent, disable, [test_eviction]),
     emqx_cth_cluster:sync_routes([Node1, Node2]),
 
+    emqx_cth_cluster:sync_routes([Node1, Node2]),
+
     %% Session is on Node2, but we connect to Node1
     {ok, C2} = emqtt_connect_for_publish(Port1),
-    emqtt:publish(C2, <<"t1">>, <<"MessageToEvictedSession2">>),
+    {ok, _} = emqtt:publish(C2, <<"t1">>, <<"MessageToEvictedSession2">>, qos1),
     ok = emqtt:disconnect(C2),
 
     ct:sleep(100),
@@ -556,7 +558,7 @@ assert_receive_publish([#{payload := Msg, topic := Topic} | Rest]) ->
             topic := Topic
         }} ->
             assert_receive_publish(Rest)
-    after 1000 ->
+    after 5000 ->
         ?assert(false, "Message `" ++ binary_to_list(Msg) ++ "` is lost")
     end.
 


### PR DESCRIPTION
Fixes none

Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

- Backports PR #17388 to `release-60`.
- Optimizes `emqx_bridge_datalayers_SUITE` runtime by replacing fixed persistence sleeps with polling, shortening the write-failure request timeout, and reducing the Datalayers CT matrix to representative HTTP/HTTPS coverage for the r60 suite shape.
- Makes rule-test trace log polling configurable in `emqx_bridge_v2_testlib` so Datalayers can use a shorter polling interval while other suites keep the default behavior.
- Hardens flaky CT cases by accepting the observed WSS certificate-required socket race, waiting for GCP Pub/Sub cluster route propagation, and making eviction-agent session takeover publishes QoS1 after route convergence.
- Local port validation: `mix compile`, `./scripts/erlfmt -c` for changed Erlang files, and `git diff --check ce/release-60..HEAD` passed. Targeted CT commands were attempted but local EMQX occupied `1883/18083`, and Datalayers required unavailable `toxiproxy:8474`.

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (not required: test-only change)
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary) (not applicable: no schema changes)
