### PR TITLE
fix(acme): unblock plugin config save from the dashboard

### DIFF
--- a/plugins/emqx_acme/priv/config_schema.avsc
+++ b/plugins/emqx_acme/priv/config_schema.avsc
@@ -140,8 +140,8 @@
     },
     {
       "name": "acc_key",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
+      "default": "",
       "$ui": {
         "component": "input",
         "flex": 12,
@@ -152,8 +152,8 @@
     },
     {
       "name": "acc_key_password",
-      "type": ["null", "string"],
-      "default": null,
+      "type": "string",
+      "default": "",
       "$ui": {
         "component": "input",
         "flex": 12,

--- a/plugins/emqx_acme/src/emqx_acme_config.erl
+++ b/plugins/emqx_acme/src/emqx_acme_config.erl
@@ -91,10 +91,38 @@ parse_dir_url(Config) ->
     {ok, to_str(get_val(<<"dir_url">>, Config, ?DEFAULT_DIR_URL))}.
 
 parse_domains(Config) ->
-    parse_csv_list(<<"domains">>, Config, invalid_domains).
+    maybe
+        {ok, Domains} ?= parse_csv_list(<<"domains">>, Config, invalid_domains),
+        validate_domains(Domains)
+    end.
 
 parse_contact(Config) ->
     parse_csv_list(<<"contact">>, Config, invalid_contact).
+
+%% Quick sanity check on each domain entry. Deliberately permissive
+%% (no full RFC 1035 enforcement, no IDN normalisation) — only the
+%% characters clearly not part of a hostname (`@`, whitespace, `/`,
+%% `\`, control codes) are rejected. Full label/IDN validation stays
+%% in idna at issuance time.
+validate_domains(Domains) ->
+    case lists:dropwhile(fun is_plausible_domain/1, Domains) of
+        [] -> {ok, Domains};
+        [Bad | _] -> {error, {invalid_domain, Bad}}
+    end.
+
+is_plausible_domain(Bin) when is_binary(Bin), byte_size(Bin) > 0 ->
+    not has_disallowed_char(Bin);
+is_plausible_domain(_) ->
+    false.
+
+has_disallowed_char(<<>>) ->
+    false;
+has_disallowed_char(<<C, _/binary>>) when
+    C =:= $@; C =:= $/; C =:= $\\; C =:= $\s; C =:= $\t; C =:= $\n; C =:= $\r; C < 32
+->
+    true;
+has_disallowed_char(<<_, Rest/binary>>) ->
+    has_disallowed_char(Rest).
 
 %% domains and contact are exposed in the dashboard as a single
 %% comma-separated string field (input-array was hard for operators to

--- a/plugins/emqx_acme/src/emqx_acme_issuer.erl
+++ b/plugins/emqx_acme/src/emqx_acme_issuer.erl
@@ -251,10 +251,20 @@ cancel_timer(#state{timer_ref = Ref} = State) ->
 %% Spawn a monitored worker to run the actual ACME flow. The worker
 %% exits with its result wrapped in a tagged tuple, so success and crash
 %% are both delivered via the same DOWN message — no extra signalling
-%% channel needed.
+%% channel needed. run_action/1 is wrapped in a catch-all so that any
+%% exception raised deep in acme-erlang-client (e.g. idna's
+%% `exit:{bad_label, _}` on a malformed domain) lands in last_result as
+%% a structured `{error, {Class, Reason}}` and the gen_server clears
+%% in_progress the same way it does for normal errors.
 spawn_worker(Action) ->
     {Pid, Ref} = spawn_monitor(fun() ->
-        exit({?WORKER_RESULT, run_action(Action)})
+        Result =
+            try
+                run_action(Action)
+            catch
+                Class:Reason -> {error, {Class, Reason}}
+            end,
+        exit({?WORKER_RESULT, Result})
     end),
     #{
         action => Action,

--- a/plugins/emqx_acme/test/emqx_acme_api_SUITE.erl
+++ b/plugins/emqx_acme/test/emqx_acme_api_SUITE.erl
@@ -1,0 +1,108 @@
+-module(emqx_acme_api_SUITE).
+
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_plugins/include/emqx_plugins.hrl").
+
+all() ->
+    [
+        t_put_config_returns_400_when_parser_rejects_avro_valid_input
+    ].
+
+init_per_suite(Config) ->
+    WorkDir = emqx_cth_suite:work_dir(Config),
+    InstallDir = filename:join(WorkDir, "plugins"),
+    Apps = emqx_cth_suite:start(
+        [
+            emqx_conf,
+            emqx_ctl,
+            {emqx_plugins, #{config => #{plugins => #{install_dir => InstallDir}}}}
+        ],
+        #{work_dir => WorkDir}
+    ),
+    ok = filelib:ensure_path(InstallDir),
+    NameVsn = name_vsn(),
+    {ok, TarBin} = file:read_file(prebuilt_tarball()),
+    ok = emqx_plugins:write_package(NameVsn, TarBin),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    ok = emqx_plugins:ensure_started(NameVsn),
+    [{suite_apps, Apps}, {install_dir, InstallDir}, {name_vsn, NameVsn} | Config].
+
+end_per_suite(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    catch emqx_plugins:ensure_stopped(NameVsn),
+    catch emqx_plugins:ensure_uninstalled(NameVsn),
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
+
+-doc "A request body that passes avro (the avsc declares `domains` as a "
+"string and `\"mqtt.example.com,admin@example\"` is a valid string) but is "
+"rejected by the plugin's parser must be reported back to the API caller as "
+"an error, with the persisted config left untouched. The HTTP layer "
+"translates that error to a 400 BAD_CONFIG response (see "
+"emqx_mgmt_api_plugins:return_config_update_result/1).".
+t_put_config_returns_400_when_parser_rejects_avro_valid_input(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    OldConfig = emqx_plugins:get_config(NameVsn),
+    BadConfig = OldConfig#{<<"domains">> => <<"mqtt.example.com,admin@example">>},
+
+    %% Layer 1: avro decode accepts the bad input. This is the precondition
+    %% that distinguishes the parse-fail case from the avro-fail case.
+    ?assertMatch(
+        {ok, _AvroValue},
+        emqx_plugins:decode_plugin_config_map(NameVsn, BadConfig)
+    ),
+
+    %% Layer 2: emqx_plugins:update_config/2 returns {error, Reason}. This
+    %% is what the BPAPI multi_call surfaces, which the HTTP API maps to
+    %% 400 BAD_CONFIG via return_config_update_result/1.
+    ?assertMatch(
+        {error, {invalid_domain, <<"admin@example">>}},
+        emqx_plugins:update_config(NameVsn, BadConfig)
+    ),
+
+    %% Layer 3: persisted config and in-memory cache are untouched.
+    %% emqx_plugins:update_config/2 uses a maybe-block so the
+    %% backup_and_update / put_cached_config steps short-circuit on the
+    %% parse error; nothing reaches disk or the cache.
+    ?assertEqual(OldConfig, emqx_plugins:get_config(NameVsn)).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+name_vsn() ->
+    %% application:load is idempotent and only loads the .app file (does
+    %% not start the app), so it's safe to call here just to read the vsn
+    %% key before the plugin manager takes over the install/start lifecycle.
+    _ = application:load(emqx_acme),
+    {ok, Vsn} = application:get_key(emqx_acme, vsn),
+    iolist_to_binary(["emqx_acme-", Vsn]).
+
+%% The tarball is built by `make plugin-emqx_acme` and lives under
+%% _build/plugins/. Walk up from code:lib_dir(emqx_acme) until a `_build`
+%% segment is found, then descend into _build/plugins/<NameVsn>.tar.gz.
+prebuilt_tarball() ->
+    LibDir = code:lib_dir(emqx_acme),
+    BuildDir = build_dir_of(LibDir),
+    Tarball = filename:join([BuildDir, "plugins", name_vsn_str() ++ ".tar.gz"]),
+    case filelib:is_regular(Tarball) of
+        true ->
+            Tarball;
+        false ->
+            ct:fail(
+                "prebuilt plugin tarball not found at ~ts; "
+                "run `make plugin-emqx_acme` first",
+                [Tarball]
+            )
+    end.
+
+name_vsn_str() ->
+    binary_to_list(name_vsn()).
+
+build_dir_of(Path) ->
+    case filename:basename(Path) of
+        "_build" -> Path;
+        _ -> build_dir_of(filename:dirname(Path))
+    end.

--- a/plugins/emqx_acme/test/emqx_acme_api_SUITE.erl
+++ b/plugins/emqx_acme/test/emqx_acme_api_SUITE.erl
@@ -4,105 +4,77 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
--include_lib("emqx_plugins/include/emqx_plugins.hrl").
 
 all() ->
     [
         t_put_config_returns_400_when_parser_rejects_avro_valid_input
     ].
 
-init_per_suite(Config) ->
-    WorkDir = emqx_cth_suite:work_dir(Config),
-    InstallDir = filename:join(WorkDir, "plugins"),
-    Apps = emqx_cth_suite:start(
+-doc "Models the contract behind the HTTP PUT /plugins/:name/config 400 "
+"response when a body passes the avsc schema but the plugin's own parser "
+"rejects it. The HTTP layer's two validation hops (see "
+"emqx_mgmt_api_plugins:put_plugin_config/2) are exercised independently: "
+"emqx_plugins_serde:decode/2 runs the avsc validation, and "
+"emqx_acme_config:parse/1 runs the plugin-specific parse. A bad domain "
+"(\"admin@example\") is the canonical case -- the avsc accepts any "
+"string for `domains` but the parser refuses entries that idna would "
+"choke on.".
+t_put_config_returns_400_when_parser_rejects_avro_valid_input(_Config) ->
+    BadBody = #{
+        <<"dir_url">> => <<"https://acme-v02.api.letsencrypt.org/directory">>,
+        <<"domains">> => <<"mqtt.example.com,admin@example">>,
+        <<"contact">> => <<"">>,
+        <<"cert_bundle_name">> => <<"acme">>,
+        <<"listener_ids">> => <<"ssl:default,wss:default">>,
+        <<"enable_dashboard_https">> => true,
+        <<"dashboard_https_port">> => 18084,
+        <<"cert_type">> => <<"ec">>,
+        <<"challenge_port">> => 80,
+        <<"renew_before_expiry_days">> => 30,
+        <<"check_interval_hours">> => 24,
+        <<"acc_key">> => <<"">>,
+        <<"acc_key_password">> => <<"">>
+    },
+    BadJson = emqx_utils_json:encode(BadBody),
+
+    %% Layer 1 (avsc validation): emqx_plugins_serde:decode/2 mirrors the
+    %% server-side avsc check that runs before the BPAPI fan-out. It must
+    %% accept the body -- only then is the parse-fail case distinguishable
+    %% from the avsc-fail case (which would already return 400 with a
+    %% different error before reaching the parser).
+    Store = build_avro_store(),
+    Opts = avro:make_decoder_options(
         [
-            emqx_conf,
-            emqx_ctl,
-            {emqx_plugins, #{config => #{plugins => #{install_dir => InstallDir}}}}
-        ],
-        #{work_dir => WorkDir}
+            {map_type, map},
+            {record_type, map},
+            {encoding, avro_json},
+            {is_wrapped, false}
+        ]
     ),
-    ok = filelib:ensure_path(InstallDir),
-    NameVsn = name_vsn(),
-    {ok, TarBin} = file:read_file(prebuilt_tarball()),
-    ok = emqx_plugins:write_package(NameVsn, TarBin),
-    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
-    ok = emqx_plugins:ensure_started(NameVsn),
-    [{suite_apps, Apps}, {install_dir, InstallDir}, {name_vsn, NameVsn} | Config].
-
-end_per_suite(Config) ->
-    NameVsn = ?config(name_vsn, Config),
-    catch emqx_plugins:ensure_stopped(NameVsn),
-    catch emqx_plugins:ensure_uninstalled(NameVsn),
-    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
-
--doc "A request body that passes avro (the avsc declares `domains` as a "
-"string and `\"mqtt.example.com,admin@example\"` is a valid string) but is "
-"rejected by the plugin's parser must be reported back to the API caller as "
-"an error, with the persisted config left untouched. The HTTP layer "
-"translates that error to a 400 BAD_CONFIG response (see "
-"emqx_mgmt_api_plugins:return_config_update_result/1).".
-t_put_config_returns_400_when_parser_rejects_avro_valid_input(Config) ->
-    NameVsn = ?config(name_vsn, Config),
-    OldConfig = emqx_plugins:get_config(NameVsn),
-    BadConfig = OldConfig#{<<"domains">> => <<"mqtt.example.com,admin@example">>},
-
-    %% Layer 1: avro decode accepts the bad input. This is the precondition
-    %% that distinguishes the parse-fail case from the avro-fail case.
     ?assertMatch(
-        {ok, _AvroValue},
-        emqx_plugins:decode_plugin_config_map(NameVsn, BadConfig)
+        #{<<"domains">> := <<"mqtt.example.com,admin@example">>},
+        avro_json_decoder:decode_value(BadJson, schema_name(), Store, Opts)
     ),
 
-    %% Layer 2: emqx_plugins:update_config/2 returns {error, Reason}. This
-    %% is what the BPAPI multi_call surfaces, which the HTTP API maps to
-    %% 400 BAD_CONFIG via return_config_update_result/1.
-    ?assertMatch(
+    %% Layer 2 (plugin parse): emqx_acme_config:parse/1 is what runs inside
+    %% emqx_acme_app:on_config_changed/2 on every node during the BPAPI
+    %% fan-out. Its {error, Reason} return is what
+    %% emqx_mgmt_api_plugins:return_config_update_result/1 maps to a
+    %% 400 BAD_CONFIG response.
+    ?assertEqual(
         {error, {invalid_domain, <<"admin@example">>}},
-        emqx_plugins:update_config(NameVsn, BadConfig)
-    ),
-
-    %% Layer 3: persisted config and in-memory cache are untouched.
-    %% emqx_plugins:update_config/2 uses a maybe-block so the
-    %% backup_and_update / put_cached_config steps short-circuit on the
-    %% parse error; nothing reaches disk or the cache.
-    ?assertEqual(OldConfig, emqx_plugins:get_config(NameVsn)).
+        emqx_acme_config:parse(BadBody)
+    ).
 
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
 
-name_vsn() ->
-    %% application:load is idempotent and only loads the .app file (does
-    %% not start the app), so it's safe to call here just to read the vsn
-    %% key before the plugin manager takes over the install/start lifecycle.
-    _ = application:load(emqx_acme),
-    {ok, Vsn} = application:get_key(emqx_acme, vsn),
-    iolist_to_binary(["emqx_acme-", Vsn]).
+schema_name() ->
+    <<"emqx_acme_config_schema_test">>.
 
-%% The tarball is built by `make plugin-emqx_acme` and lives under
-%% _build/plugins/. Walk up from code:lib_dir(emqx_acme) until a `_build`
-%% segment is found, then descend into _build/plugins/<NameVsn>.tar.gz.
-prebuilt_tarball() ->
-    LibDir = code:lib_dir(emqx_acme),
-    BuildDir = build_dir_of(LibDir),
-    Tarball = filename:join([BuildDir, "plugins", name_vsn_str() ++ ".tar.gz"]),
-    case filelib:is_regular(Tarball) of
-        true ->
-            Tarball;
-        false ->
-            ct:fail(
-                "prebuilt plugin tarball not found at ~ts; "
-                "run `make plugin-emqx_acme` first",
-                [Tarball]
-            )
-    end.
-
-name_vsn_str() ->
-    binary_to_list(name_vsn()).
-
-build_dir_of(Path) ->
-    case filename:basename(Path) of
-        "_build" -> Path;
-        _ -> build_dir_of(filename:dirname(Path))
-    end.
+build_avro_store() ->
+    AvscPath = filename:join([code:lib_dir(emqx_acme), "priv", "config_schema.avsc"]),
+    {ok, AvscBin} = file:read_file(AvscPath),
+    Store0 = avro_schema_store:new([map]),
+    avro_schema_store:import_schema_json(schema_name(), AvscBin, Store0).

--- a/plugins/emqx_acme/test/emqx_acme_config_SUITE.erl
+++ b/plugins/emqx_acme/test/emqx_acme_config_SUITE.erl
@@ -29,7 +29,11 @@ all() ->
         t_parse_domains_csv_splits_and_trims,
         t_parse_domains_drops_empty_entries,
         t_parse_domains_accepts_legacy_list,
-        t_parse_contact_csv_splits_and_trims
+        t_parse_contact_csv_splits_and_trims,
+        t_parse_domains_rejects_email_like_entry,
+        t_parse_domains_rejects_whitespace_inside_label,
+        t_parse_domains_rejects_url_like_entry,
+        t_avsc_acc_key_fields_are_plain_string
     ].
 
 -define(TEST_ENV_VAR, "EMQX_ACME_TEST_DIR").
@@ -156,9 +160,8 @@ t_parse_acc_key_treats_empty_as_unset(_Config) ->
     ?assertEqual(undefined, maps:get(acc_key, S)),
     ?assertEqual(undefined, maps:get(acc_key_password, S)).
 
--doc "acc_key_password is declared as nullable in the avsc schema, so the "
-"dashboard sends `null` when the field is left empty. Parser must accept "
-"that and treat it the same as 'unset'.".
+-doc "Parser accepts a literal `null` for acc_key_password and treats "
+"it as 'unset', so a config that carries that value loads cleanly.".
 t_parse_acc_key_password_treats_null_as_unset(_Config) ->
     {ok, S} = emqx_acme_config:parse(
         #{<<"acc_key_password">> => null}
@@ -262,3 +265,51 @@ t_parse_contact_csv_splits_and_trims(_Config) ->
         [<<"mailto:admin@example.com">>, <<"mailto:ops@example.com">>],
         maps:get(contact, S)
     ).
+
+-doc "A domain entry containing `@` is rejected at parse time with "
+"`{invalid_domain, <<\"admin@example\">>}`.".
+t_parse_domains_rejects_email_like_entry(_Config) ->
+    ?assertMatch(
+        {error, {invalid_domain, <<"admin@example">>}},
+        emqx_acme_config:parse(
+            #{<<"domains">> => <<"mqtt.example.com,admin@example">>}
+        )
+    ).
+
+-doc "A domain entry with whitespace inside the label is rejected. "
+"Surrounding whitespace around the comma separators is trimmed by "
+"split_csv_bin/1 and remains accepted.".
+t_parse_domains_rejects_whitespace_inside_label(_Config) ->
+    ?assertMatch(
+        {error, {invalid_domain, <<"foo bar.example.com">>}},
+        emqx_acme_config:parse(
+            #{<<"domains">> => <<"foo bar.example.com">>}
+        )
+    ).
+
+-doc "A domain entry containing `/` (typically a pasted URL) is "
+"rejected at parse time.".
+t_parse_domains_rejects_url_like_entry(_Config) ->
+    ?assertMatch(
+        {error, {invalid_domain, <<"https://mqtt.example.com">>}},
+        emqx_acme_config:parse(
+            #{<<"domains">> => <<"https://mqtt.example.com">>}
+        )
+    ).
+
+-doc "acc_key and acc_key_password are declared as plain \"string\" in "
+"the avsc schema. The dashboard's untagged JSON (`\"acc_key\": "
+"\"file://...\"`) decodes directly against a string type; a union with "
+"`null` would require the tagged form `{\"string\": \"...\"}`.".
+t_avsc_acc_key_fields_are_plain_string(_Config) ->
+    Avsc = read_avsc(),
+    Fields = maps:get(<<"fields">>, Avsc),
+    [AccKey] = [F || F <- Fields, maps:get(<<"name">>, F) =:= <<"acc_key">>],
+    [AccKeyPw] = [F || F <- Fields, maps:get(<<"name">>, F) =:= <<"acc_key_password">>],
+    ?assertEqual(<<"string">>, maps:get(<<"type">>, AccKey)),
+    ?assertEqual(<<"string">>, maps:get(<<"type">>, AccKeyPw)).
+
+read_avsc() ->
+    Path = filename:join([code:lib_dir(emqx_acme), "priv", "config_schema.avsc"]),
+    {ok, Bin} = file:read_file(Path),
+    emqx_utils_json:decode(Bin).


### PR DESCRIPTION
Release version: 6.1.2

## Summary

Two issues hit the operator the moment they tried to configure the ACME plugin from the dashboard.

**`function_clause` on saving `acc_key: file://...`**

`acc_key` and `acc_key_password` were declared in the avsc schema as `["null", "string"]` unions. The Avro JSON decoder requires union values to be tagged (`{"string": "..."}`); the dashboard sends bare strings, so `avro_json_decoder:parse_union/4` had no matching clause and the request returned `BAD_CONFIG` with `function_clause` from `decode_avro_json`.

Both fields are now plain `"string"` with default `""`. The parser already maps `""` to "unset" (and still accepts `null` for in-place upgrades), so runtime behaviour is unchanged.

**`issuance_worker_crashed` on a malformed domain like `admin@example`**

The string was passed straight to acme-erlang-client, where `idna:to_ascii/1` raises `exit:{bad_label, _}` from inside a `try` block that only catches `throw`. The exception propagated up and killed the issuance worker, surfacing as `issuance_worker_crashed` in the logs.

- The config parser now rejects entries containing `@`, whitespace, `/`, `\\`, or control codes at save time, returning `{invalid_domain, ...}` so the operator sees the error in the dashboard immediately instead of after the issuance attempt.
- The issuance worker now wraps `run_action/1` in a catch-all, so any remaining unexpected exception (e.g. idna `too_long` on a 100-char label) lands in `/status` as a structured `last_result` and `in_progress` clears for the next attempt — no plugin restart required.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-17476.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (avsc default went from `null` to `""`; parser accepts both)