### PR TITLE
fix(resource): count actions.executed per invocation

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
@@ -2073,3 +2073,257 @@ t_get_basic_usage_info_0(_TCConfig) ->
         },
         emqx_bridge_v2:get_basic_usage_info()
     ).
+
+-doc """
+In non-batch mode (`batch_size = 1`), `actions.executed` must equal
+`actions.messages` after sending K messages: every per-message completion is
+one action invocation handling one message.  Regression guard for the bug
+where `actions.executed` was incremented once per buffer-worker telemetry
+flush window, falling behind `actions.messages` when many single-message
+completions were aggregated into one flush event.
+""".
+t_actions_executed_equals_messages_in_single_mode(_Config) ->
+    BridgeName = ?FUNCTION_NAME,
+    BridgeConfig = emqx_utils_maps:deep_merge(
+        bridge_config(),
+        #{<<"resource_opts">> => #{<<"metrics_flush_interval">> => <<"100ms">>}}
+    ),
+    {ok, _} = create(bridge_type(), BridgeName, BridgeConfig),
+    register(registered_process_name(), self()),
+    Executed0 = emqx_metrics:val_global('actions.executed'),
+    Messages0 = emqx_metrics:val_global('actions.messages'),
+    K = 50,
+    lists:foreach(
+        fun(I) ->
+            _ = send_message(
+                bridge_type(),
+                BridgeName,
+                integer_to_binary(I),
+                #{}
+            )
+        end,
+        lists:seq(1, K)
+    ),
+    lists:foreach(
+        fun(_) -> ?assertReceive({query_called, _}, 5_000) end,
+        lists:seq(1, K)
+    ),
+    ?retry(
+        200,
+        20,
+        begin
+            ?assertEqual(
+                Messages0 + K,
+                emqx_metrics:val_global('actions.messages')
+            ),
+            ?assertEqual(
+                Executed0 + K,
+                emqx_metrics:val_global('actions.executed')
+            )
+        end
+    ),
+    unregister(registered_process_name()),
+    ok = remove(bridge_type(), BridgeName),
+    ok.
+
+-doc """
+Failed executions must still count toward `actions.executed`: the metric
+tracks attempts, not successes.  Sister test for the equality contract in
+non-batch mode, exercising the error path.
+""".
+t_actions_executed_counts_failures(_Config) ->
+    BridgeName = ?FUNCTION_NAME,
+    OnQueryFn = wrap_fun(fun(_Ctx) ->
+        {error, {unrecoverable_error, on_purpose}}
+    end),
+    BridgeConfig = emqx_utils_maps:deep_merge(
+        bridge_config(),
+        #{
+            <<"parameters">> => #{<<"on_query_fn">> => OnQueryFn},
+            <<"resource_opts">> => #{<<"metrics_flush_interval">> => <<"100ms">>}
+        }
+    ),
+    {ok, _} = create(bridge_type(), BridgeName, BridgeConfig),
+    Executed0 = emqx_metrics:val_global('actions.executed'),
+    Messages0 = emqx_metrics:val_global('actions.messages'),
+    K = 20,
+    lists:foreach(
+        fun(I) ->
+            _ = send_message(
+                bridge_type(),
+                BridgeName,
+                integer_to_binary(I),
+                #{}
+            )
+        end,
+        lists:seq(1, K)
+    ),
+    ?retry(
+        200,
+        20,
+        begin
+            ?assertEqual(
+                Messages0 + K,
+                emqx_metrics:val_global('actions.messages')
+            ),
+            ?assertEqual(
+                Executed0 + K,
+                emqx_metrics:val_global('actions.executed')
+            )
+        end
+    ),
+    ok = remove(bridge_type(), BridgeName),
+    ok.
+
+-doc """
+In batch mode, `actions.messages` counts individual messages while
+`actions.executed` counts batches (one per `on_batch_query` invocation),
+so `actions.messages > actions.executed` whenever any batch is non-trivial.
+""".
+t_actions_messages_exceeds_executed_in_batch_mode(_Config) ->
+    BridgeName = ?FUNCTION_NAME,
+    BatchSize = 20,
+    BridgeConfig = emqx_utils_maps:deep_merge(
+        bridge_config(),
+        #{
+            <<"resource_opts">> => #{
+                <<"batch_size">> => BatchSize,
+                <<"batch_time">> => <<"500ms">>,
+                <<"metrics_flush_interval">> => <<"100ms">>,
+                <<"worker_pool_size">> => 1
+            }
+        }
+    ),
+    {ok, _} = create(bridge_type(), BridgeName, BridgeConfig),
+    register(registered_process_name(), self()),
+    Executed0 = emqx_metrics:val_global('actions.executed'),
+    Messages0 = emqx_metrics:val_global('actions.messages'),
+    K = 200,
+    Parent = self(),
+    %% Fire the sends concurrently so they queue up and form actual batches.
+    _Pids = [
+        spawn(fun() ->
+            _ = send_message(bridge_type(), BridgeName, integer_to_binary(I), #{}),
+            Parent ! sent
+        end)
+     || I <- lists:seq(1, K)
+    ],
+    SeenN = collect_batch_messages(K, 10_000),
+    ?assertEqual(K, SeenN),
+    %% Drain spawn replies.
+    [
+        receive
+            sent -> ok
+        after 5_000 -> ok
+        end
+     || _ <- lists:seq(1, K)
+    ],
+    MinBatches = (K + BatchSize - 1) div BatchSize,
+    ?retry(
+        200,
+        20,
+        begin
+            ?assertEqual(
+                Messages0 + K,
+                emqx_metrics:val_global('actions.messages')
+            ),
+            Executed = emqx_metrics:val_global('actions.executed') - Executed0,
+            %% At least ceil(K / BatchSize) batches must have been executed;
+            %% possibly more if `batch_time` flushed partial batches.
+            ?assert(
+                Executed >= MinBatches,
+                {expected_at_least, MinBatches, got, Executed}
+            ),
+            %% Strictly less than K, because batching is happening.
+            ?assert(
+                Executed < K,
+                {expected_strictly_less_than, K, got, Executed}
+            )
+        end
+    ),
+    unregister(registered_process_name()),
+    ok = remove(bridge_type(), BridgeName),
+    ok.
+
+collect_batch_messages(Remaining, _Timeout) when Remaining =< 0 ->
+    0;
+collect_batch_messages(Remaining, Timeout) ->
+    receive
+        {batch_called, N, _Msgs} ->
+            N + collect_batch_messages(Remaining - N, Timeout)
+    after Timeout ->
+        0
+    end.
+
+-doc """
+Both global and per-namespace `actions.executed` counters must track the
+number of invocations correctly when the action is namespaced.
+""".
+t_actions_executed_namespaced(_Config) ->
+    Namespace = <<"ns_actions_executed">>,
+    ok = emqx_metrics:register_namespace(Namespace),
+    on_exit(fun() -> emqx_metrics:unregister_namespace(Namespace) end),
+    ConnectorName = ?FUNCTION_NAME,
+    {ok, _} = emqx_connector:create(Namespace, con_type(), ConnectorName, con_config()),
+    ActionName = ?FUNCTION_NAME,
+    ActionConfig = emqx_utils_maps:deep_merge(
+        bridge_config(),
+        #{
+            <<"connector">> => atom_to_binary(ConnectorName),
+            <<"resource_opts">> => #{<<"metrics_flush_interval">> => <<"100ms">>}
+        }
+    ),
+    {ok, _} = create(#{
+        namespace => Namespace,
+        kind => action,
+        type => bridge_type(),
+        name => ActionName,
+        config => ActionConfig
+    }),
+    _ = emqx_bridge_v2_testlib:kickoff_kind_health_check(#{
+        namespace => Namespace,
+        kind => action,
+        type => bridge_type(),
+        name => ActionName
+    }),
+    register(registered_process_name(), self()),
+    ExecutedGlobal0 = emqx_metrics:val_global('actions.executed'),
+    ExecutedNs0 = emqx_metrics:val(Namespace, 'actions.executed'),
+    MessagesGlobal0 = emqx_metrics:val_global('actions.messages'),
+    MessagesNs0 = emqx_metrics:val(Namespace, 'actions.messages'),
+    K = 10,
+    lists:foreach(
+        fun(I) ->
+            _ = emqx_bridge_v2:send_message(
+                Namespace,
+                bridge_type(),
+                ActionName,
+                integer_to_binary(I),
+                #{}
+            )
+        end,
+        lists:seq(1, K)
+    ),
+    lists:foreach(
+        fun(_) -> ?assertReceive({query_called, _}, 5_000) end,
+        lists:seq(1, K)
+    ),
+    ?retry(
+        200,
+        20,
+        begin
+            ?assertEqual(
+                MessagesNs0 + K,
+                emqx_metrics:val(Namespace, 'actions.messages')
+            ),
+            ?assertEqual(
+                ExecutedNs0 + K,
+                emqx_metrics:val(Namespace, 'actions.executed')
+            )
+        end
+    ),
+    %% Global counter unchanged (namespaced action does not bump global).
+    ?assertEqual(ExecutedGlobal0, emqx_metrics:val_global('actions.executed')),
+    ?assertEqual(MessagesGlobal0, emqx_metrics:val_global('actions.messages')),
+    unregister(registered_process_name()),
+    ok.

