### PR TITLE
chore(prometheus): scope data integration endpoint to actor's namespace

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -1115,13 +1115,14 @@ do_action_simple_create_rule_api(ActionId, Opts, _TCConfig) ->
         end,
     UniqueNum = integer_to_binary(erlang:unique_integer([positive])),
     RuleTopic = <<"t/", UniqueNum/binary>>,
-    {201, #{<<"id">> := RuleId}} = create_rule_api2(
-        #{
-            <<"sql">> => fmt(SQL, #{t => RuleTopic}),
-            <<"actions">> => [ActionId],
-            <<"description">> => <<"bridge_v2 test rule">>
-        }
-    ),
+    Params0 = #{
+        <<"sql">> => fmt(SQL, #{t => RuleTopic}),
+        <<"actions">> => [ActionId],
+        <<"description">> => <<"bridge_v2 test rule">>
+    },
+    Id0 = maps:get(id, Opts, undefined),
+    Params = emqx_utils_maps:put_if(Params0, <<"id">>, Id0, Id0 /= undefined),
+    {201, #{<<"id">> := RuleId}} = create_rule_api2(Params),
     #{topic => RuleTopic, id => RuleId}.
 
 do_source_simple_create_rule_api(Hookpoint, Opts, _TCConfig) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
@@ -62,7 +62,9 @@ init_per_group(?local, TCConfig) ->
                     )
                 end
             }},
-            emqx_prometheus,
+            {emqx_prometheus,
+                "prometheus.enable_basic_auth = false\n"
+                "prometheus.namespaced_metrics_limiter.rate = infinity"},
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],
         #{work_dir => emqx_cth_suite:work_dir(?local, TCConfig)}

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -423,7 +423,9 @@ mk_cluster(TestCase, #{n := NumNodes} = _Opts, TCConfig) ->
         emqx_auth_mnesia,
         emqx_auth,
         emqx_mt,
-        {emqx_prometheus, "prometheus.namespaced_metrics_limiter.rate = infinity"},
+        {emqx_prometheus,
+            "prometheus.enable_basic_auth = false\n"
+            "prometheus.namespaced_metrics_limiter.rate = infinity"},
         emqx_management
     ],
     MkDashApp = fun(N) ->

