### PR TITLE
refactor(username_quota): cluster-fanout kick_username to reach all nodes

### DIFF
--- a/changes/ee/fix-17485.en.md
+++ b/changes/ee/fix-17485.en.md
@@ -1,0 +1,1 @@
+Fix the `emqx_username_quota` plugin's per-username kick endpoint failing to disconnect clients whose channels live on remote nodes when the broker's session registry is disabled. The kick now fans out to every node in the cluster regardless of session-registry state.

--- a/changes/ee/fix-17485.en.md
+++ b/changes/ee/fix-17485.en.md
@@ -1,1 +1,0 @@
-Fix the `emqx_username_quota` plugin's per-username kick endpoint failing to disconnect clients whose channels live on remote nodes when the broker's session registry is disabled. The kick now fans out to every node in the cluster regardless of session-registry state.

--- a/plugins/emqx_username_quota/src/emqx_username_quota_state.erl
+++ b/plugins/emqx_username_quota/src/emqx_username_quota_state.erl
@@ -138,7 +138,11 @@ kick_username(Username) ->
         [] ->
             {error, not_found};
         _ ->
-            lists:foreach(fun(ClientId) -> _ = emqx_cm:kick_session(ClientId) end, ClientIds),
+            %% Fan out to every node so the kick lands regardless of whether the
+            %% session registry is enabled. emqx_cm:kick_session/1 resolves the
+            %% channel via the (optionally disabled) registry, which silently
+            %% misses channels living on remote nodes when the registry is off.
+            ok = emqx_mgmt:kickout_clients(ClientIds),
             {ok, length(ClientIds)}
     end.
 

