### PR TITLE
fix(mq): complete qos 0 queue deliveries

### DIFF
--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -393,7 +393,7 @@ puback(ClientInfo, PacketId, ReasonCode, Session) ->
     case ?IMPL(Session):puback(ClientInfo, PacketId, Session) of
         {ok, Msg, Replies, Session1} = Ok ->
             _ = on_delivery_completed(Msg, ReasonCode, ClientInfo, Session1),
-            _ = on_replies_delivery_completed(Replies, ClientInfo, Session1),
+            _ = on_maybe_delivery_completed_qos0(Replies, ClientInfo, Session1),
             Ok;
         {error, _} = Error ->
             Error
@@ -432,7 +432,7 @@ pubcomp(ClientInfo, PacketId, ReasonCode, Session) ->
     case ?IMPL(Session):pubcomp(ClientInfo, PacketId, Session) of
         {ok, Msg, Replies, Session1} ->
             _ = on_delivery_completed(Msg, ReasonCode, ClientInfo, Session1),
-            _ = on_replies_delivery_completed(Replies, ClientInfo, Session1),
+            _ = on_maybe_delivery_completed_qos0(Replies, ClientInfo, Session1),
             {ok, Replies, Session1};
         {error, _} = Error ->
             Error
@@ -453,7 +453,9 @@ replay(ClientInfo, ReplayContext, Session) ->
     {ok, replies(), t()}.
 deliver(ClientInfo, Delivers, Session) ->
     Messages = enrich_delivers(ClientInfo, Delivers, Session),
-    ?IMPL(Session):deliver(ClientInfo, Messages, Session).
+    Ok = {ok, Replies, Session1} = ?IMPL(Session):deliver(ClientInfo, Messages, Session),
+    _ = on_maybe_delivery_completed_qos0(Replies, ClientInfo, Session1),
+    Ok.
 
 %%--------------------------------------------------------------------
 
@@ -563,7 +565,14 @@ enrich_message(_ClientInfo, Msg, undefined, _UpgradeQoS) ->
     %% NOTE: only relevant for `common_timer_name()`
     | {ok, replies(), timeout(), t()}.
 handle_timeout(ClientInfo, Timer, Session) ->
-    ?IMPL(Session):handle_timeout(ClientInfo, Timer, Session).
+    case ?IMPL(Session):handle_timeout(ClientInfo, Timer, Session) of
+        {ok, Replies, Session1} = Ok ->
+            _ = on_maybe_delivery_completed_qos0(Replies, ClientInfo, Session1),
+            Ok;
+        {ok, Replies, _Timeout, Session1} = Ok ->
+            _ = on_maybe_delivery_completed_qos0(Replies, ClientInfo, Session1),
+            Ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Generic Messages
@@ -658,28 +667,26 @@ on_delivery_completed(Msg, ReasonCode, #{clientid := ClientId}, Session) ->
         ]
     ).
 