--- a/apps/emqx_prometheus/mix.exs
+++ b/apps/emqx_prometheus/mix.exs
@@ -27,6 +27,7 @@ defmodule EMQXPrometheus.MixProject do
   def deps() do
     UMP.deps([
       {:emqx, in_umbrella: true},
+      {:emqx_conf, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
       {:emqx_management, in_umbrella: true},

--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -10,6 +10,8 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_api_key_scopes.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
+-include_lib("emqx_utils/include/emqx_http_api.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -46,7 +48,7 @@
 -export([lookup_from_local_nodes/3]).
 -export([scopes/0]).
 
--export([namespaced_stats_filter/2]).
+-export([namespaced_stats_filter/2, namespaced_filter/2]).
 
 -define(TAGS, [<<"Monitor">>]).
 
@@ -138,11 +140,12 @@ schema("/prometheus/stats") ->
 schema("/prometheus/data_integration") ->
     #{
         'operationId' => data_integration,
+        filter => fun ?MODULE:namespaced_filter/2,
         get =>
             #{
                 description => ?DESC(get_prom_data_integration_data),
                 tags => ?TAGS,
-                parameters => [ref(mode)],
+                parameters => [ref(mode), ns_qs_param(), only_global_qs_param()],
                 security => security(),
                 responses =>
                     #{200 => prometheus_data_schema()}
@@ -180,6 +183,12 @@ security() ->
         true -> [#{'basicAuth' => []}, #{'bearerAuth' => []}];
         false -> []
     end.
+
+ns_qs_param() ->
+    {ns, mk(binary(), #{in => query, required => false})}.
+
+only_global_qs_param() ->
+    {only_global, mk(boolean(), #{in => query, required => false, default => false})}.
 
 fields(mode) ->
     [
@@ -248,8 +257,9 @@ ns_stats(get, #{headers := Headers, query_string := Qs}) ->
 auth(get, #{headers := Headers, query_string := Qs}) ->
     collect(emqx_prometheus_auth, collect_opts(Headers, Qs)).
 
-data_integration(get, #{headers := Headers, query_string := Qs}) ->
-    collect(emqx_prometheus_data_integration, collect_opts(Headers, Qs)).
+data_integration(get, Req) ->
+    Opts = collect_opts_ns_or_all(Req),
+    collect_data_integration(Opts).
 
 schema_validation(get, #{headers := Headers, query_string := Qs}) ->
     collect(emqx_prometheus_schema_validation, collect_opts(Headers, Qs)).
@@ -276,6 +286,11 @@ collect(Module, #{type := Type, mode := Mode}) ->
                 <<>>
         end,
     gen_response(Type, Data).
+
+collect_data_integration(#{namespace := Namespace, mode := Mode}) ->
+    Format = <<"prometheus">>,
+    Data = emqx_prometheus_data_integration:collect_ns(Namespace, Mode),
+    gen_response(Format, Data).
 
 collect_ns_stats(#{mode := Mode, namespace := Namespace}) ->
     Type = <<"prometheus">>,
@@ -305,6 +320,15 @@ collect_opts(Headers, Qs) ->
 
 collect_opts_ns(Qs) ->
     #{namespace => namespace(Qs), mode => mode(Qs)}.
+
+collect_opts_ns_or_all(Req = #{query_string := Qs}) ->
+    Namespace0 = get_namespace(Req),
+    Namespace =
+        case maps:get(<<"only_global">>, Qs, false) of
+            false when Namespace0 == ?global_ns -> all;
+            _ -> Namespace0
+        end,
+    #{namespace => Namespace, mode => mode(Qs)}.
 
 response_type(#{<<"accept">> := <<"application/json">>}) ->
     <<"json">>;
@@ -435,4 +459,32 @@ namespaced_stats_filter(Req0, Meta) ->
         {ok, Req1} ?= validate_not_json(Req0, Meta),
         {ok, Req2} ?= parse_collect_opt_ns(Req1, Meta),
         rate_limit_all_ns_stats(Req2, Meta)
+    end.
+
+namespaced_filter(Req0, Meta) ->
+    maybe
+        {ok, Req1} ?= resolve_namespace(Req0, Meta),
+        {ok, Req2} ?= validate_not_json(Req1, Meta),
+        {ok, Req3} ?= parse_collect_opt_ns(Req2, Meta),
+        rate_limit_all_ns_stats(Req3, Meta)
+    end.
+
+get_namespace(#{resolved_ns := Namespace}) ->
+    Namespace.
+
+parse_namespace(#{query_string := QueryString} = Req) ->
+    ActorNamespace = emqx_dashboard:get_namespace(Req),
+    case maps:get(<<"ns">>, QueryString, ActorNamespace) of
+        QSNamespace when QSNamespace /= ActorNamespace andalso ActorNamespace /= ?global_ns ->
+            {error, not_authorized};
+        QSNamespace ->
+            {ok, QSNamespace}
+    end.
+
+resolve_namespace(Req, _Meta) ->
+    case parse_namespace(Req) of
+        {ok, Namespace} ->
+            {ok, Req#{resolved_ns => Namespace}};
+        {error, not_authorized} ->
+            ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.

--- a/apps/emqx_prometheus/src/emqx_prometheus_data_integration.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_data_integration.erl
@@ -441,9 +441,9 @@ merge_acc_with_bridges(Mode, Id, BridgeMetrics, PointsAcc) ->
         BridgeMetrics
     ).
 
-get_action_status(#{resource_data := ResourceData} = _Action) ->
-    Enable = emqx_utils_maps:deep_get([config, enable], ResourceData),
-    Status = ?MG(status, ResourceData),
+get_action_status(#{raw_config := RawConfig, resource_data := ResourceData} = _Action) ->
+    Enable = maps:get(<<"enable">>, RawConfig, true),
+    Status = maps:get(status, ResourceData, disconnected),
     #{
         emqx_action_enable => emqx_prometheus_cluster:boolean_to_number(Enable),
         emqx_action_status => emqx_prometheus_cluster:status_to_number(Status)

--- a/apps/emqx_prometheus/src/emqx_prometheus_data_integration.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_data_integration.erl
@@ -10,7 +10,7 @@
     collect_metrics/2
 ]).
 
--export([collect/1]).
+-export([collect/1, collect_ns/2]).
 
 -export([
     zip_json_data_integration_metrics/3
@@ -19,6 +19,8 @@
 %% for bpapi
 -behaviour(emqx_prometheus_cluster).
 -export([
+    fetch_namespaced_metrics_v1/2,
+    fetch_cluster_wide_namespaced_metrics/2,
     fetch_from_local_node/1,
     fetch_cluster_consistented_data/0,
     aggre_or_zip_init_acc/0,
@@ -27,8 +29,13 @@
 
 -export([add_collect_family/4]).
 
+-ifdef(TEST).
+-export([put_namespace_pd/1, erase_namespace_pd/0]).
+-endif.
+
 -include("emqx_prometheus.hrl").
 -include_lib("prometheus/include/prometheus.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -import(
     prometheus_model_helpers,
@@ -51,30 +58,53 @@
 -define(MG(K, MAP), maps:get(K, MAP)).
 -define(MG0(K, MAP), maps:get(K, MAP, 0)).
 
-%% See `emqx_config.hrl`.
--define(global_ns, global).
-
 %%--------------------------------------------------------------------
 %% Callback for emqx_prometheus_cluster
 %%--------------------------------------------------------------------
 
 -define(ROOT_KEY_ACTIONS, actions).
 
+%% fixme todo : deprecated; return empty set for backwards compatibility.
 fetch_from_local_node(Mode) ->
     Rules = get_rules_all_namespaces(),
-    BridgeV2Actions = emqx_bridge_v2:list(?global_ns, ?ROOT_KEY_ACTIONS),
+    %% BridgeV2Actions = emqx_bridge_v2:list(?global_ns, ?ROOT_KEY_ACTIONS),
     Connectors = emqx_connector:list(?global_ns),
+    {node(self()), #{
+        rule_metric_data => rule_metric_data(Mode, Rules),
+        %% action_metric_data => action_metric_data(Mode, BridgeV2Actions),
+        connector_metric_data => connector_metric_data(Mode, Connectors)
+    }}.
+
+fetch_namespaced_metrics_v1(Namespace, Mode) ->
+    Rules = get_rules(Namespace),
+    BridgeV2Actions = emqx_bridge_v2:list(Namespace, ?ROOT_KEY_ACTIONS),
+    Connectors = emqx_connector:list(Namespace),
     {node(self()), #{
         rule_metric_data => rule_metric_data(Mode, Rules),
         action_metric_data => action_metric_data(Mode, BridgeV2Actions),
         connector_metric_data => connector_metric_data(Mode, Connectors)
     }}.
 
+-spec fetch_cluster_wide_namespaced_metrics(all | emqx_config:namespace(), _Mode) -> map().
+fetch_cluster_wide_namespaced_metrics(Namespace, _Mode) ->
+    Rules = get_rules(Namespace),
+    Connectors = get_connectors(Namespace),
+    (maybe_collect_schema_registry())#{
+        rules_ov_data => rules_ov_data(Rules),
+        %% note: "actions" here means rule action, not actual Actions (as in Connector
+        %% channels)....
+        actions_ov_data => actions_ov_data(Rules),
+        connectors_ov_data => connectors_ov_data(Connectors)
+    }.
+
+%% fixme todo : deprecated; return empty set for backwards compatibility.
 fetch_cluster_consistented_data() ->
     Rules = get_rules_all_namespaces(),
     Connectors = emqx_connector:list(?global_ns),
     (maybe_collect_schema_registry())#{
         rules_ov_data => rules_ov_data(Rules),
+        %% note: "actions" here means rule action, not actual Actions (as in Connector
+        %% channels)....
         actions_ov_data => actions_ov_data(Rules),
         connectors_ov_data => connectors_ov_data(Connectors)
     }.
@@ -83,7 +113,7 @@ aggre_or_zip_init_acc() ->
     #{
         rule_metric_data => maps:from_keys(rule_metric(names), []),
         action_metric_data => maps:from_keys(action_metric(names), []),
-        connector_metric_data => maps:from_keys(connectr_metric(names), [])
+        connector_metric_data => maps:from_keys(connector_metric(names), [])
     }.
 
 logic_sum_metrics() ->
@@ -105,7 +135,9 @@ deregister_cleanup(_) -> ok.
     _Registry :: prometheus_registry:registry(),
     Callback :: prometheus_collector:collect_mf_callback().
 collect_mf(?PROMETHEUS_DATA_INTEGRATION_REGISTRY, Callback) ->
-    RawData = emqx_prometheus_cluster:raw_data(?MODULE, ?GET_PROM_DATA_MODE()),
+    RawData = emqx_prometheus_cluster:raw_data_ns(
+        ?MODULE, get_namespace_pd(), ?GET_PROM_DATA_MODE()
+    ),
 
     %% Data Integration Overview
     ok = add_collect_family(
@@ -156,6 +188,16 @@ collect(<<"json">>) ->
     };
 collect(<<"prometheus">>) ->
     prometheus_text_format:format(?PROMETHEUS_DATA_INTEGRATION_REGISTRY).
+
+collect_ns(Namespace, Mode) ->
+    try
+        ?PUT_PROM_DATA_MODE(Mode),
+        put_namespace_pd(Namespace),
+        prometheus_text_format:format(?PROMETHEUS_DATA_INTEGRATION_REGISTRY)
+    after
+        _ = erase(?PROM_DATA_MODE_KEY__),
+        _ = erase_namespace_pd()
+    end.
 
 %%====================
 %% API Helpers
@@ -259,6 +301,7 @@ rules_ov_metric(names) ->
 -define(RULE_TAB, emqx_rule_engine).
 rules_ov_data(_Rules) ->
     #{
+        %% fixme: wrong, must select by namespace....
         emqx_rules_count => ets:info(?RULE_TAB, size)
     }.
 
@@ -353,24 +396,31 @@ rule_metric(names) ->
 
 rule_metric_data(Mode, Rules) ->
     lists:foldl(
-        fun(#{id := Id} = Rule, AccIn) ->
-            merge_acc_with_rules(Mode, Id, get_metric(Rule), AccIn)
+        fun(#{id := Id, namespace := Namespace} = Rule, AccIn) ->
+            merge_acc_with_rules(Namespace, Mode, Id, get_metric(Rule), AccIn)
         end,
         maps:from_keys(rule_metric(names), []),
         Rules
     ).
 
-merge_acc_with_rules(Mode, Id, RuleMetrics, PointsAcc) ->
+merge_acc_with_rules(Namespace, Mode, Id, RuleMetrics, PointsAcc) ->
     maps:fold(
         fun(K, V, AccIn) ->
-            AccIn#{K => [rule_point(Mode, Id, V) | ?MG(K, AccIn)]}
+            AccIn#{K => [rule_point(Namespace, Mode, Id, V) | ?MG(K, AccIn)]}
         end,
         PointsAcc,
         RuleMetrics
     ).
 
-rule_point(Mode, Id, V) ->
-    {with_node_label(Mode, [{id, Id}]), V}.
+rule_point(Namespace, Mode, Id, V) ->
+    Labels = mk_labels(Namespace, Id),
+    {with_node_label(Mode, Labels), V}.
+
+mk_labels(Namespace, Id) ->
+    case Namespace of
+        ?global_ns -> [{id, Id}];
+        _ -> [{id, Id}, {namespace, Namespace}]
+    end.
 
 get_metric(#{enable := Bool} = Rule) ->
     RuleResId = emqx_rule_engine:rule_resource_id(Rule),
@@ -422,20 +472,25 @@ action_metric(names) ->
 
 action_metric_data(Mode, Bridges) ->
     lists:foldl(
-        fun(#{type := Type, name := Name} = Action, AccIn) ->
+        fun(Action, AccIn) ->
+            #{
+                type := Type,
+                name := Name,
+                namespace := Namespace
+            } = Action,
             Id = emqx_bridge_resource:bridge_id(Type, Name),
             Status = get_action_status(Action),
-            Metrics = get_action_metric(Type, Name),
-            merge_acc_with_bridges(Mode, Id, maps:merge(Status, Metrics), AccIn)
+            Metrics = get_action_metric(Namespace, Type, Name),
+            merge_acc_with_bridges(Namespace, Mode, Id, maps:merge(Status, Metrics), AccIn)
         end,
         maps:from_keys(action_metric(names), []),
         Bridges
     ).
 
-merge_acc_with_bridges(Mode, Id, BridgeMetrics, PointsAcc) ->
+merge_acc_with_bridges(Namespace, Mode, Id, BridgeMetrics, PointsAcc) ->
     maps:fold(
         fun(K, V, AccIn) ->
-            AccIn#{K => [action_point(Mode, Id, V) | ?MG(K, AccIn)]}
+            AccIn#{K => [action_point(Namespace, Mode, Id, V) | ?MG(K, AccIn)]}
         end,
         PointsAcc,
         BridgeMetrics
@@ -449,12 +504,13 @@ get_action_status(#{raw_config := RawConfig, resource_data := ResourceData} = _A
         emqx_action_status => emqx_prometheus_cluster:status_to_number(Status)
     }.
 
-action_point(Mode, Id, V) ->
-    {with_node_label(Mode, [{id, Id}]), V}.
+action_point(Namespace, Mode, Id, V) ->
+    Labels = mk_labels(Namespace, Id),
+    {with_node_label(Mode, Labels), V}.
 
-get_action_metric(Type, Name) ->
+get_action_metric(Namespace, Type, Name) ->
     #{counters := Counters, gauges := Gauges} = emqx_bridge_v2:get_metrics(
-        ?global_ns, actions, Type, Name
+        Namespace, actions, Type, Name
     ),
     #{
         emqx_action_matched => ?MG0(matched, Counters),
@@ -485,34 +541,40 @@ connector_metric_meta() ->
         {emqx_connector_status, gauge}
     ].
 
-connectr_metric(names) ->
+connector_metric(names) ->
     emqx_prometheus_cluster:metric_names(connector_metric_meta()).
 
 connector_metric_data(Mode, Connectors) ->
-    AccIn = maps:from_keys(connectr_metric(names), []),
-    connector_metric_data_v2(Mode, Connectors, AccIn).
-
-connector_metric_data_v2(Mode, Connectors, InitAcc) ->
+    AccIn0 = maps:from_keys(connector_metric(names), []),
     lists:foldl(
-        fun(#{type := Type, name := Name, resource_data := ResourceData} = _Connector, AccIn) ->
+        fun(Connector, AccIn) ->
+            #{
+                type := Type,
+                name := Name,
+                resource_data := ResourceData,
+                namespace := Namespace
+            } = Connector,
             Id = emqx_connector_resource:connector_id(Type, Name),
-            merge_acc_with_connectors(Mode, Id, get_connector_status(ResourceData), AccIn)
+            merge_acc_with_connectors(
+                Namespace, Mode, Id, get_connector_status(ResourceData), AccIn
+            )
         end,
-        InitAcc,
+        AccIn0,
         Connectors
     ).
 
-merge_acc_with_connectors(Mode, Id, ConnectorMetrics, PointsAcc) ->
+merge_acc_with_connectors(Namespace, Mode, Id, ConnectorMetrics, PointsAcc) ->
     maps:fold(
         fun(K, V, AccIn) ->
-            AccIn#{K => [connector_point(Mode, Id, V) | ?MG(K, AccIn)]}
+            AccIn#{K => [connector_point(Namespace, Mode, Id, V) | ?MG(K, AccIn)]}
         end,
         PointsAcc,
         ConnectorMetrics
     ).
 
-connector_point(Mode, Id, V) ->
-    {with_node_label(Mode, [{id, Id}]), V}.
+connector_point(Namespace, Mode, Id, V) ->
+    Labels = mk_labels(Namespace, Id),
+    {with_node_label(Mode, Labels), V}.
 
 get_connector_status(ResourceData) ->
     Enabled = emqx_utils_maps:deep_get([config, enable], ResourceData),
@@ -591,3 +653,26 @@ with_node_label(?PROM_DATA_MODE__ALL_NODES_UNAGGREGATED, Labels) ->
 get_rules_all_namespaces() ->
     NamespaceToRules = emqx_rule_engine:get_rules_from_all_namespaces(),
     lists:append(maps:values(NamespaceToRules)).
+
+put_namespace_pd(Namespace) when
+    is_binary(Namespace);
+    Namespace == ?global_ns;
+    Namespace == all
+->
+    _ = put({?MODULE, ns}, Namespace),
+    ok.
+
+erase_namespace_pd() ->
+    _ = erase({?MODULE, ns}),
+    ok.
+
+get_namespace_pd() ->
+    get({?MODULE, ns}).
+
+get_rules(all) ->
+    get_rules_all_namespaces();
+get_rules(Namespace) ->
+    emqx_rule_engine:get_rules(Namespace).
+
+get_connectors(Namespace) ->
+    emqx_connector:list(Namespace).

--- a/apps/emqx_prometheus/src/emqx_prometheus_data_integration.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_data_integration.erl
@@ -51,6 +51,8 @@
 %% automatically register collectors.
 -behaviour(prometheus_collector).
 
+-deprecated([fetch_from_local_node/1, fetch_cluster_consistented_data/0]).
+
 %%--------------------------------------------------------------------
 %% Macros
 %%--------------------------------------------------------------------
@@ -63,17 +65,6 @@
 %%--------------------------------------------------------------------
 
 -define(ROOT_KEY_ACTIONS, actions).
-
-%% fixme todo : deprecated; return empty set for backwards compatibility.
-fetch_from_local_node(Mode) ->
-    Rules = get_rules_all_namespaces(),
-    %% BridgeV2Actions = emqx_bridge_v2:list(?global_ns, ?ROOT_KEY_ACTIONS),
-    Connectors = emqx_connector:list(?global_ns),
-    {node(self()), #{
-        rule_metric_data => rule_metric_data(Mode, Rules),
-        %% action_metric_data => action_metric_data(Mode, BridgeV2Actions),
-        connector_metric_data => connector_metric_data(Mode, Connectors)
-    }}.
 
 fetch_namespaced_metrics_v1(Namespace, Mode) ->
     Rules = get_rules(Namespace),
@@ -89,7 +80,7 @@ fetch_namespaced_metrics_v1(Namespace, Mode) ->
 fetch_cluster_wide_namespaced_metrics(Namespace, _Mode) ->
     Rules = get_rules(Namespace),
     Connectors = get_connectors(Namespace),
-    (maybe_collect_schema_registry())#{
+    (schema_registry_data())#{
         rules_ov_data => rules_ov_data(Rules),
         %% note: "actions" here means rule action, not actual Actions (as in Connector
         %% channels)....
@@ -97,11 +88,22 @@ fetch_cluster_wide_namespaced_metrics(Namespace, _Mode) ->
         connectors_ov_data => connectors_ov_data(Connectors)
     }.
 
-%% fixme todo : deprecated; return empty set for backwards compatibility.
+%% deprecated; return empty set for backwards compatibility. (prometheus_proto_v{1,2} bpapi)
+fetch_from_local_node(Mode) ->
+    Rules = [],
+    BridgeV2Actions = [],
+    Connectors = [],
+    {node(self()), #{
+        rule_metric_data => rule_metric_data(Mode, Rules),
+        action_metric_data => action_metric_data(Mode, BridgeV2Actions),
+        connector_metric_data => connector_metric_data(Mode, Connectors)
+    }}.
+
+%% deprecated; return empty set for backwards compatibility. (prometheus_proto_v{1,2} bpapi)
 fetch_cluster_consistented_data() ->
-    Rules = get_rules_all_namespaces(),
-    Connectors = emqx_connector:list(?global_ns),
-    (maybe_collect_schema_registry())#{
+    Rules = [],
+    Connectors = [],
+    (empty_schema_registry_data())#{
         rules_ov_data => rules_ov_data(Rules),
         %% note: "actions" here means rule action, not actual Actions (as in Connector
         %% channels)....
@@ -298,11 +300,9 @@ rules_ov_metric_meta() ->
 rules_ov_metric(names) ->
     emqx_prometheus_cluster:metric_names(rules_ov_metric_meta()).
 
--define(RULE_TAB, emqx_rule_engine).
-rules_ov_data(_Rules) ->
+rules_ov_data(Rules) ->
     #{
-        %% fixme: wrong, must select by namespace....
-        emqx_rules_count => ets:info(?RULE_TAB, size)
+        emqx_rules_count => length(Rules)
     }.
 
 %%====================
@@ -348,8 +348,10 @@ schema_registry_data() ->
         emqx_schema_registrys_count => erlang:map_size(emqx_schema_registry:list_schemas())
     }.
 
-maybe_collect_schema_registry() ->
-    schema_registry_data().
+empty_schema_registry_data() ->
+    #{
+        emqx_schema_registrys_count => 0
+    }.
 
 %%====================
 %% Connectors
@@ -610,7 +612,7 @@ collect_data_integration_overview(Rules, Connectors) ->
         #{},
         connectors_ov_metric(names)
     ),
-    M4 = maybe_collect_schema_registry(),
+    M4 = schema_registry_data(),
 
     lists:foldl(fun(M, AccIn) -> maps:merge(M, AccIn) end, #{}, [M1, M2, M3, M4]).
 

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
@@ -1,0 +1,197 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_prometheus_api_2_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+%%------------------------------------------------------------------------------
+%% Defs
+%%------------------------------------------------------------------------------
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx/include/asserts.hrl").
+-include("emqx_prometheus.hrl").
+
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
+
+all() ->
+    emqx_common_test_helpers:all_with_matrix(?MODULE).
+
+groups() ->
+    emqx_common_test_helpers:groups_with_matrix(?MODULE).
+
+init_per_suite(TCConfig) ->
+    TCConfig.
+
+end_per_suite(_TCConfig) ->
+    ok.
+
+init_per_testcase(_TestCase, TCConfig) ->
+    snabbkaffe:start_trace(),
+    TCConfig.
+
+end_per_testcase(_TestCase, _TCConfig) ->
+    snabbkaffe:stop(),
+    emqx_common_test_helpers:call_janitor(),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+get_data_integration(Mode, Format, Opts) ->
+    URL = emqx_mgmt_api_test_util:api_path(["prometheus", "data_integration"]),
+    get_prometheus(URL, Mode, Format, Opts).
+
+get_prometheus(URL, Mode, Format, Opts) ->
+    Headers =
+        case Format of
+            json -> [{"accept", "application/json"}];
+            prometheus -> []
+        end,
+    QueryString = uri_string:compose_query([{"mode", atom_to_binary(Mode)}]),
+    AuthHeader = maps:get(auth_header, Opts, {"no", "auth"}),
+    {Status, Response} = emqx_mgmt_api_test_util:simple_request(#{
+        method => get,
+        url => URL,
+        extra_headers => Headers,
+        query_params => QueryString,
+        auth_header => AuthHeader
+    }),
+    case Format of
+        json ->
+            {Status, Response};
+        prometheus when Status == 200 ->
+            {Status, parse_prometheus(Response)};
+        prometheus ->
+            {Status, Response}
+    end.
+
+parse_prometheus(RawData) ->
+    lists:foldl(
+        fun
+            (<<"#", _/binary>>, Acc) ->
+                Acc;
+            (Line, Acc) ->
+                {Name, Labels, Value} = parse_prometheus_line(Line),
+                maps:update_with(
+                    Name,
+                    fun(Old) -> Old#{Labels => Value} end,
+                    #{Labels => Value},
+                    Acc
+                )
+        end,
+        #{},
+        binary:split(iolist_to_binary(RawData), <<"\n">>, [global, trim_all])
+    ).
+
+parse_prometheus_line(Line) ->
+    RE = <<"(?<name>[a-z0-9A-Z_]+)(\\{(?<labels>[^)]*)\\})? *(?<value>[0-9]+(\\.[0-9]+)?)">>,
+    {match, [Name, Labels0, Value0]} = re:run(
+        Line, RE, [{capture, [<<"name">>, <<"labels">>, <<"value">>], binary}]
+    ),
+    Labels = parse_prometheus_labels(Labels0),
+    Value =
+        try
+            binary_to_float(Value0)
+        catch
+            error:badarg ->
+                binary_to_integer(Value0)
+        end,
+    {Name, Labels, Value}.
+
+parse_prometheus_labels(<<"">>) ->
+    #{};
+parse_prometheus_labels(Labels) ->
+    lists:foldl(
+        fun(Label, Acc) ->
+            [K, V0] = binary:split(Label, <<"=">>),
+            V = binary:replace(V0, <<"\"">>, <<"">>, [global]),
+            Acc#{K => V}
+        end,
+        #{},
+        binary:split(Labels, <<",">>, [global])
+    ).
+
+start_local(TestCase, TCConfig, Opts) ->
+    ExtraApps = maps:get(extra_apps, Opts, []),
+    AppSpecs =
+        [
+            emqx,
+            emqx_conf,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard(),
+            emqx_prometheus
+        ] ++ ExtraApps,
+    Apps = emqx_cth_suite:start(AppSpecs, #{work_dir => emqx_cth_suite:work_dir(TestCase, TCConfig)}),
+    on_exit(fun() -> emqx_cth_suite:stop(Apps) end),
+    Apps.
+
+create_namespaced_user_auth_header(Opts) ->
+    Token = emqx_bridge_v2_testlib:create_namespaced_user_and_token(Opts),
+    {"Authorization", <<"Bearer ", Token/binary>>}.
+
+global_admin_auth_header() ->
+    emqx_mgmt_api_test_util:auth_header_().
+
+create_connector_api(TCConfig, Overrides) ->
+    on_exit(fun emqx_bridge_v2_testlib:delete_all_bridges_and_connectors/0),
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:create_connector_api(TCConfig, Overrides)
+    ).
+
+create_action_api(TCConfig, Overrides) ->
+    on_exit(fun emqx_bridge_v2_testlib:delete_all_bridges_and_connectors/0),
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:create_action_api(TCConfig, Overrides)
+    ).
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
+
+-doc """
+Regression test for the case where there is an action whose connector does not exist.
+
+This may arise if someone manually edits the configuration and starts up the node like that.
+""".
+t_action_without_connector(TCConfig) ->
+    ActionConfig = emqx_bridge_schema_testlib:mqtt_action_config(#{
+        <<"connector">> => <<"a">>
+    }),
+    start_local(?FUNCTION_NAME, TCConfig, #{
+        extra_apps => [
+            emqx_bridge_mqtt,
+            {emqx_bridge, #{
+                config =>
+                    #{
+                        <<"actions">> =>
+                            #{
+                                <<"mqtt">> =>
+                                    #{<<"a">> => ActionConfig}
+                            }
+                    }
+            }},
+            emqx_rule_engine
+        ]
+    }),
+    AuthHeader = global_admin_auth_header(),
+    lists:foreach(
+        fun(Mode) ->
+            ?assertMatch(
+                {200, _},
+                get_data_integration(Mode, prometheus, #{auth_header => AuthHeader}),
+                #{mode => Mode}
+            )
+        end,
+        ?PROM_DATA_MODES
+    ),
+    ok.

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
@@ -18,6 +18,8 @@
 -include_lib("emqx/include/asserts.hrl").
 -include("emqx_prometheus.hrl").
 
+-define(with_auth_header(HEADER, BODY), with_auth_header(HEADER, fun() -> BODY end)).
+
 %%------------------------------------------------------------------------------
 %% CT boilerplate
 %%------------------------------------------------------------------------------
@@ -57,7 +59,15 @@ get_prometheus(URL, Mode, Format, Opts) ->
             json -> [{"accept", "application/json"}];
             prometheus -> []
         end,
-    QueryString = uri_string:compose_query([{"mode", atom_to_binary(Mode)}]),
+    Ns = maps:get(ns, Opts, undefined),
+    OnlyGlobal = maps:get(only_global, Opts, undefined),
+    QueryString = uri_string:compose_query(
+        lists:flatten([
+            {"mode", atom_to_binary(Mode)},
+            [{"ns", Ns} || Ns /= undefined],
+            [{"only_global", OnlyGlobal} || OnlyGlobal /= undefined]
+        ])
+    ),
     AuthHeader = maps:get(auth_header, Opts, {"no", "auth"}),
     {Status, Response} = emqx_mgmt_api_test_util:simple_request(#{
         method => get,
@@ -129,7 +139,7 @@ start_local(TestCase, TCConfig, Opts) ->
             emqx_conf,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard(),
-            emqx_prometheus
+            {emqx_prometheus, "prometheus.namespaced_metrics_limiter.rate = infinity"}
         ] ++ ExtraApps,
     Apps = emqx_cth_suite:start(AppSpecs, #{work_dir => emqx_cth_suite:work_dir(TestCase, TCConfig)}),
     on_exit(fun() -> emqx_cth_suite:stop(Apps) end),
@@ -153,6 +163,19 @@ create_action_api(TCConfig, Overrides) ->
     emqx_bridge_v2_testlib:simplify_result(
         emqx_bridge_v2_testlib:create_action_api(TCConfig, Overrides)
     ).
+
+simple_create_rule_api(Opts0, TCConfig) ->
+    Opts = maps:merge(#{sql => auto}, Opts0),
+    emqx_bridge_v2_testlib:simple_create_rule_api(Opts, TCConfig).
+
+with_auth_header(AuthHeader, Fn) ->
+    try
+        AuthFn = fun() -> AuthHeader end,
+        emqx_bridge_v2_testlib:set_auth_header_getter(AuthFn),
+        Fn()
+    after
+        emqx_bridge_v2_testlib:clear_auth_header_getter()
+    end.
 
 %%------------------------------------------------------------------------------
 %% Test cases
@@ -194,4 +217,268 @@ t_action_without_connector(TCConfig) ->
         end,
         ?PROM_DATA_MODES
     ),
+    ok.
+
+t_namespaced_data_integration(TCConfig) ->
+    start_local(?FUNCTION_NAME, TCConfig, #{
+        extra_apps => [
+            emqx_bridge_mqtt,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_mt
+        ]
+    }),
+    %% sanity check: auth should be enabled
+    ?assertMatch({401, _}, get_data_integration(?PROM_DATA_MODE__NODE, prometheus, #{})),
+
+    MkBridgeConfig = fun(Name) ->
+        [
+            {bridge_kind, action},
+            {connector_type, <<"mqtt">>},
+            {connector_name, Name},
+            {connector_config, emqx_bridge_schema_testlib:mqtt_connector_config(#{})},
+            {action_type, <<"mqtt">>},
+            {action_name, Name},
+            {action_config,
+                emqx_bridge_schema_testlib:mqtt_action_config(#{<<"connector">> => Name})}
+        ]
+    end,
+    Ns = <<"ns1">>,
+    ok = emqx_mt_config:create_managed_ns(Ns),
+    NsAuthHeader = create_namespaced_user_auth_header(#{}),
+    ?with_auth_header(NsAuthHeader, begin
+        Cfg = MkBridgeConfig(Ns),
+        {201, _} = create_connector_api(Cfg, #{}),
+        {201, _} = create_action_api(Cfg, #{}),
+        simple_create_rule_api(#{id => Ns}, Cfg),
+        ok
+    end),
+    GlobalAuthHeader = global_admin_auth_header(),
+    ?with_auth_header(GlobalAuthHeader, begin
+        Cfg = MkBridgeConfig(<<"global">>),
+        {201, _} = create_connector_api(Cfg, #{}),
+        {201, _} = create_action_api(Cfg, #{}),
+        simple_create_rule_api(#{id => <<"global">>}, Cfg),
+        ok
+    end),
+
+    GetLabels = fun(Key, Res) -> lists:sort(maps:keys(maps:get(Key, Res))) end,
+
+    lists:foreach(
+        fun(Mode) ->
+            ct:pal("mode ~s", [Mode]),
+
+            %% namespaced admin cannot see other namespaces
+            ?assertMatch(
+                {403, _},
+                get_data_integration(Mode, prometheus, #{
+                    auth_header => NsAuthHeader,
+                    ns => <<"other_ns">>
+                })
+            ),
+
+            {200, NsNodeRes1} = get_data_integration(Mode, prometheus, #{
+                auth_header => NsAuthHeader
+            }),
+            ?assertNotMatch(
+                [#{<<"id">> := <<"mqtt:global">>}],
+                GetLabels(<<"emqx_connector_status">>, NsNodeRes1)
+            ),
+            ?assertNotMatch(
+                [#{<<"id">> := <<"mqtt:global">>}], GetLabels(<<"emqx_action_enable">>, NsNodeRes1)
+            ),
+            ?assertNotMatch(
+                [#{<<"id">> := <<"mqtt:global">>}], GetLabels(<<"emqx_rule_enable">>, NsNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_connector_status">>, NsNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_action_enable">>, NsNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_rule_enable">>, NsNodeRes1)
+            ),
+
+            %% without specifying `only_global`, global admin sees metrics from all namespaces
+            {200, GlobalNodeRes1} = get_data_integration(Mode, prometheus, #{
+                auth_header => GlobalAuthHeader
+            }),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>},
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>},
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"global">>},
+                    #{
+                        <<"id">> := <<"ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes1)
+            ),
+            %% with `only_global`, global admin sees metrics only from global ns
+            {200, GlobalNodeRes2} = get_data_integration(Mode, prometheus, #{
+                auth_header => GlobalAuthHeader,
+                only_global => true
+            }),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>}
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes2)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>}
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes2)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"global">>}
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes2)
+            ),
+
+            %% namespaced admin can filter specific namespaces
+            {200, GlobalNodeRes3} = get_data_integration(Mode, prometheus, #{
+                auth_header => GlobalAuthHeader,
+                ns => Ns
+            }),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes3)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes3)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes3)
+            ),
+
+            ok
+        end,
+        ?PROM_DATA_MODES
+    ),
+
+    %% if auth is disabled, there's not much we can do.  we treat the request as if coming
+    %% from a global admin.
+    {ok, _} = emqx:update_config([prometheus, enable_basic_auth], false),
+    #{started := Started} = emqx_dashboard:listeners_status(),
+    ok = emqx_dashboard_dispatch:regenerate_dispatch(Started),
+    lists:foreach(
+        fun(Mode) ->
+            ct:pal("mode ~s", [Mode]),
+            %% without specifying `only_global`, global admin sees metrics from all namespaces
+            {200, GlobalNodeRes1} = get_data_integration(Mode, prometheus, #{}),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>},
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>},
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"global">>},
+                    #{
+                        <<"id">> := <<"ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes1)
+            ),
+            %% with `only_global`, global admin sees metrics only from global ns
+            {200, GlobalNodeRes2} = get_data_integration(Mode, prometheus, #{
+                only_global => true
+            }),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>}
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes2)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>}
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes2)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"global">>}
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes2)
+            ),
+            ok
+        end,
+        ?PROM_DATA_MODES
+    ),
+
     ok.

