### PR TITLE
Support PostgreSQL application_name

### DIFF
--- a/apps/emqx_postgresql/mix.exs
+++ b/apps/emqx_postgresql/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXPostgresql.MixProject do
   def project do
     [
       app: :emqx_postgresql,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -157,6 +157,7 @@ on_start(
         {username, User},
         {password, maps:get(password, Config, emqx_secret:wrap(""))},
         {database, DB},
+        {application_name, "emqx"},
         {auto_reconnect, ?AUTO_RECONNECT_INTERVAL},
         {pool_size, PoolSize},
         [{codecs, []} || Codecs /= undefined]
@@ -649,6 +650,8 @@ conn_opts(Opts) ->
 conn_opts([], Acc) ->
     Acc;
 conn_opts([Opt = {database, _} | Opts], Acc) ->
+    conn_opts(Opts, [Opt | Acc]);
+conn_opts([Opt = {application_name, _} | Opts], Acc) ->
     conn_opts(Opts, [Opt | Acc]);
 conn_opts([{ssl, Bool} | Opts], Acc) when is_boolean(Bool) ->
     Flag =

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -13,6 +13,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("stdlib/include/assert.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(PGSQL_HOST, "pgsql").
 -define(PGSQL_RESOURCE_MOD, emqx_postgresql).
@@ -54,6 +55,34 @@ t_lifecycle(_Config) ->
     perform_lifecycle_check(
         <<"emqx_postgresql_SUITE">>,
         pgsql_config()
+    ).
+
+t_application_name_connect_option(_Config) ->
+    ResourceId = <<"emqx_postgresql_SUITE_application_name">>,
+    {ok, #{config := CheckedConfig}} =
+        emqx_resource:check_config(
+            ?PGSQL_RESOURCE_MOD,
+            pgsql_config(#{server => <<"invalid-postgresql-host:5432">>, pool_size => 1})
+        ),
+    ?check_trace(
+        begin
+            {ok, _} = emqx_resource:create_local(
+                ResourceId,
+                ?CONNECTOR_RESOURCE_GROUP,
+                ?PGSQL_RESOURCE_MOD,
+                CheckedConfig,
+                #{spawn_buffer_workers => false, start_timeout => 500}
+            ),
+            emqx_resource:remove_local(ResourceId)
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [#{opts := _} | _],
+                ?of_kind("postgres_epgsql_connect", Trace)
+            ),
+            [#{opts := Opts} | _] = ?of_kind("postgres_epgsql_connect", Trace),
+            ?assert(lists:member({application_name, "emqx"}, Opts))
+        end
     ).
 
 %% Verify that concurrent raw queries do not produce errors because of race conditions.
@@ -116,6 +145,10 @@ perform_lifecycle_check(ResourceId, InitialConfig) ->
     % % Perform query as further check that the resource is working as expected
     ?assertMatch({ok, _, [{1}]}, emqx_resource:query(ResourceId, test_query_no_params())),
     ?assertMatch({ok, _, [{1}]}, emqx_resource:query(ResourceId, test_query_with_params())),
+    ?assertMatch(
+        {ok, _, [{<<"emqx">>}]},
+        emqx_resource:query(ResourceId, test_query_application_name())
+    ),
     ?assertEqual(ok, emqx_resource:stop(ResourceId)),
     % Resource will be listed still, but state will be changed and healthcheck will fail
     % as the worker no longer exists.
@@ -172,6 +205,9 @@ test_query_no_params() ->
 
 test_query_with_params() ->
     {query, <<"SELECT $1::integer">>, [1]}.
+
+test_query_application_name() ->
+    {query, <<"SELECT current_setting('application_name')">>}.
 
 match_ok({ok, _, _}) -> true;
 match_ok(_) -> false.

--- a/changes/ee/feat-17508.en.md
+++ b/changes/ee/feat-17508.en.md
@@ -1,0 +1,3 @@
+Set the PostgreSQL `application_name` startup parameter to `emqx` for PostgreSQL and TimescaleDB connector connections.
+
+This makes EMQX database sessions easier to identify in PostgreSQL logs and views such as `pg_stat_activity`.


### PR DESCRIPTION
Fixes #17384

Release version:
6.0.3

## Summary

PostgreSQL and TimescaleDB connectors now set the PostgreSQL startup parameter `application_name` to `emqx` for every connector connection. This makes EMQX-originated database sessions easier to identify in PostgreSQL logs and views such as `pg_stat_activity` without adding a new user-facing configuration field.

The connector keeps the `application_name` option when building epgsql connection options, bumps the `emqx_postgresql` app version for release-60, and extends the PostgreSQL connector CT suite with both option-level and live PostgreSQL assertions.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)