### PR TITLE
fix(api): move topic metrics endpoints to monitoring scope

### DIFF
--- a/apps/emqx_modules/src/emqx_topic_metrics_api.erl
+++ b/apps/emqx_modules/src/emqx_topic_metrics_api.erl
@@ -49,7 +49,7 @@ namespace() -> undefined.
 api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
-scopes() -> ?SCOPE_CONNECTIONS.
+scopes() -> ?SCOPE_MONITORING.
 
 paths() ->
     [

--- a/changes/ee/fix-17448.en.md
+++ b/changes/ee/fix-17448.en.md
@@ -1,1 +1,0 @@
-Move the API permission scope for topic metrics endpoints (`/mqtt/topic_metrics` and `/mqtt/topic_metrics/{topic}`) from `connections` to `monitoring`, so monitoring-scoped API keys can query topic metrics.

--- a/changes/ee/fix-17448.en.md
+++ b/changes/ee/fix-17448.en.md
@@ -1,0 +1,1 @@
+Move the API permission scope for topic metrics endpoints (`/mqtt/topic_metrics` and `/mqtt/topic_metrics/{topic}`) from `connections` to `monitoring`, so monitoring-scoped API keys can query topic metrics.


### PR DESCRIPTION
Release version: 6.0.3

## Summary

The `scopes/0` callback in `emqx_topic_metrics_api` returned `?SCOPE_CONNECTIONS`, but topic metrics are a monitoring/observability feature, not a connection management feature.

Move the scope to `?SCOPE_MONITORING` so monitoring-scoped API keys can query `/mqtt/topic_metrics` and `/mqtt/topic_metrics/{topic}`.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)