### PR TITLE
fix(trace): filter events by namespace

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2215,34 +2215,13 @@ fix_mountpoint(_PipelineOutput, #channel{clientinfo = ClientInfo0} = Channel0) -
 
 set_log_meta(_ConnPkt, #channel{clientinfo = #{clientid := ClientId} = ClientInfo}) ->
     Username = maps:get(username, ClientInfo, undefined),
-    Tns0 = get_tenant_namespace(ClientInfo),
-    %% No need to add Tns to log metadata if it's aready a prefix is client ID
-    %% Or if it's the username.
-    Tns =
-        case is_clientid_namespaced(ClientId, Tns0) orelse Username =:= Tns0 of
-            true ->
-                undefined;
-            false ->
-                Tns0
-        end,
+    Tns = get_tenant_namespace(ClientInfo),
     emqx_logger:set_metadata_clientid(ClientId),
-    emqx_logger:set_proc_metadata([{username, Username}, {tns, Tns}, {namespace, Tns0}]).
+    emqx_logger:set_proc_metadata([{username, Username}, {tns, Tns}]).
 
 get_tenant_namespace(ClientInfo) ->
     Attrs = maps:get(client_attrs, ClientInfo, #{}),
     maps:get(?CLIENT_ATTR_NAME_TNS, Attrs, undefined).
-
-%% clientid_override is an expression which is free to set tns as a prefix, suffix or whatsoever,
-%% but as a best-effort log metadata optimization, we only check for prefix
-is_clientid_namespaced(ClientId, Tns) when is_binary(Tns) andalso Tns =/= <<>> ->
-    case ClientId of
-        <<Tns:(size(Tns))/binary, _/binary>> ->
-            true;
-        _ ->
-            false
-    end;
-is_clientid_namespaced(_ClientId, _Tns) ->
-    false.
 
 %%--------------------------------------------------------------------
 %% Adjust limiter

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2226,7 +2226,7 @@ set_log_meta(_ConnPkt, #channel{clientinfo = #{clientid := ClientId} = ClientInf
                 Tns0
         end,
     emqx_logger:set_metadata_clientid(ClientId),
-    emqx_logger:set_proc_metadata([{username, Username}, {tns, Tns}]).
+    emqx_logger:set_proc_metadata([{username, Username}, {tns, Tns}, {namespace, Tns0}]).
 
 get_tenant_namespace(ClientInfo) ->
     Attrs = maps:get(client_attrs, ClientInfo, #{}),

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -124,23 +124,22 @@ publish(#message{topic = <<"$SYS/", _/binary>>}) ->
 publish(#message{from = From, topic = Topic, payload = Payload} = Msg) when
     is_binary(From); is_atom(From)
 ->
-    Ns = resolve_namespace([
-        get_namespace_from_message(Msg),
-        get_namespace_from_proc_metadata()
-    ]),
     ?TRACE(
         "PUBLISH",
         "publish_to",
         maybe_add_namespace(
             #{topic => Topic, payload => Payload},
-            Ns
+            maybe
+                undefined ?= get_namespace_from_message(Msg),
+                undefined ?= get_namespace_from_proc_metadata(),
+                ?global_ns
+            end
         )
     ).
 
 subscribe(<<"$SYS/", _/binary>>, _SubId, _SubOpts) ->
     ignore;
 subscribe(Topic, SubId, SubOpts) ->
-    Ns = get_namespace_from_proc_metadata(),
     ?TRACE(
         "SUBSCRIBE",
         "subscribe",
@@ -148,19 +147,19 @@ subscribe(Topic, SubId, SubOpts) ->
             #{
                 topic => Topic, sub_opts => SubOpts, sub_id => SubId
             },
-            Ns
+            get_namespace_from_proc_metadata()
         )
     ).
 
 unsubscribe(<<"$SYS/", _/binary>>, _SubOpts) ->
     ignore;
 unsubscribe(Topic, SubOpts) ->
-    Ns = get_namespace_from_proc_metadata(),
     ?TRACE(
         "UNSUBSCRIBE",
         "unsubscribe",
         maybe_add_namespace(
-            #{topic => Topic, sub_opts => SubOpts}, Ns
+            #{topic => Topic, sub_opts => SubOpts},
+            get_namespace_from_proc_metadata()
         )
     ).
 
@@ -921,15 +920,6 @@ get_namespace_from_message(#message{headers = Headers}) ->
         _ ->
             undefined
     end.
-
-resolve_namespace([?global_ns | _]) ->
-    ?global_ns;
-resolve_namespace([Ns | _]) when is_binary(Ns) ->
-    Ns;
-resolve_namespace([_ | Rest]) ->
-    resolve_namespace(Rest);
-resolve_namespace([]) ->
-    ?global_ns.
 
 %% we don't add the namespace key if it's global to differentiate it from a namespaced
 %% called "global"

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -121,20 +121,48 @@
 
 publish(#message{topic = <<"$SYS/", _/binary>>}) ->
     ignore;
-publish(#message{from = From, topic = Topic, payload = Payload}) when
+publish(#message{from = From, topic = Topic, payload = Payload} = Msg) when
     is_binary(From); is_atom(From)
 ->
-    ?TRACE("PUBLISH", "publish_to", #{topic => Topic, payload => Payload}).
+    Ns = resolve_namespace([
+        get_namespace_from_message(Msg),
+        get_namespace_from_proc_metadata()
+    ]),
+    ?TRACE(
+        "PUBLISH",
+        "publish_to",
+        maybe_add_namespace(
+            #{topic => Topic, payload => Payload},
+            Ns
+        )
+    ).
 
 subscribe(<<"$SYS/", _/binary>>, _SubId, _SubOpts) ->
     ignore;
 subscribe(Topic, SubId, SubOpts) ->
-    ?TRACE("SUBSCRIBE", "subscribe", #{topic => Topic, sub_opts => SubOpts, sub_id => SubId}).
+    Ns = get_namespace_from_proc_metadata(),
+    ?TRACE(
+        "SUBSCRIBE",
+        "subscribe",
+        maybe_add_namespace(
+            #{
+                topic => Topic, sub_opts => SubOpts, sub_id => SubId
+            },
+            Ns
+        )
+    ).
 
 unsubscribe(<<"$SYS/", _/binary>>, _SubOpts) ->
     ignore;
 unsubscribe(Topic, SubOpts) ->
-    ?TRACE("UNSUBSCRIBE", "unsubscribe", #{topic => Topic, sub_opts => SubOpts}).
+    Ns = get_namespace_from_proc_metadata(),
+    ?TRACE(
+        "UNSUBSCRIBE",
+        "unsubscribe",
+        maybe_add_namespace(
+            #{topic => Topic, sub_opts => SubOpts}, Ns
+        )
+    ).
 
 rendered_action_template(ActionID, RenderResult) when is_binary(ActionID) ->
     try emqx_resource:parse_channel_id(ActionID) of
@@ -877,6 +905,38 @@ filter_cli_handler(Names) ->
 
 now_second() ->
     os:system_time(second).
+
+get_namespace_from_proc_metadata() ->
+    case logger:get_process_metadata() of
+        #{namespace := Ns} ->
+            Ns;
+        _ ->
+            undefined
+    end.
+
+get_namespace_from_message(#message{headers = Headers}) ->
+    case Headers of
+        #{client_attrs := #{?CLIENT_ATTR_NAME_TNS := Ns}} ->
+            Ns;
+        _ ->
+            undefined
+    end.
+
+resolve_namespace([?global_ns | _]) ->
+    ?global_ns;
+resolve_namespace([Ns | _]) when is_binary(Ns) ->
+    Ns;
+resolve_namespace([_ | Rest]) ->
+    resolve_namespace(Rest);
+resolve_namespace([]) ->
+    ?global_ns.
+
+%% we don't add the namespace key if it's global to differentiate it from a namespaced
+%% called "global"
+maybe_add_namespace(Log, Ns) when is_binary(Ns) ->
+    Log#{namespace => Ns};
+maybe_add_namespace(Log, _) ->
+    Log.
 
 %% Tests
 

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -908,7 +908,7 @@ now_second() ->
 
 get_namespace_from_proc_metadata() ->
     case logger:get_process_metadata() of
-        #{namespace := Ns} ->
+        #{tns := Ns} ->
             Ns;
         _ ->
             undefined

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -527,17 +527,27 @@ filter_clientid(
     LogNamespace = maps:get(namespace, Meta, ?global_ns),
     ClientIDs = maps:get(client_ids, Meta, #{}),
     IsMatch =
-        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso (ClientId =:= MatchId) orelse
-            maps:get(MatchId, ClientIDs, false),
-    filter_ret(IsMatch andalso is_trace(Meta), Log);
+        %% If trace was created by global admin, it can see all events.
+        %% Otherwise, it matches only on events from its own namespace.
+        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso
+            %% Check if clientids match.
+            ((ClientId =:= MatchId) orelse maps:get(MatchId, ClientIDs, false)) andalso
+            %% Check if should trace
+            is_trace(Meta),
+    filter_ret(IsMatch, Log);
 filter_clientid(
     #{meta := Meta = #{client_ids := ClientIDs}} = Log,
     #filterctx{match = MatchId, namespace = Namespace}
 ) ->
     LogNamespace = maps:get(namespace, Meta, ?global_ns),
     IsMatch =
+        %% If trace was created by global admin, it can see all events.
+        %% Otherwise, it matches only on events from its own namespace.
         (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso
-            maps:get(MatchId, ClientIDs, false) andalso is_trace(Meta),
+            %% Check if clientids match.
+            maps:get(MatchId, ClientIDs, false) andalso
+            %% Check if should trace
+            is_trace(Meta),
     filter_ret(IsMatch, Log);
 filter_clientid(_Log, _FilterCtx) ->
     stop.
@@ -548,7 +558,12 @@ filter_topic(#{meta := Meta = #{topic := Topic}} = Log, #filterctx{
 }) ->
     LogNamespace = maps:get(namespace, Meta, ?global_ns),
     IsMatch =
-        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso is_trace(Meta) andalso
+        %% If trace was created by global admin, it can see all events.
+        %% Otherwise, it matches only on events from its own namespace.
+        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso
+            %% Check if should trace
+            is_trace(Meta) andalso
+            %% Check if topic matches filter
             emqx_topic:match(Topic, TopicFilter),
     filter_ret(IsMatch, Log);
 filter_topic(_Log, _FilterCtx) ->
@@ -560,7 +575,12 @@ filter_ip_address(#{meta := Meta = #{peername := Peername}} = Log, #filterctx{
 }) ->
     LogNamespace = maps:get(namespace, Meta, ?global_ns),
     IsMatch =
-        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso is_trace(Meta) andalso
+        %% If trace was created by global admin, it can see all events.
+        %% Otherwise, it matches only on events from its own namespace.
+        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso
+            %% Check if should trace
+            is_trace(Meta) andalso
+            %% Check if ip matches
             lists:prefix(IP, Peername),
     filter_ret(IsMatch, Log);
 filter_ip_address(_Log, _FilterCtx) ->

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -522,28 +522,47 @@ filter_ruleid(_Log, _FilterCtx) ->
 -spec filter_clientid(logger:log_event(), #filterctx{}) -> logger:log_event() | stop.
 filter_clientid(
     #{meta := Meta = #{clientid := ClientId}} = Log,
-    #filterctx{match = MatchId}
+    #filterctx{match = MatchId, namespace = Namespace}
 ) ->
+    LogNamespace = maps:get(namespace, Meta, ?global_ns),
     ClientIDs = maps:get(client_ids, Meta, #{}),
-    IsMatch = (ClientId =:= MatchId) orelse maps:get(MatchId, ClientIDs, false),
+    IsMatch =
+        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso (ClientId =:= MatchId) orelse
+            maps:get(MatchId, ClientIDs, false),
     filter_ret(IsMatch andalso is_trace(Meta), Log);
 filter_clientid(
     #{meta := Meta = #{client_ids := ClientIDs}} = Log,
-    #filterctx{match = MatchId}
+    #filterctx{match = MatchId, namespace = Namespace}
 ) ->
-    filter_ret(maps:get(MatchId, ClientIDs, false) andalso is_trace(Meta), Log);
+    LogNamespace = maps:get(namespace, Meta, ?global_ns),
+    IsMatch =
+        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso
+            maps:get(MatchId, ClientIDs, false) andalso is_trace(Meta),
+    filter_ret(IsMatch, Log);
 filter_clientid(_Log, _FilterCtx) ->
     stop.
 
 -spec filter_topic(logger:log_event(), #filterctx{}) -> logger:log_event() | stop.
-filter_topic(#{meta := Meta = #{topic := Topic}} = Log, #filterctx{match = TopicFilter}) ->
-    filter_ret(is_trace(Meta) andalso emqx_topic:match(Topic, TopicFilter), Log);
+filter_topic(#{meta := Meta = #{topic := Topic}} = Log, #filterctx{
+    match = TopicFilter, namespace = Namespace
+}) ->
+    LogNamespace = maps:get(namespace, Meta, ?global_ns),
+    IsMatch =
+        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso is_trace(Meta) andalso
+            emqx_topic:match(Topic, TopicFilter),
+    filter_ret(IsMatch, Log);
 filter_topic(_Log, _FilterCtx) ->
     stop.
 
 -spec filter_ip_address(logger:log_event(), #filterctx{}) -> logger:log_event() | stop.
-filter_ip_address(#{meta := Meta = #{peername := Peername}} = Log, #filterctx{match = IP}) ->
-    filter_ret(is_trace(Meta) andalso lists:prefix(IP, Peername), Log);
+filter_ip_address(#{meta := Meta = #{peername := Peername}} = Log, #filterctx{
+    match = IP, namespace = Namespace
+}) ->
+    LogNamespace = maps:get(namespace, Meta, ?global_ns),
+    IsMatch =
+        (Namespace =:= ?global_ns orelse LogNamespace =:= Namespace) andalso is_trace(Meta) andalso
+            lists:prefix(IP, Peername),
+    filter_ret(IsMatch, Log);
 filter_ip_address(_Log, _FilterCtx) ->
     stop.
 

--- a/apps/emqx/test/emqx_channel_tests.erl
+++ b/apps/emqx/test/emqx_channel_tests.erl
@@ -36,7 +36,7 @@ set_tns_in_log_meta_test_() ->
             },
             M
         ),
-        ?assertNot(maps:is_key(tns, M))
+        ?assert(maps:is_key(tns, M))
     end,
 
     Username = #{
@@ -53,7 +53,7 @@ set_tns_in_log_meta_test_() ->
                 },
                 M
             ),
-            ?assertNot(maps:is_key(tns, M))
+            ?assert(maps:is_key(tns, M))
         end,
 
     TnsAdded = #{

--- a/apps/emqx_mt/test/emqx_mt_trace_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_trace_SUITE.erl
@@ -1,0 +1,427 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_mt_trace_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("kernel/include/file.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
+
+%%------------------------------------------------------------------------------
+%% Defs
+%%------------------------------------------------------------------------------
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(TCConfig) ->
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            {emqx_conf, "mqtt.client_attrs_init = [{expression = username, set_as_attr = tns}]"},
+            emqx_mt,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(TCConfig)}
+    ),
+    [{apps, Apps} | TCConfig].
+
+end_per_suite(TCConfig) ->
+    Apps = ?config(apps, TCConfig),
+    ok = emqx_cth_suite:stop(Apps),
+    ok.
+
+init_per_testcase(_Case, TCConfig) ->
+    _ = [logger:remove_handler(Id) || #{id := Id} <- emqx_trace_handler:running()],
+    init(),
+    TCConfig.
+
+end_per_testcase(_Case, _TCConfig) ->
+    emqx_common_test_helpers:call_janitor(),
+    terminate(),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+init() ->
+    %% todo: trace should be moved to emqx's sup tree
+    emqx_trace:start_link().
+
+terminate() ->
+    catch ok = gen_server:stop(emqx_trace, normal, 5_000).
+
+gen_name() ->
+    Name0 = uuid:uuid_to_string(uuid:get_v4(), binary_standard),
+    <<"trace-", Name0/binary>>.
+
+simple_request(Params) ->
+    emqx_mgmt_api_test_util:simple_request(Params).
+
+delete_trace(TraceName) ->
+    URL = emqx_mgmt_api_test_util:api_path(["trace", TraceName]),
+    simple_request(#{
+        method => delete,
+        url => URL
+    }).
+
+start_topic_trace(TopicFilter, Opts) ->
+    Name = gen_name(),
+    on_exit(fun() -> delete_trace(Name) end),
+    Body = #{
+        <<"name">> => Name,
+        <<"type">> => <<"topic">>,
+        <<"topic">> => TopicFilter,
+        <<"formatter">> => <<"json">>,
+        <<"payload_encode">> => <<"text">>
+    },
+    AuthHeader = emqx_utils_maps:get_lazy(
+        auth_header,
+        Opts,
+        fun emqx_bridge_v2_testlib:auth_header/0
+    ),
+    URL = emqx_mgmt_api_test_util:api_path(["trace"]),
+    simple_request(#{
+        auth_header => AuthHeader,
+        method => post,
+        url => URL,
+        body => Body
+    }).
+
+start_clientid_trace(ClientId, Opts) ->
+    Name = gen_name(),
+    on_exit(fun() -> delete_trace(Name) end),
+    Body = #{
+        <<"name">> => Name,
+        <<"type">> => <<"clientid">>,
+        <<"clientid">> => ClientId,
+        <<"formatter">> => <<"json">>,
+        <<"payload_encode">> => <<"text">>
+    },
+    AuthHeader = emqx_utils_maps:get_lazy(
+        auth_header,
+        Opts,
+        fun emqx_bridge_v2_testlib:auth_header/0
+    ),
+    URL = emqx_mgmt_api_test_util:api_path(["trace"]),
+    simple_request(#{
+        auth_header => AuthHeader,
+        method => post,
+        url => URL,
+        body => Body
+    }).
+
+start_ip_address_trace(IpAddr, Opts) ->
+    Name = gen_name(),
+    on_exit(fun() -> delete_trace(Name) end),
+    Body = #{
+        <<"name">> => Name,
+        <<"type">> => <<"ip_address">>,
+        <<"ip_address">> => IpAddr,
+        <<"formatter">> => <<"json">>,
+        <<"payload_encode">> => <<"text">>
+    },
+    AuthHeader = emqx_utils_maps:get_lazy(
+        auth_header,
+        Opts,
+        fun emqx_bridge_v2_testlib:auth_header/0
+    ),
+    URL = emqx_mgmt_api_test_util:api_path(["trace"]),
+    simple_request(#{
+        auth_header => AuthHeader,
+        method => post,
+        url => URL,
+        body => Body
+    }).
+
+get_test_trace_log(TraceName) ->
+    emqx_bridge_v2_testlib:get_test_trace_log(TraceName).
+
+get_trace_log_for_ns(TraceName, Ns) ->
+    maybe
+        {ok, Events} ?= get_test_trace_log(TraceName),
+        lists:filter(
+            fun(Event) ->
+                case Event of
+                    #{<<"meta">> := #{<<"namespace">> := Ns}} ->
+                        true;
+                    #{<<"meta">> := #{} = Meta} when
+                        not is_map_key(<<"namespace">>, Meta) andalso Ns == ?global_ns
+                    ->
+                        true;
+                    _ ->
+                        false
+                end
+            end,
+            Events
+        )
+    end.
+
+ensure_managed_ns(Ns) ->
+    URL = emqx_mgmt_api_test_util:api_path(["mt", "ns", Ns]),
+    Res = simple_request(#{
+        method => post,
+        url => URL,
+        body => <<"">>
+    }),
+    case Res of
+        {204, _} ->
+            ok;
+        {400, #{<<"message">> := <<"already_exists">>}} ->
+            ok
+    end.
+
+create_user_and_token(Opts) ->
+    Token = emqx_bridge_v2_testlib:create_namespaced_user_and_token(Opts),
+    {"Authorization", <<"Bearer ", Token/binary>>}.
+
+start_client(Opts0) ->
+    Default = #{proto_ver => v5},
+    Opts = maps:merge(Default, Opts0),
+    {ok, C} = emqtt:start_link(Opts),
+    {ok, _} = emqtt:connect(C),
+    C.
+
+wait_filesync() ->
+    %% NOTE: Twice as long as `?LOG_HANDLER_FILESYNC_INTERVAL` in `emqx_trace_handler`.
+    timer:sleep(2 * 100).
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
+
+-doc """
+Checks that we filter trace events by crossing the namespace of the trace and that of the
+event.
+This tests traces of type topic.
+""".
+t_filter_topic(_TCConfig) ->
+    Ns = <<"ns1">>,
+    OtherNs = <<"other_ns">>,
+    ok = ensure_managed_ns(Ns),
+    ok = ensure_managed_ns(OtherNs),
+    HeaderNs = create_user_and_token(#{}),
+
+    Run = fun() ->
+        NsClient = start_client(#{username => Ns}),
+        OtherNsClient = start_client(#{username => OtherNs}),
+        GlobalClient = start_client(#{}),
+
+        {ok, _} = emqtt:publish(NsClient, <<"a/b/c">>, <<"from_ns1">>, [{qos, 1}]),
+        {ok, _} = emqtt:publish(OtherNsClient, <<"a/b/c">>, <<"from_other_ns">>, [{qos, 1}]),
+        {ok, _} = emqtt:publish(GlobalClient, <<"a/b/c">>, <<"from_global">>, [{qos, 1}]),
+
+        {ok, _, _} = emqtt:subscribe(NsClient, <<"t/ns1">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:subscribe(OtherNsClient, <<"t/other_ns">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:subscribe(GlobalClient, <<"t/global">>, [{qos, 1}]),
+
+        {ok, _, _} = emqtt:unsubscribe(NsClient, <<"t/ns1">>),
+        {ok, _, _} = emqtt:unsubscribe(OtherNsClient, <<"t/other_ns">>),
+        {ok, _, _} = emqtt:unsubscribe(GlobalClient, <<"t/global">>),
+
+        lists:foreach(fun emqtt:stop/1, [NsClient, OtherNsClient, GlobalClient]),
+
+        ok = wait_filesync(),
+
+        ok
+    end,
+
+    {200, #{<<"name">> := TraceName}} = start_topic_trace(<<"#">>, #{auth_header => HeaderNs}),
+    Run(),
+
+    ?assertMatch(
+        {ok, [
+            #{
+                <<"msg">> := <<"publish_to">>,
+                <<"meta">> := #{<<"username">> := Ns}
+            },
+            #{
+                <<"msg">> := <<"subscribe">>,
+                <<"meta">> := #{<<"username">> := Ns}
+            },
+            #{
+                <<"msg">> := <<"unsubscribe">>,
+                <<"meta">> := #{<<"username">> := Ns}
+            }
+        ]},
+        get_test_trace_log(TraceName)
+    ),
+    delete_trace(TraceName),
+
+    %% global admin can see all namespaces
+    {200, #{<<"name">> := GlobalTraceName}} = start_topic_trace(<<"#">>, #{}),
+    Run(),
+    ?assertMatch(
+        [_ | _],
+        get_trace_log_for_ns(GlobalTraceName, Ns)
+    ),
+    ?assertMatch(
+        [_ | _],
+        get_trace_log_for_ns(GlobalTraceName, OtherNs)
+    ),
+    ?assertMatch(
+        [_ | _],
+        get_trace_log_for_ns(GlobalTraceName, ?global_ns)
+    ),
+
+    ok.
+
+-doc """
+Checks that we filter trace events by crossing the namespace of the trace and that of the
+event.
+This tests traces of type ip_address.
+""".
+t_filter_ip_address(_TCConfig) ->
+    Ns = <<"ns1">>,
+    OtherNs = <<"other_ns">>,
+    ok = ensure_managed_ns(Ns),
+    ok = ensure_managed_ns(OtherNs),
+    HeaderNs = create_user_and_token(#{}),
+
+    Run = fun() ->
+        NsClient = start_client(#{username => Ns}),
+        OtherNsClient = start_client(#{username => OtherNs}),
+        GlobalClient = start_client(#{}),
+
+        {ok, _} = emqtt:publish(NsClient, <<"a/b/c">>, <<"from_ns1">>, [{qos, 1}]),
+        {ok, _} = emqtt:publish(OtherNsClient, <<"a/b/c">>, <<"from_other_ns">>, [{qos, 1}]),
+        {ok, _} = emqtt:publish(GlobalClient, <<"a/b/c">>, <<"from_global">>, [{qos, 1}]),
+
+        {ok, _, _} = emqtt:subscribe(NsClient, <<"t/ns1">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:subscribe(OtherNsClient, <<"t/other_ns">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:subscribe(GlobalClient, <<"t/global">>, [{qos, 1}]),
+
+        {ok, _, _} = emqtt:unsubscribe(NsClient, <<"t/ns1">>),
+        {ok, _, _} = emqtt:unsubscribe(OtherNsClient, <<"t/other_ns">>),
+        {ok, _, _} = emqtt:unsubscribe(GlobalClient, <<"t/global">>),
+
+        lists:foreach(fun emqtt:stop/1, [NsClient, OtherNsClient, GlobalClient]),
+
+        ok = wait_filesync(),
+
+        ok
+    end,
+
+    {200, #{<<"name">> := TraceName}} = start_ip_address_trace(<<"127.0.0.1">>, #{
+        auth_header => HeaderNs
+    }),
+    Run(),
+    {ok, Events} = get_test_trace_log(TraceName),
+    ?assertMatch([_ | _], Events),
+    %% events outside target namespace
+    ExtraEvents = lists:filter(
+        fun(Event) ->
+            case Event of
+                #{<<"meta">> := #{<<"namespace">> := Ns}} ->
+                    false;
+                _ ->
+                    true
+            end
+        end,
+        Events
+    ),
+    ?assertEqual([], ExtraEvents),
+    delete_trace(TraceName),
+
+    %% global admin can see all namespaces
+    {200, #{<<"name">> := GlobalTraceName}} = start_ip_address_trace(<<"127.0.0.1">>, #{}),
+    Run(),
+    ?assertMatch(
+        [_ | _],
+        get_trace_log_for_ns(GlobalTraceName, Ns)
+    ),
+    ?assertMatch(
+        [_ | _],
+        get_trace_log_for_ns(GlobalTraceName, OtherNs)
+    ),
+    ?assertMatch(
+        [_ | _],
+        get_trace_log_for_ns(GlobalTraceName, ?global_ns)
+    ),
+
+    ok.
+
+-doc """
+Checks that we filter trace events by crossing the namespace of the trace and that of the
+event.
+This tests traces of type clientid.
+""".
+t_filter_clientid(_TCConfig) ->
+    Ns = <<"ns1">>,
+    OtherNs = <<"other_ns">>,
+    ok = ensure_managed_ns(Ns),
+    ok = ensure_managed_ns(OtherNs),
+    HeaderNs = create_user_and_token(#{}),
+
+    Run = fun() ->
+        NsClient = start_client(#{username => Ns, clientid => Ns}),
+        {ok, _} = emqtt:publish(NsClient, <<"a/b/c">>, <<"from_ns1">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:subscribe(NsClient, <<"t/ns1">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:unsubscribe(NsClient, <<"t/ns1">>),
+        emqtt:stop(NsClient),
+
+        OtherNsClient = start_client(#{username => OtherNs, clientid => Ns}),
+        {ok, _} = emqtt:publish(OtherNsClient, <<"a/b/c">>, <<"from_other_ns">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:subscribe(OtherNsClient, <<"t/other_ns">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:unsubscribe(OtherNsClient, <<"t/other_ns">>),
+        emqtt:stop(OtherNsClient),
+
+        GlobalClient = start_client(#{clientid => Ns}),
+        {ok, _} = emqtt:publish(GlobalClient, <<"a/b/c">>, <<"from_global">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:subscribe(GlobalClient, <<"t/global">>, [{qos, 1}]),
+        {ok, _, _} = emqtt:unsubscribe(GlobalClient, <<"t/global">>),
+        emqtt:stop(GlobalClient),
+
+        ok = wait_filesync(),
+
+        ok
+    end,
+
+    {200, #{<<"name">> := TraceName}} = start_clientid_trace(Ns, #{auth_header => HeaderNs}),
+    Run(),
+    {ok, Events} = get_test_trace_log(TraceName),
+    ?assertMatch([_ | _], Events),
+    %% events outside target namespace
+    ExtraEvents = lists:filter(
+        fun(Event) ->
+            case Event of
+                #{<<"meta">> := #{<<"namespace">> := Ns}} ->
+                    false;
+                _ ->
+                    true
+            end
+        end,
+        Events
+    ),
+    ?assertEqual([], ExtraEvents),
+    delete_trace(TraceName),
+
+    %% global admin can see all namespaces
+    {200, #{<<"name">> := GlobalTraceName}} = start_clientid_trace(Ns, #{}),
+    Run(),
+    ?assertMatch(
+        [_ | _],
+        get_trace_log_for_ns(GlobalTraceName, Ns)
+    ),
+    ?assertMatch(
+        [_ | _],
+        get_trace_log_for_ns(GlobalTraceName, OtherNs)
+    ),
+    ?assertMatch(
+        [_ | _],
+        get_trace_log_for_ns(GlobalTraceName, ?global_ns)
+    ),
+
+    ok.

--- a/changes/ee/fix-17406.en.md
+++ b/changes/ee/fix-17406.en.md
@@ -1,0 +1,1 @@
+Now, events captured by a trace initiated by a namespaced admin are limited to the namespace of such admin, for traces of types topic, IP address, and clientid.  Traces of type rule ID already had such behavior.


### PR DESCRIPTION
Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

Restricts traces of types topic, clientid and ip address to log only events from the namespace of the admin who created them.  Traces of type ruleid were already namespaced.

If the admin is a global one, then it sees events from all namespaces (except for ruleids, which the previous behavior was already to limit it to events from the global ns only).

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
