### PR TITLE
fix(jt808): allow empty registry/authentication URLs when allow_anonymous is true

### DIFF
--- a/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.app.src
+++ b/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway_jt808, [
     {description, "JT/T 808 Gateway"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
@@ -84,13 +84,13 @@ fields(anonymous_false) ->
             )}
     ] ++ fields_reg_auth_required(true).
 
-fields_reg_auth_required(Required) ->
+fields_reg_auth_required(true) ->
     [
         {registry,
             sc(binary(), #{
                 desc => ?DESC(registry_url),
                 validator => [?NOT_EMPTY("the value of the field 'registry' cannot be empty")],
-                required => Required
+                required => true
             })},
         {authentication,
             sc(
@@ -100,7 +100,23 @@ fields_reg_auth_required(Required) ->
                     validator => [
                         ?NOT_EMPTY("the value of the field 'authentication' cannot be empty")
                     ],
-                    required => Required
+                    required => true
+                }
+            )}
+    ];
+fields_reg_auth_required(false) ->
+    [
+        {registry,
+            sc(binary(), #{
+                desc => ?DESC(registry_url),
+                required => false
+            })},
+        {authentication,
+            sc(
+                binary(),
+                #{
+                    desc => ?DESC(authentication_url),
+                    required => false
                 }
             )}
     ].

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -103,7 +103,10 @@ init_per_testcase(Case = t_case02_anonymous_register_and_auth, Config) ->
     [{suite_apps, Apps} | Config];
 init_per_testcase(Case, Config) when
     Case =:= t_create_ALLOW_invalid_auth_config;
-    Case =:= t_create_DISALLOW_invalid_auth_config
+    Case =:= t_create_DISALLOW_invalid_auth_config;
+    Case =:= t_create_ALLOW_empty_reg_url;
+    Case =:= t_create_ALLOW_omitted_reg_url;
+    Case =:= t_create_DISALLOW_empty_reg_url
 ->
     Apps = boot_apps(Case, <<>>, Config),
     [{suite_apps, Apps} | Config];
@@ -2807,6 +2810,74 @@ test_invalid_config(CreateOrUpdate, AnonymousAllowed) ->
         }},
         UpdateResult
     ).
+
+%% allow_anonymous=true with empty registry/authentication URLs should succeed
+t_create_ALLOW_empty_reg_url(_Config) ->
+    test_allow_empty_or_omitted_reg_url(create, empty).
+
+t_update_ALLOW_empty_reg_url(_Config) ->
+    test_allow_empty_or_omitted_reg_url(update, empty).
+
+%% allow_anonymous=true with omitted registry/authentication URLs should succeed
+t_create_ALLOW_omitted_reg_url(_Config) ->
+    test_allow_empty_or_omitted_reg_url(create, omitted).
+
+t_update_ALLOW_omitted_reg_url(_Config) ->
+    test_allow_empty_or_omitted_reg_url(update, omitted).
+
+%% allow_anonymous=false with empty registry/authentication URLs should fail
+t_create_DISALLOW_empty_reg_url(_Config) ->
+    test_disallow_empty_reg_url(create).
+
+t_update_DISALLOW_empty_reg_url(_Config) ->
+    test_disallow_empty_reg_url(update).
+
+test_allow_empty_or_omitted_reg_url(CreateOrUpdate, EmptyOrOmitted) ->
+    Config = raw_jt808_anonymous_config(EmptyOrOmitted),
+    Result = create_or_update(CreateOrUpdate, Config),
+    ?assertMatch({ok, _}, Result).
+
+test_disallow_empty_reg_url(CreateOrUpdate) ->
+    Config = raw_jt808_disallow_empty_config(),
+    Result = create_or_update(CreateOrUpdate, Config),
+    ?assertMatch(
+        {error, #{
+            kind := validation_error,
+            reason := matched_no_union_member,
+            path := "gateway.jt808.proto.auth"
+        }},
+        Result
+    ).
+
+%% allow_anonymous=true with empty string URLs
+raw_jt808_anonymous_config(empty) ->
+    AuthConfig = #{
+        <<"auth">> => #{
+            <<"allow_anonymous">> => true,
+            <<"registry">> => <<>>,
+            <<"authentication">> => <<>>
+        }
+    },
+    emqx_utils_maps:deep_merge(raw_jt808_config(), #{<<"proto">> => AuthConfig});
+%% allow_anonymous=true with URLs omitted entirely
+raw_jt808_anonymous_config(omitted) ->
+    AuthConfig = #{
+        <<"auth">> => #{
+            <<"allow_anonymous">> => true
+        }
+    },
+    emqx_utils_maps:deep_merge(raw_jt808_config(), #{<<"proto">> => AuthConfig}).
+
+%% allow_anonymous=false with empty string URLs (should fail validation)
+raw_jt808_disallow_empty_config() ->
+    AuthConfig = #{
+        <<"auth">> => #{
+            <<"allow_anonymous">> => false,
+            <<"registry">> => <<>>,
+            <<"authentication">> => <<>>
+        }
+    },
+    emqx_utils_maps:deep_merge(raw_jt808_config(), #{<<"proto">> => AuthConfig}).
 
 t_ignore_unsupported_frames_default(_Config) ->
     %% default value is true

--- a/changes/ee/fix-17426.en.md
+++ b/changes/ee/fix-17426.en.md
@@ -1,0 +1,1 @@
+Fixed the JT/T 808 gateway schema validation to allow empty or omitted `registry` and `authentication` URLs when `allow_anonymous` is set to `true`. Previously, the `not_empty` validator was applied to both fields regardless of the `allow_anonymous` setting, causing a 400 error when submitting an empty string for these URLs even though they are not used in anonymous mode.


### PR DESCRIPTION
## Summary

Fix the JT/T 808 gateway schema validation to allow empty or omitted `registry` and `authentication` URLs when `allow_anonymous` is set to `true`.

## Problem

When updating the JT/T 808 gateway config via `PUT /api/v5/gateways/jt808` with `"registry": ""` and `allow_anonymous = true`, the API returns a 400 error. This is because the `not_empty` validator was applied to both `registry` and `authentication` fields regardless of the `allow_anonymous` setting.

However, when `allow_anonymous = true`, these URLs are completely ignored by the runtime (`emqx_jt808_auth:init/1` hardcodes `registry = undefined, authentication = undefined`), so rejecting empty strings is unnecessarily restrictive.

## Changes

- **Schema fix**: Split `fields_reg_auth_required/1` into two clauses:
  - `fields_reg_auth_required(true)` — keeps `not_empty` validator + `required => true` (for `allow_anonymous = false`)
  - `fields_reg_auth_required(false)` — no validator, `required => false` (for `allow_anonymous = true`)

- **Tests**: 6 new CT test cases covering:
  - `allow_anonymous=true` with empty string URLs → succeeds
  - `allow_anonymous=true` with omitted URLs → succeeds
  - `allow_anonymous=false` with empty string URLs → still fails validation

- **Changelog**: `changes/ee/fix-17426.en.md`