--- a/apps/emqx_bridge/test/emqx_bridge_v2_test_connector.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_test_connector.erl
@@ -13,6 +13,7 @@
     on_start/2,
     on_stop/2,
     on_query/3,
+    on_batch_query/3,
     on_query_async/4,
     on_get_status/2,
     on_add_channel/4,
@@ -93,6 +94,26 @@ on_query(
             OnQueryFn(Ctx);
         #{parameters := #{send_to := SendTo}} ->
             SendTo ! {query_called, Ctx},
+            ok
+    end.
+
+on_batch_query(
+    _InstId,
+    [{ChannelId, _Message} | _] = Reqs,
+    ConnectorState
+) ->
+    Channels = maps:get(channels, ConnectorState, #{}),
+    ChannelState = maps:get(ChannelId, Channels, not_found),
+    case ChannelState of
+        #{parameters := #{on_query_fn := OnQueryFn0}} ->
+            OnQueryFn = emqx_bridge_v2_SUITE:unwrap_fun(OnQueryFn0),
+            OnQueryFn(#{
+                batch_size => length(Reqs),
+                action_res_id => ChannelId,
+                messages => [M || {_, M} <- Reqs]
+            });
+        #{parameters := #{send_to := SendTo}} ->
+            SendTo ! {batch_called, length(Reqs), [M || {_, M} <- Reqs]},
             ok
     end.
 

--- a/apps/emqx_resource/mix.exs
+++ b/apps/emqx_resource/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXResource.MixProject do
   def project do
     [
       app: :emqx_resource,
-      version: "6.1.1",
+      version: "6.1.2",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -549,7 +549,7 @@ retry_inflight_sync(Ref, QueryOrBatch, Data0) ->
     IsSimpleQuery = false,
     QueryOpts = #{simple_query => IsSimpleQuery},
     Result = call_query(force_sync, Id, Index, Ref, QueryOrBatch, QueryOpts),
-    {Decision, PostFn, DeltaCounters} =
+    {Decision, PostFn, DeltaCounters0} =
         case QueryOrBatch of
             ?QUERY(ReplyTo, _, HasBeenSent, _ExpireAt, RequestContext, TraceCtx) ->
                 Reply = ?REPLY(ReplyTo, HasBeenSent, Result, RequestContext, TraceCtx),
@@ -557,6 +557,7 @@ retry_inflight_sync(Ref, QueryOrBatch, Data0) ->
             [?QUERY(_, _, _, _, _, _) | _] = Batch ->
                 batch_reply_caller_defer_metrics(Id, Result, Batch, IsSimpleQuery)
         end,
+    DeltaCounters = delta_with_actions_executed(Decision, Result, DeltaCounters0),
     Queries =
         case QueryOrBatch of
             ?QUERY(_, _, _, _, _, _) ->
@@ -792,7 +793,8 @@ do_flush(
     QueryOpts = #{inflight_tid => InflightTID, simple_query => false},
     Result = call_query(async_if_possible, Id, Index, Ref, Request, QueryOpts),
     Reply = ?REPLY(ReplyTo, HasBeenSent, Result, RequestContext, TraceCtx),
-    {Decision, PostFn, DeltaCounters} = reply_caller_defer_metrics(Id, Reply, QueryOpts),
+    {Decision, PostFn, DeltaCounters0} = reply_caller_defer_metrics(Id, Reply, QueryOpts),
+    DeltaCounters = delta_with_actions_executed(Decision, Result, DeltaCounters0),
     PostFn(result_context([Request])),
     Data1 = aggregate_counters(Data0, DeltaCounters),
     case Decision of
@@ -880,8 +882,9 @@ do_flush(#{queue := Q1} = Data0, #{
     IsSimpleQuery = false,
     QueryOpts = #{inflight_tid => InflightTID, simple_query => IsSimpleQuery},
     Result = call_query(async_if_possible, Id, Index, Ref, Batch, QueryOpts),
-    {Decision, PostFn, DeltaCounters} =
+    {Decision, PostFn, DeltaCounters0} =
         batch_reply_caller_defer_metrics(Id, Result, Batch, IsSimpleQuery),
+    DeltaCounters = delta_with_actions_executed(Decision, Result, DeltaCounters0),
     PostFn(result_context(Batch)),
     Data1 = aggregate_counters(Data0, DeltaCounters),
     case Decision of
@@ -1075,7 +1078,8 @@ batch_reply_dropped(Id, Batch, Result) ->
 %% This is only called by `simple_{,a}sync_query', so we can bump the
 %% counters here.
 handle_simple_query_result(Id, Query, Result, HasBeenSent) ->
-    {Decision, PostFn, DeltaCounters} = handle_query_result_pure(Id, Result, HasBeenSent, #{}),
+    {Decision, PostFn, DeltaCounters0} = handle_query_result_pure(Id, Result, HasBeenSent, #{}),
+    DeltaCounters = delta_with_actions_executed(Decision, Result, DeltaCounters0),
     PostFn(result_context([Query])),
     Namespace = infer_namespace_from_id(Id),
     bump_counters(Id, DeltaCounters, Namespace),
@@ -1307,7 +1311,10 @@ do_bump_counters1(retried_success, Val, Id, Namespace) ->
 do_bump_counters1(dropped_resource_not_found, Val, Id, _Namespace) ->
     emqx_resource_metrics:dropped_resource_not_found_inc(Id, Val);
 do_bump_counters1(dropped_resource_stopped, Val, Id, _Namespace) ->
-    emqx_resource_metrics:dropped_resource_stopped_inc(Id, Val).
+    emqx_resource_metrics:dropped_resource_stopped_inc(Id, Val);
+do_bump_counters1(actions_executed, Val, Id, Namespace) ->
+    ExtraMeta = #{namespace => Namespace},
+    emqx_resource_metrics:actions_executed_inc(Id, Val, ExtraMeta).
 
 -spec log_expired_message_count(data()) -> ok.
 log_expired_message_count(_Data = #{id := Id, index := Index, counters := Counters}) ->
@@ -1433,6 +1440,24 @@ collect_rule_trigger_times(?QUERY(_, _, _, _, _, #{rule_trigger_ts := Time}), Ac
     [Time | Acc];
 collect_rule_trigger_times(?QUERY(_, _, _, _, _, _), Acc) ->
     Acc.
+
+%% Per-`call_query' delta that bumps `actions.executed' iff the invocation produced
+%% a final result attributable to the connector callback.  Skip when:
+%%   * Decision is `?nack' (recoverable; the same request will be retried and
+%%     finalised later in `retry_inflight_sync').
+%%   * Result indicates `call_query/6' short-circuited before `apply_query_fun/9'
+%%     (resource not found / stopped), so no callback ran.
+%% The `pre_query_channel_check/4' failure on a simple query produces a final
+%% `?ack' here even though the callback didn't run; we accept that edge case
+%% rather than thread the channel-check outcome out of `apply_query_fun/9'.
+delta_with_actions_executed(?nack, _Result, DeltaCounters) ->
+    DeltaCounters;
+delta_with_actions_executed(?ack, ?RESOURCE_ERROR_M(Kind, _), DeltaCounters) when
+    Kind =:= not_found; Kind =:= stopped
+->
+    DeltaCounters;
+delta_with_actions_executed(?ack, _Result, DeltaCounters) ->
+    DeltaCounters#{actions_executed => 1}.
 
 %% action:kafka_producer:actionname:connector:kafka_producer:connectorname
 %% ns:ns1:action:kafka_producer:actionname:connector:kafka_producer:connectorname

--- a/apps/emqx_resource/src/emqx_resource_metrics.erl
+++ b/apps/emqx_resource/src/emqx_resource_metrics.erl
@@ -80,7 +80,8 @@
     aggregated_upload_success_get/1,
     aggregated_upload_failure_inc/1,
     aggregated_upload_failure_inc/2,
-    aggregated_upload_failure_get/1
+    aggregated_upload_failure_get/1,
+    actions_executed_inc/3
 ]).
 
 -export([mk_delivery_finished_callback_for_action/1, on_delivery_finished/2]).
@@ -134,7 +135,8 @@ events() ->
             retried_success,
             success,
             aggregated_upload_success,
-            aggregated_upload_failure
+            aggregated_upload_failure,
+            actions_executed
         ]
     ].
 
@@ -234,7 +236,7 @@ handle_counter_telemetry_event(Event, ID, Val, Metadata) ->
         late_reply ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'late_reply', Val);
         failed ->
-            inc_actions_executed(Metadata, Val),
+            inc_actions_messages(Metadata, Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'failed', Val);
         matched ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'matched', Val);
@@ -242,21 +244,23 @@ handle_counter_telemetry_event(Event, ID, Val, Metadata) ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'received', Val);
         retried_failed ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'retried', Val),
-            inc_actions_executed(Metadata, Val),
+            inc_actions_messages(Metadata, Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'failed', Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'retried.failed', Val);
         retried_success ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'retried', Val),
-            inc_actions_executed(Metadata, Val),
+            inc_actions_messages(Metadata, Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'success', Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'retried.success', Val);
         success ->
-            inc_actions_executed(Metadata, Val),
+            inc_actions_messages(Metadata, Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'success', Val);
         aggregated_upload_success ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'aggregated_upload.success', Val);
         aggregated_upload_failure ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'aggregated_upload.failure', Val);
+        actions_executed ->
+            inc_actions_executed(Metadata, Val);
         _ ->
             ok
     end.
@@ -573,6 +577,15 @@ aggregated_upload_failure_inc(ID, Val) ->
 aggregated_upload_failure_get(ID) ->
     emqx_metrics_worker:get(?RES_METRICS, ID, 'aggregated_upload.failure').
 
+%% @doc Count of `on_query'/`on_batch_query' invocations.  Batch size, failures
+%% and retries do not affect this count.
+actions_executed_inc(_ID, 0, _ExtraMeta) ->
+    ok;
+actions_executed_inc(ID, Val, ExtraMeta) ->
+    telemetry:execute([?TELEMETRY_PREFIX, actions_executed], #{counter_inc => Val}, ExtraMeta#{
+        resource_id => ID
+    }).
+
 -doc """
 Helper for aggregated actions to add a callback to bump their metrics.
 """.
@@ -594,9 +607,12 @@ on_delivery_finished(Result, ActionResId) ->
             emqx_resource_metrics:aggregated_upload_failure_inc(ActionResId)
     end.
 
-inc_actions_executed(#{namespace := Namespace}, Val) ->
-    emqx_metrics:inc(Namespace, 'actions.executed'),
+inc_actions_messages(#{namespace := Namespace}, Val) ->
     emqx_metrics:inc(Namespace, 'actions.messages', Val);
-inc_actions_executed(_Metadata, Val) ->
-    emqx_metrics:inc_global('actions.executed'),
+inc_actions_messages(_Metadata, Val) ->
     emqx_metrics:inc_global('actions.messages', Val).
+
+inc_actions_executed(#{namespace := Namespace}, Val) ->
+    emqx_metrics:inc(Namespace, 'actions.executed', Val);
+inc_actions_executed(_Metadata, Val) ->
+    emqx_metrics:inc_global('actions.executed', Val).

--- a/changes/ee/fix-17497.en.md
+++ b/changes/ee/fix-17497.en.md
@@ -1,0 +1,5 @@
+Fixed the `actions.executed` metric undercounting `actions.messages` for actions configured in non-batch mode (`batch_size = 1`).
+
+The previous implementation incremented `actions.executed` once per buffer-worker telemetry flush, which could aggregate many individual completions into one event, so `actions.executed` fell behind `actions.messages` even when no batching was configured.
+
+The two metrics are now incremented at independent call sites: `actions.executed` once per action callback invocation (one per batch in batch mode, one per message in single mode), `actions.messages` per message handled.


### PR DESCRIPTION
Fixes: https://emqx.atlassian.net/browse/EMQX-15328
Release version: 6.1.3, 6.2.2

## Summary

QA-reported metric-correctness fix.  In non-batch mode (`batch_size = 1`) the documented invariant is `actions.executed == actions.messages`.  Today, `actions.executed` falls behind because it was incremented in the buffer-worker telemetry flush handler (one bump per flush window) while `actions.messages` was incremented by the flush's aggregated message count.  K consecutive single-message completions aggregated into one flush would bump `actions.executed` by 1 and `actions.messages` by K.

This PR decouples the two counters:

* `actions.executed` is now bumped once per `on_query` / `on_batch_query` invocation, from `apply_query_fun/9` in `emqx_resource_buffer_worker.erl`.  One execution per batch (regardless of size), one execution per retry, one execution per failure.
* `actions.messages` continues to be derived from the existing telemetry-flush path (renamed helper `inc_actions_messages/2`).

Most relevant files:

* `apps/emqx_resource/src/emqx_resource_metrics.erl` — split helpers; new `inc_actions_executed/2`.
* `apps/emqx_resource/src/emqx_resource_buffer_worker.erl` — call sites that bump per invocation.
* `apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl` — four new test cases covering single-mode equality, failure counting, batch mode, and namespaced actions.

No behaviour change beyond the metric values.  Metric names and the `actions.messages` semantic are unchanged.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-17497.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema change)