### PR TITLE
perf(iotdb): reduce REST health check cost

### DIFF
--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb_connector.erl
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb_connector.erl
@@ -80,6 +80,8 @@
 
 -define(CONNECTOR_TYPE, iotdb).
 -define(IOTDB_PING_PATH, <<"ping">>).
+-define(IOTDB_AUTH_PROBE_PATH, <<"rest/v2/query">>).
+-define(IOTDB_AUTH_PROBE_SQL, <<"show version">>).
 
 %% timer:seconds(10)).
 -define(DEFAULT_THRIFT_TIMEOUT, 10000).
@@ -521,8 +523,12 @@ check_auth_restapi(ConnResId, ConnState) ->
     Headers = emqx_bridge_http_connector:render_headers(Headers0),
     Req =
         {post,
-            {<<"rest/v2/nonQuery">>, Headers,
-                emqx_utils_json:encode(#{sql => <<"show databases">>})}},
+            {?IOTDB_AUTH_PROBE_PATH, Headers,
+                emqx_utils_json:encode(#{sql => ?IOTDB_AUTH_PROBE_SQL})}},
+    ?tp(iotdb_restapi_auth_probe, #{
+        path => ?IOTDB_AUTH_PROBE_PATH,
+        sql => ?IOTDB_AUTH_PROBE_SQL
+    }),
     Res = emqx_bridge_http_connector:on_query(ConnResId, Req, ConnState),
     case emqx_bridge_http_connector:transform_result(Res) of
         {ok, 200, _, _} ->

--- a/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_SUITE.erl
+++ b/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_SUITE.erl
@@ -277,6 +277,15 @@ is_success_check(Other) ->
 is_code(Code, #{<<"code">> := Code}) -> true;
 is_code(_, _) -> false.
 
+assert_restapi_auth_probe(Trace) ->
+    Probes = ?of_kind(iotdb_restapi_auth_probe, Trace),
+    ?assertMatch(
+        [#{path := <<"rest/v2/query">>, sql := <<"show version">>} | _],
+        Probes
+    ),
+    ?assertEqual([], [Probe || #{path := <<"rest/v2/nonQuery">>} = Probe <- Probes]),
+    ok.
+
 make_iotdb_payload(DeviceId, Measurement, Type, Value) ->
     #{
         measurement => bin(Measurement),
@@ -352,6 +361,45 @@ t_on_get_status(matrix) ->
     [[?iotdb130], [?thrift]];
 t_on_get_status(TCConfig) when is_list(TCConfig) ->
     emqx_bridge_v2_testlib:t_on_get_status(TCConfig).
+
+t_restapi_auth_probe_with_real_iotdb() ->
+    [{matrix, true}].
+t_restapi_auth_probe_with_real_iotdb(matrix) ->
+    [[?iotdb130]];
+t_restapi_auth_probe_with_real_iotdb(TCConfig) when is_list(TCConfig) ->
+    ResourceId = emqx_bridge_v2_testlib:connector_resource_id(TCConfig),
+    ?check_trace(
+        begin
+            {201, #{<<"status">> := <<"connected">>}} = create_connector_api(TCConfig, #{}),
+            ?retry(
+                1_000,
+                20,
+                ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
+            ),
+            ok
+        end,
+        fun assert_restapi_auth_probe/1
+    ).
+
+t_restapi_auth_probe_rejects_bad_password() ->
+    [{matrix, true}].
+t_restapi_auth_probe_rejects_bad_password(matrix) ->
+    [[?iotdb130]];
+t_restapi_auth_probe_rejects_bad_password(TCConfig) when is_list(TCConfig) ->
+    BadPassword = #{<<"authentication">> => #{<<"password">> => <<"wrong-password">>}},
+    ?check_trace(
+        begin
+            {201, #{
+                <<"status">> := <<"disconnected">>,
+                <<"status_reason">> := StatusReason
+            }} = create_connector_api(TCConfig, BadPassword),
+            ?assertMatch(
+                match, re:run(StatusReason, <<"WRONG_LOGIN_PASSWORD">>, [{capture, none}])
+            ),
+            ok
+        end,
+        fun assert_restapi_auth_probe/1
+    ).
 
 t_rule_action() ->
     [{matrix, true}].

--- a/changes/ee/perf-17474.en.md
+++ b/changes/ee/perf-17474.en.md
@@ -1,0 +1,1 @@
+Reduced the overhead of IoTDB REST API connector health checks by using a bounded version query instead of listing all databases on each check.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/17413

Release version:
6.0.3

## Summary

This ports #17472 to `release-60`.

The IoTDB REST connector previously used `rest/v2/nonQuery` with `show databases` during auth health checks. That operation can be relatively expensive and is only needed to prove credentials are accepted, so the driver now probes `rest/v2/query` with `show version` instead.

The probe remains in the driver health-check path and keeps the existing 401 handling. A trace point records the probe path and SQL so the integration tests can prove the real request shape without introducing a mocked probe server.

Checked on the latest `release-60` base with focused CT against the real IoTDB 1.3 REST service:
`t_restapi_auth_probe_with_real_iotdb` verifies the connector is connected and the health probe uses `rest/v2/query` + `show version`.
`t_restapi_auth_probe_rejects_bad_password` verifies the same probe is still authenticated by IoTDB and bad credentials return `WRONG_LOGIN_PASSWORD`.
Also checked with `erlfmt`, `apps-version-check`, and `git diff --check`.

Added changelog `changes/ee/perf-17474.en.md`. There are no schema changes.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
