### PR TITLE
Add session buffer observability

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -96,6 +96,7 @@
 {emqx_router,1}.
 {emqx_rule_engine,1}.
 {emqx_schema_registry_http_api,1}.
+{emqx_session_buffer,1}.
 {emqx_setopts,1}.
 {emqx_shared_sub,1}.
 {emqx_slow_subs,1}.

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -275,7 +275,13 @@ set_chan_stats(ClientId, Stats) when ?IS_CLIENTID(ClientId) ->
 set_chan_stats(ClientId, ChanPid, Stats) when ?IS_CLIENTID(ClientId) ->
     Chan = {ClientId, ChanPid},
     try
-        ets:update_element(?CHAN_INFO_TAB, Chan, {3, Stats})
+        case ets:update_element(?CHAN_INFO_TAB, Chan, {3, Stats}) of
+            true ->
+                ok = emqx_session_buffer_mon:maybe_log(ClientId, ChanPid, Stats),
+                true;
+            false ->
+                false
+        end
     catch
         error:badarg -> false
     end.

--- a/apps/emqx/src/emqx_message.erl
+++ b/apps/emqx/src/emqx_message.erl
@@ -184,6 +184,8 @@ estimate_size(#message{topic = Topic, payload = Payload}) ->
     FixedHeaderSize + VarLenSize + TopicLengthSize + TopicSize + PacketIdSize + PayloadSize.
 
 -spec payload_size(emqx_types:message()) -> non_neg_integer().
+payload_size(#message{payload = undefined}) ->
+    0;
 payload_size(#message{payload = Payload}) ->
     iolist_size(Payload).
 

--- a/apps/emqx/src/emqx_message.erl
+++ b/apps/emqx/src/emqx_message.erl
@@ -27,7 +27,8 @@
     topic/1,
     payload/1,
     timestamp/1,
-    timestamp/2
+    timestamp/2,
+    payload_size/1
 ]).
 
 %% Flags
@@ -181,6 +182,10 @@ estimate_size(#message{topic = Topic, payload = Payload}) ->
     PacketIdSize = 2,
     TopicLengthSize = 2,
     FixedHeaderSize + VarLenSize + TopicLengthSize + TopicSize + PacketIdSize + PayloadSize.
+
+-spec payload_size(emqx_types:message()) -> non_neg_integer().
+payload_size(#message{payload = Payload}) ->
+    iolist_size(Payload).
 
 -spec id(emqx_types:message()) -> option(binary()).
 id(#message{id = Id}) -> Id.

--- a/apps/emqx/src/emqx_mqueue.erl
+++ b/apps/emqx/src/emqx_mqueue.erl
@@ -98,7 +98,6 @@
     store_qos0 = false :: boolean(),
     max_len = ?MAX_LEN_INFINITY :: count(),
     len = 0 :: count(),
-    bytes = 0 :: non_neg_integer(),
     dropped = 0 :: count(),
     p_table = ?NO_PRIORITY_TABLE :: p_table(),
     default_p = ?LOWEST_PRIORITY :: priority(),
@@ -163,7 +162,6 @@ filter(Pred, #mqueue{q = Q, len = Len, dropped = Droppend} = MQ) ->
             MQ#mqueue{
                 q = Q2,
                 len = Len2,
-                bytes = pqueue_bytes(Q2),
                 dropped = Droppend + Diff
             }
     end.
@@ -258,8 +256,8 @@ to_list(MQ, Acc) ->
 dropped(#mqueue{dropped = Dropped}) -> Dropped.
 
 -spec bytes_size(mqueue()) -> non_neg_integer().
-bytes_size(#mqueue{bytes = Bytes}) ->
-    Bytes.
+bytes_size(#mqueue{q = Q}) ->
+    pqueue_bytes(Q).
 
 %% @doc Stats of the mqueue
 -spec stats(mqueue()) -> [stat()].
@@ -291,17 +289,9 @@ in(
             {{value, DroppedMsg}, Q1} = ?PQUEUE:out(Priority, Q),
             Q2 = ?PQUEUE:in(Msg1, Priority, Q1),
             DroppedMsg1 = without_ts(DroppedMsg),
-            MQ1 = update_bytes(
-                msg_bytes(Msg) - msg_bytes(DroppedMsg1),
-                MQ#mqueue{q = Q2, dropped = Dropped + 1}
-            ),
-            {DroppedMsg1, MQ1};
+            {DroppedMsg1, MQ#mqueue{q = Q2, dropped = Dropped + 1}};
         false ->
-            MQ1 = update_bytes(
-                msg_bytes(Msg),
-                MQ#mqueue{len = Len + 1, q = ?PQUEUE:in(Msg1, Priority, Q)}
-            ),
-            {_DroppedMsg = undefined, MQ1}
+            {_DroppedMsg = undefined, MQ#mqueue{len = Len + 1, q = ?PQUEUE:in(Msg1, Priority, Q)}}
     end.
 
 -spec out(mqueue()) -> {empty | {value, message()}, mqueue()}.
@@ -319,7 +309,7 @@ out(MQ = #mqueue{q = Q, len = Len, last_prio = undefined, shift_opts = ShiftOpts
                 last_prio = Prio,
                 p_credit = get_credits(Prio, ShiftOpts)
             },
-            {{value, Msg}, update_bytes(-msg_bytes(Msg), MQ1)};
+            {{value, Msg}, MQ1};
         {empty, Q1} ->
             {empty, reset_empty(Q1, MQ)}
     end;
@@ -334,7 +324,7 @@ out(MQ = #mqueue{q = Q, len = Len, p_credit = Cnt}) ->
         {{value, Val}, Q1} ->
             Msg = without_ts(Val),
             MQ1 = MQ#mqueue{q = Q1, len = Len - 1, p_credit = Cnt - 1},
-            {{value, Msg}, update_bytes(-msg_bytes(Msg), MQ1)};
+            {{value, Msg}, MQ1};
         {empty, Q1} ->
             {empty, reset_empty(Q1, MQ)}
     end.
@@ -351,11 +341,8 @@ pqueue_bytes(Q) ->
 msg_bytes(#message{} = Msg) ->
     emqx_message:payload_size(Msg).
 
-update_bytes(Delta, MQ = #mqueue{bytes = Bytes}) ->
-    MQ#mqueue{bytes = max(0, Bytes + Delta)}.
-
 reset_empty(Q, MQ) ->
-    MQ#mqueue{q = Q, len = 0, bytes = 0, last_prio = undefined, p_credit = undefined}.
+    MQ#mqueue{q = Q, len = 0, last_prio = undefined, p_credit = undefined}.
 
 get_opt(Key, Opts, Default) ->
     case maps:get(Key, Opts, Default) of

--- a/apps/emqx/src/emqx_mqueue.erl
+++ b/apps/emqx/src/emqx_mqueue.erl
@@ -332,7 +332,7 @@ out(MQ = #mqueue{q = Q, len = Len, p_credit = Cnt}) ->
 pqueue_bytes(Q) ->
     ?PQUEUE:fold(
         fun(Msg, _Priority, Acc) ->
-            Acc + msg_bytes(without_ts(Msg))
+            Acc + msg_bytes(Msg)
         end,
         0,
         Q

--- a/apps/emqx/src/emqx_mqueue.erl
+++ b/apps/emqx/src/emqx_mqueue.erl
@@ -55,6 +55,7 @@
     out/1,
     stats/1,
     dropped/1,
+    bytes_size/1,
     to_list/1,
     filter/2,
     query/2
@@ -97,6 +98,7 @@
     store_qos0 = false :: boolean(),
     max_len = ?MAX_LEN_INFINITY :: count(),
     len = 0 :: count(),
+    bytes = 0 :: non_neg_integer(),
     dropped = 0 :: count(),
     p_table = ?NO_PRIORITY_TABLE :: p_table(),
     default_p = ?LOWEST_PRIORITY :: priority(),
@@ -158,7 +160,12 @@ filter(Pred, #mqueue{q = Q, len = Len, dropped = Droppend} = MQ) ->
             MQ;
         Len2 ->
             Diff = Len - Len2,
-            MQ#mqueue{q = Q2, len = Len2, dropped = Droppend + Diff}
+            MQ#mqueue{
+                q = Q2,
+                len = Len2,
+                bytes = pqueue_bytes(Q2),
+                dropped = Droppend + Diff
+            }
     end.
 
 -spec query(mqueue(), #{position => Pos, limit := Limit}) ->
@@ -250,6 +257,10 @@ to_list(MQ, Acc) ->
 -spec dropped(mqueue()) -> count().
 dropped(#mqueue{dropped = Dropped}) -> Dropped.
 
+-spec bytes_size(mqueue()) -> non_neg_integer().
+bytes_size(#mqueue{bytes = Bytes}) ->
+    Bytes.
+
 %% @doc Stats of the mqueue
 -spec stats(mqueue()) -> [stat()].
 stats(#mqueue{max_len = MaxLen, dropped = Dropped} = MQ) ->
@@ -279,26 +290,39 @@ in(
             %% reached max length, drop the oldest message
             {{value, DroppedMsg}, Q1} = ?PQUEUE:out(Priority, Q),
             Q2 = ?PQUEUE:in(Msg1, Priority, Q1),
-            {without_ts(DroppedMsg), MQ#mqueue{q = Q2, dropped = Dropped + 1}};
+            DroppedMsg1 = without_ts(DroppedMsg),
+            MQ1 = update_bytes(
+                msg_bytes(Msg) - msg_bytes(DroppedMsg1),
+                MQ#mqueue{q = Q2, dropped = Dropped + 1}
+            ),
+            {DroppedMsg1, MQ1};
         false ->
-            {_DroppedMsg = undefined, MQ#mqueue{len = Len + 1, q = ?PQUEUE:in(Msg1, Priority, Q)}}
+            MQ1 = update_bytes(
+                msg_bytes(Msg),
+                MQ#mqueue{len = Len + 1, q = ?PQUEUE:in(Msg1, Priority, Q)}
+            ),
+            {_DroppedMsg = undefined, MQ1}
     end.
 
 -spec out(mqueue()) -> {empty | {value, message()}, mqueue()}.
 out(MQ = #mqueue{len = 0, q = Q}) ->
     %% assert, in this case, ?PQUEUE:len should be very cheap
     0 = ?PQUEUE:len(Q),
-    {empty, MQ};
+    {empty, reset_empty(Q, MQ)};
 out(MQ = #mqueue{q = Q, len = Len, last_prio = undefined, shift_opts = ShiftOpts}) ->
-    %% Shouldn't fail, since we've checked the length
-    {{value, Val, Prio}, Q1} = ?PQUEUE:out_p(Q),
-    MQ1 = MQ#mqueue{
-        q = Q1,
-        len = Len - 1,
-        last_prio = Prio,
-        p_credit = get_credits(Prio, ShiftOpts)
-    },
-    {{value, without_ts(Val)}, MQ1};
+    case ?PQUEUE:out_p(Q) of
+        {{value, Val, Prio}, Q1} ->
+            Msg = without_ts(Val),
+            MQ1 = MQ#mqueue{
+                q = Q1,
+                len = Len - 1,
+                last_prio = Prio,
+                p_credit = get_credits(Prio, ShiftOpts)
+            },
+            {{value, Msg}, update_bytes(-msg_bytes(Msg), MQ1)};
+        {empty, Q1} ->
+            {empty, reset_empty(Q1, MQ)}
+    end;
 out(MQ = #mqueue{q = Q, p_credit = 0}) ->
     MQ1 = MQ#mqueue{
         q = ?PQUEUE:shift(Q),
@@ -306,12 +330,32 @@ out(MQ = #mqueue{q = Q, p_credit = 0}) ->
     },
     out(MQ1);
 out(MQ = #mqueue{q = Q, len = Len, p_credit = Cnt}) ->
-    {R, Q2} =
-        case ?PQUEUE:out(Q) of
-            {{value, Val}, Q1} -> {{value, without_ts(Val)}, Q1};
-            Other -> Other
+    case ?PQUEUE:out(Q) of
+        {{value, Val}, Q1} ->
+            Msg = without_ts(Val),
+            MQ1 = MQ#mqueue{q = Q1, len = Len - 1, p_credit = Cnt - 1},
+            {{value, Msg}, update_bytes(-msg_bytes(Msg), MQ1)};
+        {empty, Q1} ->
+            {empty, reset_empty(Q1, MQ)}
+    end.
+
+pqueue_bytes(Q) ->
+    ?PQUEUE:fold(
+        fun(Msg, _Priority, Acc) ->
+            Acc + msg_bytes(without_ts(Msg))
         end,
-    {R, MQ#mqueue{q = Q2, len = Len - 1, p_credit = Cnt - 1}}.
+        0,
+        Q
+    ).
+
+msg_bytes(#message{} = Msg) ->
+    emqx_message:payload_size(Msg).
+
+update_bytes(Delta, MQ = #mqueue{bytes = Bytes}) ->
+    MQ#mqueue{bytes = max(0, Bytes + Delta)}.
+
+reset_empty(Q, MQ) ->
+    MQ#mqueue{q = Q, len = 0, bytes = 0, last_prio = undefined, p_credit = undefined}.
 
 get_opt(Key, Opts, Default) ->
     case maps:get(Key, Opts, Default) of

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -268,6 +268,7 @@ packet IDs can be reconstructed by "replaying" the stored SRSes.
     inflight_cnt,
     inflight_max,
     mqueue_len,
+    total_payload_bytes,
     mqueue_dropped,
     seqno_q1_comm,
     seqno_q1_dup,
@@ -381,6 +382,8 @@ info(retry_interval, #{props := Conf}) ->
     maps:get(retry_interval, Conf);
 info(mqueue_len, #{inflight := Inflight}) ->
     emqx_persistent_session_ds_inflight:n_buffered(all, Inflight);
+info(total_payload_bytes, _Session) ->
+    0;
 info(mqueue_dropped, _Session) ->
     0;
 info(awaiting_rel, #{s := S}) ->

--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_channel_info.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_channel_info.erl
@@ -162,6 +162,7 @@ enrich(Bin, #{
         {heap_size, 0},
         {total_heap_size, 0},
         {mqueue_dropped, 0},
+        {total_payload_bytes, 0},
         {mqueue_len, 0},
         {n_streams, maps:size(Streams)},
         %% TODO: this data is available

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -86,6 +86,7 @@
 -export([
     validate_heap_size/1,
     validate_max_packet_size/1,
+    validate_session_buffered_payload_high_watermark/1,
     convert_max_packet_size/2,
     user_lookup_fun_tr/2,
     validate_keepalive_multiplier/1,
@@ -1623,6 +1624,11 @@ fields("sysmon") ->
                 ref("sysmon_os"),
                 #{}
             )},
+        {"session",
+            sc(
+                ref("sysmon_session"),
+                #{}
+            )},
         {"mnesia_tm_mailbox_size_alarm_threshold",
             sc(
                 pos_integer(),
@@ -1637,6 +1643,18 @@ fields("sysmon") ->
                 #{
                     default => 500,
                     desc => ?DESC("sysmon_broker_pool_mailbox_size_alarm_threshold")
+                }
+            )}
+    ];
+fields("sysmon_session") ->
+    [
+        {"buffered_payload_high_watermark",
+            sc(
+                bytesize(),
+                #{
+                    default => 0,
+                    validator => fun ?MODULE:validate_session_buffered_payload_high_watermark/1,
+                    desc => ?DESC(sysmon_session_buffered_payload_high_watermark)
                 }
             )}
     ];
@@ -2388,6 +2406,8 @@ desc("sysmon_vm") ->
 desc("sysmon_os") ->
     "This part of the configuration is responsible for monitoring\n"
     " the host OS health, such as free memory, disk space, CPU load, etc.";
+desc("sysmon_session") ->
+    "This part of the configuration monitors memory session runtime signals.";
 desc("alarm") ->
     "Settings for the alarms.";
 desc("trace") ->
@@ -3226,6 +3246,11 @@ validate_max_packet_size(Siz) when is_integer(Siz) ->
     ok;
 validate_max_packet_size(_SizStr) ->
     {error, invalid_packet_size}.
+
+validate_session_buffered_payload_high_watermark(Bytes) when is_integer(Bytes), Bytes >= 0 ->
+    ok;
+validate_session_buffered_payload_high_watermark(_Bytes) ->
+    {error, #{cause => session_buffered_payload_high_watermark_out_of_range, minimum => 0}}.
 
 %% This is for backward compatibility.
 %% We used to allow setting 256MB, but in fact the limit is one byte less.

--- a/apps/emqx/src/emqx_session_buffer_mon.erl
+++ b/apps/emqx/src/emqx_session_buffer_mon.erl
@@ -61,9 +61,9 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec update(map()) -> ok.
-update(Conf) ->
-    ok = put_conf(Conf),
+-spec update(map() | undefined) -> ok.
+update(Conf0) ->
+    Conf = put_conf(Conf0),
     gen_server:cast(?MODULE, {update, Conf}).
 
 -spec maybe_log(emqx_types:clientid(), pid(), stats()) -> ok.
@@ -104,8 +104,7 @@ local_top(Count, SortBy) ->
 %%--------------------------------------------------------------------
 
 init([]) ->
-    Conf = emqx_config:get([sysmon, session], ?DEFAULT_CONF),
-    ok = put_conf(Conf),
+    Conf = put_conf(emqx_config:get([sysmon, session], ?DEFAULT_CONF)),
     {ok, #{conf => Conf, scan => undefined}}.
 
 handle_call({run_top, Opts}, _From, State = #{scan := undefined}) ->
@@ -118,8 +117,8 @@ handle_call({local_top, Count, SortBy}, _From, State) ->
 handle_call(_Call, _From, State) ->
     {reply, ignored, State}.
 
-handle_cast({update, Conf}, State) ->
-    ok = put_conf(Conf),
+handle_cast({update, Conf0}, State) ->
+    Conf = put_conf(Conf0),
     {noreply, State#{conf := Conf}};
 handle_cast(_Cast, State) ->
     {noreply, State}.
@@ -335,9 +334,15 @@ maybe_log_scan_down(Reason) ->
 %% Helpers
 %%--------------------------------------------------------------------
 
-put_conf(Conf) ->
-    persistent_term:put(?CONF_KEY, maps:merge(?DEFAULT_CONF, Conf)),
-    ok.
+put_conf(Conf0) ->
+    Conf = normalize_conf(Conf0),
+    persistent_term:put(?CONF_KEY, Conf),
+    Conf.
+
+normalize_conf(undefined) ->
+    ?DEFAULT_CONF;
+normalize_conf(Conf) when is_map(Conf) ->
+    maps:merge(?DEFAULT_CONF, maps:filter(fun(_Key, Value) -> Value =/= undefined end, Conf)).
 
 stat_value(Key, Stats, Default) when is_map(Stats) ->
     maps:get(Key, Stats, Default);

--- a/apps/emqx/src/emqx_session_buffer_mon.erl
+++ b/apps/emqx/src/emqx_session_buffer_mon.erl
@@ -14,6 +14,7 @@
     update/1,
     maybe_log/3,
     run_top/1,
+    top_status/0,
     local_top/2
 ]).
 
@@ -49,6 +50,31 @@
 
 -type stats() :: emqx_types:stats() | map().
 -type sort_by() :: mqueue_length | total_payload_bytes.
+-type top_status() ::
+    #{status := idle}
+    | #{
+        status := running,
+        pid := pid(),
+        out := file:name_all(),
+        count := pos_integer(),
+        sort := sort_by()
+    }
+    | #{
+        status := completed,
+        out := file:name_all(),
+        rows := non_neg_integer(),
+        partial := boolean(),
+        bad_nodes := [node()],
+        bad_replies := [term()]
+    }
+    | #{
+        status := failed,
+        out := file:name_all(),
+        reason := term(),
+        partial := boolean(),
+        bad_nodes := [node()],
+        bad_replies := [term()]
+    }.
 -type row() :: #{
     clientid := emqx_types:clientid(),
     pid := pid(),
@@ -100,6 +126,10 @@ maybe_log(ClientId, ChanPid, Stats) ->
 run_top(Opts) ->
     gen_server:call(?MODULE, {run_top, Opts}, infinity).
 
+-spec top_status() -> top_status().
+top_status() ->
+    gen_server:call(?MODULE, top_status, infinity).
+
 -spec local_top(pos_integer(), sort_by()) -> [row()].
 local_top(Count, SortBy) ->
     gen_server:call(?MODULE, {local_top, Count, SortBy}, infinity).
@@ -110,13 +140,31 @@ local_top(Count, SortBy) ->
 
 init([]) ->
     Conf = put_conf(emqx_config:get([sysmon, session], ?DEFAULT_CONF)),
-    {ok, #{conf => Conf, scan => undefined}}.
+    {ok, #{conf => Conf, scan => undefined, top_status => #{status => idle}}}.
 
 handle_call({run_top, Opts}, _From, State = #{scan := undefined}) ->
-    {Pid, MRef} = erlang:spawn_monitor(fun() -> do_run_top(Opts) end),
-    {reply, {ok, Pid}, State#{scan := {Pid, MRef}}};
+    Server = self(),
+    {Pid, MRef} =
+        erlang:spawn_monitor(fun() ->
+            ok = gen_server:call(Server, {top_scan_result, self(), do_run_top(Opts)}, infinity)
+        end),
+    Scan = #{pid => Pid, mref => MRef, opts => Opts},
+    Status = #{
+        status => running,
+        pid => Pid,
+        out => maps:get(out, Opts),
+        count => maps:get(count, Opts),
+        sort => maps:get(sort, Opts)
+    },
+    {reply, {ok, Pid}, State#{scan := Scan, top_status => Status}};
 handle_call({run_top, _Opts}, _From, State) ->
     {reply, {error, busy}, State};
+handle_call({top_scan_result, Pid, Result}, _From, State = #{scan := Scan = #{pid := Pid}}) ->
+    {reply, ok, State#{scan := Scan#{result => Result}}};
+handle_call({top_scan_result, _Pid, _Result}, _From, State) ->
+    {reply, ok, State};
+handle_call(top_status, _From, State) ->
+    {reply, maps:get(top_status, State, #{status => idle}), State};
 handle_call({local_top, Count, SortBy}, _From, State) ->
     {reply, scan_local(Count, SortBy), State};
 handle_call(_Call, _From, State) ->
@@ -128,9 +176,18 @@ handle_cast({update, Conf0}, State) ->
 handle_cast(_Cast, State) ->
     {noreply, State}.
 
+handle_info(
+    {'DOWN', MRef, process, Pid, Reason},
+    State = #{scan := Scan = #{pid := Pid, mref := MRef, opts := Opts}}
+) ->
+    maybe_log_scan_down(Reason),
+    Status = maps:get(result, Scan, top_scan_failed_status(Opts, Reason)),
+    {noreply, State#{scan := undefined, top_status => Status}};
 handle_info({'DOWN', MRef, process, Pid, Reason}, State = #{scan := {Pid, MRef}}) ->
     maybe_log_scan_down(Reason),
-    {noreply, State#{scan := undefined}};
+    {noreply, State#{
+        scan := undefined, top_status => maps:get(top_status, State, #{status => idle})
+    }};
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -138,7 +195,7 @@ terminate(_Reason, _State) ->
     ok.
 
 code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+    {ok, ensure_top_status(State)}.
 
 %%--------------------------------------------------------------------
 %% Top-K scan
@@ -153,25 +210,42 @@ do_run_top(#{count := Count, sort := SortBy, out := OutFile}) ->
     BadNodes = BadNodes0 ++ UnsupportedNodes,
     {Rows0, BadReplies} = result_rows(Results),
     Rows = top_rows(Rows0, Count, SortBy),
+    Partial = BadNodes =/= [] orelse BadReplies =/= [],
     case write_csv(OutFile, Rows) of
         ok ->
             ?SLOG(info, #{
                 msg => session_top_written,
                 file => OutFile,
                 rows => length(Rows),
-                partial => BadNodes =/= [] orelse BadReplies =/= [],
+                partial => Partial,
                 bad_nodes => BadNodes,
                 bad_replies => BadReplies
-            });
+            }),
+            #{
+                status => completed,
+                out => OutFile,
+                rows => length(Rows),
+                partial => Partial,
+                bad_nodes => BadNodes,
+                bad_replies => BadReplies
+            };
         {error, Reason} ->
             ?SLOG(error, #{
                 msg => session_top_write_failed,
                 file => OutFile,
                 reason => Reason,
-                partial => BadNodes =/= [] orelse BadReplies =/= [],
+                partial => Partial,
                 bad_nodes => BadNodes,
                 bad_replies => BadReplies
-            })
+            }),
+            #{
+                status => failed,
+                out => OutFile,
+                reason => Reason,
+                partial => Partial,
+                bad_nodes => BadNodes,
+                bad_replies => BadReplies
+            }
     end.
 
 result_rows(Results) ->
@@ -336,6 +410,21 @@ maybe_log_scan_down(normal) ->
     ok;
 maybe_log_scan_down(Reason) ->
     ?SLOG(error, #{msg => session_top_scan_failed, reason => Reason}).
+
+top_scan_failed_status(Opts, Reason) ->
+    #{
+        status => failed,
+        out => maps:get(out, Opts),
+        reason => Reason,
+        partial => false,
+        bad_nodes => [],
+        bad_replies => []
+    }.
+
+ensure_top_status(State = #{top_status := _}) ->
+    State;
+ensure_top_status(State) ->
+    State#{top_status => #{status => idle}}.
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/apps/emqx/src/emqx_session_buffer_mon.erl
+++ b/apps/emqx/src/emqx_session_buffer_mon.erl
@@ -132,7 +132,7 @@ top_status() ->
 
 -spec local_top(pos_integer(), sort_by()) -> [row()].
 local_top(Count, SortBy) ->
-    gen_server:call(?MODULE, {local_top, Count, SortBy}, infinity).
+    scan_local(Count, SortBy).
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks
@@ -165,8 +165,6 @@ handle_call({top_scan_result, _Pid, _Result}, _From, State) ->
     {reply, ok, State};
 handle_call(top_status, _From, State) ->
     {reply, maps:get(top_status, State, #{status => idle}), State};
-handle_call({local_top, Count, SortBy}, _From, State) ->
-    {reply, scan_local(Count, SortBy), State};
 handle_call(_Call, _From, State) ->
     {reply, ignored, State}.
 
@@ -183,11 +181,6 @@ handle_info(
     maybe_log_scan_down(Reason),
     Status = maps:get(result, Scan, top_scan_failed_status(Opts, Reason)),
     {noreply, State#{scan := undefined, top_status => Status}};
-handle_info({'DOWN', MRef, process, Pid, Reason}, State = #{scan := {Pid, MRef}}) ->
-    maybe_log_scan_down(Reason),
-    {noreply, State#{
-        scan := undefined, top_status => maps:get(top_status, State, #{status => idle})
-    }};
 handle_info(_Info, State) ->
     {noreply, State}.
 

--- a/apps/emqx/src/emqx_session_buffer_mon.erl
+++ b/apps/emqx/src/emqx_session_buffer_mon.erl
@@ -231,21 +231,22 @@ insert_top(Row, Count, Key, TopRows) ->
         true ->
             gb_trees:insert(Key, Row, TopRows);
         false ->
-            {SmallestKey, SmallestRow, TopRows1} = gb_trees:take_smallest(TopRows),
+            {SmallestKey, _SmallestRow} = gb_trees:smallest(TopRows),
             case Key > SmallestKey of
                 true ->
+                    {_, _, TopRows1} = gb_trees:take_smallest(TopRows),
                     gb_trees:insert(Key, Row, TopRows1);
                 false ->
-                    gb_trees:insert(SmallestKey, SmallestRow, TopRows1)
+                    TopRows
             end
     end.
 
 top_key(Row, SortBy) ->
     {
         sort_value(Row, SortBy),
-        stable_value(Row, clientid),
-        stable_value(Row, node),
-        stable_value(Row, pid)
+        maps:get(clientid, Row),
+        maps:get(node, Row),
+        maps:get(pid, Row)
     }.
 
 top_heap_rows(TopRows) ->
@@ -255,9 +256,6 @@ sort_value(Row, mqueue_length) ->
     maps:get(mqueue_length, Row, 0);
 sort_value(Row, total_payload_bytes) ->
     maps:get(total_payload_bytes, Row, 0).
-
-stable_value(Row, Key) ->
-    to_binary(maps:get(Key, Row)).
 
 write_csv(OutFile, Rows) ->
     case file:open(OutFile, [write, raw, binary]) of

--- a/apps/emqx/src/emqx_session_buffer_mon.erl
+++ b/apps/emqx/src/emqx_session_buffer_mon.erl
@@ -17,6 +17,11 @@
     local_top/2
 ]).
 
+-export_type([
+    sort_by/0,
+    row/0
+]).
+
 -export([
     init/1,
     handle_call/3,
@@ -140,8 +145,12 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 
 do_run_top(#{count := Count, sort := SortBy, out := OutFile}) ->
-    Nodes = emqx:running_nodes(),
-    {Results, BadNodes} = rpc:multicall(Nodes, ?MODULE, local_top, [Count, SortBy], ?TOP_TIMEOUT),
+    RunningNodes = emqx:running_nodes(),
+    Nodes = emqx_bpapi:nodes_supporting_bpapi_version(emqx_session_buffer, 1),
+    UnsupportedNodes = RunningNodes -- Nodes,
+    {Results, BadNodes0} =
+        emqx_session_buffer_proto_v1:local_top(Nodes, Count, SortBy, ?TOP_TIMEOUT),
+    BadNodes = BadNodes0 ++ UnsupportedNodes,
     {Rows0, BadReplies} = result_rows(Results),
     Rows = top_rows(Rows0, Count, SortBy),
     case write_csv(OutFile, Rows) of

--- a/apps/emqx/src/emqx_session_buffer_mon.erl
+++ b/apps/emqx/src/emqx_session_buffer_mon.erl
@@ -1,0 +1,345 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_session_buffer_mon).
+
+-behaviour(gen_server).
+
+-include("emqx_cm.hrl").
+-include("logger.hrl").
+
+-export([
+    start_link/0,
+    update/1,
+    maybe_log/3,
+    run_top/1,
+    local_top/2
+]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-ifdef(TEST).
+-export([
+    scan_local/2,
+    csv_rows/1,
+    result_rows/1,
+    write_csv/2
+]).
+-endif.
+
+-define(CONF_KEY, {?MODULE, conf}).
+-define(DEFAULT_CONF, #{buffered_payload_high_watermark => 0}).
+-define(LOG_MSG, session_buffer_high_watermark).
+-define(TOP_TIMEOUT, 300000).
+-define(SCAN_BATCH_SIZE, 1000).
+-define(SCAN_SLEEP_MS, 1).
+
+-type stats() :: emqx_types:stats() | map().
+-type sort_by() :: mqueue_length | total_payload_bytes.
+-type row() :: #{
+    clientid := emqx_types:clientid(),
+    pid := pid(),
+    node := node(),
+    mqueue_length := non_neg_integer(),
+    total_payload_bytes := non_neg_integer(),
+    inflight_count := non_neg_integer()
+}.
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+-spec start_link() -> gen_server:start_ret().
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec update(map()) -> ok.
+update(Conf) ->
+    ok = put_conf(Conf),
+    gen_server:cast(?MODULE, {update, Conf}).
+
+-spec maybe_log(emqx_types:clientid(), pid(), stats()) -> ok.
+maybe_log(ClientId, ChanPid, Stats) ->
+    Conf = persistent_term:get(?CONF_KEY, ?DEFAULT_CONF),
+    HighWatermark = maps:get(buffered_payload_high_watermark, Conf, 0),
+    TotalPayloadBytes = stat_value(total_payload_bytes, Stats, 0),
+    case HighWatermark > 0 andalso TotalPayloadBytes > HighWatermark of
+        true ->
+            ?SLOG_THROTTLE(
+                warning,
+                #{
+                    msg => ?LOG_MSG,
+                    clientid => ClientId,
+                    pid => ChanPid,
+                    mqueue_length => stat_value(mqueue_len, Stats, 0),
+                    inflight_count => stat_value(inflight_cnt, Stats, 0),
+                    total_payload_bytes => TotalPayloadBytes,
+                    buffered_payload_high_watermark => HighWatermark
+                },
+                #{clientid => ClientId}
+            );
+        false ->
+            ok
+    end.
+
+-spec run_top(#{count := pos_integer(), sort := sort_by(), out := file:name_all()}) ->
+    {ok, pid()} | {error, busy}.
+run_top(Opts) ->
+    gen_server:call(?MODULE, {run_top, Opts}, infinity).
+
+-spec local_top(pos_integer(), sort_by()) -> [row()].
+local_top(Count, SortBy) ->
+    gen_server:call(?MODULE, {local_top, Count, SortBy}, infinity).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+init([]) ->
+    Conf = emqx_config:get([sysmon, session], ?DEFAULT_CONF),
+    ok = put_conf(Conf),
+    {ok, #{conf => Conf, scan => undefined}}.
+
+handle_call({run_top, Opts}, _From, State = #{scan := undefined}) ->
+    {Pid, MRef} = erlang:spawn_monitor(fun() -> do_run_top(Opts) end),
+    {reply, {ok, Pid}, State#{scan := {Pid, MRef}}};
+handle_call({run_top, _Opts}, _From, State) ->
+    {reply, {error, busy}, State};
+handle_call({local_top, Count, SortBy}, _From, State) ->
+    {reply, scan_local(Count, SortBy), State};
+handle_call(_Call, _From, State) ->
+    {reply, ignored, State}.
+
+handle_cast({update, Conf}, State) ->
+    ok = put_conf(Conf),
+    {noreply, State#{conf := Conf}};
+handle_cast(_Cast, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', MRef, process, Pid, Reason}, State = #{scan := {Pid, MRef}}) ->
+    maybe_log_scan_down(Reason),
+    {noreply, State#{scan := undefined}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% Top-K scan
+%%--------------------------------------------------------------------
+
+do_run_top(#{count := Count, sort := SortBy, out := OutFile}) ->
+    Nodes = emqx:running_nodes(),
+    {Results, BadNodes} = rpc:multicall(Nodes, ?MODULE, local_top, [Count, SortBy], ?TOP_TIMEOUT),
+    {Rows0, BadReplies} = result_rows(Results),
+    Rows = top_rows(Rows0, Count, SortBy),
+    case write_csv(OutFile, Rows) of
+        ok ->
+            ?SLOG(info, #{
+                msg => session_top_written,
+                file => OutFile,
+                rows => length(Rows),
+                partial => BadNodes =/= [] orelse BadReplies =/= [],
+                bad_nodes => BadNodes,
+                bad_replies => BadReplies
+            });
+        {error, Reason} ->
+            ?SLOG(error, #{
+                msg => session_top_write_failed,
+                file => OutFile,
+                reason => Reason,
+                partial => BadNodes =/= [] orelse BadReplies =/= [],
+                bad_nodes => BadNodes,
+                bad_replies => BadReplies
+            })
+    end.
+
+result_rows(Results) ->
+    lists:foldr(fun result_rows/2, {[], []}, Results).
+
+result_rows(Rows, {AccRows, AccBad}) when is_list(Rows) ->
+    {Rows ++ AccRows, AccBad};
+result_rows({badrpc, Reason}, {AccRows, AccBad}) ->
+    {AccRows, [Reason | AccBad]};
+result_rows(Other, {AccRows, AccBad}) ->
+    {AccRows, [Other | AccBad]}.
+
+-spec scan_local(pos_integer(), sort_by()) -> [row()].
+scan_local(Count, SortBy) ->
+    try
+        scan_local(ets:first(?CHAN_INFO_TAB), Count, SortBy, gb_trees:empty(), 0)
+    catch
+        error:badarg ->
+            []
+    end.
+
+scan_local('$end_of_table', _Count, _SortBy, TopRows, _BatchCount) ->
+    top_heap_rows(TopRows);
+scan_local(Key, Count, SortBy, TopRows, BatchCount) ->
+    NextKey = ets:next(?CHAN_INFO_TAB, Key),
+    TopRows1 =
+        case ets:lookup(?CHAN_INFO_TAB, Key) of
+            [{Key = {ClientId, ChanPid}, _Info, Stats}] ->
+                keep_top(row(ClientId, ChanPid, Stats), Count, SortBy, TopRows);
+            _ ->
+                TopRows
+        end,
+    BatchCount1 = BatchCount + 1,
+    case BatchCount1 rem ?SCAN_BATCH_SIZE of
+        0 ->
+            timer:sleep(?SCAN_SLEEP_MS);
+        _ ->
+            ok
+    end,
+    scan_local(NextKey, Count, SortBy, TopRows1, BatchCount1).
+
+row(ClientId, ChanPid, Stats) ->
+    #{
+        clientid => ClientId,
+        pid => ChanPid,
+        node => node(),
+        mqueue_length => stat_value(mqueue_len, Stats, 0),
+        total_payload_bytes => stat_value(total_payload_bytes, Stats, 0),
+        inflight_count => stat_value(inflight_cnt, Stats, 0)
+    }.
+
+keep_top(_Row, 0, _SortBy, TopRows) ->
+    TopRows;
+keep_top(Row, Count, SortBy, TopRows) ->
+    insert_top(Row, Count, top_key(Row, SortBy), TopRows).
+
+top_rows(Rows, Count, SortBy) ->
+    top_heap_rows(
+        lists:foldl(
+            fun(Row, Heap) -> keep_top(Row, Count, SortBy, Heap) end, gb_trees:empty(), Rows
+        )
+    ).
+
+insert_top(Row, Count, Key, TopRows) ->
+    case gb_trees:size(TopRows) < Count of
+        true ->
+            gb_trees:insert(Key, Row, TopRows);
+        false ->
+            {SmallestKey, SmallestRow, TopRows1} = gb_trees:take_smallest(TopRows),
+            case Key > SmallestKey of
+                true ->
+                    gb_trees:insert(Key, Row, TopRows1);
+                false ->
+                    gb_trees:insert(SmallestKey, SmallestRow, TopRows1)
+            end
+    end.
+
+top_key(Row, SortBy) ->
+    {
+        sort_value(Row, SortBy),
+        stable_value(Row, clientid),
+        stable_value(Row, node),
+        stable_value(Row, pid)
+    }.
+
+top_heap_rows(TopRows) ->
+    [Row || {_Key, Row} <- lists:reverse(gb_trees:to_list(TopRows))].
+
+sort_value(Row, mqueue_length) ->
+    maps:get(mqueue_length, Row, 0);
+sort_value(Row, total_payload_bytes) ->
+    maps:get(total_payload_bytes, Row, 0).
+
+stable_value(Row, Key) ->
+    to_binary(maps:get(Key, Row)).
+
+write_csv(OutFile, Rows) ->
+    case file:open(OutFile, [write, raw, binary]) of
+        {ok, IoDev} ->
+            try
+                write_csv_chunks(IoDev, [
+                    <<"clientid,pid,node,mqueue_length,total_payload_bytes,inflight_count\n">>,
+                    csv_rows(Rows)
+                ])
+            after
+                _ = file:close(IoDev)
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+write_csv_chunks(_IoDev, []) ->
+    ok;
+write_csv_chunks(IoDev, [Chunk | More]) ->
+    case file:write(IoDev, Chunk) of
+        ok -> write_csv_chunks(IoDev, More);
+        {error, Reason} -> {error, Reason}
+    end.
+
+csv_rows(Rows) ->
+    [csv_row(Row) || Row <- Rows].
+
+csv_row(Row) ->
+    [
+        csv_cell(maps:get(clientid, Row)),
+        <<",">>,
+        csv_cell(maps:get(pid, Row)),
+        <<",">>,
+        csv_cell(maps:get(node, Row)),
+        <<",">>,
+        integer_to_binary(maps:get(mqueue_length, Row)),
+        <<",">>,
+        integer_to_binary(maps:get(total_payload_bytes, Row)),
+        <<",">>,
+        integer_to_binary(maps:get(inflight_count, Row)),
+        $\n
+    ].
+
+csv_cell(Value) ->
+    Bin = to_binary(Value),
+    case needs_quote(Bin) of
+        true -> [$", binary:replace(Bin, <<"\"">>, <<"\"\"">>, [global]), $"];
+        false -> Bin
+    end.
+
+needs_quote(Bin) ->
+    lists:any(
+        fun(Pattern) -> binary:match(Bin, Pattern) =/= nomatch end,
+        [<<",">>, <<"\"">>, <<"\n">>, <<"\r">>]
+    ).
+
+to_binary(Value) when is_binary(Value) ->
+    Value;
+to_binary(Value) when is_atom(Value) ->
+    atom_to_binary(Value, utf8);
+to_binary(Value) when is_pid(Value) ->
+    list_to_binary(pid_to_list(Value));
+to_binary(Value) when is_integer(Value) ->
+    integer_to_binary(Value);
+to_binary(Value) ->
+    unicode:characters_to_binary(io_lib:format("~p", [Value])).
+
+maybe_log_scan_down(normal) ->
+    ok;
+maybe_log_scan_down(Reason) ->
+    ?SLOG(error, #{msg => session_top_scan_failed, reason => Reason}).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+put_conf(Conf) ->
+    persistent_term:put(?CONF_KEY, maps:merge(?DEFAULT_CONF, Conf)),
+    ok.
+
+stat_value(Key, Stats, Default) when is_map(Stats) ->
+    maps:get(Key, Stats, Default);
+stat_value(Key, Stats, Default) when is_list(Stats) ->
+    proplists:get_value(Key, Stats, Default).

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -142,6 +142,7 @@
     inflight_max,
     mqueue_len,
     mqueue_max,
+    total_payload_bytes,
     mqueue_dropped,
     next_pkt_id,
     awaiting_rel_cnt,
@@ -281,6 +282,8 @@ info(mqueue_len, #session{mqueue = MQueue}) ->
     emqx_mqueue:len(MQueue);
 info(mqueue_max, #session{mqueue = MQueue}) ->
     emqx_mqueue:max_len(MQueue);
+info(total_payload_bytes, #session{inflight = Inflight, mqueue = MQueue}) ->
+    inflight_payload_bytes(Inflight) + emqx_mqueue:bytes_size(MQueue);
 info(mqueue_dropped, #session{mqueue = MQueue}) ->
     emqx_mqueue:dropped(MQueue);
 info({mqueue_msgs, PagerParams}, #session{mqueue = MQueue}) ->
@@ -1058,6 +1061,18 @@ inflight_insert_ts(#message{extra = #{?INFLIGHT_INSERT_TS := Ts}}) -> Ts.
 
 without_inflight_insert_ts(#message{extra = Extra} = Msg) ->
     Msg#message{extra = maps:remove(?INFLIGHT_INSERT_TS, Extra)}.
+
+inflight_payload_bytes(Inflight) ->
+    emqx_inflight:fold(
+        fun
+            (_PacketId, #inflight_data{message = #message{} = Msg}, Acc) ->
+                Acc + emqx_message:payload_size(Msg);
+            (_PacketId, _Data, Acc) ->
+                Acc
+        end,
+        0,
+        Inflight
+    ).
 
 batch_n(Inflight) ->
     case emqx_inflight:max_size(Inflight) of

--- a/apps/emqx/src/emqx_sys_mon.erl
+++ b/apps/emqx/src/emqx_sys_mon.erl
@@ -46,8 +46,11 @@ remove_handler() ->
 post_config_update(_, _Req, NewConf, OldConf, _AppEnvs) ->
     #{os := OS1, vm := VM1} = OldConf,
     #{os := OS2, vm := VM2} = NewConf,
+    Session1 = maps:get(session, OldConf, #{}),
+    Session2 = maps:get(session, NewConf, #{}),
     (VM1 =/= VM2) andalso ?MODULE:update(VM2),
     (OS1 =/= OS2) andalso emqx_os_mon:update(OS2),
+    (Session1 =/= Session2) andalso emqx_session_buffer_mon:update(Session2),
     ok.
 
 update(VM) ->

--- a/apps/emqx/src/emqx_sys_sup.erl
+++ b/apps/emqx/src/emqx_sys_sup.erl
@@ -32,7 +32,8 @@ init([]) ->
             child_spec(emqx_sys),
             child_spec(emqx_sys_mon),
             child_spec(emqx_vm_mon),
-            child_spec(emqx_broker_mon)
+            child_spec(emqx_broker_mon),
+            child_spec(emqx_session_buffer_mon)
         ] ++ OsMon ++ [child_spec(emqx_corrupt_namespace_config_checker)],
     {ok, {{one_for_one, 10, 100}, Children}}.
 

--- a/apps/emqx/src/proto/emqx_session_buffer_proto_v1.erl
+++ b/apps/emqx/src/proto/emqx_session_buffer_proto_v1.erl
@@ -1,0 +1,22 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_session_buffer_proto_v1).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+    local_top/4
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+introduced_in() ->
+    "6.3.0".
+
+-spec local_top([node()], pos_integer(), emqx_session_buffer_mon:sort_by(), timeout()) ->
+    emqx_rpc:multicall_result([emqx_session_buffer_mon:row()]).
+local_top(Nodes, Count, SortBy, Timeout) ->
+    rpc:multicall(Nodes, emqx_session_buffer_mon, local_top, [Count, SortBy], Timeout).

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -104,6 +104,36 @@ t_get_set_chan_stats(_) ->
     ok = emqx_cm:unregister_channel(<<"clientid">>),
     ?assertEqual(undefined, emqx_cm:get_chan_stats(<<"clientid">>)).
 
+t_set_chan_stats_triggers_session_buffer_check(_) ->
+    ClientId = <<"session-buffer-check">>,
+    Stats = [{mqueue_len, 1}, {inflight_cnt, 1}, {total_payload_bytes, 2}],
+    Info = #{conninfo := ConnInfo} = ?ChanInfo,
+    ok = emqx_cm:register_channel(ClientId, self(), ConnInfo),
+    ok = emqx_cm:insert_channel_info(ClientId, Info, []),
+    TestPid = self(),
+    ok = meck:new(emqx_session_buffer_mon, [passthrough, no_link]),
+    ok = meck:expect(
+        emqx_session_buffer_mon,
+        maybe_log,
+        fun(ClientId0, ChanPid0, Stats0) ->
+            TestPid ! {session_buffer_check, ClientId0, ChanPid0, Stats0},
+            ok
+        end
+    ),
+    try
+        ChanPid = self(),
+        true = emqx_cm:set_chan_stats(ClientId, Stats),
+        receive
+            {session_buffer_check, ClientId, ChanPid, Stats} ->
+                ok
+        after 1000 ->
+            error(session_buffer_check_not_called)
+        end
+    after
+        ok = meck:unload(emqx_session_buffer_mon),
+        ok = emqx_cm:unregister_channel(ClientId)
+    end.
+
 t_open_session(_) ->
     ok = meck:new(emqx_connection, [passthrough, no_history]),
     ok = meck:expect(emqx_connection, call, fun(_, _) -> ok end),

--- a/apps/emqx/test/emqx_log_throttler_SUITE.erl
+++ b/apps/emqx/test/emqx_log_throttler_SUITE.erl
@@ -15,6 +15,7 @@
 -define(THROTTLE_MSG, authorization_permission_denied).
 -define(THROTTLE_MSG1, cannot_publish_to_topic_due_to_not_authorized).
 -define(THROTTLE_UNRECOVERABLE_MSG, unrecoverable_resource_error).
+-define(THROTTLE_SESSION_BUFFER_MSG, session_buffer_high_watermark).
 -define(TIME_WINDOW, <<"1s">>).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
@@ -68,6 +69,10 @@ end_per_testcase(t_throttle_recoverable_msg, _Config) ->
     {ok, _} = emqx_conf:update([log, throttling, msgs], [?THROTTLE_MSG], #{}),
     ok;
 end_per_testcase(t_throttle_add_new_msg, _Config) ->
+    ok = snabbkaffe:stop(),
+    {ok, _} = emqx_conf:update([log, throttling, msgs], [?THROTTLE_MSG], #{}),
+    ok;
+end_per_testcase(t_throttle_session_buffer_msg_globally, _Config) ->
     ok = snabbkaffe:stop(),
     {ok, _} = emqx_conf:update([log, throttling, msgs], [?THROTTLE_MSG], #{}),
     ok;
@@ -162,6 +167,29 @@ t_throttle_add_new_msg(_Config) ->
                 },
                 3000
             )
+        end,
+        []
+    ).
+
+t_throttle_session_buffer_msg_globally(_Config) ->
+    ?check_trace(
+        begin
+            [?THROTTLE_MSG] = Conf = emqx:get_config([log, throttling, msgs]),
+            {ok, _} = emqx_conf:update(
+                [log, throttling, msgs],
+                [?THROTTLE_SESSION_BUFFER_MSG | Conf],
+                #{}
+            ),
+            {ok, _} = ?block_until(
+                #{
+                    ?snk_kind := log_throttler_new_msg,
+                    throttled_msg := ?THROTTLE_SESSION_BUFFER_MSG
+                },
+                5000
+            ),
+            ?assert(emqx_log_throttler:allow(?THROTTLE_SESSION_BUFFER_MSG, <<"c1">>)),
+            ?assertNot(emqx_log_throttler:allow(?THROTTLE_SESSION_BUFFER_MSG, <<"c1">>)),
+            ?assertNot(emqx_log_throttler:allow(?THROTTLE_SESSION_BUFFER_MSG, <<"c2">>))
         end,
         []
     ).

--- a/apps/emqx/test/emqx_message_SUITE.erl
+++ b/apps/emqx/test/emqx_message_SUITE.erl
@@ -55,7 +55,8 @@ t_payload_size(_) ->
     Payload = [<<"payload">>, <<" data">>],
     Msg = emqx_message:make(<<"clientid">>, ?QOS_1, <<"topic">>, Payload),
     ?assertEqual(iolist_size(Payload), emqx_message:payload_size(Msg)),
-    ?assertEqual(0, emqx_message:payload_size(#message{payload = <<>>})).
+    ?assertEqual(0, emqx_message:payload_size(#message{payload = <<>>})),
+    ?assertEqual(0, emqx_message:payload_size(#message{})).
 
 t_timestamp(_) ->
     Msg = emqx_message:make(<<"t">>, <<"payload">>),

--- a/apps/emqx/test/emqx_message_SUITE.erl
+++ b/apps/emqx/test/emqx_message_SUITE.erl
@@ -51,6 +51,12 @@ t_payload(_) ->
     Msg = emqx_message:make(<<"t">>, <<"payload">>),
     ?assertEqual(<<"payload">>, emqx_message:payload(Msg)).
 
+t_payload_size(_) ->
+    Payload = [<<"payload">>, <<" data">>],
+    Msg = emqx_message:make(<<"clientid">>, ?QOS_1, <<"topic">>, Payload),
+    ?assertEqual(iolist_size(Payload), emqx_message:payload_size(Msg)),
+    ?assertEqual(0, emqx_message:payload_size(#message{payload = <<>>})).
+
 t_timestamp(_) ->
     Msg = emqx_message:make(<<"t">>, <<"payload">>),
     timer:sleep(1),

--- a/apps/emqx/test/emqx_mqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_mqueue_SUITE.erl
@@ -30,6 +30,10 @@ t_info(_) ->
         dropped := 0
     } = ?Q:info(Q).
 
+t_record_shape_stays_compatible(_) ->
+    Q = ?Q:init(#{max_len => 5, store_qos0 => true}),
+    ?assertEqual(11, tuple_size(Q)).
+
 t_in(_) ->
     Opts = #{max_len => 5, store_qos0 => true},
     Q = ?Q:init(Opts),
@@ -60,11 +64,11 @@ t_out(_) ->
     ?assertEqual(0, ?Q:len(Q2)),
     ?assertEqual({value, #message{payload = <<>>}}, Value).
 
-t_out_resets_stale_counters(_) ->
+t_out_resets_stale_len(_) ->
     Q = ?Q:init(#{max_len => 5, store_qos0 => true}),
-    StaleQ = set_mqueue_counters(Q, 1, 42),
+    StaleQ = set_mqueue_len(Q, 1),
     ?assertEqual(1, ?Q:len(StaleQ)),
-    ?assertEqual(42, ?Q:bytes_size(StaleQ)),
+    ?assertEqual(0, ?Q:bytes_size(StaleQ)),
     ?assertEqual({empty, Q}, ?Q:out(StaleQ)).
 
 t_simple_mqueue(_) ->
@@ -534,8 +538,8 @@ drain(Q) ->
 drain_numeric_payloads(Q) ->
     [{Topic, binary_to_integer(Payload)} || {Topic, Payload} <- drain(Q)].
 
-set_mqueue_counters(Q, Len, Bytes) ->
-    setelement(5, setelement(4, Q, Len), Bytes).
+set_mqueue_len(Q, Len) ->
+    setelement(4, Q, Len).
 
 mqueue_ts(#message{extra = #{mqueue_insert_ts := Ts}}) -> Ts.
 mqueue_prio(#message{extra = #{mqueue_priority := Prio}}) -> Prio.

--- a/apps/emqx/test/emqx_mqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_mqueue_SUITE.erl
@@ -34,31 +34,38 @@ t_in(_) ->
     Opts = #{max_len => 5, store_qos0 => true},
     Q = ?Q:init(Opts),
     ?assert(?Q:is_empty(Q)),
-    {_, Q1} = ?Q:in(#message{}, Q),
+    {_, Q1} = ?Q:in(#message{payload = <<>>}, Q),
     ?assertEqual(1, ?Q:len(Q1)),
-    {_, Q2} = ?Q:in(#message{qos = 1}, Q1),
+    {_, Q2} = ?Q:in(#message{qos = 1, payload = <<>>}, Q1),
     ?assertEqual(2, ?Q:len(Q2)),
-    {_, Q3} = ?Q:in(#message{qos = 2}, Q2),
-    {_, Q4} = ?Q:in(#message{}, Q3),
-    {_, Q5} = ?Q:in(#message{}, Q4),
+    {_, Q3} = ?Q:in(#message{qos = 2, payload = <<>>}, Q2),
+    {_, Q4} = ?Q:in(#message{payload = <<>>}, Q3),
+    {_, Q5} = ?Q:in(#message{payload = <<>>}, Q4),
     ?assertEqual(5, ?Q:len(Q5)).
 
 t_in_qos0(_) ->
     Opts = #{max_len => 5, store_qos0 => false},
     Q = ?Q:init(Opts),
-    {_, Q1} = ?Q:in(#message{qos = 0}, Q),
+    {_, Q1} = ?Q:in(#message{qos = 0, payload = <<>>}, Q),
     ?assert(?Q:is_empty(Q1)),
-    {_, Q2} = ?Q:in(#message{qos = 0}, Q1),
+    {_, Q2} = ?Q:in(#message{qos = 0, payload = <<>>}, Q1),
     ?assert(?Q:is_empty(Q2)).
 
 t_out(_) ->
     Opts = #{max_len => 5, store_qos0 => true},
     Q = ?Q:init(Opts),
     {empty, Q} = ?Q:out(Q),
-    {_, Q1} = ?Q:in(#message{}, Q),
+    {_, Q1} = ?Q:in(#message{payload = <<>>}, Q),
     {Value, Q2} = ?Q:out(Q1),
     ?assertEqual(0, ?Q:len(Q2)),
-    ?assertEqual({value, #message{}}, Value).
+    ?assertEqual({value, #message{payload = <<>>}}, Value).
+
+t_out_resets_stale_counters(_) ->
+    Q = ?Q:init(#{max_len => 5, store_qos0 => true}),
+    StaleQ = set_mqueue_counters(Q, 1, 42),
+    ?assertEqual(1, ?Q:len(StaleQ)),
+    ?assertEqual(42, ?Q:bytes_size(StaleQ)),
+    ?assertEqual({empty, Q}, ?Q:out(StaleQ)).
 
 t_simple_mqueue(_) ->
     Opts = #{max_len => 3, store_qos0 => false},
@@ -73,6 +80,30 @@ t_simple_mqueue(_) ->
     {{value, Msg}, Q5} = ?Q:out(Q4),
     ?assertEqual(<<"2">>, Msg#message.payload),
     ?assertEqual([{len, 2}, {max_len, 3}, {dropped, 1}], ?Q:stats(Q5)).
+
+t_bytes(_) ->
+    Opts = #{max_len => 2, store_qos0 => false},
+    Q = ?Q:init(Opts),
+    ?assertEqual(0, ?Q:bytes_size(Q)),
+    Msg1 = #message{topic = <<"x">>, qos = 1, payload = <<"1">>},
+    Msg2 = #message{topic = <<"x">>, qos = 1, payload = <<"22">>},
+    Msg3 = #message{topic = <<"x">>, qos = 1, payload = <<"333">>},
+    {_, Q1} = ?Q:in(Msg1, Q),
+    ?assertEqual(emqx_message:payload_size(Msg1), ?Q:bytes_size(Q1)),
+    {_, Q2} = ?Q:in(Msg2, Q1),
+    ?assertEqual(
+        emqx_message:payload_size(Msg1) + emqx_message:payload_size(Msg2),
+        ?Q:bytes_size(Q2)
+    ),
+    {Msg1, Q3} = ?Q:in(Msg3, Q2),
+    ?assertEqual(
+        emqx_message:payload_size(Msg2) + emqx_message:payload_size(Msg3),
+        ?Q:bytes_size(Q3)
+    ),
+    {{value, Msg2}, Q4} = ?Q:out(Q3),
+    ?assertEqual(emqx_message:payload_size(Msg3), ?Q:bytes_size(Q4)),
+    Q5 = ?Q:filter(fun(#message{payload = Payload}) -> Payload =:= <<"333">> end, Q3),
+    ?assertEqual(emqx_message:payload_size(Msg3), ?Q:bytes_size(Q5)).
 
 t_infinity_simple_mqueue(_) ->
     Opts = #{max_len => 0, store_qos0 => false},
@@ -106,15 +137,15 @@ t_priority_mqueue(_) ->
     Q = ?Q:init(Opts),
     ?assertEqual(3, ?Q:max_len(Q)),
     ?assert(?Q:is_empty(Q)),
-    {_, Q1} = ?Q:in(#message{qos = 1, topic = <<"t2">>}, Q),
-    {_, Q2} = ?Q:in(#message{qos = 1, topic = <<"t1">>}, Q1),
-    {_, Q3} = ?Q:in(#message{qos = 1, topic = <<"t3">>}, Q2),
+    {_, Q1} = ?Q:in(#message{qos = 1, topic = <<"t2">>, payload = <<>>}, Q),
+    {_, Q2} = ?Q:in(#message{qos = 1, topic = <<"t1">>, payload = <<>>}, Q1),
+    {_, Q3} = ?Q:in(#message{qos = 1, topic = <<"t3">>, payload = <<>>}, Q2),
     ?assertEqual(3, ?Q:len(Q3)),
-    {_, Q4} = ?Q:in(#message{qos = 1, topic = <<"t2">>}, Q3),
+    {_, Q4} = ?Q:in(#message{qos = 1, topic = <<"t2">>, payload = <<>>}, Q3),
     ?assertEqual(4, ?Q:len(Q4)),
-    {_, Q5} = ?Q:in(#message{qos = 1, topic = <<"t2">>}, Q4),
+    {_, Q5} = ?Q:in(#message{qos = 1, topic = <<"t2">>, payload = <<>>}, Q4),
     ?assertEqual(5, ?Q:len(Q5)),
-    {_, Q6} = ?Q:in(#message{qos = 1, topic = <<"t2">>}, Q5),
+    {_, Q6} = ?Q:in(#message{qos = 1, topic = <<"t2">>, payload = <<>>}, Q5),
     ?assertEqual(5, ?Q:len(Q6)),
     {{value, _Msg}, Q7} = ?Q:out(Q6),
     ?assertEqual(4, ?Q:len(Q7)).
@@ -141,7 +172,8 @@ t_priority_order(_) ->
     ],
     Q = lists:foldl(
         fun({Topic, Message}, Q) ->
-            element(2, ?Q:in(#message{topic = Topic, qos = 1, payload = Message}, Q))
+            Payload = integer_to_binary(Message),
+            element(2, ?Q:in(#message{topic = Topic, qos = 1, payload = Payload}, Q))
         end,
         ?Q:init(Opts),
         Messages
@@ -174,7 +206,7 @@ t_priority_order(_) ->
             {<<"t1">>, 9},
             {<<"t1">>, 10}
         ],
-        drain(Q)
+        drain_numeric_payloads(Q)
     ).
 
 t_priority_order2(_) ->
@@ -195,7 +227,8 @@ t_priority_order2(_) ->
     ],
     Q = lists:foldl(
         fun({Topic, Message}, Q) ->
-            element(2, ?Q:in(#message{topic = Topic, qos = 1, payload = Message}, Q))
+            Payload = integer_to_binary(Message),
+            element(2, ?Q:in(#message{topic = Topic, qos = 1, payload = Payload}, Q))
         end,
         ?Q:init(Opts),
         Messages
@@ -216,7 +249,7 @@ t_priority_order2(_) ->
             {<<"t1">>, 9},
             {<<"t1">>, 10}
         ],
-        drain(Q)
+        drain_numeric_payloads(Q)
     ).
 
 t_infinity_priority_mqueue(_) ->
@@ -497,6 +530,12 @@ drain(Q) ->
         {{value, #message{topic = T, payload = P}}, Q1} ->
             [{T, P} | drain(Q1)]
     end.
+
+drain_numeric_payloads(Q) ->
+    [{Topic, binary_to_integer(Payload)} || {Topic, Payload} <- drain(Q)].
+
+set_mqueue_counters(Q, Len, Bytes) ->
+    setelement(5, setelement(4, Q, Len), Bytes).
 
 mqueue_ts(#message{extra = #{mqueue_insert_ts := Ts}}) -> Ts.
 mqueue_prio(#message{extra = #{mqueue_priority := Prio}}) -> Prio.

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -1031,6 +1031,22 @@ max_packet_size_test_() ->
             )}
     ].
 
+session_buffered_payload_high_watermark_test_() ->
+    [
+        {"0 disables warning logs",
+            ?_assertEqual(ok, emqx_schema:validate_session_buffered_payload_high_watermark(0))},
+        {"bytesize units are accepted",
+            ?_assertEqual({ok, 1024}, typerefl:from_string(emqx_schema:bytesize(), <<"1KB">>))},
+        {"negative values are rejected",
+            ?_assertMatch(
+                {error, #{
+                    cause := session_buffered_payload_high_watermark_out_of_range,
+                    minimum := 0
+                }},
+                emqx_schema:validate_session_buffered_payload_high_watermark(-1)
+            )}
+    ].
+
 max_heap_size_test_() ->
     WordSize = erlang:system_info(wordsize),
     MaxWords = 128 * 1024 * 1024 * 1024 div WordSize,

--- a/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
+++ b/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
@@ -8,10 +8,122 @@
 -compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx_cm.hrl").
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
+
+t_a_top_status_idle(_) ->
+    with_session_buffer_mon(fun() ->
+        ?assertEqual(#{status => idle}, emqx_session_buffer_mon:top_status())
+    end).
+
+t_top_status_running_and_busy(Config) ->
+    with_session_buffer_mon(
+        fun() ->
+            OutFile = filename:join(?config(priv_dir, Config), "session-top-running.csv"),
+            TestPid = self(),
+            with_top_scan_mocks(
+                fun(_Nodes, _Count, _SortBy, _Timeout) ->
+                    TestPid ! top_scan_started,
+                    receive
+                        finish_top_scan -> {[], []}
+                    after 5000 ->
+                        error(timeout)
+                    end
+                end,
+                fun() ->
+                    Opts = #{count => 1, sort => total_payload_bytes, out => OutFile},
+                    {ok, Pid} = emqx_session_buffer_mon:run_top(Opts),
+                    receive
+                        top_scan_started -> ok
+                    after 1000 ->
+                        error(top_scan_not_started)
+                    end,
+                    ?assertEqual(
+                        #{
+                            status => running,
+                            pid => Pid,
+                            out => OutFile,
+                            count => 1,
+                            sort => total_payload_bytes
+                        },
+                        emqx_session_buffer_mon:top_status()
+                    ),
+                    ?assertEqual(
+                        {error, busy},
+                        emqx_session_buffer_mon:run_top(#{
+                            count => 1,
+                            sort => mqueue_length,
+                            out => OutFile
+                        })
+                    ),
+                    Pid ! finish_top_scan,
+                    ?assertMatch(
+                        #{status := completed, out := OutFile, rows := 0, partial := false},
+                        wait_top_status(completed, 100)
+                    )
+                end
+            )
+        end
+    ).
+
+t_top_status_completed(Config) ->
+    with_session_buffer_mon(fun() ->
+        OutFile = filename:join(?config(priv_dir, Config), "session-top-completed.csv"),
+        _ = file:delete(OutFile),
+        Row = top_row(<<"c1">>, 10, 100, 1),
+        try
+            with_top_scan_mocks(
+                fun(_Nodes, _Count, _SortBy, _Timeout) -> {[[Row]], []} end,
+                fun() ->
+                    ?assertMatch(
+                        {ok, _Pid},
+                        emqx_session_buffer_mon:run_top(#{
+                            count => 1,
+                            sort => total_payload_bytes,
+                            out => OutFile
+                        })
+                    ),
+                    ?assertMatch(
+                        #{status := completed, out := OutFile, rows := 1, partial := false},
+                        wait_top_status(completed, 100)
+                    )
+                end
+            )
+        after
+            _ = file:delete(OutFile)
+        end
+    end).
+
+t_top_status_failed_on_write_error(_) ->
+    with_session_buffer_mon(fun() ->
+        case file:open("/dev/full", [write, raw, binary]) of
+            {ok, IoDev} ->
+                ok = file:close(IoDev),
+                Row = top_row(<<"c1">>, 10, 100, 1),
+                with_top_scan_mocks(
+                    fun(_Nodes, _Count, _SortBy, _Timeout) -> {[[Row]], []} end,
+                    fun() ->
+                        ?assertMatch(
+                            {ok, _Pid},
+                            emqx_session_buffer_mon:run_top(#{
+                                count => 1,
+                                sort => total_payload_bytes,
+                                out => "/dev/full"
+                            })
+                        ),
+                        ?assertMatch(
+                            #{status := failed, out := "/dev/full", reason := enospc},
+                            wait_top_status(failed, 100)
+                        )
+                    end
+                );
+            {error, _} ->
+                {skip, no_dev_full}
+        end
+    end).
 
 t_scan_local_top_by_total_payload_bytes(_) ->
     with_chan_info_table(fun() ->
@@ -164,6 +276,19 @@ t_update_normalizes_missing_upgrade_conf(_) ->
         ok = emqx_session_buffer_mon:update(#{buffered_payload_high_watermark => 0})
     end.
 
+with_session_buffer_mon(Fun) ->
+    case whereis(emqx_session_buffer_mon) of
+        undefined ->
+            {ok, Pid} = emqx_session_buffer_mon:start_link(),
+            try
+                Fun()
+            after
+                ok = gen_server:stop(Pid)
+            end;
+        _Pid ->
+            Fun()
+    end.
+
 with_chan_info_table(Fun) ->
     case ets:info(?CHAN_INFO_TAB) of
         undefined ->
@@ -197,6 +322,47 @@ insert_channel_info(ClientId, Pid, MqueueLength, TotalPayloadBytes, InflightCoun
             ]
         }
     ).
+
+top_row(ClientId, MqueueLength, TotalPayloadBytes, InflightCount) ->
+    #{
+        clientid => ClientId,
+        pid => self(),
+        node => node(),
+        mqueue_length => MqueueLength,
+        total_payload_bytes => TotalPayloadBytes,
+        inflight_count => InflightCount
+    }.
+
+with_top_scan_mocks(LocalTopFun, TestFun) ->
+    ok = meck:new(emqx, [passthrough, no_link]),
+    ok = meck:new(emqx_bpapi, [passthrough, no_link]),
+    ok = meck:new(emqx_session_buffer_proto_v1, [passthrough, no_link]),
+    try
+        ok = meck:expect(emqx, running_nodes, fun() -> [node()] end),
+        ok = meck:expect(
+            emqx_bpapi,
+            nodes_supporting_bpapi_version,
+            fun(emqx_session_buffer, 1) -> [node()] end
+        ),
+        ok = meck:expect(emqx_session_buffer_proto_v1, local_top, LocalTopFun),
+        TestFun()
+    after
+        ok = meck:unload(emqx_session_buffer_proto_v1),
+        ok = meck:unload(emqx_bpapi),
+        ok = meck:unload(emqx)
+    end.
+
+wait_top_status(Expected, Attempts) when Attempts > 0 ->
+    Status = emqx_session_buffer_mon:top_status(),
+    case maps:get(status, Status) of
+        Expected ->
+            Status;
+        _ ->
+            timer:sleep(10),
+            wait_top_status(Expected, Attempts - 1)
+    end;
+wait_top_status(_Expected, 0) ->
+    emqx_session_buffer_mon:top_status().
 
 spawn_waiter() ->
     spawn(fun() ->

--- a/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
+++ b/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
@@ -97,6 +97,44 @@ t_top_status_completed(Config) ->
         end
     end).
 
+t_top_status_completed_partial_on_unsupported_node(Config) ->
+    with_session_buffer_mon(fun() ->
+        OutFile = filename:join(?config(priv_dir, Config), "session-top-partial.csv"),
+        _ = file:delete(OutFile),
+        OldNode = 'old-emqx@127.0.0.1',
+        Row = top_row(<<"c1">>, 10, 100, 1),
+        try
+            with_top_scan_mocks(
+                [node(), OldNode],
+                [node()],
+                fun([Node], _Count, _SortBy, _Timeout) when Node =:= node() -> {[[Row]], []} end,
+                fun() ->
+                    ?assertMatch(
+                        {ok, _Pid},
+                        emqx_session_buffer_mon:run_top(#{
+                            count => 1,
+                            sort => total_payload_bytes,
+                            out => OutFile
+                        })
+                    ),
+                    ?assertMatch(
+                        #{
+                            status := completed,
+                            out := OutFile,
+                            rows := 1,
+                            partial := true,
+                            bad_nodes := [OldNode],
+                            bad_replies := []
+                        },
+                        wait_top_status(completed, 100)
+                    )
+                end
+            )
+        after
+            _ = file:delete(OutFile)
+        end
+    end).
+
 t_top_status_failed_on_write_error(_) ->
     with_session_buffer_mon(fun() ->
         case file:open("/dev/full", [write, raw, binary]) of
@@ -334,15 +372,18 @@ top_row(ClientId, MqueueLength, TotalPayloadBytes, InflightCount) ->
     }.
 
 with_top_scan_mocks(LocalTopFun, TestFun) ->
+    with_top_scan_mocks([node()], [node()], LocalTopFun, TestFun).
+
+with_top_scan_mocks(RunningNodes, SupportedNodes, LocalTopFun, TestFun) ->
     ok = meck:new(emqx, [passthrough, no_link]),
     ok = meck:new(emqx_bpapi, [passthrough, no_link]),
     ok = meck:new(emqx_session_buffer_proto_v1, [passthrough, no_link]),
     try
-        ok = meck:expect(emqx, running_nodes, fun() -> [node()] end),
+        ok = meck:expect(emqx, running_nodes, fun() -> RunningNodes end),
         ok = meck:expect(
             emqx_bpapi,
             nodes_supporting_bpapi_version,
-            fun(emqx_session_buffer, 1) -> [node()] end
+            fun(emqx_session_buffer, 1) -> SupportedNodes end
         ),
         ok = meck:expect(emqx_session_buffer_proto_v1, local_top, LocalTopFun),
         TestFun()

--- a/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
+++ b/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
@@ -140,6 +140,30 @@ t_maybe_log_uses_supported_throttle_key(_) ->
         ok = emqx_session_buffer_mon:update(#{buffered_payload_high_watermark => 0})
     end.
 
+t_update_normalizes_missing_upgrade_conf(_) ->
+    try
+        ok = emqx_session_buffer_mon:update(undefined),
+        ?assertEqual(
+            #{buffered_payload_high_watermark => 0},
+            persistent_term:get({emqx_session_buffer_mon, conf})
+        ),
+        ok = emqx_session_buffer_mon:update(#{buffered_payload_high_watermark => undefined}),
+        ?assertEqual(
+            #{buffered_payload_high_watermark => 0},
+            persistent_term:get({emqx_session_buffer_mon, conf})
+        ),
+        ?assertEqual(
+            ok,
+            emqx_session_buffer_mon:maybe_log(
+                <<"c1">>,
+                self(),
+                [{mqueue_len, 1}, {inflight_cnt, 1}, {total_payload_bytes, 2}]
+            )
+        )
+    after
+        ok = emqx_session_buffer_mon:update(#{buffered_payload_high_watermark => 0})
+    end.
+
 with_chan_info_table(Fun) ->
     case ets:info(?CHAN_INFO_TAB) of
         undefined ->

--- a/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
+++ b/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
@@ -186,6 +186,22 @@ t_scan_local_top_by_total_payload_bytes(_) ->
         end
     end).
 
+t_local_top_scans_without_server(_) ->
+    without_session_buffer_mon(fun() ->
+        with_chan_info_table(fun() ->
+            Pid = spawn_waiter(),
+            try
+                insert_channel_info(<<"c1">>, Pid, 10, 100, 1),
+                ?assertMatch(
+                    [#{clientid := <<"c1">>, total_payload_bytes := 100}],
+                    emqx_session_buffer_mon:local_top(1, total_payload_bytes)
+                )
+            after
+                stop_waiter(Pid)
+            end
+        end)
+    end).
+
 t_scan_local_top_by_mqueue_length(_) ->
     with_chan_info_table(fun() ->
         Pid1 = spawn_waiter(),
@@ -324,6 +340,15 @@ with_session_buffer_mon(Fun) ->
                 ok = gen_server:stop(Pid)
             end;
         _Pid ->
+            Fun()
+    end.
+
+without_session_buffer_mon(Fun) ->
+    case whereis(emqx_session_buffer_mon) of
+        undefined ->
+            Fun();
+        Pid ->
+            ok = gen_server:stop(Pid),
             Fun()
     end.
 

--- a/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
+++ b/apps/emqx/test/emqx_session_buffer_mon_SUITE.erl
@@ -1,0 +1,185 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_session_buffer_mon_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("emqx/include/emqx_cm.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+t_scan_local_top_by_total_payload_bytes(_) ->
+    with_chan_info_table(fun() ->
+        Pid1 = spawn_waiter(),
+        Pid2 = spawn_waiter(),
+        Pid3 = spawn_waiter(),
+        try
+            insert_channel_info(<<"c1">>, Pid1, 10, 100, 1),
+            insert_channel_info(<<"c2">>, Pid2, 5, 300, 2),
+            insert_channel_info(<<"c3">>, Pid3, 20, 200, 3),
+            ?assertMatch(
+                [
+                    #{clientid := <<"c2">>, total_payload_bytes := 300},
+                    #{clientid := <<"c3">>, total_payload_bytes := 200}
+                ],
+                emqx_session_buffer_mon:scan_local(2, total_payload_bytes)
+            )
+        after
+            stop_waiter(Pid1),
+            stop_waiter(Pid2),
+            stop_waiter(Pid3)
+        end
+    end).
+
+t_scan_local_top_by_mqueue_length(_) ->
+    with_chan_info_table(fun() ->
+        Pid1 = spawn_waiter(),
+        Pid2 = spawn_waiter(),
+        Pid3 = spawn_waiter(),
+        try
+            insert_channel_info(<<"c1">>, Pid1, 10, 100, 1),
+            insert_channel_info(<<"c2">>, Pid2, 5, 300, 2),
+            insert_channel_info(<<"c3">>, Pid3, 20, 200, 3),
+            ?assertMatch(
+                [
+                    #{clientid := <<"c3">>, mqueue_length := 20},
+                    #{clientid := <<"c1">>, mqueue_length := 10}
+                ],
+                emqx_session_buffer_mon:scan_local(2, mqueue_length)
+            )
+        after
+            stop_waiter(Pid1),
+            stop_waiter(Pid2),
+            stop_waiter(Pid3)
+        end
+    end).
+
+t_scan_local_top_with_equal_values(_) ->
+    with_chan_info_table(fun() ->
+        Pid1 = spawn_waiter(),
+        Pid2 = spawn_waiter(),
+        Pid3 = spawn_waiter(),
+        try
+            insert_channel_info(<<"c1">>, Pid1, 10, 100, 1),
+            insert_channel_info(<<"c2">>, Pid2, 10, 100, 1),
+            insert_channel_info(<<"c3">>, Pid3, 10, 100, 1),
+            ?assertMatch(
+                [
+                    #{clientid := <<"c3">>, mqueue_length := 10},
+                    #{clientid := <<"c2">>, mqueue_length := 10}
+                ],
+                emqx_session_buffer_mon:scan_local(2, mqueue_length)
+            )
+        after
+            stop_waiter(Pid1),
+            stop_waiter(Pid2),
+            stop_waiter(Pid3)
+        end
+    end).
+
+t_csv_rows(_) ->
+    Row = #{
+        clientid => <<"c,1\"">>,
+        pid => self(),
+        node => node(),
+        mqueue_length => 2,
+        total_payload_bytes => 10,
+        inflight_count => 1
+    },
+    ?assertEqual(
+        iolist_to_binary([
+            <<"\"c,1\"\"\",">>,
+            pid_to_list(self()),
+            <<",">>,
+            atom_to_binary(node(), utf8),
+            <<",2,10,1\n">>
+        ]),
+        iolist_to_binary(emqx_session_buffer_mon:csv_rows([Row]))
+    ).
+
+t_result_rows_keeps_bad_replies(_) ->
+    Row = #{
+        clientid => <<"c1">>,
+        pid => self(),
+        node => node(),
+        mqueue_length => 1,
+        total_payload_bytes => 10,
+        inflight_count => 0
+    },
+    ?assertEqual(
+        {[Row], [nodedown, unexpected]},
+        emqx_session_buffer_mon:result_rows([[Row], {badrpc, nodedown}, unexpected])
+    ).
+
+t_write_csv_reports_write_error(_) ->
+    case file:open("/dev/full", [write, raw, binary]) of
+        {ok, IoDev} ->
+            ok = file:close(IoDev),
+            ?assertEqual({error, enospc}, emqx_session_buffer_mon:write_csv("/dev/full", []));
+        {error, _} ->
+            {skip, no_dev_full}
+    end.
+
+t_maybe_log_uses_supported_throttle_key(_) ->
+    try
+        ok = emqx_session_buffer_mon:update(#{buffered_payload_high_watermark => 1}),
+        ?assertEqual(
+            ok,
+            emqx_session_buffer_mon:maybe_log(
+                <<"c1">>,
+                self(),
+                [{mqueue_len, 1}, {inflight_cnt, 1}, {total_payload_bytes, 2}]
+            )
+        )
+    after
+        ok = emqx_session_buffer_mon:update(#{buffered_payload_high_watermark => 0})
+    end.
+
+with_chan_info_table(Fun) ->
+    case ets:info(?CHAN_INFO_TAB) of
+        undefined ->
+            _ = ets:new(?CHAN_INFO_TAB, [named_table, public, ordered_set]),
+            try
+                Fun()
+            after
+                ets:delete(?CHAN_INFO_TAB)
+            end;
+        _ ->
+            Saved = ets:tab2list(?CHAN_INFO_TAB),
+            ets:delete_all_objects(?CHAN_INFO_TAB),
+            try
+                Fun()
+            after
+                ets:delete_all_objects(?CHAN_INFO_TAB),
+                _ = [ets:insert(?CHAN_INFO_TAB, Row) || Row <- Saved]
+            end
+    end.
+
+insert_channel_info(ClientId, Pid, MqueueLength, TotalPayloadBytes, InflightCount) ->
+    ets:insert(
+        ?CHAN_INFO_TAB,
+        {
+            {ClientId, Pid},
+            #{},
+            [
+                {mqueue_len, MqueueLength},
+                {total_payload_bytes, TotalPayloadBytes},
+                {inflight_cnt, InflightCount}
+            ]
+        }
+    ).
+
+spawn_waiter() ->
+    spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end).
+
+stop_waiter(Pid) ->
+    Pid ! stop.

--- a/apps/emqx/test/emqx_session_mem_SUITE.erl
+++ b/apps/emqx/test/emqx_session_mem_SUITE.erl
@@ -116,6 +116,35 @@ t_session_stats(_) ->
         maps:from_list(Stats)
     ).
 
+t_session_buffer_bytes_stats(_) ->
+    MqueueMsg = emqx_message:make(<<"clientid">>, ?QOS_1, <<"mqueue/topic">>, <<"queued">>),
+    InflightMsg = emqx_message:make(
+        <<"clientid">>, ?QOS_1, <<"inflight/topic">>, <<"inflight">>
+    ),
+    {undefined, MQueue} = emqx_mqueue:in(
+        MqueueMsg,
+        emqx_mqueue:init(#{max_len => 10, store_qos0 => false})
+    ),
+    Inflight = emqx_inflight:insert(
+        1,
+        emqx_session_mem:with_ts(InflightMsg),
+        emqx_inflight:new(10)
+    ),
+    Stats = maps:from_list(
+        emqx_session_mem:stats(
+            session(#{
+                mqueue => MQueue,
+                inflight => Inflight
+            })
+        )
+    ),
+    MqueueBytes = emqx_message:payload_size(MqueueMsg),
+    InflightBytes = emqx_message:payload_size(InflightMsg),
+    ?assertEqual(MqueueBytes + InflightBytes, maps:get(total_payload_bytes, Stats)),
+    ?assertNot(maps:is_key(mqueue_bytes, Stats)),
+    ?assertNot(maps:is_key(inflight_bytes, Stats)),
+    ?assertNot(maps:is_key(buffered_bytes, Stats)).
+
 t_session_inflight_query(_) ->
     EmptyInflight = emqx_inflight:new(500),
     Session = session(#{inflight => EmptyInflight}),

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -125,6 +125,7 @@
     retain_failed_for_rate_exceeded_limit,
     retained_fetch_rate_limit_exceeded,
     retained_delete_failed_for_rate_exceeded_limit,
+    session_buffer_high_watermark,
     socket_receive_paused_by_rate_limit,
     streams_message_db_key_expression_error,
     %% ==== message transformation/validation ====

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -586,6 +586,7 @@ fields(client) ->
             hoconsc:mk(integer(), #{
                 desc => ?DESC("mqueue_dropped")
             })},
+        {total_payload_bytes, hoconsc:mk(integer(), #{desc => ?DESC("total_payload_bytes")})},
         {mqueue_len, hoconsc:mk(integer(), #{desc => ?DESC("mqueue_len")})},
         {mqueue_max,
             hoconsc:mk(integer(), #{
@@ -2008,6 +2009,7 @@ client_example() ->
         <<"mqueue_max">> => 1000,
         <<"send_oct">> => 31,
         <<"send_msg.dropped.queue_full">> => 0,
+        <<"total_payload_bytes">> => 0,
         <<"mqueue_len">> => 0,
         <<"heap_size">> => 610,
         <<"is_persistent">> => false,

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1791,10 +1791,11 @@ format_channel_info(WhichNode, {_, ClientInfo0, ClientStats}, Opts) ->
         maps:get(conninfo, ClientInfo0)
     ),
     ClientInfo1 = ClientInfo0#{conninfo := ConnInfo},
-    StatsMap = maps:without(
+    StatsMap0 = maps:without(
         [memory, next_pkt_id, total_heap_size],
         maps:from_list(ClientStats)
     ),
+    StatsMap = maps:merge(#{total_payload_bytes => 0}, StatsMap0),
     ClientInfo2 = maps:remove(will_msg, ClientInfo1),
     ClientInfoMap0 = maps:fold(fun take_maps_from_inner/3, #{}, ClientInfo2),
     {IpAddress, Port} = peername_dispart(maps:get(peername, ClientInfoMap0)),

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -23,6 +23,7 @@
     broker/1,
     cluster/1,
     clients/1,
+    'session-top'/1,
     topics/1,
     subscriptions/1,
     plugins/1,
@@ -253,6 +254,31 @@ clients(_) ->
             "--sleep controls delay between batches (default: 10ms).\n"},
         {"clients show <ClientId>", "Show a client"},
         {"clients kick <ClientId>", "Kick out a client"}
+    ]).
+
+'session-top'(Args) ->
+    case parse_session_top_args(Args) of
+        {ok, Opts} ->
+            case emqx_session_buffer_mon:run_top(Opts) of
+                {ok, _Pid} ->
+                    emqx_ctl:print(
+                        "Session top scan started. Results will be written to ~s~n",
+                        [maps:get(out, Opts)]
+                    );
+                {error, busy} ->
+                    emqx_ctl:print("[error] A session-top scan is already running.~n")
+            end;
+        {error, Msg} ->
+            emqx_ctl:print("[error] ~s~n", [Msg]),
+            session_top_usage()
+    end.
+
+session_top_usage() ->
+    emqx_ctl:usage([
+        {
+            "session-top --out <File> [--count <K>] [--sort <mqueue_length|total_payload_bytes>]",
+            "Write cluster top sessions by mqueue length or total payload bytes to a CSV file."
+        }
     ]).
 
 %%--------------------------------------------------------------------
@@ -1192,6 +1218,52 @@ validate_dump_stats_args(Opts) ->
         false ->
             {error, "Invalid parameters"}
     end.
+
+parse_session_top_args(Args) ->
+    maybe
+        {ok, Opts} ?=
+            collect_session_top_args(Args, #{
+                count => 10,
+                sort => total_payload_bytes
+            }),
+        ok ?= validate_session_top_args(Opts),
+        {ok, Opts}
+    end.
+
+collect_session_top_args([], Acc) ->
+    {ok, Acc};
+collect_session_top_args(["--out", Out | Rest], Acc) ->
+    collect_session_top_args(Rest, Acc#{out => Out});
+collect_session_top_args(["--count", CountStr | Rest], Acc) ->
+    case string:to_integer(CountStr) of
+        {Count, []} when Count > 0, Count =< 1000 ->
+            collect_session_top_args(Rest, Acc#{count => Count});
+        {Count, []} when Count > 1000 ->
+            {error, "Invalid count: maximum is 1000."};
+        _ ->
+            {error, io_lib:format("Invalid count: ~s. Must be a positive integer.", [CountStr])}
+    end;
+collect_session_top_args(["--sort", SortStr | Rest], Acc) ->
+    case parse_session_top_sort(SortStr) of
+        {ok, Sort} ->
+            collect_session_top_args(Rest, Acc#{sort => Sort});
+        error ->
+            {error, "Invalid sort key. Supported values are mqueue_length and total_payload_bytes."}
+    end;
+collect_session_top_args(Args, _Acc) ->
+    {error, io_lib:format("unknown arguments: ~p", [Args])}.
+
+parse_session_top_sort("mqueue_length") ->
+    {ok, mqueue_length};
+parse_session_top_sort("total_payload_bytes") ->
+    {ok, total_payload_bytes};
+parse_session_top_sort(_) ->
+    error.
+
+validate_session_top_args(#{out := _Out}) ->
+    ok;
+validate_session_top_args(_Opts) ->
+    {error, "--out <File> is required."}.
 
 %%--------------------------------------------------------------------
 %% @doc Durable storage

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -256,15 +256,14 @@ clients(_) ->
         {"clients kick <ClientId>", "Kick out a client"}
     ]).
 
+'session-top'(["status"]) ->
+    print_session_top_status(emqx_session_buffer_mon:top_status());
 'session-top'(Args) ->
     case parse_session_top_args(Args) of
         {ok, Opts} ->
             case emqx_session_buffer_mon:run_top(Opts) of
                 {ok, _Pid} ->
-                    emqx_ctl:print(
-                        "Session top scan started. Results will be written to ~s~n",
-                        [maps:get(out, Opts)]
-                    );
+                    print_session_top_started(Opts);
                 {error, busy} ->
                     emqx_ctl:print("[error] A session-top scan is already running.~n")
             end;
@@ -276,10 +275,87 @@ clients(_) ->
 session_top_usage() ->
     emqx_ctl:usage([
         {
+            "session-top status",
+            "Show status of the latest session-top scan."
+        },
+        {
             "session-top --out <File> [--count <K>] [--sort <mqueue_length|total_payload_bytes>]",
             "Write cluster top sessions by mqueue length or total payload bytes to a CSV file."
         }
     ]).
+
+print_session_top_started(Opts) ->
+    emqx_ctl:print(
+        "Session top scan started.~n"
+        "Status: running~n"
+        "Output: ~ts~n"
+        "Run 'emqx ctl session-top status' to check progress.~n",
+        [maps:get(out, Opts)]
+    ).
+
+print_session_top_status(#{status := idle}) ->
+    emqx_ctl:print("Status: idle~nNo session-top scan has been started.~n");
+print_session_top_status(#{
+    status := running,
+    pid := Pid,
+    out := OutFile,
+    count := Count,
+    sort := Sort
+}) ->
+    emqx_ctl:print(
+        "Status: running~n"
+        "Output: ~ts~n"
+        "Limit: ~B~n"
+        "Sort by: ~s~n"
+        "Worker: ~p~n",
+        [OutFile, Count, atom_to_list(Sort), Pid]
+    );
+print_session_top_status(
+    Status = #{
+        status := completed,
+        out := OutFile,
+        rows := Rows,
+        partial := Partial
+    }
+) ->
+    emqx_ctl:print(
+        "Status: completed~n"
+        "Output: ~ts~n"
+        "Result rows: ~B~n"
+        "Partial result: ~s~n",
+        [OutFile, Rows, yes_no(Partial)]
+    ),
+    print_session_top_bad_results(Status);
+print_session_top_status(
+    Status = #{
+        status := failed,
+        out := OutFile,
+        reason := Reason,
+        partial := Partial
+    }
+) ->
+    emqx_ctl:print(
+        "Status: failed~n"
+        "Output: ~ts~n"
+        "Reason: ~p~n"
+        "Partial result: ~s~n",
+        [OutFile, Reason, yes_no(Partial)]
+    ),
+    print_session_top_bad_results(Status).
+
+print_session_top_bad_results(Status) ->
+    BadNodes = maps:get(bad_nodes, Status, []),
+    BadReplies = maps:get(bad_replies, Status, []),
+    maybe_print_session_top_bad_results("Bad nodes", BadNodes),
+    maybe_print_session_top_bad_results("Bad replies", BadReplies).
+
+maybe_print_session_top_bad_results(_Label, []) ->
+    ok;
+maybe_print_session_top_bad_results(Label, Values) ->
+    emqx_ctl:print("~s: ~p~n", [Label, Values]).
+
+yes_no(true) -> "yes";
+yes_no(false) -> "no".
 
 %%--------------------------------------------------------------------
 %% @private Dump client statistics to CSV file

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -158,6 +158,8 @@ end_per_group(Group, Config) when
 end_per_group(_Group, _Config) ->
     ok.
 
+init_per_testcase(t_format_old_style_client_stats_defaults_total_payload_bytes, Config) ->
+    Config;
 init_per_testcase(_TC, Config) ->
     %% NOTE
     %% Wait until there are no stale clients data before running the testcase.
@@ -174,6 +176,8 @@ init_per_testcase(_TC, Config) ->
     ok = snabbkaffe:start_trace(),
     Config.
 
+end_per_testcase(t_format_old_style_client_stats_defaults_total_payload_bytes, _Config) ->
+    ok;
 end_per_testcase(TC, _Config) when
     TC =:= t_inflight_messages;
     TC =:= t_mqueue_messages
@@ -1003,6 +1007,36 @@ t_query_clients_with_fields(Config) ->
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=bad_field_name")),
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=all,bad_field_name")),
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=all,username,clientid")).
+
+t_format_old_style_client_stats_defaults_total_payload_bytes(_) ->
+    ClientId = <<"old-style-client-stats">>,
+    ChanInfo = old_style_chan_info(ClientId, _Stats = [{mqueue_len, 0}]),
+    ?assertEqual(
+        #{clientid => ClientId, total_payload_bytes => 0},
+        emqx_mgmt_api_clients:format_channel_info(
+            node(),
+            ChanInfo,
+            #{fields => [clientid, total_payload_bytes]}
+        )
+    ),
+    ?assertMatch(
+        #{clientid := ClientId, total_payload_bytes := 0},
+        emqx_mgmt_api_clients:format_channel_info(node(), ChanInfo, #{fields => all})
+    ).
+
+old_style_chan_info(ClientId, Stats) ->
+    ClientInfo = #{
+        clientid => ClientId,
+        username => undefined,
+        conn_state => connected,
+        conninfo => #{
+            clientid => ClientId,
+            username => undefined,
+            peername => {{127, 0, 0, 1}, 1883},
+            expiry_interval => 0
+        }
+    },
+    {{ClientId, self()}, ClientInfo, Stats}.
 
 get_clients_all_fields(Auth, Qs) ->
     get_clients(Auth, Qs, false, false).

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -981,6 +981,15 @@ t_query_clients_with_fields(Config) ->
         [#{<<"clientid">> => ClientId, <<"username">> => Username}],
         get_clients_all_fields(Auth, "fields=clientid,username")
     ),
+    ?assertEqual(
+        [
+            #{
+                <<"clientid">> => ClientId,
+                <<"total_payload_bytes">> => 0
+            }
+        ],
+        get_clients_all_fields(Auth, "fields=clientid,total_payload_bytes")
+    ),
 
     AllFields = get_clients_all_fields(Auth, "fields=all"),
     DefaultFields = get_clients_all_fields(Auth, ""),

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1176,6 +1176,7 @@ t_mqueue_messages(Config) ->
     Topic = <<"t/test_mqueue_msgs">>,
     Count = emqx_mgmt:default_row_limit(),
     ok = client_with_mqueue(ClientId, Topic, Count),
+    assert_total_payload_bytes(ClientId, payloads_bytes(Count), Config),
     Path = emqx_mgmt_api_test_util:api_path(["clients", ClientId, "mqueue_messages"]),
     ?assert(Count =< emqx:get_config([mqtt, max_mqueue_len])),
 
@@ -1248,6 +1249,35 @@ publish_msgs(Topic, Count) ->
         end,
         lists:seq(1, Count)
     ).
+
+assert_total_payload_bytes(ClientId, ExpectedBytes, Config) ->
+    ?retry(100, 20, begin
+        ?assertMatch(
+            {ok, {?HTTP200, _, #{<<"total_payload_bytes">> := ExpectedBytes}}},
+            get_client_request(ClientId, Config)
+        ),
+        ?assertMatch(
+            {ok,
+                {?HTTP200, _, #{
+                    <<"data">> := [
+                        #{
+                            <<"clientid">> := ClientId,
+                            <<"total_payload_bytes">> := ExpectedBytes
+                        }
+                    ]
+                }}},
+            list_request(
+                [
+                    {"clientid", ClientId},
+                    {"fields", "clientid,total_payload_bytes"}
+                ],
+                Config
+            )
+        )
+    end).
+
+payloads_bytes(Count) ->
+    lists:sum([byte_size(integer_to_binary(Seq)) || Seq <- lists:seq(1, Count)]).
 
 test_messages(Path, Topic, Count, AuthHeader, PayloadEncoding, IsMqueue) ->
     Qs0 = io_lib:format("payload=~s", [PayloadEncoding]),

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -157,6 +157,40 @@ t_session_top_status_running_labels(_Config) ->
         end
     ).
 
+t_session_top_invalid_args(_Config) ->
+    {ok, MissingOut} = capture_ctl(["session-top"]),
+    ?assertEqual(match, re:run(MissingOut, <<"--out <File> is required">>, [{capture, none}])),
+    ?assertEqual(match, re:run(MissingOut, <<"session-top --out <File>">>, [{capture, none}])),
+
+    {ok, InvalidCount} = capture_ctl([
+        "session-top",
+        "--out",
+        "/tmp/session-top.csv",
+        "--count",
+        "1001"
+    ]),
+    ?assertEqual(
+        match,
+        re:run(InvalidCount, <<"Invalid count: maximum is 1000">>, [
+            {capture, none}
+        ])
+    ),
+
+    {ok, InvalidSort} = capture_ctl([
+        "session-top",
+        "--out",
+        "/tmp/session-top.csv",
+        "--sort",
+        "mailbox_len"
+    ]),
+    ?assertEqual(match, re:run(InvalidSort, <<"Invalid sort key">>, [{capture, none}])),
+    ?assertEqual(
+        match,
+        re:run(InvalidSort, <<"mqueue_length and total_payload_bytes">>, [
+            {capture, none}
+        ])
+    ).
+
 t_session_top(Config) ->
     OutFile = filename:join(?config(priv_dir, Config), "session-top.csv"),
     _ = file:delete(OutFile),

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -8,6 +8,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/emqx_cm.hrl").
 -include_lib("snabbkaffe/include/test_macros.hrl").
 
 -define(ON(NODES, BODY),
@@ -122,6 +123,61 @@ t_clients(_Config) ->
     %% clients show <ClientId> # Show a client
     %% clients kick <ClientId> # Kick out a client
     ok.
+
+t_session_top(Config) ->
+    OutFile = filename:join(?config(priv_dir, Config), "session-top.csv"),
+    _ = file:delete(OutFile),
+    Rows = [
+        {<<"session-top-c1">>, 10, 1000000001, 1},
+        {<<"session-top-c2">>, 5, 1000000003, 2},
+        {<<"session-top-c3">>, 20, 1000000002, 3}
+    ],
+    lists:foreach(fun insert_session_top_row/1, Rows),
+    try
+        ?assertEqual(
+            ok,
+            emqx_ctl:run_command([
+                "session-top",
+                "--out",
+                OutFile,
+                "--count",
+                "2",
+                "--sort",
+                "total_payload_bytes"
+            ])
+        ),
+        {ok, CSV} = wait_csv_rows(OutFile, 3, 100),
+        [
+            <<"clientid,pid,node,mqueue_length,total_payload_bytes,inflight_count">>,
+            Row1,
+            Row2
+        ] = binary:split(CSV, <<"\n">>, [global, trim_all]),
+        ?assertEqual(
+            [
+                <<"session-top-c2">>,
+                pid_to_list_bin(self()),
+                atom_to_binary(node(), utf8),
+                <<"5">>,
+                <<"1000000003">>,
+                <<"2">>
+            ],
+            binary:split(Row1, <<",">>, [global])
+        ),
+        ?assertEqual(
+            [
+                <<"session-top-c3">>,
+                pid_to_list_bin(self()),
+                atom_to_binary(node(), utf8),
+                <<"20">>,
+                <<"1000000002">>,
+                <<"3">>
+            ],
+            binary:split(Row2, <<",">>, [global])
+        )
+    after
+        [ets:delete(?CHAN_INFO_TAB, {ClientId, self()}) || {ClientId, _, _, _} <- Rows],
+        _ = file:delete(OutFile)
+    end.
 
 t_routes(_Config) ->
     %% routes list         # List all routes
@@ -639,6 +695,37 @@ dump_client_stats(File, Batch, Sleep) ->
         "--sleep",
         str(Sleep)
     ]).
+
+insert_session_top_row({ClientId, MqueueLength, TotalPayloadBytes, InflightCount}) ->
+    ok = emqx_cm:insert_channel_info(
+        ClientId,
+        #{},
+        [
+            {mqueue_len, MqueueLength},
+            {total_payload_bytes, TotalPayloadBytes},
+            {inflight_cnt, InflightCount}
+        ]
+    ).
+
+wait_csv_rows(File, ExpectedRows, Attempts) when Attempts > 0 ->
+    case file:read_file(File) of
+        {ok, Bin} ->
+            case length(binary:split(Bin, <<"\n">>, [global, trim_all])) >= ExpectedRows of
+                true ->
+                    {ok, Bin};
+                false ->
+                    timer:sleep(10),
+                    wait_csv_rows(File, ExpectedRows, Attempts - 1)
+            end;
+        _ ->
+            timer:sleep(10),
+            wait_csv_rows(File, ExpectedRows, Attempts - 1)
+    end;
+wait_csv_rows(File, _ExpectedRows, 0) ->
+    file:read_file(File).
+
+pid_to_list_bin(Pid) ->
+    list_to_binary(pid_to_list(Pid)).
 
 str(I) when is_integer(I) -> integer_to_list(I);
 str(L) when is_list(L) -> L.

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -124,6 +124,39 @@ t_clients(_Config) ->
     %% clients kick <ClientId> # Kick out a client
     ok.
 
+t_a_session_top_status_idle(_Config) ->
+    {ok, Output} = capture_ctl(["session-top", "status"]),
+    ?assertEqual(match, re:run(Output, <<"Status: idle">>, [{capture, none}])),
+    ?assertEqual(
+        match,
+        re:run(Output, <<"No session-top scan has been started">>, [{capture, none}])
+    ).
+
+t_session_top_status_running_labels(_Config) ->
+    emqx_common_test_helpers:with_mock(
+        emqx_session_buffer_mon,
+        top_status,
+        fun() ->
+            #{
+                status => running,
+                pid => self(),
+                out => "/tmp/session-top.csv",
+                count => 10,
+                sort => total_payload_bytes
+            }
+        end,
+        fun() ->
+            {ok, Output} = capture_ctl(["session-top", "status"]),
+            ?assertEqual(match, re:run(Output, <<"Status: running">>, [{capture, none}])),
+            ?assertEqual(match, re:run(Output, <<"Limit: 10">>, [{capture, none}])),
+            ?assertEqual(
+                match, re:run(Output, <<"Sort by: total_payload_bytes">>, [{capture, none}])
+            ),
+            ?assertEqual(nomatch, re:run(Output, <<"Count:">>, [{capture, none}])),
+            ?assertEqual(nomatch, re:run(Output, <<"Sort:">>, [{capture, none}]))
+        end
+    ).
+
 t_session_top(Config) ->
     OutFile = filename:join(?config(priv_dir, Config), "session-top.csv"),
     _ = file:delete(OutFile),
@@ -134,19 +167,25 @@ t_session_top(Config) ->
     ],
     lists:foreach(fun insert_session_top_row/1, Rows),
     try
-        ?assertEqual(
-            ok,
-            emqx_ctl:run_command([
-                "session-top",
-                "--out",
-                OutFile,
-                "--count",
-                "2",
-                "--sort",
-                "total_payload_bytes"
-            ])
-        ),
+        {ok, StartOutput} = capture_ctl([
+            "session-top",
+            "--out",
+            OutFile,
+            "--count",
+            "2",
+            "--sort",
+            "total_payload_bytes"
+        ]),
+        ?assertEqual(match, re:run(StartOutput, <<"Session top scan started">>, [{capture, none}])),
+        ?assertEqual(match, re:run(StartOutput, <<"Status: running">>, [{capture, none}])),
+        ?assertEqual(match, re:run(StartOutput, <<"session-top status">>, [{capture, none}])),
         {ok, CSV} = wait_csv_rows(OutFile, 3, 100),
+        StatusOutput = wait_session_top_status(<<"Status: completed">>, 100),
+        ?assertEqual(match, re:run(StatusOutput, <<"Status: completed">>, [{capture, none}])),
+        ?assertEqual(match, re:run(StatusOutput, <<"Result rows: 2">>, [{capture, none}])),
+        ?assertEqual(match, re:run(StatusOutput, <<"Partial result: no">>, [{capture, none}])),
+        ?assertEqual(nomatch, re:run(StatusOutput, <<"Rows:">>, [{capture, none}])),
+        ?assertEqual(nomatch, re:run(StatusOutput, <<"Partial:">>, [{capture, none}])),
         [
             <<"clientid,pid,node,mqueue_length,total_payload_bytes,inflight_count">>,
             Row1,
@@ -695,6 +734,24 @@ dump_client_stats(File, Batch, Sleep) ->
         "--sleep",
         str(Sleep)
     ]).
+
+capture_ctl(Args) ->
+    {Result, OutputChunks} =
+        emqx_common_test_helpers:capture_io_format(fun() -> emqx_ctl:run_command(Args) end),
+    {Result, iolist_to_binary(OutputChunks)}.
+
+wait_session_top_status(Expected, Attempts) when Attempts > 0 ->
+    {ok, Output} = capture_ctl(["session-top", "status"]),
+    case re:run(Output, Expected, [{capture, none}]) of
+        match ->
+            Output;
+        nomatch ->
+            timer:sleep(10),
+            wait_session_top_status(Expected, Attempts - 1)
+    end;
+wait_session_top_status(_Expected, 0) ->
+    {ok, Output} = capture_ctl(["session-top", "status"]),
+    Output.
 
 insert_session_top_row({ClientId, MqueueLength, TotalPayloadBytes, InflightCount}) ->
     ok = emqx_cm:insert_channel_info(

--- a/changes/ee/feat-17396.en.md
+++ b/changes/ee/feat-17396.en.md
@@ -1,0 +1,7 @@
+Added observability for bytes held by MQTT session buffers.
+
+The client list API now reports `total_payload_bytes`, the MQTT payload bytes retained by an in-memory session's message queue and inflight window. Durable sessions report `0` for this field.
+
+Added `sysmon.session.buffered_payload_high_watermark` for throttled warning logs when one in-memory session keeps more payload bytes than the configured threshold. Set it to `0` to disable the warning log.
+
+Added `emqx ctl session-top --out <File>` to scan the cluster and write top sessions by `total_payload_bytes` or `mqueue_length` to a CSV file.

--- a/rel/i18n/emqx_mgmt_api_clients.hocon
+++ b/rel/i18n/emqx_mgmt_api_clients.hocon
@@ -299,6 +299,11 @@ mqueue_dropped.desc:
 mqueue_dropped.label:
 """Mqueue Dropped"""
 
+total_payload_bytes.desc:
+"""MQTT payload bytes retained by the in-memory session mqueue and inflight window"""
+total_payload_bytes.label:
+"""Total Payload Bytes"""
+
 mqueue_len.desc:
 """Current length of send-buffer queue"""
 mqueue_len.label:

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1996,6 +1996,11 @@ socket_tcp_keepalive.label:
     - Check if intra-cluster network bandwidth is reaching a maximum.~"""
   }
 
+  sysmon_session_buffered_payload_high_watermark {
+    label: "Buffered Payload High Watermark"
+    desc: "Per-session total_payload_bytes threshold for emitting throttled warning logs. Set to 0 to disable the warning log."
+  }
+
   config_backup_interval {
     label: "Config Backup Interval"
     desc: """~


### PR DESCRIPTION
Fixes #17396

Design discussion: emqx/eip#110

Release version:
6.3.0

## Summary

This PR adds lightweight observability for payload bytes retained by MQTT sessions.

User-facing changes:

- The client list APIs expose `total_payload_bytes` for each session. For in-memory sessions, this is the MQTT payload bytes currently retained by the session mqueue and inflight window. Durable sessions report `0` because their backlog is not retained in the channel process in the same way.
- `sysmon.session.buffered_payload_high_watermark` controls throttled warning logs for a single in-memory session whose `total_payload_bytes` is above the configured threshold. The default is `0`, which disables the warning log.
- `emqx ctl session-top --out <File> [--count <K>] [--sort <mqueue_length|total_payload_bytes>]` scans the cluster on demand and writes a CSV file with `clientid,pid,node,mqueue_length,total_payload_bytes,inflight_count`. `--count` defaults to `10` and is capped at `1000`; `--out` is required to avoid large console output.

Implementation notes:

- In-memory sessions expose payload bytes through the existing channel stats cache. Mqueue payload bytes are derived from current mqueue contents when session stats are refreshed, and inflight payload bytes are derived from the bounded inflight window. This keeps the in-memory mqueue record shape compatible with existing session state; the mqueue part is O(mqueue_len) during stats refresh. APIs and `session-top` read cached stats from `emqx_channel_info` instead of asking every session process to inspect buffered messages.
- The warning check piggybacks on the existing channel stats update path and is O(1) per stats update after the stats are prepared. No EMQX alarms are created.
- `session-top` is handled by the named `emqx_session_buffer_mon` process. Each node scans local `emqx_channel_info` with a small batch sleep and keeps only the bounded top-K rows in memory before the caller merges cluster results.
- The top-K heap skips rows that cannot enter the current top-K set without deleting and reinserting the smallest row, and uses Erlang term ordering for tie-break keys instead of converting keys to binaries on every scanned row.
- This PR intentionally does not add node-level stats, Prometheus gauges, a management top-N endpoint, or periodic background aggregation.

Manual performance check:

- Used `mix run --no-start` to populate a synthetic `emqx_channel_info` cache and call `emqx_session_buffer_mon:scan_local/2` directly. This measures scanner cost over cached channel stats; real-node results can vary with actual ETS row size and node load.
- Direct local scan results after the top-K heap optimization:

| cached rows | top 10 by `total_payload_bytes` | top 1000 by `total_payload_bytes` | top 10 by `mqueue_length` | ETS table size |
|---:|---:|---:|---:|---:|
| 100,000 | 305 ms | 384 ms | 302 ms | 16.8 MB |
| 1,000,000 | 3.40 s | 3.79 s | 3.06 s | 167.9 MB |
| 2,000,000 | 6.40 s | 7.07 s | 6.16 s | 335.7 MB |

- Full async worker path with 2,000,000 cached rows and `--count 1000` wrote 1000 CSV rows in about 7.6 s when sorting by `total_payload_bytes`, and about 6.7 s when sorting by `mqueue_length`. The benchmark data setup took about 10 s and is not part of the runtime command cost.

Checked locally with `git diff --check`, `make test-compile`, `./scripts/apps-version-check.exs`, focused CT cases for message payload size, mqueue payload sizing, memory session stats, management API exposure, `session-top` CSV output, session-buffer warning checks, and session-buffer log throttling, plus the manual scanner benchmark above.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)