### PR TITLE
fix(connector): scope SSRF validation per-connector and re-check on enable

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
@@ -34,7 +34,12 @@
 ]).
 
 -define(CONNECTOR_TYPE, mqtt).
--define(MQTT_HOST_OPTS, #{default_port => 1883, ssrf_check => true}).
+%% SSRF check is intentionally NOT part of the schema-level host options:
+%% schema validation runs on the whole `connectors.mqtt' subtree, which would
+%% reject creating an unrelated valid connector whenever any sibling connector's
+%% `server' is denied by the current SSRF policy. The check is enforced per
+%% connector in `emqx_connector_resource:parse_confs/3' instead.
+-define(MQTT_HOST_OPTS, #{default_port => 1883}).
 
 namespace() -> "connector_mqtt".
 

--- a/apps/emqx_connector/src/emqx_connector_resource.erl
+++ b/apps/emqx_connector/src/emqx_connector_resource.erl
@@ -163,6 +163,7 @@ update(Namespace, Type, Name, {OldConf, Conf0}, Opts) ->
     %% without restarting the connector.
     %%
     Conf = Conf0#{connector_type => bin(Type), connector_name => bin(Name)},
+    TypeBin = bin(Type),
     case emqx_utils_maps:if_only_to_toggle_enable(OldConf, Conf0) of
         false ->
             ?SLOG(info, #{
@@ -193,6 +194,10 @@ update(Namespace, Type, Name, {OldConf, Conf0}, Opts) ->
             _ =
                 case maps:get(enable, Conf, true) of
                     true ->
+                        %% Re-validate the connector (incl. SSRF policy) before
+                        %% re-enabling; disabling is always allowed so admins can
+                        %% always take down a now-denied connector.
+                        _ = parse_confs(TypeBin, Name, Conf),
                         restart(Namespace, Type, Name);
                     false ->
                         stop(Namespace, Type, Name)
@@ -276,6 +281,13 @@ remove(Namespace, Type, Name) ->
 parse_confs(
     <<"mqtt">> = Type,
     Name,
+    #{server := Server} = Conf
+) ->
+    _ = check_ssrf(parse_mqtt_host(Server)),
+    insert_hookpoints(Type, Name, Conf);
+parse_confs(
+    <<"mqtt">> = Type,
+    Name,
     Conf
 ) ->
     insert_hookpoints(Type, Name, Conf);
@@ -350,6 +362,12 @@ check_ssrf(Host) ->
     case emqx_utils_ssrf:check_host(Host) of
         ok -> ok;
         {error, Err} -> invalid_data(emqx_utils_ssrf:format_error(Err))
+    end.
+
+parse_mqtt_host(Server) ->
+    case emqx_schema:parse_server(Server, #{default_port => 1883}) of
+        #{hostname := Host} -> Host;
+        _ -> undefined
     end.
 
 -spec invalid_data(binary()) -> no_return().

--- a/apps/emqx_connector/test/emqx_connector_ssrf_lifecycle_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_ssrf_lifecycle_SUITE.erl
@@ -1,0 +1,247 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% Regression tests for two SSRF-policy bugs:
+%%   #17483 — HTTP enable/disable toggle bypassed SSRF re-validation.
+%%   #17484 — Creating a new MQTT connector failed when an unrelated
+%%            existing MQTT connector targeted a denied server.
+-module(emqx_connector_ssrf_lifecycle_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
+
+-define(CACHE_KEY, {emqx_utils_ssrf, cache}).
+-define(CONNECTOR, emqx_connector_dummy_impl).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_connector,
+            emqx_bridge_http,
+            emqx_bridge_mqtt,
+            emqx_bridge
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    Apps = ?config(apps, Config),
+    emqx_cth_suite:stop(Apps),
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    mock_resource(),
+    set_ssrf_disabled(),
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    clear_connectors(),
+    set_ssrf_disabled(),
+    catch meck:unload(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+mock_resource() ->
+    meck:new(emqx_connector_resource, [passthrough]),
+    meck:expect(emqx_connector_resource, connector_to_resource_type, 1, ?CONNECTOR),
+    meck:new(?CONNECTOR, [non_strict]),
+    meck:expect(?CONNECTOR, resource_type, 0, dummy),
+    meck:expect(?CONNECTOR, callback_mode, 0, async_if_possible),
+    meck:expect(?CONNECTOR, on_start, 2, {ok, connector_state}),
+    meck:expect(?CONNECTOR, on_stop, 2, ok),
+    meck:expect(?CONNECTOR, on_get_status, 2, connected),
+    meck:expect(?CONNECTOR, on_get_channels, 1, []),
+    ok.
+
+set_ssrf_disabled() ->
+    persistent_term:put(?CACHE_KEY, #{
+        enable => false,
+        allow_cidrs => [],
+        deny_cidrs => [],
+        deny_hosts => []
+    }).
+
+set_ssrf_deny(DenyCidrs) ->
+    persistent_term:put(?CACHE_KEY, #{
+        enable => true,
+        allow_cidrs => [],
+        deny_cidrs => emqx_utils_ssrf:compile_cidrs(DenyCidrs),
+        deny_hosts => []
+    }).
+
+clear_connectors() ->
+    Items = emqx_connector:list(?global_ns),
+    lists:foreach(
+        fun(#{type := Type, name := Name}) ->
+            catch emqx_connector:remove(?global_ns, Type, Name)
+        end,
+        Items
+    ),
+    ok.
+
+http_config(URL) ->
+    #{
+        <<"url">> => URL,
+        <<"headers">> => #{},
+        <<"enable">> => true,
+        <<"connect_timeout">> => <<"5s">>,
+        <<"pool_size">> => 1,
+        <<"pool_type">> => <<"random">>,
+        <<"resource_opts">> => #{<<"health_check_interval">> => <<"15s">>}
+    }.
+
+mqtt_config(Server) ->
+    #{
+        <<"server">> => Server,
+        <<"enable">> => true,
+        <<"pool_size">> => 1,
+        <<"proto_ver">> => <<"v5">>,
+        <<"ssl">> => #{<<"enable">> => false},
+        <<"resource_opts">> => #{<<"health_check_interval">> => <<"15s">>}
+    }.
+
+%%--------------------------------------------------------------------
+%% HTTP cases
+%%--------------------------------------------------------------------
+
+-doc "Creating an HTTP connector targeting a denied URL is rejected.".
+t_http_create_denied_rejected(_Config) ->
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_connector:create(
+            ?global_ns,
+            http,
+            http_denied,
+            http_config(<<"http://127.0.0.1:18083">>)
+        )
+    ),
+    ok.
+
+-doc """
+Regression for #17483: `PUT /connectors/{id}/enable/true` must re-validate
+the connector against the current SSRF policy. The toggle fast-path
+previously skipped `parse_confs/3`, so a connector created under a
+permissive policy could be re-enabled after the policy tightened.
+""".
+t_http_enable_re_validates(_Config) ->
+    {ok, _} = emqx_connector:create(
+        ?global_ns,
+        http,
+        http_revalidate,
+        http_config(<<"http://127.0.0.1:18083">>)
+    ),
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    {ok, _} = emqx_connector:disable_enable(?global_ns, disable, http, http_revalidate),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_connector:disable_enable(?global_ns, enable, http, http_revalidate)
+    ),
+    ok.
+
+-doc "Disabling a now-denied HTTP connector is always allowed.".
+t_http_disable_always_allowed(_Config) ->
+    {ok, _} = emqx_connector:create(
+        ?global_ns,
+        http,
+        http_disable_ok,
+        http_config(<<"http://127.0.0.1:18083">>)
+    ),
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    ?assertMatch(
+        {ok, _},
+        emqx_connector:disable_enable(?global_ns, disable, http, http_disable_ok)
+    ),
+    ok.
+
+%%--------------------------------------------------------------------
+%% MQTT cases
+%%--------------------------------------------------------------------
+
+-doc "Creating an MQTT connector targeting a denied server is rejected.".
+t_mqtt_create_denied_rejected(_Config) ->
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_connector:create(
+            ?global_ns,
+            mqtt,
+            mqtt_denied,
+            mqtt_config(<<"127.0.0.1:1883">>)
+        )
+    ),
+    ok.
+
+-doc """
+Regression for #17484: an existing denied MQTT connector must not block
+creating an unrelated MQTT connector. Before the fix, schema-level SSRF
+validation ran on the whole `connectors.mqtt' subtree on every update
+and rejected the new connector because of the existing sibling.
+""".
+t_mqtt_create_valid_with_existing_denied(_Config) ->
+    {ok, _} = emqx_connector:create(
+        ?global_ns,
+        mqtt,
+        mqtt_denied_existing,
+        mqtt_config(<<"10.0.0.1:1883">>)
+    ),
+    set_ssrf_deny([<<"10.0.0.0/8">>]),
+    ?assertMatch(
+        {ok, _},
+        emqx_connector:create(
+            ?global_ns,
+            mqtt,
+            mqtt_valid_new,
+            mqtt_config(<<"8.8.8.8:1883">>)
+        )
+    ),
+    %% The denied connector must still be there, unchanged.
+    Names = [Name || #{name := Name} <- emqx_connector:list(?global_ns)],
+    ?assert(lists:member(mqtt_denied_existing, Names)),
+    ?assert(lists:member(mqtt_valid_new, Names)),
+    ok.
+
+-doc "Mirror of #17483 for MQTT: re-enable toggle re-runs SSRF validation.".
+t_mqtt_enable_re_validates(_Config) ->
+    {ok, _} = emqx_connector:create(
+        ?global_ns,
+        mqtt,
+        mqtt_revalidate,
+        mqtt_config(<<"127.0.0.1:1883">>)
+    ),
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    {ok, _} = emqx_connector:disable_enable(?global_ns, disable, mqtt, mqtt_revalidate),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_connector:disable_enable(?global_ns, enable, mqtt, mqtt_revalidate)
+    ),
+    ok.
+
+-doc "Disabling a now-denied MQTT connector is always allowed.".
+t_mqtt_disable_always_allowed(_Config) ->
+    {ok, _} = emqx_connector:create(
+        ?global_ns,
+        mqtt,
+        mqtt_disable_ok,
+        mqtt_config(<<"127.0.0.1:1883">>)
+    ),
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    ?assertMatch(
+        {ok, _},
+        emqx_connector:disable_enable(?global_ns, disable, mqtt, mqtt_disable_ok)
+    ),
+    ok.


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Fixes two SSRF-policy bugs symmetrically. The bug isn't released yet, so no changelog entry.

### #17483 — HTTP enable/disable bypassed SSRF re-validation

\`PUT /api/v5/connectors/{id}/enable/true\` took the toggle fast-path in \`emqx_connector_resource:update/5\` and skipped \`parse_confs/3\`, so a connector created when SSRF was disabled (or temporarily allowed) could be re-enabled after the policy tightened.

Fix: re-run \`parse_confs/3\` before \`restart\` on the toggle-to-true branch. The toggle-to-false branch deliberately keeps skipping validation so administrators can always take down a now-denied connector.

### #17484 — Existing denied MQTT connector blocked creating a new MQTT connector

\`?MQTT_HOST_OPTS\` in \`emqx_bridge_mqtt_connector_schema\` carried \`ssrf_check => true\` into \`emqx_schema:servers_sc/2\`. Because HOCON re-validates the whole \`connectors.mqtt\` subtree on every add/update, creating a new MQTT connector failed whenever any sibling connector's \`server\` was denied — and the same broke single-connector updates / imports.

Fix: drop \`ssrf_check => true\` from \`?MQTT_HOST_OPTS\` and run an explicit \`check_ssrf/1\` in the new \`parse_confs(<<\"mqtt\">>, …)\` clause. This matches the HTTP layout (HTTP's check is in \`parse_url/1\` called from \`parse_confs(<<\"http\">>, …)\`).

### Files

- \`apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl\` — remove schema-level SSRF flag from MQTT host opts; comment explains why.
- \`apps/emqx_connector/src/emqx_connector_resource.erl\` — new \`parse_confs(<<\"mqtt\">>, …)\` clause + \`parse_mqtt_host/1\` helper; re-validation on enable-toggle.
- \`apps/emqx_connector/test/emqx_connector_ssrf_lifecycle_SUITE.erl\` — 7 cases covering create/enable/disable across HTTP and MQTT under SSRF policy. Verified that the 4 regression cases (\`t_http_enable_re_validates\`, \`t_mqtt_create_valid_with_existing_denied\`, \`t_mqtt_enable_re_validates\`, \`t_mqtt_disable_always_allowed\`) fail without the fix and pass with it.

### Scope of SSRF migration in this PR

Only MQTT is migrated. S3Tables — which the brief expected — already enforces SSRF at runtime in \`emqx_bridge_s3tables_connector_schema:parse_base_endpoint/1\` called from the impl module's \`on_start\`; no schema-level \`ssrf_check\` exists there.

### Known gap (out of scope)

The same schema-level \`ssrf_check\` pattern (and the same #17484-shape fanout bug) exists in many other connector types that pipe a \`HOST_OPTS\` macro through \`emqx_schema:servers_sc/2\` or \`servers_validator/2\`:

- \`emqx_bridge_iotdb\` (\`?THRIFT_HOST_OPTIONS\`)
- \`emqx_bridge_kafka\` (\`host_opts/0\`)
- \`emqx_bridge_confluent\` (\`host_opts/0\`)
- \`emqx_bridge_azure_event_hub\` (\`host_opts/0\`)
- \`emqx_bridge_couchbase\` (\`?SERVER_OPTIONS\`)
- \`emqx_bridge_sqlserver\` (\`?SQLSERVER_HOST_OPTIONS\`)
- \`emqx_bridge_syskeeper\` (\`?SYSKEEPER_HOST_OPTIONS\`, both connector and proxy)
- \`emqx_bridge_greptimedb\` (\`?GREPTIMEDB_HOST_OPTIONS\`)
- \`emqx_bridge_influxdb\` (\`?INFLUXDB_HOST_OPTIONS\`)
- \`emqx_bridge_rocketmq\` (\`?ROCKETMQ_HOST_OPTIONS\`)
- \`emqx_bridge_cassandra\` (\`?DEFAULT_SERVER_OPTION\`)
- \`emqx_mysql\` (\`?MYSQL_HOST_OPTIONS\`)
- \`emqx_bridge_snowflake\` (\`?SERVER_OPTS\`, used in two schema modules)
- \`emqx_bridge_pulsar\` (\`?PULSAR_HOST_OPTIONS\`)
- \`emqx_bridge_datalayers\` (\`?DATALAYERS_HOST_*_OPTIONS\`)

These are not migrated here because each one needs its own runtime check site, its own removal-from-schema decision (most also call \`parse_server/2\` again at impl \`on_start\` with the same opts, so a naive macro change loses the runtime check too), and its own test surface. Filing as a follow-up.

\`emqx_bridge_dynamo\`, \`emqx_bridge_bigquery\`, \`emqx_bridge_gcp_pubsub\`, \`emqx_bridge_doris\`, \`emqx_bridge_tdengine\`, \`emqx_bridge_kinesis\` keep \`ssrf_check => true\` only in runtime impl-module \`parse_server\` calls — not in any schema validator — so they are not affected by #17484.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to \`changes/ee/...\` (intentionally omitted — bug is not released yet)
- [x] Schema changes are backward compatible (removing \`ssrf_check\` from the host-opts is strictly more permissive at the schema layer; runtime gate replaces it)