### PR TITLE
260601 clean stale cm registry record

### DIFF
--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -281,36 +281,48 @@ set_chan_stats(ClientId, ChanPid, Stats) when ?IS_CLIENTID(ClientId) ->
     | {error, Reason :: term()}.
 open_session(CleanStart, ClientInfo = #{clientid := ClientId}, ConnInfo, MaybeWillMsg) ->
     Pids = emqx_cm_registry:lookup_all_channels(ClientId),
-    {LocalAlive, LocalDown, Remote} = lists:foldl(
-        fun(Pid, {LA, LD, R}) ->
-            IsLocal = (node(Pid) =:= node()),
-            case {IsLocal, IsLocal andalso is_process_alive(Pid)} of
-                {true, true} ->
-                    {LA + 1, LD, R};
-                {true, false} ->
-                    {LA, LD + 1, R};
-                _ ->
-                    {LA, LD, R + 1}
-            end
-        end,
-        {0, 0, 0},
-        Pids
-    ),
-    case LocalDown > 0 of
-        true ->
+    {Local, Remote} = lists:partition(fun(Pid) -> node(Pid) =:= node() end, Pids),
+    {LocalAlive, LocalDown} = lists:partition(fun erlang:is_process_alive/1, Local),
+    LocalStillDown = drop_stale_local_rows(ClientId, LocalDown),
+    case LocalStillDown of
+        [_ | _] ->
             %% At least one old session is in the middle of getting cleaned up.
             %% i.e. emqx_cm_pool is busy handling the async clean_down messages.
             %% Do not accept this client ID in this node.
             ?SLOG(warning, #{
                 msg => "clientid_registration_throttled",
-                local_alive => LocalAlive,
-                local_down => LocalDown,
-                remote => Remote
+                local_alive => length(LocalAlive),
+                local_down => length(LocalStillDown),
+                remote => length(Remote)
             }),
             {error, client_id_unavailable};
-        false ->
+        [] ->
             do_open_session(CleanStart, ClientInfo, ConnInfo, MaybeWillMsg)
     end.
