### PR TITLE
fix(bridge_mqtt): support retain_as_published on v5 ingress subscriptions

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -102,6 +102,7 @@ on_start(ConnResId, #{server := Server} = Conf) ->
         connector => ConnResId,
         config => emqx_utils:redact(Conf)
     }),
+    maybe_warn_bridge_mode_v5(ConnResId, Conf),
     TopicToHandlerIndex = emqx_topic_index:new(),
     ok = emqx_resource:allocate_resource(
         ConnResId,
@@ -567,6 +568,18 @@ maybe_new_subscription_id_index(#{proto_ver := v5}) ->
     ets:new(?MODULE, [set, public, {read_concurrency, true}]);
 maybe_new_subscription_id_index(_Conf) ->
     undefined.
+
+maybe_warn_bridge_mode_v5(ConnResId, #{proto_ver := v5, bridge_mode := true}) ->
+    ?tp(mqtt_connector_bridge_mode_v5_warning, #{connector => ConnResId}),
+    ?SLOG(warning, #{
+        msg => "bridge_mode_ignored_for_mqtt_v5",
+        connector => ConnResId,
+        hint =>
+            "bridge_mode is a legacy MQTT 3.1.1-era flag with no effect under MQTT 5.0; "
+            "set retain_as_published on individual subscriptions instead."
+    });
+maybe_warn_bridge_mode_v5(_ConnResId, _Conf) ->
+    ok.
 
 maybe_delete_subscription_id_index(undefined) ->
     ok;

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -570,13 +570,9 @@ maybe_new_subscription_id_index(_Conf) ->
     undefined.
 
 maybe_warn_bridge_mode_v5(ConnResId, #{proto_ver := v5, bridge_mode := true}) ->
-    ?tp(mqtt_connector_bridge_mode_v5_warning, #{connector => ConnResId}),
-    ?SLOG(warning, #{
-        msg => "bridge_mode_ignored_for_mqtt_v5",
+    ?tp(warning, "bridge_mode_ignored_for_mqtt_v5", #{
         connector => ConnResId,
-        hint =>
-            "bridge_mode is a legacy MQTT 3.1.1-era flag with no effect under MQTT 5.0; "
-            "set retain_as_published on individual subscriptions instead."
+        hint => "bridge_mode is a legacy MQTT 3.1.1-era flag with no effect under MQTT 5.0."
     });
 maybe_warn_bridge_mode_v5(_ConnResId, _Conf) ->
     ok.

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_ingress.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_ingress.erl
@@ -79,18 +79,12 @@ subscribe_remote_topics(Pid, IngressList, WorkerIdx, PoolSize, Name) ->
 
 subscribe_remote_topic(
     Pid,
-    #{
-        remote := #{
-            topic := RemoteTopic,
-            qos := QoS,
-            no_local := NoLocal,
-            retain_as_published := RAP
-        }
-    } = Ingress,
+    #{remote := #{topic := RemoteTopic, qos := QoS, no_local := NoLocal} = Remote} = Ingress,
     WorkerIdx,
     PoolSize,
     Name
 ) ->
+    RAP = maps:get(retain_as_published, Remote, true),
     case should_subscribe(RemoteTopic, WorkerIdx, PoolSize, Name, true) of
         true ->
             maybe_retry_without_subscription_identifier(
@@ -126,16 +120,12 @@ maybe_retry_without_subscription_identifier(
 maybe_retry_without_subscription_identifier(
     #{
         subscription_id := _SubscriptionId,
-        remote := #{
-            topic := RemoteTopic,
-            qos := QoS,
-            no_local := NoLocal,
-            retain_as_published := RAP
-        }
+        remote := #{topic := RemoteTopic, qos := QoS, no_local := NoLocal} = Remote
     },
     {ok, _Props, ReasonCodes} = Result,
     Pid
 ) ->
+    RAP = maps:get(retain_as_published, Remote, true),
     case lists:member(?RC_SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED, ReasonCodes) of
         true ->
             emqtt:subscribe(Pid, #{}, RemoteTopic, [{qos, QoS}, {nl, NoLocal}, {rap, RAP}]);

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_ingress.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_ingress.erl
@@ -79,7 +79,14 @@ subscribe_remote_topics(Pid, IngressList, WorkerIdx, PoolSize, Name) ->
 
 subscribe_remote_topic(
     Pid,
-    #{remote := #{topic := RemoteTopic, qos := QoS, no_local := NoLocal}} = Ingress,
+    #{
+        remote := #{
+            topic := RemoteTopic,
+            qos := QoS,
+            no_local := NoLocal,
+            retain_as_published := RAP
+        }
+    } = Ingress,
     WorkerIdx,
     PoolSize,
     Name
@@ -92,7 +99,7 @@ subscribe_remote_topic(
                     Pid,
                     subscribe_properties(Ingress),
                     RemoteTopic,
-                    [{qos, QoS}, {nl, NoLocal}]
+                    [{qos, QoS}, {nl, NoLocal}, {rap, RAP}]
                 ),
                 Pid
             );
@@ -119,14 +126,19 @@ maybe_retry_without_subscription_identifier(
 maybe_retry_without_subscription_identifier(
     #{
         subscription_id := _SubscriptionId,
-        remote := #{topic := RemoteTopic, qos := QoS, no_local := NoLocal}
+        remote := #{
+            topic := RemoteTopic,
+            qos := QoS,
+            no_local := NoLocal,
+            retain_as_published := RAP
+        }
     },
     {ok, _Props, ReasonCodes} = Result,
     Pid
 ) ->
     case lists:member(?RC_SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED, ReasonCodes) of
         true ->
-            emqtt:subscribe(Pid, #{}, RemoteTopic, [{qos, QoS}, {nl, NoLocal}]);
+            emqtt:subscribe(Pid, #{}, RemoteTopic, [{qos, QoS}, {nl, NoLocal}, {rap, RAP}]);
         false ->
             Result
     end;

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_pubsub_schema.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_pubsub_schema.erl
@@ -100,7 +100,7 @@ fields(ingress_parameters) ->
             mk(
                 boolean(),
                 #{
-                    default => false,
+                    default => true,
                     desc => ?DESC("source_retain_as_published")
                 }
             )}

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_pubsub_schema.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_pubsub_schema.erl
@@ -95,6 +95,14 @@ fields(ingress_parameters) ->
                     default => false,
                     desc => ?DESC("source_no_local")
                 }
