### PR TITLE
fix(mq): complete qos0 deliveries

### DIFF
--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -458,7 +458,9 @@ replay(ClientInfo, ReplayContext, Session) ->
     {ok, replies(), t()}.
 deliver(ClientInfo, Delivers, Session) ->
     Messages = enrich_delivers(ClientInfo, Delivers, Session),
-    ?IMPL(Session):deliver(ClientInfo, Messages, Session).
+    Ok = {ok, Replies, Session1} = ?IMPL(Session):deliver(ClientInfo, Messages, Session),
+    _ = on_replies_delivery_completed(Replies, ClientInfo, Session1),
+    Ok.
 
 %%--------------------------------------------------------------------
 
@@ -573,7 +575,14 @@ enrich_message(_ClientInfo, Msg, undefined, _UpgradeQoS) ->
     %% NOTE: only relevant for `common_timer_name()`
     | {ok, replies(), timeout(), t()}.
 handle_timeout(ClientInfo, Timer, Session) ->
-    ?IMPL(Session):handle_timeout(ClientInfo, Timer, Session).
+    case ?IMPL(Session):handle_timeout(ClientInfo, Timer, Session) of
+        {ok, Replies, Session1} = Ok ->
+            _ = on_replies_delivery_completed(Replies, ClientInfo, Session1),
+            Ok;
+        {ok, Replies, _Timeout, Session1} = Ok ->
+            _ = on_replies_delivery_completed(Replies, ClientInfo, Session1),
+            Ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Generic Messages

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -963,6 +963,9 @@ subscribe(_TopicFilter, _SubOpts = #{}, {?MODULE, Session0}) ->
 get_subscription(_TopicFilter, {?MODULE, _Session}) ->
     undefined.
 
+info(created_at, {?MODULE, _Session}) ->
+    0.
+
 handle_timeout(_ClientInfo, t1, {?MODULE, Session0}) ->
     Msg = emqx_message:make(<<"a/b">>, <<"t1">>),
     Session1 = maps:remove(t1, Session0),

--- a/apps/emqx_extsub/src/emqx_extsub.erl
+++ b/apps/emqx_extsub/src/emqx_extsub.erl
@@ -111,7 +111,7 @@ inspect(ChannelPid) ->
 on_message_delivered(_ClientInfo, Msg) ->
     ?tp_debug(extsub_message_delivered, #{message => Msg}),
     emqx_extsub_metrics:inc(delivered_messages),
-    case emqx_message:qos(Msg) =:= ?QOS_0 orelse (not can_receive_acks()) of
+    case emqx_message:qos(Msg) =/= ?QOS_0 andalso (not can_receive_acks()) of
         true ->
             ok = on_delivered(Msg, undefined);
         false ->

--- a/apps/emqx_extsub/test/emqx_extsub_SUITE.erl
+++ b/apps/emqx_extsub/test/emqx_extsub_SUITE.erl
@@ -143,3 +143,37 @@ test_smoke(_Config, NBatches, BatchSize, IntervalMs) ->
     }),
     ?assertEqual(ExpectedMessages, length(Msgs)),
     ok = emqtt:disconnect(CSub).
+
+%% Test that session's QoS0 fallback for `delivery.completed` does
+%% not interfere with extsubs's fallback.
+%%
+%% Previously, there was an issue where extsubs's fallback counted a message
+%% as delivered in `message.delivered` and then once more in `delivery.completed`.
+t_qos0_not_double_completed(_Config) ->
+    ClientId = <<"qos0-not-double-completed">>,
+    TopicFilter = <<"extsub_st_test/qos0/1/5/0">>,
+    CSub = emqx_extsub_test_utils:emqtt_connect([
+        {clientid, ClientId},
+        {clean_start, true}
+    ]),
+    [ChanPid] = emqx_cm:lookup_channels(ClientId),
+    ok = emqx_extsub_test_utils:emqtt_subscribe(CSub, TopicFilter),
+    {ok, Msgs} = emqx_extsub_test_utils:emqtt_drain(5, 5000),
+    ?assertEqual(5, length(Msgs)),
+    ?retry(
+        100,
+        20,
+        begin
+            {ok, #{
+                registry := #{
+                    buffer := #{
+                        message_buffer_size := 0,
+                        delivering := Delivering
+                    }
+                },
+                unacked_count := 0
+            }} = emqx_extsub:inspect(ChanPid),
+            ?assert(lists:all(fun(N) -> N =:= 0 end, maps:values(Delivering)))
+        end
+    ),
+    ok = emqtt:disconnect(CSub).

