### PR TITLE
perf(iotdb): reduce REST health check cost

### DIFF
--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.app.src
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_iotdb, [
     {description, "EMQX Enterprise Apache IoTDB Bridge"},
-    {vsn, "0.2.11"},
+    {vsn, "0.2.12"},
     {modules, [
         emqx_bridge_iotdb,
         emqx_bridge_iotdb_connector

--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb_connector.erl
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb_connector.erl
@@ -80,6 +80,8 @@
 
 -define(CONNECTOR_TYPE, iotdb).
 -define(IOTDB_PING_PATH, <<"ping">>).
+-define(IOTDB_AUTH_PROBE_PATH, <<"rest/v2/query">>).
+-define(IOTDB_AUTH_PROBE_SQL, <<"show version">>).
 
 %% timer:seconds(10)).
 -define(DEFAULT_THRIFT_TIMEOUT, 10000).
@@ -523,8 +525,12 @@ check_auth_restapi(ConnResId, ConnState) ->
     Headers = emqx_bridge_http_connector:render_headers(Headers0),
     Req =
         {post,
-            {<<"rest/v2/nonQuery">>, Headers,
-                emqx_utils_json:encode(#{sql => <<"show databases">>})}},
+            {?IOTDB_AUTH_PROBE_PATH, Headers,
+                emqx_utils_json:encode(#{sql => ?IOTDB_AUTH_PROBE_SQL})}},
+    ?tp(iotdb_restapi_auth_probe, #{
+        path => ?IOTDB_AUTH_PROBE_PATH,
+        sql => ?IOTDB_AUTH_PROBE_SQL
+    }),
     Res = emqx_bridge_http_connector:on_query(ConnResId, Req, ConnState),
     case emqx_bridge_http_connector:transform_result(Res) of
         {ok, 200, _, _} ->

--- a/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
+++ b/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
@@ -25,6 +25,7 @@ all() ->
 
 groups() ->
     ThriftOnlyTCs = [t_thrift_auto_recon, t_thrift_protocol_version_1_or_2_is_deprecated],
+    RestAPIOnlyTCs = [t_restapi_auth_probe_with_real_iotdb],
     AllTCs = emqx_common_test_helpers:all(?MODULE) -- ThriftOnlyTCs,
     Async = [
         t_async_device_id_missing,
@@ -33,7 +34,7 @@ groups() ->
     ],
     [
         {iotdb130, AllTCs},
-        {thrift, (AllTCs -- Async) ++ ThriftOnlyTCs}
+        {thrift, ((AllTCs -- Async) -- RestAPIOnlyTCs) ++ ThriftOnlyTCs}
     ].
 
 init_per_suite(Config) ->
@@ -426,6 +427,32 @@ t_probe_connector_api(Config) ->
 
 t_on_get_status(Config) ->
     emqx_bridge_v2_testlib:t_on_get_status(Config).
+
+t_restapi_auth_probe_with_real_iotdb(Config) ->
+    ResourceId = emqx_bridge_v2_testlib:connector_resource_id(Config),
+    ?check_trace(
+        begin
+            ?assertMatch(
+                {ok, {{_, 201, _}, _, #{<<"status">> := <<"connected">>}}},
+                emqx_bridge_v2_testlib:create_connector_api(Config)
+            ),
+            ?retry(
+                _Sleep = 1_000,
+                _Attempts = 20,
+                ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
+            ),
+            ok
+        end,
+        fun(Trace) ->
+            Probes = ?of_kind(iotdb_restapi_auth_probe, Trace),
+            ?assertMatch(
+                [#{path := <<"rest/v2/query">>, sql := <<"show version">>} | _],
+                Probes
+            ),
+            ?assertEqual([], [Probe || #{path := <<"rest/v2/nonQuery">>} = Probe <- Probes]),
+            ok
+        end
+    ).
 
 t_device_id(Config) ->
     %% Create without device_id configured

--- a/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
+++ b/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
@@ -25,7 +25,10 @@ all() ->
 
 groups() ->
     ThriftOnlyTCs = [t_thrift_auto_recon, t_thrift_protocol_version_1_or_2_is_deprecated],
-    RestAPIOnlyTCs = [t_restapi_auth_probe_with_real_iotdb],
+    RestAPIOnlyTCs = [
+        t_restapi_auth_probe_with_real_iotdb,
+        t_restapi_auth_probe_rejects_bad_password
+    ],
     AllTCs = emqx_common_test_helpers:all(?MODULE) -- ThriftOnlyTCs,
     Async = [
         t_async_device_id_missing,
@@ -441,6 +444,30 @@ t_restapi_auth_probe_with_real_iotdb(Config) ->
                 _Attempts = 20,
                 ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
             ),
+            ok
+        end,
+        fun(Trace) ->
+            Probes = ?of_kind(iotdb_restapi_auth_probe, Trace),
+            ?assertMatch(
+                [#{path := <<"rest/v2/query">>, sql := <<"show version">>} | _],
+                Probes
+            ),
+            ?assertEqual([], [Probe || #{path := <<"rest/v2/nonQuery">>} = Probe <- Probes]),
+            ok
+        end
+    ).
+
+t_restapi_auth_probe_rejects_bad_password(Config) ->
+    BadPassword = #{<<"authentication">> => #{<<"password">> => <<"wrong-password">>}},
+    ?check_trace(
+        begin
+            {ok, {{_, 201, _}, _, Body}} =
+                emqx_bridge_v2_testlib:create_connector_api(Config, BadPassword),
+            #{
+                <<"status">> := <<"disconnected">>,
+                <<"status_reason">> := StatusReason
+            } = Body,
+            ?assertMatch({_, _}, binary:match(StatusReason, <<"WRONG_LOGIN_PASSWORD">>)),
             ok
         end,
         fun(Trace) ->

--- a/changes/ee/perf-17472.en.md
+++ b/changes/ee/perf-17472.en.md
@@ -1,0 +1,1 @@
+Reduced the overhead of IoTDB REST API connector health checks by using a bounded version query instead of listing all databases on each check.


### PR DESCRIPTION
Release version:
5.10.5

## Summary

Fixes #17413.

This PR reduces the REST API driver health-check cost for IoTDB connectors.

- Replaces the REST auth probe from `POST /rest/v2/nonQuery` with `show databases` to `POST /rest/v2/query` with `show version`, so each health-check tick no longer depends on the number of IoTDB databases/storage groups.
- Adds focused integration tests against a real IoTDB service: one creates a healthy connector and asserts that the driver used the bounded auth probe instead of `rest/v2/nonQuery`; another uses a bad password and asserts the same probe is rejected with `WRONG_LOGIN_PASSWORD`.
- Adds `changes/ee/perf-17472.en.md` and bumps `emqx_bridge_iotdb` app version to `0.2.12` for release-510 app version checks.
- Checks run: `./scripts/ct/run.sh --app apps/emqx_bridge_iotdb -- --suite apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl --group iotdb130 --case t_restapi_auth_probe_with_real_iotdb` (`All 1 tests passed`); `./scripts/ct/run.sh --app apps/emqx_bridge_iotdb -- --suite apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl --group iotdb130 --case t_restapi_auth_probe_rejects_bad_password` (`All 1 tests passed`); `git diff --check ce/release-510..HEAD`; pre-commit `erlfmt` and `apps-version-check`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
