### PR TITLE
test(cassandra): use cassandra-named TLS keystores

### DIFF
--- a/.ci/docker-compose-file/cassandra/cassandra.yaml
+++ b/.ci/docker-compose-file/cassandra/cassandra.yaml
@@ -1047,11 +1047,11 @@ client_encryption_options:
     enabled: true
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
-    keystore: /certs/kafka.keystore.jks
+    keystore: /certs/cassandra.keystore.jks
     keystore_password: password
     require_client_auth: true
     # Set trustore and truststore_password if require_client_auth is true
-    truststore: /certs/kafka.truststore.jks
+    truststore: /certs/cassandra.truststore.jks
     truststore_password: password
     # More advanced defaults below:
     protocol: TLS

--- a/.ci/docker-compose-file/cassandra/cassandra_noauth.yaml
+++ b/.ci/docker-compose-file/cassandra/cassandra_noauth.yaml
@@ -1047,11 +1047,11 @@ client_encryption_options:
     enabled: true
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
-    keystore: /certs/kafka.keystore.jks
+    keystore: /certs/cassandra.keystore.jks
     keystore_password: password
     require_client_auth: true
     # Set trustore and truststore_password if require_client_auth is true
-    truststore: /certs/kafka.truststore.jks
+    truststore: /certs/cassandra.truststore.jks
     truststore_password: password
     # More advanced defaults below:
     protocol: TLS

--- a/.ci/docker-compose-file/docker-compose-cassandra.yaml
+++ b/.ci/docker-compose-file/docker-compose-cassandra.yaml
@@ -27,6 +27,8 @@ services:
     image: ghcr.io/emqx/certgen:latest
     container_name: ssl_cert_gen
     user: "${DOCKER_USER:-root}"
+    environment:
+      CERTGEN_JKS_PREFIX: cassandra
     volumes:
       - /tmp/emqx-ci/emqx-shared-secret:/var/lib/secret
 

--- a/apps/emqx_gateway_coap/src/emqx_gateway_coap.app.src
+++ b/apps/emqx_gateway_coap/src/emqx_gateway_coap.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway_coap, [
     {description, "CoAP Gateway"},
-    {vsn, "0.1.16"},
+    {vsn, "0.1.17"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway]},
     {env, []},


### PR DESCRIPTION
Release version:
5.10.5

## Summary

Follow-up to #17364 after `ghcr.io/emqx/certgen:latest` was updated to support `CERTGEN_JKS_PREFIX`.

- Configure the Cassandra certgen service with `CERTGEN_JKS_PREFIX=cassandra`.
- Update Cassandra TLS settings to read `cassandra.keystore.jks` and `cassandra.truststore.jks` instead of Kafka-named JKS files.
- Bump `emqx_gateway_coap` app version for the already merged #17395 changes so release-510 sanity checks compare cleanly after `e5.10.4`.
- Checks run: RED/GREEN grep check for Cassandra-named JKS usage; `git diff --check`; `docker compose -f .ci/docker-compose-file/docker-compose-cassandra.yaml -f <network override> config`; `docker run --pull always ghcr.io/emqx/certgen:latest` with `CERTGEN_JKS_PREFIX=cassandra`; `./scripts/apps-version-check.sh`.
- Full Cassandra CT was not run locally.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (Cassandra change is test compose config only; CoAP changelog was added by #17395)
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)