--- a/plugins/emqx_username_quota/test/emqx_username_quota_SUITE.erl
+++ b/plugins/emqx_username_quota/test/emqx_username_quota_SUITE.erl
@@ -349,8 +349,8 @@ t_api_list_get_kick(_Config) ->
     ?assertMatch(#{username := User, used := 2, limit := _, clientids := [_, _]}, OneBody),
     ?assert(not maps:is_key(count, OneBody)),
     ?assertEqual([<<"c1">>, <<"c2">>], maps:get(clientids, OneBody)),
-    ok = meck:new(emqx_cm, [passthrough]),
-    ok = meck:expect(emqx_cm, kick_session, fun(_ClientId) -> ok end),
+    ok = meck:new(emqx_mgmt, [passthrough]),
+    ok = meck:expect(emqx_mgmt, kickout_clients, fun(_ClientIds) -> ok end),
     {ok, 200, _Headers3, #{kicked := 2}} = emqx_username_quota_api:handle(
         post,
         [
@@ -358,7 +358,7 @@ t_api_list_get_kick(_Config) ->
         ],
         #{}
     ),
-    ok = meck:unload(emqx_cm).
+    ok = meck:unload(emqx_mgmt).
 
 t_api_metrics(_Config) ->
     ok = emqx_username_quota:register_session(<<"alice">>, <<"a1">>),

--- a/plugins/emqx_username_quota/test/emqx_username_quota_cluster_kick_SUITE.erl
+++ b/plugins/emqx_username_quota/test/emqx_username_quota_cluster_kick_SUITE.erl
@@ -1,0 +1,141 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_username_quota_cluster_kick_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(USER, <<"clustered-user">>).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(TestCase, Config) ->
+    RegistryEnabled = registry_enabled(TestCase),
+    {Port1, Port2} = ports_for(TestCase),
+    AppSpec = fun(Port) ->
+        [
+            emqx_conf,
+            {emqx, listener_and_broker_conf(Port, RegistryEnabled)},
+            emqx_management,
+            emqx_username_quota
+        ]
+    end,
+    Cluster = emqx_cth_cluster:start(
+        [
+            {node_name(TestCase, 1), #{role => core, apps => AppSpec(Port1)}},
+            {node_name(TestCase, 2), #{role => core, apps => AppSpec(Port2)}}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(TestCase, Config)}
+    ),
+    [{cluster, Cluster}, {ports, {Port1, Port2}} | Config].
+
+end_per_testcase(_TestCase, Config) ->
+    case ?config(cluster, Config) of
+        undefined -> ok;
+        Nodes -> ok = emqx_cth_cluster:stop(Nodes)
+    end,
+    ok.
+
+registry_enabled(t_kick_username_kicks_clients_across_nodes) -> false;
+registry_enabled(t_kick_username_kicks_clients_with_registry_enabled) -> true.
+
+ports_for(t_kick_username_kicks_clients_across_nodes) -> {21883, 21884};
+ports_for(t_kick_username_kicks_clients_with_registry_enabled) -> {21885, 21886}.
+
+node_name(TestCase, N) ->
+    list_to_atom(atom_to_list(TestCase) ++ "_n" ++ integer_to_list(N)).
+
+listener_and_broker_conf(Port, RegistryEnabled) ->
+    io_lib:format(
+        "listeners.tcp.default.bind = ~p~n"
+        "listeners.ssl.default.enable = false~n"
+        "listeners.ws.default.enable = false~n"
+        "listeners.wss.default.enable = false~n"
+        "broker.enable_session_registry = ~s~n",
+        [Port, atom_to_list(RegistryEnabled)]
+    ).
+
+t_kick_username_kicks_clients_across_nodes(Config) ->
+    do_kick_test(Config).
+
+t_kick_username_kicks_clients_with_registry_enabled(Config) ->
+    do_kick_test(Config).
+
+do_kick_test(Config) ->
+    [N1, N2] = ?config(cluster, Config),
+    {Port1, Port2} = ?config(ports, Config),
+    C1 = connect_client(Port1, ?USER, <<"c-n1-1">>),
+    C2 = connect_client(Port1, ?USER, <<"c-n1-2">>),
+    C3 = connect_client(Port2, ?USER, <<"c-n2-1">>),
+    C4 = connect_client(Port2, ?USER, <<"c-n2-2">>),
+    Clients = [C1, C2, C3, C4],
+    MRefs = [erlang:monitor(process, C) || C <- Clients],
+    try
+        ok = wait_username_count(N1, ?USER, 4, 200),
+        ok = wait_username_count(N2, ?USER, 4, 200),
+        {ok, 4} = erpc:call(N1, emqx_username_quota_state, kick_username, [?USER]),
+        ok = wait_clients_down(MRefs, 5000),
+        ok = wait_username_count(N1, ?USER, 0, 200),
+        ok = wait_username_count(N2, ?USER, 0, 200)
+    after
+        lists:foreach(fun stop_client/1, Clients)
+    end.
+
+connect_client(Port, Username, ClientId) ->
+    {ok, Pid} = emqtt:start_link([
+        {host, "127.0.0.1"},
+        {port, Port},
+        {proto_ver, v5},
+        {clientid, ClientId},
+        {username, Username},
+        {clean_start, true}
+    ]),
+    true = unlink(Pid),
+    case emqtt:connect(Pid) of
+        {ok, _} ->
+            Pid;
+        {error, Reason} ->
+            stop_client(Pid),
+            erlang:error({connect_failed, Reason})
+    end.
+
+stop_client(Pid) when is_pid(Pid) ->
+    catch emqtt:stop(Pid),
+    catch exit(Pid, kill),
+    ok.
+
+wait_username_count(Node, Username, Expected, Retries) when Retries > 0 ->
+    case erpc:call(Node, emqx_username_quota_state, count, [Username]) of
+        Expected ->
+            ok;
+        _ ->
+            timer:sleep(25),
+            wait_username_count(Node, Username, Expected, Retries - 1)
+    end;
+wait_username_count(Node, Username, Expected, 0) ->
+    ?assertEqual(
+        Expected,
+        erpc:call(Node, emqx_username_quota_state, count, [Username])
+    ),
+    ok.
+
+wait_clients_down([], _Timeout) ->
+    ok;
+wait_clients_down([MRef | Rest], Timeout) ->
+    receive
+        {'DOWN', MRef, process, _Pid, _Reason} ->
+            wait_clients_down(Rest, Timeout)
+    after Timeout ->
+        ?assert(false, "timeout waiting for client DOWN")
+    end.


### PR DESCRIPTION
Release version: 6.1.2

## Summary

Call existing internal API to batch kick a list of Client IDs.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)