### PR TITLE
feat(cluster_link): gate cluster linking behind non-community license

### DIFF
--- a/apps/emqx/src/emqx_cluster.erl
+++ b/apps/emqx/src/emqx_cluster.erl
@@ -9,7 +9,8 @@
     leave/0,
     force_leave/1,
     ensure_normal_mode/0,
-    ensure_singleton_mode/0
+    ensure_singleton_mode/0,
+    is_single_node_mode/0
 ]).
 
 %% RPC callback functions
@@ -70,6 +71,8 @@ can_i_join(_RequestingNode) ->
             ok
     end.
 
+%% @doc Returns `true' when this node runs under a community (single-node) license.
+-spec is_single_node_mode() -> boolean().
 is_single_node_mode() ->
     case application:get_env(emqx, cluster_mode, ?DEFAULT_MODE) of
         ?CLUSTER_MODE_SINGLE -> true;

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_api.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_api.erl
@@ -282,6 +282,8 @@ handle_create(Name, Params) ->
                     ?CREATED(redact(add_status(Name, Link)));
                 {error, already_exists} ->
                     ?LINK_ALREADY_EXISTS;
+                {error, single_node_license} ->
+                    ?BAD_REQUEST(single_node_license_message());
                 {error, Reason} ->
                     Message = emqx_utils:format("Create link failed: ~p", [redact(Reason)]),
                     ?BAD_REQUEST(Message)
@@ -303,6 +305,8 @@ handle_update(Name, Params0, OldLinkRaw) ->
             ?OK(redact(add_status(Name, Link)));
         {error, not_found} ->
             ?LINK_NOT_FOUND;
+        {error, single_node_license} ->
+            ?BAD_REQUEST(single_node_license_message());
         {error, Reason} ->
             Message = emqx_utils:format("Update link failed: ~p", [redact(Reason)]),
             ?BAD_REQUEST(Message)
@@ -318,6 +322,12 @@ handle_delete(Name) ->
             Message = list_to_binary(io_lib:format("Delete link failed: ~p", [Reason])),
             ?BAD_REQUEST(Message)
     end.
+
+single_node_license_message() ->
+    <<
+        "Cluster linking is not available under the community (single-node) license. "
+        "Load a non-community license and retry."
+    >>.
 
 handle_metrics(Name) ->
     Results = emqx_cluster_link_metrics:get_cluster_metrics(Name),

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_app.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_app.erl
@@ -6,6 +6,8 @@
 
 -behaviour(application).
 
+-include_lib("emqx/include/logger.hrl").
+
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
@@ -14,14 +16,40 @@ start(_StartType, _StartArgs) ->
     ok = emqx_cluster_link:register_external_broker(),
     ok = emqx_cluster_link:put_hook(),
     {ok, Sup} = emqx_cluster_link_sup:start_link(),
-    lists:foreach(
-        fun(LinkConf) ->
-            {ok, _} = emqx_cluster_link_sup:ensure_actor(LinkConf),
-            {ok, _} = emqx_cluster_link_mqtt:ensure_msg_fwd_resource(LinkConf)
-        end,
-        emqx_cluster_link_config:get_enabled_links()
-    ),
+    ok = start_configured_links(),
     {ok, Sup}.
+
+start_configured_links() ->
+    %% Cluster linking requires a non-community license. Under a community
+    %% (single-node) license, configured links stay inert until the license
+    %% is upgraded and a user toggles them via the REST API or dashboard.
+    case emqx_cluster:is_single_node_mode() of
+        true ->
+            warn_if_links_configured(),
+            ok;
+        false ->
+            lists:foreach(
+                fun(LinkConf) ->
+                    {ok, _} = emqx_cluster_link_sup:ensure_actor(LinkConf),
+                    {ok, _} = emqx_cluster_link_mqtt:ensure_msg_fwd_resource(LinkConf)
+                end,
+                emqx_cluster_link_config:get_enabled_links()
+            )
+    end.
+
+warn_if_links_configured() ->
+    case [Name || #{name := Name} <- emqx_cluster_link_config:get_enabled_links()] of
+        [] ->
+            ok;
+        Names ->
+            ?SLOG(warning, #{
+                msg => "cluster_link_disabled_no_license",
+                hint =>
+                    "cluster linking requires a non-community license; "
+                    "configured links are inactive on this node",
+                configured_links => Names
+            })
+    end.
 
 stop(_State) ->
     _ = emqx_cluster_link:delete_hook(),

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
@@ -248,22 +248,28 @@ pre_config_update(?LINKS_PATH, RawConf, RawConf) ->
 pre_config_update(?LINKS_PATH, {create, LinkRawConf}, OldRawConf) ->
     #{<<"name">> := Name} = LinkRawConf,
     maybe
+        ok ?= check_license([LinkRawConf]),
         undefined ?= find_link(Name, OldRawConf),
         NewRawConf0 = OldRawConf ++ [LinkRawConf],
         NewRawConf = convert_certs(maybe_increment_ps_actor_incr(NewRawConf0, OldRawConf)),
         {ok, NewRawConf}
     else
+        {error, _} = Err ->
+            Err;
         _ ->
             {error, already_exists}
     end;
 pre_config_update(?LINKS_PATH, {update, LinkRawConf}, OldRawConf) ->
     #{<<"name">> := Name} = LinkRawConf,
     maybe
+        ok ?= check_license([LinkRawConf]),
         {_Found, Front, Rear} ?= safe_take(Name, OldRawConf),
         NewRawConf0 = Front ++ [LinkRawConf] ++ Rear,
         NewRawConf = convert_certs(maybe_increment_ps_actor_incr(NewRawConf0, OldRawConf)),
         {ok, NewRawConf}
     else
+        {error, _} = Err ->
+            Err;
         not_found ->
             {error, not_found}
     end;
@@ -277,7 +283,29 @@ pre_config_update(?LINKS_PATH, {delete, Name}, OldRawConf) ->
             {error, not_found}
     end;
 pre_config_update(?LINKS_PATH, NewRawConf, OldRawConf) ->
-    {ok, convert_certs(maybe_increment_ps_actor_incr(NewRawConf, OldRawConf))}.
+    maybe
+        ok ?= check_license(NewRawConf),
+        {ok, convert_certs(maybe_increment_ps_actor_incr(NewRawConf, OldRawConf))}
+    end.
+
+%% Cluster linking requires a non-community license. Reject any config update
+%% that would enable a link when this node is running under a community
+%% (single-node) license. Disabling or deleting links is always allowed.
+check_license(RawLinks) ->
+    case emqx_cluster:is_single_node_mode() of
+        false ->
+            ok;
+        true ->
+            case lists:any(fun is_link_enabled/1, RawLinks) of
+                true -> {error, single_node_license};
+                false -> ok
+            end
+    end.
+
+%% `enable' defaults to `true' in the schema, so a raw link map without the
+%% key is treated as enabled.
+is_link_enabled(#{<<"enable">> := Enabled}) -> Enabled;
+is_link_enabled(#{}) -> true.
 
 post_config_update(?LINKS_PATH, _Req, Old, Old, _AppEnvs) ->
     ok;

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_license_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_license_SUITE.erl
@@ -19,15 +19,9 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    %% Disable the default MQTT listener so the suite can run on a host
-    %% where ports 1883/8083 are already taken.
     Apps = emqx_cth_suite:start(
         [
-            {emqx,
-                "listeners.tcp.default.enable = false\n"
-                "listeners.ssl.default.enable = false\n"
-                "listeners.ws.default.enable = false\n"
-                "listeners.wss.default.enable = false\n"},
+            emqx,
             emqx_conf,
             emqx_cluster_link
         ],

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_license_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_license_SUITE.erl
@@ -1,0 +1,160 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_cluster_link_license_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+%%
+
+suite() ->
+    [{timetrap, {seconds, 30}}].
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    %% Disable the default MQTT listener so the suite can run on a host
+    %% where ports 1883/8083 are already taken.
+    Apps = emqx_cth_suite:start(
+        [
+            {emqx,
+                "listeners.tcp.default.enable = false\n"
+                "listeners.ssl.default.enable = false\n"
+                "listeners.ws.default.enable = false\n"
+                "listeners.wss.default.enable = false\n"},
+            emqx_conf,
+            emqx_cluster_link
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{suite_apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    ok = set_mode(normal),
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
+
+init_per_testcase(_TC, Config) ->
+    ok = set_mode(normal),
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    ok = set_mode(normal),
+    cleanup_links(),
+    ok.
+
+%%
+
+-doc """
+Booting cluster_link under a community license leaves the supervisor up but
+does not spawn per-link actors, even when the config has enabled links.
+""".
+t_boot_under_community_license_skips_actors(_Config) ->
+    %% Configure an enabled link via the raw schema and bypass the gate by
+    %% writing to the config directly (simulating a config carried over from
+    %% before the license downgraded).
+    Link = link_raw(<<"lic_boot">>, true),
+    ok = write_links_directly([Link]),
+    ok = restart_app(singleton),
+    ?assertEqual([], routerepl_children()),
+    %% Re-booting under normal mode starts the actor.
+    ok = restart_app(normal),
+    ?assertMatch([_ | _], routerepl_children()).
+
+-doc "Creating an enabled link via the REST/config layer is rejected under community license.".
+t_reject_enabled_create_under_community(_Config) ->
+    ok = set_mode(singleton),
+    Link = link_raw(<<"lic_create">>, true),
+    ?assertEqual({error, single_node_license}, emqx_cluster_link_config:create_link(Link)).
+
+-doc "Updating a link to enabled is rejected; deleting/disabling is allowed.".
+t_reject_enable_toggle_under_community(_Config) ->
+    %% Start in normal mode so we can create a disabled link.
+    Link = link_raw(<<"lic_toggle">>, false),
+    {ok, _} = emqx_cluster_link_config:create_link(Link),
+    ok = set_mode(singleton),
+    ?assertEqual(
+        {error, single_node_license},
+        emqx_cluster_link_config:update_link(Link#{<<"enable">> => true})
+    ),
+    %% Toggling to disabled is allowed (it was disabled to begin with, but
+    %% the gate must accept it explicitly).
+    {ok, _} = emqx_cluster_link_config:update_link(Link#{<<"enable">> => false}),
+    %% Deleting is allowed too.
+    ?assertEqual(ok, emqx_cluster_link_config:delete_link(<<"lic_toggle">>)).
+
+-doc "After license upgrade, the user can toggle enable via the same REST path.".
+t_upgrade_license_then_enable(_Config) ->
+    ok = set_mode(singleton),
+    %% Disabled-link create is fine under community.
+    Link = link_raw(<<"lic_upgrade">>, false),
+    {ok, _} = emqx_cluster_link_config:create_link(Link),
+    %% Simulate a license upgrade.
+    ok = set_mode(normal),
+    %% Now the toggle goes through and the actor starts.
+    {ok, _} = emqx_cluster_link_config:update_link(Link#{<<"enable">> => true}),
+    ?assertMatch([_ | _], routerepl_children()).
+
+%%
+
+%% NOTE: `emqx_cluster:ensure_singleton_mode/0' resolves `?DEFAULT_MODE' which
+%% is defined as `normal' under the TEST profile, so we set the env directly
+%% to drive the gate from inside CT.
+set_mode(singleton) ->
+    application:set_env(emqx, cluster_mode, singleton),
+    ok;
+set_mode(normal) ->
+    application:set_env(emqx, cluster_mode, normal),
+    ok.
+
+restart_app(Mode) ->
+    _ = application:stop(emqx_cluster_link),
+    ok = set_mode(Mode),
+    {ok, _} = application:ensure_all_started(emqx_cluster_link),
+    ok.
+
+routerepl_children() ->
+    case whereis(emqx_cluster_link_sup) of
+        undefined ->
+            [];
+        Pid ->
+            %% Infrastructure children (`metrics', `bookkeeper',
+            %% `{extrouter, gc}') are always present; per-link routerepl
+            %% supervisors are added under the link's cluster name.
+            Infra = [metrics, bookkeeper, {extrouter, gc}],
+            [C || {Id, _, _, _} = C <- supervisor:which_children(Pid), not lists:member(Id, Infra)]
+    end.
+
+write_links_directly(RawLinks) ->
+    {ok, _} = emqx_conf:update(
+        [cluster, links],
+        RawLinks,
+        #{rawconf_with_defaults => true, override_to => cluster}
+    ),
+    ok.
+
+cleanup_links() ->
+    lists:foreach(
+        fun(#{name := Name}) ->
+            _ = emqx_cluster_link_config:delete_link(Name)
+        end,
+        emqx_cluster_link_config:get_links()
+    ).
+
+link_raw(Name, Enable) ->
+    #{
+        <<"name">> => Name,
+        <<"enable">> => Enable,
+        <<"server">> => <<"localhost:31883">>,
+        <<"topics">> => [<<"t/#">>],
+        <<"pool_size">> => 1,
+        <<"resource_opts">> => #{
+            <<"health_check_interval">> => 1000,
+            <<"worker_pool_size">> => 1
+        }
+    }.

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_license_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_license_SUITE.erl
@@ -55,10 +55,10 @@ t_boot_under_community_license_skips_actors(_Config) ->
     Link = link_raw(<<"lic_boot">>, true),
     ok = write_links_directly([Link]),
     ok = restart_app(singleton),
-    ?assertEqual([], routerepl_children()),
-    %% Re-booting under normal mode starts the actor.
+    ?assertEqual(#{}, link_resources()),
+    %% Re-booting under normal mode starts the resource.
     ok = restart_app(normal),
-    ?assertMatch([_ | _], routerepl_children()).
+    ?assertMatch(#{<<"lic_boot">> := _}, link_resources()).
 
 -doc "Creating an enabled link via the REST/config layer is rejected under community license.".
 t_reject_enabled_create_under_community(_Config) ->
@@ -90,9 +90,9 @@ t_upgrade_license_then_enable(_Config) ->
     {ok, _} = emqx_cluster_link_config:create_link(Link),
     %% Simulate a license upgrade.
     ok = set_mode(normal),
-    %% Now the toggle goes through and the actor starts.
+    %% Now the toggle goes through and the message forwarding resource starts.
     {ok, _} = emqx_cluster_link_config:update_link(Link#{<<"enable">> => true}),
-    ?assertMatch([_ | _], routerepl_children()).
+    ?assertMatch(#{<<"lic_upgrade">> := _}, link_resources()).
 
 %%
 
@@ -112,17 +112,8 @@ restart_app(Mode) ->
     {ok, _} = application:ensure_all_started(emqx_cluster_link),
     ok.
 
-routerepl_children() ->
-    case whereis(emqx_cluster_link_sup) of
-        undefined ->
-            [];
-        Pid ->
-            %% Infrastructure children (`metrics', `bookkeeper',
-            %% `{extrouter, gc}') are always present; per-link routerepl
-            %% supervisors are added under the link's cluster name.
-            Infra = [metrics, bookkeeper, {extrouter, gc}],
-            [C || {Id, _, _, _} = C <- supervisor:which_children(Pid), not lists:member(Id, Infra)]
-    end.
+link_resources() ->
+    emqx_cluster_link_mqtt:get_all_resources_local_v1().
 
 write_links_directly(RawLinks) ->
     {ok, _} = emqx_conf:update(

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -189,7 +189,11 @@ runtime_deps() ->
         {emqx_connector, fun(App) -> lists:prefix("emqx_bridge_", atom_to_list(App)) end},
         %% emqx_ds_builtin is an EE app
         {emqx_ds_backends, emqx_ds_builtin_raft},
-        {emqx_dashboard, emqx_license}
+        {emqx_dashboard, emqx_license},
+        %% Cluster link reads `emqx_cluster:is_single_node_mode/0' at boot to
+        %% decide whether to start configured links; the license checker is
+        %% what writes the underlying `cluster_mode' env, so it must boot first.
+        {emqx_cluster_link, emqx_license}
     ].
 
 sorted_reboot_apps(Apps) ->

--- a/changes/ee/feat-17530.en.md
+++ b/changes/ee/feat-17530.en.md
@@ -1,0 +1,3 @@
+Cluster linking now requires a non-community license.
+Under the default community license, configured links stay inactive (no message forwarding or route replication) and the REST API rejects attempts to enable a link with a clear hint to load a non-community license.
+Disabling and deleting links remain available so that legacy configuration can be tidied up. After upgrading the license, links can be enabled from the dashboard or REST API without restarting the node.


### PR DESCRIPTION
Release version:
6.0.3, 6.1.3, 6.2.2

## Summary

Cluster linking now requires a non-community license. The gate is at the actor layer, not at app boot:

- `emqx_cluster_link_app:start/2` always sets up the broker provider, routing hook and supervisor. Per-link actors are spawned only when `emqx_cluster:is_single_node_mode/0` returns `false`. Under a community license the configured links stay inert and a single warning is logged listing the link names that were left inactive.
- `emqx_cluster_link_config:pre_config_update/3` rejects `create` / `update` (and raw catch-all) requests that would result in any enabled link, returning `{error, single_node_license}`. `delete`/`disable` are always accepted.
- The REST handler maps `single_node_license` to a 400 with a clear message ("Cluster linking is not available under the community (single-node) license. Load a non-community license and retry.") instead of the generic "failed: <reason>" formatting.

After loading a non-community license, the user toggles existing links from disabled to enabled via REST/UI; no node restart is needed.

`emqx_cluster_link` now depends on `cluster_mode` having been written by `emqx_license_checker`. This is enforced by an explicit runtime dependency in `emqx_machine_boot:runtime_deps/0`, so the topsort always boots `emqx_license` first.

New CT suite `emqx_cluster_link_license_SUITE` covers:
- Boot under community with an enabled link configured → no per-link actor; re-boot under normal → actor present.
- `create_link` with `enable = true` under community → `single_node_license`.
- `update_link` to enabled under community → `single_node_license`; `disable` and `delete` still allowed.
- Simulated license upgrade → `update_link` to enabled succeeds and the actor starts.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)