### PR TITLE
fix(bin): use wide ps output to avoid command line truncation

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -441,7 +441,7 @@ check_emqx_process() {
     ## Find the running node from 'ps -ef'
     ##  * The grep args like '[e]mqx' but not 'emqx' is to avoid greping the grep command itself
     ##  * The running 'remsh' and 'nodetool' processes must be excluded
-    ps -ef | $GREP '[e]mqx' | $GREP -v -E '(remsh|nodetool)' | $GREP -oE "\-[r]oot ${rootdir}.*" || true
+    ps -efww | $GREP '[e]mqx' | $GREP -v -E '(remsh|nodetool)' | $GREP -oE "\-[r]oot ${rootdir}.*" || true
 }
 
 find_emqx_process() {


### PR DESCRIPTION
Fixes #17494

Release version:

5.8.10, 5.10.4
6.0.3, 6.1.2, 6.2.0


## Summary

This commit replaces `ps -ef` with `ps -efww` in `check_emqx_process()`, ensuring that long process command lines are not truncated by terminal width or `COLUMNS` restrictions. Without this fix, the grep for `"-root ${rootdir}.*"` can fail to match, falsely reporting the node as not running.

For example, on some customized container platform, the narrow default terminal width caused `ps -ef` output to end at "-root /opt/em", making `emqx ctl status` always return `ERROR: Node emqx@... is not running` even though the node was up.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible 