### PR TITLE
chore: prep release 5.10.4

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -19,4 +19,4 @@
 %% NOTE: Also make sure to follow the instructions in end of
 %% `apps/emqx/src/bpapi/README.md'
 
--define(EMQX_RELEASE_EE, "5.10.4-rc.5").
+-define(EMQX_RELEASE_EE, "5.10.4").

--- a/changes/e5.10.4.en.md
+++ b/changes/e5.10.4.en.md
@@ -247,6 +247,10 @@
 
 - [#17402](https://github.com/emqx/emqx/pull/17402) Improved responsiveness of a Cluster Link in situations when route replication was stuck connecting to an unresponsive target cluster. Deleting such a Cluster Link now finishes slightly sooner.
 
+- [#17424](https://github.com/emqx/emqx/pull/17424) Fixed a global session registry leak that could leave duplicate or stale entries for the same client ID after a network partition followed by Mnesia autoheal.
+
+  Discard and takeover-kick RPC handlers now also remove the registry row when the target process is no longer alive, and the registration throttle on the connect path now recognizes tombstone rows (no local channel state) and reaps them instead of blocking new connections for the same client ID indefinitely.
+
 ### Access Control
 
 - [#16690](https://github.com/emqx/emqx/pull/16690) Fixed a CRL cache regression where `emqx_crl_cache:evict/1` did not fully clear internal URL state.

--- a/deploy/charts/emqx-enterprise/Chart.yaml
+++ b/deploy/charts/emqx-enterprise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.10.4-rc.5
+version: 5.10.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 5.10.4-rc.5
+appVersion: 5.10.4


### PR DESCRIPTION
Release version:
5.10.4

## Summary

Cut formal `5.10.4` release.

- Bumped `?EMQX_RELEASE_EE` and `deploy/charts/emqx-enterprise` chart/app version from `5.10.4-rc.5` to `5.10.4`.
- Added the #17424 fix (CM registry leak after partition + autoheal) to the e5.10.4 changelog under Bug Fixes → Clustering.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)