--- a/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
@@ -11,6 +11,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 %% erlfmt-ignore
 -define(EMQX_CONF_CONFIG, <<"
@@ -165,7 +166,13 @@ init_per_group('/prometheus/stats', Config) ->
 init_per_group('/prometheus/auth', Config) ->
     [{module, emqx_prometheus_auth} | Config];
 init_per_group('/prometheus/data_integration', Config) ->
-    [{module, emqx_prometheus_data_integration} | Config];
+    [
+        {module, emqx_prometheus_data_integration},
+        {setup, fun() ->
+            emqx_prometheus_data_integration:put_namespace_pd(?global_ns)
+        end}
+        | Config
+    ];
 init_per_group('/prometheus/schema_validation', Config) ->
     [{module, emqx_prometheus_schema_validation} | Config];
 init_per_group('/prometheus/message_transformation', Config) ->
@@ -203,6 +210,10 @@ end_per_testcase(_, _Config) ->
 t_collect_prom_data(Config) ->
     CollectOpts = collect_opts(Config),
     Module = ?config(module, Config),
+    maybe
+        {setup, SetupFn} ?= lists:keyfind(setup, 1, Config),
+        SetupFn()
+    end,
     Response = emqx_prometheus_api:collect(Module, CollectOpts),
     assert_data(Module, Response, CollectOpts).
 

--- a/changes/ee/feat-17454.en.md
+++ b/changes/ee/feat-17454.en.md
@@ -1,0 +1,1 @@
+Now, we enforce that the returned prometheus data for data integrations (`/prometheus/data_integrations`) is scoped to the requesting actor's namespace.  A global admin can see data from all namespaces and can filter specific namespaces.


### PR DESCRIPTION
Release version:
6.3.0

## Summary

Now, we enforce that the returned prometheus data for data integrations is scoped to the actor's namespace.  A global admin can see data from all namespaces.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
