### PR TITLE
docs(api): force-subscribe/unsubscribe APIs bypass ACL

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -566,6 +566,18 @@ list_subscriptions_via_topic(Node, Topic, _FormatFun = {M, F}) ->
 %% PubSub
 %%--------------------------------------------------------------------
 
+-doc """
+Force-subscribe topics on behalf of an already-connected client.
+
+Backs `POST /api/v5/clients/:clientid/subscribe[/bulk]`. The subscription
+is installed directly in the target client's channel and persists for the
+channel's lifetime, just like a client-issued SUBSCRIBE.
+
+By design, this path **bypasses** MQTT authorization
+(`emqx_access_control:authorize/3`): the REST API key / dashboard role is
+the authorization boundary for this operation, not the broker's
+`authorization` configuration.
+""".
 subscribe(ClientId, TopicTables) ->
     case emqx_cm_registry:is_enabled() of
         false ->
@@ -592,8 +604,13 @@ subscribe([], _ClientId, _TopicTables) ->
     {subscribe, _} | {error, atom()}.
 do_subscribe(ClientId, TopicTables) ->
     case ets:lookup(?CHAN_TAB, ClientId) of
-        [] -> {error, channel_not_found};
-        [{_, Pid}] -> Pid ! {subscribe, TopicTables}
+        [] ->
+            {error, channel_not_found};
+        [{_, Pid}] ->
+            %% Hand the subscription straight to the channel process.
+            %% No emqx_access_control:authorize/3 call is made on this path -- the
+            %% ACL bypass is intentional; see -doc on subscribe/2.
+            Pid ! {subscribe, TopicTables}
     end.
 
 publish(Message) ->
@@ -609,6 +626,15 @@ publish(Message) ->
         [Message]
     ).
 
+-doc """
+Force-unsubscribe a topic on behalf of an already-connected client.
+
+Backs `POST /api/v5/clients/:clientid/unsubscribe`. The unsubscribe is
+delivered directly to the target client's channel, mirroring a
+client-issued UNSUBSCRIBE. Like `subscribe/2`, this path bypasses MQTT
+authorization by design; the REST API key / dashboard role is the
+authorization boundary.
+""".
 -spec unsubscribe(emqx_types:clientid(), emqx_types:topic()) ->
     {unsubscribe, _} | {error, channel_not_found}.
 unsubscribe(ClientId, Topic) ->
@@ -632,6 +658,12 @@ do_unsubscribe(ClientId, Topic) ->
         [{_, Pid}] -> Pid ! {unsubscribe, [emqx_topic:parse(Topic)]}
     end.
 
+-doc """
+Bulk variant of `unsubscribe/2`, backing
+`POST /api/v5/clients/:clientid/unsubscribe/bulk`. Same ACL-bypass
+behavior applies: authorization is enforced at the REST API layer, not
+by the broker's `authorization` rules.
+""".
 -spec unsubscribe_batch(emqx_types:clientid(), [emqx_types:topic()]) ->
     {unsubscribe, _} | {error, channel_not_found}.
 unsubscribe_batch(ClientId, Topics) ->

--- a/rel/i18n/emqx_mgmt_api_clients.hocon
+++ b/rel/i18n/emqx_mgmt_api_clients.hocon
@@ -99,22 +99,28 @@ msg_mqueue_priority.label:
 """Message Mqueue Priority"""
 
 subscribe.desc:
-"""Subscribe"""
+"""Force the broker to add a subscription on the named client's behalf.
+The subscription is installed directly in the client's channel and persists for the channel's lifetime, just like a client-issued SUBSCRIBE.
+This operation bypasses MQTT authorization (ACL) rules by design: the REST API key / dashboard role is the authorization boundary, not the broker's `authorization` configuration."""
 subscribe.label:
 """Subscribe"""
 
 subscribe_g.desc:
-"""Subscribe bulk"""
+"""Force the broker to add multiple subscriptions on the named client's behalf, in a single request.
+Each subscription is installed directly in the client's channel and persists for the channel's lifetime, just like a client-issued SUBSCRIBE.
+This operation bypasses MQTT authorization (ACL) rules by design: the REST API key / dashboard role is the authorization boundary, not the broker's `authorization` configuration."""
 subscribe_g.label:
 """Subscribe bulk"""
 
 unsubscribe.desc:
-"""Unsubscribe"""
+"""Force the broker to remove a subscription on the named client's behalf.
+This operation bypasses MQTT authorization (ACL) rules by design: the REST API key / dashboard role is the authorization boundary, not the broker's `authorization` configuration."""
 unsubscribe.label:
 """Unsubscribe"""
 
 unsubscribe_g.desc:
-"""Unsubscribe bulk"""
+"""Force the broker to remove multiple subscriptions on the named client's behalf, in a single request.
+This operation bypasses MQTT authorization (ACL) rules by design: the REST API key / dashboard role is the authorization boundary, not the broker's `authorization` configuration."""
 unsubscribe_g.label:
 """Unsubscribe bulk"""
 


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Documentation-only clarification: the REST `force-subscribe` and `force-unsubscribe` endpoints for clients install (or remove) subscriptions directly on the target channel without invoking `emqx_access_control:authorize/3`. This is intentional — the REST API key / dashboard role is the authorization boundary, not the broker's `authorization` configuration — but it was not documented, and a deny-by-default ACL operator could reasonably expect the force path to be re-checked.

Endpoints covered:
- `POST /api/v5/clients/:clientid/subscribe`
- `POST /api/v5/clients/:clientid/subscribe/bulk`
- `POST /api/v5/clients/:clientid/unsubscribe`
- `POST /api/v5/clients/:clientid/unsubscribe/bulk`

Changes:
- Expanded swagger `desc` for the four endpoint keys in `rel/i18n/emqx_mgmt_api_clients.hocon`.
- Added `-doc` attributes on `emqx_mgmt:subscribe/2`, `unsubscribe/2`, and `unsubscribe_batch/2`, plus an inline comment at the channel-pid send in `do_subscribe/2`.

No code behavior change.

Follow-ups deferred:
- The `rel/i18n/*.hocon` files only ship English; Chinese translation pipeline lives outside this repo and was not touched.
- emqx-docs has no dedicated page for these endpoints (only changelog mentions). No docs PR opened; can be filed if the site adds a REST API reference page for these endpoints.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)