### PR TITLE
test(cm): stabilize open_session throttle flaky case

### DIFF
--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -579,10 +579,25 @@ t_open_session_throttled_on_inflight_local_cleanup(_) ->
     ChanInfo = ?ChanInfo,
     #{conninfo := ConnInfo} = ChanInfo,
     ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
-    ok = emqx_cm:register_channel(ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}),
-    ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
-    %% Idempotent cleanup in case cm pool didn't get there first.
-    ok = emqx_cm:do_unregister_channel({ClientId, DeadPid}).
+    %% Suspend emqx_cm so the {registered, DeadPid} cast from
+    %% register_channel sits in its mailbox: the monitor is not set up,
+    %% no DOWN fires, the cm-pool cleanup cannot race us, the chan-conn
+    %% row stays, and the throttle has the conditions it is meant to
+    %% detect.
+    ok = sys:suspend(emqx_cm),
+    try
+        ok = emqx_cm:register_channel(
+            ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}
+        ),
+        ?assertEqual(
+            {error, client_id_unavailable},
+            open_session(true, ClientInfo, ConnInfo)
+        )
+    after
+        ok = sys:resume(emqx_cm),
+        %% Idempotent cleanup in case cm pool didn't get there first.
+        ok = emqx_cm:do_unregister_channel({ClientId, DeadPid})
+    end.
 
 %% A stale local tombstone (registry row pointing at a dead pid that this
 %% node never registered) used to block the same clientid on this node


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Fix the flaky CT case `emqx_cm_SUITE:t_open_session_throttled_on_inflight_local_cleanup`.

The test registers a dead pid via `emqx_cm:register_channel/3` to simulate the in-flight cleanup race the throttle in `emqx_cm:drop_stale_local_rows/2` is meant to detect. `register_channel/3` inserts into `?CHAN_CONN_TAB` and then casts `{registered, ChanPid}` to the `emqx_cm` gen_server, which monitors the pid. Because the pid is already dead, the monitor immediately fires `DOWN`, the `emqx_cm` pool removes the `?CHAN_CONN_TAB` row, and by the time `open_session/3` reaches `do_get_chann_conn_mod/2` the row is gone. The throttle no longer triggers and `open_session/3` returns `{ok, _}` instead of the expected `{error, client_id_unavailable}`.

Suspend `emqx_cm` (`sys:suspend/1`) around `register_channel/3` + `open_session/3` so the `{registered, DeadPid}` cast stays in the mailbox. No monitor is set up, no `DOWN` fires, and the chan-conn row stays in place — the throttle observes the conditions it is designed to detect. `sys:resume/1` runs in the `after` clause so the gen_server is always restored, even if the assertion fails.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)