### PR TITLE
fix(gateway): repair CoAP observe notifications

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -170,8 +170,12 @@ deliver(
             {Token, SeqId, OM2} ->
                 metrics_inc('messages.delivered', Ctx),
                 Msg = mqtt_to_coap(Message, Token, SeqId),
-                #{out := Out, tm := TM2} = emqx_coap_tm:handle_out(Msg, TMAcc),
-                {Out ++ OutAcc, OM2, TM2}
+                case emqx_coap_tm:handle_out(Msg, TMAcc) of
+                    #{out := Out, tm := TM2} ->
+                        {Out ++ OutAcc, OM2, TM2};
+                    Empty when map_size(Empty) =:= 0 ->
+                        {OutAcc, OM2, TMAcc}
+                end
         end
     end,
     {Outs, OM2, TM2} = lists:foldl(Fun, {[], OM, TM}, lists:reverse(Delivers)),
@@ -247,7 +251,7 @@ mqtt_to_coap(MQTT, Token, SeqId) ->
     }.
 
 get_notify_type(#message{qos = Qos}) ->
-    case emqx_conf:get([gateway, coap, notify_qos], non) of
+    case emqx_conf:get([gateway, coap, notify_type], qos) of
         qos ->
             case Qos of
                 ?QOS_0 ->

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -35,6 +35,10 @@
 -record(session, {
     transport_manager :: emqx_coap_tm:manager(),
     observe_manager :: emqx_coap_observe_res:manager(),
+    observe_inflight = 0 :: non_neg_integer(),
+    observe_pending :: queue:queue(),
+    observe_pending_len = 0 :: non_neg_integer(),
+    observe_pending_dropped = 0 :: non_neg_integer(),
     created_at :: pos_integer()
 }).
 
@@ -62,6 +66,9 @@
     awaiting_rel_max
 ]).
 
+-define(OBSERVE_INFLIGHT_WINDOW, 1).
+-define(OBSERVE_NOTIFICATION_QUEUE_MAX_LEN, 100).
+
 -import(emqx_coap_medium, [iter/3]).
 -import(emqx_coap_channel, [metrics_inc/2]).
 
@@ -74,6 +81,7 @@ new() ->
     #session{
         transport_manager = emqx_coap_tm:new(),
         observe_manager = emqx_coap_observe_res:new_manager(),
+        observe_pending = queue:new(),
         created_at = erlang:system_time(millisecond)
     }.
 
@@ -102,20 +110,20 @@ info(upgrade_qos, _) ->
     ?QOS_0;
 info(inflight, _) ->
     emqx_inflight:new();
