### PR TITLE
fix(clink): ensure config / API handlers map link existence correctly

### DIFF
--- a/apps/emqx_cluster_link/src/emqx_cluster_link_api.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_api.erl
@@ -26,6 +26,10 @@
     '/cluster/links/link/:name/metrics'/2,
     '/cluster/links/link/:name/metrics/reset'/2
 ]).
+
+%% Request filters:
+-export([filter_nonexistent/2]).
+
 -export([scopes/0]).
 
 -define(CONF_PATH, [cluster, links]).
@@ -77,6 +81,7 @@ schema("/cluster/links") ->
 schema("/cluster/links/link/:name") ->
     #{
         'operationId' => '/cluster/links/link/:name',
+        filter => fun ?MODULE:filter_nonexistent/2,
         get =>
             #{
                 description => ?DESC("get_cluster_link_config"),
@@ -125,6 +130,7 @@ schema("/cluster/links/link/:name") ->
 schema("/cluster/links/link/:name/metrics") ->
     #{
         'operationId' => '/cluster/links/link/:name/metrics',
+        filter => fun ?MODULE:filter_nonexistent/2,
         get =>
             #{
                 description => ?DESC("get_cluster_link_metrics"),
@@ -142,6 +148,7 @@ schema("/cluster/links/link/:name/metrics") ->
 schema("/cluster/links/link/:name/metrics/reset") ->
     #{
         'operationId' => '/cluster/links/link/:name/metrics/reset',
+        filter => fun ?MODULE:filter_nonexistent/2,
         put =>
             #{
                 description => ?DESC("reset_cluster_link_metrics"),
@@ -186,39 +193,44 @@ fields(node_metrics) ->
 %% API Handler funcs
 %%--------------------------------------------------------------------
 
