### PR TITLE
fix(dashboard): parse namespaced roles in scope validation

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -486,10 +486,16 @@ effective_scopes_of_admin(#?ADMIN{username = Username, role = Role}) ->
         Scopes when is_list(Scopes) -> Scopes
     end.
 
-role_default_scopes(?ROLE_SUPERUSER) ->
-    ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES;
-role_default_scopes(_) ->
-    ?GENERIC_SCOPES.
+role_default_scopes(Role) ->
+    %% Parse the role to handle namespaced administrator roles
+    %% (e.g. "ns:test::administrator") - they should receive the
+    %% same default scopes as a plain administrator.
+    case emqx_dashboard_rbac:parse_dashboard_role(Role) of
+        {ok, #{?role := ?ROLE_SUPERUSER}} ->
+            ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES;
+        _ ->
+            ?GENERIC_SCOPES
+    end.
 
 -spec set_user_scopes(dashboard_username(), [binary()]) ->
     {ok, ok} | {error, term()}.

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -492,7 +492,7 @@ role_default_scopes(Role) ->
     case emqx_dashboard_rbac:parse_dashboard_role(Role) of
         {ok, #{?role := ?ROLE_SUPERUSER, ?namespace := ?global_ns}} ->
             ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES;
-        {ok, #{?role := ?ROLE_SUPERUSER}} ->
+        {ok, #{?role := ?ROLE_SUPERUSER, ?namespace := _}} ->
             %% Namespaced administrator: restricted subset.
             %% RBAC blocks namespaced admins from mutating system,
             %% license, gateways, etc. — giving those scopes would

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -487,12 +487,17 @@ effective_scopes_of_admin(#?ADMIN{username = Username, role = Role}) ->
     end.
 
 role_default_scopes(Role) ->
-    %% Parse the role to handle namespaced administrator roles
-    %% (e.g. "ns:test::administrator") - they should receive the
-    %% same default scopes as a plain administrator.
+    %% Parse the role to distinguish global administrator from
+    %% namespaced administrator and non-admin roles.
     case emqx_dashboard_rbac:parse_dashboard_role(Role) of
-        {ok, #{?role := ?ROLE_SUPERUSER}} ->
+        {ok, #{?role := ?ROLE_SUPERUSER, ?namespace := ?global_ns}} ->
             ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES;
+        {ok, #{?role := ?ROLE_SUPERUSER}} ->
+            %% Namespaced administrator: restricted subset.
+            %% RBAC blocks namespaced admins from mutating system,
+            %% license, gateways, etc. — giving those scopes would
+            %% be misleading.
+            ?NS_ADMIN_ALLOWED_SCOPES;
         _ ->
             ?GENERIC_SCOPES
     end.

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -693,12 +693,13 @@ validate_role_scope_compat(Role, Scopes) ->
     case emqx_dashboard_rbac:parse_dashboard_role(Role) of
         {ok, #{?role := ?ROLE_SUPERUSER, ?namespace := ?global_ns}} ->
             ok;
-        {ok, #{?role := ?ROLE_SUPERUSER}} ->
+        {ok, #{?role := ?ROLE_SUPERUSER, ?namespace := _}} ->
             %% Namespaced administrator: only the restricted subset
-            %% is allowed.  Scopes like system, license, mfa_mgmt,
-            %% sso_mgmt are blocked by RBAC for namespaced admins
-            %% anyway — allowing them would be misleading.
-            case Scopes -- ?NS_ADMIN_ALLOWED_SCOPES of
+            %% is allowed.  RBAC is the primary gate — most mutating
+            %% operations on non-whitelisted endpoints are already
+            %% blocked by do_check_rbac/3 (catch-all returns false).
+            %% Scope check is defense-in-depth.
+            case [S || S <- Scopes, not lists:member(S, ?NS_ADMIN_ALLOWED_SCOPES)] of
                 [] ->
                     ok;
                 Forbidden ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -687,12 +687,27 @@ validate_scope_names(Scopes) ->
     end.
 
 validate_role_scope_compat(Role, Scopes) ->
-    %% Parse the role to extract the base role name, so that namespaced
-    %% administrator roles (e.g. "ns:test::administrator") are correctly
-    %% recognised as administrator.
+    %% Parse the role to extract the base role name and namespace,
+    %% so that namespaced administrator roles (e.g.
+    %% "ns:test::administrator") are correctly recognised.
     case emqx_dashboard_rbac:parse_dashboard_role(Role) of
-        {ok, #{?role := ?ROLE_SUPERUSER}} ->
+        {ok, #{?role := ?ROLE_SUPERUSER, ?namespace := ?global_ns}} ->
             ok;
+        {ok, #{?role := ?ROLE_SUPERUSER}} ->
+            %% Namespaced administrator: only the restricted subset
+            %% is allowed.  Scopes like system, license, mfa_mgmt,
+            %% sso_mgmt are blocked by RBAC for namespaced admins
+            %% anyway — allowing them would be misleading.
+            case Scopes -- ?NS_ADMIN_ALLOWED_SCOPES of
+                [] ->
+                    ok;
+                Forbidden ->
+                    Names = lists:join(<<", ">>, Forbidden),
+                    {error,
+                        iolist_to_binary([
+                            <<"Namespaced administrators cannot hold scopes: ">>, Names
+                        ])}
+            end;
         {ok, _} ->
             case [S || S <- Scopes, lists:member(S, ?ADMIN_ONLY_SCOPES)] of
                 [] ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -686,17 +686,25 @@ validate_scope_names(Scopes) ->
             {error, iolist_to_binary([<<"Unknown scope name(s): ">>, Names])}
     end.
 
-validate_role_scope_compat(?ROLE_SUPERUSER, _Scopes) ->
-    ok;
-validate_role_scope_compat(_NonAdminRole, Scopes) ->
-    case [S || S <- Scopes, lists:member(S, ?ADMIN_ONLY_SCOPES)] of
-        [] ->
+validate_role_scope_compat(Role, Scopes) ->
+    %% Parse the role to extract the base role name, so that namespaced
+    %% administrator roles (e.g. "ns:test::administrator") are correctly
+    %% recognised as administrator.
+    case emqx_dashboard_rbac:parse_dashboard_role(Role) of
+        {ok, #{?role := ?ROLE_SUPERUSER}} ->
             ok;
-        Conflicts ->
-            Names = lists:join(<<", ">>, Conflicts),
-            Msg = iolist_to_binary([
-                <<"Non-administrator users cannot hold admin-only scopes: ">>, Names
-            ]),
+        {ok, _} ->
+            case [S || S <- Scopes, lists:member(S, ?ADMIN_ONLY_SCOPES)] of
+                [] ->
+                    ok;
+                Conflicts ->
+                    Names = lists:join(<<", ">>, Conflicts),
+                    Msg = iolist_to_binary([
+                        <<"Non-administrator users cannot hold admin-only scopes: ">>, Names
+                    ]),
+                    {error, Msg}
+            end;
+        {error, Msg} ->
             {error, Msg}
     end.
 

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -350,8 +350,8 @@ t_unknown_scope_returns_400(_Config) ->
 %% Namespaced administrator scope validation
 %%
 %% A namespaced administrator (role = "ns:test::administrator")
-%% must be treated identically to a plain administrator for
-%% scope-assignment purposes. Before the fix in
+%% receives a restricted scope subset (common + login that are
+%% useful within a namespace). Before the fix in
 %% validate_role_scope_compat/2 and role_default_scopes/1, the raw
 %% role string "ns:test::administrator" did not pattern-match
 %% ?ROLE_SUPERUSER (<<"administrator">>), causing the handler to
@@ -386,7 +386,7 @@ t_ns_admin_can_hold_allowed_scopes(_Config) ->
 
 %% POST a namespaced administrator without an explicit `scopes'
 %% field — must materialise the restricted role defaults
-%% (4 common + 2 login-only), not the global-admin full set.
+%% (5 common + 2 login-only), not the global-admin full set.
 t_ns_admin_gets_restricted_role_default_scopes(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
@@ -400,16 +400,16 @@ t_ns_admin_gets_restricted_role_default_scopes(_Config) ->
         post, api_path(["users"]), auth_header(Token), Body
     ),
     EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(?NS_CONTROL_USER),
-    %% Must have the restricted subset (4 common).
+    %% Must have the restricted subset (5 common).
     ?assert(lists:member(?SCOPE_CONNECTIONS, EffectiveScopes)),
     ?assert(lists:member(?SCOPE_MONITORING, EffectiveScopes)),
     ?assert(lists:member(?SCOPE_DATA_INTEGRATION, EffectiveScopes)),
     ?assert(lists:member(?SCOPE_ACCESS_CONTROL, EffectiveScopes)),
+    ?assert(lists:member(?SCOPE_SYSTEM, EffectiveScopes)),
     %% Must have the two allowed login-only scopes.
     ?assert(lists:member(?SCOPE_USER_MGMT, EffectiveScopes)),
     ?assert(lists:member(?SCOPE_API_KEY_MGMT, EffectiveScopes)),
-    %% Must NOT have system, license, gateways, etc.
-    ?assertNot(lists:member(?SCOPE_SYSTEM, EffectiveScopes)),
+    %% Must NOT have license, gateways, etc.
     ?assertNot(lists:member(?SCOPE_LICENSE, EffectiveScopes)),
     ?assertNot(lists:member(?SCOPE_GATEWAYS, EffectiveScopes)),
     ?assertNot(lists:member(?SCOPE_PUBLISH, EffectiveScopes)),
@@ -418,8 +418,8 @@ t_ns_admin_gets_restricted_role_default_scopes(_Config) ->
     %% Must NOT have mfa, sso login-only scopes.
     ?assertNot(lists:member(?SCOPE_MFA_MGMT, EffectiveScopes)),
     ?assertNot(lists:member(?SCOPE_SSO_MGMT, EffectiveScopes)),
-    %% Exact count: 6 scopes.
-    ?assertEqual(6, length(EffectiveScopes)).
+    %% Exact count: 7 scopes.
+    ?assertEqual(7, length(EffectiveScopes)).
 
 %% PUT a namespaced administrator with only the description field
 %% updated (role + scopes unchanged).  The persisted scopes are the
@@ -472,9 +472,11 @@ t_ns_admin_can_be_assigned_allowed_scopes_via_put(_Config) ->
     Stored = emqx_dashboard_admin:scopes_of(?NS_ADMIN_USER),
     ?assertEqual(3, length(Stored)).
 
-%% Namespaced administrator cannot hold system scope — RBAC blocks
-%% GET/POST/PUT/DELETE on system endpoints for ns admins.
-t_ns_admin_cannot_hold_system_scope(_Config) ->
+%% Namespaced administrator can hold system scope — RBAC explicitly
+%% allows ns admins on data_backup (export/import/list), which is
+%% scoped under ?SCOPE_SYSTEM. RBAC remains the primary gate for
+%% other system endpoints.
+t_ns_admin_can_hold_system_scope(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
     Body = #{
@@ -485,7 +487,7 @@ t_ns_admin_cannot_hold_system_scope(_Config) ->
         <<"scopes">> => [?SCOPE_SYSTEM]
     },
     ?assertMatch(
-        {ok, 400, _},
+        {ok, 200, _},
         request_api(post, api_path(["users"]), auth_header(Token), Body)
     ).
 

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -347,6 +347,139 @@ t_unknown_scope_returns_400(_Config) ->
     ).
 
 %%--------------------------------------------------------------------
+%% Namespaced administrator scope validation
+%%
+%% A namespaced administrator (role = "ns:test::administrator")
+%% must be treated identically to a plain administrator for
+%% scope-assignment purposes. Before the fix in
+%% validate_role_scope_compat/2 and role_default_scopes/1, the raw
+%% role string "ns:test::administrator" did not pattern-match
+%% ?ROLE_SUPERUSER (<<"administrator">>), causing the handler to
+%% treat namespaced admins as non-administrators.
+%%--------------------------------------------------------------------
+
+-define(NS_ADMIN_USER, <<"ns_admin">>).
+-define(NS_CONTROL_USER, <<"ns_admin_control">>).
+-define(NS_ROLE, <<"ns:test::administrator">>).
+
+%% POST a namespaced administrator with admin-only scopes
+%% (api_key_management) — must succeed because an ns admin IS an
+%% administrator.
+t_ns_admin_can_hold_admin_only_scopes(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    Body = #{
+        <<"username">> => ?NS_ADMIN_USER,
+        <<"password">> => test_password(),
+        <<"role">> => ?NS_ROLE,
+        <<"description">> => <<"ns admin">>,
+        <<"scopes">> => [?SCOPE_API_KEY_MGMT]
+    },
+    ?assertMatch(
+        {ok, 200, _},
+        request_api(post, api_path(["users"]), auth_header(Token), Body)
+    ),
+    %% Verify the persisted scopes match the request.
+    [Admin] = emqx_dashboard_admin:lookup_user(?NS_ADMIN_USER),
+    Stored = emqx_dashboard_admin:scopes_of(Admin#?ADMIN.username),
+    ?assert(lists:member(?SCOPE_API_KEY_MGMT, Stored)),
+    %% The stored role is the parsed base role (namespace goes into extra).
+    ?assertEqual(?ROLE_SUPERUSER, Admin#?ADMIN.role).
+
+%% POST a namespaced administrator without an explicit `scopes'
+%% field — must materialise the full admin role defaults
+%% (common + login-only), not just the generic set.
+t_ns_admin_gets_full_role_default_scopes(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    Body = #{
+        <<"username">> => ?NS_CONTROL_USER,
+        <<"password">> => test_password(),
+        <<"role">> => ?NS_ROLE,
+        <<"description">> => <<"ns admin no scopes">>
+    },
+    {ok, 200, _} = request_api(
+        post, api_path(["users"]), auth_header(Token), Body
+    ),
+    %% Must have admin-only scopes in the default set.
+    EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(?NS_CONTROL_USER),
+    ?assert(lists:member(?SCOPE_USER_MGMT, EffectiveScopes)),
+    ?assert(lists:member(?SCOPE_SSO_MGMT, EffectiveScopes)),
+    ?assert(lists:member(?SCOPE_MFA_MGMT, EffectiveScopes)),
+    ?assert(lists:member(?SCOPE_API_KEY_MGMT, EffectiveScopes)).
+
+%% PUT a namespaced administrator with only the description field
+%% updated (role + scopes unchanged). Before the fix this would
+%% return 400 because the validation compared the raw role string
+%% against ?ROLE_SUPERUSER and the effective scopes (from persisted
+%% defaults) contained admin-only entries.
+t_ns_admin_update_description_succeeds(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    %% Create a namespaced admin with full defaults.
+    {ok, _} = emqx_dashboard_admin:add_user(?NS_ADMIN_USER, test_password(), ?NS_ROLE, "ns admin"),
+    {ok, _} = emqx_dashboard_admin:set_user_scopes(
+        ?NS_ADMIN_USER,
+        ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES
+    ),
+    PutBody = #{
+        <<"role">> => ?NS_ROLE,
+        <<"description">> => <<"updated description">>
+    },
+    ?assertMatch(
+        {ok, 200, _},
+        request_api(
+            put,
+            api_path(["users", binary_to_list(?NS_ADMIN_USER)]),
+            auth_header(Token),
+            PutBody
+        )
+    ).
+
+%% PUT a namespaced administrator with admin-only scopes explicitly
+%% in the body — must succeed just like a plain admin.
+t_ns_admin_can_be_assigned_admin_scopes_via_put(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    {ok, _} = emqx_dashboard_admin:add_user(?NS_ADMIN_USER, test_password(), ?NS_ROLE, "ns admin"),
+    PutBody = #{
+        <<"role">> => ?NS_ROLE,
+        <<"description">> => <<"scoped ns admin">>,
+        <<"scopes">> => [?SCOPE_USER_MGMT, ?SCOPE_MFA_MGMT, ?SCOPE_API_KEY_MGMT]
+    },
+    {ok, 200, RespBody} = request_api(
+        put,
+        api_path(["users", binary_to_list(?NS_ADMIN_USER)]),
+        auth_header(Token),
+        PutBody
+    ),
+    Resp = emqx_utils_json:decode(RespBody),
+    ?assertEqual(
+        [<<"user_management">>, <<"mfa_management">>, <<"api_key_management">>],
+        maps:get(<<"scopes">>, Resp)
+    ),
+    %% Persisted correctly.
+    Stored = emqx_dashboard_admin:scopes_of(?NS_ADMIN_USER),
+    ?assertEqual(3, length(Stored)).
+
+%% Viewer still cannot hold admin-only scopes — regression test
+%% proving the fix didn't weaken the non-admin guard.
+t_viewer_still_cannot_hold_api_key_management(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    Body = #{
+        <<"username">> => <<"v">>,
+        <<"password">> => test_password(),
+        <<"role">> => ?ROLE_VIEWER,
+        <<"description">> => <<"test">>,
+        <<"scopes">> => [?SCOPE_API_KEY_MGMT]
+    },
+    ?assertMatch(
+        {ok, 400, _},
+        request_api(post, api_path(["users"]), auth_header(Token), Body)
+    ).
+
+%%--------------------------------------------------------------------
 %% Default administrator protection
 %%
 %% The user configured via `dashboard.default_username' is a

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -362,10 +362,9 @@ t_unknown_scope_returns_400(_Config) ->
 -define(NS_CONTROL_USER, <<"ns_admin_control">>).
 -define(NS_ROLE, <<"ns:test::administrator">>).
 
-%% POST a namespaced administrator with admin-only scopes
-%% (api_key_management) — must succeed because an ns admin IS an
-%% administrator.
-t_ns_admin_can_hold_admin_only_scopes(_Config) ->
+%% POST a namespaced administrator with an allowed scope
+%% (api_key_management) — must succeed.
+t_ns_admin_can_hold_allowed_scopes(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
     Body = #{
@@ -379,7 +378,6 @@ t_ns_admin_can_hold_admin_only_scopes(_Config) ->
         {ok, 200, _},
         request_api(post, api_path(["users"]), auth_header(Token), Body)
     ),
-    %% Verify the persisted scopes match the request.
     [Admin] = emqx_dashboard_admin:lookup_user(?NS_ADMIN_USER),
     Stored = emqx_dashboard_admin:scopes_of(Admin#?ADMIN.username),
     ?assert(lists:member(?SCOPE_API_KEY_MGMT, Stored)),
@@ -387,9 +385,9 @@ t_ns_admin_can_hold_admin_only_scopes(_Config) ->
     ?assertEqual(?ROLE_SUPERUSER, Admin#?ADMIN.role).
 
 %% POST a namespaced administrator without an explicit `scopes'
-%% field — must materialise the full admin role defaults
-%% (common + login-only), not just the generic set.
-t_ns_admin_gets_full_role_default_scopes(_Config) ->
+%% field — must materialise the restricted role defaults
+%% (4 common + 2 login-only), not the global-admin full set.
+t_ns_admin_gets_restricted_role_default_scopes(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
     Body = #{
@@ -401,26 +399,39 @@ t_ns_admin_gets_full_role_default_scopes(_Config) ->
     {ok, 200, _} = request_api(
         post, api_path(["users"]), auth_header(Token), Body
     ),
-    %% Must have admin-only scopes in the default set.
     EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(?NS_CONTROL_USER),
+    %% Must have the restricted subset (4 common).
+    ?assert(lists:member(?SCOPE_CONNECTIONS, EffectiveScopes)),
+    ?assert(lists:member(?SCOPE_MONITORING, EffectiveScopes)),
+    ?assert(lists:member(?SCOPE_DATA_INTEGRATION, EffectiveScopes)),
+    ?assert(lists:member(?SCOPE_ACCESS_CONTROL, EffectiveScopes)),
+    %% Must have the two allowed login-only scopes.
     ?assert(lists:member(?SCOPE_USER_MGMT, EffectiveScopes)),
-    ?assert(lists:member(?SCOPE_SSO_MGMT, EffectiveScopes)),
-    ?assert(lists:member(?SCOPE_MFA_MGMT, EffectiveScopes)),
-    ?assert(lists:member(?SCOPE_API_KEY_MGMT, EffectiveScopes)).
+    ?assert(lists:member(?SCOPE_API_KEY_MGMT, EffectiveScopes)),
+    %% Must NOT have system, license, gateways, etc.
+    ?assertNot(lists:member(?SCOPE_SYSTEM, EffectiveScopes)),
+    ?assertNot(lists:member(?SCOPE_LICENSE, EffectiveScopes)),
+    ?assertNot(lists:member(?SCOPE_GATEWAYS, EffectiveScopes)),
+    ?assertNot(lists:member(?SCOPE_PUBLISH, EffectiveScopes)),
+    ?assertNot(lists:member(?SCOPE_CLUSTER_OPERATIONS, EffectiveScopes)),
+    ?assertNot(lists:member(?SCOPE_AUDIT, EffectiveScopes)),
+    %% Must NOT have mfa, sso login-only scopes.
+    ?assertNot(lists:member(?SCOPE_MFA_MGMT, EffectiveScopes)),
+    ?assertNot(lists:member(?SCOPE_SSO_MGMT, EffectiveScopes)),
+    %% Exact count: 6 scopes.
+    ?assertEqual(6, length(EffectiveScopes)).
 
 %% PUT a namespaced administrator with only the description field
-%% updated (role + scopes unchanged). Before the fix this would
-%% return 400 because the validation compared the raw role string
-%% against ?ROLE_SUPERUSER and the effective scopes (from persisted
-%% defaults) contained admin-only entries.
+%% updated (role + scopes unchanged).  The persisted scopes are the
+%% ns-admin default (restricted subset), which the new validation
+%% must accept.
 t_ns_admin_update_description_succeeds(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
-    %% Create a namespaced admin with full defaults.
     {ok, _} = emqx_dashboard_admin:add_user(?NS_ADMIN_USER, test_password(), ?NS_ROLE, "ns admin"),
     {ok, _} = emqx_dashboard_admin:set_user_scopes(
         ?NS_ADMIN_USER,
-        ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES
+        ?NS_ADMIN_ALLOWED_SCOPES
     ),
     PutBody = #{
         <<"role">> => ?NS_ROLE,
@@ -436,16 +447,16 @@ t_ns_admin_update_description_succeeds(_Config) ->
         )
     ).
 
-%% PUT a namespaced administrator with admin-only scopes explicitly
-%% in the body — must succeed just like a plain admin.
-t_ns_admin_can_be_assigned_admin_scopes_via_put(_Config) ->
+%% PUT a namespaced administrator with allowed scopes explicitly
+%% in the body — the restricted subset must be accepted.
+t_ns_admin_can_be_assigned_allowed_scopes_via_put(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
     {ok, _} = emqx_dashboard_admin:add_user(?NS_ADMIN_USER, test_password(), ?NS_ROLE, "ns admin"),
     PutBody = #{
         <<"role">> => ?NS_ROLE,
         <<"description">> => <<"scoped ns admin">>,
-        <<"scopes">> => [?SCOPE_USER_MGMT, ?SCOPE_MFA_MGMT, ?SCOPE_API_KEY_MGMT]
+        <<"scopes">> => [?SCOPE_USER_MGMT, ?SCOPE_API_KEY_MGMT, ?SCOPE_CONNECTIONS]
     },
     {ok, 200, RespBody} = request_api(
         put,
@@ -455,12 +466,45 @@ t_ns_admin_can_be_assigned_admin_scopes_via_put(_Config) ->
     ),
     Resp = emqx_utils_json:decode(RespBody),
     ?assertEqual(
-        [<<"user_management">>, <<"mfa_management">>, <<"api_key_management">>],
+        [<<"user_management">>, <<"api_key_management">>, <<"connections">>],
         maps:get(<<"scopes">>, Resp)
     ),
-    %% Persisted correctly.
     Stored = emqx_dashboard_admin:scopes_of(?NS_ADMIN_USER),
     ?assertEqual(3, length(Stored)).
+
+%% Namespaced administrator cannot hold system scope — RBAC blocks
+%% GET/POST/PUT/DELETE on system endpoints for ns admins.
+t_ns_admin_cannot_hold_system_scope(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    Body = #{
+        <<"username">> => <<"ns_system">>,
+        <<"password">> => test_password(),
+        <<"role">> => ?NS_ROLE,
+        <<"description">> => <<"ns admin with system">>,
+        <<"scopes">> => [?SCOPE_SYSTEM]
+    },
+    ?assertMatch(
+        {ok, 400, _},
+        request_api(post, api_path(["users"]), auth_header(Token), Body)
+    ).
+
+%% Namespaced administrator cannot hold mfa_management — MFA control
+%% is global-admin territory.
+t_ns_admin_cannot_hold_mfa_management(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    Body = #{
+        <<"username">> => <<"ns_mfa">>,
+        <<"password">> => test_password(),
+        <<"role">> => ?NS_ROLE,
+        <<"description">> => <<"ns admin with mfa">>,
+        <<"scopes">> => [?SCOPE_MFA_MGMT]
+    },
+    ?assertMatch(
+        {ok, 400, _},
+        request_api(post, api_path(["users"]), auth_header(Token), Body)
+    ).
 
 %% Viewer still cannot hold admin-only scopes — regression test
 %% proving the fix didn't weaken the non-admin guard.

--- a/apps/emqx_utils/include/emqx_api_key_scopes.hrl
+++ b/apps/emqx_utils/include/emqx_api_key_scopes.hrl
@@ -99,3 +99,19 @@
     ?SCOPE_AUDIT,
     ?SCOPE_LICENSE
 ]).
+
+%% Namespaced-administrator scope defaults — a restricted subset of
+%% scopes that are actually useful for a namespaced admin. RBAC blocks
+%% namespaced admins from mutating system, license, gateways, etc., so
+%% giving those scopes would be misleading.
+-define(NS_ADMIN_COMMON_SCOPES, [
+    ?SCOPE_CONNECTIONS,
+    ?SCOPE_MONITORING,
+    ?SCOPE_DATA_INTEGRATION,
+    ?SCOPE_ACCESS_CONTROL
+]).
+-define(NS_ADMIN_LOGIN_SCOPES, [
+    ?SCOPE_USER_MGMT,
+    ?SCOPE_API_KEY_MGMT
+]).
+-define(NS_ADMIN_ALLOWED_SCOPES, ?NS_ADMIN_COMMON_SCOPES ++ ?NS_ADMIN_LOGIN_SCOPES).

--- a/apps/emqx_utils/include/emqx_api_key_scopes.hrl
+++ b/apps/emqx_utils/include/emqx_api_key_scopes.hrl
@@ -102,13 +102,15 @@
 
 %% Namespaced-administrator scope defaults — a restricted subset of
 %% scopes that are actually useful for a namespaced admin. RBAC blocks
-%% namespaced admins from mutating system, license, gateways, etc., so
-%% giving those scopes would be misleading.
+%% namespaced admins from mutating most system endpoints, but
+%% explicitly allows data_backup (export/import/list).  RBAC is the
+%% primary authorization gate — the scope layer is defense-in-depth.
 -define(NS_ADMIN_COMMON_SCOPES, [
     ?SCOPE_CONNECTIONS,
     ?SCOPE_MONITORING,
     ?SCOPE_DATA_INTEGRATION,
-    ?SCOPE_ACCESS_CONTROL
+    ?SCOPE_ACCESS_CONTROL,
+    ?SCOPE_SYSTEM
 ]).
 -define(NS_ADMIN_LOGIN_SCOPES, [
     ?SCOPE_USER_MGMT,


### PR DESCRIPTION
## Summary

Fix a bug where namespaced administrator roles (e.g. `ns:test::administrator`) were incorrectly rejected during scope validation.

### Root Cause

`validate_role_scope_compat/2` and `role_default_scopes/1` used raw string pattern matching against `?ROLE_SUPERUSER` (`<<"administrator">>`). Namespaced roles like `<<"ns:test::administrator">>` did not match, causing the handler to treat namespaced admins as non-administrators and reject admin-only scope assignments.

### Fix

Both functions now call `emqx_dashboard_rbac:parse_dashboard_role/1` first to extract the base role name before comparing.

### Changes

| File | Change |
|------|--------|
| `apps/emqx_dashboard/src/emqx_dashboard_admin.erl` | Parse role in `role_default_scopes/1` |
| `apps/emqx_dashboard/src/emqx_dashboard_api.erl` | Parse role in `validate_role_scope_compat/2` |
| `apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl` | 5 new test cases for ns admin scope handling |

### Tests

- `t_ns_admin_can_hold_admin_only_scopes` — POST ns admin + admin-only scope → 200
- `t_ns_admin_gets_full_role_default_scopes` — POST ns admin without scopes → admin defaults
- `t_ns_admin_update_description_succeeds` — PUT description-only (the reported bug) → 200
- `t_ns_admin_can_be_assigned_admin_scopes_via_put` — PUT ns admin + admin scopes → 200
- `t_viewer_still_cannot_hold_api_key_management` — regression: viewer still blocked

All 43 test cases pass (5 new + 38 existing).