-info(inflight_cnt, _) ->
-    0;
+info(inflight_cnt, #session{observe_inflight = Inflight}) ->
+    Inflight;
 info(inflight_max, _) ->
-    infinity;
+    ?OBSERVE_INFLIGHT_WINDOW;
 info(retry_interval, _) ->
     infinity;
 info(mqueue, _) ->
     emqx_mqueue:init(#{max_len => 0, store_qos0 => false});
-info(mqueue_len, _) ->
-    0;
+info(mqueue_len, #session{observe_pending_len = Len}) ->
+    Len;
 info(mqueue_max, _) ->
-    infinity;
-info(mqueue_dropped, _) ->
-    0;
+    ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN;
+info(mqueue_dropped, #session{observe_pending_dropped = Dropped}) ->
+    Dropped;
 info(next_pkt_id, _) ->
     0;
 info(awaiting_rel, _) ->
@@ -156,12 +164,11 @@ set_reply(Msg, #session{transport_manager = TM} = Session) ->
 deliver(
     Delivers,
     Ctx,
-    #session{
-        observe_manager = OM,
-        transport_manager = TM
-    } = Session
+    #session{} = Session
 ) ->
-    Fun = fun({_, Topic, Message}, {OutAcc, OMAcc, TMAcc} = Acc) ->
+    Fun = fun(
+        {_, Topic, Message}, {OutAcc, #session{observe_manager = OMAcc} = SessionAcc} = Acc
+    ) ->
         case emqx_coap_observe_res:res_changed(Topic, OMAcc) of
             undefined ->
                 metrics_inc('delivery.dropped', Ctx),
@@ -170,22 +177,17 @@ deliver(
             {Token, SeqId, OM2} ->
                 metrics_inc('messages.delivered', Ctx),
                 Msg = mqtt_to_coap(Message, Token, SeqId),
-                case emqx_coap_tm:handle_out(Msg, TMAcc) of
-                    #{out := Out, tm := TM2} ->
-                        {Out ++ OutAcc, OM2, TM2};
-                    Empty when map_size(Empty) =:= 0 ->
-                        {OutAcc, OM2, TMAcc}
-                end
+                SessionAcc1 = SessionAcc#session{observe_manager = OM2},
+                {Out, SessionAcc2} =
+                    send_or_queue_observe_notification(Topic, Msg, Message, Ctx, SessionAcc1),
+                {[Out | OutAcc], SessionAcc2}
         end
     end,
-    {Outs, OM2, TM2} = lists:foldl(Fun, {[], OM, TM}, lists:reverse(Delivers)),
+    {Outs, Session2} = lists:foldl(Fun, {[], Session}, lists:reverse(Delivers)),
 
     #{
-        out => lists:reverse(Outs),
-        session => Session#session{
-            observe_manager = OM2,
-            transport_manager = TM2
-        }
+        out => lists:flatten(lists:reverse(Outs)),
+        session => Session2
     }.
 
 timeout(Timer, Session) ->
@@ -209,8 +211,177 @@ call_transport_manager(
 process_tm(TM, Result, Session, Cursor) ->
     iter(Cursor, Result, Session#session{transport_manager = TM}).
 
-process_session(_, Result, Session) ->
-    Result#{session => Session}.
+process_session(_, Result, Session0) ->
+    {Result1, Session1} = maybe_drain_observe_notifications(Result, Session0),
+    Result1#{session => Session1}.
+
+send_or_queue_observe_notification(ObservedTopic, Msg, MQTT, Ctx, Session) ->
+    TrackInflight = is_confirmable_observe_notification(Msg),
+    case should_queue_observe_notification(Session) of
+        true ->
+            {[], enqueue_observe_notification(ObservedTopic, Msg, MQTT, Ctx, Session)};
+        false ->
+            maybe_send_or_enqueue_observe_notification(
+                ObservedTopic, Msg, MQTT, Ctx, Session, TrackInflight
+            )
+    end.
+
+should_queue_observe_notification(#session{
+    observe_inflight = Inflight,
+    observe_pending_len = PendingLen
+}) ->
+    Inflight >= ?OBSERVE_INFLIGHT_WINDOW orelse PendingLen > 0.
+
+maybe_send_or_enqueue_observe_notification(ObservedTopic, Msg, MQTT, Ctx, Session, TrackInflight) ->
+    case send_observe_notification_now(Msg, TrackInflight, Session) of
+        {[], Session1} ->
+            Session2 = enqueue_observe_notification(ObservedTopic, Msg, MQTT, Ctx, Session1),
+            {[], Session2};
+        {Out, Session1} ->
+            {Out, Session1}
+    end.
+
+send_observe_notification_now(Msg, TrackInflight, #session{transport_manager = TM0} = Session) ->
+    case emqx_coap_tm:handle_out(Msg, TM0) of
+        #{out := Out, tm := TM1} ->
+            Session1 = Session#session{transport_manager = TM1},
+            {Out, maybe_inc_observe_inflight(TrackInflight, Session1)};
+        #{tm := TM1} ->
+            {[], Session#session{transport_manager = TM1}};
+        Empty when map_size(Empty) =:= 0 ->
+            {[], Session}
+    end.
+
+maybe_inc_observe_inflight(true, #session{observe_inflight = Inflight} = Session) ->
+    Session#session{observe_inflight = Inflight + 1};
+maybe_inc_observe_inflight(false, Session) ->
+    Session.
+
+enqueue_observe_notification(
+    ObservedTopic,
+    Msg,
+    MQTT,
+    _Ctx,
+    #session{
+        observe_pending = Queue0,
+        observe_pending_len = Len0,
+        observe_pending_dropped = Dropped0
+    } = Session
+) when Len0 < ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN ->
+    Session#session{
+        observe_pending = queue:in({Msg, MQTT, ObservedTopic}, Queue0),
+        observe_pending_len = Len0 + 1,
+        observe_pending_dropped = Dropped0
+    };
+enqueue_observe_notification(
+    ObservedTopic,
+    Msg,
+    MQTT,
+    Ctx,
+    #session{
+        observe_pending = Queue0,
+        observe_pending_dropped = Dropped0
+    } = Session
+) ->
+    {{value, Dropped}, Queue1} = queue:out(Queue0),
+    DroppedMQTT = pending_mqtt(Dropped),
+    metrics_inc('delivery.dropped', Ctx),
+    metrics_inc('delivery.dropped.queue_full', Ctx),
+    log_observe_notification_queue_full(DroppedMQTT),
+    Session#session{
+        observe_pending = queue:in({Msg, MQTT, ObservedTopic}, Queue1),
+        observe_pending_dropped = Dropped0 + 1
+    }.
+
+maybe_drain_observe_notifications(Result0, Session0) ->
+    Done = maps:get(observe_notification_done, Result0, 0),
+    Result1 = maps:remove(observe_notification_done, Result0),
+    Session1 = release_observe_inflight(Done, Session0),
+    drain_observe_notifications(Result1, Session1).
+
+release_observe_inflight(0, Session) ->
+    Session;
+release_observe_inflight(Done, #session{observe_inflight = Inflight} = Session) ->
+    Session#session{observe_inflight = max(0, Inflight - Done)}.
+
+drain_observe_notifications(
+    Result,
+    #session{observe_inflight = Inflight} = Session
+) when Inflight >= ?OBSERVE_INFLIGHT_WINDOW ->
+    {Result, Session};
+drain_observe_notifications(Result, #session{observe_pending_len = 0} = Session) ->
+    {Result, Session};
+drain_observe_notifications(
+    Result,
+    #session{observe_pending = Queue0, observe_pending_len = Len0} = Session0
+) ->
+    case queue:out(Queue0) of
+        {{value, {Msg, _MQTT, _ObservedTopic} = Pending}, Queue1} ->
+            Session1 = Session0#session{
+                observe_pending = Queue1,
+                observe_pending_len = Len0 - 1
+            },
+            TrackInflight = is_confirmable_observe_notification(Msg),
+            case send_observe_notification_now(Msg, TrackInflight, Session1) of
+                {[], Session2} ->
+                    {Result, Session2#session{
+                        observe_pending = queue:in_r(Pending, Queue1),
+                        observe_pending_len = Len0
+                    }};
+                {Out, Session2} ->
+                    drain_observe_notifications(add_outs(Out, Result), Session2)
+            end;
+        {empty, _} ->
+            {Result, Session0#session{observe_pending_len = 0}}
+    end.
+
+add_outs(Outs, Result) ->
+    lists:foldl(
+        fun(Out, Acc) -> emqx_coap_medium:out(Out, Acc) end,
+        Result,
+        Outs
+    ).
+
+is_confirmable_observe_notification(#coap_message{type = con, method = {ok, _}} = Msg) ->
+    emqx_coap_message:get_option(observe, Msg, undefined) =/= undefined;
+is_confirmable_observe_notification(_) ->
+    false.
+
+log_observe_notification_queue_full(#message{topic = Topic, payload = Payload}) ->
+    ?SLOG_THROTTLE(
+        warning,
+        #{
+            msg => dropped_msg_due_to_mqueue_is_full,
+            queue => coap_observe_notification,
+            payload => Payload
+        },
+        #{topic => Topic}
+    ).
+
+pending_msg({Msg, _MQTT, _ObservedTopic}) ->
+    Msg.
+
+pending_mqtt({_Msg, MQTT, _ObservedTopic}) ->
+    MQTT.
+
+pending_observed_topic({_Msg, _MQTT, ObservedTopic}) ->
+    ObservedTopic.
+
+pending_token(Pending) ->
+    case pending_msg(Pending) of
+        #coap_message{token = Token} ->
+            Token;
+        _ ->
+            undefined
+    end.
+
+pending_message_topic(Pending) ->
+    case pending_mqtt(Pending) of
+        #message{topic = Topic} ->
+            Topic;
+        _ ->
+            undefined
+    end.
 
 process_subscribe(
     Sub,
@@ -232,13 +403,56 @@ process_subscribe(
                 session => Session#session{observe_manager = OM2}
             };
         Topic ->
+            Token = observe_token(Topic, OM),
             OM2 = emqx_coap_observe_res:remove(Topic, OM),
             Replay = emqx_coap_message:piggyback({ok, nocontent}, Msg),
+            Session1 = purge_pending_observe_notifications(Topic, Token, Session),
             Result#{
                 reply => Replay,
-                session => Session#session{observe_manager = OM2}
+                session => Session1#session{observe_manager = OM2}
             }
     end.
+
+observe_token(Topic, OM) ->
+    case maps:get(Topic, OM, undefined) of
+        #{token := Token} ->
+            Token;
+        _ ->
+            undefined
+    end.
+
+purge_pending_observe_notifications(_Topic, undefined, Session) ->
+    Session;
+purge_pending_observe_notifications(
+    Topic,
+    Token,
+    #session{observe_pending = Queue0, observe_pending_len = Len0} = Session
+) ->
+    Pending0 = queue:to_list(Queue0),
+    Pending = [
+        Entry
+     || Entry <- Pending0, not is_pending_observe_notification(Topic, Token, Entry)
+    ],
+    case length(Pending) of
+        Len0 ->
+            Session;
+        Len ->
+            Session#session{
+                observe_pending = queue:from_list(Pending),
+                observe_pending_len = Len
+            }
+    end.
+
+is_pending_observe_notification(Topic, Token, Pending) ->
+    pending_token(Pending) =:= Token andalso
+        case pending_observed_topic(Pending) of
+            Topic ->
+                true;
+            undefined ->
+                pending_message_topic(Pending) =:= Topic;
+            _ ->
+                false
+        end.
 
 mqtt_to_coap(MQTT, Token, SeqId) ->
     #message{payload = Payload} = MQTT,

--- a/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
@@ -26,7 +26,9 @@
     seq_id :: seq_id(),
     id :: state_machine_key(),
     token :: token() | undefined,
+    token_key :: token_key() | undefined,
     observe :: 0 | 1 | undefined | observed,
+    observe_notification = false :: boolean(),
     state :: atom(),
     timers :: map(),
     transport :: emqx_coap_transport:transport()
@@ -250,10 +252,21 @@ process_timeouts(
     ),
     iter(Iter, Result, Machine#state_machine{timers = NewTimers}, TM).
 
-process_manager(stop, Result, #state_machine{seq_id = SeqId}, TM) ->
-    Result#{tm => delete_machine(SeqId, TM)};
+process_manager(
+    stop,
+    Result,
+    #state_machine{seq_id = SeqId, observe_notification = ObserveNotification} = Machine,
+    TM
+) ->
+    Result2 = maybe_mark_observe_notification_done(ObserveNotification, Machine, Result),
+    Result2#{tm => delete_machine(SeqId, TM)};
 process_manager(_, Result, #state_machine{seq_id = SeqId} = Machine2, TM) ->
     Result#{tm => TM#{SeqId => Machine2}}.
+
+maybe_mark_observe_notification_done(true, _Machine, Result) ->
+    Result#{observe_notification_done => maps:get(observe_notification_done, Result, 0) + 1};
+maybe_mark_observe_notification_done(false, _Machine, Result) ->
+    Result.
 
 cancel_state_timer(#state_machine{timers = Timers} = Machine) ->
     case maps:get(state_timer, Timers, undefined) of
@@ -276,7 +289,7 @@ delete_machine(Id, Manager) ->
         #state_machine{
             seq_id = SeqId,
             id = MachineId,
-            token = Token,
+            token_key = TokenKey,
             timers = Timers
         } ->
             lists:foreach(
@@ -285,7 +298,12 @@ delete_machine(Id, Manager) ->
                 end,
                 maps:to_list(Timers)
             ),
-            maps:without([SeqId, MachineId, ?TOKEN_ID(Token)], Manager)
+            DeleteKeys =
+                case TokenKey of
+                    undefined -> [SeqId, MachineId];
+                    _ -> [SeqId, MachineId, TokenKey]
+                end,
+            maps:without(DeleteKeys, Manager)
     end.
 
 -spec find_machine(manager_key(), manager()) -> state_machine() | undefined.
@@ -339,15 +357,18 @@ new_in_machine(MachineId, #{seq_id := SeqId} = Manager) ->
 new_out_machine(
     MachineId,
     Ctx,
-    #coap_message{type = Type, token = Token, options = Opts},
+    #coap_message{type = Type, token = Token, options = Opts} = Msg,
     #{seq_id := SeqId} = Manager
 ) ->
     Observe = maps:get(observe, Opts, undefined),
+    IsObserveNotification = is_observe_notification(Msg),
+    ObserveNotification = is_confirmable_observe_notification(Msg),
     Machine = #state_machine{
         seq_id = SeqId,
         id = MachineId,
         token = Token,
         observe = Observe,
+        observe_notification = ObserveNotification,
         state = idle,
         timers = #{},
         transport = emqx_coap_transport:new(Ctx)
@@ -355,27 +376,37 @@ new_out_machine(
 
     Manager2 = Manager#{
         seq_id := SeqId + 1,
-        SeqId => Machine,
         MachineId => SeqId
     },
-    {Machine,
+    {Machine1, Manager3} =
         if
             Token =:= <<>> ->
-                Manager2;
-            Observe =:= 1 ->
+                {Machine, Manager2};
+            Observe =:= 1 andalso not IsObserveNotification ->
                 TokenId = ?TOKEN_ID(Token),
-                delete_machine(TokenId, Manager2);
-            Type =:= con orelse Observe =:= 0 ->
+                {Machine, delete_machine(TokenId, Manager2)};
+            Type =:= con orelse (Observe =:= 0 andalso not IsObserveNotification) ->
                 TokenId = ?TOKEN_ID(Token),
                 case maps:get(TokenId, Manager, undefined) of
                     undefined ->
-                        Manager2#{TokenId => SeqId};
+                        {Machine#state_machine{token_key = TokenId}, Manager2#{TokenId => SeqId}};
                     _ ->
                         throw("token conflict")
                 end;
             true ->
-                Manager2
-        end}.
+                {Machine, Manager2}
+        end,
+    {Machine1, Manager3#{SeqId => Machine1}}.
+
+is_observe_notification(#coap_message{method = {ok, _}} = Msg) ->
+    emqx_coap_message:get_option(observe, Msg, undefined) =/= undefined;
+is_observe_notification(_) ->
+    false.
+
+is_confirmable_observe_notification(#coap_message{type = con, method = {ok, _}} = Msg) ->
+    emqx_coap_message:get_option(observe, Msg, undefined) =/= undefined;
+is_confirmable_observe_notification(_) ->
+    false.
 
 alloc_message_id(#{next_msg_id := MsgId} = TM) ->
     alloc_message_id(MsgId, TM).

--- a/apps/emqx_gateway_coap/src/emqx_coap_transport.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_transport.erl
@@ -111,7 +111,8 @@ idle(out, Msg, Transport) ->
     Timeout = ?ACK_TIMEOUT + rand:uniform(?ACK_RANDOM_FACTOR),
     out(Msg, #{
         next => wait_ack,
-        transport => Transport#transport{cache = Msg},
+        %% RFC 7252 Section 4.2: initialize retransmission timeout for ACK handling.
+        transport => Transport#transport{cache = Msg, retry_interval = Timeout},
         timeouts => [
             {state_timeout, Timeout, ack_timeout},
             {stop_timeout, ?EXCHANGE_LIFETIME}
@@ -162,7 +163,11 @@ maybe_reset(
             reset(Message, Ret)
     end.
 
-wait_ack(in, #coap_message{type = Type, method = Method} = Msg, #transport{req_context = Ctx}) ->
+wait_ack(
+    in,
+    #coap_message{type = Type, method = Method} = Msg,
+    #transport{req_context = Ctx, cache = Cache}
+) ->
     CtxMsg = {Ctx, Msg},
     case Type of
         reset ->
@@ -170,8 +175,14 @@ wait_ack(in, #coap_message{type = Type, method = Method} = Msg, #transport{req_c
         _ ->
             case Method of
                 undefined ->
-                    %% empty ack, keep transport to recv response
-                    proto_out({ack, CtxMsg});
+                    case is_response(Cache) of
+                        true ->
+                            %% Empty ACK completes a CON response/notification sent by this server.
+                            proto_out({ack, CtxMsg}, #{next => stop});
+                        false ->
+                            %% Empty ACK for a CON request keeps transport waiting for separate response.
+                            proto_out({ack, CtxMsg})
+                    end;
                 {_, _} ->
                     %% ack with payload
                     proto_out({response, CtxMsg}, #{next => stop});
@@ -202,7 +213,7 @@ wait_ack(
                 }
             );
         _ ->
-            proto_out({ack_failure, Msg}, #{next_state => stop})
+            proto_out({ack_failure, Msg}, #{next => stop})
     end.
 
 observe(
@@ -256,3 +267,8 @@ on_response(
         true ->
             emqx_coap_message:reset(Message)
     end.
+
+is_response(#coap_message{method = {_, _}}) ->
+    true;
+is_response(_) ->
+    false.

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -17,6 +17,7 @@
 
 -include_lib("er_coap_client/include/coap.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -133,6 +134,18 @@ update_coap_with_mountpoint(Mp) ->
         coap,
         Conf#{<<"mountpoint">> => Mp}
     ).
+
+with_notify_type(NotifyType, Fun) ->
+    OldConf = emqx:get_raw_config([gateway, coap]),
+    {ok, _} = emqx_gateway_conf:update_gateway(
+        coap,
+        OldConf#{<<"notify_type">> => atom_to_binary(NotifyType)}
+    ),
+    try
+        Fun()
+    after
+        {ok, _} = emqx_gateway_conf:update_gateway(coap, OldConf)
+    end.
 
 %%--------------------------------------------------------------------
 %% Test Cases
@@ -521,6 +534,77 @@ t_observe_wildcard(_) ->
 
     with_connection(Fun).
 
+t_observe_notify_type_qos(_) ->
+    with_notify_type(qos, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_qos">>,
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            Req = make_req(get, <<>>, [{observe, 0}]),
+            {ok, content, _} = do_request(Channel, URI, Req),
+
+            Payload0 = <<"qos0">>,
+            publish(Topic, ?QOS_0, Payload0),
+            Notify0 = assert_notify(Channel, non, Payload0),
+            ack_if_con(Channel, Notify0),
+
+            Payload1 = <<"qos1">>,
+            publish(Topic, ?QOS_1, Payload1),
+            Notify1 = assert_notify(Channel, con, Payload1),
+            ack_if_con(Channel, Notify1),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_notify_type_con(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_con">>,
+            Payload = <<"confirmable">>,
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            Req = make_req(get, <<>>, [{observe, 0}]),
+            {ok, content, _} = do_request(Channel, URI, Req),
+
+            publish(Topic, ?QOS_0, Payload),
+            Notify = assert_notify(Channel, con, Payload),
+            ack_if_con(Channel, Notify),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_con_notify_drops_duplicate_while_ack_pending(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_duplicate">>,
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            Req = make_req(get, <<>>, [{observe, 0}]),
+            {ok, content, _} = do_request(Channel, URI, Req),
+
+            Payload1 = <<"first">>,
+            publish(Topic, ?QOS_0, Payload1),
+            Notify1 = assert_notify(Channel, con, Payload1),
+            ack_if_con(Channel, Notify1),
+
+            Payload2 = <<"second">>,
+            publish(Topic, ?QOS_0, Payload2),
+            Notify2 = assert_notify(Channel, con, Payload2),
+
+            Payload3 = <<"third">>,
+            publish(Topic, ?QOS_0, Payload3),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            ?assertNotEqual(
+                [],
+                emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+            ),
+            ?assertMatch({ok, changed, _}, send_heartbeat(Token)),
+            ack_if_con(Channel, Notify2),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
 t_clients_api(_) ->
     Fun = fun(_Channel, _Token) ->
         ClientId = <<"client1">>,
@@ -896,6 +980,20 @@ make_req(Method, Payload) ->
 make_req(Method, Payload, Opts) ->
     er_coap_message:request(con, Method, Payload, Opts).
 
+publish(Topic, QoS, Payload) ->
+    emqx:publish(emqx_message:make(<<"coap">>, QoS, Topic, Payload)).
+
+assert_notify(Channel, Type, Payload) ->
+    {ok, content, Notify = #coap_message{type = Type}} = with_message_response(Channel),
+    #coap_content{payload = Payload} = er_coap_message:get_content(Notify),
+    Notify.
+
+ack_if_con(Channel, #coap_message{type = con} = Message) ->
+    {ok, _} = er_coap_channel:send(Channel, er_coap_message:ack(Message)),
+    ok;
+ack_if_con(_Channel, #coap_message{}) ->
+    ok.
+
 do_request(Channel, URI, #coap_message{options = Opts} = Req) ->
     {_, _, Path, Query} = er_coap_client:resolve_uri(URI),
     Opts2 = [{uri_path, Path}, {uri_query, Query} | Opts],
@@ -915,12 +1013,30 @@ with_response(Channel) ->
         {error, timeout}
     end.
 
+with_message_response(Channel) ->
+    with_message_response(Channel, 2000).
+
+with_message_response(Channel, Timeout) ->
+    receive
+        {coap_response, _ChId, Channel, _Ref, Message = #coap_message{method = Code}} ->
+            return_message_response(Code, Message);
+        {coap_error, _ChId, Channel, _Ref, reset} ->
+            {error, reset}
+    after Timeout ->
+        {error, timeout}
+    end.
+
 return_response({ok, Code}, Message) ->
     {ok, Code, er_coap_message:get_content(Message)};
 return_response({error, Code}, #coap_message{payload = <<>>}) ->
     {error, Code};
 return_response({error, Code}, Message) ->
     {error, Code, er_coap_message:get_content(Message)}.
+
+return_message_response({ok, Code}, Message) ->
+    {ok, Code, Message};
+return_message_response({error, Code}, Message) ->
+    {error, Code, Message}.
 
 do(Fun) ->
     ChId = {{127, 0, 0, 1}, 5683},

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -42,6 +42,7 @@
 -define(LOGT(Format, Args), ct:pal("TEST_SUITE: " ++ Format, Args)).
 -define(PS_PREFIX, "coap://127.0.0.1/ps").
 -define(MQTT_PREFIX, "coap://127.0.0.1/mqtt").
+-define(OBSERVE_NOTIFICATION_QUEUE_MAX_LEN, 100).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -573,33 +574,187 @@ t_observe_notify_type_con(_) ->
         with_connection(Fun)
     end).
 
-t_observe_con_notify_drops_duplicate_while_ack_pending(_) ->
-    with_notify_type(con, fun() ->
+t_observe_notify_type_non(_) ->
+    with_notify_type(non, fun() ->
         Fun = fun(Channel, Token) ->
-            Topic = <<"coap/observe_notify_duplicate">>,
+            Topic = <<"coap/observe_notify_non">>,
+            Payload = <<"non-confirmable">>,
             URI = pubsub_uri(binary_to_list(Topic), Token),
             Req = make_req(get, <<>>, [{observe, 0}]),
             {ok, content, _} = do_request(Channel, URI, Req),
 
-            Payload1 = <<"first">>,
-            publish(Topic, ?QOS_0, Payload1),
-            Notify1 = assert_notify(Channel, con, Payload1),
+            publish(Topic, ?QOS_1, Payload),
+            Notify = assert_notify(Channel, non, Payload),
+            ack_if_con(Channel, Notify),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_non_notify_waits_for_con_inflight(_) ->
+    with_notify_type(qos, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_non_queue">>,
+            observe_topic(Channel, Token, Topic, <<"obsnq">>),
+
+            publish(Topic, ?QOS_1, <<"qos1-con">>),
+            Notify1 = assert_notify(Channel, con, <<"qos1-con">>),
+            publish(Topic, ?QOS_0, <<"qos0-non">>),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
             ack_if_con(Channel, Notify1),
+            Notify2 = assert_notify(Channel, non, <<"qos0-non">>),
+            ack_if_con(Channel, Notify2),
+            true
+        end,
+        with_connection(Fun)
+    end).
 
-            Payload2 = <<"second">>,
-            publish(Topic, ?QOS_0, Payload2),
-            Notify2 = assert_notify(Channel, con, Payload2),
+t_observe_con_notify_uses_shared_session_queue(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            TopicA = <<"coap/observe_notify_queue/a">>,
+            TopicB = <<"coap/observe_notify_queue/b">>,
+            observe_topic(Channel, Token, TopicA, <<"obsqa">>),
+            observe_topic(Channel, Token, TopicB, <<"obsqb">>),
 
-            Payload3 = <<"third">>,
-            publish(Topic, ?QOS_0, Payload3),
+            Payload1 = <<"first-a">>,
+            publish(TopicA, ?QOS_0, Payload1),
+            Notify1 = assert_notify(Channel, con, Payload1),
+
+            Payload2 = <<"second-b">>,
+            publish(TopicB, ?QOS_0, Payload2),
             ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
 
             ?assertNotEqual(
                 [],
                 emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
             ),
-            ?assertMatch({ok, changed, _}, send_heartbeat(Token)),
+            ack_if_con(Channel, Notify1),
+            Notify2 = assert_notify(Channel, con, Payload2),
+
+            Payload3 = <<"third-a">>,
+            publish(TopicA, ?QOS_0, Payload3),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
             ack_if_con(Channel, Notify2),
+            Notify3 = assert_notify(Channel, con, Payload3),
+            ack_if_con(Channel, Notify3),
+            ?assertMatch({ok, changed, _}, send_heartbeat(Token)),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_con_notify_queue_drops_oldest_when_full(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_queue_full">>,
+            observe_topic(Channel, Token, Topic, <<"obsqf">>),
+            Before = gateway_metric('delivery.dropped.queue_full'),
+
+            publish(Topic, ?QOS_0, <<"inflight">>),
+            Notify = assert_notify(Channel, con, <<"inflight">>),
+
+            QueueOverflow = 1,
+            lists:foreach(
+                fun(N) ->
+                    Payload = iolist_to_binary(["queued-", integer_to_binary(N)]),
+                    publish(Topic, ?QOS_0, Payload)
+                end,
+                lists:seq(1, ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN + QueueOverflow)
+            ),
+            wait_gateway_metric(
+                'delivery.dropped.queue_full',
+                Before + QueueOverflow,
+                20
+            ),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            ack_if_con(Channel, Notify),
+            Notify2 = assert_notify(Channel, con),
+            ?assertEqual(<<"queued-2">>, notify_payload(Notify2)),
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            UnReq = (make_req(get, <<>>, [{observe, 1}]))#coap_message{token = <<"obsqf">>},
+            {ok, nocontent, _} = do_request(Channel, URI, UnReq),
+            ack_if_con(Channel, Notify2),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_con_notify_queue_drains_after_reset(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            TopicA = <<"coap/observe_notify_queue_reset/a">>,
+            TopicB = <<"coap/observe_notify_queue_reset/b">>,
+            observe_topic(Channel, Token, TopicA, <<"obsra">>),
+            observe_topic(Channel, Token, TopicB, <<"obsrb">>),
+
+            publish(TopicA, ?QOS_0, <<"first-a">>),
+            Notify1 = assert_notify(Channel, con, <<"first-a">>),
+            publish(TopicB, ?QOS_0, <<"second-b">>),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            reset_if_con(Channel, Notify1),
+            Notify2 = assert_notify(Channel, con, <<"second-b">>),
+            ack_if_con(Channel, Notify2),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_cancel_drops_pending_notifications(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_queue_cancel">>,
+            ObserveToken = <<"obs-cancel">>,
+            observe_topic(Channel, Token, Topic, ObserveToken),
+
+            publish(Topic, ?QOS_0, <<"first">>),
+            Notify1 = assert_notify(Channel, con, <<"first">>),
+            publish(Topic, ?QOS_0, <<"queued-after-cancel">>),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            UnReq = (make_req(get, <<>>, [{observe, 1}]))#coap_message{
+                token = ObserveToken
+            },
+            {ok, nocontent, _} = do_request(Channel, URI, UnReq),
+
+            ack_if_con(Channel, Notify1),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 500)),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_cancel_wildcard_drops_pending_notifications(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            ObserveTopic = <<"coap/observe_notify_queue_cancel_wildcard/+">>,
+            PublishTopic1 = <<"coap/observe_notify_queue_cancel_wildcard/1">>,
+            PublishTopic2 = <<"coap/observe_notify_queue_cancel_wildcard/2">>,
+            ObserveToken = <<"obs-cancel-wildcard">>,
+            observe_topic(Channel, Token, ObserveTopic, ObserveToken),
+
+            publish(PublishTopic1, ?QOS_0, <<"first">>),
+            Notify1 = assert_notify(Channel, con, <<"first">>),
+            publish(PublishTopic2, ?QOS_0, <<"queued-after-wildcard-cancel">>),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            URI = pubsub_uri(binary_to_list(ObserveTopic), Token),
+            UnReq = (make_req(get, <<>>, [{observe, 1}]))#coap_message{
+                token = ObserveToken
+            },
+            {ok, nocontent, _} = do_request(Channel, URI, UnReq),
+
+            ack_if_con(Channel, Notify1),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 500)),
+
+            ?assertNotEqual(
+                [],
+                emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+            ),
             true
         end,
         with_connection(Fun)
@@ -957,6 +1112,12 @@ observe(Channel, Token, false, ShortenParamName) ->
     {ok, nocontent, _Data} = do_request(Channel, URI, Req),
     ok.
 
+observe_topic(Channel, Token, Topic, ObserveToken) ->
+    URI = pubsub_uri(binary_to_list(Topic), Token),
+    Req = (make_req(get, <<>>, [{observe, 0}]))#coap_message{token = ObserveToken},
+    {ok, content, _} = do_request(Channel, URI, Req),
+    ok.
+
 pubsub_uri(Topic) when is_list(Topic) ->
     ?PS_PREFIX ++ "/" ++ Topic.
 
@@ -983,15 +1144,43 @@ make_req(Method, Payload, Opts) ->
 publish(Topic, QoS, Payload) ->
     emqx:publish(emqx_message:make(<<"coap">>, QoS, Topic, Payload)).
 
+gateway_metric(Name) ->
+    proplists:get_value(Name, emqx_gateway_metrics:lookup(coap), 0).
+
+wait_gateway_metric(Name, Expected, 0) ->
+    ?assertEqual(Expected, gateway_metric(Name));
+wait_gateway_metric(Name, Expected, Retries) ->
+    case gateway_metric(Name) of
+        Value when Value >= Expected ->
+            ok;
+        _ ->
+            timer:sleep(100),
+            wait_gateway_metric(Name, Expected, Retries - 1)
+    end.
+
 assert_notify(Channel, Type, Payload) ->
-    {ok, content, Notify = #coap_message{type = Type}} = with_message_response(Channel),
-    #coap_content{payload = Payload} = er_coap_message:get_content(Notify),
+    Notify = assert_notify(Channel, Type),
+    ?assertEqual(Payload, notify_payload(Notify)),
     Notify.
+
+assert_notify(Channel, Type) ->
+    {ok, content, Notify = #coap_message{type = Type}} = with_message_response(Channel),
+    Notify.
+
+notify_payload(Notify) ->
+    #coap_content{payload = Payload} = er_coap_message:get_content(Notify),
+    Payload.
 
 ack_if_con(Channel, #coap_message{type = con} = Message) ->
     {ok, _} = er_coap_channel:send(Channel, er_coap_message:ack(Message)),
     ok;
 ack_if_con(_Channel, #coap_message{}) ->
+    ok.
+
+reset_if_con(Channel, #coap_message{type = con} = Message) ->
+    {ok, _} = er_coap_channel:send(Channel, emqx_coap_message:reset(Message)),
+    ok;
+reset_if_con(_Channel, #coap_message{}) ->
     ok.
 
 do_request(Channel, URI, #coap_message{options = Opts} = Req) ->

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -42,6 +42,7 @@
 -define(LOGT(Format, Args), ct:pal("TEST_SUITE: " ++ Format, Args)).
 -define(PS_PREFIX, "coap://127.0.0.1/ps").
 -define(MQTT_PREFIX, "coap://127.0.0.1/mqtt").
+-define(REQUEST_TIMEOUT, 5000).
 -define(OBSERVE_NOTIFICATION_QUEUE_MAX_LEN, 100).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
@@ -1198,7 +1199,7 @@ with_response(Channel) ->
             return_response(Code, Message);
         {coap_error, _ChId, Channel, _Ref, reset} ->
             {error, reset}
-    after 2000 ->
+    after ?REQUEST_TIMEOUT ->
         {error, timeout}
     end.
 

--- a/changes/ee/fix-17395.en.md
+++ b/changes/ee/fix-17395.en.md
@@ -1,0 +1,1 @@
+Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type` setting and avoid crashing when a confirmable observe notification is suppressed while a previous notification for the same token is still pending.

--- a/changes/ee/fix-17395.en.md
+++ b/changes/ee/fix-17395.en.md
@@ -1,1 +1,1 @@
-Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type` setting and avoid crashing when a confirmable observe notification is suppressed while a previous notification for the same token is still pending.
+Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type` setting and queue pending confirmable Observe notifications instead of silently dropping them while another notification is waiting for ACK.


### PR DESCRIPTION
Fixes none

port: https://github.com/emqx/emqx/pull/17398 but not inclued the Block-wise transfer related fixes that introduced on the r61

Release version:
5.10.5

## Summary

This fixes coupled CoAP Observe notification delivery issues in the gateway session path.

* Runtime notification type selection now reads the schema-backed `gateway.coap.notify_type` key instead of the stale `notify_qos` key, so `non`, `qos`, and `con` settings take effect.
* Confirmable Observe notifications now use a session-level inflight window of 1 and a shared FIFO pending queue while another confirmable notification is waiting for ACK, RST, or retry exhaustion.
* Pending Observe notifications are no longer silently dropped. The queue keeps up to 100 notifications, drops the oldest entry when full, increments `delivery.dropped.queue_full`, and logs the drop.
* Pending notifications are drained in order after ACK/RST/retry exhaustion and are purged when the matching Observe relation is canceled, including wildcard observations.
* Added CoAP gateway CT coverage for notify type selection, CON/NON ordering behind inflight CON notifications, shared queue ordering across observed topics, queue-full drop-oldest behavior, RST-triggered draining, and cancel cleanup. LwM2M gateway CT was also run because it depends on the CoAP transport manager.

Checks run: `./scripts/erlfmt -c apps/emqx_gateway_coap/src/emqx_coap_session.erl apps/emqx_gateway_coap/src/emqx_coap_tm.erl apps/emqx_gateway_coap/src/emqx_coap_transport.erl apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl`; `git diff --check ce/release-510..HEAD`; `./scripts/apps-version-check.sh`; `make apps/emqx_gateway_coap-ct PROFILE=emqx-enterprise`; `env ENABLE_COVER_COMPILE=1 CT_COVER_EXPORT_PREFIX=emqx-enterprise-sg1_1 make apps/emqx_gateway_coap-ct PROFILE=emqx-enterprise`; `make apps/emqx_gateway_lwm2m-ct PROFILE=emqx-enterprise`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
