### PR TITLE
test(cassandra): generate TLS certs for common tests

### DIFF
--- a/.ci/docker-compose-file/cassandra/cassandra.yaml
+++ b/.ci/docker-compose-file/cassandra/cassandra.yaml
@@ -1047,12 +1047,12 @@ client_encryption_options:
     enabled: true
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
-    keystore: /certs/server.jks
-    keystore_password: my_password
+    keystore: /certs/cassandra.keystore.jks
+    keystore_password: password
     require_client_auth: true
     # Set trustore and truststore_password if require_client_auth is true
-    truststore: /certs/truststore.jks
-    truststore_password: my_password
+    truststore: /certs/cassandra.truststore.jks
+    truststore_password: password
     # More advanced defaults below:
     protocol: TLS
     store_type: JKS

--- a/.ci/docker-compose-file/cassandra/cassandra_noauth.yaml
+++ b/.ci/docker-compose-file/cassandra/cassandra_noauth.yaml
@@ -1047,12 +1047,12 @@ client_encryption_options:
     enabled: true
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
-    keystore: /certs/server.jks
-    keystore_password: my_password
+    keystore: /certs/cassandra.keystore.jks
+    keystore_password: password
     require_client_auth: true
     # Set trustore and truststore_password if require_client_auth is true
-    truststore: /certs/truststore.jks
-    truststore_password: my_password
+    truststore: /certs/cassandra.truststore.jks
+    truststore_password: password
     # More advanced defaults below:
     protocol: TLS
     store_type: JKS

--- a/.ci/docker-compose-file/docker-compose-cassandra.yaml
+++ b/.ci/docker-compose-file/docker-compose-cassandra.yaml
@@ -22,15 +22,31 @@ x-cassandra: &cassandra
     - emqx_bridge
 
 services:
+  ssl_cert_gen:
+    # see https://github.com/emqx/docker-images
+    image: ghcr.io/emqx/certgen:latest
+    container_name: ssl_cert_gen
+    user: "${DOCKER_USER:-root}"
+    environment:
+      CERTGEN_JKS_PREFIX: cassandra
+    volumes:
+      - /tmp/emqx-ci/emqx-shared-secret:/var/lib/secret
+
   cassandra_server:
     <<: *cassandra
     container_name: cassandra
+    depends_on:
+      ssl_cert_gen:
+        condition: service_completed_successfully
     volumes:
-      - ./certs:/certs
+      - /tmp/emqx-ci/emqx-shared-secret:/certs:ro
       - ./cassandra/cassandra.yaml:/etc/cassandra/cassandra.yaml
   cassandra_noauth_server:
     <<: *cassandra
     container_name: cassandra_noauth
+    depends_on:
+      ssl_cert_gen:
+        condition: service_completed_successfully
     volumes:
-      - ./certs:/certs
+      - /tmp/emqx-ci/emqx-shared-secret:/certs:ro
       - ./cassandra/cassandra_noauth.yaml:/etc/cassandra/cassandra.yaml

--- a/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
+++ b/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
@@ -230,13 +230,13 @@ with_failure(FailureType, TCConfig, Fn) ->
     emqx_common_test_helpers:with_failure(FailureType, ProxyName, ?PROXY_HOST, ?PROXY_PORT, Fn).
 
 cert_root() ->
-    filename:join([emqx_common_test_helpers:proj_root(), ".ci", "docker-compose-file", "certs"]).
+    os:getenv("CI_SHARED_SECRET_PATH", "/var/lib/secret").
 
 cacertfile() ->
     filename:join(cert_root(), ["ca.crt"]).
 
 certfile() ->
-    filename:join(cert_root(), ["client.pem"]).
+    filename:join(cert_root(), ["client.crt"]).
 
 keyfile() ->
     filename:join(cert_root(), ["client.key"]).


### PR DESCRIPTION
Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

- Backports PR #17364 to `release-60`.
- Generates Cassandra TLS certificates through the shared `ssl_cert_gen` service instead of relying on static files under `.ci/docker-compose-file/certs`.
- Updates Cassandra TLS configs to consume the generated JKS files from `/tmp/emqx-ci/emqx-shared-secret`, and updates the r60 Cassandra CT suite to read client certificates from `CI_SHARED_SECRET_PATH`.
- Local port validation: `mix compile`, `./scripts/erlfmt -c apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl`, `git diff --check ce/release-60..HEAD`, and Docker Compose config validation passed. The Cassandra CT command was attempted, but Docker failed while pulling `public.ecr.aws/docker/library/cassandra:3.11` with `toomanyrequests: Rate exceeded`.

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (not required: test-only change)
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary) (not applicable: no schema changes)
