### PR TITLE
refactor(rbac): unify rbac for namespace admins

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -359,8 +359,8 @@ api_key_authorize(Req, HandlerInfo, Key, Secret) ->
                 <<"Please use bearer Token instead, using API key/secret in ", Resource/binary,
                     " path is not permitted">>
             );
-        {error, unauthorized_role} ->
-            {403, 'UNAUTHORIZED_ROLE', ?API_KEY_NOT_ALLOW_MSG};
+        {error, {unauthorized_role, Msg}} when is_binary(Msg) ->
+            {403, 'UNAUTHORIZED_ROLE', Msg};
         {error, _} ->
             return_unauthorized(
                 ?BAD_API_KEY_OR_SECRET,
@@ -401,8 +401,8 @@ jwt_token_bearer_authorize(Req, HandlerInfo, Token) ->
                 "API keys can be bootstrapped from config "
                 "(api_key.bootstrap_file) or created via POST /api/v5/api_key"
             >>};
-        {error, unauthorized_role} ->
-            {403, 'UNAUTHORIZED_ROLE', <<"You don't have permission to access this resource">>}
+        {error, {unauthorized_role, Msg}} when is_binary(Msg) ->
+            {403, 'UNAUTHORIZED_ROLE', Msg}
     end.
 
 ensure_ssl_cert(Listeners = #{https := Https0 = #{ssl_options := SslOpts}}) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -1035,7 +1035,7 @@ sign_token(Username, Password, MfaToken) ->
 
 -spec verify_token(emqx_dashboard:request(), emqx_dashboard:handler_info(), Token :: binary()) ->
     {ok, emqx_dashboard_rbac:actor_context()}
-    | {error, token_timeout | not_found | unauthorized_role}.
+    | {error, token_timeout | not_found | {unauthorized_role, binary()}}.
 verify_token(Req, HandlerInfo, Token) ->
     emqx_dashboard_token:verify(Req, HandlerInfo, Token).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
@@ -5,7 +5,6 @@
 -module(emqx_dashboard_audit).
 
 -include_lib("emqx/include/logger.hrl").
--include_lib("emqx_utils/include/emqx_http_api.hrl").
 %% API
 -export([log/2, log_fun/0, importance/1]).
 
@@ -54,7 +53,7 @@ log_meta(Importance, Meta, Req) ->
             Code = maps:get(code, Meta),
             Meta1 = #{
                 time => logger:timestamp(),
-                from => from(Meta),
+                from => from(Meta, Req),
                 source => source(Meta),
                 duration_ms => duration_ms(Meta),
                 source_ip => source_ip(Req),
@@ -73,20 +72,27 @@ log_meta(Importance, Meta, Req) ->
 duration_ms(#{req_start := ReqStart, req_end := ReqEnd}) ->
     erlang:convert_time_unit(ReqEnd - ReqStart, native, millisecond).
 
-from(#{auth_type := jwt_token}) ->
+from(#{auth_type := jwt_token}, _Req) ->
     dashboard;
-from(#{auth_type := api_key}) ->
+from(#{auth_type := api_key}, _Req) ->
     rest_api;
-from(#{log_from := From}) ->
+from(#{log_from := From}, _Req) ->
     From;
-from(#{code := Code} = Meta) when Code =:= 401 orelse Code =:= 403 ->
+from(#{code := Code} = Meta, Req) when Code =:= 401 orelse Code =:= 403 ->
+    %% Auth failed before `auth_type` could be populated by the authoriser.
+    %% Distinguish by the request's `Authorization` header: Basic ⇒ API key,
+    %% Bearer (or anything else) ⇒ dashboard.  This avoids matching against
+    %% the response body message text, which now varies by RBAC reason.
     case maps:find(failure, Meta) of
-        {ok, #{code := 'BAD_API_KEY_OR_SECRET'}} -> rest_api;
-        {ok, #{code := 'UNAUTHORIZED_ROLE', message := ?API_KEY_NOT_ALLOW_MSG}} -> rest_api;
-        %% 'TOKEN_TIME_OUT' 'BAD_TOKEN' is dashboard code.
-        _ -> dashboard
+        {ok, #{code := 'BAD_API_KEY_OR_SECRET'}} ->
+            rest_api;
+        _ ->
+            case cowboy_req:parse_header(<<"authorization">>, Req) of
+                {basic, _, _} -> rest_api;
+                _ -> dashboard
+            end
     end;
-from(_) ->
+from(_, _Req) ->
     unknown.
 
 source(#{source := Source}) -> Source;

--- a/apps/emqx_dashboard/src/emqx_dashboard_token.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_token.erl
@@ -52,7 +52,7 @@
 
 -spec verify(emqx_dashboard:request(), emqx_dashboard:handler_info(), Token :: binary()) ->
     {ok, emqx_dashboard_rbac:actor_context()}
-    | {error, token_timeout | not_found | unauthorized_role}.
+    | {error, token_timeout | not_found | {unauthorized_role, binary()}}.
 verify(Req, HandlerInfo, Token) ->
     do_verify(Req, HandlerInfo, Token).
 
@@ -114,7 +114,7 @@ sign(#?ADMIN{username = Username} = User) ->
 
 -spec do_verify(emqx_dashboard:request(), emqx_dashboard:handler_info(), Token :: binary()) ->
     {ok, emqx_dashboard_rbac:actor_context()}
-    | {error, token_timeout | not_found | unauthorized_role}.
+    | {error, token_timeout | not_found | {unauthorized_role, binary()}}.
 do_verify(Req, HandlerInfo, Token) ->
     case lookup(Token) of
         {ok, JWT = #?ADMIN_JWT{exptime = ExpTime, extra = _Extra, username = _Username}} ->
@@ -297,10 +297,11 @@ check_rbac(Req, HandlerInfo, JWT) ->
                     ok = save_new_jwt(JWT),
                     {ok, ActorContextFinal};
                 false ->
-                    {error, unauthorized_role}
+                    {error,
+                        {unauthorized_role, <<"Login user scope does not permit this endpoint">>}}
             end;
-        false ->
-            {error, unauthorized_role}
+        {error, Reason} when is_binary(Reason) ->
+            {error, {unauthorized_role, Reason}}
     end.
 
 full_admin_key(Username, #{backend := ?BACKEND_LOCAL}) ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
@@ -507,6 +507,11 @@ Simple assertions about namespaced user permissions.
    - Both viewers and admins can `GET` anything, even outside their namespace.  Namespaces
      are mostly to avoid accidentally mutating the wrong resources rather than hiding
      information.
+   - Exception: endpoints whose response would expose MQTT payload content (per-client
+     mqueue/inflight, retained, delayed) are denied for namespaced users by RBAC, because
+     the underlying stores are global and cannot be safely filtered by namespace.  Those
+     handlers are kept in a static deny list here so this assertion does not have to
+     reach into RBAC internals.
 """.
 t_namespaced_user_permissions(_TCConfig) ->
     GlobalAdminHeader = create_superuser(),
@@ -524,7 +529,14 @@ t_namespaced_user_permissions(_TCConfig) ->
     ),
     {ok, #{token := Token}} = emqx_dashboard_admin:sign_token(Username, Password),
     AllHandlers = [_ | _] = all_handlers(),
-    GetHandlers = [_ | _] = [FHI || #{method := get} = FHI <- AllHandlers],
+    Denied = namespaced_get_denylist(),
+    GetHandlers =
+        [_ | _] =
+        [
+            FHI
+         || #{method := get} = FHI <- AllHandlers,
+            not lists:member(maps:with([method, module, function], FHI), Denied)
+        ],
     FakeReq = #{path => <<"/api/v5/clients">>},
     Failures =
         lists:filtermap(
@@ -543,6 +555,19 @@ t_namespaced_user_permissions(_TCConfig) ->
         ct:fail({should_have_been_allowed, Failures})
     end,
     ok.
+
+%% Keep in sync with the namespaced-deny clauses in
+%% `emqx_dashboard_rbac:do_check_rbac/3' for these three modules.  Adding a new
+%% global-only message endpoint there means adding it here too.
+namespaced_get_denylist() ->
+    [
+        #{method => get, module => emqx_mgmt_api_clients, function => mqueue_msgs},
+        #{method => get, module => emqx_mgmt_api_clients, function => inflight_msgs},
+        #{method => get, module => emqx_retainer_api, function => '/messages'},
+        #{method => get, module => emqx_retainer_api, function => with_topic_warp},
+        #{method => get, module => emqx_delayed_api, function => delayed_messages},
+        #{method => get, module => emqx_delayed_api, function => delayed_message}
+    ].
 
 -doc """
 Checks the authorization behavior of namespaced publisher API keys.

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -50,7 +50,7 @@
 %%=====================================================================
 %% API
 -spec check_rbac(emqx_dashboard:request(), emqx_dashboard:handler_info(), actor_context()) ->
-    {ok, actor_context()} | false.
+    {ok, actor_context()} | {error, binary()}.
 check_rbac(Req, HandlerInfo, ActorContext) ->
     maybe
         true ?= do_check_rbac(ActorContext, Req, HandlerInfo),
@@ -198,7 +198,7 @@ parse_namespace_tag(NsTag) ->
 
 %% ===================================================================
 -spec do_check_rbac(actor_context(), emqx_dashboard:request(), emqx_dashboard:handler_info()) ->
-    boolean().
+    true | {error, binary()}.
 do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := ?global_ns}, _, _) ->
     %% Global administrator
     true;
@@ -209,7 +209,7 @@ do_check_rbac(#{?namespace := Namespace}, _, ?CLIENTS_API(get, Fn)) when
     %% Whole-endpoint visibility policy belongs in RBAC. These endpoints
     %% expose MQTT payloads for arbitrary clients and cannot be safely scoped
     %% by a generic route filter.
-    false;
+    {error, <<"Per-client message endpoints are not available to namespaced users">>};
 do_check_rbac(#{?namespace := Namespace}, _, ?RETAINER_API(Method, Fn)) when
     is_binary(Namespace) andalso
         (Fn == '/messages' orelse Fn == with_topic_warp) andalso
@@ -217,7 +217,7 @@ do_check_rbac(#{?namespace := Namespace}, _, ?RETAINER_API(Method, Fn)) when
 ->
     %% The retained message store is global. Listing, fetching, or deleting by
     %% topic would expose or mutate messages outside the caller's namespace.
-    false;
+    {error, <<"Retained message endpoints are not available to namespaced users">>};
 do_check_rbac(#{?namespace := Namespace}, _, ?DELAYED_API(Method, Fn)) when
     is_binary(Namespace) andalso
         ((Fn == delayed_messages andalso Method == get) orelse
@@ -227,7 +227,7 @@ do_check_rbac(#{?namespace := Namespace}, _, ?DELAYED_API(Method, Fn)) when
     %% Delayed message records are global and include MQTT payloads. Keep the
     %% coarse global-only endpoint decision here; filters should resolve or
     %% validate a namespace, not define the static RBAC surface.
-    false;
+    {error, <<"Delayed message endpoints are not available to namespaced users">>};
 do_check_rbac(#{?role := ?ROLE_SUPERUSER}, _, #{method := get}) ->
     %% Namespaced administrator; It's fine for such admins to `GET` anything, even outside
     %% their namespace.  Namespaces are mostly to avoid accidentally mutating the wrong
@@ -252,7 +252,7 @@ do_check_rbac(
     %% emqx_mgmt_api_publish:publish
     %% emqx_mgmt_api_publish:publish_batch
     %% Currently, only namespaced publisher roles may not use these APIs.
-    false;
+    {error, <<"Publishing is not allowed for namespaced API keys">>};
 %% everyone should allow to logout
 do_check_rbac(#{}, _, ?DASHBOARD_API(post, logout)) ->
     %% emqx_dashboard_api:logout
@@ -270,7 +270,7 @@ do_check_rbac(
         #{bindings := #{username := Username}} ->
             true;
         _ ->
-            false
+            {error, <<"Viewers may only change their own password or MFA">>}
     end;
 do_check_rbac(
     #{?role := ?ROLE_VIEWER, ?actor := Username},
@@ -285,7 +285,7 @@ do_check_rbac(
     %% scope holders from self-exempting.
     case Req of
         #{bindings := #{username := Username}} -> true;
-        _ -> false
+        _ -> {error, <<"Viewers may only delete their own MFA">>}
     end;
 do_check_rbac(
     #{?role := ?ROLE_SUPERUSER, ?namespace := Namespace, ?actor := Username},
@@ -301,7 +301,7 @@ do_check_rbac(
     %% admin is a known social-engineering vector.
     case Req of
         #{bindings := #{username := Username}} -> true;
-        _ -> false
+        _ -> {error, <<"Namespaced administrators may only change their own password or MFA">>}
     end;
 do_check_rbac(
     #{?role := ?ROLE_SUPERUSER, ?namespace := Namespace, ?actor := Username},
@@ -312,7 +312,7 @@ do_check_rbac(
     %% Self only -- see the post change_mfa clause above for rationale.
     case Req of
         #{bindings := #{username := Username}} -> true;
-        _ -> false
+        _ -> {error, <<"Namespaced administrators may only delete their own MFA">>}
     end;
 do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := Namespace}, _Req, ?CONNECTOR_API(_, _)) when
     is_binary(Namespace)
@@ -348,7 +348,7 @@ do_check_rbac(
     %% Configuration backup export/import.
     true;
 do_check_rbac(_, _, _) ->
-    false.
+    {error, <<"You don't have permission to access this resource">>}.
 
 role_list(dashboard) ->
     [?ROLE_VIEWER, ?ROLE_SUPERUSER];

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -43,6 +43,9 @@
 -define(TRACE_API(METHOD, FN), ?API(emqx_mgmt_api_trace, METHOD, FN)).
 -define(PUBLISH_API(METHOD, FN), ?API(emqx_mgmt_api_publish, METHOD, FN)).
 -define(DATA_BACKUP_API(METHOD, FN), ?API(emqx_mgmt_api_data_backup, METHOD, FN)).
+-define(CLIENTS_API(METHOD, FN), ?API(emqx_mgmt_api_clients, METHOD, FN)).
+-define(RETAINER_API(METHOD, FN), ?API(emqx_retainer_api, METHOD, FN)).
+-define(DELAYED_API(METHOD, FN), ?API(emqx_delayed_api, METHOD, FN)).
 
 %%=====================================================================
 %% API
@@ -199,6 +202,32 @@ parse_namespace_tag(NsTag) ->
 do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := ?global_ns}, _, _) ->
     %% Global administrator
     true;
+do_check_rbac(#{?namespace := Namespace}, _, ?CLIENTS_API(get, Fn)) when
+    is_binary(Namespace) andalso
+        (Fn == mqueue_msgs orelse Fn == inflight_msgs)
+->
+    %% Whole-endpoint visibility policy belongs in RBAC. These endpoints
+    %% expose MQTT payloads for arbitrary clients and cannot be safely scoped
+    %% by a generic route filter.
+    false;
+do_check_rbac(#{?namespace := Namespace}, _, ?RETAINER_API(Method, Fn)) when
+    is_binary(Namespace) andalso
+        (Fn == '/messages' orelse Fn == with_topic_warp) andalso
+        (Method == get orelse Method == delete)
+->
+    %% The retained message store is global. Listing, fetching, or deleting by
+    %% topic would expose or mutate messages outside the caller's namespace.
+    false;
+do_check_rbac(#{?namespace := Namespace}, _, ?DELAYED_API(Method, Fn)) when
+    is_binary(Namespace) andalso
+        ((Fn == delayed_messages andalso Method == get) orelse
+            (Fn == delayed_message andalso (Method == get orelse Method == delete)) orelse
+            (Fn == delayed_message_topic andalso Method == delete))
+->
+    %% Delayed message records are global and include MQTT payloads. Keep the
+    %% coarse global-only endpoint decision here; filters should resolve or
+    %% validate a namespace, not define the static RBAC surface.
+    false;
 do_check_rbac(#{?role := ?ROLE_SUPERUSER}, _, #{method := get}) ->
     %% Namespaced administrator; It's fine for such admins to `GET` anything, even outside
     %% their namespace.  Namespaces are mostly to avoid accidentally mutating the wrong

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -210,19 +210,18 @@ do_check_rbac(#{?namespace := Namespace}, _, ?CLIENTS_API(get, Fn)) when
     %% expose MQTT payloads for arbitrary clients and cannot be safely scoped
     %% by a generic route filter.
     {error, <<"Per-client message endpoints are not available to namespaced users">>};
-do_check_rbac(#{?namespace := Namespace}, _, ?RETAINER_API(Method, Fn)) when
+do_check_rbac(#{?namespace := Namespace}, _, ?RETAINER_API(_, Fn)) when
     is_binary(Namespace) andalso
-        (Fn == '/messages' orelse Fn == with_topic_warp) andalso
-        (Method == get orelse Method == delete)
+        (Fn == '/messages' orelse Fn == with_topic_warp)
 ->
     %% The retained message store is global. Listing, fetching, or deleting by
     %% topic would expose or mutate messages outside the caller's namespace.
     {error, <<"Retained message endpoints are not available to namespaced users">>};
-do_check_rbac(#{?namespace := Namespace}, _, ?DELAYED_API(Method, Fn)) when
+do_check_rbac(#{?namespace := Namespace}, _, ?DELAYED_API(_, Fn)) when
     is_binary(Namespace) andalso
-        ((Fn == delayed_messages andalso Method == get) orelse
-            (Fn == delayed_message andalso (Method == get orelse Method == delete)) orelse
-            (Fn == delayed_message_topic andalso Method == delete))
+        (Fn == delayed_messages orelse
+            Fn == delayed_message orelse
+            Fn == delayed_message_topic)
 ->
     %% Delayed message records are global and include MQTT payloads. Keep the
     %% coarse global-only endpoint decision here; filters should resolve or

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -10,6 +10,7 @@
 -include("../../emqx_dashboard/include/emqx_dashboard.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 -include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
 
 -import(emqx_dashboard_api_test_helpers, [uri/1]).
@@ -719,6 +720,67 @@ t_check_login_user_scopes_sso_explicit_scope_grants_only_that_path(_) ->
     ?assertEqual(
         false,
         emqx_dashboard_rbac:check_login_user_scopes(SsoKey, <<"/alarms">>)
+    ).
+
+t_global_only_message_endpoints_reject_namespaced_actors(_) ->
+    Req = #{},
+    lists:foreach(
+        fun(HandlerInfo) ->
+            lists:foreach(
+                fun(ActorContext) ->
+                    ?assertEqual(
+                        false,
+                        emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, ActorContext)
+                    )
+                end,
+                namespaced_actor_contexts()
+            ),
+            ?assertMatch(
+                {ok, _},
+                emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, global_admin_actor_context())
+            ),
+            assert_global_viewer_rbac(Req, HandlerInfo)
+        end,
+        global_only_message_endpoint_handlers()
+    ).
+
+global_only_message_endpoint_handlers() ->
+    [
+        #{method => get, module => emqx_mgmt_api_clients, function => mqueue_msgs},
+        #{method => get, module => emqx_mgmt_api_clients, function => inflight_msgs},
+        #{method => get, module => emqx_retainer_api, function => '/messages'},
+        #{method => delete, module => emqx_retainer_api, function => '/messages'},
+        #{method => get, module => emqx_retainer_api, function => with_topic_warp},
+        #{method => delete, module => emqx_retainer_api, function => with_topic_warp},
+        #{method => get, module => emqx_delayed_api, function => delayed_messages},
+        #{method => get, module => emqx_delayed_api, function => delayed_message},
+        #{method => delete, module => emqx_delayed_api, function => delayed_message},
+        #{method => delete, module => emqx_delayed_api, function => delayed_message_topic}
+    ].
+
+namespaced_actor_contexts() ->
+    [
+        #{?actor => <<"ns_admin">>, ?role => ?ROLE_SUPERUSER, ?namespace => <<"ns1">>},
+        #{?actor => <<"ns_viewer">>, ?role => ?ROLE_VIEWER, ?namespace => <<"ns1">>},
+        #{?actor => <<"ns_api_admin">>, ?role => ?ROLE_API_SUPERUSER, ?namespace => <<"ns1">>},
+        #{?actor => <<"ns_api_viewer">>, ?role => ?ROLE_API_VIEWER, ?namespace => <<"ns1">>}
+    ].
+
+global_admin_actor_context() ->
+    #{?actor => <<"global_admin">>, ?role => ?ROLE_SUPERUSER, ?namespace => ?global_ns}.
+
+global_viewer_actor_context() ->
+    #{?actor => <<"global_viewer">>, ?role => ?ROLE_VIEWER, ?namespace => ?global_ns}.
+
+assert_global_viewer_rbac(Req, #{method := get} = HandlerInfo) ->
+    ?assertMatch(
+        {ok, _},
+        emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, global_viewer_actor_context())
+    );
+assert_global_viewer_rbac(Req, HandlerInfo) ->
+    ?assertEqual(
+        false,
+        emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, global_viewer_actor_context())
     ).
 
 delete_mfa(Token, Username) ->

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -249,8 +249,8 @@ t_change_pwd(_) ->
     %% viewer can change own password
     ?assertMatch({ok, #{actor := Viewer1}}, change_pwd(Viewer1Token, Viewer1)),
     %% viewer can't change other's password
-    ?assertEqual({error, unauthorized_role}, change_pwd(Viewer1Token, Viewer2)),
-    ?assertEqual({error, unauthorized_role}, change_pwd(Viewer1Token, SuperUser)),
+    ?assertMatch({error, {unauthorized_role, _}}, change_pwd(Viewer1Token, Viewer2)),
+    ?assertMatch({error, {unauthorized_role, _}}, change_pwd(Viewer1Token, SuperUser)),
     %% superuser can change other's password
     ?assertMatch({ok, #{actor := SuperUser}}, change_pwd(SuperToken, Viewer1)),
     ?assertMatch({ok, #{actor := SuperUser}}, change_pwd(SuperToken, Viewer2)),
@@ -368,8 +368,8 @@ test_mfa(VerifyFn) ->
     %% viewer can change own MFA
     ?assertMatch({ok, #{actor := Viewer1}}, VerifyFn(Viewer1Token, Viewer1)),
     %% viewer can't change other's MFA
-    ?assertEqual({error, unauthorized_role}, VerifyFn(Viewer1Token, Viewer2)),
-    ?assertEqual({error, unauthorized_role}, VerifyFn(Viewer1Token, SuperUser)),
+    ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, Viewer2)),
+    ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, SuperUser)),
     %% superuser can change other's MFA
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, Viewer1)),
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, Viewer2)),
@@ -379,7 +379,7 @@ test_mfa(VerifyFn) ->
         {ok, #{actor := NamespacedSuperUser}},
         VerifyFn(NamespacedSuperToken, NamespacedSuperUser)
     ),
-    ?assertEqual({error, unauthorized_role}, VerifyFn(NamespacedSuperToken, Viewer1)),
+    ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(NamespacedSuperToken, Viewer1)),
     ok.
 
 %%--------------------------------------------------------------------
@@ -728,8 +728,8 @@ t_global_only_message_endpoints_reject_namespaced_actors(_) ->
         fun(HandlerInfo) ->
             lists:foreach(
                 fun(ActorContext) ->
-                    ?assertEqual(
-                        false,
+                    ?assertMatch(
+                        {error, _},
                         emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, ActorContext)
                     )
                 end,
@@ -778,8 +778,8 @@ assert_global_viewer_rbac(Req, #{method := get} = HandlerInfo) ->
         emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, global_viewer_actor_context())
     );
 assert_global_viewer_rbac(Req, HandlerInfo) ->
-    ?assertEqual(
-        false,
+    ?assertMatch(
+        {error, _},
         emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, global_viewer_actor_context())
     ).
 

--- a/apps/emqx_management/src/emqx_mgmt_api.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api.erl
@@ -6,7 +6,6 @@
 
 -include_lib("stdlib/include/qlc.hrl").
 -include_lib("emqx/include/emqx_config.hrl").
--include_lib("emqx_utils/include/emqx_http_api.hrl").
 -include("emqx_mgmt.hrl").
 
 -elvis([{elvis_style, dont_repeat_yourself, #{min_complexity => 100}}]).
@@ -43,8 +42,6 @@
     format_query_result/4,
     maybe_collect_total_from_tail_nodes/2
 ]).
-
--export([require_global_namespace_filter/2]).
 
 -ifdef(TEST).
 -include_lib("proper/include/proper.hrl").
@@ -810,22 +807,6 @@ b2i(Bin) when is_binary(Bin) ->
     binary_to_integer(Bin);
 b2i(Any) ->
     Any.
-
-%% Minirest filter: reject requests whose authenticated actor is bound to a
-%% non-global namespace. Used on endpoints that expose MQTT message content
-%% (mqueue/inflight/retained/delayed payloads, trace logs) which would
-%% otherwise leak across tenants.
--spec require_global_namespace_filter(Req, map()) ->
-    {ok, Req} | {403, map()}
-when
-    Req :: emqx_dashboard:request().
-require_global_namespace_filter(Req, _Meta) ->
-    case emqx_dashboard:get_namespace(Req) of
-        ?global_ns ->
-            {ok, Req};
-        _ ->
-            ?FORBIDDEN(<<"This endpoint is not available to namespaced users">>)
-    end.
 
 %%--------------------------------------------------------------------
 %% EUnits

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1282,7 +1282,6 @@ unsubscribe_batch(#{clientid := ClientId, topics := Topics}) ->
 client_msgs_schema(OpId, Desc, ContExample, RespSchema) ->
     #{
         'operationId' => OpId,
-        filter => fun emqx_mgmt_api:require_global_namespace_filter/2,
         get => #{
             description => Desc,
             tags => ?TAGS,

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -15,6 +15,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
+-include_lib("emqx_utils/include/emqx_http_api.hrl").
 -include_lib("emqx_dashboard/include/emqx_dashboard_rbac.hrl").
 -include_lib("emqx/include/emqx_config.hrl").
 
@@ -293,11 +294,13 @@ check_rbac_and_scopes(Req, HandlerInfo, ApiKey, Role, Namespace, Extra) ->
     case check_rbac(Req, HandlerInfo, ApiKey, Role, Namespace) of
         {ok, ActorContext} ->
             case check_scopes(Extra, HandlerInfo) of
-                ok -> {ok, ActorContext};
-                {error, _} = Error -> Error
+                ok ->
+                    {ok, ActorContext};
+                {error, unauthorized_role} ->
+                    {error, {unauthorized_role, ?API_KEY_NOT_ALLOW_MSG}}
             end;
-        false ->
-            {error, unauthorized_role}
+        {error, Reason} when is_binary(Reason) ->
+            {error, {unauthorized_role, Reason}}
     end.
 
 find_by_api_key(ApiKey) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -620,12 +620,12 @@ t_bootstrap_file_scope_runtime_check(_) ->
         {ok, _},
         auth_authorize(BannedPath, <<"scope-conn-only">>, <<"secret-1">>)
     ),
-    ?assertEqual(
-        {error, unauthorized_role},
+    ?assertMatch(
+        {error, {unauthorized_role, _}},
         auth_authorize(PublishPath, <<"scope-conn-only">>, <<"secret-1">>)
     ),
-    ?assertEqual(
-        {error, unauthorized_role},
+    ?assertMatch(
+        {error, {unauthorized_role, _}},
         auth_authorize(StatusPath, <<"scope-conn-only">>, <<"secret-1">>)
     ),
 
@@ -656,17 +656,17 @@ t_bootstrap_file_scope_runtime_check(_) ->
     update_file(File),
 
     %% Mapped paths under `connections' / `publish' scopes — denied.
-    ?assertEqual(
-        {error, unauthorized_role},
+    ?assertMatch(
+        {error, {unauthorized_role, _}},
         auth_authorize(BannedPath, <<"scope-empty">>, <<"secret-3">>)
     ),
-    ?assertEqual(
-        {error, unauthorized_role},
+    ?assertMatch(
+        {error, {unauthorized_role, _}},
         auth_authorize(PublishPath, <<"scope-empty">>, <<"secret-3">>)
     ),
     %% `/status' is mapped to `system' scope — also denied.
-    ?assertEqual(
-        {error, unauthorized_role},
+    ?assertMatch(
+        {error, {unauthorized_role, _}},
         auth_authorize(StatusPath, <<"scope-empty">>, <<"secret-3">>)
     ),
     %% Unmapped path: there should not be any in the management app at the

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -2020,9 +2020,9 @@ t_list_clients_v2_bad_query_string_parameters(Config) ->
 
 -doc """
 Namespaced users (administrator or viewer) must not be able to read MQTT
-message content via the per-client mqueue / inflight endpoints. The
-filter is wired at the schema level, so we use a bogus clientid: 403
-confirms the gate fires before the handler resolves the client, 404
+message content via the per-client mqueue / inflight endpoints. RBAC owns
+this whole-endpoint restriction, so we use a bogus clientid: 403 confirms
+the request is rejected before the handler resolves the client, while 404
 would mean the request leaked through.
 """.
 t_namespaced_user_message_endpoints(TCConfig0) ->

--- a/apps/emqx_modules/src/emqx_delayed_api.erl
+++ b/apps/emqx_modules/src/emqx_delayed_api.erl
@@ -90,7 +90,6 @@ schema("/mqtt/delayed") ->
 schema("/mqtt/delayed/messages/:topic") ->
     #{
         'operationId' => delayed_message_topic,
-        filter => fun emqx_mgmt_api:require_global_namespace_filter/2,
         delete => #{
             tags => ?API_TAG_MQTT,
             description => ?DESC(delete_api),
@@ -117,7 +116,6 @@ schema("/mqtt/delayed/messages/:topic") ->
 schema("/mqtt/delayed/messages/:node/:msgid") ->
     #{
         'operationId' => delayed_message,
-        filter => fun emqx_mgmt_api:require_global_namespace_filter/2,
         get => #{
             tags => ?API_TAG_MQTT,
             description => ?DESC(get_message_api),
@@ -168,7 +166,6 @@ schema("/mqtt/delayed/messages/:node/:msgid") ->
 schema("/mqtt/delayed/messages") ->
     #{
         'operationId' => delayed_messages,
-        filter => fun emqx_mgmt_api:require_global_namespace_filter/2,
         get => #{
             tags => ?API_TAG_MQTT,
             description => ?DESC(list_api),

--- a/apps/emqx_modules/test/emqx_delayed_api_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_delayed_api_SUITE.erl
@@ -263,10 +263,9 @@ t_large_payload(_) ->
 -doc """
 Namespaced users (admin or viewer) must not be able to reach the delayed
 message endpoints, because the delayed store is global and `GET` returns
-the message `payload`. The minirest filter is wired at the schema level,
-so all methods on those paths return `403` -- including the `DELETE`
-variants that would let a namespaced caller drop other-namespace delayed
-messages.
+the message `payload`. RBAC owns this whole-endpoint restriction, so all
+methods on those paths return `403` -- including the `DELETE` variants
+that would let a namespaced caller drop other-namespace delayed messages.
 """.
 t_namespaced_user_forbidden(_Config) ->
     Topic = <<"some/topic">>,

--- a/apps/emqx_retainer/src/emqx_retainer_api.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_api.erl
@@ -66,7 +66,6 @@ schema(?PREFIX) ->
 schema(?PREFIX ++ "/messages") ->
     #{
         'operationId' => '/messages',
-        filter => fun emqx_mgmt_api:require_global_namespace_filter/2,
         get => #{
             tags => ?TAGS,
             description => ?DESC(list_retained_api),
@@ -90,7 +89,6 @@ schema(?PREFIX ++ "/messages") ->
 schema(?PREFIX ++ "/message/:topic") ->
     #{
         'operationId' => with_topic_warp,
-        filter => fun emqx_mgmt_api:require_global_namespace_filter/2,
         get => #{
             tags => ?TAGS,
             description => ?DESC(lookup_api),

--- a/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
@@ -492,15 +492,14 @@ t_retained_sys_messages(_Config) ->
 -doc """
 Namespaced users (admin or viewer) must not be able to reach the retained
 message endpoints, because the retained store is global and exposes MQTT
-payloads from other namespaces. The minirest filter is wired at the
-schema level, so all methods on those paths return `403` -- including
-the `DELETE` variants that would let a namespaced caller wipe other-
-namespace retained messages.
+payloads from other namespaces. RBAC owns this whole-endpoint restriction,
+so all methods on those paths return `403` -- including the `DELETE`
+variants that would let a namespaced caller wipe other-namespace retained
+messages.
 """.
 t_namespaced_user_forbidden(_Config) ->
     %% No slash in the topic so we don't have to URL-encode it just to
-    %% exercise the schema-level filter; the gate fires before any
-    %% topic parsing happens.
+    %% exercise the RBAC gate; it fires before any topic parsing happens.
     Topic = <<"sometopic">>,
     lists:foreach(
         fun(AuthHeader) ->


### PR DESCRIPTION
unify rbac control for namespace admin/api-key over api endpoints

a follow up of https://github.com/emqx/emqx/pull/17501
https://github.com/emqx/emqx/pull/17501#discussion_r3372412117