### PR TITLE
fix(prometheus): correct authz matched metric keys

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -57,7 +57,7 @@
 ]).
 
 -ifdef(TEST).
--export([cert_expiry_at_from_path/1]).
+-export([cert_expiry_at_from_path/1, acl_metric_meta/0]).
 -endif.
 
 %%--------------------------------------------------------------------
@@ -949,8 +949,8 @@ acl_metric_meta() ->
         {emqx_authorization_cache_miss, counter, 'authorization.cache_miss'},
         {emqx_authorization_superuser, counter, 'authorization.superuser'},
         {emqx_authorization_nomatch, counter, 'authorization.nomatch'},
-        {emqx_authorization_matched_allow, counter, 'authorization.matched_allow'},
-        {emqx_authorization_matched_deny, counter, 'authorization.matched_deny'}
+        {emqx_authorization_matched_allow, counter, 'authorization.matched.allow'},
+        {emqx_authorization_matched_deny, counter, 'authorization.matched.deny'}
     ].
 
 %%==========

--- a/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
@@ -196,6 +196,20 @@ t_collector_no_crash_test(_) ->
     prometheus_text_format:format(),
     ok.
 
+t_authz_matched_metrics(_) ->
+    ?assert(
+        lists:member(
+            {emqx_authorization_matched_allow, counter, 'authorization.matched.allow'},
+            emqx_prometheus:acl_metric_meta()
+        )
+    ),
+    ?assert(
+        lists:member(
+            {emqx_authorization_matched_deny, counter, 'authorization.matched.deny'},
+            emqx_prometheus:acl_metric_meta()
+        )
+    ).
+
 t_assert_push(_) ->
     Self = self(),
     AssertPush = fun(Method, Req = {Url, Headers, ContentType, Data}, HttpOpts, Opts) ->

--- a/changes/ee/fix-17513.en.md
+++ b/changes/ee/fix-17513.en.md
@@ -1,0 +1,1 @@
+Fixed Prometheus matched authorization allow/deny metrics so they reflect real matched authorization decisions.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.1, 6.2.0

Fixes emqx/emqx-dev-team-tasks#117

## Summary

Fix Prometheus matched authorization allow/deny counters to read the metric keys incremented by the authorization subsystem.

The authorization code increments `authorization.matched.allow` and `authorization.matched.deny`; Prometheus now uses those dotted keys while keeping the exported metric names `emqx_authorization_matched_allow` and `emqx_authorization_matched_deny` unchanged. A regression test covers the ACL metric metadata mapping.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

No schema changes.

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->