### PR TITLE
fix(gateway): handle CoAP state machine timeouts

### DIFF
--- a/apps/emqx_gateway_coap/mix.exs
+++ b/apps/emqx_gateway_coap/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayCoap.MixProject do
   def project do
     [
       app: :emqx_gateway_coap,
-      version: "6.2.0",
+      version: "6.2.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -228,6 +228,8 @@ handle_timeout(_, {keepalive, NewVal}, #channel{keepalive = KeepAlive} = Channel
         {error, timeout} ->
             {shutdown, timeout, ensure_disconnected(keepalive_timeout, Channel)}
     end;
+handle_timeout(_, {state_machine, Msg}, Channel) ->
+    call_session(timeout, Msg, Channel);
 handle_timeout(_, {transport, Msg}, Channel) ->
     call_session(timeout, Msg, Channel);
 handle_timeout(_, disconnect, Channel) ->

--- a/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
@@ -94,13 +94,24 @@ handle_request(#coap_message{id = MsgId} = Msg, TM) ->
     end.
 
 %% client response
-handle_response(#coap_message{type = Type, id = MsgId, token = Token} = Msg, TM) ->
+handle_response(#coap_message{type = Type, method = Method, id = MsgId, token = Token} = Msg, TM) ->
     Id = {out, MsgId},
     TokenId = ?TOKEN_ID(Token),
-    case find_machine_by_keys([Id, TokenId], TM) of
+    MachineIdKeys =
+        case {Type, Method} of
+            {ack, undefined} ->
+                [Id];
+            {reset, _} ->
+                [Id];
+            _ ->
+                [Id, TokenId]
+        end,
+    case find_machine_by_keys(MachineIdKeys, TM) of
         undefined ->
-            case Type of
-                reset ->
+            case {Type, Method} of
+                {reset, _} ->
+                    empty();
+                {ack, undefined} ->
                     empty();
                 _ ->
                     reset(Msg)

--- a/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
@@ -815,6 +815,15 @@ t_channel_observe_blockwise_ack_failure_drains_pending(_) ->
     ?assertEqual(ObserveToken, NotifyB0#coap_message.token),
     ?assertEqual(binary:copy(<<"B">>, 16), NotifyB0#coap_message.payload),
     ?assertEqual({0, true, 16}, emqx_coap_message:get_option(block2, NotifyB0, undefined)),
+    ?assertEqual(1, proplists:get_value(inflight_cnt, emqx_coap_channel:stats(Channel8))),
+
+    OldAck = #coap_message{
+        type = ack,
+        id = NotifyA0#coap_message.id,
+        token = ObserveToken
+    },
+    {ok, Channel9} = emqx_coap_channel:handle_in(OldAck, Channel8),
+    ?assertEqual(1, proplists:get_value(inflight_cnt, emqx_coap_channel:stats(Channel9))),
 
     FollowReq = #coap_message{
         type = con,
@@ -827,8 +836,8 @@ t_channel_observe_blockwise_ack_failure_drains_pending(_) ->
             block2 => {1, false, 16}
         }
     },
-    {ok, [{outgoing, [FollowResp]}], _Channel9} =
-        emqx_coap_channel:handle_in(FollowReq, Channel8),
+    {ok, [{outgoing, [FollowResp]}], _Channel10} =
+        emqx_coap_channel:handle_in(FollowReq, Channel9),
     ?assertEqual({ok, content}, FollowResp#coap_message.method),
     ?assertEqual(binary:copy(<<"b">>, 16), FollowResp#coap_message.payload),
     ?assertEqual({1, true, 16}, emqx_coap_message:get_option(block2, FollowResp, undefined)).
@@ -903,11 +912,14 @@ ps_get_request(Id, Token, ExtraOpts) ->
     }.
 
 ack_timeout(Channel) ->
-    emqx_coap_channel:handle_timeout(
-        make_ref(),
-        {transport, {1, state_timeout, ack_timeout}},
-        Channel
-    ).
+    receive
+        {timeout, TRef, {state_machine, {_SeqId, state_timeout, ack_timeout}} = Msg} ->
+            emqx_coap_channel:handle_timeout(TRef, Msg, Channel);
+        Other ->
+            ct:fail({unexpected_ack_timeout_message, Other})
+    after 70000 ->
+        ct:fail(ack_timeout_not_received)
+    end.
 
 observe_channel(Topic, ObserveToken, #channel{session = Session0} = Channel) ->
     SubData = #{topic => Topic, token => ObserveToken, subopts => #{qos => 0}},

--- a/apps/emqx_gateway_coap/test/emqx_coap_transport_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_transport_SUITE.erl
@@ -171,8 +171,13 @@ t_tm_paths(_) ->
     ?assertThrow("token conflict", emqx_coap_tm:handle_out(Msg, TMConflict)),
     Empty = emqx_coap_tm:handle_response(#coap_message{type = reset, id = 99, token = <<>>}, TM0),
     ?assertEqual(#{}, Empty),
+    EmptyAck = emqx_coap_tm:handle_response(#coap_message{type = ack, id = 98, token = <<>>}, TM0),
+    ?assertEqual(#{}, EmptyAck),
     #{out := _} =
-        emqx_coap_tm:handle_response(#coap_message{type = ack, id = 98, token = <<>>}, TM0),
+        emqx_coap_tm:handle_response(
+            #coap_message{type = ack, method = {ok, content}, id = 98, token = <<>>},
+            TM0
+        ),
     _ = emqx_coap_tm:handle_out(
         #coap_message{type = non, method = get, token = <<"tok2">>},
         TM0


### PR DESCRIPTION
Fixes none

Release version:
6.2.1

## Summary

Follow-up to #17398.

Fixes CoAP gateway timeout handling for confirmable Observe notifications.

`emqx_coap_tm` starts retransmission timers with `{state_machine, {SeqId, state_timeout, ack_timeout}}`, but `emqx_coap_channel` only routed `{transport, ...}` timeout messages into the CoAP session. The real timer message was therefore ignored by the channel, so a missed client ACK could leave a CON Observe notification in flight without retransmission or retransmit-exhausted cleanup. Later Observe notifications for the same session stayed queued until an unrelated inbound packet or reconnect progressed the session.

This change routes real `{state_machine, ...}` timeout messages through `emqx_coap_session:timeout/2` and keeps the existing `{transport, ...}` route for compatibility with older callers. It also prevents stale empty ACK/RST packets from matching a newer same-token Observe notification by token; empty ACK/RST packets now match only by message ID.

The regression test waits for the real timer message emitted by `emqx_utils:start_timer/2` instead of fabricating a timeout payload, and the Observe/blockwise coverage now includes the late-ACK boundary after a timeout-drained notification.

No separate changelog is added because this is a follow-up fix for the CoAP Observe notification changes from #17398.

Checks run: `./scripts/erlfmt -c apps/emqx_gateway_coap/src/emqx_coap_tm.erl apps/emqx_gateway_coap/src/emqx_coap_channel.erl apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl apps/emqx_gateway_coap/test/emqx_coap_transport_SUITE.erl`; `mix format --check-formatted apps/emqx_gateway_coap/mix.exs`; `git diff --check`; `make ct-suite SUITE=apps/emqx_gateway_coap/test/emqx_coap_transport_SUITE.erl TESTCASE=t_tm_paths PROFILE=emqx-enterprise`; `make ct-suite SUITE=apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl TESTCASE=t_channel_observe_blockwise_ack_failure_drains_pending PROFILE=emqx-enterprise`; `make apps/emqx_gateway_coap-ct PROFILE=emqx-enterprise`; `./scripts/apps-version-check.exs`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
