### PR TITLE
chore(clink): streamline metrics module API and startup order

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -472,7 +472,7 @@ install_bridge_v2_helper(
     CreationOpts0 = emqx_resource:fetch_creation_opts(Config),
     CreationOpts = CreationOpts0#{namespace => Namespace},
     %% Create metrics for Bridge V2
-    ok = emqx_resource:create_metrics(BridgeV2Id),
+    ok = emqx_resource_metrics:create_metrics(BridgeV2Id),
     %% We might need to create buffer workers for Bridge V2
     case get_resource_query_mode(BridgeV2Type, Config) of
         %% the Bridge V2 has built-in buffer, so there is no need for resource workers

--- a/apps/emqx_cluster_link/src/emqx_cluster_link.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link.erl
@@ -117,21 +117,17 @@ forward(Routes, Delivery) ->
 %% EMQX Hooks
 %%--------------------------------------------------------------------
 
-on_message_publish(
-    #message{topic = <<?ROUTE_TOPIC_PREFIX, _/binary>>} = Msg
-) ->
+on_message_publish(#message{topic = <<?ROUTE_TOPIC_PREFIX, _/binary>>} = Msg) ->
     case handle_route_op_msg(Msg) of
         ok ->
             {stop, []};
         error ->
             %% Disconnect so that upstream agent starts anew
-            Headers0 = Msg#message.headers,
-            Headers = Headers0#{
+            Headers = #{
                 allow_publish => false,
                 should_disconnect => true
             },
-            StopMsg = emqx_message:set_headers(Headers, Msg),
-            {stop, StopMsg}
+            {stop, emqx_message:set_headers(Headers, Msg)}
     end;
 on_message_publish(#message{topic = <<?MSG_TOPIC_PREFIX, ClusterName/binary>>, payload = Payload}) ->
     case emqx_cluster_link_mqtt:decode_forwarded_msg(Payload) of

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_api.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_api.erl
@@ -320,7 +320,7 @@ handle_delete(Name) ->
     end.
 
 handle_metrics(Name) ->
-    Results = emqx_cluster_link_metrics:get_metrics(Name),
+    Results = emqx_cluster_link_metrics:get_cluster_metrics(Name),
     {NodeMetrics0, NodeErrors} =
         lists:foldl(
             fun({Node, RouterMetrics0, ResourceMetrics0}, {OkAccIn, ErrAccIn}) ->
@@ -424,7 +424,7 @@ format_metrics(Node, RouterMetrics, ResourceMetrics) ->
     }.
 
 handle_reset_metrics(Name) ->
-    Res = emqx_cluster_link_metrics:reset_metrics(Name),
+    Res = emqx_cluster_link_metrics:reset_cluster_metrics(Name),
     ErrorNodes =
         lists:filtermap(
             fun

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_app.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_app.erl
@@ -13,48 +13,23 @@ start(_StartType, _StartArgs) ->
     ok = emqx_cluster_link_config:load(),
     ok = emqx_cluster_link:register_external_broker(),
     ok = emqx_cluster_link:put_hook(),
-    LinksConf = emqx_cluster_link_config:get_enabled_links(),
-    case LinksConf of
-        [_ | _] ->
-            ok = start_msg_fwd_resources(LinksConf);
-        _ ->
-            ok
-    end,
     {ok, Sup} = emqx_cluster_link_sup:start_link(),
-    ok = create_metrics(LinksConf),
+    lists:foreach(
+        fun(LinkConf) ->
+            {ok, _} = emqx_cluster_link_sup:ensure_actor(LinkConf),
+            {ok, _} = emqx_cluster_link_mqtt:ensure_msg_fwd_resource(LinkConf)
+        end,
+        emqx_cluster_link_config:get_enabled_links()
+    ),
     {ok, Sup}.
 
 stop(_State) ->
     _ = emqx_cluster_link:delete_hook(),
     _ = emqx_cluster_link:unregister_external_broker(),
-    ok = emqx_cluster_link_config:unload(),
-    _ = remove_msg_fwd_resources(emqx_cluster_link_config:get_links()),
-    ok.
-
-%%--------------------------------------------------------------------
-%% Internal functions
-%%--------------------------------------------------------------------
-
-start_msg_fwd_resources(LinksConf) ->
+    _ = emqx_cluster_link_config:unload(),
     lists:foreach(
-        fun(LinkConf) ->
-            {ok, _} = emqx_cluster_link_mqtt:ensure_msg_fwd_resource(LinkConf)
+        fun(_LinkConf = #{name := ClusterName}) ->
+            emqx_cluster_link_mqtt:remove_msg_fwd_resource(ClusterName)
         end,
-        LinksConf
-    ).
-
-remove_msg_fwd_resources(LinksConf) ->
-    lists:foreach(
-        fun(#{name := Name}) ->
-            emqx_cluster_link_mqtt:remove_msg_fwd_resource(Name)
-        end,
-        LinksConf
-    ).
-
-create_metrics(LinksConf) ->
-    lists:foreach(
-        fun(#{name := ClusterName}) ->
-            ok = emqx_cluster_link_metrics:maybe_create_metrics(ClusterName)
-        end,
-        LinksConf
+        emqx_cluster_link_config:get_links()
     ).

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_bookkeeper.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_bookkeeper.erl
@@ -84,7 +84,7 @@ handle_tally_routes() ->
 
 tally_routes([ClusterName | ClusterNames]) ->
     NumRoutes = emqx_cluster_link_extrouter:count(ClusterName),
-    emqx_cluster_link_metrics:routes_set(ClusterName, NumRoutes),
+    emqx_cluster_link_metrics:set_num_external_routes(ClusterName, NumRoutes),
     tally_routes(ClusterNames);
 tally_routes([]) ->
     ok.

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
@@ -343,10 +343,9 @@ all_ok(Results) ->
 add_links(LinksConf) ->
     [add_link(Link) || Link <- LinksConf].
 
-add_link(#{name := ClusterName, enable := true} = LinkConf) ->
+add_link(#{enable := true} = LinkConf) ->
     {ok, _Pid} = emqx_cluster_link_sup:ensure_actor(LinkConf),
     {ok, _} = emqx_cluster_link_mqtt:ensure_msg_fwd_resource(LinkConf),
-    ok = emqx_cluster_link_metrics:maybe_create_metrics(ClusterName),
     ok;
 add_link(_DisabledLinkConf) ->
     ok.
@@ -356,8 +355,7 @@ remove_links(LinksConf) ->
 
 remove_link(Name) ->
     _ = emqx_cluster_link_mqtt:remove_msg_fwd_resource(Name),
-    _ = ensure_actor_stopped(Name),
-    emqx_cluster_link_metrics:drop_metrics(Name).
+    _ = ensure_actor_stopped(Name).
 
 update_links(LinksConf) ->
     [do_update_link(Link) || Link <- LinksConf].

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_metrics.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_metrics.erl
@@ -7,12 +7,14 @@
 
 %% API
 -export([
-    maybe_create_metrics/1,
-    drop_metrics/1,
-
-    get_metrics/1,
-    reset_metrics/1,
-    routes_set/2
+    %% Lifecycle
+    child_spec/0,
+    child_spec_link/1,
+    %% Reporting
+    set_num_external_routes/2,
+    %% Cluster-wide operations
+    get_cluster_metrics/1,
+    reset_cluster_metrics/1
 ]).
 
 %%--------------------------------------------------------------------
@@ -22,50 +24,64 @@
 -define(METRICS, [
     ?route_metric
 ]).
+
 -define(RATE_METRICS, []).
+
+-define(METRICS_RPC_TIMEOUT, 15_000).
 
 %%--------------------------------------------------------------------
 %% metrics API
 %%--------------------------------------------------------------------
 
-get_metrics(ClusterName) ->
-    Nodes = emqx:running_nodes(),
-    Timeout = 15_000,
-    RouterResults = emqx_metrics_proto_v2:get_metrics(Nodes, ?METRIC_NAME, ClusterName, Timeout),
-    ResourceId = emqx_cluster_link_mqtt:resource_id(ClusterName),
-    ResourceResults = emqx_metrics_proto_v2:get_metrics(
-        Nodes, resource_metrics, ResourceId, Timeout
-    ),
-    lists:zip3(Nodes, RouterResults, ResourceResults).
+child_spec() ->
+    emqx_metrics_worker:child_spec(metrics, ?METRIC_NAME).
 
-maybe_create_metrics(ClusterName) ->
-    case emqx_metrics_worker:has_metrics(?METRIC_NAME, ClusterName) of
-        true ->
-            ok = emqx_metrics_worker:reset_metrics(?METRIC_NAME, ClusterName);
-        false ->
-            ok = emqx_metrics_worker:create_metrics(
-                ?METRIC_NAME, ClusterName, ?METRICS, ?RATE_METRICS
-            )
-    end.
-
-reset_metrics(ClusterName) ->
-    Nodes = emqx:running_nodes(),
-    Timeout = 15_000,
-    RouterResults = emqx_metrics_proto_v2:reset_metrics(Nodes, ?METRIC_NAME, ClusterName, Timeout),
-    ResourceId = emqx_cluster_link_mqtt:resource_id(ClusterName),
-    ResourceResults = emqx_metrics_proto_v2:reset_metrics(
-        Nodes, resource_metrics, ResourceId, Timeout
-    ),
-    lists:zip3(Nodes, RouterResults, ResourceResults).
-
-drop_metrics(ClusterName) ->
-    ok = emqx_metrics_worker:clear_metrics(?METRIC_NAME, ClusterName).
-
-routes_set(ClusterName, Val) ->
-    catch emqx_metrics_worker:set_gauge(
-        ?METRIC_NAME, ClusterName, <<"singleton">>, ?route_metric, Val
+child_spec_link(ClusterName) ->
+    emqx_metrics_installer:child_spec(
+        metrics_installer,
+        ?METRIC_NAME,
+        ClusterName,
+        ?METRICS,
+        ?RATE_METRICS
     ).
 
 %%--------------------------------------------------------------------
-%% Internal functions
+
+-spec set_num_external_routes(emqx_cluster_link_schema:cluster(), non_neg_integer()) ->
+    ok.
+set_num_external_routes(ClusterName, N) ->
+    emqx_metrics_worker:set_gauge(?METRIC_NAME, ClusterName, routerepl, ?route_metric, N).
+
 %%--------------------------------------------------------------------
+
+-spec get_cluster_metrics(emqx_cluster_link_schema:cluster()) ->
+    [
+        {
+            node(),
+            emqx_rpc:erpc(_Router :: emqx_metrics_worker:metrics()),
+            emqx_rpc:erpc(_Resource :: emqx_metrics_worker:metrics())
+        }
+    ].
+get_cluster_metrics(ClusterName) ->
+    Nodes = emqx:running_nodes(),
+    RouterResults = emqx_metrics_proto_v2:get_metrics(
+        Nodes, ?METRIC_NAME, ClusterName, ?METRICS_RPC_TIMEOUT
+    ),
+    ResourceId = emqx_cluster_link_mqtt:resource_id(ClusterName),
+    ResourceResults = emqx_metrics_proto_v2:get_metrics(
+        Nodes, resource_metrics, ResourceId, ?METRICS_RPC_TIMEOUT
+    ),
+    lists:zip3(Nodes, RouterResults, ResourceResults).
+
+-spec reset_cluster_metrics(emqx_cluster_link_schema:cluster()) ->
+    [{node(), emqx_rpc:erpc(ok), emqx_rpc:erpc(ok)}].
+reset_cluster_metrics(ClusterName) ->
+    Nodes = emqx:running_nodes(),
+    RouterResults = emqx_metrics_proto_v2:reset_metrics(
+        Nodes, ?METRIC_NAME, ClusterName, ?METRICS_RPC_TIMEOUT
+    ),
+    ResourceId = emqx_cluster_link_mqtt:resource_id(ClusterName),
+    ResourceResults = emqx_metrics_proto_v2:reset_metrics(
+        Nodes, resource_metrics, ResourceId, ?METRICS_RPC_TIMEOUT
+    ),
+    lists:zip3(Nodes, RouterResults, ResourceResults).

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -386,6 +386,10 @@ mk_disconnect_handler(ResourceId, WorkerId, ClientId, TargetCluster) ->
 ) -> ok.
 handle_disconnect(Reason, ResourceId, WorkerId, EventCtx) ->
     case Reason of
+        shutdown ->
+            %% NOTE
+            %% Ignoring plain `shutdown`s as they are likely the result of stopping a link.
+            ok;
         {disconnected, RC, _Props} ->
             %% NOTE
             %% Emit warning if RC hints at misconfiguration or integration issues.

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_sup.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_sup.erl
@@ -34,20 +34,19 @@ init(root) ->
         intensity => 10,
         period => 5
     },
-    Links = emqx_cluster_link_config:get_enabled_links(),
-    Metrics = emqx_metrics_worker:child_spec(metrics, ?METRIC_NAME),
+    MetricsSpec = emqx_cluster_link_metrics:child_spec(),
     BookKeeper = bookkeeper_spec(),
     ExtrouterGC = extrouter_gc_spec(),
-    RouteReplSups = [routerepl_sup_spec(LinkConf) || LinkConf <- Links],
-    {ok, {SupFlags, [Metrics, BookKeeper, ExtrouterGC | RouteReplSups]}};
-init({routerepl, LinkConf}) ->
+    {ok, {SupFlags, [MetricsSpec, BookKeeper, ExtrouterGC]}};
+init({routerepl, LinkConf = #{name := ClusterName}}) ->
     SupFlags = #{
         strategy => one_for_one,
         intensity => 5,
         period => 5
     },
+    InstallerSpec = emqx_cluster_link_metrics:child_spec_link(ClusterName),
     ChildSpecs = [routerepl_spec(Type, Actor, LinkConf) || {Type, Actor} <- actors()],
-    {ok, {SupFlags, ChildSpecs}}.
+    {ok, {SupFlags, [InstallerSpec | ChildSpecs]}}.
 
 extrouter_gc_spec() ->
     %% NOTE: This one is currently global, not per-link.

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -38,12 +38,7 @@
     remove_local/1,
     reset_metrics/1,
     reset_metrics_local/1,
-    reset_metrics_local/2,
-    %% Create metrics for a resource ID
-    create_metrics/1,
-    ensure_metrics/1,
-    %% Delete metrics for a resource ID
-    clear_metrics/1
+    reset_metrics_local/2
 ]).
 
 %% Calls to the callback module with current resource state
@@ -367,7 +362,7 @@ reset_metrics_local(ResId) ->
 
 -spec reset_metrics_local(resource_id(), map()) -> ok.
 reset_metrics_local(ResId, _ClusterOpts) ->
-    emqx_resource_manager:reset_metrics(ResId).
+    emqx_resource_metrics:reset_metrics(ResId).
 
 -spec reset_metrics(resource_id()) -> ok | {error, Reason :: term()}.
 reset_metrics(ResId) ->
@@ -495,7 +490,7 @@ is_exist(ResId) ->
 -spec get_metrics(resource_id()) ->
     emqx_metrics_worker:metrics().
 get_metrics(ResId) ->
-    emqx_resource_manager:get_metrics(ResId).
+    emqx_resource_metrics:get_metrics(ResId).
 
 -spec fetch_creation_opts(map()) -> creation_opts().
 fetch_creation_opts(Opts) ->
@@ -805,43 +800,10 @@ deallocate_resource(InstanceId, Key) ->
 
 -undef(RES_MOD_KEY).
 
--spec create_metrics(resource_id()) -> ok.
-create_metrics(ResId) ->
-    emqx_metrics_worker:create_metrics(?RES_METRICS, ResId, metrics(), rate_metrics()).
-
--spec ensure_metrics(resource_id()) -> {ok, created | already_created}.
-ensure_metrics(ResId) ->
-    emqx_metrics_worker:ensure_metrics(?RES_METRICS, ResId, metrics(), rate_metrics()).
-
--spec clear_metrics(resource_id()) -> ok.
-clear_metrics(ResId) ->
-    emqx_metrics_worker:clear_metrics(?RES_METRICS, ResId).
-
 get_health_check_timeout(Opts) ->
     emqx_utils_maps:deep_get([resource_opts, health_check_timeout], Opts, ?HEALTHCHECK_TIMEOUT).
 
 %% =================================================================================
-
-metrics() ->
-    [
-        'matched',
-        'retried',
-        'retried.success',
-        'retried.failed',
-        'success',
-        'late_reply',
-        'failed',
-        'dropped',
-        'dropped.expired',
-        'dropped.queue_full',
-        'dropped.resource_not_found',
-        'dropped.resource_stopped',
-        'dropped.other',
-        'received'
-    ].
-
-rate_metrics() ->
-    ['matched'].
 
 filter_instances(Filter) ->
     [Id || #{id := Id, mod := Mod} <- list_instances_verbose(), Filter(Id, Mod)].

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -280,8 +280,6 @@ create_and_return_data(ResId, Group, ResourceType, Config, Opts) ->
 create(ResId, Group, ResourceType, Config, Opts) ->
     % The state machine will make the actual call to the callback/resource module after init
     ok = emqx_resource_manager_sup:ensure_child(ResId, Group, ResourceType, Config, Opts),
-    % Create metrics for the resource
-    ok = emqx_resource:create_metrics(ResId),
     QueryMode = emqx_resource:query_mode(ResourceType, Config, Opts),
     SpawnBufferWorkers = maps:get(spawn_buffer_workers, Opts, false),
     case SpawnBufferWorkers andalso lists:member(QueryMode, [sync, async]) of
@@ -759,11 +757,18 @@ start_link(ResId, Group, ResourceType, Config, Opts) ->
 
 init({DataIn, Opts}) ->
     process_flag(trap_exit, true),
+    #data{
+        id = ResId,
+        namespace = Namespace,
+        config = Config
+    } = DataIn,
     Data = DataIn#data{pid = self()},
-    set_label({resource_manager, Data#data.namespace, Data#data.id}),
+    set_label({resource_manager, Namespace, ResId}),
     ok = set_log_meta(Data),
-    emqx_resource_cache_cleaner:add_cache(Data#data.id, self()),
-    IsEnabled = maps:get(enable, Data#data.config, true),
+    emqx_resource_cache_cleaner:add_cache(ResId, self()),
+    % Create metrics for the resource
+    ok = emqx_resource_metrics:create_metrics(ResId),
+    IsEnabled = maps:get(enable, Config, true),
     StartAfterCreated = maps:get(start_after_created, Opts, IsEnabled),
     case IsEnabled andalso StartAfterCreated of
         true ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -39,8 +39,6 @@
     list_group/1,
     lookup_cached/1,
     is_exist/1,
-    get_metrics/1,
-    reset_metrics/1,
     get_query_mode_and_last_error/2
 ]).
 
@@ -477,16 +475,6 @@ lookup_cached(ResId) ->
 %% @doc Check if the resource is cached.
 is_exist(ResId) ->
     emqx_resource_cache:is_exist(ResId).
-
-%% @doc Get the metrics for the specified resource
-get_metrics(ResId) ->
-    emqx_metrics_worker:get_metrics(?RES_METRICS, ResId).
-
-%% @doc Reset the metrics for the specified resource
--spec reset_metrics(resource_id()) -> ok.
-reset_metrics(ResId) ->
-    ok = ensure_metrics(ResId),
-    emqx_metrics_worker:reset_metrics(?RES_METRICS, ResId).
 
 %% @doc Returns the data for all resources
 -spec list_all() -> [resource_data()].
@@ -1071,7 +1059,7 @@ handle_remove_event(From, ClearMetrics, Data) ->
     %% now stop the resource, this can be slow
     _ = stop_resource(Data),
     case ClearMetrics of
-        true -> ok = emqx_metrics_worker:clear_metrics(?RES_METRICS, Data#data.id);
+        true -> ok = emqx_resource_metrics:clear_metrics(Data#data.id);
         false -> ok
     end,
     _ = erase_cache(Data),
@@ -1294,7 +1282,7 @@ stop_resource(#data{id = ResId} = Data) ->
     end,
     IsDryRun = emqx_resource:is_dry_run(ResId),
     _ = maybe_clear_alarm(IsDryRun, ResId),
-    ok = emqx_metrics_worker:reset_metrics(?RES_METRICS, ResId),
+    ok = emqx_resource_metrics:reset_metrics(ResId),
     NewData#data{status = ?rm_status_stopped}.
 
 remove_channels(Data) ->
@@ -1452,7 +1440,7 @@ handle_remove_channel_exists(From, ChannelId, Data) ->
         )
     of
         {ok, NewState} ->
-            ok = emqx_resource:clear_metrics(ChannelId),
+            ok = emqx_resource_metrics:clear_metrics(ChannelId),
             NewAddedChannelsMap = maps:remove(ChannelId, AddedChannelsMap),
             UpdatedData = Data#data{
                 state = NewState,
@@ -2532,7 +2520,7 @@ set_log_meta(Data) ->
 %% errors.  As mitigation, we ensure such metrics are created here so that restarting
 %% the resource or resetting its metrics can recreate them.
 ensure_metrics(ResId) ->
-    {ok, _} = emqx_resource:ensure_metrics(ResId),
+    {ok, _} = emqx_resource_metrics:ensure_metrics(ResId),
     ok.
 
 %% When a resource enters a `?status_disconnected' state, late channel health check
@@ -2724,7 +2712,7 @@ collect_channel_operations(N, Acc) ->
 ensure_channel_metrics_exist(Data) ->
     lists:foreach(
         fun({ChannelId, _Config}) ->
-            {ok, _} = emqx_resource:ensure_metrics(ChannelId)
+            {ok, _} = emqx_resource_metrics:ensure_metrics(ChannelId)
         end,
         emqx_resource:call_get_channels(Data#data.id, Data#data.mod)
     ).

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -766,8 +766,8 @@ init({DataIn, Opts}) ->
     set_label({resource_manager, Namespace, ResId}),
     ok = set_log_meta(Data),
     emqx_resource_cache_cleaner:add_cache(ResId, self()),
-    % Create metrics for the resource
-    ok = emqx_resource_metrics:create_metrics(ResId),
+    % Ensure metrics for the resource
+    {ok, _} = emqx_resource_metrics:ensure_metrics(ResId),
     IsEnabled = maps:get(enable, Config, true),
     StartAfterCreated = maps:get(start_after_created, Opts, IsEnabled),
     case IsEnabled andalso StartAfterCreated of

--- a/apps/emqx_resource/src/emqx_resource_metrics.erl
+++ b/apps/emqx_resource/src/emqx_resource_metrics.erl
@@ -15,6 +15,14 @@
 ]).
 
 -export([
+    create_metrics/1,
+    ensure_metrics/1,
+    reset_metrics/1,
+    clear_metrics/1,
+    get_metrics/1
+]).
+
+-export([
     inflight_set/3,
     inflight_get/1,
     queuing_set/3,
@@ -65,7 +73,30 @@
     success_get/1
 ]).
 
+-define(METRICS, [
+    'matched',
+    'retried',
+    'retried.success',
+    'retried.failed',
+    'success',
+    'late_reply',
+    'failed',
+    'dropped',
+    'dropped.expired',
+    'dropped.queue_full',
+    'dropped.resource_not_found',
+    'dropped.resource_stopped',
+    'dropped.other',
+    'received'
+]).
+
+-define(RATE_METRICS, [
+    'matched'
+]).
+
 -define(TELEMETRY_PREFIX, emqx, resource).
+
+%%
 
 -spec events() -> [telemetry:event_name()].
 events() ->
@@ -216,6 +247,29 @@ handle_gauge_telemetry_event(Event, ID, WorkerID, Val) ->
         _ ->
             ok
     end.
+
+%%
+
+-spec create_metrics(resource_id()) -> ok.
+create_metrics(ID) ->
+    emqx_metrics_worker:create_metrics(?RES_METRICS, ID, ?METRICS, ?RATE_METRICS).
+
+-spec ensure_metrics(resource_id()) -> {ok, created | already_created}.
+ensure_metrics(ID) ->
+    emqx_metrics_worker:ensure_metrics(?RES_METRICS, ID, ?METRICS, ?RATE_METRICS).
+
+%% @doc Get the metrics for the specified resource
+get_metrics(ID) ->
+    emqx_metrics_worker:get_metrics(?RES_METRICS, ID).
+
+%% @doc Reset the metrics for the specified resource
+-spec reset_metrics(resource_id()) -> ok.
+reset_metrics(ID) ->
+    emqx_metrics_worker:reset_metrics(?RES_METRICS, ID).
+
+-spec clear_metrics(resource_id()) -> ok.
+clear_metrics(ID) ->
+    emqx_metrics_worker:clear_metrics(?RES_METRICS, ID).
 
 %% Gauges (value can go both up and down):
 %% --------------------------------------

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -397,8 +397,8 @@ add_channel_async(ConnResId, ChanId, Config) ->
     do_add_channel(ConnResId, ChanId, Config, async).
 
 do_add_channel(ConnResId, ChanId, Config, Mode) ->
-    ok = emqx_resource:create_metrics(ChanId),
-    on_exit(fun() -> emqx_resource:clear_metrics(ChanId) end),
+    ok = emqx_resource_metrics:create_metrics(ChanId),
+    on_exit(fun() -> emqx_resource_metrics:clear_metrics(ChanId) end),
     ResourceOpts = emqx_resource:fetch_creation_opts(Config),
     on_exit(fun() -> emqx_resource_buffer_worker_sup:stop_workers(ChanId, ResourceOpts) end),
     ok = emqx_resource_buffer_worker_sup:start_workers(ChanId, ResourceOpts),

--- a/apps/emqx_utils/src/emqx_metrics_installer.erl
+++ b/apps/emqx_utils/src/emqx_metrics_installer.erl
@@ -1,0 +1,82 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_metrics_installer).
+-moduledoc """
+This module implements a helper process that owns the lifetime of a set
+of metrics, for an existing metrics worker:
+* Metrics are created on process startup.
+* Metrics are cleaerd on terminate.
+
+Supposed to be included as a child in a supervisor for some resource that
+needs metrics to be present in a shared "parent" metrics worker.
+""".
+
+-behaviour(gen_server).
+
+%% API functions
+-export([
+    start_link/4,
+    child_spec/5
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_info/2,
+    handle_cast/2,
+    terminate/2
+]).
+
+-spec child_spec(
+    _ChildId :: term(),
+    emqx_metrics_worker:handler_name(),
+    emqx_metrics_worker:metric_id(),
+    [emqx_metrics_worker:metric_spec()],
+    [emqx_metrics_worker:metric_name()]
+) -> supervisor:child_spec().
+child_spec(ChldName, Name, MetricId, Metrics, RateMetrics) ->
+    #{
+        id => ChldName,
+        start => {?MODULE, start_link, [Name, MetricId, Metrics, RateMetrics]},
+        restart => permanent,
+        shutdown => 5000,
+        type => worker
+    }.
+
+-spec start_link(
+    emqx_metrics_worker:handler_name(),
+    emqx_metrics_worker:metric_id(),
+    [emqx_metrics_worker:metric_spec()],
+    [emqx_metrics_worker:metric_name()]
+) -> gen_server:start_ret().
+start_link(Name, MetricId, Metrics, RateMetrics) ->
+    gen_server:start_link(?MODULE, {Name, MetricId, Metrics, RateMetrics}, []).
+
+%%------------------------------------------------------------------------------
+%% gen_server callbacks
+%%------------------------------------------------------------------------------
+
+init({Name, MetricId, Metrics, RateMetrics}) ->
+    erlang:process_flag(trap_exit, true),
+    case emqx_metrics_worker:ensure_metrics(Name, MetricId, Metrics, RateMetrics) of
+        {ok, _} ->
+            ok = emqx_metrics_worker:reset_metrics(Name, MetricId),
+            {ok, {Name, MetricId}, hibernate};
+        {error, Reason} ->
+            {stop, Reason}
+    end.
+
+handle_call(_Request, _From, State) ->
+    {reply, {?MODULE, invalid_call}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, {Name, MetricId}) ->
+    emqx_metrics_worker:clear_metrics(Name, MetricId).

--- a/apps/emqx_utils/src/emqx_metrics_worker.erl
+++ b/apps/emqx_utils/src/emqx_metrics_worker.erl
@@ -82,7 +82,13 @@
 %% =<10ms, =<100ms, =<1s, =<5s, =<30s, >30s
 -define(DEFAULT_HIST_BUCKETS, [10, 100, 1000, 5000, 30000]).
 
--export_type([metrics/0, handler_name/0, metric_id/0, metric_spec/0]).
+-export_type([
+    handler_name/0,
+    metrics/0,
+    metric_id/0,
+    metric_name/0,
+    metric_spec/0
+]).
 
 -type handler_name() :: atom().
 %% metric_id() is actually a resource id
@@ -126,8 +132,10 @@
 }.
 
 -type init_metrics() ::
-    [{metric_id(), [metric_spec()], [metric_name()]}]
-    | [{metric_id(), [metric_spec()]}].
+    [
+        {metric_id(), [metric_spec()], [metric_name()]}
+        | {metric_id(), [metric_spec()]}
+    ].
 
 -define(CntrRef(Name), {?MODULE, Name}).
 -define(SAMPCOUNT_5M, (?SECS_5M div ?SAMPLING)).

--- a/changes/ee/fix-17469.en.md
+++ b/changes/ee/fix-17469.en.md
@@ -1,0 +1,4 @@
+Fixed the issue where warnings similiar to those below are emitted when enabling or disabling an active Cluster Link.
+```
+[warning] tag: RESOURCE, msg: handle_resource_metrics_failed, reason: {badkey, matched}, event: matched, ...
+```


### PR DESCRIPTION
Fixes [EMQX-15262](https://emqx.atlassian.net/browse/EMQX-15262)

Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

This PR addresses issues with metrics lifetime mismatch in Cluster Link resources, and resources in general.
1. Lifetime of per-resource metrics is extended, metrics are created _before_ resource itself.
2. Lifetime of Cluster Link actor metrics are managed through the actor supervisor.

Various modules APIs in `emqx_resource` and `emqx_cluster_link` apps are streamlined and simplified.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible

[EMQX-15262]: https://emqx.atlassian.net/browse/EMQX-15262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