### PR TITLE
test(mt): retry MQTT connect on transient server_busy

### DIFF
--- a/apps/emqx_mt/test/emqx_mt_trace_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_trace_SUITE.erl
@@ -190,9 +190,21 @@ create_user_and_token(Opts) ->
 start_client(Opts0) ->
     Default = #{proto_ver => v5},
     Opts = maps:merge(Default, Opts0),
+    start_client(Opts, 10).
+
+start_client(Opts, Retries) ->
     {ok, C} = emqtt:start_link(Opts),
-    {ok, _} = emqtt:connect(C),
-    C.
+    unlink(C),
+    case emqtt:connect(C) of
+        {ok, _} ->
+            link(C),
+            C;
+        {error, {server_busy, _}} when Retries > 0 ->
+            _ = catch emqtt:stop(C),
+            ct:pal("server_busy on connect, retrying (~p left)", [Retries - 1]),
+            timer:sleep(10),
+            start_client(Opts, Retries - 1)
+    end.
 
 wait_filesync() ->
     %% NOTE: Twice as long as `?LOG_HANDLER_FILESYNC_INTERVAL` in `emqx_trace_handler`.


### PR DESCRIPTION
`emqx_mt_trace_SUITE:t_filter_clientid` was flaking in CI with `{shutdown, server_busy}`: the test process was linked to `emqtt` via `start_link/1`, so a CONNACK with reason code 0x97 (server busy) from listener-side rate limiting killed the case before `emqtt:connect/1` returned.

Update the local `start_client/1` helper to `unlink` the emqtt pid before calling `connect/1`, retry up to 10× with a 10ms sleep on `{error, {server_busy, _}}`, then re-`link` on success so existing `emqtt:stop/1` cleanup still works.