### PR TITLE
fix(gateway): fix CoAP observe notifications

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -693,8 +693,74 @@ ensure_disconnected(Reason, Channel) ->
 shutdown(Reason, Channel) -> {shutdown, Reason, Channel}.
 shutdown_and_reply(Reason, Reply, Channel) -> {shutdown, Reason, Reply, Channel}.
 call_session(Fun, Msg, #channel{session = Session} = Channel) ->
-    Result = emqx_coap_session:Fun(Msg, Session),
-    handle_result(Result, Channel).
+    Result0 = emqx_coap_session:Fun(Msg, Session),
+    {Result, Channel1} = maybe_attach_blockwise_to_session_result(Fun, Msg, Result0, Channel),
+    handle_result(Result, Channel1).
+
+maybe_attach_blockwise_to_session_result(
+    handle_response,
+    #coap_message{type = reset, token = Token},
+    Result,
+    Channel0
+) ->
+    Channel = clear_discarded_observe_blockwise(Result, clear_observe_blockwise(Token, Channel0)),
+    {attach_and_drain_channel_blockwise(Result, Channel), Channel};
+maybe_attach_blockwise_to_session_result(timeout, _Timer, Result, Channel0) ->
+    Channel = clear_discarded_observe_blockwise(Result, Channel0),
+    {attach_and_drain_channel_blockwise(Result, Channel), Channel};
+maybe_attach_blockwise_to_session_result(handle_response, _Msg, Result, Channel) ->
+    {attach_and_drain_channel_blockwise(Result, Channel), Channel};
+maybe_attach_blockwise_to_session_result(_Fun, _Msg, Result, Channel) ->
+    {Result, Channel}.
+
+attach_and_drain_channel_blockwise(Result0, Channel) ->
+    Result = attach_channel_blockwise(Result0, Channel),
+    case {maps:get(session, Result, undefined), maps:get(blockwise, Result, undefined)} of
+        {Session, BW} when Session =/= undefined, is_map(BW) ->
+            DrainResult = emqx_coap_session:drain_pending_observe_notifications(Session, BW),
+            merge_session_drain_result(Result, DrainResult);
+        _ ->
+            Result
+    end.
+
+attach_channel_blockwise(#{blockwise := _} = Result, _Channel) ->
+    Result;
+attach_channel_blockwise(Result, #channel{blockwise = BW}) when is_map(BW) ->
+    Result#{blockwise => BW};
+attach_channel_blockwise(Result, _Channel) ->
+    Result.
+
+clear_discarded_observe_blockwise(Result, Channel) ->
+    case is_discarded_observe_notification(Result) of
+        true ->
+            lists:foldl(
+                fun clear_observe_blockwise/2,
+                Channel,
+                maps:get(observe_notification_done_tokens, Result, [])
+            );
+        false ->
+            Channel
+    end.
+
+is_discarded_observe_notification(#{proto := {reset, _}}) ->
+    true;
+is_discarded_observe_notification(#{proto := {ack_failure, _}}) ->
+    true;
+is_discarded_observe_notification(_Result) ->
+    false.
+
+clear_observe_blockwise(<<>>, Channel) ->
+    Channel;
+clear_observe_blockwise(
+    Token, #channel{blockwise = #{server_tx_block2 := ServerTx0} = BW0} = Channel
+) ->
+    #channel{conninfo = ConnInfo} = Channel,
+    PeerKey = maps:get(peername, ConnInfo, undefined),
+    ServerTx = maps:remove({server_tx_block2, PeerKey, Token}, ServerTx0),
+    Channel#channel{blockwise = BW0#{server_tx_block2 => ServerTx}};
+clear_observe_blockwise(_Token, Channel) ->
+    Channel.
+
 handle_result(Result, Channel) ->
     iter(
         [
@@ -720,12 +786,12 @@ call_handler(
     case emqx_coap_blockwise:server_incoming(Msg, PeerKey, BW0) of
         {reply, Reply, BW1} ->
             maybe_inc_block2_completed(Reply, Ctx),
-            iter(Iter, reply(Reply, Result), Channel#channel{blockwise = BW1});
+            drain_observe_after_blockwise(reply(Reply, Result), BW1, Channel, Iter);
         {error, Reply, BW1} ->
             metrics_inc('blockwise.tx_block2.failed', Ctx),
-            iter(Iter, reply(Reply, Result), Channel#channel{blockwise = BW1});
+            drain_observe_after_blockwise(reply(Reply, Result), BW1, Channel, Iter);
         {continue, Reply, BW1} ->
-            iter(Iter, reply(Reply, Result), Channel#channel{blockwise = BW1});
+            drain_observe_after_blockwise(reply(Reply, Result), BW1, Channel, Iter);
         {Tag, Msg2, BW1} when Tag =:= pass; Tag =:= complete ->
             do_call_handler_request(Msg2, Result, Channel#channel{blockwise = BW1}, Iter)
     end;
@@ -764,6 +830,35 @@ process_out(Outs, Result, Channel, _) ->
     Events = maps:get(events, Result, []),
     {ok, [{outgoing, Outs2}] ++ Events, Channel}.
 process_nothing(_, _, Channel) -> {ok, Channel}.
+
+drain_observe_after_blockwise(
+    Result0,
+    BW0,
+    #channel{session = Session0} = Channel0,
+    Iter
+) when Session0 =/= undefined ->
+    DrainResult = emqx_coap_session:drain_pending_observe_notifications(Session0, BW0),
+    Session = maps:get(session, DrainResult, Session0),
+    BW = maps:get(blockwise, DrainResult, BW0),
+    Result = merge_observe_drain_result(Result0, DrainResult),
+    iter(Iter, Result, Channel0#channel{session = Session, blockwise = BW});
+drain_observe_after_blockwise(Result, BW, Channel, Iter) ->
+    iter(Iter, Result, Channel#channel{blockwise = BW}).
+
+merge_observe_drain_result(Result0, DrainResult) ->
+    Result1 = maps:merge(Result0, maps:without([out, session], DrainResult)),
+    add_outs(maps:get(out, DrainResult, []), Result1).
+
+merge_session_drain_result(Result0, DrainResult) ->
+    Result1 = maps:merge(Result0, maps:without([out], DrainResult)),
+    add_outs(maps:get(out, DrainResult, []), Result1).
+
+add_outs(Outs, Result) ->
+    lists:foldl(
+        fun(Out, Acc) -> emqx_coap_medium:out(Out, Acc) end,
+        Result,
+        Outs
+    ).
 
 process_connection({open, Req}, Result, Channel = #channel{conn_state = idle}, Iter) ->
     Queries = emqx_coap_message:extract_uri_query(Req),

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -428,21 +428,36 @@ process_subscribe(
                 session => Session#session{observe_manager = OM2}
             };
         Topic ->
+            Token = observe_token(Topic, OM),
             OM2 = emqx_coap_observe_res:remove(Topic, OM),
             Replay = emqx_coap_message:piggyback({ok, nocontent}, Msg),
-            Session1 = purge_pending_observe_notifications(Topic, Session),
+            Session1 = purge_pending_observe_notifications(Topic, Token, Session),
             Result#{
                 reply => Replay,
                 session => Session1#session{observe_manager = OM2}
             }
     end.
 
+observe_token(Topic, OM) ->
+    case maps:get(Topic, OM, undefined) of
+        #{token := Token} ->
+            Token;
+        _ ->
+            undefined
+    end.
+
+purge_pending_observe_notifications(_Topic, undefined, Session) ->
+    Session;
 purge_pending_observe_notifications(
     Topic,
+    Token,
     #session{observe_pending = Queue0, observe_pending_len = Len0} = Session
 ) ->
     Pending0 = queue:to_list(Queue0),
-    Pending = [Entry || Entry <- Pending0, not is_pending_observe_topic(Topic, Entry)],
+    Pending = [
+        Entry
+     || Entry <- Pending0, not is_pending_observe_notification(Topic, Token, Entry)
+    ],
     case length(Pending) of
         Len0 ->
             Session;
@@ -453,9 +468,13 @@ purge_pending_observe_notifications(
             }
     end.
 
-is_pending_observe_topic(Topic, {_Msg, #message{topic = Topic}, _BW}) ->
+is_pending_observe_notification(
+    Topic,
+    Token,
+    {#coap_message{token = Token}, #message{topic = Topic}, _BW}
+) ->
     true;
-is_pending_observe_topic(_Topic, _Pending) ->
+is_pending_observe_notification(_Topic, _Token, _Pending) ->
     false.
 
 mqtt_to_coap(MQTT, Token, SeqId) ->

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -194,8 +194,12 @@ do_deliver(
                 metrics_inc('messages.delivered', Ctx),
                 Msg0 = mqtt_to_coap(Message, Token, SeqId),
                 {Msg, BW2} = maybe_split_notify_block2(Msg0, PeerKey, BWAcc, Ctx),
-                #{out := Out, tm := TM2} = emqx_coap_tm:handle_out(Msg, TMAcc),
-                {[Out | OutAcc], OM2, TM2, BW2}
+                case emqx_coap_tm:handle_out(Msg, TMAcc) of
+                    #{out := Out, tm := TM2} ->
+                        {[Out | OutAcc], OM2, TM2, BW2};
+                    Empty when map_size(Empty) =:= 0 ->
+                        {OutAcc, OM2, TMAcc, BW2}
+                end
         end
     end,
     {Outs, OM2, TM2, BW2} = lists:foldl(Fun, {[], OM, TM, BW0}, lists:reverse(Delivers)),
@@ -281,7 +285,7 @@ mqtt_to_coap(MQTT, Token, SeqId) ->
     }.
 
 get_notify_type(#message{qos = Qos}) ->
-    case emqx_conf:get([gateway, coap, notify_qos], non) of
+    case emqx_conf:get([gateway, coap, notify_type], qos) of
         qos ->
             case Qos of
                 ?QOS_0 ->

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -430,11 +430,33 @@ process_subscribe(
         Topic ->
             OM2 = emqx_coap_observe_res:remove(Topic, OM),
             Replay = emqx_coap_message:piggyback({ok, nocontent}, Msg),
+            Session1 = purge_pending_observe_notifications(Topic, Session),
             Result#{
                 reply => Replay,
-                session => Session#session{observe_manager = OM2}
+                session => Session1#session{observe_manager = OM2}
             }
     end.
+
+purge_pending_observe_notifications(
+    Topic,
+    #session{observe_pending = Queue0, observe_pending_len = Len0} = Session
+) ->
+    Pending0 = queue:to_list(Queue0),
+    Pending = [Entry || Entry <- Pending0, not is_pending_observe_topic(Topic, Entry)],
+    case length(Pending) of
+        Len0 ->
+            Session;
+        Len ->
+            Session#session{
+                observe_pending = queue:from_list(Pending),
+                observe_pending_len = Len
+            }
+    end.
+
+is_pending_observe_topic(Topic, {_Msg, #message{topic = Topic}, _BW}) ->
+    true;
+is_pending_observe_topic(_Topic, _Pending) ->
+    false.
 
 mqtt_to_coap(MQTT, Token, SeqId) ->
     #message{payload = Payload} = MQTT,

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -40,6 +40,10 @@
 -record(session, {
     transport_manager :: emqx_coap_tm:manager(),
     observe_manager :: emqx_coap_observe_res:manager(),
+    observe_inflight = 0 :: non_neg_integer(),
+    observe_pending :: queue:queue(),
+    observe_pending_len = 0 :: non_neg_integer(),
+    observe_pending_dropped = 0 :: non_neg_integer(),
     created_at :: pos_integer()
 }).
 
@@ -67,6 +71,9 @@
     awaiting_rel_max
 ]).
 
+-define(OBSERVE_INFLIGHT_WINDOW, 1).
+-define(OBSERVE_NOTIFICATION_QUEUE_MAX_LEN, 100).
+
 -import(emqx_coap_medium, [iter/3]).
 -import(emqx_coap_channel, [metrics_inc/2]).
 
@@ -79,6 +86,7 @@ new() ->
     #session{
         transport_manager = emqx_coap_tm:new(),
         observe_manager = emqx_coap_observe_res:new_manager(),
+        observe_pending = queue:new(),
         created_at = erlang:system_time(millisecond)
     }.
 
@@ -107,20 +115,20 @@ info(upgrade_qos, _) ->
     ?QOS_0;
 info(inflight, _) ->
     emqx_inflight:new();
-info(inflight_cnt, _) ->
-    0;
+info(inflight_cnt, #session{observe_inflight = Inflight}) ->
+    Inflight;
 info(inflight_max, _) ->
-    infinity;
+    ?OBSERVE_INFLIGHT_WINDOW;
 info(retry_interval, _) ->
     infinity;
 info(mqueue, _) ->
     emqx_mqueue:init(#{max_len => 0, store_qos0 => false});
-info(mqueue_len, _) ->
-    0;
+info(mqueue_len, #session{observe_pending_len = Len}) ->
+    Len;
 info(mqueue_max, _) ->
-    infinity;
-info(mqueue_dropped, _) ->
-    0;
+    ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN;
+info(mqueue_dropped, #session{observe_pending_dropped = Dropped}) ->
+    Dropped;
 info(next_pkt_id, _) ->
     0;
 info(awaiting_rel, _) ->
@@ -177,14 +185,13 @@ deliver(
 do_deliver(
     Delivers,
     Ctx,
-    #session{
-        observe_manager = OM,
-        transport_manager = TM
-    } = Session,
+    #session{} = Session,
     BW0,
     PeerKey
 ) ->
-    Fun = fun({_, Topic, Message}, {OutAcc, OMAcc, TMAcc, BWAcc} = Acc) ->
+    Fun = fun(
+        {_, Topic, Message}, {OutAcc, #session{observe_manager = OMAcc} = SessionAcc, BWAcc} = Acc
+    ) ->
         case emqx_coap_observe_res:res_changed(Topic, OMAcc) of
             undefined ->
                 metrics_inc('delivery.dropped', Ctx),
@@ -194,22 +201,17 @@ do_deliver(
                 metrics_inc('messages.delivered', Ctx),
                 Msg0 = mqtt_to_coap(Message, Token, SeqId),
                 {Msg, BW2} = maybe_split_notify_block2(Msg0, PeerKey, BWAcc, Ctx),
-                case emqx_coap_tm:handle_out(Msg, TMAcc) of
-                    #{out := Out, tm := TM2} ->
-                        {[Out | OutAcc], OM2, TM2, BW2};
-                    Empty when map_size(Empty) =:= 0 ->
-                        {OutAcc, OM2, TMAcc, BW2}
-                end
+                SessionAcc1 = SessionAcc#session{observe_manager = OM2},
+                {Out, SessionAcc2} =
+                    send_or_queue_observe_notification(Msg, Message, Ctx, SessionAcc1),
+                {[Out | OutAcc], SessionAcc2, BW2}
         end
     end,
-    {Outs, OM2, TM2, BW2} = lists:foldl(Fun, {[], OM, TM, BW0}, lists:reverse(Delivers)),
+    {Outs, Session2, BW2} = lists:foldl(Fun, {[], Session, BW0}, lists:reverse(Delivers)),
 
     BaseResult = #{
         out => lists:flatten(lists:reverse(Outs)),
-        session => Session#session{
-            observe_manager = OM2,
-            transport_manager = TM2
-        }
+        session => Session2
     },
     maybe_attach_blockwise_result(BaseResult, BW0, BW2).
 
@@ -239,8 +241,145 @@ call_transport_manager(
 process_tm(TM, Result, Session, Cursor) ->
     iter(Cursor, Result, Session#session{transport_manager = TM}).
 
-process_session(_, Result, Session) ->
-    Result#{session => Session}.
+process_session(_, Result, Session0) ->
+    {Result1, Session1} = maybe_drain_observe_notifications(Result, Session0),
+    Result1#{session => Session1}.
+
+send_or_queue_observe_notification(Msg, MQTT, Ctx, Session) ->
+    case is_confirmable_observe_notification(Msg) of
+        true ->
+            maybe_send_or_enqueue_confirmable_observe_notification(Msg, MQTT, Ctx, Session);
+        false ->
+            send_observe_notification_now(Msg, false, Session)
+    end.
+
+maybe_send_or_enqueue_confirmable_observe_notification(
+    Msg,
+    MQTT,
+    Ctx,
+    #session{observe_inflight = Inflight} = Session
+) when Inflight < ?OBSERVE_INFLIGHT_WINDOW ->
+    case send_observe_notification_now(Msg, true, Session) of
+        {[], Session1} ->
+            {[], enqueue_observe_notification(Msg, MQTT, Ctx, Session1)};
+        Sent ->
+            Sent
+    end;
+maybe_send_or_enqueue_confirmable_observe_notification(Msg, MQTT, Ctx, Session) ->
+    {[], enqueue_observe_notification(Msg, MQTT, Ctx, Session)}.
+
+send_observe_notification_now(Msg, TrackInflight, #session{transport_manager = TM0} = Session) ->
+    case emqx_coap_tm:handle_out(Msg, TM0) of
+        #{out := Out, tm := TM1} ->
+            Session1 = Session#session{transport_manager = TM1},
+            {Out, maybe_inc_observe_inflight(TrackInflight, Session1)};
+        #{tm := TM1} ->
+            {[], Session#session{transport_manager = TM1}};
+        Empty when map_size(Empty) =:= 0 ->
+            {[], Session}
+    end.
+
+maybe_inc_observe_inflight(true, #session{observe_inflight = Inflight} = Session) ->
+    Session#session{observe_inflight = Inflight + 1};
+maybe_inc_observe_inflight(false, Session) ->
+    Session.
+
+enqueue_observe_notification(
+    Msg,
+    MQTT,
+    _Ctx,
+    #session{
+        observe_pending = Queue0,
+        observe_pending_len = Len0,
+        observe_pending_dropped = Dropped0
+    } = Session
+) when Len0 < ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN ->
+    Session#session{
+        observe_pending = queue:in({Msg, MQTT}, Queue0),
+        observe_pending_len = Len0 + 1,
+        observe_pending_dropped = Dropped0
+    };
+enqueue_observe_notification(
+    Msg,
+    MQTT,
+    Ctx,
+    #session{
+        observe_pending = Queue0,
+        observe_pending_dropped = Dropped0
+    } = Session
+) ->
+    {{value, {_DroppedMsg, DroppedMQTT}}, Queue1} = queue:out(Queue0),
+    metrics_inc('delivery.dropped', Ctx),
+    metrics_inc('delivery.dropped.queue_full', Ctx),
+    log_observe_notification_queue_full(DroppedMQTT),
+    Session#session{
+        observe_pending = queue:in({Msg, MQTT}, Queue1),
+        observe_pending_dropped = Dropped0 + 1
+    }.
+
+maybe_drain_observe_notifications(Result0, Session0) ->
+    Done = maps:get(observe_notification_done, Result0, 0),
+    Result1 = maps:remove(observe_notification_done, Result0),
+    Session1 = release_observe_inflight(Done, Session0),
+    drain_observe_notifications(Result1, Session1).
+
+release_observe_inflight(0, Session) ->
+    Session;
+release_observe_inflight(Done, #session{observe_inflight = Inflight} = Session) ->
+    Session#session{observe_inflight = max(0, Inflight - Done)}.
+
+drain_observe_notifications(
+    Result,
+    #session{observe_inflight = Inflight} = Session
+) when Inflight >= ?OBSERVE_INFLIGHT_WINDOW ->
+    {Result, Session};
+drain_observe_notifications(Result, #session{observe_pending_len = 0} = Session) ->
+    {Result, Session};
+drain_observe_notifications(
+    Result,
+    #session{observe_pending = Queue0, observe_pending_len = Len0} = Session0
+) ->
+    case queue:out(Queue0) of
+        {{value, {Msg, _MQTT} = Pending}, Queue1} ->
+            Session1 = Session0#session{
+                observe_pending = Queue1,
+                observe_pending_len = Len0 - 1
+            },
+            case send_observe_notification_now(Msg, true, Session1) of
+                {[], Session2} ->
+                    {Result, Session2#session{
+                        observe_pending = queue:in_r(Pending, Queue1),
+                        observe_pending_len = Len0
+                    }};
+                {Out, Session2} ->
+                    {add_outs(Out, Result), Session2}
+            end;
+        {empty, _} ->
+            {Result, Session0#session{observe_pending_len = 0}}
+    end.
+
+add_outs(Outs, Result) ->
+    lists:foldl(
+        fun(Out, Acc) -> emqx_coap_medium:out(Out, Acc) end,
+        Result,
+        Outs
+    ).
+
+is_confirmable_observe_notification(#coap_message{type = con, method = {ok, _}} = Msg) ->
+    emqx_coap_message:get_option(observe, Msg, undefined) =/= undefined;
+is_confirmable_observe_notification(_) ->
+    false.
+
+log_observe_notification_queue_full(#message{topic = Topic, payload = Payload}) ->
+    ?SLOG_THROTTLE(
+        warning,
+        #{
+            msg => dropped_msg_due_to_mqueue_is_full,
+            queue => coap_observe_notification,
+            payload => Payload
+        },
+        #{topic => Topic}
+    ).
 
 process_subscribe(
     Sub,

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -200,10 +200,11 @@ do_deliver(
             {Token, SeqId, OM2} ->
                 metrics_inc('messages.delivered', Ctx),
                 Msg0 = mqtt_to_coap(Message, Token, SeqId),
-                {Msg, BW2} = maybe_split_notify_block2(Msg0, PeerKey, BWAcc, Ctx),
                 SessionAcc1 = SessionAcc#session{observe_manager = OM2},
-                {Out, SessionAcc2} =
-                    send_or_queue_observe_notification(Msg, Message, Ctx, SessionAcc1),
+                {Out, SessionAcc2, BW2} =
+                    send_or_queue_observe_notification(
+                        Msg0, Message, Ctx, SessionAcc1, BWAcc, PeerKey
+                    ),
                 {[Out | OutAcc], SessionAcc2, BW2}
         end
     end,
@@ -245,28 +246,42 @@ process_session(_, Result, Session0) ->
     {Result1, Session1} = maybe_drain_observe_notifications(Result, Session0),
     Result1#{session => Session1}.
 
-send_or_queue_observe_notification(Msg, MQTT, Ctx, Session) ->
-    case is_confirmable_observe_notification(Msg) of
+send_or_queue_observe_notification(Msg0, MQTT, Ctx, Session, BW0, PeerKey) ->
+    TrackInflight = is_confirmable_observe_notification(Msg0),
+    case should_queue_observe_notification(Session) of
         true ->
-            maybe_send_or_enqueue_confirmable_observe_notification(Msg, MQTT, Ctx, Session);
+            {Msg, BW1} = maybe_split_notify_block2(Msg0, PeerKey, BW0, Ctx),
+            Session1 = enqueue_observe_notification(Msg, MQTT, BW1, Ctx, Session),
+            {[], Session1, BW0};
         false ->
-            send_observe_notification_now(Msg, false, Session)
+            maybe_send_or_enqueue_observe_notification(
+                Msg0, MQTT, Ctx, Session, BW0, PeerKey, TrackInflight
+            )
     end.
 
-maybe_send_or_enqueue_confirmable_observe_notification(
-    Msg,
+should_queue_observe_notification(#session{
+    observe_inflight = Inflight,
+    observe_pending_len = PendingLen
+}) ->
+    Inflight >= ?OBSERVE_INFLIGHT_WINDOW orelse PendingLen > 0.
+
+maybe_send_or_enqueue_observe_notification(
+    Msg0,
     MQTT,
     Ctx,
-    #session{observe_inflight = Inflight} = Session
-) when Inflight < ?OBSERVE_INFLIGHT_WINDOW ->
-    case send_observe_notification_now(Msg, true, Session) of
+    Session,
+    BW0,
+    PeerKey,
+    TrackInflight
+) ->
+    {Msg, BW1} = maybe_split_notify_block2(Msg0, PeerKey, BW0, Ctx),
+    case send_observe_notification_now(Msg, TrackInflight, Session) of
         {[], Session1} ->
-            {[], enqueue_observe_notification(Msg, MQTT, Ctx, Session1)};
-        Sent ->
-            Sent
-    end;
-maybe_send_or_enqueue_confirmable_observe_notification(Msg, MQTT, Ctx, Session) ->
-    {[], enqueue_observe_notification(Msg, MQTT, Ctx, Session)}.
+            Session2 = enqueue_observe_notification(Msg, MQTT, BW1, Ctx, Session1),
+            {[], Session2, BW0};
+        {Out, Session1} ->
+            {Out, Session1, BW1}
+    end.
 
 send_observe_notification_now(Msg, TrackInflight, #session{transport_manager = TM0} = Session) ->
     case emqx_coap_tm:handle_out(Msg, TM0) of
@@ -287,6 +302,7 @@ maybe_inc_observe_inflight(false, Session) ->
 enqueue_observe_notification(
     Msg,
     MQTT,
+    BW,
     _Ctx,
     #session{
         observe_pending = Queue0,
@@ -295,25 +311,26 @@ enqueue_observe_notification(
     } = Session
 ) when Len0 < ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN ->
     Session#session{
-        observe_pending = queue:in({Msg, MQTT}, Queue0),
+        observe_pending = queue:in({Msg, MQTT, BW}, Queue0),
         observe_pending_len = Len0 + 1,
         observe_pending_dropped = Dropped0
     };
 enqueue_observe_notification(
     Msg,
     MQTT,
+    BW,
     Ctx,
     #session{
         observe_pending = Queue0,
         observe_pending_dropped = Dropped0
     } = Session
 ) ->
-    {{value, {_DroppedMsg, DroppedMQTT}}, Queue1} = queue:out(Queue0),
+    {{value, {_DroppedMsg, DroppedMQTT, _DroppedBW}}, Queue1} = queue:out(Queue0),
     metrics_inc('delivery.dropped', Ctx),
     metrics_inc('delivery.dropped.queue_full', Ctx),
     log_observe_notification_queue_full(DroppedMQTT),
     Session#session{
-        observe_pending = queue:in({Msg, MQTT}, Queue1),
+        observe_pending = queue:in({Msg, MQTT, BW}, Queue1),
         observe_pending_dropped = Dropped0 + 1
     }.
 
@@ -340,23 +357,30 @@ drain_observe_notifications(
     #session{observe_pending = Queue0, observe_pending_len = Len0} = Session0
 ) ->
     case queue:out(Queue0) of
-        {{value, {Msg, _MQTT} = Pending}, Queue1} ->
+        {{value, {Msg, _MQTT, BW} = Pending}, Queue1} ->
             Session1 = Session0#session{
                 observe_pending = Queue1,
                 observe_pending_len = Len0 - 1
             },
-            case send_observe_notification_now(Msg, true, Session1) of
+            TrackInflight = is_confirmable_observe_notification(Msg),
+            case send_observe_notification_now(Msg, TrackInflight, Session1) of
                 {[], Session2} ->
                     {Result, Session2#session{
                         observe_pending = queue:in_r(Pending, Queue1),
                         observe_pending_len = Len0
                     }};
                 {Out, Session2} ->
-                    {add_outs(Out, Result), Session2}
+                    Result1 = add_outs(Out, maybe_attach_pending_blockwise_result(Result, BW)),
+                    drain_observe_notifications(Result1, Session2)
             end;
         {empty, _} ->
             {Result, Session0#session{observe_pending_len = 0}}
     end.
+
+maybe_attach_pending_blockwise_result(Result, BW) when is_map(BW) ->
+    Result#{blockwise => BW};
+maybe_attach_pending_blockwise_result(Result, _BW) ->
+    Result.
 
 add_outs(Outs, Result) ->
     lists:foldl(

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -28,6 +28,7 @@
     set_reply/2,
     deliver/3,
     deliver/5,
+    drain_pending_observe_notifications/2,
     timeout/2
 ]).
 
@@ -224,6 +225,15 @@ maybe_attach_blockwise_result(BaseResult, _BW0, _BW2) ->
 timeout(Timer, Session) ->
     call_transport_manager(?FUNCTION_NAME, Timer, Session).
 
+drain_pending_observe_notifications(#session{} = Session0, BW0) ->
+    Result0 =
+        case is_map(BW0) of
+            true -> #{blockwise => BW0};
+            false -> #{}
+        end,
+    {Result, Session} = drain_observe_notifications(Result0, Session0),
+    Result#{session => Session}.
+
 %%%-------------------------------------------------------------------
 %%% Internal functions
 %%%-------------------------------------------------------------------
@@ -248,10 +258,17 @@ process_session(_, Result, Session0) ->
 
 send_or_queue_observe_notification(Msg0, MQTT, Ctx, Session, BW0, PeerKey) ->
     TrackInflight = is_confirmable_observe_notification(Msg0),
-    case should_queue_observe_notification(Session) of
+    DeferBlockwise = should_defer_observe_blockwise(Msg0, Session, BW0, PeerKey),
+    case should_queue_observe_notification(Session) orelse DeferBlockwise of
         true ->
-            {Msg, BW1} = maybe_split_notify_block2(Msg0, PeerKey, BW0, Ctx),
-            Session1 = enqueue_observe_notification(Msg, MQTT, BW1, Ctx, Session),
+            {Msg, BW1} =
+                case DeferBlockwise of
+                    true -> {Msg0, undefined};
+                    false -> maybe_split_notify_block2(Msg0, PeerKey, BW0, Ctx)
+                end,
+            Session1 = enqueue_observe_notification(
+                Msg, MQTT, BW1, PeerKey, Ctx, DeferBlockwise, Session
+            ),
             {[], Session1, BW0};
         false ->
             maybe_send_or_enqueue_observe_notification(
@@ -277,7 +294,7 @@ maybe_send_or_enqueue_observe_notification(
     {Msg, BW1} = maybe_split_notify_block2(Msg0, PeerKey, BW0, Ctx),
     case send_observe_notification_now(Msg, TrackInflight, Session) of
         {[], Session1} ->
-            Session2 = enqueue_observe_notification(Msg, MQTT, BW1, Ctx, Session1),
+            Session2 = enqueue_observe_notification(Msg, MQTT, BW1, PeerKey, Ctx, false, Session1),
             {[], Session2, BW0};
         {Out, Session1} ->
             {Out, Session1, BW1}
@@ -303,15 +320,18 @@ enqueue_observe_notification(
     Msg,
     MQTT,
     BW,
-    _Ctx,
+    PeerKey,
+    Ctx,
+    ForceBlockwiseKey,
     #session{
         observe_pending = Queue0,
         observe_pending_len = Len0,
         observe_pending_dropped = Dropped0
     } = Session
 ) when Len0 < ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN ->
+    Pending = new_pending_observe_notification(Msg, MQTT, BW, PeerKey, Ctx, ForceBlockwiseKey),
     Session#session{
-        observe_pending = queue:in({Msg, MQTT, BW}, Queue0),
+        observe_pending = queue:in(Pending, Queue0),
         observe_pending_len = Len0 + 1,
         observe_pending_dropped = Dropped0
     };
@@ -319,18 +339,22 @@ enqueue_observe_notification(
     Msg,
     MQTT,
     BW,
+    PeerKey,
     Ctx,
+    ForceBlockwiseKey,
     #session{
         observe_pending = Queue0,
         observe_pending_dropped = Dropped0
     } = Session
 ) ->
-    {{value, {_DroppedMsg, DroppedMQTT, _DroppedBW}}, Queue1} = queue:out(Queue0),
+    {{value, Dropped}, Queue1} = queue:out(Queue0),
+    DroppedMQTT = pending_mqtt(Dropped),
+    Pending = new_pending_observe_notification(Msg, MQTT, BW, PeerKey, Ctx, ForceBlockwiseKey),
     metrics_inc('delivery.dropped', Ctx),
     metrics_inc('delivery.dropped.queue_full', Ctx),
     log_observe_notification_queue_full(DroppedMQTT),
     Session#session{
-        observe_pending = queue:in({Msg, MQTT, BW}, Queue1),
+        observe_pending = queue:in(Pending, Queue1),
         observe_pending_dropped = Dropped0 + 1
     }.
 
@@ -357,24 +381,174 @@ drain_observe_notifications(
     #session{observe_pending = Queue0, observe_pending_len = Len0} = Session0
 ) ->
     case queue:out(Queue0) of
-        {{value, {Msg, _MQTT, BW} = Pending}, Queue1} ->
+        {{value, Pending}, Queue1} ->
             Session1 = Session0#session{
                 observe_pending = Queue1,
                 observe_pending_len = Len0 - 1
             },
-            TrackInflight = is_confirmable_observe_notification(Msg),
-            case send_observe_notification_now(Msg, TrackInflight, Session1) of
-                {[], Session2} ->
-                    {Result, Session2#session{
+            case pending_blockwise_active(Pending, Result) of
+                true ->
+                    {Result, Session1#session{
                         observe_pending = queue:in_r(Pending, Queue1),
                         observe_pending_len = Len0
                     }};
-                {Out, Session2} ->
-                    Result1 = add_outs(Out, maybe_attach_pending_blockwise_result(Result, BW)),
-                    drain_observe_notifications(Result1, Session2)
+                false ->
+                    case prepare_pending_observe_notification(Pending, Result) of
+                        wait ->
+                            {Result, Session1#session{
+                                observe_pending = queue:in_r(Pending, Queue1),
+                                observe_pending_len = Len0
+                            }};
+                        {Msg, BW} ->
+                            do_drain_observe_notification(
+                                Msg, BW, Pending, Queue1, Len0, Result, Session1
+                            )
+                    end
             end;
         {empty, _} ->
             {Result, Session0#session{observe_pending_len = 0}}
+    end.
+
+do_drain_observe_notification(Msg, BW, Pending, Queue, Len0, Result, Session0) ->
+    TrackInflight = is_confirmable_observe_notification(Msg),
+    case send_observe_notification_now(Msg, TrackInflight, Session0) of
+        {[], Session} ->
+            {Result, Session#session{
+                observe_pending = queue:in_r(Pending, Queue),
+                observe_pending_len = Len0
+            }};
+        {Out, Session} ->
+            Result1 = add_outs(Out, maybe_attach_pending_blockwise_result(Result, BW)),
+            drain_observe_notifications(Result1, Session)
+    end.
+
+prepare_pending_observe_notification(Pending, Result) ->
+    Msg = pending_msg(Pending),
+    case pending_blockwise(Pending) of
+        BW when is_map(BW) ->
+            {Msg, BW};
+        _ ->
+            case {pending_blockwise_key(Pending), maps:get(blockwise, Result, undefined)} of
+                {undefined, _} ->
+                    {Msg, undefined};
+                {_BlockwiseKey, BW0} when is_map(BW0) ->
+                    maybe_split_notify_block2(
+                        Msg,
+                        pending_peer_key(Pending),
+                        BW0,
+                        pending_ctx(Pending)
+                    );
+                {_BlockwiseKey, _} ->
+                    wait
+            end
+    end.
+
+should_defer_observe_blockwise(Msg, Session, BW, PeerKey) ->
+    case observe_notification_needs_block2(Msg, BW) of
+        false ->
+            false;
+        true ->
+            BlockwiseKey = observe_blockwise_key(Msg, PeerKey),
+            blockwise_key_active(BlockwiseKey, BW) orelse
+                pending_blockwise_key_exists(BlockwiseKey, Session)
+    end.
+
+observe_notification_needs_block2(#coap_message{options = Opts, payload = Payload}, BW) when
+    is_map(Opts), is_map(BW)
+->
+    emqx_coap_blockwise:enabled(BW) andalso
+        byte_size(Payload) > emqx_coap_blockwise:blockwise_size(BW) andalso
+        not maps:is_key(block2, Opts);
+observe_notification_needs_block2(_Msg, _BW) ->
+    false.
+
+pending_blockwise_key_exists(undefined, _Session) ->
+    false;
+pending_blockwise_key_exists(BlockwiseKey, #session{observe_pending = Queue}) ->
+    lists:any(
+        fun(Pending) -> pending_blockwise_key(Pending) =:= BlockwiseKey end,
+        queue:to_list(Queue)
+    ).
+
+blockwise_key_active(undefined, _BW) ->
+    false;
+blockwise_key_active(BlockwiseKey, #{server_tx_block2 := ServerTx}) when is_map(ServerTx) ->
+    maps:is_key(BlockwiseKey, ServerTx);
+blockwise_key_active(_BlockwiseKey, _BW) ->
+    false.
+
+new_pending_observe_notification(Msg, MQTT, BW, PeerKey, Ctx, true) ->
+    {Msg, MQTT, BW, observe_blockwise_key(Msg, PeerKey), PeerKey, Ctx};
+new_pending_observe_notification(Msg, MQTT, BW, PeerKey, Ctx, false) ->
+    {Msg, MQTT, BW, pending_blockwise_key(Msg, PeerKey), PeerKey, Ctx}.
+
+pending_msg({Msg, _MQTT, _BW}) ->
+    Msg;
+pending_msg({Msg, _MQTT, _BW, _BlockwiseKey}) ->
+    Msg;
+pending_msg({Msg, _MQTT, _BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
+    Msg.
+
+pending_mqtt({_Msg, MQTT, _BW}) ->
+    MQTT;
+pending_mqtt({_Msg, MQTT, _BW, _BlockwiseKey}) ->
+    MQTT;
+pending_mqtt({_Msg, MQTT, _BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
+    MQTT.
+
+pending_blockwise({_Msg, _MQTT, BW}) ->
+    BW;
+pending_blockwise({_Msg, _MQTT, BW, _BlockwiseKey}) ->
+    BW;
+pending_blockwise({_Msg, _MQTT, BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
+    BW.
+
+pending_blockwise_key({_Msg, _MQTT, _BW}) ->
+    undefined;
+pending_blockwise_key({_Msg, _MQTT, _BW, BlockwiseKey}) ->
+    BlockwiseKey;
+pending_blockwise_key({_Msg, _MQTT, _BW, BlockwiseKey, _PeerKey, _Ctx}) ->
+    BlockwiseKey.
+
+pending_peer_key({_Msg, _MQTT, _BW, _BlockwiseKey, PeerKey, _Ctx}) ->
+    PeerKey;
+pending_peer_key(_Pending) ->
+    undefined.
+
+pending_ctx({_Msg, _MQTT, _BW, _BlockwiseKey, _PeerKey, Ctx}) ->
+    Ctx;
+pending_ctx(_Pending) ->
+    undefined.
+
+pending_blockwise_key(#coap_message{token = Token} = Msg, PeerKey) when Token =/= <<>> ->
+    case emqx_coap_message:get_option(block2, Msg, undefined) of
+        {_, true, _} ->
+            observe_blockwise_key_from_token(Token, PeerKey);
+        _ ->
+            undefined
+    end;
+pending_blockwise_key(_Msg, _PeerKey) ->
+    undefined.
+
+observe_blockwise_key(#coap_message{token = Token}, PeerKey) when Token =/= <<>> ->
+    observe_blockwise_key_from_token(Token, PeerKey);
+observe_blockwise_key(_Msg, _PeerKey) ->
+    undefined.
+
+observe_blockwise_key_from_token(Token, PeerKey) ->
+    {server_tx_block2, PeerKey, Token}.
+
+pending_blockwise_active(Pending, Result) ->
+    case pending_blockwise_key(Pending) of
+        undefined ->
+            false;
+        BlockwiseKey ->
+            case maps:get(blockwise, Result, undefined) of
+                #{server_tx_block2 := ServerTx} when is_map(ServerTx) ->
+                    maps:is_key(BlockwiseKey, ServerTx);
+                _ ->
+                    false
+            end
     end.
 
 maybe_attach_pending_blockwise_result(Result, BW) when is_map(BW) ->
@@ -487,6 +661,18 @@ is_pending_observe_notification(
     Topic,
     Token,
     {#coap_message{token = Token}, #message{topic = Topic}, _BW}
+) ->
+    true;
+is_pending_observe_notification(
+    Topic,
+    Token,
+    {#coap_message{token = Token}, #message{topic = Topic}, _BW, _BlockwiseKey}
+) ->
+    true;
+is_pending_observe_notification(
+    Topic,
+    Token,
+    {#coap_message{token = Token}, #message{topic = Topic}, _BW, _BlockwiseKey, _PeerKey, _Ctx}
 ) ->
     true;
 is_pending_observe_notification(_Topic, _Token, _Pending) ->

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -378,9 +378,24 @@ drain_observe_notifications(
     end.
 
 maybe_attach_pending_blockwise_result(Result, BW) when is_map(BW) ->
-    Result#{blockwise => BW};
+    case maps:get(blockwise, Result, undefined) of
+        CurrentBW when is_map(CurrentBW) ->
+            Result#{blockwise => merge_blockwise_state(CurrentBW, BW)};
+        _ ->
+            Result#{blockwise => BW}
+    end;
 maybe_attach_pending_blockwise_result(Result, _BW) ->
     Result.
+
+merge_blockwise_state(CurrentBW, NextBW) ->
+    maps:fold(fun merge_blockwise_entry/3, CurrentBW, NextBW).
+
+merge_blockwise_entry(opts, Opts, Acc) ->
+    Acc#{opts => Opts};
+merge_blockwise_entry(Key, Value, Acc) when is_map(Value) ->
+    Acc#{Key => maps:merge(maps:get(Key, Acc, #{}), Value)};
+merge_blockwise_entry(Key, Value, Acc) ->
+    Acc#{Key => Value}.
 
 add_outs(Outs, Result) ->
     lists:foldl(

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -204,7 +204,7 @@ do_deliver(
                 SessionAcc1 = SessionAcc#session{observe_manager = OM2},
                 {Out, SessionAcc2, BW2} =
                     send_or_queue_observe_notification(
-                        Msg0, Message, Ctx, SessionAcc1, BWAcc, PeerKey
+                        Topic, Msg0, Message, Ctx, SessionAcc1, BWAcc, PeerKey
                     ),
                 {[Out | OutAcc], SessionAcc2, BW2}
         end
@@ -256,7 +256,7 @@ process_session(_, Result, Session0) ->
     {Result1, Session1} = maybe_drain_observe_notifications(Result, Session0),
     Result1#{session => Session1}.
 
-send_or_queue_observe_notification(Msg0, MQTT, Ctx, Session, BW0, PeerKey) ->
+send_or_queue_observe_notification(ObservedTopic, Msg0, MQTT, Ctx, Session, BW0, PeerKey) ->
     TrackInflight = is_confirmable_observe_notification(Msg0),
     DeferBlockwise = should_defer_observe_blockwise(Msg0, Session, BW0, PeerKey),
     case should_queue_observe_notification(Session) orelse DeferBlockwise of
@@ -267,12 +267,12 @@ send_or_queue_observe_notification(Msg0, MQTT, Ctx, Session, BW0, PeerKey) ->
                     false -> maybe_split_notify_block2(Msg0, PeerKey, BW0, Ctx)
                 end,
             Session1 = enqueue_observe_notification(
-                Msg, MQTT, BW1, PeerKey, Ctx, DeferBlockwise, Session
+                Msg, MQTT, ObservedTopic, BW1, PeerKey, Ctx, DeferBlockwise, Session
             ),
             {[], Session1, BW0};
         false ->
             maybe_send_or_enqueue_observe_notification(
-                Msg0, MQTT, Ctx, Session, BW0, PeerKey, TrackInflight
+                ObservedTopic, Msg0, MQTT, Ctx, Session, BW0, PeerKey, TrackInflight
             )
     end.
 
@@ -283,6 +283,7 @@ should_queue_observe_notification(#session{
     Inflight >= ?OBSERVE_INFLIGHT_WINDOW orelse PendingLen > 0.
 
 maybe_send_or_enqueue_observe_notification(
+    ObservedTopic,
     Msg0,
     MQTT,
     Ctx,
@@ -294,7 +295,9 @@ maybe_send_or_enqueue_observe_notification(
     {Msg, BW1} = maybe_split_notify_block2(Msg0, PeerKey, BW0, Ctx),
     case send_observe_notification_now(Msg, TrackInflight, Session) of
         {[], Session1} ->
-            Session2 = enqueue_observe_notification(Msg, MQTT, BW1, PeerKey, Ctx, false, Session1),
+            Session2 = enqueue_observe_notification(
+                Msg, MQTT, ObservedTopic, BW1, PeerKey, Ctx, false, Session1
+            ),
             {[], Session2, BW0};
         {Out, Session1} ->
             {Out, Session1, BW1}
@@ -319,6 +322,7 @@ maybe_inc_observe_inflight(false, Session) ->
 enqueue_observe_notification(
     Msg,
     MQTT,
+    ObservedTopic,
     BW,
     PeerKey,
     Ctx,
@@ -329,7 +333,9 @@ enqueue_observe_notification(
         observe_pending_dropped = Dropped0
     } = Session
 ) when Len0 < ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN ->
-    Pending = new_pending_observe_notification(Msg, MQTT, BW, PeerKey, Ctx, ForceBlockwiseKey),
+    Pending = new_pending_observe_notification(
+        Msg, MQTT, ObservedTopic, BW, PeerKey, Ctx, ForceBlockwiseKey
+    ),
     Session#session{
         observe_pending = queue:in(Pending, Queue0),
         observe_pending_len = Len0 + 1,
@@ -338,6 +344,7 @@ enqueue_observe_notification(
 enqueue_observe_notification(
     Msg,
     MQTT,
+    ObservedTopic,
     BW,
     PeerKey,
     Ctx,
@@ -349,7 +356,9 @@ enqueue_observe_notification(
 ) ->
     {{value, Dropped}, Queue1} = queue:out(Queue0),
     DroppedMQTT = pending_mqtt(Dropped),
-    Pending = new_pending_observe_notification(Msg, MQTT, BW, PeerKey, Ctx, ForceBlockwiseKey),
+    Pending = new_pending_observe_notification(
+        Msg, MQTT, ObservedTopic, BW, PeerKey, Ctx, ForceBlockwiseKey
+    ),
     metrics_inc('delivery.dropped', Ctx),
     metrics_inc('delivery.dropped.queue_full', Ctx),
     log_observe_notification_queue_full(DroppedMQTT),
@@ -477,11 +486,13 @@ blockwise_key_active(BlockwiseKey, #{server_tx_block2 := ServerTx}) when is_map(
 blockwise_key_active(_BlockwiseKey, _BW) ->
     false.
 
-new_pending_observe_notification(Msg, MQTT, BW, PeerKey, Ctx, true) ->
-    {Msg, MQTT, BW, observe_blockwise_key(Msg, PeerKey), PeerKey, Ctx};
-new_pending_observe_notification(Msg, MQTT, BW, PeerKey, Ctx, false) ->
-    {Msg, MQTT, BW, pending_blockwise_key(Msg, PeerKey), PeerKey, Ctx}.
+new_pending_observe_notification(Msg, MQTT, ObservedTopic, BW, PeerKey, Ctx, true) ->
+    {Msg, MQTT, ObservedTopic, BW, observe_blockwise_key(Msg, PeerKey), PeerKey, Ctx};
+new_pending_observe_notification(Msg, MQTT, ObservedTopic, BW, PeerKey, Ctx, false) ->
+    {Msg, MQTT, ObservedTopic, BW, pending_blockwise_key(Msg, PeerKey), PeerKey, Ctx}.
 
+pending_msg({Msg, _MQTT, _ObservedTopic, _BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
+    Msg;
 pending_msg({Msg, _MQTT, _BW}) ->
     Msg;
 pending_msg({Msg, _MQTT, _BW, _BlockwiseKey}) ->
@@ -489,6 +500,8 @@ pending_msg({Msg, _MQTT, _BW, _BlockwiseKey}) ->
 pending_msg({Msg, _MQTT, _BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
     Msg.
 
+pending_mqtt({_Msg, MQTT, _ObservedTopic, _BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
+    MQTT;
 pending_mqtt({_Msg, MQTT, _BW}) ->
     MQTT;
 pending_mqtt({_Msg, MQTT, _BW, _BlockwiseKey}) ->
@@ -496,6 +509,13 @@ pending_mqtt({_Msg, MQTT, _BW, _BlockwiseKey}) ->
 pending_mqtt({_Msg, MQTT, _BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
     MQTT.
 
+pending_observed_topic({_Msg, _MQTT, ObservedTopic, _BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
+    ObservedTopic;
+pending_observed_topic(_Pending) ->
+    undefined.
+
+pending_blockwise({_Msg, _MQTT, _ObservedTopic, BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
+    BW;
 pending_blockwise({_Msg, _MQTT, BW}) ->
     BW;
 pending_blockwise({_Msg, _MQTT, BW, _BlockwiseKey}) ->
@@ -503,6 +523,8 @@ pending_blockwise({_Msg, _MQTT, BW, _BlockwiseKey}) ->
 pending_blockwise({_Msg, _MQTT, BW, _BlockwiseKey, _PeerKey, _Ctx}) ->
     BW.
 
+pending_blockwise_key({_Msg, _MQTT, _ObservedTopic, _BW, BlockwiseKey, _PeerKey, _Ctx}) ->
+    BlockwiseKey;
 pending_blockwise_key({_Msg, _MQTT, _BW}) ->
     undefined;
 pending_blockwise_key({_Msg, _MQTT, _BW, BlockwiseKey}) ->
@@ -510,11 +532,15 @@ pending_blockwise_key({_Msg, _MQTT, _BW, BlockwiseKey}) ->
 pending_blockwise_key({_Msg, _MQTT, _BW, BlockwiseKey, _PeerKey, _Ctx}) ->
     BlockwiseKey.
 
+pending_peer_key({_Msg, _MQTT, _ObservedTopic, _BW, _BlockwiseKey, PeerKey, _Ctx}) ->
+    PeerKey;
 pending_peer_key({_Msg, _MQTT, _BW, _BlockwiseKey, PeerKey, _Ctx}) ->
     PeerKey;
 pending_peer_key(_Pending) ->
     undefined.
 
+pending_ctx({_Msg, _MQTT, _ObservedTopic, _BW, _BlockwiseKey, _PeerKey, Ctx}) ->
+    Ctx;
 pending_ctx({_Msg, _MQTT, _BW, _BlockwiseKey, _PeerKey, Ctx}) ->
     Ctx;
 pending_ctx(_Pending) ->
@@ -657,26 +683,32 @@ purge_pending_observe_notifications(
             }
     end.
 
-is_pending_observe_notification(
-    Topic,
-    Token,
-    {#coap_message{token = Token}, #message{topic = Topic}, _BW}
-) ->
-    true;
-is_pending_observe_notification(
-    Topic,
-    Token,
-    {#coap_message{token = Token}, #message{topic = Topic}, _BW, _BlockwiseKey}
-) ->
-    true;
-is_pending_observe_notification(
-    Topic,
-    Token,
-    {#coap_message{token = Token}, #message{topic = Topic}, _BW, _BlockwiseKey, _PeerKey, _Ctx}
-) ->
-    true;
-is_pending_observe_notification(_Topic, _Token, _Pending) ->
-    false.
+is_pending_observe_notification(Topic, Token, Pending) ->
+    pending_token(Pending) =:= Token andalso
+        case pending_observed_topic(Pending) of
+            Topic ->
+                true;
+            undefined ->
+                pending_message_topic(Pending) =:= Topic;
+            _ ->
+                false
+        end.
+
+pending_token(Pending) ->
+    case pending_msg(Pending) of
+        #coap_message{token = Token} ->
+            Token;
+        _ ->
+            undefined
+    end.
+
+pending_message_topic(Pending) ->
+    case pending_mqtt(Pending) of
+        #message{topic = Topic} ->
+            Topic;
+        _ ->
+            undefined
+    end.
 
 mqtt_to_coap(MQTT, Token, SeqId) ->
     #message{payload = Payload} = MQTT,

--- a/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
@@ -27,6 +27,7 @@
     id :: state_machine_key(),
     token :: token() | undefined,
     observe :: 0 | 1 | undefined | observed,
+    observe_notification = false :: boolean(),
     state :: atom(),
     timers :: map(),
     transport :: emqx_coap_transport:transport()
@@ -248,10 +249,21 @@ process_timeouts(
     ),
     iter(Iter, Result, Machine#state_machine{timers = NewTimers}, TM).
 
-process_manager(stop, Result, #state_machine{seq_id = SeqId}, TM) ->
-    Result#{tm => delete_machine(SeqId, TM)};
+process_manager(
+    stop,
+    Result,
+    #state_machine{seq_id = SeqId, observe_notification = ObserveNotification},
+    TM
+) ->
+    Result2 = maybe_mark_observe_notification_done(ObserveNotification, Result),
+    Result2#{tm => delete_machine(SeqId, TM)};
 process_manager(_, Result, #state_machine{seq_id = SeqId} = Machine2, TM) ->
     Result#{tm => TM#{SeqId => Machine2}}.
+
+maybe_mark_observe_notification_done(true, Result) ->
+    Result#{observe_notification_done => maps:get(observe_notification_done, Result, 0) + 1};
+maybe_mark_observe_notification_done(false, Result) ->
+    Result.
 
 cancel_state_timer(#state_machine{timers = Timers} = Machine) ->
     case maps:get(state_timer, Timers, undefined) of
@@ -337,15 +349,17 @@ new_in_machine(MachineId, #{seq_id := SeqId} = Manager) ->
 new_out_machine(
     MachineId,
     Ctx,
-    #coap_message{type = Type, token = Token, options = Opts},
+    #coap_message{type = Type, token = Token, options = Opts} = Msg,
     #{seq_id := SeqId} = Manager
 ) ->
     Observe = maps:get(observe, Opts, undefined),
+    ObserveNotification = is_confirmable_observe_notification(Msg),
     Machine = #state_machine{
         seq_id = SeqId,
         id = MachineId,
         token = Token,
         observe = Observe,
+        observe_notification = ObserveNotification,
         state = idle,
         timers = #{},
         transport = emqx_coap_transport:new(Ctx)
@@ -360,7 +374,7 @@ new_out_machine(
         if
             Token =:= <<>> ->
                 Manager2;
-            Observe =:= 1 ->
+            Observe =:= 1 andalso not ObserveNotification ->
                 TokenId = ?TOKEN_ID(Token),
                 delete_machine(TokenId, Manager2);
             Type =:= con orelse Observe =:= 0 ->
@@ -374,6 +388,11 @@ new_out_machine(
             true ->
                 Manager2
         end}.
+
+is_confirmable_observe_notification(#coap_message{type = con, method = {ok, _}} = Msg) ->
+    emqx_coap_message:get_option(observe, Msg, undefined) =/= undefined;
+is_confirmable_observe_notification(_) ->
+    false.
 
 alloc_message_id(#{next_msg_id := MsgId} = TM) ->
     alloc_message_id(MsgId, TM).

--- a/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
@@ -26,6 +26,7 @@
     seq_id :: seq_id(),
     id :: state_machine_key(),
     token :: token() | undefined,
+    token_key :: token_key() | undefined,
     observe :: 0 | 1 | undefined | observed,
     observe_notification = false :: boolean(),
     state :: atom(),
@@ -252,17 +253,21 @@ process_timeouts(
 process_manager(
     stop,
     Result,
-    #state_machine{seq_id = SeqId, observe_notification = ObserveNotification},
+    #state_machine{seq_id = SeqId, observe_notification = ObserveNotification} = Machine,
     TM
 ) ->
-    Result2 = maybe_mark_observe_notification_done(ObserveNotification, Result),
+    Result2 = maybe_mark_observe_notification_done(ObserveNotification, Machine, Result),
     Result2#{tm => delete_machine(SeqId, TM)};
 process_manager(_, Result, #state_machine{seq_id = SeqId} = Machine2, TM) ->
     Result#{tm => TM#{SeqId => Machine2}}.
 
-maybe_mark_observe_notification_done(true, Result) ->
-    Result#{observe_notification_done => maps:get(observe_notification_done, Result, 0) + 1};
-maybe_mark_observe_notification_done(false, Result) ->
+maybe_mark_observe_notification_done(true, #state_machine{token = Token}, Result) ->
+    Result#{
+        observe_notification_done => maps:get(observe_notification_done, Result, 0) + 1,
+        observe_notification_done_tokens =>
+            [Token | maps:get(observe_notification_done_tokens, Result, [])]
+    };
+maybe_mark_observe_notification_done(false, _Machine, Result) ->
     Result.
 
 cancel_state_timer(#state_machine{timers = Timers} = Machine) ->
@@ -286,7 +291,7 @@ delete_machine(Id, Manager) ->
         #state_machine{
             seq_id = SeqId,
             id = MachineId,
-            token = Token,
+            token_key = TokenKey,
             timers = Timers
         } ->
             lists:foreach(
@@ -295,7 +300,12 @@ delete_machine(Id, Manager) ->
                 end,
                 maps:to_list(Timers)
             ),
-            maps:without([SeqId, MachineId, ?TOKEN_ID(Token)], Manager)
+            DeleteKeys =
+                case TokenKey of
+                    undefined -> [SeqId, MachineId];
+                    _ -> [SeqId, MachineId, TokenKey]
+                end,
+            maps:without(DeleteKeys, Manager)
     end.
 
 -spec find_machine(manager_key(), manager()) -> state_machine() | undefined.
@@ -368,27 +378,27 @@ new_out_machine(
 
     Manager2 = Manager#{
         seq_id := SeqId + 1,
-        SeqId => Machine,
         MachineId => SeqId
     },
-    {Machine,
+    {Machine1, Manager3} =
         if
             Token =:= <<>> ->
-                Manager2;
+                {Machine, Manager2};
             Observe =:= 1 andalso not IsObserveNotification ->
                 TokenId = ?TOKEN_ID(Token),
-                delete_machine(TokenId, Manager2);
+                {Machine, delete_machine(TokenId, Manager2)};
             Type =:= con orelse (Observe =:= 0 andalso not IsObserveNotification) ->
                 TokenId = ?TOKEN_ID(Token),
                 case maps:get(TokenId, Manager, undefined) of
                     undefined ->
-                        Manager2#{TokenId => SeqId};
+                        {Machine#state_machine{token_key = TokenId}, Manager2#{TokenId => SeqId}};
                     _ ->
                         throw("token conflict")
                 end;
             true ->
-                Manager2
-        end}.
+                {Machine, Manager2}
+        end,
+    {Machine1, Manager3#{SeqId => Machine1}}.
 
 is_observe_notification(#coap_message{method = {ok, _}} = Msg) ->
     emqx_coap_message:get_option(observe, Msg, undefined) =/= undefined;

--- a/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
@@ -353,6 +353,7 @@ new_out_machine(
     #{seq_id := SeqId} = Manager
 ) ->
     Observe = maps:get(observe, Opts, undefined),
+    IsObserveNotification = is_observe_notification(Msg),
     ObserveNotification = is_confirmable_observe_notification(Msg),
     Machine = #state_machine{
         seq_id = SeqId,
@@ -374,10 +375,10 @@ new_out_machine(
         if
             Token =:= <<>> ->
                 Manager2;
-            Observe =:= 1 andalso not ObserveNotification ->
+            Observe =:= 1 andalso not IsObserveNotification ->
                 TokenId = ?TOKEN_ID(Token),
                 delete_machine(TokenId, Manager2);
-            Type =:= con orelse Observe =:= 0 ->
+            Type =:= con orelse (Observe =:= 0 andalso not IsObserveNotification) ->
                 TokenId = ?TOKEN_ID(Token),
                 case maps:get(TokenId, Manager, undefined) of
                     undefined ->
@@ -388,6 +389,11 @@ new_out_machine(
             true ->
                 Manager2
         end}.
+
+is_observe_notification(#coap_message{method = {ok, _}} = Msg) ->
+    emqx_coap_message:get_option(observe, Msg, undefined) =/= undefined;
+is_observe_notification(_) ->
+    false.
 
 is_confirmable_observe_notification(#coap_message{type = con, method = {ok, _}} = Msg) ->
     emqx_coap_message:get_option(observe, Msg, undefined) =/= undefined;

--- a/apps/emqx_gateway_coap/src/emqx_coap_transport.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_transport.erl
@@ -162,7 +162,11 @@ maybe_reset(
             reset(Message, Ret)
     end.
 
-wait_ack(in, #coap_message{type = Type, method = Method} = Msg, #transport{req_context = Ctx}) ->
+wait_ack(
+    in,
+    #coap_message{type = Type, method = Method} = Msg,
+    #transport{req_context = Ctx, cache = Cache}
+) ->
     CtxMsg = {Ctx, Msg},
     case Type of
         reset ->
@@ -170,8 +174,14 @@ wait_ack(in, #coap_message{type = Type, method = Method} = Msg, #transport{req_c
         _ ->
             case Method of
                 undefined ->
-                    %% empty ack, keep transport to recv response
-                    proto_out({ack, CtxMsg});
+                    case is_response(Cache) of
+                        true ->
+                            %% Empty ACK completes a CON response/notification sent by this server.
+                            proto_out({ack, CtxMsg}, #{next => stop});
+                        false ->
+                            %% Empty ACK for a CON request keeps transport waiting for separate response.
+                            proto_out({ack, CtxMsg})
+                    end;
                 {_, _} ->
                     %% ack with payload
                     proto_out({response, CtxMsg}, #{next => stop});
@@ -205,7 +215,7 @@ wait_ack(
                 }
             );
         _ ->
-            proto_out({ack_failure, Msg}, #{next_state => stop})
+            proto_out({ack_failure, Msg}, #{next => stop})
     end.
 
 observe(
@@ -271,3 +281,8 @@ maybe_update_observe(#coap_message{method = {ok, _}} = Msg) ->
     end;
 maybe_update_observe(Msg) ->
     Msg.
+
+is_response(#coap_message{method = {_, _}}) ->
+    true;
+is_response(_) ->
+    false.

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -1047,8 +1047,6 @@ t_observe_con_notify_uses_shared_session_queue(_) ->
 
             Payload2 = <<"second-b">>,
             publish(TopicB, ?QOS_0, Payload2),
-            Payload3 = <<"third-a">>,
-            publish(TopicA, ?QOS_0, Payload3),
             ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
 
             ?assertNotEqual(
@@ -1057,6 +1055,9 @@ t_observe_con_notify_uses_shared_session_queue(_) ->
             ),
             ack_if_con(Channel, Notify1),
             Notify2 = assert_notify(Channel, con, Payload2),
+
+            Payload3 = <<"third-a">>,
+            publish(TopicA, ?QOS_0, Payload3),
             ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
             ack_if_con(Channel, Notify2),
             Notify3 = assert_notify(Channel, con, Payload3),

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -1163,6 +1163,83 @@ t_observe_non_blockwise_queue_preserves_all_drained_tokens(_) ->
         end)
     end).
 
+t_observe_same_token_blockwise_queue_serializes_drained_notifications(_) ->
+    with_notify_type(qos, fun() ->
+        with_blockwise_max_size(16, fun() ->
+            Fun = fun(Channel, Token) ->
+                Topic = <<"coap/observe_notify_queue_block2_same_token">>,
+                ObserveToken = <<"obsbst">>,
+                observe_topic(Channel, Token, Topic, ObserveToken),
+
+                publish(Topic, ?QOS_1, <<"inflight">>),
+                NotifyA = assert_notify(Channel, con, <<"inflight">>),
+
+                PayloadB = blockwise_payload(<<"B">>, <<"b">>, <<"1">>),
+                PayloadC = blockwise_payload(<<"C">>, <<"c">>, <<"2">>),
+                publish(Topic, ?QOS_0, PayloadB),
+                publish(Topic, ?QOS_0, PayloadC),
+                ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+                ack_if_con(Channel, NotifyA),
+                Notify0 = assert_notify(Channel, non),
+                ?assertEqual({0, true, 16}, coap_option(block2, Notify0, undefined)),
+                FirstPayload = notify_payload(Notify0),
+                ?assert(
+                    lists:member(FirstPayload, [binary:copy(<<"B">>, 16), binary:copy(<<"C">>, 16)])
+                ),
+                {FirstMid, FirstTail, SecondHead, SecondMid, SecondTail} =
+                    case FirstPayload of
+                        <<"BBBBBBBBBBBBBBBB">> ->
+                            {<<"b">>, <<"1">>, <<"C">>, <<"c">>, <<"2">>};
+                        <<"CCCCCCCCCCCCCCCC">> ->
+                            {<<"c">>, <<"2">>, <<"B">>, <<"b">>, <<"1">>}
+                    end,
+                ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+                URI = pubsub_uri(binary_to_list(Topic), Token),
+                _ = assert_block2_followup(
+                    Channel,
+                    URI,
+                    Notify0#coap_message.token,
+                    1,
+                    binary:copy(FirstMid, 16),
+                    {1, true, 16}
+                ),
+                ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+                _ = assert_block2_followup(
+                    Channel,
+                    URI,
+                    Notify0#coap_message.token,
+                    2,
+                    binary:copy(FirstTail, 8),
+                    {2, false, 16}
+                ),
+                Notify1 = assert_block2_notify(
+                    Channel, non, binary:copy(SecondHead, 16), {0, true, 16}
+                ),
+                _ = assert_block2_followup(
+                    Channel,
+                    URI,
+                    Notify1#coap_message.token,
+                    1,
+                    binary:copy(SecondMid, 16),
+                    {1, true, 16}
+                ),
+                _ = assert_block2_followup(
+                    Channel,
+                    URI,
+                    Notify1#coap_message.token,
+                    2,
+                    binary:copy(SecondTail, 8),
+                    {2, false, 16}
+                ),
+                true
+            end,
+            with_connection(Fun)
+        end)
+    end).
+
 t_observe_con_notify_queue_drops_oldest_when_full(_) ->
     with_notify_type(con, fun() ->
         Fun = fun(Channel, Token) ->
@@ -1682,6 +1759,15 @@ assert_block2_notify(Channel, Type, Payload, Block2) ->
     Notify = assert_notify(Channel, Type, Payload),
     ?assertEqual(Block2, coap_option(block2, Notify, undefined)),
     Notify.
+
+assert_block2_followup(Channel, URI, Token, Num, Payload, Block2) ->
+    FollowReq = (make_req(get, <<>>, [{block2, {Num, false, 16}}]))#coap_message{
+        token = Token
+    },
+    {ok, content, FollowResp} = do_message_request(Channel, URI, FollowReq),
+    ?assertEqual(Payload, notify_payload(FollowResp)),
+    ?assertEqual(Block2, coap_option(block2, FollowResp, undefined)),
+    FollowResp.
 
 notify_payload(Notify) ->
     #coap_content{payload = Payload} = er_coap_message:get_content(Notify),

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -1108,6 +1108,61 @@ t_observe_con_notify_queue_preserves_block2_until_drained(_) ->
         end)
     end).
 
+t_observe_non_blockwise_queue_preserves_all_drained_tokens(_) ->
+    with_notify_type(qos, fun() ->
+        with_blockwise_max_size(16, fun() ->
+            Fun = fun(Channel, Token) ->
+                TopicA = <<"coap/observe_notify_queue_block2_multi/a">>,
+                TopicB = <<"coap/observe_notify_queue_block2_multi/b">>,
+                TopicC = <<"coap/observe_notify_queue_block2_multi/c">>,
+                observe_topic(Channel, Token, TopicA, <<"obsbqa">>),
+                observe_topic(Channel, Token, TopicB, <<"obsbqb">>),
+                observe_topic(Channel, Token, TopicC, <<"obsbqc">>),
+
+                publish(TopicA, ?QOS_1, <<"inflight-a">>),
+                NotifyA = assert_notify(Channel, con, <<"inflight-a">>),
+
+                PayloadB = blockwise_payload(<<"B">>, <<"b">>, <<"1">>),
+                PayloadC = blockwise_payload(<<"C">>, <<"c">>, <<"2">>),
+                publish(TopicB, ?QOS_0, PayloadB),
+                publish(TopicC, ?QOS_0, PayloadC),
+                ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+                ack_if_con(Channel, NotifyA),
+                Notify1 = assert_notify(Channel, non),
+                Notify2 = assert_notify(Channel, non),
+                NotifyB = find_notify_by_payload(binary:copy(<<"B">>, 16), Notify1, Notify2),
+                NotifyC = find_notify_by_payload(binary:copy(<<"C">>, 16), Notify1, Notify2),
+                ?assertEqual({0, true, 16}, coap_option(block2, NotifyB, undefined)),
+                ?assertEqual({0, true, 16}, coap_option(block2, NotifyC, undefined)),
+
+                URIb = pubsub_uri(binary_to_list(TopicB), Token),
+                FollowReqB = (make_req(get, <<>>, [{block2, {1, false, 16}}]))#coap_message{
+                    token = NotifyB#coap_message.token
+                },
+                {ok, content, FollowRespB} = do_message_request(Channel, URIb, FollowReqB),
+                ?assertEqual(binary:copy(<<"b">>, 16), notify_payload(FollowRespB)),
+                ?assertEqual(
+                    {1, true, 16},
+                    coap_option(block2, FollowRespB, undefined)
+                ),
+
+                URIc = pubsub_uri(binary_to_list(TopicC), Token),
+                FollowReqC = (make_req(get, <<>>, [{block2, {1, false, 16}}]))#coap_message{
+                    token = NotifyC#coap_message.token
+                },
+                {ok, content, FollowRespC} = do_message_request(Channel, URIc, FollowReqC),
+                ?assertEqual(binary:copy(<<"c">>, 16), notify_payload(FollowRespC)),
+                ?assertEqual(
+                    {1, true, 16},
+                    coap_option(block2, FollowRespC, undefined)
+                ),
+                true
+            end,
+            with_connection(Fun)
+        end)
+    end).
+
 t_observe_con_notify_queue_drops_oldest_when_full(_) ->
     with_notify_type(con, fun() ->
         Fun = fun(Channel, Token) ->
@@ -1643,6 +1698,14 @@ blockwise_payload(First, Second, Third) ->
         binary:copy(Second, 16),
         binary:copy(Third, 8)
     ]).
+
+find_notify_by_payload(Payload, Notify1, Notify2) ->
+    case {notify_payload(Notify1), notify_payload(Notify2)} of
+        {Payload, _} ->
+            Notify1;
+        {_, Payload} ->
+            Notify2
+    end.
 
 ack_if_con(Channel, #coap_message{type = con} = Message) ->
     {ok, _} = er_coap_channel:send(Channel, er_coap_message:ack(Message)),

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -1166,6 +1166,31 @@ t_observe_con_notify_queue_drains_after_reset(_) ->
         with_connection(Fun)
     end).
 
+t_observe_cancel_drops_pending_notifications(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_queue_cancel">>,
+            ObserveToken = <<"obscancel">>,
+            observe_topic(Channel, Token, Topic, ObserveToken),
+
+            publish(Topic, ?QOS_0, <<"first">>),
+            Notify1 = assert_notify(Channel, con, <<"first">>),
+            publish(Topic, ?QOS_0, <<"queued-after-cancel">>),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            UnReq = (make_req(get, <<>>, [{observe, 1}]))#coap_message{
+                token = ObserveToken
+            },
+            {ok, nocontent, _} = do_request(Channel, URI, UnReq),
+
+            ack_if_con(Channel, Notify1),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 500)),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
 t_clients_api(_) ->
     Fun = fun(_Channel, _Token) ->
         ClientId = <<"client1">>,

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -17,6 +17,7 @@
 
 -include_lib("er_coap_client/include/coap.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -87,6 +88,18 @@ update_coap_with_mountpoint(Mp) ->
         coap,
         Conf#{<<"mountpoint">> => Mp}
     ).
+
+with_notify_type(NotifyType, Fun) ->
+    OldConf = emqx:get_raw_config([gateway, coap]),
+    {ok, _} = emqx_gateway_conf:update_gateway(
+        coap,
+        OldConf#{<<"notify_type">> => atom_to_binary(NotifyType)}
+    ),
+    try
+        Fun()
+    after
+        {ok, _} = emqx_gateway_conf:update_gateway(coap, OldConf)
+    end.
 
 %%--------------------------------------------------------------------
 %% Test Cases
@@ -929,6 +942,72 @@ t_observe_wildcard(_) ->
 
     with_connection(Fun).
 
+t_observe_notify_type_qos(_) ->
+    with_notify_type(qos, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_qos">>,
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            Req = make_req(get, <<>>, [{observe, 0}]),
+            {ok, content, _} = do_request(Channel, URI, Req),
+
+            Payload0 = <<"qos0">>,
+            publish(Topic, ?QOS_0, Payload0),
+            Notify0 = assert_notify(Channel, non, Payload0),
+            ack_if_con(Channel, Notify0),
+
+            Payload1 = <<"qos1">>,
+            publish(Topic, ?QOS_1, Payload1),
+            Notify1 = assert_notify(Channel, con, Payload1),
+            ack_if_con(Channel, Notify1),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_notify_type_con(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_con">>,
+            Payload = <<"confirmable">>,
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            Req = make_req(get, <<>>, [{observe, 0}]),
+            {ok, content, _} = do_request(Channel, URI, Req),
+
+            publish(Topic, ?QOS_0, Payload),
+            Notify = assert_notify(Channel, con, Payload),
+            ack_if_con(Channel, Notify),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_con_notify_drops_duplicate_while_ack_pending(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_duplicate">>,
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            Req = make_req(get, <<>>, [{observe, 0}]),
+            {ok, content, _} = do_request(Channel, URI, Req),
+
+            Payload1 = <<"first">>,
+            publish(Topic, ?QOS_0, Payload1),
+            Notify1 = assert_notify(Channel, con, Payload1),
+
+            Payload2 = <<"second">>,
+            publish(Topic, ?QOS_0, Payload2),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            ?assertNotEqual(
+                [],
+                emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+            ),
+            ack_if_con(Channel, Notify1),
+            ?assertMatch({ok, changed, _}, send_heartbeat(Channel, Token)),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
 t_clients_api(_) ->
     Fun = fun(_Channel, _Token) ->
         ClientId = <<"client1">>,
@@ -1329,6 +1408,20 @@ make_req(Method, Payload, Opts) ->
 make_req_type(Type, Method, Payload, Opts) ->
     er_coap_message:request(Type, Method, Payload, Opts).
 
+publish(Topic, QoS, Payload) ->
+    emqx:publish(emqx_message:make(<<"coap">>, QoS, Topic, Payload)).
+
+assert_notify(Channel, Type, Payload) ->
+    {ok, content, Notify = #coap_message{type = Type}} = with_message_response(Channel),
+    #coap_content{payload = Payload} = er_coap_message:get_content(Notify),
+    Notify.
+
+ack_if_con(Channel, #coap_message{type = con} = Message) ->
+    {ok, _} = er_coap_channel:send(Channel, er_coap_message:ack(Message)),
+    ok;
+ack_if_con(_Channel, #coap_message{}) ->
+    ok.
+
 do_request(Channel, URI, #coap_message{options = Opts} = Req) ->
     {_, _, Path, Query} = er_coap_client:resolve_uri(URI),
     Opts2 = [{uri_path, Path}, {uri_query, Query} | Opts],
@@ -1348,12 +1441,30 @@ with_response(Channel) ->
         {error, timeout}
     end.
 
+with_message_response(Channel) ->
+    with_message_response(Channel, 2000).
+
+with_message_response(Channel, Timeout) ->
+    receive
+        {coap_response, _ChId, Channel, _Ref, Message = #coap_message{method = Code}} ->
+            return_message_response(Code, Message);
+        {coap_error, _ChId, Channel, _Ref, reset} ->
+            {error, reset}
+    after Timeout ->
+        {error, timeout}
+    end.
+
 return_response({ok, Code}, Message) ->
     {ok, Code, er_coap_message:get_content(Message)};
 return_response({error, Code}, #coap_message{payload = <<>>}) ->
     {error, Code};
 return_response({error, Code}, Message) ->
     {error, Code, er_coap_message:get_content(Message)}.
+
+return_message_response({ok, Code}, Message) ->
+    {ok, Code, Message};
+return_message_response({error, Code}, Message) ->
+    {error, Code, Message}.
 
 do(Fun) ->
     emqx_coap_test_helpers:with_udp_channel(Fun).

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -102,6 +102,21 @@ with_notify_type(NotifyType, Fun) ->
         {ok, _} = emqx_gateway_conf:update_gateway(coap, OldConf)
     end.
 
+with_blockwise_max_size(MaxBlockSize, Fun) ->
+    OldConf = emqx:get_raw_config([gateway, coap]),
+    OldBlockwise = maps:get(<<"blockwise">>, OldConf, #{}),
+    {ok, _} = emqx_gateway_conf:update_gateway(
+        coap,
+        OldConf#{
+            <<"blockwise">> => OldBlockwise#{<<"max_block_size">> => MaxBlockSize}
+        }
+    ),
+    try
+        Fun()
+    after
+        {ok, _} = emqx_gateway_conf:update_gateway(coap, OldConf)
+    end.
+
 %%--------------------------------------------------------------------
 %% Test Cases
 %%--------------------------------------------------------------------
@@ -982,6 +997,42 @@ t_observe_notify_type_con(_) ->
         with_connection(Fun)
     end).
 
+t_observe_notify_type_non(_) ->
+    with_notify_type(non, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_non">>,
+            Payload = <<"non-confirmable">>,
+            URI = pubsub_uri(binary_to_list(Topic), Token),
+            Req = make_req(get, <<>>, [{observe, 0}]),
+            {ok, content, _} = do_request(Channel, URI, Req),
+
+            publish(Topic, ?QOS_1, Payload),
+            Notify = assert_notify(Channel, non, Payload),
+            ack_if_con(Channel, Notify),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_non_notify_waits_for_con_inflight(_) ->
+    with_notify_type(qos, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_non_queue">>,
+            observe_topic(Channel, Token, Topic, <<"obsnq">>),
+
+            publish(Topic, ?QOS_1, <<"qos1-con">>),
+            Notify1 = assert_notify(Channel, con, <<"qos1-con">>),
+            publish(Topic, ?QOS_0, <<"qos0-non">>),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            ack_if_con(Channel, Notify1),
+            Notify2 = assert_notify(Channel, non, <<"qos0-non">>),
+            ack_if_con(Channel, Notify2),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
 t_observe_con_notify_uses_shared_session_queue(_) ->
     with_notify_type(con, fun() ->
         Fun = fun(Channel, Token) ->
@@ -1014,6 +1065,46 @@ t_observe_con_notify_uses_shared_session_queue(_) ->
             true
         end,
         with_connection(Fun)
+    end).
+
+t_observe_con_notify_queue_preserves_block2_until_drained(_) ->
+    with_notify_type(con, fun() ->
+        with_blockwise_max_size(16, fun() ->
+            Fun = fun(Channel, Token) ->
+                Topic = <<"coap/observe_notify_queue_block2">>,
+                ObserveToken = <<"obsbq">>,
+                observe_topic(Channel, Token, Topic, ObserveToken),
+
+                PayloadA = blockwise_payload(<<"A">>, <<"B">>, <<"C">>),
+                PayloadB = blockwise_payload(<<"X">>, <<"Y">>, <<"Z">>),
+                publish(Topic, ?QOS_0, PayloadA),
+                NotifyA0 = assert_block2_notify(
+                    Channel, con, binary:copy(<<"A">>, 16), {0, true, 16}
+                ),
+
+                publish(Topic, ?QOS_0, PayloadB),
+                ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+                URI = pubsub_uri(binary_to_list(Topic), Token),
+                FollowReq = (make_req(get, <<>>, [{block2, {1, false, 16}}]))#coap_message{
+                    token = NotifyA0#coap_message.token
+                },
+                {ok, content, FollowResp} = do_message_request(Channel, URI, FollowReq),
+                ?assertEqual(binary:copy(<<"B">>, 16), notify_payload(FollowResp)),
+                ?assertEqual(
+                    {1, true, 16},
+                    coap_option(block2, FollowResp, undefined)
+                ),
+
+                reset_if_con(Channel, NotifyA0),
+                NotifyB0 = assert_block2_notify(
+                    Channel, con, binary:copy(<<"X">>, 16), {0, true, 16}
+                ),
+                reset_if_con(Channel, NotifyB0),
+                true
+            end,
+            with_connection(Fun)
+        end)
     end).
 
 t_observe_con_notify_queue_drops_oldest_when_full(_) ->
@@ -1506,9 +1597,26 @@ assert_notify(Channel, Type) ->
     {ok, content, Notify = #coap_message{type = Type}} = with_message_response(Channel),
     Notify.
 
+assert_block2_notify(Channel, Type, Payload, Block2) ->
+    Notify = assert_notify(Channel, Type, Payload),
+    ?assertEqual(Block2, coap_option(block2, Notify, undefined)),
+    Notify.
+
 notify_payload(Notify) ->
     #coap_content{payload = Payload} = er_coap_message:get_content(Notify),
     Payload.
+
+coap_option(Option, #coap_message{options = Options}, Default) when is_map(Options) ->
+    maps:get(Option, Options, Default);
+coap_option(Option, #coap_message{options = Options}, Default) when is_list(Options) ->
+    proplists:get_value(Option, Options, Default).
+
+blockwise_payload(First, Second, Third) ->
+    iolist_to_binary([
+        binary:copy(First, 16),
+        binary:copy(Second, 16),
+        binary:copy(Third, 8)
+    ]).
 
 ack_if_con(Channel, #coap_message{type = con} = Message) ->
     {ok, _} = er_coap_channel:send(Channel, er_coap_message:ack(Message)),
@@ -1528,6 +1636,15 @@ do_request(Channel, URI, #coap_message{options = Opts} = Req) ->
 
     {ok, _} = er_coap_channel:send(Channel, Req2),
     with_response(Channel).
+
+do_message_request(Channel, URI, #coap_message{options = Opts} = Req) ->
+    {_, _, Path, Query} = er_coap_client:resolve_uri(URI),
+    Opts2 = [{uri_path, Path}, {uri_query, Query} | Opts],
+    Req2 = Req#coap_message{options = Opts2},
+    ?LOGT("send request:~ts~nReq:~p~n", [URI, Req2]),
+
+    {ok, _} = er_coap_channel:send_message(Channel, make_ref(), Req2),
+    with_message_response(Channel).
 
 with_response(Channel) ->
     receive

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -1266,12 +1266,12 @@ t_observe_con_notify_queue_drops_oldest_when_full(_) ->
             ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
 
             ack_if_con(Channel, Notify),
-            %% The oldest queued entry is dropped when the fixed session queue
-            %% limit is reached.  Later retained entries may vary slightly with
-            %% asynchronous MQTT delivery scheduling, but queued-1 must not be
-            %% delivered after the queue_full metric has advanced.
+            %% MQTT delivery scheduling may slightly reorder the published
+            %% payloads by the time they reach the CoAP session, so this
+            %% integration case asserts the observable queue-full drop metric
+            %% and that the queue remains drainable.
             Notify2 = assert_notify(Channel, con),
-            ?assertNotEqual(<<"queued-1">>, notify_payload(Notify2)),
+            ?assert(is_queued_payload(notify_payload(Notify2))),
             true
         end,
         with_connection(Fun)
@@ -1792,6 +1792,11 @@ find_notify_by_payload(Payload, Notify1, Notify2) ->
         {_, Payload} ->
             Notify2
     end.
+
+is_queued_payload(<<"queued-", _/binary>>) ->
+    true;
+is_queued_payload(_) ->
+    false.
 
 ack_if_con(Channel, #coap_message{type = con} = Message) ->
     {ok, _} = er_coap_channel:send(Channel, er_coap_message:ack(Message)),

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -25,6 +25,7 @@
 -define(LOGT(Format, Args), ct:pal("TEST_SUITE: " ++ Format, Args)).
 -define(PS_PREFIX, "coap://127.0.0.1/ps").
 -define(MQTT_PREFIX, "coap://127.0.0.1/mqtt").
+-define(OBSERVE_NOTIFICATION_QUEUE_MAX_LEN, 100).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -981,20 +982,22 @@ t_observe_notify_type_con(_) ->
         with_connection(Fun)
     end).
 
-t_observe_con_notify_drops_duplicate_while_ack_pending(_) ->
+t_observe_con_notify_uses_shared_session_queue(_) ->
     with_notify_type(con, fun() ->
         Fun = fun(Channel, Token) ->
-            Topic = <<"coap/observe_notify_duplicate">>,
-            URI = pubsub_uri(binary_to_list(Topic), Token),
-            Req = make_req(get, <<>>, [{observe, 0}]),
-            {ok, content, _} = do_request(Channel, URI, Req),
+            TopicA = <<"coap/observe_notify_queue/a">>,
+            TopicB = <<"coap/observe_notify_queue/b">>,
+            observe_topic(Channel, Token, TopicA, <<"obsqa">>),
+            observe_topic(Channel, Token, TopicB, <<"obsqb">>),
 
-            Payload1 = <<"first">>,
-            publish(Topic, ?QOS_0, Payload1),
+            Payload1 = <<"first-a">>,
+            publish(TopicA, ?QOS_0, Payload1),
             Notify1 = assert_notify(Channel, con, Payload1),
 
-            Payload2 = <<"second">>,
-            publish(Topic, ?QOS_0, Payload2),
+            Payload2 = <<"second-b">>,
+            publish(TopicB, ?QOS_0, Payload2),
+            Payload3 = <<"third-a">>,
+            publish(TopicA, ?QOS_0, Payload3),
             ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
 
             ?assertNotEqual(
@@ -1002,7 +1005,70 @@ t_observe_con_notify_drops_duplicate_while_ack_pending(_) ->
                 emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
             ),
             ack_if_con(Channel, Notify1),
+            Notify2 = assert_notify(Channel, con, Payload2),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+            ack_if_con(Channel, Notify2),
+            Notify3 = assert_notify(Channel, con, Payload3),
+            ack_if_con(Channel, Notify3),
             ?assertMatch({ok, changed, _}, send_heartbeat(Channel, Token)),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_con_notify_queue_drops_oldest_when_full(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            Topic = <<"coap/observe_notify_queue_full">>,
+            observe_topic(Channel, Token, Topic, <<"obsqf">>),
+            Before = gateway_metric('delivery.dropped.queue_full'),
+
+            publish(Topic, ?QOS_0, <<"inflight">>),
+            Notify = assert_notify(Channel, con, <<"inflight">>),
+
+            QueueOverflow = 1,
+            lists:foreach(
+                fun(N) ->
+                    Payload = iolist_to_binary(["queued-", integer_to_binary(N)]),
+                    publish(Topic, ?QOS_0, Payload)
+                end,
+                lists:seq(1, ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN + QueueOverflow)
+            ),
+            wait_gateway_metric(
+                'delivery.dropped.queue_full',
+                Before + QueueOverflow,
+                20
+            ),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            ack_if_con(Channel, Notify),
+            %% The oldest queued entry is dropped when the fixed session queue
+            %% limit is reached.  Later retained entries may vary slightly with
+            %% asynchronous MQTT delivery scheduling, but queued-1 must not be
+            %% delivered after the queue_full metric has advanced.
+            Notify2 = assert_notify(Channel, con),
+            ?assertNotEqual(<<"queued-1">>, notify_payload(Notify2)),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
+t_observe_con_notify_queue_drains_after_reset(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            TopicA = <<"coap/observe_notify_queue_reset/a">>,
+            TopicB = <<"coap/observe_notify_queue_reset/b">>,
+            observe_topic(Channel, Token, TopicA, <<"obsra">>),
+            observe_topic(Channel, Token, TopicB, <<"obsrb">>),
+
+            publish(TopicA, ?QOS_0, <<"first-a">>),
+            Notify1 = assert_notify(Channel, con, <<"first-a">>),
+            publish(TopicB, ?QOS_0, <<"second-b">>),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            reset_if_con(Channel, Notify1),
+            Notify2 = assert_notify(Channel, con, <<"second-b">>),
+            ack_if_con(Channel, Notify2),
             true
         end,
         with_connection(Fun)
@@ -1382,6 +1448,12 @@ observe(Channel, Token, false, ShortenParamName) ->
     {ok, nocontent, _Data} = do_request(Channel, URI, Req),
     ok.
 
+observe_topic(Channel, Token, Topic, ObserveToken) ->
+    URI = pubsub_uri(binary_to_list(Topic), Token),
+    Req = (make_req(get, <<>>, [{observe, 0}]))#coap_message{token = ObserveToken},
+    {ok, content, _} = do_request(Channel, URI, Req),
+    ok.
+
 pubsub_uri(Topic) when is_list(Topic) ->
     ?PS_PREFIX ++ "/" ++ Topic.
 
@@ -1411,15 +1483,41 @@ make_req_type(Type, Method, Payload, Opts) ->
 publish(Topic, QoS, Payload) ->
     emqx:publish(emqx_message:make(<<"coap">>, QoS, Topic, Payload)).
 
+gateway_metric(Name) ->
+    proplists:get_value(Name, emqx_gateway_metrics:lookup(coap), 0).
+
+wait_gateway_metric(Name, Expected, 0) ->
+    ?assertEqual(Expected, gateway_metric(Name));
+wait_gateway_metric(Name, Expected, Retries) ->
+    case gateway_metric(Name) of
+        Value when Value >= Expected ->
+            ok;
+        _ ->
+            timer:sleep(100),
+            wait_gateway_metric(Name, Expected, Retries - 1)
+    end.
+
 assert_notify(Channel, Type, Payload) ->
-    {ok, content, Notify = #coap_message{type = Type}} = with_message_response(Channel),
-    #coap_content{payload = Payload} = er_coap_message:get_content(Notify),
+    Notify = assert_notify(Channel, Type),
+    ?assertEqual(Payload, notify_payload(Notify)),
     Notify.
+
+assert_notify(Channel, Type) ->
+    {ok, content, Notify = #coap_message{type = Type}} = with_message_response(Channel),
+    Notify.
+
+notify_payload(Notify) ->
+    #coap_content{payload = Payload} = er_coap_message:get_content(Notify),
+    Payload.
 
 ack_if_con(Channel, #coap_message{type = con} = Message) ->
     {ok, _} = er_coap_channel:send(Channel, er_coap_message:ack(Message)),
     ok;
 ack_if_con(_Channel, #coap_message{}) ->
+    ok.
+
+reset_if_con(Channel, #coap_message{type = con} = Message) ->
+    {ok, _} = er_coap_channel:send(Channel, emqx_coap_message:reset(Message)),
     ok.
 
 do_request(Channel, URI, #coap_message{options = Opts} = Req) ->

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -1323,6 +1323,33 @@ t_observe_cancel_drops_pending_notifications(_) ->
         with_connection(Fun)
     end).
 
+t_observe_cancel_wildcard_drops_pending_notifications(_) ->
+    with_notify_type(con, fun() ->
+        Fun = fun(Channel, Token) ->
+            ObserveTopic = <<"coap/observe_notify_queue_cancel_wildcard/+">>,
+            PublishTopic1 = <<"coap/observe_notify_queue_cancel_wildcard/1">>,
+            PublishTopic2 = <<"coap/observe_notify_queue_cancel_wildcard/2">>,
+            ObserveToken = <<"obscancelwild">>,
+            observe_topic(Channel, Token, ObserveTopic, ObserveToken),
+
+            publish(PublishTopic1, ?QOS_0, <<"first">>),
+            Notify1 = assert_notify(Channel, con, <<"first">>),
+            publish(PublishTopic2, ?QOS_0, <<"queued-after-wildcard-cancel">>),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 300)),
+
+            URI = pubsub_uri(binary_to_list(ObserveTopic), Token),
+            UnReq = (make_req(get, <<>>, [{observe, 1}]))#coap_message{
+                token = ObserveToken
+            },
+            {ok, nocontent, _} = do_request(Channel, URI, UnReq),
+
+            ack_if_con(Channel, Notify1),
+            ?assertEqual({error, timeout}, with_message_response(Channel, 500)),
+            true
+        end,
+        with_connection(Fun)
+    end).
+
 t_clients_api(_) ->
     Fun = fun(_Channel, _Token) ->
         ClientId = <<"client1">>,

--- a/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
@@ -9,8 +9,11 @@
 
 -include("emqx_coap.hrl").
 -include("emqx_coap_test.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
+
+-define(OBSERVE_NOTIFICATION_QUEUE_MAX_LEN, 100).
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -830,6 +833,43 @@ t_channel_observe_blockwise_ack_failure_drains_pending(_) ->
     ?assertEqual(binary:copy(<<"b">>, 16), FollowResp#coap_message.payload),
     ?assertEqual({1, true, 16}, emqx_coap_message:get_option(block2, FollowResp, undefined)).
 
+t_channel_observe_queue_drops_oldest_deterministically(_) ->
+    with_notify_type(con, fun() ->
+        Topic = <<"queue/drop/oldest">>,
+        ObserveToken = <<"obs-drop-oldest">>,
+        Channel0 = new_block2_channel(#{enable => false}),
+        Channel1 = observe_channel(Topic, ObserveToken, Channel0),
+
+        {ok, [{outgoing, [Notify0]}], Channel2} =
+            emqx_coap_channel:handle_deliver(
+                [deliver(Topic, ?QOS_0, <<"inflight">>)],
+                Channel1
+            ),
+        ?assertEqual(con, Notify0#coap_message.type),
+        ?assertEqual(<<"inflight">>, Notify0#coap_message.payload),
+
+        Channel3 =
+            lists:foldl(
+                fun(N, ChannelAcc) ->
+                    Payload = iolist_to_binary(["queued-", integer_to_binary(N)]),
+                    {ok, [{outgoing, []}], ChannelNext} =
+                        emqx_coap_channel:handle_deliver(
+                            [deliver(Topic, ?QOS_0, Payload)],
+                            ChannelAcc
+                        ),
+                    ChannelNext
+                end,
+                Channel2,
+                lists:seq(1, ?OBSERVE_NOTIFICATION_QUEUE_MAX_LEN + 1)
+            ),
+
+        Ack = #coap_message{type = ack, id = Notify0#coap_message.id, token = ObserveToken},
+        {ok, [{outgoing, [Notify1]}], _Channel4} =
+            emqx_coap_channel:handle_in(Ack, Channel3),
+        ?assertEqual(con, Notify1#coap_message.type),
+        ?assertEqual(<<"queued-2">>, Notify1#coap_message.payload)
+    end).
+
 new_block2_channel(Opts) ->
     ConnInfo = #{
         peername => {{127, 0, 0, 1}, 9999},
@@ -868,6 +908,36 @@ ack_timeout(Channel) ->
         {transport, {1, state_timeout, ack_timeout}},
         Channel
     ).
+
+observe_channel(Topic, ObserveToken, #channel{session = Session0} = Channel) ->
+    SubData = #{topic => Topic, token => ObserveToken, subopts => #{qos => 0}},
+    ObserveReq = #coap_message{
+        type = con,
+        method = get,
+        token = ObserveToken,
+        options = #{observe => 0}
+    },
+    #{session := Session1} =
+        emqx_coap_session:process_subscribe(SubData, ObserveReq, #{}, Session0),
+    Channel#channel{session = Session1}.
+
+deliver(Topic, QoS, Payload) ->
+    {deliver, Topic, emqx_message:make(undefined, QoS, Topic, Payload)}.
+
+with_notify_type(NotifyType, Fun) ->
+    KeyPath = [gateway, coap, notify_type],
+    OldValue = emqx_config:find(KeyPath),
+    ok = emqx_config:force_put(KeyPath, NotifyType),
+    try
+        Fun()
+    after
+        case OldValue of
+            {ok, Val} ->
+                ok = emqx_config:force_put(KeyPath, Val);
+            _ ->
+                ok = emqx_config:force_put(KeyPath, qos)
+        end
+    end.
 
 blockwise_payload(First, Second, Third) ->
     iolist_to_binary([

--- a/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
@@ -768,6 +768,68 @@ t_channel_block2_reply_error(_) ->
     {ok, [{outgoing, [Reply]}], _Channel2} = emqx_coap_channel:handle_in(Req, Channel1),
     ?assertEqual({error, bad_option}, Reply#coap_message.method).
 
+t_channel_observe_blockwise_ack_failure_drains_pending(_) ->
+    Topic = <<"topic">>,
+    ObserveToken = <<"obs-ack-failure">>,
+    Channel0 = new_block2_channel(#{max_block_size => 16}),
+    SubData = #{topic => Topic, token => ObserveToken, subopts => #{qos => 0}},
+    ObserveReq = #coap_message{
+        type = con,
+        method = get,
+        id = 730,
+        token = ObserveToken,
+        options = #{observe => 0}
+    },
+    #{session := Session1} =
+        emqx_coap_session:process_subscribe(
+            SubData,
+            ObserveReq,
+            #{},
+            Channel0#channel.session
+        ),
+    Channel1 = Channel0#channel{session = Session1},
+
+    PayloadA = blockwise_payload(<<"A">>, <<"a">>, <<"1">>),
+    PayloadB = blockwise_payload(<<"B">>, <<"b">>, <<"2">>),
+    DeliverA = {deliver, Topic, emqx_message:make(undefined, 1, Topic, PayloadA)},
+    DeliverB = {deliver, Topic, emqx_message:make(undefined, 1, Topic, PayloadB)},
+
+    {ok, [{outgoing, [NotifyA0]}], Channel2} =
+        emqx_coap_channel:handle_deliver([DeliverA], Channel1),
+    ?assertEqual(con, NotifyA0#coap_message.type),
+    ?assertEqual(ObserveToken, NotifyA0#coap_message.token),
+    ?assertEqual(binary:copy(<<"A">>, 16), NotifyA0#coap_message.payload),
+    ?assertEqual({0, true, 16}, emqx_coap_message:get_option(block2, NotifyA0, undefined)),
+
+    {ok, [{outgoing, []}], Channel3} = emqx_coap_channel:handle_deliver([DeliverB], Channel2),
+    {ok, [{outgoing, [_Retry1]}], Channel4} = ack_timeout(Channel3),
+    {ok, [{outgoing, [_Retry2]}], Channel5} = ack_timeout(Channel4),
+    {ok, [{outgoing, [_Retry3]}], Channel6} = ack_timeout(Channel5),
+    {ok, [{outgoing, [_Retry4]}], Channel7} = ack_timeout(Channel6),
+
+    {ok, [{outgoing, [NotifyB0]}], Channel8} = ack_timeout(Channel7),
+    ?assertEqual(con, NotifyB0#coap_message.type),
+    ?assertEqual(ObserveToken, NotifyB0#coap_message.token),
+    ?assertEqual(binary:copy(<<"B">>, 16), NotifyB0#coap_message.payload),
+    ?assertEqual({0, true, 16}, emqx_coap_message:get_option(block2, NotifyB0, undefined)),
+
+    FollowReq = #coap_message{
+        type = con,
+        method = get,
+        id = 731,
+        token = ObserveToken,
+        options = #{
+            uri_path => [<<"ps">>, Topic],
+            uri_query => #{},
+            block2 => {1, false, 16}
+        }
+    },
+    {ok, [{outgoing, [FollowResp]}], _Channel9} =
+        emqx_coap_channel:handle_in(FollowReq, Channel8),
+    ?assertEqual({ok, content}, FollowResp#coap_message.method),
+    ?assertEqual(binary:copy(<<"b">>, 16), FollowResp#coap_message.payload),
+    ?assertEqual({1, true, 16}, emqx_coap_message:get_option(block2, FollowResp, undefined)).
+
 new_block2_channel(Opts) ->
     ConnInfo = #{
         peername => {{127, 0, 0, 1}, 9999},
@@ -799,6 +861,20 @@ ps_get_request(Id, Token, ExtraOpts) ->
         token = Token,
         options = maps:merge(#{uri_path => [<<"ps">>, <<"topic">>], uri_query => #{}}, ExtraOpts)
     }.
+
+ack_timeout(Channel) ->
+    emqx_coap_channel:handle_timeout(
+        make_ref(),
+        {transport, {1, state_timeout, ack_timeout}},
+        Channel
+    ).
+
+blockwise_payload(First, Second, Third) ->
+    iolist_to_binary([
+        binary:copy(First, 16),
+        binary:copy(Second, 16),
+        binary:copy(Third, 8)
+    ]).
 
 coap_ctx() ->
     #{

--- a/apps/emqx_gateway_coap/test/emqx_coap_session_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_session_SUITE.erl
@@ -62,7 +62,7 @@ t_session_notify_qos_types(_) ->
             {ok, Val} ->
                 ok = emqx_config:force_put(KeyPath, Val);
             _ ->
-                ok = emqx_config:force_put(KeyPath, non)
+                ok = emqx_config:force_put(KeyPath, qos)
         end
     end,
     ok.

--- a/apps/emqx_gateway_coap/test/emqx_coap_session_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_session_SUITE.erl
@@ -40,7 +40,7 @@ t_session_info_and_deliver(_) ->
     ok.
 
 t_session_notify_qos_types(_) ->
-    KeyPath = [gateway, coap, notify_qos],
+    KeyPath = [gateway, coap, notify_type],
     OldValue = emqx_config:find(KeyPath),
     ok = emqx_config:force_put(KeyPath, qos),
     try

--- a/apps/emqx_gateway_coap/test/emqx_coap_session_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_session_SUITE.erl
@@ -39,8 +39,8 @@ t_session_info_and_deliver(_) ->
     ?assertEqual(1, length(Out)),
     ok.
 
-t_session_notify_type_qos_types(_) ->
-    KeyPath = [gateway, coap, notify_type],
+t_session_notify_qos_types(_) ->
+    KeyPath = [gateway, coap, notify_qos],
     OldValue = emqx_config:find(KeyPath),
     ok = emqx_config:force_put(KeyPath, qos),
     try
@@ -62,7 +62,7 @@ t_session_notify_type_qos_types(_) ->
             {ok, Val} ->
                 ok = emqx_config:force_put(KeyPath, Val);
             _ ->
-                ok = emqx_config:force_put(KeyPath, qos)
+                ok = emqx_config:force_put(KeyPath, non)
         end
     end,
     ok.

--- a/apps/emqx_gateway_coap/test/emqx_coap_session_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_session_SUITE.erl
@@ -39,8 +39,8 @@ t_session_info_and_deliver(_) ->
     ?assertEqual(1, length(Out)),
     ok.
 
-t_session_notify_qos_types(_) ->
-    KeyPath = [gateway, coap, notify_qos],
+t_session_notify_type_qos_types(_) ->
+    KeyPath = [gateway, coap, notify_type],
     OldValue = emqx_config:find(KeyPath),
     ok = emqx_config:force_put(KeyPath, qos),
     try
@@ -62,7 +62,7 @@ t_session_notify_qos_types(_) ->
             {ok, Val} ->
                 ok = emqx_config:force_put(KeyPath, Val);
             _ ->
-                ok = emqx_config:force_put(KeyPath, non)
+                ok = emqx_config:force_put(KeyPath, qos)
         end
     end,
     ok.

--- a/apps/emqx_gateway_coap/test/emqx_coap_test.hrl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_test.hrl
@@ -27,6 +27,7 @@
     seq_id,
     id,
     token,
+    token_key,
     observe,
     observe_notification = false,
     state,

--- a/apps/emqx_gateway_coap/test/emqx_coap_test.hrl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_test.hrl
@@ -28,6 +28,7 @@
     id,
     token,
     observe,
+    observe_notification = false,
     state,
     timers,
     transport

--- a/apps/emqx_gateway_coap/test/emqx_coap_transport_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_transport_SUITE.erl
@@ -238,6 +238,36 @@ t_tm_non_observe_notification_does_not_register_token(_) ->
     ?assertEqual(false, maps:is_key({token, Token}, TM1)),
     ok.
 
+t_tm_non_observe_notification_timeout_preserves_token_owner(_) ->
+    TM0 = emqx_coap_tm:new(),
+    Token = <<"obsnonowner">>,
+    Notify = #coap_message{
+        type = non,
+        method = {ok, content},
+        token = Token,
+        options = #{observe => 0}
+    },
+    #{out := [NotifyOut], tm := TM1} = emqx_coap_tm:handle_out(Notify, TM0),
+    NotifySeqId = maps:get({out, NotifyOut#coap_message.id}, TM1),
+
+    Request = #coap_message{
+        type = con,
+        method = get,
+        token = Token
+    },
+    #{tm := TM2} = emqx_coap_tm:handle_out(Request, TM1),
+    TokenKey = {token, Token},
+    RequestSeqId = maps:get(TokenKey, TM2),
+    ?assertNotEqual(NotifySeqId, RequestSeqId),
+
+    NotifyMachine = maps:get(NotifySeqId, TM2),
+    TM3 = TM2#{
+        NotifySeqId => NotifyMachine#state_machine{timers = #{stop_timeout => make_ref()}}
+    },
+    #{tm := TM4} = emqx_coap_tm:timeout({NotifySeqId, stop_timeout, stop}, TM3),
+    ?assertEqual(RequestSeqId, maps:get(TokenKey, TM4)),
+    ok.
+
 t_tm_cancel_state_timer_manual(_) ->
     TM0 = emqx_coap_tm:new(),
     MsgId = 77,

--- a/apps/emqx_gateway_coap/test/emqx_coap_transport_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_transport_SUITE.erl
@@ -225,6 +225,19 @@ t_tm_observe_delete_token(_) ->
     ?assertEqual(false, maps:is_key({token, <<"obsdel">>}, TM1)),
     ok.
 
+t_tm_non_observe_notification_does_not_register_token(_) ->
+    TM0 = emqx_coap_tm:new(),
+    Token = <<"obsnon">>,
+    Notify = #coap_message{
+        type = non,
+        method = {ok, content},
+        token = Token,
+        options = #{observe => 0}
+    },
+    #{tm := TM1} = emqx_coap_tm:handle_out(Notify, TM0),
+    ?assertEqual(false, maps:is_key({token, Token}, TM1)),
+    ok.
+
 t_tm_cancel_state_timer_manual(_) ->
     TM0 = emqx_coap_tm:new(),
     MsgId = 77,

--- a/changes/ee/fix-17398.en.md
+++ b/changes/ee/fix-17398.en.md
@@ -2,4 +2,4 @@ Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type`
 
 Observe notifications now use a per-session confirmable in-flight window of 1 and a fixed pending queue of 100 entries shared by all observe tokens. When a confirmable notification is in flight, later observe notifications are queued instead of being silently lost. When the queue is full, the oldest pending notification is dropped, `delivery.dropped.queue_full` is incremented, and a throttled warning is logged.
 
-Cancelling an observe relation now also removes pending notifications for that topic, so queued notifications are not delivered after the client has cancelled the observe.
+Cancelling an observe relation now also removes pending notifications for that topic and observe token, so queued notifications are not delivered after the client has cancelled the observe.

--- a/changes/ee/fix-17398.en.md
+++ b/changes/ee/fix-17398.en.md
@@ -1,3 +1,5 @@
 Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type` setting.
 
 Observe notifications now use a per-session confirmable in-flight window of 1 and a fixed pending queue of 100 entries shared by all observe tokens. When a confirmable notification is in flight, later observe notifications are queued instead of being silently lost. When the queue is full, the oldest pending notification is dropped, `delivery.dropped.queue_full` is incremented, and a throttled warning is logged.
+
+Cancelling an observe relation now also removes pending notifications for that topic, so queued notifications are not delivered after the client has cancelled the observe.

--- a/changes/ee/fix-17398.en.md
+++ b/changes/ee/fix-17398.en.md
@@ -1,3 +1,3 @@
 Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type` setting.
 
-Confirmable observe notifications now use a per-session in-flight window of 1 and a fixed pending queue of 100 entries. When the queue is full, the oldest pending notification is dropped, `delivery.dropped.queue_full` is incremented, and a throttled warning is logged.
+Observe notifications now use a per-session confirmable in-flight window of 1 and a fixed pending queue of 100 entries shared by all observe tokens. When a confirmable notification is in flight, later observe notifications are queued instead of being silently lost. When the queue is full, the oldest pending notification is dropped, `delivery.dropped.queue_full` is incremented, and a throttled warning is logged.

--- a/changes/ee/fix-17398.en.md
+++ b/changes/ee/fix-17398.en.md
@@ -1,0 +1,1 @@
+Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type` setting and avoid crashing the CoAP session when a confirmable observe notification is suppressed while a previous notification for the same token is still awaiting ACK.

--- a/changes/ee/fix-17398.en.md
+++ b/changes/ee/fix-17398.en.md
@@ -1,1 +1,3 @@
-Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type` setting and avoid crashing the CoAP session when a confirmable observe notification is suppressed while a previous notification for the same token is still awaiting ACK.
+Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type` setting.
+
+Confirmable observe notifications now use a per-session in-flight window of 1 and a fixed pending queue of 100 entries. When the queue is full, the oldest pending notification is dropped, `delivery.dropped.queue_full` is incremented, and a throttled warning is logged.

--- a/changes/ee/fix-17398.en.md
+++ b/changes/ee/fix-17398.en.md
@@ -2,4 +2,4 @@ Fixed CoAP gateway observe notifications to honor the `gateway.coap.notify_type`
 
 Observe notifications now use a per-session confirmable in-flight window of 1 and a fixed pending queue of 100 entries shared by all observe tokens. When a confirmable notification is in flight, later observe notifications are queued instead of being silently lost. When the queue is full, the oldest pending notification is dropped, `delivery.dropped.queue_full` is incremented, and a throttled warning is logged.
 
-Cancelling an observe relation now also removes pending notifications for that topic and observe token, so queued notifications are not delivered after the client has cancelled the observe.
+Cancelling an observe relation now also removes pending notifications for that observed topic/filter and observe token, so queued notifications are not delivered after the client has cancelled the observe, including wildcard observe filters.


### PR DESCRIPTION
Fixes none

Release version:
6.2.1

## Summary

Fixes coupled CoAP observe notification issues in the CoAP gateway:

* Observe notifications now read `gateway.coap.notify_type`, so `qos` maps MQTT QoS 0 to NON and QoS 1+ to CON, while `con` and `non` force the corresponding CoAP message type.
* CoAP observe notifications now use a shared per-session confirmable in-flight window of 1, matching the default Observe/NSTART behavior for notifications to the same client.
* When the window is occupied, later observe notifications enter a session-level FIFO queue shared by all observe tokens/topics. The queue is fixed at 100 entries for now and is not exposed as configuration.
* Queued blockwise observe notifications no longer update the active block2 state before they are actually sent, so a queued notification cannot corrupt the currently in-flight blockwise notification.
* Cancelling an observe relation now removes pending notifications matching the observed topic/filter and observe token, including wildcard filters, so queued notifications are not delivered after the client has cancelled the observe.
* NON observe notifications with Observe sequence values no longer register or delete observe request tokens in the CoAP transaction manager, so later same-token notifications are not suppressed by stale token tracking.
* When the queue is full, the oldest pending notification is dropped, `delivery.dropped.queue_full` is incremented, and a throttled warning is logged with `queue => coap_observe_notification`.
* ACK, RST, and retransmit-exhausted stop paths release the observe notification window and drain queued notifications in FIFO order.
* Added CoAP integration coverage for `notify_type = qos`, `notify_type = con`, `notify_type = non`, QoS0/NON queuing behind an in-flight CON notification, block2 state preservation while queued and across multiple drained NON tokens, shared FIFO drain after ACK, drain after RST, queue full drop-oldest metric behavior, deterministic drop-oldest queue behavior, exact-topic and wildcard cancellation dropping pending notifications, and NON observe notification token tracking.

Checks run: `mix compile`; `make apps/emqx_gateway_coap-ct PROFILE=emqx-enterprise` (194 cases); focused `emqx_coap_SUITE` integration cases `t_observe_con_notify_uses_shared_session_queue`, `t_observe_cancel_drops_pending_notifications`, `t_observe_cancel_wildcard_drops_pending_notifications`, and `t_observe_non_blockwise_queue_preserves_all_drained_tokens`; focused `emqx_coap_channel_SUITE` case `t_channel_observe_queue_drops_oldest_deterministically`; `./scripts/erlfmt -c`; `git diff --check`; `./scripts/apps-version-check.exs`; `./scripts/elvis-check.sh release-62`.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
