### PR TITLE
fix(gateway): prevent unauthenticated publish paths

### DIFF
--- a/apps/emqx_gateway_coap/mix.exs
+++ b/apps/emqx_gateway_coap/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayCoap.MixProject do
   def project do
     [
       app: :emqx_gateway_coap,
-      version: "6.2.1",
+      version: "6.2.2",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -427,7 +427,12 @@ ensure_keepalive_timer(Fun, #channel{keepalive = KeepAlive} = Channel) ->
     Fun(keepalive, Heartbeat, keepalive, Channel).
 
 check_auth_state(Msg, #channel{connection_required = false} = Channel) ->
-    call_session(handle_request, Msg, Channel);
+    case is_pubsub_request(Msg) of
+        true ->
+            authenticate_connectionless_pubsub(Msg, Channel);
+        false ->
+            call_session(handle_request, Msg, Channel)
+    end;
 check_auth_state(Msg, #channel{connection_required = true} = Channel) ->
     case is_create_connection_request(Msg) of
         true ->
@@ -442,6 +447,11 @@ check_auth_state(Msg, #channel{connection_required = true} = Channel) ->
                 _ ->
                     check_token(Msg, Channel)
             end
+    end.
+is_pubsub_request(Msg) ->
+    case emqx_coap_message:get_option(uri_path, Msg, []) of
+        [<<"ps">> | _] -> true;
+        _ -> false
     end.
 is_create_connection_request(#coap_message{method = Method} = Msg) ->
     URIPath = emqx_coap_message:get_option(uri_path, Msg, []),
@@ -478,6 +488,71 @@ check_token(Msg, Channel) ->
                     missing_token_or_clientid_reply(Msg, Channel)
             end
     end.
+
+authenticate_connectionless_pubsub(Msg, Channel = #channel{ctx = Ctx}) ->
+    AuthChannel = enrich_connectionless_auth_info(Msg, Channel),
+    #channel{conninfo = ConnInfo0, clientinfo = ClientInfo0} = Channel,
+    #channel{clientinfo = AuthClientInfo} = AuthChannel,
+    case emqx_gateway_ctx:authenticate(Ctx, AuthClientInfo) of
+        {ok, NClientInfo} ->
+            restore_connectionless_auth_info(
+                call_session(handle_request, Msg, AuthChannel#channel{clientinfo = NClientInfo}),
+                ConnInfo0,
+                ClientInfo0
+            );
+        {error, Reason} ->
+            ?SLOG(warning, #{
+                msg => "client_login_failed",
+                clientid => maps:get(clientid, AuthClientInfo, undefined),
+                username => maps:get(username, AuthClientInfo, undefined),
+                reason => Reason
+            }),
+            connectionless_unauthorized_reply(Msg, Channel)
+    end.
+
+enrich_connectionless_auth_info(Msg, Channel) ->
+    URIQuery = emqx_coap_message:extract_uri_query(Msg),
+    Channel1 = enrich_connectionless_conninfo(URIQuery, Channel),
+    {ok, Channel2} = enrich_clientinfo({URIQuery, Msg}, Channel1),
+    Channel2.
+
+enrich_connectionless_conninfo(
+    URIQuery,
+    Channel = #channel{
+        keepalive = KeepAlive,
+        conninfo = ConnInfo0,
+        clientinfo = ClientInfo
+    }
+) ->
+    ClientId =
+        case get_query_value(<<"clientid">>, URIQuery) of
+            undefined -> maps:get(clientid, ClientInfo);
+            ReqClientId -> ReqClientId
+        end,
+    IntervalMs = emqx_keepalive:info(check_interval, KeepAlive),
+    InternalS = floor(IntervalMs / 1000),
+    NConnInfo = ConnInfo0#{
+        clientid => ClientId,
+        proto_name => <<"CoAP">>,
+        proto_ver => <<"1">>,
+        clean_start => true,
+        keepalive => InternalS,
+        expiry_interval => 0
+    },
+    Channel#channel{conninfo = NConnInfo}.
+
+restore_connectionless_auth_info({ok, NChannel}, ConnInfo, ClientInfo) ->
+    {ok, NChannel#channel{conninfo = ConnInfo, clientinfo = ClientInfo}};
+restore_connectionless_auth_info({ok, Replies, NChannel}, ConnInfo, ClientInfo) ->
+    {ok, Replies, NChannel#channel{conninfo = ConnInfo, clientinfo = ClientInfo}};
+restore_connectionless_auth_info({shutdown, Reason, NChannel}, ConnInfo, ClientInfo) ->
+    {shutdown, Reason, NChannel#channel{conninfo = ConnInfo, clientinfo = ClientInfo}};
+restore_connectionless_auth_info({shutdown, Reason, Replies, NChannel}, ConnInfo, ClientInfo) ->
+    {shutdown, Reason, Replies, NChannel#channel{conninfo = ConnInfo, clientinfo = ClientInfo}}.
+
+connectionless_unauthorized_reply(Msg, Channel) ->
+    Reply = emqx_coap_message:piggyback({error, unauthorized}, Msg),
+    {ok, {outgoing, Reply}, Channel}.
 
 try_takeover_with_token(Msg, ReqClientId, ReqToken, Channel) ->
     case emqx_gateway_cm:call(coap, ReqClientId, {check_token_and_get_clientinfo, ReqToken}) of
@@ -603,8 +678,8 @@ enrich_clientinfo({Queries, Msg}, Channel) ->
     #channel{conninfo = ConnInfo, clientinfo = ClientInfo0} = Channel,
     ClientInfo = ClientInfo0#{
         clientid => maps:get(clientid, ConnInfo),
-        username => maps:get(<<"username">>, Queries, undefined),
-        password => maps:get(<<"password">>, Queries, undefined)
+        username => get_query_value(<<"username">>, Queries),
+        password => get_query_value(<<"password">>, Queries)
     },
     {ok, NClientInfo} = fix_mountpoint(Msg, ClientInfo),
     {ok, Channel#channel{clientinfo = NClientInfo}}.

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -26,6 +26,7 @@
 -define(PS_PREFIX, "coap://127.0.0.1/ps").
 -define(MQTT_PREFIX, "coap://127.0.0.1/mqtt").
 -define(OBSERVE_NOTIFICATION_QUEUE_MAX_LEN, 100).
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -89,6 +90,48 @@ update_coap_with_mountpoint(Mp) ->
         coap,
         Conf#{<<"mountpoint">> => Mp}
     ).
+
+with_security_profile(Profile, Fun) ->
+    os:putenv(?PROFILE_ENV_VAR, Profile),
+    emqx_security_profile:clear_profile(),
+    try
+        Fun()
+    after
+        os:unsetenv(?PROFILE_ENV_VAR),
+        emqx_security_profile:clear_profile()
+    end.
+
+with_connectionless_coap(EnableAuthn, Fun) ->
+    OldConf = emqx:get_raw_config([gateway, coap]),
+    OldListenerConf = emqx_conf:get([gateway, coap, listeners, udp, default]),
+    try
+        {ok, _} = emqx_gateway_conf:update_gateway(
+            coap,
+            OldConf#{<<"connection_required">> => <<"false">>}
+        ),
+        ok = update_coap_udp_listener_authn(EnableAuthn),
+        Fun()
+    after
+        ok = update_coap_udp_listener(OldListenerConf),
+        {ok, _} = emqx_gateway_conf:update_gateway(coap, OldConf)
+    end.
+
+update_coap_udp_listener_authn(EnableAuthn) ->
+    ListenerPath = [gateway, coap, listeners, udp, default],
+    ListenerConf0 = emqx_conf:get(ListenerPath),
+    ListenerConf1 = ListenerConf0#{enable_authn => EnableAuthn},
+    ok = update_coap_udp_listener(ListenerConf1),
+    ?assertEqual(
+        EnableAuthn,
+        emqx_conf:get([gateway, coap, listeners, udp, default, enable_authn], undefined)
+    ),
+    ok.
+
+update_coap_udp_listener(ListenerConf) ->
+    case emqx_gateway_conf:update_listener(coap, {udp, default}, ListenerConf) of
+        ok -> ok;
+        {ok, _} -> ok
+    end.
 
 with_notify_type(NotifyType, Fun) ->
     OldConf = emqx:get_raw_config([gateway, coap]),
@@ -668,6 +711,123 @@ t_pubsub_unauthorized(_) ->
         ok = emqx_gateway_auth_ct:stop_auth(authz_http),
         {ok, _} = emqx:update_config([authorization], OldAuthz)
     end.
+
+t_connectionless_hardened_no_auth_config_rejects_pub_sub(_) ->
+    with_security_profile("hardened", fun() ->
+        with_connectionless_coap(true, fun() ->
+            PublishTopic = <<"security/coap/hardened/publish">>,
+            SubscribeTopic = <<"security/coap/hardened/subscribe">>,
+            Payload = <<"blocked">>,
+            emqx:subscribe(PublishTopic),
+            try
+                do(fun(Channel) ->
+                    PublishURI = pubsub_uri(binary_to_list(PublishTopic)),
+                    assert_coap_unauthorized(
+                        do_request(Channel, PublishURI, make_req(post, Payload))
+                    ),
+                    receive
+                        {deliver, PublishTopic, _Msg} ->
+                            ct:fail(connectionless_publish_was_published)
+                    after 500 ->
+                        ok
+                    end,
+
+                    SubscribeURI = pubsub_uri(binary_to_list(SubscribeTopic)),
+                    assert_coap_unauthorized(
+                        do_request(Channel, SubscribeURI, make_req(get, <<>>, [{observe, 0}]))
+                    ),
+                    timer:sleep(100),
+                    ?assertEqual([], emqx:subscribers(SubscribeTopic))
+                end)
+            after
+                emqx:unsubscribe(PublishTopic)
+            end
+        end)
+    end).
+
+t_connectionless_legacy_no_auth_config_allows_pub_sub(_) ->
+    with_security_profile("legacy", fun() ->
+        with_connectionless_coap(true, fun() ->
+            assert_connectionless_pub_sub_allowed(
+                <<"security/coap/legacy/publish">>,
+                <<"security/coap/legacy/subscribe">>
+            )
+        end)
+    end).
+
+t_connectionless_hardened_listener_authn_disabled_allows_pub_sub(_) ->
+    with_security_profile("hardened", fun() ->
+        with_connectionless_coap(false, fun() ->
+            assert_connectionless_pub_sub_allowed(
+                <<"security/coap/authn-disabled/publish">>,
+                <<"security/coap/authn-disabled/subscribe">>
+            )
+        end)
+    end).
+
+t_connectionless_hardened_authn_allows_pub_sub(_) ->
+    with_security_profile("hardened", fun() ->
+        ok = emqx_gateway_auth_ct:start_auth(authn_http),
+        try
+            with_connectionless_coap(true, fun() ->
+                Query = #{
+                    "clientid" => <<"connless-auth-ok">>,
+                    "username" => <<"admin">>,
+                    "password" => <<"public">>
+                },
+                assert_connectionless_pub_sub_allowed(
+                    <<"security/coap/authn/publish">>,
+                    <<"security/coap/authn/subscribe">>,
+                    Query
+                )
+            end)
+        after
+            ok = emqx_gateway_auth_ct:stop_auth(authn_http)
+        end
+    end).
+
+t_connectionless_hardened_bad_authn_rejects_pub_sub(_) ->
+    with_security_profile("hardened", fun() ->
+        ok = emqx_gateway_auth_ct:start_auth(authn_http),
+        try
+            with_connectionless_coap(true, fun() ->
+                Query = #{
+                    "clientid" => <<"connless-auth-bad">>,
+                    "username" => <<"deny">>,
+                    "password" => <<"public">>
+                },
+                assert_connectionless_pub_sub_rejected(
+                    <<"security/coap/authn-bad/publish">>,
+                    <<"security/coap/authn-bad/subscribe">>,
+                    Query
+                )
+            end)
+        after
+            ok = emqx_gateway_auth_ct:stop_auth(authn_http)
+        end
+    end).
+
+t_connectionless_hardened_authn_is_request_scoped(_) ->
+    with_security_profile("hardened", fun() ->
+        ok = emqx_gateway_auth_ct:start_auth(authn_http),
+        try
+            with_connectionless_coap(true, fun() ->
+                Query = #{
+                    "clientid" => <<"connless-auth-scoped">>,
+                    "username" => <<"admin">>,
+                    "password" => <<"public">>
+                },
+                assert_connectionless_auth_is_request_scoped(
+                    <<"security/coap/authn-scoped/allowed">>,
+                    <<"security/coap/authn-scoped/rejected-publish">>,
+                    <<"security/coap/authn-scoped/rejected-subscribe">>,
+                    Query
+                )
+            end)
+        after
+            ok = emqx_gateway_auth_ct:stop_auth(authn_http)
+        end
+    end).
 
 t_subscribe_opts_nl_rh(_) ->
     Fun = fun(Channel, Token) ->
@@ -1768,6 +1928,8 @@ observe_topic(Channel, Token, Topic, ObserveToken) ->
 pubsub_uri(Topic) when is_list(Topic) ->
     ?PS_PREFIX ++ "/" ++ Topic.
 
+pubsub_uri(Topic, Query) when is_list(Topic), is_map(Query) ->
+    compose_uri(pubsub_uri(Topic), Query, false);
 pubsub_uri(Topic, Token) ->
     pubsub_uri(Topic, Token, false).
 
@@ -1925,6 +2087,110 @@ return_message_response({error, Code}, Message) ->
 
 do(Fun) ->
     emqx_coap_test_helpers:with_udp_channel(Fun).
+
+assert_connectionless_pub_sub_allowed(PublishTopic, SubscribeTopic) ->
+    assert_connectionless_pub_sub_allowed(PublishTopic, SubscribeTopic, #{}).
+
+assert_connectionless_pub_sub_allowed(PublishTopic, SubscribeTopic, Query) ->
+    Payload = <<"allowed">>,
+    emqx:subscribe(PublishTopic),
+    try
+        do(fun(Channel) ->
+            PublishURI = pubsub_uri(binary_to_list(PublishTopic), Query),
+            {ok, changed, _} = do_request(Channel, PublishURI, make_req(post, Payload)),
+            receive
+                {deliver, PublishTopic, Msg} ->
+                    ?assertEqual(Payload, Msg#message.payload)
+            after 500 ->
+                ct:fail(connectionless_publish_not_delivered)
+            end,
+
+            SubscribeURI = pubsub_uri(binary_to_list(SubscribeTopic), Query),
+            {ok, content, _} = do_request(
+                Channel,
+                SubscribeURI,
+                make_req(get, <<>>, [{observe, 0}])
+            ),
+            timer:sleep(100),
+            [_SubPid] = emqx:subscribers(SubscribeTopic),
+            ok
+        end)
+    after
+        emqx:unsubscribe(PublishTopic)
+    end.
+
+assert_connectionless_pub_sub_rejected(PublishTopic, SubscribeTopic, Query) ->
+    Payload = <<"blocked">>,
+    emqx:subscribe(PublishTopic),
+    try
+        do(fun(Channel) ->
+            PublishURI = pubsub_uri(binary_to_list(PublishTopic), Query),
+            assert_coap_unauthorized(
+                do_request(Channel, PublishURI, make_req(post, Payload))
+            ),
+            receive
+                {deliver, PublishTopic, _Msg} ->
+                    ct:fail(connectionless_publish_was_published)
+            after 500 ->
+                ok
+            end,
+
+            SubscribeURI = pubsub_uri(binary_to_list(SubscribeTopic), Query),
+            assert_coap_unauthorized(
+                do_request(Channel, SubscribeURI, make_req(get, <<>>, [{observe, 0}]))
+            ),
+            timer:sleep(100),
+            ?assertEqual([], emqx:subscribers(SubscribeTopic))
+        end)
+    after
+        emqx:unsubscribe(PublishTopic)
+    end.
+
+assert_connectionless_auth_is_request_scoped(
+    AllowedTopic, RejectedPublishTopic, RejectedSubscribeTopic, Query
+) ->
+    AllowedPayload = <<"allowed">>,
+    BlockedPayload = <<"blocked">>,
+    emqx:subscribe(AllowedTopic),
+    emqx:subscribe(RejectedPublishTopic),
+    try
+        do(fun(Channel) ->
+            AllowedURI = pubsub_uri(binary_to_list(AllowedTopic), Query),
+            {ok, changed, _} = do_request(Channel, AllowedURI, make_req(post, AllowedPayload)),
+            receive
+                {deliver, AllowedTopic, Msg} ->
+                    ?assertEqual(AllowedPayload, Msg#message.payload)
+            after 500 ->
+                ct:fail(connectionless_publish_not_delivered)
+            end,
+
+            RejectedPublishURI = pubsub_uri(binary_to_list(RejectedPublishTopic)),
+            assert_coap_unauthorized(
+                do_request(Channel, RejectedPublishURI, make_req(post, BlockedPayload))
+            ),
+            receive
+                {deliver, RejectedPublishTopic, _Msg} ->
+                    ct:fail(connectionless_publish_was_published)
+            after 500 ->
+                ok
+            end,
+
+            RejectedSubscribeURI = pubsub_uri(binary_to_list(RejectedSubscribeTopic)),
+            assert_coap_unauthorized(
+                do_request(Channel, RejectedSubscribeURI, make_req(get, <<>>, [{observe, 0}]))
+            ),
+            timer:sleep(100),
+            ?assertEqual([], emqx:subscribers(RejectedSubscribeTopic))
+        end)
+    after
+        emqx:unsubscribe(AllowedTopic),
+        emqx:unsubscribe(RejectedPublishTopic)
+    end.
+
+assert_coap_unauthorized({error, unauthorized}) ->
+    ok;
+assert_coap_unauthorized({error, unauthorized, _}) ->
+    ok.
 
 send_raw(Packet, Timeout) ->
     emqx_coap_test_helpers:send_raw(Packet, Timeout).

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -792,6 +792,41 @@ t_publish(_) ->
     end,
     with_connection(Topics, Action).
 
+t_publish_mountpoint_from_authn_client_attrs(_) ->
+    update_coap_with_mountpoint(<<"mp/${client_attrs.group}/">>),
+    ok = meck:new(emqx_access_control, [passthrough, no_history]),
+    ok = meck:expect(
+        emqx_access_control,
+        authenticate,
+        fun
+            (#{username := <<"admin">>}) ->
+                {ok, #{client_attrs => #{<<"group">> => <<"g1">>}}};
+            (ClientInfo) ->
+                meck:passthrough([ClientInfo])
+        end
+    ),
+    MountedTopic = <<"mp/g1/abc">>,
+    Payload = <<"123">>,
+    try
+        emqx:subscribe(MountedTopic),
+        with_connection(fun(Channel, Token) ->
+            URI = pubsub_uri("abc", Token),
+            Req = make_req(post, Payload),
+            {ok, changed, _} = do_request(Channel, URI, Req),
+            receive
+                {deliver, MountedTopic, Msg} ->
+                    ?assertEqual(Payload, Msg#message.payload)
+            after 500 ->
+                ?assert(false)
+            end,
+            true
+        end)
+    after
+        update_coap_with_mountpoint(<<>>),
+        emqx:unsubscribe(MountedTopic),
+        meck:unload(emqx_access_control)
+    end.
+
 t_publish_with_retain_qos_expiry(_) ->
     Topics = [<<"abc">>],
     Action = fun(Topic, Channel, Token) ->

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -829,6 +829,62 @@ t_connectionless_hardened_authn_is_request_scoped(_) ->
         end
     end).
 
+t_connectionless_mountpoint_from_authn_client_attrs(_) ->
+    with_security_profile("hardened", fun() ->
+        update_coap_with_mountpoint(<<"mp/${client_attrs.group}/">>),
+        ok = meck:new(emqx_access_control, [passthrough, no_history]),
+        ok = meck:expect(
+            emqx_access_control,
+            authenticate,
+            fun
+                (#{username := <<"admin">>}) ->
+                    {ok, #{client_attrs => #{<<"group">> => <<"g1">>}}};
+                (ClientInfo) ->
+                    meck:passthrough([ClientInfo])
+            end
+        ),
+        Query = #{
+            "clientid" => <<"connless-auth-mountpoint">>,
+            "username" => <<"admin">>,
+            "password" => <<"public">>
+        },
+        PublishTopic = <<"security/coap/authn-mountpoint/publish">>,
+        MountedPublishTopic = <<"mp/g1/security/coap/authn-mountpoint/publish">>,
+        SubscribeTopic = <<"security/coap/authn-mountpoint/subscribe">>,
+        MountedSubscribeTopic = <<"mp/g1/security/coap/authn-mountpoint/subscribe">>,
+        Payload = <<"mounted">>,
+        emqx:subscribe(MountedPublishTopic),
+        try
+            with_connectionless_coap(true, fun() ->
+                do(fun(Channel) ->
+                    PublishURI = pubsub_uri(binary_to_list(PublishTopic), Query),
+                    {ok, changed, _} = do_request(Channel, PublishURI, make_req(post, Payload)),
+                    receive
+                        {deliver, MountedPublishTopic, Msg} ->
+                            ?assertEqual(Payload, Msg#message.payload)
+                    after 500 ->
+                        ct:fail(connectionless_mounted_publish_not_delivered)
+                    end,
+
+                    SubscribeURI = pubsub_uri(binary_to_list(SubscribeTopic), Query),
+                    {ok, content, _} = do_request(
+                        Channel,
+                        SubscribeURI,
+                        make_req(get, <<>>, [{observe, 0}])
+                    ),
+                    timer:sleep(100),
+                    ?assertEqual([], emqx:subscribers(SubscribeTopic)),
+                    [_SubPid] = emqx:subscribers(MountedSubscribeTopic),
+                    ok
+                end)
+            end)
+        after
+            emqx:unsubscribe(MountedPublishTopic),
+            update_coap_with_mountpoint(<<>>),
+            meck:unload(emqx_access_control)
+        end
+    end).
+
 t_subscribe_opts_nl_rh(_) ->
     Fun = fun(Channel, Token) ->
         Topic = <<"nlrh">>,

--- a/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
+++ b/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
@@ -544,7 +544,9 @@ enrich_clientinfo(
     {ok, NPacket, NClientInfo} = emqx_utils:pipeline(
         [
             fun maybe_assign_clientid/2,
-            %% FIXME: CALL After authentication successfully
+            %% Mountpoint is evaluated again after successful authentication in
+            %% emqx_gateway_ctx:authenticate/2, because authentication results
+            %% may add client attributes used by mountpoint templates.
             fun fix_mountpoint/2
         ],
         Packet,

--- a/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
+++ b/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
@@ -68,6 +68,13 @@ update_gbt32960_with_idle_timeout(IdleTimeout) ->
         Conf#{<<"idle_timeout">> => IdleTimeout}
     ).
 
+update_gbt32960_with_mountpoint(Mountpoint) ->
+    Conf = emqx:get_raw_config([gateway, gbt32960]),
+    emqx_gateway_conf:update_gateway(
+        gbt32960,
+        Conf#{<<"mountpoint">> => Mountpoint}
+    ).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% helper functions %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 encode(Cmd, Vin, Data) ->
@@ -193,6 +200,43 @@ t_case01_login_channel_info(_Config) ->
     ),
 
     ok = gen_tcp:close(Socket).
+
+t_case01_login_mountpoint_from_authn_client_attrs(_Config) ->
+    Vin = <<"1G1BL52P7TR115520">>,
+    Mountpoint = <<"gbt32960/${client_attrs.group}/${clientid}/">>,
+    MountedVLoginTopic = <<"gbt32960/g1/1G1BL52P7TR115520/upstream/vlogin">>,
+    MountedDnstreamTopic = <<"gbt32960/g1/1G1BL52P7TR115520/dnstream">>,
+    update_gbt32960_with_mountpoint(Mountpoint),
+    ok = meck:new(emqx_access_control, [passthrough, no_history]),
+    ok = meck:expect(
+        emqx_access_control,
+        authenticate,
+        fun
+            (#{clientid := Vin0}) when Vin0 =:= Vin ->
+                {ok, #{client_attrs => #{<<"group">> => <<"g1">>}}};
+            (ClientInfo) ->
+                meck:passthrough([ClientInfo])
+        end
+    ),
+    ok = emqx:subscribe(MountedVLoginTopic),
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+    try
+        Time = <<12, 12, 29, 12, 19, 20>>,
+        Data = <<Time/binary, 1:?WORD, "12345678901234567890", 1, 1, "C">>,
+        Packet = encode(?CMD_VIHECLE_LOGIN, Vin, Data),
+
+        ok = gen_tcp:send(Socket, Packet),
+        timer:sleep(200),
+        {ok, _AckPacket} = gen_tcp:recv(Socket, 0, 500),
+
+        ?assertEqual(true, lists:member(MountedDnstreamTopic, get_subscriptions())),
+        {MountedVLoginTopic, _PubedMsg} = get_published_msg()
+    after
+        gen_tcp:close(Socket),
+        update_gbt32960_with_mountpoint(<<"gbt32960/${clientid}/">>),
+        emqx:unsubscribe(MountedVLoginTopic),
+        meck:unload(emqx_access_control)
+    end.
 
 t_case01_auth_expire(_Config) ->
     ok = meck:new(emqx_access_control, [passthrough, no_history]),

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -192,6 +192,13 @@ update_jt808_with_idle_timeout(IdleTimeout) ->
         Conf#{<<"idle_timeout">> => IdleTimeout}
     ).
 
+update_jt808_with_mountpoint(Mountpoint) ->
+    Conf = emqx:get_raw_config([gateway, jt808]),
+    emqx_gateway_conf:update_gateway(
+        jt808,
+        Conf#{<<"mountpoint">> => Mountpoint}
+    ).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% helper functions %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 gen_packet(Header, Body) ->
@@ -564,6 +571,44 @@ t_case04(_) ->
     ),
 
     ok = gen_tcp:close(Socket).
+
+t_case04_mountpoint_from_register_clientinfo(_) ->
+    ClientId = <<"000123456789">>,
+    Mountpoint = <<"jt808/custom/000123456789/">>,
+    update_jt808_with_mountpoint(<<"jt808/custom/${clientid}/">>),
+    ok = emqx:subscribe(?JT808_UP_TOPIC),
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+    try
+        {ok, AuthCode} = client_regi_procedure(Socket),
+        ok = client_auth_procedure(Socket, AuthCode),
+        ?assertMatch(
+            #{clientinfo := #{mountpoint := Mountpoint}},
+            emqx_gateway_cm:get_chan_info(jt808, ClientId)
+        ),
+
+        PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
+        EventReportId = 98,
+        MsgBody3 = <<EventReportId>>,
+        MsgId3 = ?MC_EVENT_REPORT,
+        MsgSn3 = 79,
+        Size3 = size(MsgBody3),
+        Header3 =
+            <<MsgId3:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size3),
+                PhoneBCD/binary, MsgSn3:?WORD>>,
+        S3 = gen_packet(Header3, MsgBody3),
+
+        ok = gen_tcp:send(Socket, S3),
+        {ok, _Packet4} = gen_tcp:recv(Socket, 0, 500),
+        timer:sleep(100),
+        {?JT808_UP_TOPIC, Payload} = receive_msg(),
+        ?assertEqual(
+            EventReportId,
+            emqx_utils_maps:deep_get([<<"body">>, <<"id">>], emqx_utils_json:decode(Payload))
+        )
+    after
+        update_jt808_with_mountpoint(<<"jt808/${clientid}/">>),
+        gen_tcp:close(Socket)
+    end.
 
 t_case05(_Config) ->
     {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),

--- a/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
+++ b/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
@@ -146,7 +146,8 @@ groups() ->
         {test_grp_10_rest_api, [RepeatOpt], [
             case100_clients_api,
             case100_subscription_api,
-            case102_mountpoint_peerhost_api
+            case102_mountpoint_peerhost_api,
+            case103_mountpoint_from_authn_client_attrs
         ]},
         {test_grp_11_internal, [RepeatOpt], [
             case110_xml_object_helpers,
@@ -227,6 +228,10 @@ init_per_testcase(TestCase, Config) ->
             case102_mountpoint_peerhost_api ->
                 default_config_with_mountpoint_raw(
                     "\"lwm2m/${peerhost}/${endpoint_name}/\""
+                );
+            case103_mountpoint_from_authn_client_attrs ->
+                default_config_with_mountpoint_raw(
+                    "\"lwm2m/${client_attrs.group}/${endpoint_name}/\""
                 );
             _ ->
                 default_config()
@@ -4893,6 +4898,35 @@ case102_mountpoint_peerhost_api(Config) ->
     ExpectedTopic =
         <<"lwm2m/127.0.0.1/", (list_to_binary(Epn))/binary, "/dn/#">>,
     ?assertEqual(ExpectedTopic, maps:get(topic, InitSub)).
+
+case103_mountpoint_from_authn_client_attrs(Config) ->
+    ok = meck:new(emqx_access_control, [passthrough, no_history]),
+    ok = meck:expect(
+        emqx_access_control,
+        authenticate,
+        fun
+            (#{username := Username}) when Username =:= <<"urn:oma:lwm2m:oma:103">> ->
+                {ok, #{client_attrs => #{<<"group">> => <<"g1">>}}};
+            (ClientInfo) ->
+                meck:passthrough([ClientInfo])
+        end
+    ),
+    try
+        Epn = "urn:oma:lwm2m:oma:103",
+        MsgId1 = 26,
+        UdpSock = ?config(sock, Config),
+        ObjectList = <<"</1>, </2>, </3/0>, </4>, </5>">>,
+        RespTopic = list_to_binary("lwm2m/g1/" ++ Epn ++ "/up/resp"),
+        emqtt:subscribe(?config(emqx_c, Config), RespTopic, qos0),
+        timer:sleep(200),
+        std_register(UdpSock, Epn, ObjectList, MsgId1, RespTopic),
+
+        SubTopic = list_to_binary("lwm2m/g1/" ++ Epn ++ "/dn/#"),
+        ?assertEqual(true, lists:member(SubTopic, test_mqtt_broker:get_subscrbied_topics()))
+    after
+        meck:unload(emqx_access_control)
+    end.
+
 case110_xml_object_helpers(_Config) ->
     ObjDefinition = emqx_lwm2m_xml_object:get_obj_def(3, true),
     ?assert(is_tuple(ObjDefinition)),

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -264,7 +264,9 @@ enrich_clientinfo(
     {ok, NPacket, NClientInfo} = emqx_utils:pipeline(
         [
             fun maybe_assign_clientid/2,
-            %% FIXME: CALL After authentication successfully
+            %% Mountpoint is evaluated again after successful authentication in
+            %% emqx_gateway_ctx:authenticate/2, because authentication results
+            %% may add client attributes used by mountpoint templates.
             fun fix_mountpoint/2
         ],
         Packet,
@@ -453,7 +455,7 @@ handle_in(
 handle_in(
     Publish =
         ?SN_PUBLISH_MSG(
-            #mqtt_sn_flags{
+            Flags = #mqtt_sn_flags{
                 qos = ?QOS_NEG1,
                 topic_id_type = TopicIdType
             },
@@ -477,19 +479,7 @@ handle_in(
                 end,
             case TopicName =/= undefined of
                 true ->
-                    Msg = emqx_message:make(
-                        ?NEG_QOS_CLIENT_ID,
-                        ?QOS_0,
-                        TopicName,
-                        Data
-                    ),
-                    ?SLOG(debug, #{
-                        msg => "receive_qo3_message_in_idle_mode",
-                        topic => TopicName,
-                        data => Data
-                    }),
-                    _ = emqx_broker:publish(Msg),
-                    ok;
+                    maybe_publish_idle_negative_qos(Publish, {TopicName, Flags, Data}, Channel);
                 false ->
                     ok
             end,
@@ -1127,10 +1117,53 @@ check_pub_authz(
     {TopicName, #mqtt_sn_flags{qos = QoS, retain = Retain}, _Data},
     #channel{ctx = Ctx, clientinfo = ClientInfo}
 ) ->
-    Action = ?AUTHZ_PUBLISH(QoS, Retain),
+    Action = ?AUTHZ_PUBLISH(get_corrected_qos(QoS), Retain),
     case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, TopicName) of
         allow -> ok;
         deny -> {error, ?SN_RC2_NOT_AUTHORIZE}
+    end.
+
+maybe_publish_idle_negative_qos(Packet, Publish = {TopicName, _Flags, Data}, Channel) ->
+    case authenticate_idle_negative_qos(Packet, Channel) of
+        {ok, NChannel} ->
+            case check_pub_authz(Publish, NChannel) of
+                ok ->
+                    Msg = emqx_message:make(
+                        ?NEG_QOS_CLIENT_ID,
+                        ?QOS_0,
+                        TopicName,
+                        Data
+                    ),
+                    ?SLOG(debug, #{
+                        msg => "receive_qo3_message_in_idle_mode",
+                        topic => TopicName,
+                        data => Data
+                    }),
+                    _ = emqx_broker:publish(Msg),
+                    ok;
+                {error, RC} ->
+                    ?tp(info, idle_negative_qos_publish_rejected, #{
+                        topic => TopicName,
+                        return_code => RC
+                    }),
+                    ok
+            end;
+        {error, RC} ->
+            ?tp(info, idle_negative_qos_publish_rejected, #{
+                topic => TopicName,
+                return_code => RC
+            }),
+            ok
+    end.
+
+authenticate_idle_negative_qos(Packet, Channel = #channel{conninfo = ConnInfo}) ->
+    NConnInfo = ConnInfo#{clientid => ?NEG_QOS_CLIENT_ID},
+    {ok, _Packet, NChannel} = enrich_clientinfo(Packet, Channel#channel{conninfo = NConnInfo}),
+    case auth_connect(Packet, NChannel) of
+        {ok, AuthenticatedChannel} ->
+            {ok, AuthenticatedChannel};
+        {error, RC} ->
+            {error, RC}
     end.
 
 convert_pub_to_msg(
@@ -2300,4 +2333,13 @@ returncode_name(?SN_RC2_EXCEED_LIMITATION) -> rejected_exceed_limitation;
 returncode_name(?SN_RC2_REACHED_MAX_RETRY) -> reached_max_retry_times;
 returncode_name(_) -> accepted.
 
-name_to_returncode(not_authorized) -> ?SN_RC2_NOT_AUTHORIZE.
+name_to_returncode(Reason) ->
+    maps:get(
+        Reason,
+        #{
+            not_authorized => ?SN_RC2_NOT_AUTHORIZE,
+            not_authenticated => ?SN_RC2_NOT_AUTHORIZE,
+            bad_username_or_password => ?SN_RC2_NOT_AUTHORIZE
+        },
+        ?SN_RC2_NOT_AUTHORIZE
+    ).

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -30,6 +30,7 @@
 -define(PORT, 1884).
 
 -define(LOG(Format, Args), ct:log("TEST: " ++ Format, Args)).
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 -define(MAX_PRED_TOPIC_ID, ?SN_MAX_PREDEF_TOPIC_ID).
 -define(PREDEF_TOPIC_ID1, 1).
@@ -763,6 +764,97 @@ t_publish_negqos_disabled(_) ->
     update_mqttsn_with_neg_qos_on(),
     gen_udp:close(Socket).
 
+t_publish_negqos_idle_requires_authn_in_hardened_profile(_) ->
+    Topic = <<"ab">>,
+    Payload = <<"idle-negqos-authn">>,
+    ok = emqx:subscribe(Topic),
+    os:putenv(?PROFILE_ENV_VAR, "hardened"),
+    emqx_security_profile:clear_profile(),
+    try
+        {ok, Socket} = gen_udp:open(0, [binary]),
+        ?check_trace(
+            begin
+                send_publish_msg_short_topic(Socket, 3, 1, Topic, Payload),
+                ?assertNotReceive({deliver, Topic, #message{payload = Payload}}, 500)
+            end,
+            fun(Trace0) ->
+                Trace = ?of_kind(idle_negative_qos_publish_rejected, Trace0),
+                ?assertMatch([#{return_code := ?SN_RC2_NOT_AUTHORIZE}], Trace)
+            end
+        ),
+        gen_udp:close(Socket)
+    after
+        os:unsetenv(?PROFILE_ENV_VAR),
+        emqx_security_profile:clear_profile(),
+        emqx:unsubscribe(Topic)
+    end.
+
+t_publish_negqos_idle_allows_authn_in_hardened_profile(_) ->
+    Topic = <<"ab">>,
+    Payload = <<"idle-negqos-authn-allowed">>,
+    OldAuthz = emqx:get_raw_config([authorization]),
+    ok = emqx:subscribe(Topic),
+    ok = emqx_gateway_test_utils:update_authz_file_rule(
+        <<
+            "{allow, {username, \"user1\"}, {publish, [{qos, 0}, {retain, false}]}, [\"ab\"]}.\n"
+            "{deny, all}."
+        >>
+    ),
+    ok = emqx_gateway_test_utils:enable_gateway_auth(<<"mqttsn">>),
+    ok = emqx_gateway_test_utils:add_gateway_auth_user(<<"mqttsn">>, #{
+        user_id => <<"user1">>,
+        password => <<"pw123">>,
+        is_superuser => false
+    }),
+    os:putenv(?PROFILE_ENV_VAR, "hardened"),
+    emqx_security_profile:clear_profile(),
+    try
+        {ok, Socket} = gen_udp:open(0, [binary]),
+        send_publish_msg_short_topic(Socket, 3, 1, Topic, Payload),
+        ?assertReceive({deliver, Topic, #message{payload = Payload}}, 1000),
+        gen_udp:close(Socket)
+    after
+        os:unsetenv(?PROFILE_ENV_VAR),
+        emqx_security_profile:clear_profile(),
+        emqx_gateway_test_utils:delete_gateway_auth_user(<<"mqttsn">>, <<"user1">>),
+        emqx_gateway_test_utils:disable_gateway_auth(<<"mqttsn">>),
+        {ok, _} = emqx:update_config([authorization], OldAuthz),
+        emqx:unsubscribe(Topic)
+    end.
+
+t_publish_negqos_idle_rejects_bad_authn_in_hardened_profile(_) ->
+    Topic = <<"ab">>,
+    Payload = <<"idle-negqos-authn-bad">>,
+    ok = emqx:subscribe(Topic),
+    ok = emqx_gateway_test_utils:enable_gateway_auth(<<"mqttsn">>),
+    ok = emqx_gateway_test_utils:add_gateway_auth_user(<<"mqttsn">>, #{
+        user_id => <<"user1">>,
+        password => <<"bad-password">>,
+        is_superuser => false
+    }),
+    os:putenv(?PROFILE_ENV_VAR, "hardened"),
+    emqx_security_profile:clear_profile(),
+    try
+        {ok, Socket} = gen_udp:open(0, [binary]),
+        ?check_trace(
+            begin
+                send_publish_msg_short_topic(Socket, 3, 1, Topic, Payload),
+                ?assertNotReceive({deliver, Topic, #message{payload = Payload}}, 500)
+            end,
+            fun(Trace0) ->
+                Trace = ?of_kind(idle_negative_qos_publish_rejected, Trace0),
+                ?assertMatch([#{return_code := ?SN_RC2_NOT_AUTHORIZE}], Trace)
+            end
+        ),
+        gen_udp:close(Socket)
+    after
+        os:unsetenv(?PROFILE_ENV_VAR),
+        emqx_security_profile:clear_profile(),
+        emqx_gateway_test_utils:delete_gateway_auth_user(<<"mqttsn">>, <<"user1">>),
+        emqx_gateway_test_utils:disable_gateway_auth(<<"mqttsn">>),
+        emqx:unsubscribe(Topic)
+    end.
+
 t_publish_qos0_case01(_) ->
     Dup = 0,
     QoS = 0,
@@ -1287,6 +1379,57 @@ t_publish_mountpoint(_) ->
     send_disconnect_msg(Socket, undefined),
     update_mqttsn_with_mountpoint(<<>>),
     gen_udp:close(Socket).
+
+t_publish_mountpoint_from_authn_client_attrs(_) ->
+    update_mqttsn_with_mountpoint(<<"mp/${client_attrs.group}/">>),
+    ok = meck:new(emqx_access_control, [passthrough, no_history]),
+    ok = meck:expect(
+        emqx_access_control,
+        authenticate,
+        fun
+            (#{username := <<"user1">>}) ->
+                {ok, #{client_attrs => #{<<"group">> => <<"g1">>}}};
+            (ClientInfo) ->
+                meck:passthrough([ClientInfo])
+        end
+    ),
+    Topic = <<"abc">>,
+    MountedTopic = <<"mp/g1/abc">>,
+    Payload = <<20, 21, 22, 23>>,
+    ok = emqx:subscribe(MountedTopic),
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    try
+        Dup = 0,
+        QoS = 1,
+        Retain = 0,
+        Will = 0,
+        CleanSession = 0,
+        MsgId = 1,
+        TopicId1 = ?MAX_PRED_TOPIC_ID + 1,
+        ClientId = ?CLIENTID,
+        send_connect_msg(Socket, ClientId),
+        ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+        send_subscribe_msg_normal_topic(Socket, QoS, Topic, MsgId),
+        ?assertEqual(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, Will:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                TopicId1:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            receive_response(Socket)
+        ),
+
+        send_publish_msg_normal_topic(Socket, QoS, MsgId, TopicId1, Payload),
+        ?assertEqual(
+            <<7, ?SN_PUBACK, TopicId1:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            receive_response(Socket)
+        ),
+        ?assertReceive({deliver, MountedTopic, #message{payload = Payload}}, 1000),
+
+        send_disconnect_msg(Socket, undefined)
+    after
+        update_mqttsn_with_mountpoint(<<>>),
+        emqx:unsubscribe(MountedTopic),
+        meck:unload(emqx_access_control),
+        gen_udp:close(Socket)
+    end.
 
 t_delivery_qos1_register_invalid_topic_id(_) ->
     Dup = 0,

--- a/apps/emqx_gateway_nats/mix.exs
+++ b/apps/emqx_gateway_nats/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayNats.MixProject do
   def project do
     [
       app: :emqx_gateway_nats,
-      version: "6.2.0",
+      version: "6.2.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_nats/src/emqx_nats_authn.erl
+++ b/apps/emqx_gateway_nats/src/emqx_nats_authn.erl
@@ -49,7 +49,8 @@ is_auth_required(#{enable_authn := false}, _Authn) ->
     false;
 is_auth_required(#{enable_authn := true}, Authn) ->
     has_enabled_internal_method(Authn) orelse
-        gateway_auth_enabled(Authn).
+        gateway_auth_enabled(Authn) orelse
+        authn_not_configured_requires_authn().
 
 -spec ensure_nkey_nonce(map(), authn_ctx()) -> map().
 ensure_nkey_nonce(ConnInfo, Authn) ->
@@ -643,6 +644,9 @@ nonce_auth_enabled(Authn) ->
 
 gateway_auth_enabled(Authn) ->
     maps:get(gateway_auth_enabled, Authn, false) =:= true.
+
+authn_not_configured_requires_authn() ->
+    emqx_security_profile:policy(authn_not_configured) =:= deny.
 
 has_enabled_internal_method(Authn) ->
     lists:any(fun method_enabled/1, maps:get(methods, Authn, [])).

--- a/apps/emqx_gateway_nats/src/emqx_nats_channel.erl
+++ b/apps/emqx_gateway_nats/src/emqx_nats_channel.erl
@@ -117,7 +117,7 @@ init(
             undefined -> undefined;
             {GwName, Type, LisName} -> emqx_gateway_utils:listener_id(GwName, Type, LisName)
         end,
-    EnableAuthn = maps:get(enable_authn, Option, true),
+    EnableAuthn = listener_enable_authn(ListenerId, maps:get(enable_authn, Option, true)),
     ClientInfo = setting_peercert_infos(
         Peercert,
         #{
@@ -241,6 +241,12 @@ tls_required_and_verify(ListenerId) ->
         _ ->
             #{tls_required => false}
     end.
+
+listener_enable_authn(undefined, Default) ->
+    Default;
+listener_enable_authn(ListenerId, Default) ->
+    {_, Type, Name} = emqx_gateway_utils:parse_listener_id(ListenerId),
+    emqx_conf:get([gateway, nats, listeners, Type, Name, enable_authn], Default).
 
 setting_peercert_infos(NoSSL, ClientInfo) when
     NoSSL =:= nossl;
@@ -444,14 +450,29 @@ auth_connect(
                                 Username
                             );
                         false ->
-                            NClientInfo0 = maps:put(auth_expire_at, undefined, NClientInfo),
-                            NClientInfo1 = normalize_mountpoint(ConnParams, NClientInfo0),
-                            {ok, set_clientinfo(Channel, NClientInfo1)}
+                            auth_connect_without_configured_authn(
+                                ConnParams,
+                                NClientInfo,
+                                Channel,
+                                ClientId,
+                                Username
+                            )
                     end;
                 {error, {Method, Reason}} ->
                     log_auth_failed(auth_failed_msg(Method), ClientId, Username, Reason),
                     {error, Reason}
             end
+    end.
+
+auth_connect_without_configured_authn(ConnParams, ClientInfo, Channel, ClientId, Username) ->
+    case emqx_security_profile:policy(authn_not_configured) of
+        allow ->
+            NClientInfo0 = maps:put(auth_expire_at, undefined, ClientInfo),
+            NClientInfo1 = normalize_mountpoint(ConnParams, NClientInfo0),
+            {ok, set_clientinfo(Channel, NClientInfo1)};
+        deny ->
+            log_auth_failed("client_login_failed", ClientId, Username, not_authorized),
+            {error, not_authorized}
     end.
 
 auth_connect_with_gateway(Ctx, ConnParams, ClientInfo, Channel, ClientId, Username) ->

--- a/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
@@ -12,6 +12,7 @@
 -define(NKEY_ACCOUNT_PREFIX, 16#00).
 -define(NKEY_OPERATOR_PREFIX, 16#70).
 -define(NKEY_USER_PREFIX, 16#A0).
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -23,7 +24,13 @@ all() ->
 t_build_authn_ctx_and_auth_required(_Config) ->
     Disabled = mk_authn_ctx(undefined, [], undefined, false),
     ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => false}, Disabled)),
-    ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => true}, Disabled)),
+    with_security_profile("legacy", fun() ->
+        ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => true}, Disabled))
+    end),
+    with_security_profile("hardened", fun() ->
+        ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => false}, Disabled)),
+        ?assertEqual(true, emqx_nats_authn:is_auth_required(#{enable_authn => true}, Disabled))
+    end),
 
     GatewayOnly = mk_authn_ctx(undefined, [], undefined, true),
     ?assertEqual(true, emqx_nats_authn:is_auth_required(#{enable_authn => true}, GatewayOnly)),
@@ -34,7 +41,12 @@ t_build_authn_ctx_and_auth_required(_Config) ->
         #{enable => false, trusted_operators => [<<"OP_TEST">>]},
         false
     ),
-    ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => true}, JWTDisabled)),
+    with_security_profile("legacy", fun() ->
+        ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => true}, JWTDisabled))
+    end),
+    with_security_profile("hardened", fun() ->
+        ?assertEqual(true, emqx_nats_authn:is_auth_required(#{enable_authn => true}, JWTDisabled))
+    end),
 
     Enabled = mk_authn_ctx(
         "token",
@@ -881,3 +893,13 @@ mutate_jwt_signature(JWT) ->
 
 replace_first_char(<<_Old, Rest/binary>>, New) ->
     <<New, Rest/binary>>.
+
+with_security_profile(Profile, Fun) ->
+    os:putenv(?PROFILE_ENV_VAR, Profile),
+    emqx_security_profile:clear_profile(),
+    try
+        Fun()
+    after
+        os:unsetenv(?PROFILE_ENV_VAR),
+        emqx_security_profile:clear_profile()
+    end.

--- a/apps/emqx_gateway_nats/test/emqx_nats_channel_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_nats_channel_SUITE.erl
@@ -483,22 +483,35 @@ update_nats_with_clientinfo_override(ClientInfoOverride) ->
 
 restore_nats_conf(Conf) ->
     _ = emqx_gateway_conf:update_gateway(nats, Conf),
+    restore_nats_listeners(Conf),
     ok.
 
 update_nats_tcp_listener_authn_and_mountpoint(EnableAuthn, Mountpoint) ->
-    Conf = emqx:get_config([gateway, nats]),
-    Conf1 = emqx_utils_maps:deep_put([mountpoint], Conf, Mountpoint),
-    Conf2 = emqx_utils_maps:deep_put(
-        [listeners, tcp, default, enable_authn],
-        Conf1,
-        EnableAuthn
-    ),
+    Conf = emqx:get_raw_config([gateway, nats]),
+    _ = emqx_gateway_conf:update_gateway(nats, Conf#{<<"mountpoint">> => Mountpoint}),
+    ListenerConf0 = emqx_conf:get([gateway, nats, listeners, tcp, default]),
+    ListenerConf1 = ListenerConf0#{enable_authn => EnableAuthn},
     ok =
-        case emqx_gateway:update(nats, Conf2) of
+        case emqx_gateway_conf:update_listener(nats, {tcp, default}, ListenerConf1) of
             ok -> ok;
             {ok, _} -> ok
         end,
     ok.
+
+restore_nats_listeners(Conf) ->
+    Listeners = maps:get(<<"listeners">>, Conf, maps:get(listeners, Conf, #{})),
+    maps:foreach(
+        fun(Type, TypeListeners) ->
+            maps:foreach(
+                fun(Name, ListenerConf) ->
+                    _ = emqx_gateway_conf:update_listener(nats, {Type, Name}, ListenerConf),
+                    ok
+                end,
+                TypeListeners
+            )
+        end,
+        Listeners
+    ).
 
 update_nats_with_internal_authn_and_mountpoint(InternalAuthn, Mountpoint) ->
     Conf = emqx:get_raw_config([gateway, nats]),

--- a/apps/emqx_gateway_nats/test/emqx_nats_protocol_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_nats_protocol_SUITE.erl
@@ -13,6 +13,7 @@
 
 -define(NKEY_ACCOUNT_PREFIX, 16#00).
 -define(NKEY_OPERATOR_PREFIX, 16#70).
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 %%--------------------------------------------------------------------
 %% CT Callbacks
@@ -533,7 +534,8 @@ target_caps(emqx, _Group) ->
     [
         jwt_auth,
         jwt_acl_intersection,
-        mixed_auth_priority
+        mixed_auth_priority,
+        security_profile
     ];
 target_caps(nats, Group) ->
     case nats_jwt_fixture_available(Group) of
@@ -576,6 +578,12 @@ required_caps(t_nkey_auth_priority_over_jwt) ->
     [jwt_auth];
 required_caps(t_nkey_auth_fallback_to_jwt) ->
     [jwt_auth];
+required_caps(t_hardened_no_auth_config_rejects_anonymous_pub_sub_connect) ->
+    [security_profile];
+required_caps(t_legacy_no_auth_config_allows_anonymous_pub_sub_connect) ->
+    [security_profile];
+required_caps(t_hardened_listener_authn_disabled_allows_anonymous_pub_sub_connect) ->
+    [security_profile];
 required_caps(_TestCase) ->
     [].
 
@@ -849,6 +857,52 @@ auth_cleanup(Config) ->
             ok
     end,
     Config.
+
+with_nats_no_auth_config(Config, EnableAuthn, Fun) ->
+    PrevConf = emqx:get_config([gateway, nats]),
+    try
+        _ = emqx_conf:update(
+            [gateway, nats, internal_authn],
+            [],
+            #{override_to => cluster}
+        ),
+        _ = disable_auth(),
+        ok = update_listener_authn(Config, EnableAuthn),
+        Fun()
+    after
+        ok = update_nats_gateway(PrevConf)
+    end.
+
+update_listener_authn(Config, EnableAuthn) ->
+    Group = group_from(Config),
+    ListenerConf0 = emqx_conf:get([gateway, nats, listeners, Group, default]),
+    ListenerConf1 = ListenerConf0#{enable_authn => EnableAuthn},
+    ok =
+        case emqx_gateway_conf:update_listener(nats, {Group, default}, ListenerConf1) of
+            ok -> ok;
+            {ok, _} -> ok
+        end,
+    ?assertEqual(
+        EnableAuthn,
+        emqx_conf:get([gateway, nats, listeners, Group, default, enable_authn], undefined)
+    ),
+    ok.
+
+update_nats_gateway(Conf) ->
+    case emqx_gateway:update(nats, Conf) of
+        ok -> ok;
+        {ok, _} -> ok
+    end.
+
+with_security_profile(Profile, Fun) ->
+    os:putenv(?PROFILE_ENV_VAR, Profile),
+    emqx_security_profile:clear_profile(),
+    try
+        Fun()
+    after
+        os:unsetenv(?PROFILE_ENV_VAR),
+        emqx_security_profile:clear_profile()
+    end.
 
 token_auth_setup(Config, Type, Token) ->
     case target_from(Config) of
@@ -1790,6 +1844,37 @@ t_auth_dynamic_enable_disable(Config) ->
     recv_ok_frame(Client3),
     emqx_nats_client:stop(Client3).
 
+t_hardened_no_auth_config_rejects_anonymous_pub_sub_connect(Config) ->
+    with_security_profile("hardened", fun() ->
+        with_nats_no_auth_config(Config, true, fun() ->
+            ClientOpts = maps:merge(?config(auth_disabled_opts, Config), #{verbose => true}),
+            assert_info_auth_required(ClientOpts, true),
+            assert_pre_connect_publish_rejected(ClientOpts),
+            assert_pre_connect_subscribe_rejected(ClientOpts),
+            assert_connect_rejected(ClientOpts)
+        end)
+    end).
+
+t_legacy_no_auth_config_allows_anonymous_pub_sub_connect(Config) ->
+    with_security_profile("legacy", fun() ->
+        with_nats_no_auth_config(Config, true, fun() ->
+            ClientOpts = maps:merge(?config(auth_disabled_opts, Config), #{verbose => true}),
+            assert_info_auth_required(ClientOpts, false),
+            assert_pre_connect_pub_sub_allowed(ClientOpts),
+            assert_connect_allowed(ClientOpts)
+        end)
+    end).
+
+t_hardened_listener_authn_disabled_allows_anonymous_pub_sub_connect(Config) ->
+    with_security_profile("hardened", fun() ->
+        with_nats_no_auth_config(Config, false, fun() ->
+            ClientOpts = maps:merge(?config(auth_disabled_opts, Config), #{verbose => true}),
+            assert_info_auth_required(ClientOpts, false),
+            assert_pre_connect_pub_sub_allowed(ClientOpts),
+            assert_connect_allowed(ClientOpts)
+        end)
+    end).
+
 t_token_auth_plain_success(init, Config) ->
     token_auth_setup(Config, plain, token_plain());
 t_token_auth_plain_success('end', Config) ->
@@ -2400,6 +2485,54 @@ assert_info_message(#nats_frame{operation = ?OP_INFO, message = Message}) ->
 assert_auth_required(#nats_frame{operation = ?OP_INFO, message = Message}, Expected) ->
     ?assert(is_map(Message)),
     ?assertEqual(Expected, maps:get(<<"auth_required">>, Message, false)).
+
+assert_info_auth_required(ClientOpts, Expected) ->
+    {ok, Client} = emqx_nats_client:start_link(ClientOpts),
+    InfoMsg = recv_info_frame(Client),
+    assert_auth_required(InfoMsg, Expected),
+    emqx_nats_client:stop(Client).
+
+assert_pre_connect_publish_rejected(ClientOpts) ->
+    {ok, Client} = emqx_nats_client:start_link(ClientOpts),
+    recv_info_frame(Client),
+    ok = emqx_nats_client:publish(Client, <<"test.topic">>, <<"test message">>),
+    {ok, [ErrorMsg]} = emqx_nats_client:receive_message(Client),
+    ?assertMatch(#nats_frame{operation = ?OP_ERR}, ErrorMsg),
+    emqx_nats_client:stop(Client).
+
+assert_pre_connect_subscribe_rejected(ClientOpts) ->
+    {ok, Client} = emqx_nats_client:start_link(ClientOpts),
+    recv_info_frame(Client),
+    ok = emqx_nats_client:subscribe(Client, <<"test.topic">>, <<"sid-1">>),
+    {ok, [ErrorMsg]} = emqx_nats_client:receive_message(Client),
+    ?assertMatch(#nats_frame{operation = ?OP_ERR}, ErrorMsg),
+    emqx_nats_client:stop(Client).
+
+assert_connect_rejected(ClientOpts) ->
+    {ok, Client} = emqx_nats_client:start_link(ClientOpts),
+    recv_info_frame(Client),
+    ok = emqx_nats_client:connect(Client),
+    {ok, Msgs} = emqx_nats_client:receive_message(Client),
+    assert_auth_failed(Msgs),
+    emqx_nats_client:stop(Client).
+
+assert_pre_connect_pub_sub_allowed(ClientOpts) ->
+    {ok, Client} = emqx_nats_client:start_link(ClientOpts),
+    recv_info_frame(Client),
+    ok = emqx_nats_client:subscribe(Client, <<"test.topic">>, <<"sid-1">>),
+    recv_ok_frame(Client),
+    ok = emqx_nats_client:publish(Client, <<"test.topic">>, <<"test message">>),
+    recv_ok_frame(Client),
+    {ok, [Msg]} = emqx_nats_client:receive_message(Client),
+    ?assertMatch(#nats_frame{operation = ?OP_MSG}, Msg),
+    emqx_nats_client:stop(Client).
+
+assert_connect_allowed(ClientOpts) ->
+    {ok, Client} = emqx_nats_client:start_link(ClientOpts),
+    recv_info_frame(Client),
+    ok = emqx_nats_client:connect(Client),
+    recv_ok_frame(Client),
+    emqx_nats_client:stop(Client).
 
 assert_auth_failed(Msgs) ->
     case Msgs of

--- a/apps/emqx_gateway_stomp/mix.exs
+++ b/apps/emqx_gateway_stomp/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayStomp.MixProject do
   def project do
     [
       app: :emqx_gateway_stomp,
-      version: "6.2.0",
+      version: "6.2.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_stomp/src/emqx_stomp_channel.erl
+++ b/apps/emqx_gateway_stomp/src/emqx_stomp_channel.erl
@@ -249,7 +249,9 @@ enrich_clientinfo(
         [
             fun maybe_assign_clientid/2,
             fun parse_heartbeat/2,
-            %% FIXME: CALL After authentication successfully
+            %% Mountpoint is evaluated again after successful authentication in
+            %% emqx_gateway_ctx:authenticate/2, because authentication results
+            %% may add client attributes used by mountpoint templates.
             fun fix_mountpoint/2
         ],
         Packet,

--- a/apps/emqx_gateway_stomp/src/emqx_stomp_channel.erl
+++ b/apps/emqx_gateway_stomp/src/emqx_stomp_channel.erl
@@ -456,6 +456,11 @@ handle_in(Packet = ?PACKET(?CMD_CONNECT), Channel) ->
             handle_out(connerr, {[], undefined, ReasonCode, ErrMsg}, NChannel)
     end;
 handle_in(
+    ?PACKET(?CMD_SEND, Headers),
+    Channel = #channel{conn_state = ConnState}
+) when ConnState =/= connected ->
+    reject_not_connected(Headers, Channel);
+handle_in(
     Frame = ?PACKET(?CMD_SEND, Headers),
     Channel = #channel{
         ctx = Ctx,
@@ -484,6 +489,11 @@ handle_in(
                     )
             end
     end;
+handle_in(
+    ?PACKET(?CMD_SUBSCRIBE, Headers),
+    Channel = #channel{conn_state = ConnState}
+) when ConnState =/= connected ->
+    reject_not_connected(Headers, Channel);
 handle_in(
     ?PACKET(?CMD_SUBSCRIBE, Headers),
     Channel = #channel{
@@ -751,6 +761,10 @@ check_sub_acl(
         deny -> {error, acl_denied};
         allow -> ok
     end.
+
+reject_not_connected(Headers, Channel) ->
+    ErrorFrame = error_frame(receipt_id(Headers), <<"Not connected">>),
+    shutdown(not_connected, ErrorFrame, Channel).
 
 do_subscribe(TopicFilters, Channel) ->
     do_subscribe(TopicFilters, Channel, []).

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -1150,6 +1150,41 @@ t_mountpoint(_) ->
     with_connection(ReceiveMsgFromMqtt),
     update_stomp_with_mountpoint(<<>>).
 
+t_mountpoint_from_authn_client_attrs(_) ->
+    update_stomp_with_mountpoint(<<"stomp/${client_attrs.group}/">>),
+    meck:new(emqx_access_control, [passthrough, no_history]),
+    meck:expect(
+        emqx_access_control,
+        authenticate,
+        fun
+            (#{username := <<"user1">>}) ->
+                {ok, #{client_attrs => #{<<"group">> => <<"g1">>}}};
+            (ClientInfo) ->
+                meck:passthrough([ClientInfo])
+        end
+    ),
+    MountedTopic = <<"stomp/g1/t/a">>,
+    ok = emqx:subscribe(MountedTopic),
+    try
+        with_connection(fun(Sock) ->
+            ok = send_connection_frame(Sock, <<"user1">>, <<"public">>),
+            ?assertMatch({ok, #stomp_frame{command = <<"CONNECTED">>}}, recv_a_frame(Sock)),
+            ok = send_message_frame(Sock, <<"t/a">>, <<"hello">>),
+            ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),
+            receive
+                {deliver, MountedTopic, Msg} ->
+                    ?assertEqual(<<"hello">>, emqx_message:payload(Msg))
+            after 1000 ->
+                ?assert(false, "waiting message timeout")
+            end,
+            ok = send_disconnect_frame(Sock)
+        end)
+    after
+        update_stomp_with_mountpoint(<<>>),
+        emqx:unsubscribe(MountedTopic),
+        meck:unload(emqx_access_control)
+    end.
+
 t_update_not_restart_listener(_) ->
     update_stomp_with_mountpoint(<<"stomp/">>),
     with_connection(fun(Sock) ->

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -22,6 +22,7 @@
 ).
 
 -define(HEARTBEAT, <<$\n>>).
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 -define(CONF_DEFAULT, <<
     "\n"
@@ -87,6 +88,42 @@ update_stomp_with_mountpoint(Mountpoint) ->
         stomp,
         Conf#{<<"mountpoint">> => Mountpoint}
     ).
+
+with_security_profile(Profile, Fun) ->
+    os:putenv(?PROFILE_ENV_VAR, Profile),
+    emqx_security_profile:clear_profile(),
+    try
+        Fun()
+    after
+        os:unsetenv(?PROFILE_ENV_VAR),
+        emqx_security_profile:clear_profile()
+    end.
+
+with_stomp_tcp_listener_authn(EnableAuthn, Fun) ->
+    ListenerPath = [gateway, stomp, listeners, tcp, default],
+    PrevListenerConf = emqx_conf:get(ListenerPath),
+    try
+        update_stomp_tcp_listener_authn(EnableAuthn),
+        Fun()
+    after
+        ok = update_stomp_tcp_listener(PrevListenerConf)
+    end.
+
+update_stomp_tcp_listener_authn(EnableAuthn) ->
+    ListenerConf0 = emqx_conf:get([gateway, stomp, listeners, tcp, default]),
+    ListenerConf1 = ListenerConf0#{enable_authn => EnableAuthn},
+    ok = update_stomp_tcp_listener(ListenerConf1),
+    ?assertEqual(
+        EnableAuthn,
+        emqx_conf:get([gateway, stomp, listeners, tcp, default, enable_authn], undefined)
+    ),
+    ok.
+
+update_stomp_tcp_listener(ListenerConf) ->
+    case emqx_gateway_conf:update_listener(stomp, {tcp, default}, ListenerConf) of
+        ok -> ok;
+        {ok, _} -> ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Test Cases
@@ -196,6 +233,85 @@ t_auth_failed(_) ->
         ?assertEqual([{not_authenticated, 1}], esockd:get_shutdown_count(ListenerId))
     end),
     meck:unload(emqx_access_control).
+
+t_hardened_rejects_pre_connect_send(_) ->
+    with_security_profile("hardened", fun() ->
+        Topic = <<"security/stomp/pre-connect-send">>,
+        Payload = <<"blocked">>,
+        emqx:subscribe(Topic),
+        try
+            with_connection(fun(Sock) ->
+                ok = send_message_frame(Sock, Topic, Payload),
+                assert_error_and_closed(Sock)
+            end),
+            receive
+                {deliver, Topic, _Msg} ->
+                    ct:fail(pre_connect_send_was_published)
+            after 500 ->
+                ok
+            end
+        after
+            emqx:unsubscribe(Topic)
+        end
+    end).
+
+t_hardened_rejects_pre_connect_subscribe(_) ->
+    with_security_profile("hardened", fun() ->
+        Topic = <<"security/stomp/pre-connect-subscribe">>,
+        with_connection(fun(Sock) ->
+            ok = send_subscribe_frame(Sock, 0, Topic),
+            assert_error_and_closed(Sock)
+        end),
+        timer:sleep(100),
+        ?assertEqual([], emqx:subscribers(Topic))
+    end).
+
+t_hardened_rejects_pre_connect_transactional_send(_) ->
+    with_security_profile("hardened", fun() ->
+        Topic = <<"security/stomp/pre-connect-transaction">>,
+        Payload = <<"blocked">>,
+        emqx:subscribe(Topic),
+        try
+            with_connection(fun(Sock) ->
+                ok = send_begin_frame(Sock, <<"tx-pre-connect">>),
+                ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),
+                ok = send_message_frame(Sock, Topic, Payload, [
+                    {<<"transaction">>, <<"tx-pre-connect">>}
+                ]),
+                assert_error_and_closed(Sock)
+            end),
+            receive
+                {deliver, Topic, _Msg} ->
+                    ct:fail(pre_connect_transactional_send_was_published)
+            after 500 ->
+                ok
+            end
+        after
+            emqx:unsubscribe(Topic)
+        end
+    end).
+
+t_hardened_listener_authn_disabled_allows_pub_sub(_) ->
+    with_security_profile("hardened", fun() ->
+        with_stomp_tcp_listener_authn(false, fun() ->
+            with_connection(fun(Sock) ->
+                Topic = <<"security/stomp/authn-disabled">>,
+                Payload = <<"allowed">>,
+                ok = send_connection_frame(Sock, undefined, undefined),
+                ?assertMatch({ok, #stomp_frame{command = <<"CONNECTED">>}}, recv_a_frame(Sock)),
+
+                ok = send_subscribe_frame(Sock, 0, Topic),
+                ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),
+
+                ok = send_message_frame(Sock, Topic, Payload),
+                ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),
+                ?assertMatch(
+                    {ok, #stomp_frame{command = <<"MESSAGE">>, body = Payload}},
+                    recv_a_frame(Sock)
+                )
+            end)
+        end)
+    end).
 
 t_heartbeat(_) ->
     %% Test heartbeat
@@ -1336,6 +1452,18 @@ send_message_frame(Sock, Topic, Payload, Headers0) ->
             | Headers0
         ],
     ok = gen_tcp:send(Sock, serialize(<<"SEND">>, Headers, Payload)).
+
+send_begin_frame(Sock, TxId) ->
+    Headers =
+        [
+            {<<"transaction">>, TxId},
+            {<<"receipt">>, <<"rp-", TxId/binary>>}
+        ],
+    ok = gen_tcp:send(Sock, serialize(<<"BEGIN">>, Headers)).
+
+assert_error_and_closed(Sock) ->
+    ?assertMatch({ok, #stomp_frame{command = <<"ERROR">>}}, recv_a_frame(Sock)),
+    ?assertMatch({error, closed}, recv_a_frame(Sock)).
 
 send_disconnect_frame(Sock) ->
     ok = gen_tcp:send(Sock, serialize(<<"DISCONNECT">>, [])).

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -313,6 +313,35 @@ t_hardened_listener_authn_disabled_allows_pub_sub(_) ->
         end)
     end).
 
+t_authn_disabled_rejects_pre_connect_pub_sub(_) ->
+    with_stomp_tcp_listener_authn(false, fun() ->
+        SendTopic = <<"security/stomp/authn-disabled/pre-connect-send">>,
+        SubTopic = <<"security/stomp/authn-disabled/pre-connect-subscribe">>,
+        Payload = <<"blocked">>,
+        emqx:subscribe(SendTopic),
+        try
+            with_connection(fun(Sock) ->
+                ok = send_message_frame(Sock, SendTopic, Payload),
+                assert_error_and_closed(Sock)
+            end),
+            receive
+                {deliver, SendTopic, _Msg} ->
+                    ct:fail(pre_connect_send_was_published)
+            after 500 ->
+                ok
+            end,
+
+            with_connection(fun(Sock) ->
+                ok = send_subscribe_frame(Sock, 0, SubTopic),
+                assert_error_and_closed(Sock)
+            end),
+            timer:sleep(100),
+            ?assertEqual([], emqx:subscribers(SubTopic))
+        after
+            emqx:unsubscribe(SendTopic)
+        end
+    end).
+
 t_heartbeat(_) ->
     %% Test heartbeat
     with_connection(fun(Sock) ->

--- a/changes/ee/fix-17507.en.md
+++ b/changes/ee/fix-17507.en.md
@@ -1,3 +1,9 @@
-Fixed an issue where MQTT-SN QoS -1 publishes sent before CONNECT could bypass gateway authentication and authorization.
+Fixed several gateway paths that could reach publish or subscribe handling before authentication completed.
 
-Such publishes now use the existing fixed negative-QoS client identity and must pass the normal gateway authentication and publish authorization checks before being delivered.
+MQTT-SN QoS -1 publishes now use the existing fixed negative-QoS client identity and must pass gateway authentication and publish authorization checks before delivery.
+
+NATS now honors the security profile when no authentication is configured. Under the hardened profile, anonymous publish, subscribe, and connect attempts are rejected unless listener authentication is explicitly disabled.
+
+STOMP now rejects SEND and SUBSCRIBE frames before CONNECT completes, including transactional SEND frames.
+
+CoAP connectionless `/ps` publish and observe requests now authenticate before entering pub/sub handling. Under the hardened profile, such requests are rejected when no authentication is configured unless listener authentication is explicitly disabled.

--- a/changes/ee/fix-17507.en.md
+++ b/changes/ee/fix-17507.en.md
@@ -1,0 +1,3 @@
+Fixed an issue where MQTT-SN QoS -1 publishes sent before CONNECT could bypass gateway authentication and authorization.
+
+Such publishes now use the existing fixed negative-QoS client identity and must pass the normal gateway authentication and publish authorization checks before being delivered.


### PR DESCRIPTION
Release version:
6.2.x

## Summary

Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/74.
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/75.
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/82.

This fixes gateway paths that could publish or subscribe before the client had gone through the expected authentication posture.

For MQTT-SN, the idle-state QoS -1 publish path now builds client info with the existing fixed negative-QoS client ID, runs the normal gateway authentication flow, then checks publish authorization before calling the broker. Since MQTT-SN QoS -1 is forwarded as a QoS 0 broker publish, authorization is checked with QoS 0 semantics.

For NATS, the gateway now follows `security_profile` when listener authentication is enabled but no NATS internal authenticator or gateway authenticator is configured. The legacy profile keeps the current anonymous behavior, while the hardened profile advertises `auth_required=true`, rejects PUB/SUB before CONNECT, and rejects CONNECT with `not_authorized`. Explicit anonymous access remains available by setting the listener `enable_authn=false`.

For STOMP, SEND and SUBSCRIBE frames are rejected before CONNECT completes, including transactional SEND frames. Explicit anonymous access after CONNECT remains available when listener authentication is disabled.

For CoAP, connectionless `/ps` publish and observe requests now authenticate before entering pub/sub handling. The request identity is built from the `/ps` URI query when present and is scoped to that request, so a successful connectionless request does not authenticate later requests without credentials. Under the hardened profile, such requests are rejected when no authentication is configured or when credentials are bad; legacy mode and explicit listener `enable_authn=false` preserve the intended anonymous paths.

The tests cover legacy allowed behavior, hardened rejection, bad credential rejection, successful authenticated publish/subscribe, request-scoped connectionless CoAP authentication, explicit listener-authn-disabled anonymous behavior, and the existing authenticated MQTT-SN/NATS/STOMP paths that are runnable in this environment.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
