### PR TITLE
test(mq_consumer): fix t_quick_reconnect flake from meck/cover race

### DIFF
--- a/apps/emqx_mq/test/emqx_mq_consumer_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_consumer_SUITE.erl
@@ -95,7 +95,6 @@ t_quick_reconnect(_Config) ->
 
     %% Stop the "conflicting consumer"
     erlang:send(Pid, stop),
-    meck:unload(emqx_mq_consumer),
 
     %% Verify that the message is received within little threshold
     receive
@@ -105,8 +104,18 @@ t_quick_reconnect(_Config) ->
         ct:fail("message not received")
     end,
 
-    %% Clean up
-    ok = emqtt:disconnect(CSub).
+    %% Cleanly tear down the subscriber and wait for the consumer it
+    %% started to auto-shut down BEFORE `meck:unload' restores the
+    %% original `emqx_mq_consumer' BEAM.  Otherwise meck races with
+    %% cover purge: the still-running consumer gen_server holds the
+    %% cover-compiled module, and `restore_original' -> `code:load_file'
+    %% returns `{error, not_purged}', crashing `meck_proc'.
+    ?assertWaitEvent(
+        emqtt:disconnect(CSub),
+        #{?snk_kind := mq_consumer_shutdown, mq_topic_filter := <<"t/#">>},
+        1000
+    ),
+    meck:unload(emqx_mq_consumer).
 
 %% A subscriber may be considered dead and removed by the consumer,
 %% but the it may still try to send late acks/pings.


### PR DESCRIPTION
## Summary

\`emqx_mq_consumer_SUITE:t_quick_reconnect\` is intermittently failing in CI under cover:

\`\`\`
Error detected: {'EXIT',{badmatch,{...}}}
emqx_mq_consumer_SUITE ==> t_quick_reconnect: FAILED
{'EXIT',{badmatch,{error,"/__w/emqx/emqx/_build/.../emqx_mq_consumer.beam"}}}
[error] Loading of cover_compiled failed: not_purged
\`\`\`

with the crash in \`meck_proc:restore_original/4\`. The state dump also shows in-flight \`{error, already_registered}\` / \`{error, not_found}\` from \`emqx_mq_consumer:connect\` / \`start_link\` / \`init\` — i.e. the subscriber is still cycling through reconnect attempts via the cover-compiled module when \`meck:unload\` fires.

## Root cause

The test mocks \`emqx_mq_consumer\` (passthrough), forces \`find -> not_found\` to drive the reconnect path, sends \`stop\` to the conflicting consumer, and then calls \`meck:unload\` immediately. Under cover the just-spawned \"real\" mq consumer gen_server is still running cover-compiled code, so meck's \`restore_original\` -> \`code:load_file\` hits \`{error, not_purged}\` and the testcase crashes with the badmatch.

## Fix

Reorder \`t_quick_reconnect\` so the unload happens after every process executing \`emqx_mq_consumer\` code has exited:

1. wait for the published message to arrive (subscriber is now attached to a real consumer);
2. disconnect the subscriber and use \`?assertWaitEvent\` to wait for the resulting \`mq_consumer_shutdown\` snabbkaffe event;
3. then call \`meck:unload\`.

The mq consumer's \`consumer_max_inactive => 50\` ms means the auto-shutdown lands well inside the existing 1000 ms wait. No production code changes.

## Test plan

- [x] \`SUITE=apps/emqx_mq/test/emqx_mq_consumer_SUITE.erl TESTCASE=t_quick_reconnect make ct-suite\` — 1/1 ok.
- [x] \`SUITE=apps/emqx_mq/test/emqx_mq_consumer_SUITE.erl make ct-suite\` — 3/3 ok.