-on_delivery_completed_qos0(Msg, #{clientid := ClientId}, Session) ->
-    emqx_hooks:run(
-        'delivery.completed',
-        [
-            Msg,
-            #{
-                session_birth_time => ?IMPL(Session):info(created_at, Session),
-                clientid => ClientId
-            }
-        ]
-    ).
-
-on_replies_delivery_completed(Replies, ClientInfo, Session) ->
+%% NOTE
+%% The function is called when the session returns new messages
+%% to send to the client.
+%% The client will not send PUBACK for QoS 0 messages.
+%% So we call the 'delivery.completed' callback for them here.
+on_maybe_delivery_completed_qos0(Replies, #{clientid := ClientId}, Session) ->
     lists:foreach(
         fun({_PacketId, Msg}) ->
             case Msg of
                 #message{qos = ?QOS_0} ->
-                    %% NOTE
-                    %% Session returned some new messages to send to the client.
-                    %% The client will not send PUBACK for QoS 0 messages.
-                    %% So we call the callback for them here.
-                    on_delivery_completed_qos0(Msg, ClientInfo, Session);
+                    emqx_hooks:run(
+                        'delivery.completed',
+                        [
+                            Msg,
+                            #{
+                                session_birth_time => ?IMPL(Session):info(created_at, Session),
+                                clientid => ClientId
+                            }
+                        ]
+                    );
                 _ ->
                     ok
             end

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -911,6 +911,9 @@ subscribe(_TopicFilter, _SubOpts = #{}, {?MODULE, Session0}) ->
 get_subscription(_TopicFilter, {?MODULE, _Session}) ->
     undefined.
 
+info(created_at, {?MODULE, _Session}) ->
+    0.
+
 handle_timeout(_ClientInfo, t1, {?MODULE, Session0}) ->
     Msg = emqx_message:make(<<"a/b">>, <<"t1">>),
     Session1 = maps:remove(t1, Session0),

--- a/apps/emqx_mq/test/emqx_mq_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_SUITE.erl
@@ -203,7 +203,7 @@ t_backpressure(_Config) ->
 %% Verify that QoS 0 queue subscriptions auto-ack messages in the MQ subscriber.
 t_qos0_subscription_auto_acks_mq_messages(_Config) ->
     LocalMaxInflight = 2,
-    _ = emqx_mq_test_utils:ensure_mq_created(#{
+    _ = emqx_mq_test_utils:create_mq(#{
         name => <<"qos0_auto_ack">>,
         topic_filter => <<"t/#">>,
         is_lastvalue => false,

--- a/apps/emqx_mq/test/emqx_mq_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_SUITE.erl
@@ -200,6 +200,31 @@ t_backpressure(_Config) ->
     %% Clean up
     ok = emqtt:disconnect(CSub).
 
+%% Verify that QoS 0 queue subscriptions auto-ack messages in the MQ subscriber.
+t_qos0_subscription_auto_acks_mq_messages(_Config) ->
+    LocalMaxInflight = 2,
+    _ = emqx_mq_test_utils:ensure_mq_created(#{
+        name => <<"qos0_auto_ack">>,
+        topic_filter => <<"t/#">>,
+        is_lastvalue => false,
+        local_max_inflight => LocalMaxInflight
+    }),
+
+    %% Populate the MQ with messages to exceed the local max inflight
+    emqx_mq_test_utils:populate(LocalMaxInflight + 1, #{topic_prefix => <<"t/">>}),
+
+    %% Connect a subscriber and subscribe to the queue
+    CSub = emqx_mq_test_utils:emqtt_connect([]),
+    {ok, _, [?QOS_0]} = emqtt:subscribe(CSub, {<<"$queue/qos0_auto_ack/t/#">>, ?QOS_0}),
+
+    %% Drain the subscriber to receive all messages, without auto ack qos0
+    %% this would receive only 2 messages.
+    {ok, Msgs} = emqx_mq_test_utils:emqtt_drain(_MinMsg = LocalMaxInflight + 1, _Timeout = 1000),
+    ?assertEqual(LocalMaxInflight + 1, length(Msgs)),
+
+    %% Clean up
+    ok = emqtt:disconnect(CSub).
+
 %% Verify that the consumer redispatches a message to another subscriber
 %% if a subscriber received the message but disconnected before acknowledging it
 t_redispatch_on_disconnect(_Config) ->

--- a/apps/emqx_mq/test/emqx_mq_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_SUITE.erl
@@ -215,7 +215,7 @@ t_qos0_subscription_auto_acks_mq_messages(_Config) ->
 
     %% Connect a subscriber and subscribe to the queue
     CSub = emqx_mq_test_utils:emqtt_connect([]),
-    {ok, _, [?QOS_0]} = emqtt:subscribe(CSub, {<<"$queue/qos0_auto_ack/t/#">>, ?QOS_0}),
+    {ok, _, [?QOS_0]} = emqtt:subscribe(CSub, {<<"$q/t/#">>, ?QOS_0}),
 
     %% Drain the subscriber to receive all messages, without auto ack qos0
     %% this would receive only 2 messages.

--- a/changes/ee/fix-17515.en.md
+++ b/changes/ee/fix-17515.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where Message Queue subscriptions using QoS 0 could stop receiving messages after the queue subscriber's local inflight window became full.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.0

Fixes #17489

## Summary

This fixes Message Queue subscriptions using QoS 0 so queue messages no longer remain stuck in the MQ subscriber inflight state.

Previously, QoS 0 queue deliveries could be sent to the client without emitting `delivery.completed`, leaving the MQ subscriber waiting for acknowledgements that would never arrive. Once `local_max_inflight` was reached, the queue stopped dispatching further messages to that subscriber.

The session wrapper now emits `delivery.completed` for QoS 0 messages returned from direct delivery and timeout/dequeue flows, matching the existing behavior for QoS 0 messages released after PUBACK/PUBCOMP. A regression test covers queue subscriptions with QoS 0 and verifies delivery continues beyond the local MQ inflight limit.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