+
+%% A local dead pid in the registry is either:
+%%   (a) a channel that just exited; its DOWN is queued, emqx_cm_pool is
+%%       about to call do_unregister_channel and remove the row. The
+%%       chan-conn table still has its conn_mod entry. Throttle so the new
+%%       register does not race with the pending unregister.
+%%   (b) a tombstone: the row points at a pid that this node never
+%%       registered (or already cleaned up). No DOWN is coming, the
+%%       chan-conn table has no entry, and the throttle would block this
+%%       clientid on this node forever. Remove the stale row and let the
+%%       connect proceed.
+drop_stale_local_rows(ClientId, LocalDownPids) ->
+    lists:filter(
+        fun(DeadPid) ->
+            case do_get_chann_conn_mod(ClientId, DeadPid) of
+                undefined ->
+                    _ = emqx_cm_registry:unregister_channel({ClientId, DeadPid}),
+                    false;
+                _ConnMod ->
+                    true
+            end
+        end,
+        LocalDownPids
+    ).
 
 %% @private
 do_open_session(_CleanStart = true, ClientInfo = #{clientid := ClientId}, ConnInfo, MaybeWillMsg) ->

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -521,8 +521,7 @@ kick_session(ClientId, ChanPid) ->
 do_kick_session(Action, ClientId, ChanPid) when node(ChanPid) =:= node() ->
     case do_get_chann_conn_mod(ClientId, ChanPid) of
         undefined ->
-            %% already deregistered
-            ok;
+            ensure_stale_unregistered(ClientId, ChanPid);
         ConnMod when is_atom(ConnMod) ->
             %% NOTE: Ignoring any errors here.
             _ = request_stepdown(Action, ConnMod, ChanPid, ?T_KICK),
@@ -534,12 +533,24 @@ do_kick_session(Action, ClientId, ChanPid) when node(ChanPid) =:= node() ->
 do_takeover_kick_session_v3(ClientId, ChanPid) when node(ChanPid) =:= node() ->
     case do_get_chann_conn_mod(ClientId, ChanPid) of
         undefined ->
-            %% already deregistered
-            ok;
+            ensure_stale_unregistered(ClientId, ChanPid);
         ConnMod when is_atom(ConnMod) ->
             %% NOTE: Ignoring any errors here.
             _ = request_stepdown(takeover_kick, ConnMod, ChanPid, ?T_KICK),
             ok
+    end.
+
+%% The local channel-conn table has no entry for ChanPid.
+%% Either the channel never ran on this node (stale registry row from a
+%% lost dirty_delete during a partition + autoheal) or it exited and its
+%% unregister did not propagate. If the pid is no longer alive, delete the
+%% registry row so the cluster view converges; otherwise leave it alone.
+ensure_stale_unregistered(ClientId, ChanPid) ->
+    case erlang:is_process_alive(ChanPid) of
+        true ->
+            ok;
+        false ->
+            emqx_cm_registry:unregister_channel({ClientId, ChanPid})
     end.
 
 %% @private This function is shared for session `kick' and `discard' (as the first arg

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -563,6 +563,53 @@ t_do_kick_session_keeps_alive_pid(_) ->
         exit(AlivePid, kill)
     end.
 
+%% The open_session throttle protects against a real race: a channel exited,
+%% its DOWN is queued at emqx_cm, the cm pool is about to unregister it. The
+%% chan-conn table still has its conn_mod row. Reconnect must wait.
+t_open_session_throttled_on_inflight_local_cleanup(_) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    ClientInfo = #{
+        zone => default,
+        listener => 'tcp:default',
+        clientid => ClientId,
+        username => <<"username">>,
+        peerhost => {127, 0, 0, 1}
+    },
+    {DeadPid, MRef} = spawn_monitor(fun() -> exit(normal) end),
+    ChanInfo = ?ChanInfo,
+    #{conninfo := ConnInfo} = ChanInfo,
+    ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
+    ok = emqx_cm:register_channel(ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}),
+    ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
+    %% Idempotent cleanup in case cm pool didn't get there first.
+    ok = emqx_cm:do_unregister_channel({ClientId, DeadPid}).
+
+%% A stale local tombstone (registry row pointing at a dead pid that this
+%% node never registered) used to block the same clientid on this node
+%% forever: lookup_all_channels reports a local-down pid, throttle fires,
+%% no DOWN is ever queued, retry blocks again. The throttle must now
+%% recognize the row is stale (no chan-conn entry), reap it, and let the
+%% connect proceed. (open_session creates the session record; the new
+%% channel pid registers itself later via emqx_channel.)
+t_open_session_reaps_local_tombstone(_) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    ClientInfo = #{
+        zone => default,
+        listener => 'tcp:default',
+        clientid => ClientId,
+        username => <<"username">>,
+        peerhost => {127, 0, 0, 1}
+    },
+    #{conninfo := ConnInfo} = ?ChanInfo,
+    {DeadPid, MRef} = spawn_monitor(fun() -> exit(normal) end),
+    ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
+    ok = mria:dirty_write(?CHAN_REG_TAB, #channel{chid = ClientId, pid = DeadPid}),
+    ?assertEqual([DeadPid], emqx_cm_registry:lookup_all_channels(ClientId)),
+    ?assertMatch({ok, _}, open_session(true, ClientInfo, ConnInfo)),
+    %% Stale tombstone is gone; open_session does not register the new pid
+    %% (that happens later in the channel's connect handler).
+    ?assertEqual([], emqx_cm_registry:lookup_all_channels(ClientId)).
+
 spawn_dummy_chann(Mod, Count) ->
     #{conninfo := ConnInfo0} = ?ChanInfo,
     ConnInfo = ConnInfo0#{conn_mod => Mod},

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -523,6 +523,46 @@ t_clientid_registration_throttled(_) ->
     ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
     ok = emqx_cm:do_unregister_channel({ClientId, DeadPid}).
 
+%% Stale registry rows can survive a partition + autoheal (the unregister
+%% dirty_delete was on the loser side and got thrown away). When a kick or
+%% takeover-kick RPC subsequently lands on the node owning the dead pid,
+%% the local channel-conn table has no entry for it, so the handler used to
+%% return ok and leave the registry row behind. The handler must now delete
+%% the row so the duplicate doesn't persist.
+t_do_kick_session_cleans_stale_dead_pid(_) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    {DeadPid, MRef} = spawn_monitor(fun() -> exit(normal) end),
+    ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
+    ok = mria:dirty_write(?CHAN_REG_TAB, #channel{chid = ClientId, pid = DeadPid}),
+    ?assertEqual([DeadPid], emqx_cm_registry:lookup_all_channels(ClientId)),
+    ok = emqx_cm:do_kick_session(discard, ClientId, DeadPid),
+    ?assertEqual([], emqx_cm_registry:lookup_all_channels(ClientId)).
+
+t_do_takeover_kick_session_cleans_stale_dead_pid(_) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    {DeadPid, MRef} = spawn_monitor(fun() -> exit(normal) end),
+    ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
+    ok = mria:dirty_write(?CHAN_REG_TAB, #channel{chid = ClientId, pid = DeadPid}),
+    ?assertEqual([DeadPid], emqx_cm_registry:lookup_all_channels(ClientId)),
+    ok = emqx_cm:do_takeover_kick_session_v3(ClientId, DeadPid),
+    ?assertEqual([], emqx_cm_registry:lookup_all_channels(ClientId)).
+
+%% If the registry points at a still-living process that this node knows
+%% nothing about (no chan_conn entry), do NOT delete the row, since the
+%% process might be a real channel in some weird half-state.
+t_do_kick_session_keeps_alive_pid(_) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    AlivePid = erlang:spawn_link(fun() -> timer:sleep(60000) end),
+    try
+        ok = mria:dirty_write(?CHAN_REG_TAB, #channel{chid = ClientId, pid = AlivePid}),
+        ok = emqx_cm:do_kick_session(discard, ClientId, AlivePid),
+        ?assertEqual([AlivePid], emqx_cm_registry:lookup_all_channels(ClientId))
+    after
+        mria:dirty_delete_object(?CHAN_REG_TAB, #channel{chid = ClientId, pid = AlivePid}),
+        unlink(AlivePid),
+        exit(AlivePid, kill)
+    end.
+
 spawn_dummy_chann(Mod, Count) ->
     #{conninfo := ConnInfo0} = ?ChanInfo,
     ConnInfo = ConnInfo0#{conn_mod => Mod},

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -8,6 +8,7 @@
 -compile(nowarn_export_all).
 
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx/include/emqx_cm.hrl").
 -include_lib("emqx_utils/include/emqx_message.hrl").
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -737,7 +738,16 @@ t_connack_assigned_clientid(Config) ->
 t_connack_client_id_unavailable(Config) ->
     ConnFun = ?config(conn_fun, Config),
     ClientId = atom_to_binary(?FUNCTION_NAME),
+    %% Simulate the race the throttle protects against: a local channel
+    %% just exited, its CHAN_CONN_TAB row is still present (cm pool hasn't
+    %% drained the cleanup yet), and the same client tries to reconnect.
+    %% We bypass emqx_cm:register_channel/3 to keep no monitor on DeadPid
+    %% so the cm pool never drains, and the throttle stays firing for the
+    %% duration of the test.
     DeadPid = spawn(fun() -> exit(normal) end),
+    true = ets:insert(?CHAN_CONN_TAB, #chan_conn{
+        pid = DeadPid, mod = emqx_connection, clientid = ClientId
+    }),
     ok = emqx_cm_registry:register_channel({ClientId, DeadPid}),
     WillTopic = iolist_to_binary([atom_to_binary(?FUNCTION_NAME), "/will"]),
     NotWillMsg = #message{topic = WillTopic, payload = <<"NotWillMsg">>},
@@ -761,7 +771,8 @@ t_connack_client_id_unavailable(Config) ->
             ConnAck
         )
     after
-        ok = emqx_cm_registry:unregister_channel({ClientId, DeadPid})
+        ok = emqx_cm_registry:unregister_channel({ClientId, DeadPid}),
+        true = ets:delete(?CHAN_CONN_TAB, DeadPid)
     end,
     %% Assert no will message is published for server_busy CONNACK reason
     emqx_broker:publish(NotWillMsg),

--- a/changes/ee/fix-17424.en.md
+++ b/changes/ee/fix-17424.en.md
@@ -1,0 +1,3 @@
+Fixed a global session registry leak that could leave duplicate or stale entries for the same client ID after a network partition followed by Mnesia autoheal.
+Discard and takeover-kick RPC handlers now also remove the registry row when the target process is no longer alive, and the registration throttle on the connect
+path now recognizes tombstone rows (no local channel state) and reaps them instead of blocking new connections for the same client ID indefinitely.


### PR DESCRIPTION
Release version: 5.10.4

## Summary

session/channel registry records may leak if the 'delete' operation to the registry table is lost due to for example cluster network partition.
this results in consiquence:

A stale channel/session pid is never deleted even after cluster network split healed.

The fix is to delete stale records (pid is no longer alive) during takeover/kick.

NOTE: for random client IDs, the records may still leak, it will require a gc process to periodically scan the registry.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
