### PR TITLE
fix(redis): isolate Sentinel managers per resource

### DIFF
--- a/apps/emqx_redis/mix.exs
+++ b/apps/emqx_redis/mix.exs
@@ -26,7 +26,7 @@ defmodule EMQXRedis.MixProject do
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:eredis_cluster,
-       github: "emqx/eredis_cluster", ref: "34b55acb50f95fd6887c755d2b27b3170502d4e4"}
+       github: "emqx/eredis_cluster", ref: "32333e1cfae9fc16a2ba943048e1cfdc379c95d5"}
     ]
   end
 end

--- a/apps/emqx_redis/mix.exs
+++ b/apps/emqx_redis/mix.exs
@@ -25,7 +25,8 @@ defmodule EMQXRedis.MixProject do
     [
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
-      {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.8.12"}
+      {:eredis_cluster,
+       github: "emqx/eredis_cluster", ref: "34b55acb50f95fd6887c755d2b27b3170502d4e4"}
     ]
   end
 end

--- a/apps/emqx_redis/rebar.config
+++ b/apps/emqx_redis/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     %% NOTE: mind ecpool version when updating eredis_cluster version
-    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.8.12"}}},
+    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {ref, "34b55acb50f95fd6887c755d2b27b3170502d4e4"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.

--- a/apps/emqx_redis/rebar.config
+++ b/apps/emqx_redis/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     %% NOTE: mind ecpool version when updating eredis_cluster version
-    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {ref, "34b55acb50f95fd6887c755d2b27b3170502d4e4"}}},
+    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {ref, "32333e1cfae9fc16a2ba943048e1cfdc379c95d5"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.

--- a/apps/emqx_redis/src/emqx_redis.app.src
+++ b/apps/emqx_redis/src/emqx_redis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_redis, [
     {description, "EMQX Redis Database Connector"},
-    {vsn, "0.1.10"},
+    {vsn, "0.1.11"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_redis/src/emqx_redis.erl
+++ b/apps/emqx_redis/src/emqx_redis.erl
@@ -124,7 +124,8 @@ on_start(InstId, Config0) ->
     }),
     Config = config(Config0),
     #{pool_size := PoolSize, ssl := SSL, redis_type := Type} = Config,
-    Options = ssl_options(SSL) ++ [{sentinel, maps:get(sentinel, Config, undefined)}],
+    BaseOptions = ssl_options(SSL) ++ [{sentinel, maps:get(sentinel, Config, undefined)}],
+    Options = runtime_options(Type, InstId, BaseOptions),
     Opts =
         [
             {username, maps:get(username, Config, undefined)},
@@ -138,7 +139,7 @@ on_start(InstId, Config0) ->
     State = #{pool_name => InstId, type => Type},
     ok = emqx_resource:allocate_resource(InstId, ?MODULE, type, Type),
     ok = emqx_resource:allocate_resource(InstId, ?MODULE, pool_name, InstId),
-    case validate_sentinel_connection(Type, InstId, Config, Options) of
+    case validate_sentinel_connection(Type, InstId, Config, BaseOptions) of
         ok ->
             do_start(Type, InstId, Opts, State);
         {error, Reason} ->
@@ -159,8 +160,17 @@ do_start(_Type, InstId, Opts, State) ->
         ok ->
             {ok, State};
         {error, Reason} ->
+            ok = stop_sentinel_manager(State),
             {error, Reason}
     end.
+
+runtime_options(sentinel, InstId, Options) ->
+    [{sentinel_manager_ref, sentinel_manager_ref(InstId)} | Options];
+runtime_options(_Type, _InstId, Options) ->
+    Options.
+
+sentinel_manager_ref(InstId) ->
+    {?MODULE, InstId}.
 
 validate_sentinel_connection(sentinel, InstId, Config, Options) ->
     Servers = servers(Config),
@@ -252,6 +262,11 @@ on_stop(InstId, _State) ->
     }),
     Resources = emqx_resource:get_allocated_resources(InstId),
     ok = stop_sentinel_validation_client(Resources),
+    StopResult = stop_pool(Resources),
+    ok = stop_sentinel_manager(Resources),
+    StopResult.
+
+stop_pool(Resources) ->
     case Resources of
         #{pool_name := PoolName, type := cluster} ->
             case eredis_cluster:stop_pool(PoolName) of
