### PR TITLE
fix(license): API serves monthly session HWM history symmetric with CLI

### DIFF
--- a/apps/emqx_license/src/emqx_license_http_api.erl
+++ b/apps/emqx_license/src/emqx_license_http_api.erl
@@ -121,14 +121,13 @@ schema("/license/session_hwm_history") ->
                     hoconsc:mk(hoconsc:enum([daily, monthly]), #{
                         in => query,
                         required => false,
-                        default => daily,
+                        default => monthly,
                         desc => ?DESC("param_history_period")
                     })},
                 {limit,
                     hoconsc:mk(pos_integer(), #{
                         in => query,
                         required => false,
-                        default => 30,
                         desc => ?DESC("param_history_limit")
                     })}
             ],
@@ -183,8 +182,15 @@ error_msg(Code, Msg) ->
     {400, error_msg(?BAD_REQUEST, <<"Invalid request params">>)}.
 
 '/license/session_hwm_history'(get, #{query_string := QS}) ->
-    Period = maps:get(period, QS, daily),
-    Limit = maps:get(limit, QS, 30),
+    %% NOTE: minirest passes query-string parameters as binary keys with
+    %% values coerced per the declared schema (atoms for enums, ints for
+    %% pos_integer). Keep the key form binary; values come typed.
+    Period = maps:get(<<"period">>, QS, monthly),
+    Limit =
+        case Period of
+            daily -> maps:get(<<"limit">>, QS, 30);
+            monthly -> maps:get(<<"limit">>, QS, 24)
+        end,
     Rows = emqx_license_session_hwm:list_history(Period, Limit),
     Data = [maps:remove(observed_at_ms, Row) || Row <- Rows],
     {200, #{period => Period, count => length(Data), data => Data}}.

--- a/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -372,3 +372,90 @@ validate_setting(Res, ExpectLow, ExpectHigh, DynMax) ->
         <<"dynamic_max_connections">> := DynMax
     } =
         emqx_utils_json:decode(Payload).
+
+%%------------------------------------------------------------------------------
+%% Session HWM history API tests
+%%------------------------------------------------------------------------------
+
+session_hwm_setup(Config) ->
+    %% Pin timezone so the period labels are host-independent.
+    OrigTz = emqx_config:get([license, high_watermark_timezone], system),
+    emqx_config:put([license, high_watermark_timezone], <<"+00:00">>),
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm),
+    %% Seed three days across two months so daily and monthly responses differ.
+    %% 2026-04-18T00:00:00Z
+    ok = emqx_license_session_hwm:observe(1_776_470_400_000, 10),
+    ok = emqx_license_session_hwm:sync(),
+    %% 2026-04-19T00:00:00Z
+    ok = emqx_license_session_hwm:observe(1_776_556_800_000, 20),
+    ok = emqx_license_session_hwm:sync(),
+    %% 2026-05-01T00:00:00Z
+    ok = emqx_license_session_hwm:observe(1_777_593_600_000, 5),
+    ok = emqx_license_session_hwm:sync(),
+    [{orig_tz, OrigTz} | Config].
+
+session_hwm_teardown(Config) ->
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm),
+    emqx_config:put([license, high_watermark_timezone], ?config(orig_tz, Config)),
+    ok.
+
+session_hwm_uri(Query) ->
+    uri(["license", "session_hwm_history"]) ++ Query.
+
+t_session_hwm_history_default_monthly({init, Config}) ->
+    session_hwm_setup(Config);
+t_session_hwm_history_default_monthly({'end', Config}) ->
+    session_hwm_teardown(Config);
+t_session_hwm_history_default_monthly(_Config) ->
+    %% No `period` query → defaults to monthly, matching the CLI default.
+    {ok, 200, Payload} = request(get, session_hwm_uri(""), []),
+    #{<<"period">> := Period, <<"data">> := Rows} = emqx_utils_json:decode(Payload),
+    ?assertEqual(<<"monthly">>, Period),
+    ?assertMatch(
+        [#{<<"period">> := <<"2026-05">>}, #{<<"period">> := <<"2026-04">>}],
+        Rows
+    ).
+
+t_session_hwm_history_monthly({init, Config}) ->
+    session_hwm_setup(Config);
+t_session_hwm_history_monthly({'end', Config}) ->
+    session_hwm_teardown(Config);
+t_session_hwm_history_monthly(_Config) ->
+    {ok, 200, Payload} = request(get, session_hwm_uri("?period=monthly"), []),
+    #{<<"period">> := Period, <<"data">> := Rows} = emqx_utils_json:decode(Payload),
+    ?assertEqual(<<"monthly">>, Period),
+    ?assertMatch(
+        [
+            #{<<"period">> := <<"2026-05">>, <<"high_watermark">> := 5},
+            #{<<"period">> := <<"2026-04">>, <<"high_watermark">> := 20}
+        ],
+        Rows
+    ).
+
+t_session_hwm_history_daily({init, Config}) ->
+    session_hwm_setup(Config);
+t_session_hwm_history_daily({'end', Config}) ->
+    session_hwm_teardown(Config);
+t_session_hwm_history_daily(_Config) ->
+    {ok, 200, Payload} = request(get, session_hwm_uri("?period=daily"), []),
+    #{<<"period">> := Period, <<"data">> := Rows} = emqx_utils_json:decode(Payload),
+    ?assertEqual(<<"daily">>, Period),
+    ?assertMatch(
+        [
+            #{<<"period">> := <<"2026-05-01">>, <<"high_watermark">> := 5},
+            #{<<"period">> := <<"2026-04-19">>, <<"high_watermark">> := 20},
+            #{<<"period">> := <<"2026-04-18">>, <<"high_watermark">> := 10}
+        ],
+        Rows
+    ).
+
+t_session_hwm_history_limit({init, Config}) ->
+    session_hwm_setup(Config);
+t_session_hwm_history_limit({'end', Config}) ->
+    session_hwm_teardown(Config);
+t_session_hwm_history_limit(_Config) ->
+    {ok, 200, Payload} = request(get, session_hwm_uri("?period=daily&limit=2"), []),
+    #{<<"period">> := <<"daily">>, <<"count">> := Count, <<"data">> := Rows} =
+        emqx_utils_json:decode(Payload),
+    ?assertEqual(2, Count),
+    ?assertEqual(2, length(Rows)).

--- a/rel/i18n/emqx_license_http_api.hocon
+++ b/rel/i18n/emqx_license_http_api.hocon
@@ -39,12 +39,12 @@ desc_session_hwm_history_api.label:
 """Session High-Watermark History"""
 
 param_history_period.desc:
-"""Aggregation period: `daily` returns one row per day, `monthly` folds daily peaks into month-level maximums."""
+"""Aggregation period: `daily` returns one row per day, `monthly` folds daily peaks into month-level maximums. Defaults to `monthly`."""
 param_history_period.label:
 """Period"""
 
 param_history_limit.desc:
-"""Maximum number of rows to return. Applies only to `daily` period (defaults to 30). Ignored for `monthly` period, which always returns the full 24-month retention window."""
+"""Maximum number of rows to return. Defaults to 30 for `daily` and 24 for `monthly` (matching the 24-month retention window)."""
 param_history_limit.label:
 """Limit"""
 


### PR DESCRIPTION
Fixes: https://emqx.atlassian.net/browse/EMQX-15311
Release version: 6.1.2, 6.2.1

## Summary

The session high-watermark history REST API (`GET /api/v5/license/session_hwm_history`) ignored the `period=monthly` query parameter and always returned daily rows, while the CLI (`emqx ctl license history`) correctly defaulted to monthly.

Two issues:

- The handler read `period` and `limit` from the query string using atom keys, but minirest passes parsed query parameters as binary keys (verified against sibling handlers such as `emqx_mgmt_api_configs:configs/2`). The atom lookup always missed and fell back to `daily`. Regression from 711da0d0d4 (the `check_schema => true` switch).
- The default was `daily` and the limit was hardcoded to 30, both inconsistent with the CLI which defaults to monthly with effectively no row cap.

Fix: read query params with binary keys (values are already coerced to the schema types — atom for the enum, integer for the limit), default to `monthly`, and apply per-period limit defaults (30 for daily, 24 for monthly — matches the 24-month retention window).

i18n description for `param_history_period` / `param_history_limit` updated to match the new defaults.

No changelog: the session HWM history feature has not been released yet.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)