### PR TITLE
fix(azure blob storage connector): limit list_containers in health check

### DIFF
--- a/apps/emqx_bridge_azure_blob_storage/mix.exs
+++ b/apps/emqx_bridge_azure_blob_storage/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeAzureBlobStorage.MixProject do
   def project do
     [
       app: :emqx_bridge_azure_blob_storage,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
@@ -675,7 +675,7 @@ channel_status(#{mode := aggregated} = ActionState, ConnState) ->
     ?status_connected.
 
 health_check(DriverState) ->
-    case erlazure:list_containers(DriverState, []) of
+    case erlazure:list_containers(DriverState, [{max_results, "1"}]) of
         {error, Reason} ->
             {?status_disconnected, Reason};
         {L, _} when is_list(L) ->

--- a/changes/ee/fix-17439.en.md
+++ b/changes/ee/fix-17439.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the health check of an Azure Blob Storage Connector could timeout, or generate large bandwidth costs, if the storage account contained too many containers.  Companion fix to #16935.


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Port of #17414 to the v6 line.

The Azure Blob Storage **connector-level** `health_check/1` calls `erlazure:list_containers(DriverState, [])` with no result limit, which enumerates every container in the storage account on every health-check tick. On accounts with many containers this can time out and/or generate large bandwidth costs.

This is the missing half of #16935, which limited the channel-level `do_list_blobs/2` to one result but left the connector-level container listing unbounded. This PR applies the same `[{max_results, \"1\"}]` option to `erlazure:list_containers/2` at `apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl:678`.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)