@@ -264,6 +279,11 @@ on_stop(InstId, _State) ->
         _ ->
             ok
     end.
+
+stop_sentinel_manager(#{pool_name := PoolName, type := sentinel}) ->
+    eredis:stop_sentinel_manager(sentinel_manager_ref(PoolName));
+stop_sentinel_manager(_Resources) ->
+    ok.
 
 on_query(InstId, {cmd, _} = Query, State) ->
     do_query(InstId, Query, State);

--- a/apps/emqx_redis/test/emqx_redis_SUITE.erl
+++ b/apps/emqx_redis/test/emqx_redis_SUITE.erl
@@ -153,6 +153,47 @@ t_sentinel_auth_master_auth_sentinel_auth(_Config) ->
         sentinel_auth => password
     }).
 
+t_sentinel_resources_do_not_share_sentinel_state(_Config) ->
+    catch eredis_sentinel:stop(),
+    ResourceId1 = <<"emqx_redis_SUITE_sentinel_isolation_noauth">>,
+    ResourceId2 = <<"emqx_redis_SUITE_sentinel_isolation_auth">>,
+    Config1 = redis_config_sentinel_auth_matrix(
+        ?REDIS_SENTINEL_S_NO_AUTH_M_NO_AUTH_HOST,
+        none,
+        none
+    ),
+    Config2 = redis_config_sentinel_auth_matrix(
+        ?REDIS_SENTINEL_S_NO_AUTH_M_AUTH_HOST,
+        password,
+        none
+    ),
+    {ok, #{config := CheckedConfig1}} = emqx_resource:check_config(?REDIS_RESOURCE_MOD, Config1),
+    {ok, #{config := CheckedConfig2}} = emqx_resource:check_config(?REDIS_RESOURCE_MOD, Config2),
+    try
+        {ok, #{status := connected}} = emqx_resource:create_local(
+            ResourceId1,
+            ?CONNECTOR_RESOURCE_GROUP,
+            ?REDIS_RESOURCE_MOD,
+            CheckedConfig1,
+            #{spawn_buffer_workers => true}
+        ),
+        ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId1)),
+        ?assertEqual({ok, <<"PONG">>}, emqx_resource:query(ResourceId1, {cmd, [<<"PING">>]})),
+        {ok, #{status := connected}} = emqx_resource:create_local(
+            ResourceId2,
+            ?CONNECTOR_RESOURCE_GROUP,
+            ?REDIS_RESOURCE_MOD,
+            CheckedConfig2,
+            #{spawn_buffer_workers => true}
+        ),
+        ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId2)),
+        ?assertEqual({ok, <<"PONG">>}, emqx_resource:query(ResourceId2, {cmd, [<<"PING">>]}))
+    after
+        catch emqx_resource:remove_local(ResourceId1),
+        catch emqx_resource:remove_local(ResourceId2),
+        catch eredis_sentinel:stop()
+    end.
+
 t_sentinel_dry_run_rejects_stale_sentinel_auth(_Config) ->
     ResourceId = <<"emqx_redis_SUITE_sentinel_dry_run_auth">>,
     GoodConfig = redis_config_sentinel_auth_matrix(

--- a/changes/ce/fix-redis-sentinel-manager-isolation.en.md
+++ b/changes/ce/fix-redis-sentinel-manager-isolation.en.md
@@ -1,0 +1,4 @@
+Fixed Redis Sentinel resources sharing one global Sentinel manager.  Multiple
+Redis Sentinel resources on the same node now keep independent Sentinel server
+lists and credentials, preventing one resource from connecting through another
+resource's Sentinel configuration.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/56

Release version: 5.10.4

## Summary

- Gives each Redis Sentinel connector resource its own runtime Sentinel manager by passing a per-resource `sentinel_manager_ref` to `eredis` and stopping that manager when the resource stops.
- Updates `emqx_redis` to consume the released `eredis_cluster` `0.9.0` tag, which depends on `eredis` `1.3.0`.
- Adds a regression CT case proving two Sentinel resources with different Sentinel endpoints/master credentials can coexist, and fixes the changelog filename for the PR sanity gate.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/fix-17521.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