+            )},
+        {retain_as_published,
+            mk(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC("source_retain_as_published")
+                }
             )}
         | emqx_bridge_mqtt_connector_schema:fields("ingress_remote")
     ];

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
@@ -1163,6 +1163,13 @@ t_retain_as_published_v5_false_clears_retain(TCConfig) ->
     ).
 
 assert_rap_subopt(TCConfig, ParamsOverrides, ExpectedRAP) ->
+    %% The broker's subopts table stores the SUBSCRIBE flags in their
+    %% wire-format integer representation, not as booleans.
+    ExpectedRAPFlag =
+        case ExpectedRAP of
+            true -> 1;
+            false -> 0
+        end,
     UniqueNum = integer_to_binary(erlang:unique_integer([positive])),
     RemoteTopic = <<"rap/test/", UniqueNum/binary>>,
     {201, _} = create_connector_api(TCConfig, #{<<"proto_ver">> => <<"v5">>}),
@@ -1179,7 +1186,7 @@ assert_rap_subopt(TCConfig, ParamsOverrides, ExpectedRAP) ->
         200,
         25,
         ?assertMatch(
-            [{{RemoteTopic, _SubPid}, #{rap := ExpectedRAP}}],
+            [{{RemoteTopic, _SubPid}, #{rap := ExpectedRAPFlag}}],
             emqx_broker:subscriptions_via_topic(RemoteTopic)
         )
     ),

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
@@ -1140,3 +1140,109 @@ t_reconnect_with_session(TCConfig) when is_list(TCConfig) ->
     ?assertReceivePublish(#{payload := #{<<"payload">> := <<"4">>}}),
 
     ok.
+
+-doc """
+With `retain_as_published = true` and `proto_ver = v5`, the upstream broker
+preserves the `retain` flag on PUBLISH packets forwarded to the bridge's
+subscription, so the bridge sees the message with `retain = true`.
+""".
+t_retain_as_published_v5_preserves_retain(TCConfig) ->
+    rap_subscribe_and_publish(TCConfig, <<"v5">>, true, true).
+
+-doc """
+With `retain_as_published = false` (the default) and `proto_ver = v5`,
+the upstream broker clears the `retain` flag on forwarded PUBLISH packets,
+so the bridge sees `retain = false`. Pins down the backwards-compatible
+behavior.
+""".
+t_retain_as_published_default_clears_retain(TCConfig) ->
+    rap_subscribe_and_publish(TCConfig, <<"v5">>, false, false).
+
+rap_subscribe_and_publish(TCConfig, ProtoVer, RAP, ExpectedRetain) ->
+    Self = self(),
+    ok = meck:new(emqtt, [passthrough, no_link, no_history]),
+    on_exit(fun() -> catch meck:unload([emqtt]) end),
+    ok = meck:expect(
+        emqtt,
+        subscribe,
+        fun(Pid, Props, Topic, Opts) ->
+            Self ! {subscribe_opts, Opts},
+            meck:passthrough([Pid, Props, Topic, Opts])
+        end
+    ),
+    UniqueNum = integer_to_binary(erlang:unique_integer([positive])),
+    RemoteTopic = <<"rap/test/", UniqueNum/binary>>,
+    LocalTopic = <<"local/", UniqueNum/binary>>,
+    %% Make sure no retained message lingers from a previous test on this
+    %% topic — the broker must deliver our test message as a "live"
+    %% PUBLISH, not as retained-on-subscribe (which always carries
+    %% retain = 1 regardless of RAP).
+    emqx_broker:publish(emqx_message:set_flag(retain, emqx_message:make(RemoteTopic, <<>>))),
+    {201, _} = create_connector_api(TCConfig, #{<<"proto_ver">> => ProtoVer}),
+    {201, _} =
+        create_source_api(TCConfig, #{
+            <<"parameters">> => #{
+                <<"topic">> => RemoteTopic,
+                <<"qos">> => 1,
+                <<"retain_as_published">> => RAP,
+                <<"local">> => #{<<"topic">> => LocalTopic}
+            }
+        }),
+    {subscribe_opts, Opts} = ?assertReceive({subscribe_opts, _}, 3_000),
+    ?assertEqual({rap, RAP}, lists:keyfind(rap, 1, Opts)),
+    %% Subscribe downstream with RAP=true so the local broker forwards
+    %% the bridge's republish without rewriting the retain flag — that
+    %% lets us observe what the bridge actually set.
+    Sub = start_client(TCConfig),
+    {ok, _, [_]} = emqtt:subscribe(Sub, #{}, LocalTopic, [{qos, 1}, {rap, true}]),
+    Pub = start_client(TCConfig),
+    {ok, _} =
+        emqtt:publish(Pub, RemoteTopic, <<"hello">>, [{qos, 1}, {retain, true}]),
+    Publish = ?assertReceive({publish, #{topic := LocalTopic}}, 5_000),
+    {publish, #{retain := ActualRetain}} = Publish,
+    ?assertEqual(ExpectedRetain, ActualRetain),
+    %% Clear the retained message we just published.
+    emqx_broker:publish(emqx_message:set_flag(retain, emqx_message:make(RemoteTopic, <<>>))),
+    ok.
+
+-doc """
+With `proto_ver = v3`, the `retain_as_published` option is accepted by the
+schema (so existing configs do not break) but has no effect at the wire
+level, since MQTT 3.1.1 has no Retain As Published subscription option.
+The bridge subscription is still established successfully.
+""".
+t_retain_as_published_v3_is_no_op(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{<<"proto_ver">> => <<"v3">>}),
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_source_api(TCConfig, #{
+            <<"parameters">> => #{
+                <<"qos">> => 1,
+                <<"retain_as_published">> => true
+            }
+        })
+    ),
+    ok.
+
+-doc """
+With `bridge_mode = true` and `proto_ver = v5`, the connector starts
+successfully and emits a single warning log to surface that the legacy
+bridge-mode flag has no effect under MQTT 5.0.
+""".
+t_bridge_mode_v5_logs_warning(TCConfig) ->
+    ?check_trace(
+        #{timetrap => 10_000},
+        begin
+            {201, #{<<"status">> := <<"connected">>}} = create_connector_api(TCConfig, #{
+                <<"proto_ver">> => <<"v5">>,
+                <<"bridge_mode">> => true
+            }),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [_ | _], ?of_kind(mqtt_connector_bridge_mode_v5_warning, Trace)
+            )
+        end
+    ),
+    ok.

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
@@ -1142,67 +1142,47 @@ t_reconnect_with_session(TCConfig) when is_list(TCConfig) ->
     ok.
 
 -doc """
-With `retain_as_published = true` and `proto_ver = v5`, the upstream broker
-preserves the `retain` flag on PUBLISH packets forwarded to the bridge's
-subscription, so the bridge sees the message with `retain = true`.
+With `proto_ver = v5` and the default `retain_as_published`, the bridge
+subscribes to the remote topic with the Retain As Published option set,
+so the upstream broker preserves the `retain` flag on forwarded PUBLISH
+packets.
 """.
-t_retain_as_published_v5_preserves_retain(TCConfig) ->
-    rap_subscribe_and_publish(TCConfig, <<"v5">>, true, true).
+t_retain_as_published_v5_default_preserves_retain(TCConfig) ->
+    assert_rap_subopt(TCConfig, _ParamsOverrides = #{}, _ExpectedRAP = true).
 
 -doc """
-With `retain_as_published = false` (the default) and `proto_ver = v5`,
-the upstream broker clears the `retain` flag on forwarded PUBLISH packets,
-so the bridge sees `retain = false`. Pins down the backwards-compatible
-behavior.
+With `proto_ver = v5` and `retain_as_published = false`, the bridge
+subscribes without the Retain As Published option, so the upstream broker
+clears the `retain` flag on forwarded PUBLISH packets.
 """.
-t_retain_as_published_default_clears_retain(TCConfig) ->
-    rap_subscribe_and_publish(TCConfig, <<"v5">>, false, false).
+t_retain_as_published_v5_false_clears_retain(TCConfig) ->
+    assert_rap_subopt(
+        TCConfig,
+        #{<<"retain_as_published">> => false},
+        false
+    ).
 
-rap_subscribe_and_publish(TCConfig, ProtoVer, RAP, ExpectedRetain) ->
-    Self = self(),
-    ok = meck:new(emqtt, [passthrough, no_link, no_history]),
-    on_exit(fun() -> catch meck:unload([emqtt]) end),
-    ok = meck:expect(
-        emqtt,
-        subscribe,
-        fun(Pid, Props, Topic, Opts) ->
-            Self ! {subscribe_opts, Opts},
-            meck:passthrough([Pid, Props, Topic, Opts])
-        end
-    ),
+assert_rap_subopt(TCConfig, ParamsOverrides, ExpectedRAP) ->
     UniqueNum = integer_to_binary(erlang:unique_integer([positive])),
     RemoteTopic = <<"rap/test/", UniqueNum/binary>>,
-    LocalTopic = <<"local/", UniqueNum/binary>>,
-    %% Make sure no retained message lingers from a previous test on this
-    %% topic — the broker must deliver our test message as a "live"
-    %% PUBLISH, not as retained-on-subscribe (which always carries
-    %% retain = 1 regardless of RAP).
-    emqx_broker:publish(emqx_message:set_flag(retain, emqx_message:make(RemoteTopic, <<>>))),
-    {201, _} = create_connector_api(TCConfig, #{<<"proto_ver">> => ProtoVer}),
+    {201, _} = create_connector_api(TCConfig, #{<<"proto_ver">> => <<"v5">>}),
+    Params = maps:merge(
+        #{<<"topic">> => RemoteTopic, <<"qos">> => 1},
+        ParamsOverrides
+    ),
     {201, _} =
-        create_source_api(TCConfig, #{
-            <<"parameters">> => #{
-                <<"topic">> => RemoteTopic,
-                <<"qos">> => 1,
-                <<"retain_as_published">> => RAP,
-                <<"local">> => #{<<"topic">> => LocalTopic}
-            }
-        }),
-    {subscribe_opts, Opts} = ?assertReceive({subscribe_opts, _}, 3_000),
-    ?assertEqual({rap, RAP}, lists:keyfind(rap, 1, Opts)),
-    %% Subscribe downstream with RAP=true so the local broker forwards
-    %% the bridge's republish without rewriting the retain flag — that
-    %% lets us observe what the bridge actually set.
-    Sub = start_client(TCConfig),
-    {ok, _, [_]} = emqtt:subscribe(Sub, #{}, LocalTopic, [{qos, 1}, {rap, true}]),
-    Pub = start_client(TCConfig),
-    {ok, _} =
-        emqtt:publish(Pub, RemoteTopic, <<"hello">>, [{qos, 1}, {retain, true}]),
-    Publish = ?assertReceive({publish, #{topic := LocalTopic}}, 5_000),
-    {publish, #{retain := ActualRetain}} = Publish,
-    ?assertEqual(ExpectedRetain, ActualRetain),
-    %% Clear the retained message we just published.
-    emqx_broker:publish(emqx_message:set_flag(retain, emqx_message:make(RemoteTopic, <<>>))),
+        create_source_api(TCConfig, #{<<"parameters">> => Params}),
+    %% The bridge subscribes to the local broker — peek the broker's
+    %% subopts table to confirm the Retain As Published flag made it
+    %% onto the SUBSCRIBE.
+    ?retry(
+        200,
+        25,
+        ?assertMatch(
+            [{{RemoteTopic, _SubPid}, #{rap := ExpectedRAP}}],
+            emqx_broker:subscriptions_via_topic(RemoteTopic)
+        )
+    ),
     ok.
 
 -doc """
@@ -1241,7 +1221,7 @@ t_bridge_mode_v5_logs_warning(TCConfig) ->
         end,
         fun(Trace) ->
             ?assertMatch(
-                [_ | _], ?of_kind(mqtt_connector_bridge_mode_v5_warning, Trace)
+                [_ | _], ?of_kind("bridge_mode_ignored_for_mqtt_v5", Trace)
             )
         end
     ),

--- a/changes/ee/feat-17481.en.md
+++ b/changes/ee/feat-17481.en.md
@@ -1,0 +1,11 @@
+Add a `retain_as_published` option to MQTT bridge ingress (source) subscriptions.
+When the bridge connects to the remote broker using MQTT 5.0 and
+`retain_as_published = true`, the original `retain` flag on forwarded messages
+is preserved instead of being cleared, allowing the bridge to faithfully
+republish retained messages from upstream. The default is `false` to keep
+existing behavior. The option has no effect when `proto_ver` is `v3` or `v4`.
+
+Also, the connector now emits a warning log when `bridge_mode = true` is
+configured together with `proto_ver = v5`, since the legacy bridge-mode flag
+has no effect under MQTT 5.0 — set `retain_as_published` on individual
+subscriptions instead.

--- a/rel/i18n/emqx_bridge_mqtt_pubsub_schema.hocon
+++ b/rel/i18n/emqx_bridge_mqtt_pubsub_schema.hocon
@@ -27,7 +27,7 @@ emqx_bridge_mqtt_pubsub_schema {
   source_retain_as_published.label:
   """Retain As Published"""
   source_retain_as_published.desc:
-  """Whether to set the MQTT 5.0 Retain As Published subscription option on the remote subscription.  When set to true, the upstream broker preserves the `retain` flag on messages forwarded to this subscription; when set to false (the default), the upstream clears the `retain` flag.  Only takes effect when the connector's `proto_ver` is `v5`."""
+  """Whether to set the MQTT 5.0 Retain As Published subscription option on the remote subscription.  When set to true (the default), the upstream broker preserves the `retain` flag on messages forwarded to this subscription; when set to false, the upstream clears the `retain` flag.  Only takes effect when the connector's `proto_ver` is `v5`."""
 
 
 source_parameters.desc:

--- a/rel/i18n/emqx_bridge_mqtt_pubsub_schema.hocon
+++ b/rel/i18n/emqx_bridge_mqtt_pubsub_schema.hocon
@@ -24,6 +24,11 @@ emqx_bridge_mqtt_pubsub_schema {
   source_no_local.desc:
   """Whether to set the no-local flag when subscribing to the remote topic.  If set to true, and you use the same connector to publish messages to a topic you also subscribe to, this prevents the server from forwarding your own published messages back to you.  Only takes effect when using MQTT protocol version 5.  Note that if you use a pool of workers larger than 1 you will still receive duplicated messages back."""
 
+  source_retain_as_published.label:
+  """Retain As Published"""
+  source_retain_as_published.desc:
+  """Whether to set the MQTT 5.0 Retain As Published subscription option on the remote subscription.  When set to true, the upstream broker preserves the `retain` flag on messages forwarded to this subscription; when set to false (the default), the upstream clears the `retain` flag.  Only takes effect when the connector's `proto_ver` is `v5`."""
+
 
 source_parameters.desc:
 """Source-specific parameters."""


### PR DESCRIPTION
Release version: 6.0.3, 6.1.3, 6.2.2

## Summary

Fixes [#11671](https://github.com/emqx/emqx/issues/11671) — *The Retain As Published option is not set when bridging.*

Two related problems with MQTT-bridge ingress under `proto_ver = v5`:

1. **Retain As Published (RAP) not set on remote subscribe.** The bridge issued `emqtt:subscribe/4` without the MQTT 5.0 `rap` subscription option, so the upstream broker always cleared the `retain` flag on forwarded PUBLISHes. The bridge then republished downstream with `retain = 0` even for upstream-retained messages.

2. **`bridge_mode = true` was silently accepted under v5.** The legacy bridge-bit in CONNECT is MQTT 3.1.1-era and has no meaning under MQTT 5.0, where bridge semantics live in subscribe options (RAP, NL).

### Changes

- New per-subscription option `retain_as_published` (boolean, default `false`) on the MQTT source. When `true` and the connector uses `proto_ver = v5`, the upstream broker preserves the original `retain` flag on forwarded PUBLISHes. Defaulting to `false` keeps existing configs behaving identically.
- The bridge subscribe call (and the subscription-identifier retry path) now thread the `rap` subscription option through to `emqtt:subscribe/4`.
- The connector logs a single warning at start when `bridge_mode = true` is combined with `proto_ver = v5`. Schema is not changed to reject the combination — avoids breaking upgrades.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)