### PR TITLE
ci(build): refresh dynlibs in builder before packaging

### DIFF
--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -164,7 +164,7 @@ elif docker info; then
         --env ACLOCAL_PATH="/usr/share/aclocal:/usr/local/share/aclocal" \
         --env EMQX_FLAVOR="$EMQX_FLAVOR" \
         "$EMQX_BUILDER" \
-        bash -euc "git config --global --add safe.directory /emqx && $CMD_RUN"
+        bash -euc "git config --global --add safe.directory /emqx && /emqx/scripts/refresh-builder-dynlibs.sh && $CMD_RUN"
 else
     echo "Error: Docker not available on unsupported platform"
     exit 1;

--- a/scripts/refresh-builder-dynlibs.sh
+++ b/scripts/refresh-builder-dynlibs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Refresh dynamic libraries (notably openssl) in the builder image before
+# building a package. Builder images are not rebuilt on a schedule, so the
+# libs they ship can be weeks-to-months stale by the time we build against
+# them. Pull current security-patched versions from the distro repos so the
+# package links/bundles fresh shared objects.
+#
+# Failure is non-fatal: if the distro repos are EOL (e.g. CentOS 7) or
+# unreachable, we log a warning and proceed with the image as-is rather
+# than blocking the build.
+#
+# Set REFRESH_DYNLIBS=no to skip (offline / sandboxed local builds).
+
+set -uo pipefail
+
+if [[ "${REFRESH_DYNLIBS:-yes}" != "yes" ]]; then
+    echo "REFRESH_DYNLIBS=no; skipping in-builder dynlib refresh."
+    exit 0
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+    apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade -qq \
+        || echo "WARNING: apt upgrade failed; continuing with builder image's libs as-is"
+elif command -v dnf >/dev/null 2>&1; then
+    dnf -y upgrade -q \
+        || echo "WARNING: dnf upgrade failed; continuing with builder image's libs as-is"
+elif command -v yum >/dev/null 2>&1; then
+    yum -y update -q \
+        || echo "WARNING: yum update failed; continuing with builder image's libs as-is"
+else
+    echo "WARNING: no recognized package manager; cannot refresh dynlibs."
+fi


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Builder Docker images are not rebuilt on a schedule, so the system libraries they ship (notably openssl / libssl / libcrypto) can be weeks-to-months stale by the time we link or bundle them into release packages. A reporter noticed our zip / tarball packages shipping stale openssl on this account.

Add a small \`scripts/refresh-builder-dynlibs.sh\` that runs \`apt-get update && apt-get upgrade\` (or \`dnf upgrade\` / \`yum update\` depending on the distro family) inside the builder container right before \`make\`, so each package build picks up current security-patched dynlibs from the distro repos.

Failure is non-fatal: if a distro repo is EOL (e.g. CentOS 7) or unreachable, the script logs a warning and proceeds with the image as-is rather than blocking the build. \`REFRESH_DYNLIBS=no\` skips the step for offline / sandboxed local builds.

Only applied on the docker-run path of \`scripts/buildx.sh\` — not the native path, where it would modify the developer's own host.

Companion PR: #17509 (same change on release-58).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)