+-define(LINK_NOT_FOUND, ?NOT_FOUND(<<"Cluster link not found">>)).
+-define(LINK_ALREADY_EXISTS, ?BAD_REQUEST('ALREADY_EXISTS', <<"Cluster link already exists">>)).
+
 '/cluster/links'(get, _Params) ->
     handle_list();
 '/cluster/links'(post, #{body := Body = #{<<"name">> := Name}}) ->
-    with_link(
-        Name,
-        return(?BAD_REQUEST('ALREADY_EXISTS', <<"Cluster link already exists">>)),
-        fun() -> handle_create(Name, Body) end
-    ).
+    case emqx_cluster_link_config:get_link_raw(Name) of
+        undefined ->
+            handle_create(Name, Body);
+        _Link = #{} ->
+            ?LINK_ALREADY_EXISTS
+    end.
 
-'/cluster/links/link/:name'(get, #{bindings := #{name := Name}}) ->
-    with_link(Name, fun(Link) -> handle_lookup(Name, Link) end, not_found());
-'/cluster/links/link/:name'(put, #{bindings := #{name := Name}, body := Params0}) ->
-    with_link(Name, fun(OldLink) -> handle_update(Name, Params0, OldLink) end, not_found());
+'/cluster/links/link/:name'(get, #{bindings := #{name := Name}, link := Link}) ->
+    handle_lookup(Name, Link);
+'/cluster/links/link/:name'(put, #{bindings := #{name := Name}, link := Link, body := Update}) ->
+    handle_update(Name, Update, Link);
 '/cluster/links/link/:name'(delete, #{bindings := #{name := Name}}) ->
-    with_link(
-        Name,
-        fun() ->
-            case emqx_cluster_link_config:delete_link(Name) of
-                ok ->
-                    ?NO_CONTENT;
-                {error, Reason} ->
-                    Message = list_to_binary(io_lib:format("Delete link failed ~p", [Reason])),
-                    ?BAD_REQUEST(Message)
-            end
-        end,
-        not_found()
-    ).
+    handle_delete(Name).
 
 '/cluster/links/link/:name/metrics'(get, #{bindings := #{name := Name}}) ->
-    with_link(Name, fun() -> handle_metrics(Name) end, not_found()).
+    handle_metrics(Name).
 
 '/cluster/links/link/:name/metrics/reset'(put, #{bindings := #{name := Name}}) ->
-    with_link(Name, fun() -> handle_reset_metrics(Name) end, not_found()).
+    handle_reset_metrics(Name).
+
+filter_nonexistent(Request = #{bindings := Bindings}, _Meta) ->
+    case Bindings of
+        #{name := Name} ->
+            case emqx_cluster_link_config:get_link_raw(Name) of
+                Link = #{} ->
+                    {ok, Request#{link => Link}};
+                undefined ->
+                    ?LINK_NOT_FOUND
+            end;
+        #{} ->
+            ?LINK_NOT_FOUND
+    end.
 
 %%--------------------------------------------------------------------
 %% Internal funcs
@@ -265,22 +277,47 @@ handle_create(Name, Params) ->
         end,
     case Check of
         ok ->
-            do_create(Name, Params);
+            case emqx_cluster_link_config:create_link(Params) of
+                {ok, Link} ->
+                    ?CREATED(redact(add_status(Name, Link)));
+                {error, already_exists} ->
+                    ?LINK_ALREADY_EXISTS;
+                {error, Reason} ->
+                    Message = emqx_utils:format("Create link failed: ~p", [redact(Reason)]),
+                    ?BAD_REQUEST(Message)
+            end;
         BadRequest ->
             redact(BadRequest)
     end.
 
-do_create(Name, Params) ->
-    case emqx_cluster_link_config:create_link(Params) of
+handle_lookup(Name, Link0) ->
+    Link1 = fill_defaults_single(Link0),
+    Link = add_status(Name, Link1),
+    ?OK(redact(Link)).
+
+handle_update(Name, Params0, OldLinkRaw) ->
+    Params1 = Params0#{<<"name">> => Name},
+    Params = emqx_utils:deobfuscate(Params1, OldLinkRaw),
+    case emqx_cluster_link_config:update_link(Params) of
         {ok, Link} ->
-            ?CREATED(redact(add_status(Name, Link)));
+            ?OK(redact(add_status(Name, Link)));
+        {error, not_found} ->
+            ?LINK_NOT_FOUND;
         {error, Reason} ->
-            Message = list_to_binary(io_lib:format("Create link failed ~p", [redact(Reason)])),
+            Message = emqx_utils:format("Update link failed: ~p", [redact(Reason)]),
             ?BAD_REQUEST(Message)
     end.
 
-handle_lookup(Name, Link) ->
-    ?OK(redact(add_status(Name, Link))).
+handle_delete(Name) ->
+    case emqx_cluster_link_config:delete_link(Name) of
+        ok ->
+            ?NO_CONTENT;
+        {error, not_found} ->
+            ?LINK_NOT_FOUND;
+        {error, Reason} ->
+            Message = list_to_binary(io_lib:format("Delete link failed: ~p", [Reason])),
+            ?BAD_REQUEST(Message)
+    end.
 
 handle_metrics(Name) ->
     Results = emqx_cluster_link_metrics:get_metrics(Name),
@@ -412,17 +449,6 @@ add_status(Name, Link) ->
     NodeRPCResults = emqx_cluster_link_mqtt:get_resource_cluster(Name),
     Status = collect_single_status(NodeRPCResults),
     maps:merge(Link, Status).
-
-handle_update(Name, Params0, OldLinkRaw) ->
-    Params1 = Params0#{<<"name">> => Name},
-    Params = emqx_utils:deobfuscate(Params1, OldLinkRaw),
-    case emqx_cluster_link_config:update_link(Params) of
-        {ok, Link} ->
-            ?OK(redact(add_status(Name, Link)));
-        {error, Reason} ->
-            Message = list_to_binary(io_lib:format("Update link failed ~p", [redact(Reason)])),
-            ?BAD_REQUEST(Message)
-    end.
 
 get_raw() ->
     #{<<"cluster">> := #{<<"links">> := Links}} =
@@ -647,17 +673,6 @@ link_metrics_response_example() ->
         ]
     }.
 
-with_link(Name, FoundFn, NotFoundFn) ->
-    case emqx_cluster_link_config:get_link_raw(Name) of
-        undefined ->
-            NotFoundFn();
-        Link0 = #{} when is_function(FoundFn, 1) ->
-            Link = fill_defaults_single(Link0),
-            FoundFn(Link);
-        _Link = #{} when is_function(FoundFn, 0) ->
-            FoundFn()
-    end.
-
 fill_defaults_single(Link0) ->
     #{<<"cluster">> := #{<<"links">> := [Link]}} =
         emqx_config:fill_defaults(
@@ -665,12 +680,6 @@ fill_defaults_single(Link0) ->
             #{obfuscate_sensitive_values => false}
         ),
     Link.
-
-return(Response) ->
-    fun() -> Response end.
-
-not_found() ->
-    return(?NOT_FOUND(<<"Cluster link not found">>)).
 
 redact(Value) ->
     emqx_utils:redact(Value).

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
@@ -181,6 +181,8 @@ create_link(LinkConfig) ->
         {ok, #{raw_config := NewConfigRows}} ->
             NewLinkConfig = find_link(Name, NewConfigRows),
             {ok, NewLinkConfig};
+        {error, {pre_config_update, ?MODULE, Reason}} ->
+            {error, Reason};
         {error, Reason} ->
             {error, Reason}
     end.
@@ -195,6 +197,8 @@ delete_link(Name) ->
     of
         {ok, _} ->
             ok;
+        {error, {pre_config_update, ?MODULE, Reason}} ->
+            {error, Reason};
         {error, Reason} ->
             {error, Reason}
     end.
@@ -211,6 +215,8 @@ update_link(LinkConfig) ->
         {ok, #{raw_config := NewConfigRows}} ->
             NewLinkConfig = find_link(Name, NewConfigRows),
             {ok, NewLinkConfig};
+        {error, {pre_config_update, ?MODULE, Reason}} ->
+            {error, Reason};
         {error, Reason} ->
             {error, Reason}
     end.

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
@@ -119,7 +119,7 @@ get_enabled_links() ->
 get_link(Name) ->
     find_link(Name, get_links()).
 
--spec get_link_raw(_Name :: binary()) -> emqx_config:raw_config().
+-spec get_link_raw(_Name :: binary()) -> emqx_config:raw_config() | undefined.
 get_link_raw(Name) ->
     find_link(Name, get_links_raw()).
 

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
@@ -368,6 +368,34 @@ t_crud(Config) ->
 
     ok.
 
+%% Verify that concurrent DELETEs get either `204` or `404` responses.
+t_concurrent_delete(Config) ->
+    Name = <<"concurrent-delete">>,
+    {201, _} = create_link(Name, link_params(), Config),
+
+    NRequests = 8,
+    Results = emqx_utils:pmap(
+        fun(_) -> delete_link(Name, Config) end,
+        lists:seq(1, NRequests)
+    ),
+    ?assertMatch(
+        [
+            %% Luckiest one gets `204`:
+            {204, _},
+            %% Rest get `404`; no `400`s or `500`s:
+            {404, _},
+            {404, _},
+            {404, _},
+            {404, _},
+            {404, _},
+            {404, _},
+            {404, _}
+        ],
+        lists:sort(Results)
+    ),
+
+    ?assertMatch({404, _}, get_link(Name, Config)).
+
 t_create_invalid(Config) ->
     Params = link_params(),
     EmptyName = <<>>,

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
@@ -14,29 +14,6 @@
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 
--define(CACERT, <<
-    "-----BEGIN CERTIFICATE-----\n"
-    "MIIDUTCCAjmgAwIBAgIJAPPYCjTmxdt/MA0GCSqGSIb3DQEBCwUAMD8xCzAJBgNV\n"
-    "BAYTAkNOMREwDwYDVQQIDAhoYW5nemhvdTEMMAoGA1UECgwDRU1RMQ8wDQYDVQQD\n"
-    "DAZSb290Q0EwHhcNMjAwNTA4MDgwNjUyWhcNMzAwNTA2MDgwNjUyWjA/MQswCQYD\n"
-    "VQQGEwJDTjERMA8GA1UECAwIaGFuZ3pob3UxDDAKBgNVBAoMA0VNUTEPMA0GA1UE\n"
-    "AwwGUm9vdENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzcgVLex1\n"
-    "EZ9ON64EX8v+wcSjzOZpiEOsAOuSXOEN3wb8FKUxCdsGrsJYB7a5VM/Jot25Mod2\n"
-    "juS3OBMg6r85k2TWjdxUoUs+HiUB/pP/ARaaW6VntpAEokpij/przWMPgJnBF3Ur\n"
-    "MjtbLayH9hGmpQrI5c2vmHQ2reRZnSFbY+2b8SXZ+3lZZgz9+BaQYWdQWfaUWEHZ\n"
-    "uDaNiViVO0OT8DRjCuiDp3yYDj3iLWbTA/gDL6Tf5XuHuEwcOQUrd+h0hyIphO8D\n"
-    "tsrsHZ14j4AWYLk1CPA6pq1HIUvEl2rANx2lVUNv+nt64K/Mr3RnVQd9s8bK+TXQ\n"
-    "KGHd2Lv/PALYuwIDAQABo1AwTjAdBgNVHQ4EFgQUGBmW+iDzxctWAWxmhgdlE8Pj\n"
-    "EbQwHwYDVR0jBBgwFoAUGBmW+iDzxctWAWxmhgdlE8PjEbQwDAYDVR0TBAUwAwEB\n"
-    "/zANBgkqhkiG9w0BAQsFAAOCAQEAGbhRUjpIred4cFAFJ7bbYD9hKu/yzWPWkMRa\n"
-    "ErlCKHmuYsYk+5d16JQhJaFy6MGXfLgo3KV2itl0d+OWNH0U9ULXcglTxy6+njo5\n"
-    "CFqdUBPwN1jxhzo9yteDMKF4+AHIxbvCAJa17qcwUKR5MKNvv09C6pvQDJLzid7y\n"
-    "E2dkgSuggik3oa0427KvctFf8uhOV94RvEDyqvT5+pgNYZ2Yfga9pD/jjpoHEUlo\n"
-    "88IGU8/wJCx3Ds2yc8+oBg/ynxG8f/HmCC1ET6EHHoe2jlo8FpU/SgGtghS1YL30\n"
-    "IWxNsPrUP+XsZpBJy/mvOhE5QXo6Y35zDqqj8tI7AGmAWu22jg==\n"
-    "-----END CERTIFICATE-----"
->>).
-
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
 -define(REDACTED, <<"******">>).
 
@@ -289,7 +266,8 @@ t_put_get_valid(Config) ->
     ?assertMatch({200, #{<<"enable">> := false}}, get_link(Name1, Config)),
     ?assertMatch({200, #{<<"enable">> := true}}, get_link(Name2, Config)),
 
-    SSL = #{<<"enable">> => true, <<"cacertfile">> => ?CACERT},
+    {CACert, _CAKey} = emqx_cth_tls:gen_cert(#{issuer => root, key => ec}),
+    SSL = #{<<"enable">> => true, <<"cacertfile">> => public_key:pem_encode([CACert])},
     SSLLink1 = Link1#{<<"ssl">> => SSL},
     ?assertMatch({200, _}, update_link(Name1, maps:remove(<<"name">>, SSLLink1), Config)),
     ?assertMatch(

--- a/changes/ee/fix-17432.en.md
+++ b/changes/ee/fix-17432.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where concurrent Cluster Link API requests could return generic error responses, instead of returning either success or not found.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

This PR refines handling of Link (non-)existence in config CRUD wrappers and respective API handlers to correctly map it to HTTP status codes / allowed error responses.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