--- a/apps/emqx_extsub/test/emqx_extsub_test_st_handler.erl
+++ b/apps/emqx_extsub/test/emqx_extsub_test_st_handler.erl
@@ -136,7 +136,12 @@ make_messages(#{batch_size := BatchSize} = State, #fake_msg{n = BatchN}) ->
 
 make_message(#{topic_filter := TopicFilter} = _State, BatchN, I, _BatchSize) ->
     Body = iolist_to_binary(io_lib:format("fake msg batch_n=~p, n in batch=~p", [BatchN, I])),
-    emqx_message:make(<<"from">>, ?QOS_1, TopicFilter, Body).
+    QoS =
+        case TopicFilter of
+            <<"extsub_st_test/qos0/", _/binary>> -> ?QOS_0;
+            _ -> ?QOS_1
+        end,
+    emqx_message:make(<<"from">>, QoS, TopicFilter, Body).
 
 %% Toy buffer functions
 

--- a/apps/emqx_mq/test/emqx_mq_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_SUITE.erl
@@ -150,6 +150,36 @@ t_publish_and_consume_regular(Config) ->
     %% Clean up
     ok = emqtt:disconnect(CSub).
 
+%% Verify that QoS 0 queue subscriptions auto-ack messages in the MQ subscriber.
+t_qos0_subscription_auto_acks_mq_messages(Config) ->
+    LocalMaxInflight = 2,
+    _ = emqx_mq_test_utils:ensure_mq_created(#{
+        name => <<"qos0_auto_ack">>,
+        topic_filter => <<"t/#">>,
+        is_lastvalue => false,
+        dispatch_strategy => ?config(dispatch_strategy, Config),
+        local_max_inflight => LocalMaxInflight
+    }),
+
+    %% Populate the MQ with messages to exceed the local max inflight.
+    emqx_mq_test_utils:populate(LocalMaxInflight + 1, #{topic_prefix => <<"t/">>}),
+
+    %% Connect a subscriber and subscribe to the queue.
+    CSub = emqx_mq_test_utils:emqtt_connect([]),
+    {ok, _, [?QOS_0]} = emqtt:subscribe(
+        CSub, {<<"$queue/qos0_auto_ack/t/#">>, ?QOS_0}
+    ),
+
+    %% Drain the subscriber to receive all messages; without QoS 0 auto-ack,
+    %% this would receive only LocalMaxInflight messages.
+    {ok, Msgs} = emqx_mq_test_utils:emqtt_drain(
+        _MinMsg = LocalMaxInflight + 1, _Timeout = 1000
+    ),
+    ?assertEqual(LocalMaxInflight + 1, length(Msgs)),
+
+    %% Clean up
+    ok = emqtt:disconnect(CSub).
+
 %% Consume some history messages from a lastvalue queue
 t_publish_and_consume_lastvalue(Config) ->
     %% Create a lastvalue Queue

--- a/changes/ee/fix-17529.en.md
+++ b/changes/ee/fix-17529.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where QoS 0 messages delivered through Message Queue subscriptions could remain unacknowledged internally, causing the queue subscriber to stop receiving more messages after reaching its local inflight limit.


### PR DESCRIPTION
Port of https://github.com/emqx/emqx/pull/17515 for release-61.