### PR TITLE
fix(azure blob storage connector): limit list_containers in health check

### DIFF
--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage.app.src
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_azure_blob_storage, [
     {description, "EMQX Enterprise Azure Blob Storage Bridge"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, [emqx_bridge_azure_blob_storage_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
@@ -650,7 +650,7 @@ channel_status(#{mode := aggregated} = ActionState, ConnState) ->
     ?status_connected.
 
 health_check(DriverState) ->
-    case erlazure:list_containers(DriverState, []) of
+    case erlazure:list_containers(DriverState, [{max_results, "1"}]) of
         {error, Reason} ->
             {?status_disconnected, Reason};
         {L, _} when is_list(L) ->

--- a/changes/ee/fix-17414.en.md
+++ b/changes/ee/fix-17414.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the health check of an Azure Blob Storage Connector could timeout, or generate large bandwidth costs, if the storage account contained too many containers.  Companion fix to #16935.


### PR DESCRIPTION
Release version: 5.8.11

## Summary

Fixes https://github.com/emqx/emqx/issues/17408.

The Azure Blob Storage **connector-level** `health_check/1` calls `erlazure:list_containers(DriverState, [])` with no result limit, which enumerates every container in the storage account on every health-check tick. On accounts with many containers this can time out and/or generate large bandwidth costs.

This is the missing half of #16935 (commit d94cbde4), which limited the channel-level `do_list_blobs/2` to one result but left the connector-level container listing unbounded. This PR applies the same `[{max_results, "1"}]` option to `erlazure:list_containers/2`.

The `max_results` option threads through to the Azure REST `ListContainers` `maxresults` query parameter via the same erlazure dispatch mechanism used for `ListBlobs` (confirmed in `deps/erlazure/src/erlazure.erl`).

## Follow-ups

- Forward-port to `release-59` and `release-510` via the usual sync PRs.
- Same bug exists on the v6 line (`release-60`, `apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl:678`); will be ported separately.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)