### PR TITLE
fix: swagger spec corruption

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -636,7 +636,13 @@ trans_summary(Spec, Hocon, Options) ->
     end.
 
 trans_tags(Spec = #{tags := Tags}) ->
-    Spec#{tags => [string:titlecase(to_bin(Tag)) || Tag <- Tags]};
+    %% `string:titlecase/1' may return chardata (an improper list with
+    %% a binary tail) even for a plain binary input. JSON encoders then
+    %% serialise that chardata as a JSON array of integers + strings,
+    %% which crashes downstream OpenAPI tooling (e.g. Redocly's
+    %% `slugify(tagName)`). Flatten back to a binary so the wire shape
+    %% is always a JSON string.
+    Spec#{tags => [iolist_to_binary(string:titlecase(to_bin(Tag))) || Tag <- Tags]};
 trans_tags(Spec) ->
     Spec.
 

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -243,6 +243,10 @@ t_rest_api(_Config) ->
     ok.
 
 t_swagger_json(_Config) ->
+    mnesia:clear_table(?ADMIN),
+    emqx_dashboard_admin:add_user(
+        <<"admin">>, <<"public_www1">>, ?ROLE_SUPERUSER, <<"administrator">>
+    ),
     Url = ?HOST ++ "/api-docs/swagger.json",
     %% with auth
     Auth = auth_header_(<<"admin">>, <<"public_www1">>),
@@ -252,6 +256,7 @@ t_swagger_json(_Config) ->
     {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, Body2}} =
         httpc:request(get, {Url, []}, [], [{body_format, binary}]),
     ?assertEqual(Body1, Body2),
+    Spec = emqx_utils_json:decode(Body1),
     ?assertMatch(
         #{
             <<"info">> := #{
@@ -259,9 +264,39 @@ t_swagger_json(_Config) ->
                 <<"version">> := _
             }
         },
-        emqx_utils_json:decode(Body1)
+        Spec
     ),
+    %% Every operation's `tags' field must be a flat JSON array of
+    %% strings. A regression in `trans_tags' (e.g. forgetting to
+    %% flatten the chardata returned by `string:titlecase/1', or a
+    %% callsite mistakenly wrapping a list tag in another list) would
+    %% leak an iolist into the JSON and emit a tag such as
+    %% `[68, "ashboard SSO"]', which crashes downstream OpenAPI
+    %% tooling like Redocly's `slugify(tagName)'.
+    BadTags = collect_non_string_tags(Spec),
+    ?assertEqual([], BadTags, {non_string_tags_in_openapi_spec, BadTags}),
     ok.
+
+collect_non_string_tags(#{<<"paths">> := Paths}) ->
+    maps:fold(
+        fun(Path, Methods, Acc) ->
+            maps:fold(
+                fun
+                    (Method, #{<<"tags">> := Tags}, InnerAcc) when is_list(Tags) ->
+                        case [T || T <- Tags, not is_binary(T)] of
+                            [] -> InnerAcc;
+                            Bad -> [{Path, Method, Bad} | InnerAcc]
+                        end;
+                    (_Method, _Op, InnerAcc) ->
+                        InnerAcc
+                end,
+                Acc,
+                Methods
+            )
+        end,
+        [],
+        Paths
+    ).
 
 t_disable_swagger_json(_Config) ->
     Url = ?HOST ++ "/api-docs/index.html",


### PR DESCRIPTION
Release version: 6.0.3

Port of https://github.com/emqx/emqx/pull/17403 to release-60. Bug is caught in emqx-docs.git CI; not released yet, so no changelog.

## Summary

`string:titlecase/1` can return chardata (an improper list with a binary tail) even for plain binary input. JSON encoders then serialise that chardata as a JSON array of integers + strings, which crashes downstream OpenAPI tooling (e.g. Redocly's `slugify(tagName)`).

`trans_tags/1` in `emqx_dashboard_swagger.erl` now wraps the titlecased value in `iolist_to_binary/1` so each tag is always a JSON string on the wire.

A regression test in `emqx_dashboard_SUITE:t_swagger_json/1` walks every operation's `tags` array and fails on any non-binary entry.

The v6 branch's `emqx_dashboard_sso` modules already use a consistent `tags => [?TAGS]` shape (where `?TAGS` is a binary), so the SSO callsite tweak from the v5.10 PR is not needed here.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)