### PR TITLE
fix(plugins): demote stop-deps warning to info

### DIFF
--- a/apps/emqx_plugins/src/emqx_plugins_apps.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_apps.erl
@@ -81,7 +81,7 @@ stop(#{rel_apps := Apps}) ->
             %% all apps stopped
             ok;
         {ok, Left} ->
-            ?SLOG(warning, #{
+            ?SLOG(info, #{
                 msg => "unabled_to_stop_plugin_apps",
                 apps => Left,
                 reason => "running_apps_still_depends_on_this_apps"

--- a/apps/emqx_plugins/src/emqx_plugins_apps.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_apps.erl
@@ -82,7 +82,7 @@ stop(#{rel_apps := Apps}) ->
             ok;
         {ok, Left} ->
             ?SLOG(info, #{
-                msg => "unabled_to_stop_plugin_apps",
+                msg => "unable_to_stop_plugin_apps",
                 apps => Left,
                 reason => "running_apps_still_depends_on_this_apps"
             }),

--- a/changes/ee/fix-17473.en.md
+++ b/changes/ee/fix-17473.en.md
@@ -1,0 +1,1 @@
+Lower the log level of `unabled_to_stop_plugin_apps` from warning to info when the plugin's Erlang applications cannot be stopped because other running applications still depend on them. This is an expected, non-actionable condition during plugin unload and no longer raises a warning.


### PR DESCRIPTION
fixes https://emqx.atlassian.net/browse/EMQX-15319
Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

`unabled_to_stop_plugin_apps` is an expected condition during plugin unload — when other running apps still depend on the plugin's apps, those apps stay loaded. Logging it at `warning` was noisy and non-actionable for operators. Demoted to `info`.

The log statement is at `apps/emqx_plugins/src/emqx_plugins_apps.erl:84-88`. Reason is hardcoded to `"running_apps_still_depends_on_this_apps"` at that call site, so the level change is scoped exactly to that condition.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)