### PR TITLE
refactor(prometheus): require authentication for scrape endpoints by default

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -379,7 +379,7 @@ recommend_setting_example() ->
     {Summary, #{
         summary => Summary,
         value => #{
-            enable_basic_auth => false,
+            enable_basic_auth => true,
             push_gateway => #{
                 interval => <<"15s">>,
                 method => put,

--- a/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
@@ -36,7 +36,7 @@ fields(recommend_setting) ->
             ?HOCON(
                 boolean(),
                 #{
-                    default => false,
+                    default => true,
                     required => true,
                     importance => ?IMPORTANCE_HIGH,
                     desc => ?DESC(enable_basic_auth)

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -347,7 +347,47 @@ t_stats_auth_api(_) ->
     Auth = emqx_mgmt_api_test_util:auth_header_(),
     Headers = [Auth | accept_json_header()],
     request_stats(Headers, Auth),
+    {ok, _} = emqx:update_config([prometheus, enable_basic_auth], false),
+    ok = emqx_dashboard_dispatch:regenerate_dispatch(Started),
     ok.
+
+-doc """
+Verify the secure-by-default behavior introduced in 6.3.0: with
+`enable_basic_auth` set to its schema default `true`, unauthenticated requests
+to `/api/v5/prometheus/stats` are rejected with 401, and the same request
+succeeds when authenticated or after the operator explicitly opts out by
+setting `enable_basic_auth = false`.
+""".
+t_stats_default_basic_auth_enabled(_) ->
+    {ok, _} = emqx:update_config([prometheus, enable_basic_auth], true),
+    #{started := Started} = emqx_dashboard:listeners_status(),
+    ok = emqx_dashboard_dispatch:regenerate_dispatch(Started),
+    try
+        Path = emqx_mgmt_api_test_util:api_path(["prometheus", "stats"]),
+        ?assertMatch(
+            {error, {"HTTP/1.1", 401, _}},
+            emqx_mgmt_api_test_util:request_api(get, Path, "", accept_json_header())
+        ),
+        Auth = emqx_mgmt_api_test_util:auth_header_(),
+        {ok, AuthedBody} = emqx_mgmt_api_test_util:request_api(
+            get, Path, "", [Auth | accept_json_header()]
+        ),
+        ?assertMatch(#{<<"client">> := _}, emqx_utils_json:decode(AuthedBody)),
+        {ok, _} = emqx:update_config([prometheus, enable_basic_auth], false),
+        ok = emqx_dashboard_dispatch:regenerate_dispatch(Started),
+        {ok, NoAuthBody} = emqx_mgmt_api_test_util:request_api(
+            get, Path, "", accept_json_header()
+        ),
+        ?assertMatch(#{<<"client">> := _}, emqx_utils_json:decode(NoAuthBody))
+    after
+        case emqx:get_config([prometheus, enable_basic_auth], undefined) of
+            false ->
+                ok;
+            _ ->
+                {ok, _} = emqx:update_config([prometheus, enable_basic_auth], false),
+                ok = emqx_dashboard_dispatch:regenerate_dispatch(Started)
+        end
+    end.
 
 %% Simple smoke test for verifying reason code labels in `emqx_client_disconnected_reason'
 %% counter metric.

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -622,10 +622,11 @@ all_collectors() ->
     emqx_prometheus_config:all_collectors().
 
 get_stats(Format, Mode) ->
+    Auth = emqx_mgmt_api_test_util:auth_header_(),
     Headers =
         case Format of
-            json -> accept_json_header();
-            prometheus -> []
+            json -> [Auth | accept_json_header()];
+            prometheus -> [Auth]
         end,
     QueryString = uri_string:compose_query([{"mode", atom_to_binary(Mode)}]),
     Path = emqx_mgmt_api_test_util:api_path(["prometheus", "stats"]),

--- a/apps/emqx_prometheus/test/emqx_prometheus_cluster_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_cluster_SUITE.erl
@@ -50,7 +50,7 @@ mk_cluster(TestCase, #{n := NumNodes} = Opts, TCConfig) ->
     AppSpecs0 = [
         emqx_conf,
         emqx_management,
-        emqx_prometheus
+        {emqx_prometheus, "prometheus { enable_basic_auth = false }"}
     ],
     NodeSpecs0 = lists:map(
         fun(N) ->

--- a/changes/ee/breaking-17437.en.md
+++ b/changes/ee/breaking-17437.en.md
@@ -1,0 +1,6 @@
+Prometheus scrape endpoints (`/api/v5/prometheus/*`) now require authentication
+by default. Set `prometheus.enable_basic_auth = false` explicitly to restore
+the previous unauthenticated behavior. Deployments that scrape these endpoints
+without credentials will need to either configure credentials on the scraper
+or set the config field. The recommended setup is a dedicated API key with the
+`monitoring` scope, used with Bearer auth in the scraper.

--- a/rel/i18n/emqx_prometheus_schema.hocon
+++ b/rel/i18n/emqx_prometheus_schema.hocon
@@ -31,7 +31,7 @@ push_gateway.desc:
 
 enable_basic_auth.desc:
 """Enable or disable authentication (basic or bearer) for the Prometheus scrape API. Does not affect Push Gateway.
-Defaults to `true` starting from 6.3.0 so the scrape endpoints under `/api/v5/prometheus/*` require credentials.
+Defaults to `true` starting from 6.3.0, so the scrape endpoints under `/api/v5/prometheus/*` require credentials.
 When set to `false`, the endpoints are reachable without authentication, matching the pre-6.3.0 behavior."""
 
 collectors.desc:

--- a/rel/i18n/emqx_prometheus_schema.hocon
+++ b/rel/i18n/emqx_prometheus_schema.hocon
@@ -17,8 +17,11 @@ variable takes value <code>emqx</code> and the <code>host</code> variable takes 
 Default value is: <code>${name}/instance/${name}~${host}</code>"""
 
 prometheus.desc:
-"""EMQX's Prometheus scraping endpoint is enabled by default without authentication.
-You can inspect it with a `curl` command like this: `curl -f "127.0.0.1:18083/api/v5/prometheus/stats"`"""
+"""EMQX's Prometheus scraping endpoint is enabled by default.
+Starting from 6.3.0, the scraping endpoints require authentication by default;
+set `prometheus.enable_basic_auth = false` to restore the previous unauthenticated behavior.
+You can inspect the endpoint with a `curl` command like this:
+`curl -f -u <api-key>:<api-secret> "127.0.0.1:18083/api/v5/prometheus/stats"`."""
 
 prometheus.label:
 """Prometheus"""
@@ -27,7 +30,9 @@ push_gateway.desc:
 """Push Gateway is optional, should not be configured if prometheus is to scrape EMQX."""
 
 enable_basic_auth.desc:
-"""Enable or disable basic authentication for prometheus scrape api, not for Push Gateway"""
+"""Enable or disable authentication (basic or bearer) for the Prometheus scrape API. Does not affect Push Gateway.
+Defaults to `true` starting from 6.3.0 so the scrape endpoints under `/api/v5/prometheus/*` require credentials.
+When set to `false`, the endpoints are reachable without authentication, matching the pre-6.3.0 behavior."""
 
 collectors.desc:
 """The internal advanced metrics of the virtual machine are initially disabled


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Flip the schema default for `prometheus.enable_basic_auth` from `false` to
`true` on `release-63` so the Prometheus scrape endpoints under
`/api/v5/prometheus/*` require authentication out of the box. This closes a
secure-by-default gap where a fresh install exposed cluster, ACL/AuthN, and
data-integration metrics without credentials unless the operator explicitly
opted in.

### Behavior change

Operators who scrape these endpoints without credentials will start receiving
`401` after upgrade. They have two paths to choose:

* Recommended: configure the scraper with a dedicated `monitoring`-scope API
  key and use Bearer auth.
* Opt-out: set `prometheus.enable_basic_auth = false` in `cluster.hocon` /
  `emqx.conf` to restore the prior unauthenticated behavior.

Legacy-shape configs (`prometheus.enable = true`, …) are unaffected because the
legacy schema has no `enable_basic_auth` field at all; their runtime read of
`emqx_config:get([prometheus, enable_basic_auth], false)` continues to return
`false`. The legacy-to-recommend converter in
`emqx_prometheus_config:to_recommend_type/1` also still hardcodes `false` so
that operators migrating a legacy config see no behavior change at the API
surface.

### Files touched

* `apps/emqx_prometheus/src/emqx_prometheus_schema.erl` — schema default flip.
* `apps/emqx_prometheus/src/emqx_prometheus_api.erl` — recommend-setting Swagger
  example updated to match the new default.
* `rel/i18n/emqx_prometheus_schema.hocon` — `enable_basic_auth.desc` and the
  `prometheus.desc` blurb note the change and the opt-out.
* `apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl` — new CT case
  `t_stats_default_basic_auth_enabled` confirms no-auth → 401, auth → 200, and
  the explicit opt-out path. `t_stats_auth_api` now resets the config at the
  end so it does not leak `enable_basic_auth=true` into subsequent tests.
* `changes/ee/breaking-17437.en.md` — user-facing changelog entry in the
  `breaking` bucket.

## Branch scope

This PR lands on `release-63` only. Earlier maintenance branches
(`release-60`/`release-61`/`release-62`) and the v5 line still default to
`false`. If the change should also land on older minors, that's a separate
port — call it out and we can open follow-up PRs.

## CS heads-up

Worth flagging to the CS team before 6.3.0 ships: any Enterprise customers
running customer-side Prometheus scrapers without credentials will need to
update their scraper config or set the opt-out flag.

## Local validation

* `make fmt-diff` — clean.
* `./scripts/elvis-check.sh \$(git merge-base origin/release-63 HEAD)` — clean.
* Schema default verified end-to-end via an `erl` shell against the freshly
  built beam on the previous (release-60) base — returns `true`. The same
  schema source applies on release-63.
* The `emqx_prometheus` CT suite could not be exercised locally: the host
  already has an EMQX listening on `1883`/`18083` (port collision in
  `init_per_suite`) and the docker runner hit a pre-existing quicer NIF
  mismatch unrelated to this change. CI will exercise the suite.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)