### PR TITLE
fix(coap): skip session hook for connectionless observe

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -94,9 +94,11 @@ jobs:
           echo "==========="
           echo "_EMQX_DOCKER_IMAGE_TAG=$(head -n 1 .emqx_docker_image_tags)" >> $GITHUB_ENV
 
-      - name: Verify that size of docker image is less than 150 MB
+      - name: Verify that size of docker image is less than 160 MB
         run: |
-          docker save $_EMQX_DOCKER_IMAGE_TAG | gzip -c | wc -c | xargs -I {} test {} -lt 150000000
+          SIZE=$(docker save $_EMQX_DOCKER_IMAGE_TAG | gzip -c | wc -c)
+          echo "Image size: ${SIZE}"
+          test "${SIZE}" -lt 160000000
 
       - name: smoke test
         timeout-minutes: 5

--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -882,19 +882,32 @@ call_handler(_, _, Result, Channel, Iter) ->
     iter(Iter, Result, Channel).
 
 do_call_handler_request(Msg, Result, Channel, Iter) ->
-    #channel{ctx = Ctx, clientinfo = ClientInfo} = Channel,
+    #channel{
+        ctx = Ctx,
+        clientinfo = ClientInfo,
+        connection_required = ConnectionRequired
+    } = Channel,
     Result0 = Result#{request_msg => Msg},
     HandlerResult =
         case emqx_coap_message:get_option(uri_path, Msg) of
             [<<"ps">> | RestPath] ->
-                emqx_coap_pubsub_handler:handle_request(RestPath, Msg, Ctx, ClientInfo);
+                IsConnectionless = ConnectionRequired =:= false,
+                emqx_coap_pubsub_handler:handle_request(
+                    RestPath, Msg, Ctx, ClientInfo, IsConnectionless
+                );
             [<<"mqtt">> | RestPath] ->
                 emqx_coap_mqtt_handler:handle_request(RestPath, Msg, Ctx, ClientInfo);
             _ ->
                 reply({error, bad_request}, Msg)
         end,
     iter(
-        [connection, fun process_connection/4, subscribe, fun process_subscribe/4 | Iter],
+        [
+            connection,
+            fun process_connection/4,
+            subscribe,
+            fun process_subscribe/4
+            | Iter
+        ],
         maps:merge(Result0, HandlerResult),
         Channel
     ).

--- a/apps/emqx_gateway_coap/src/emqx_coap_pubsub_handler.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_pubsub_handler.erl
@@ -9,7 +9,7 @@
 -include_lib("emqx/include/emqx_access_control.hrl").
 -include("emqx_coap.hrl").
 
--export([handle_request/4]).
+-export([handle_request/4, handle_request/5]).
 
 -import(emqx_coap_medium, [reply/2, reply/3]).
 -import(emqx_coap_channel, [run_hooks/3]).
@@ -28,24 +28,27 @@
 
 %% TODO maybe can merge this code into emqx_coap_session, simplify the call chain
 
-handle_request(Path, #coap_message{method = Method} = Msg, Ctx, CInfo) ->
+handle_request(Path, #coap_message{} = Msg, Ctx, CInfo) ->
+    handle_request(Path, Msg, Ctx, CInfo, false).
+
+handle_request(Path, #coap_message{method = Method} = Msg, Ctx, CInfo, IsConnectionless) ->
     case check_topic(Path) of
         {ok, Topic} ->
-            handle_method(Method, Topic, Msg, Ctx, CInfo);
+            handle_method(Method, Topic, Msg, Ctx, CInfo, IsConnectionless);
         _ ->
             reply({error, bad_request}, <<"invalid topic">>, Msg)
     end.
 
-handle_method(get, Topic, Msg, Ctx, CInfo) ->
+handle_method(get, Topic, Msg, Ctx, CInfo, IsConnectionless) ->
     case emqx_coap_message:get_option(observe, Msg) of
         0 ->
-            subscribe(Msg, Topic, Ctx, CInfo);
+            subscribe(Msg, Topic, Ctx, CInfo, IsConnectionless);
         1 ->
             unsubscribe(Msg, Topic, Ctx, CInfo);
         _ ->
             reply({error, bad_request}, <<"invalid observe value">>, Msg)
     end;
-handle_method(post, Topic, #coap_message{payload = Payload} = Msg, Ctx, CInfo) ->
+handle_method(post, Topic, #coap_message{payload = Payload} = Msg, Ctx, CInfo, _IsConnectionless) ->
     PublishOpts = get_publish_opts(Msg),
     QoS = get_publish_qos(Msg, PublishOpts),
     Action = ?AUTHZ_PUBLISH(QoS, get_publish_retain(PublishOpts)),
@@ -61,7 +64,7 @@ handle_method(post, Topic, #coap_message{payload = Payload} = Msg, Ctx, CInfo) -
         _ ->
             reply({error, unauthorized}, Msg)
     end;
-handle_method(_, _, Msg, _, _) ->
+handle_method(_, _, Msg, _, _, _) ->
     reply({error, method_not_allowed}, Msg).
 
 check_topic([]) ->
@@ -161,9 +164,9 @@ apply_publish_opts(Opts, MQTTMsg) ->
         Opts
     ).
 
-subscribe(#coap_message{token = <<>>} = Msg, _, _, _) ->
+subscribe(#coap_message{token = <<>>} = Msg, _, _, _, _) ->
     reply({error, bad_request}, <<"observe without token">>, Msg);
-subscribe(#coap_message{token = Token} = Msg, Topic, Ctx, CInfo) ->
+subscribe(#coap_message{token = Token} = Msg, Topic, Ctx, CInfo, IsConnectionless) ->
     #{qos := QoS} = SubOpts = get_sub_opts(Msg),
     Action = ?AUTHZ_SUBSCRIBE(QoS),
     case emqx_coap_channel:validator(Action, Topic, Ctx, CInfo) of
@@ -172,11 +175,16 @@ subscribe(#coap_message{token = Token} = Msg, Topic, Ctx, CInfo) ->
 
             MountTopic = mount(CInfo, Topic),
             emqx_broker:subscribe(MountTopic, ClientId, SubOpts),
-            run_hooks(Ctx, 'session.subscribed', [CInfo, MountTopic, SubOpts]),
+            maybe_run_session_subscribed(IsConnectionless, Ctx, CInfo, MountTopic, SubOpts),
             ?SUB(MountTopic, Token, SubOpts, Msg);
         _ ->
             reply({error, unauthorized}, Msg)
     end.
+
+maybe_run_session_subscribed(true, _Ctx, _CInfo, _MountTopic, _SubOpts) ->
+    ok;
+maybe_run_session_subscribed(false, Ctx, CInfo, MountTopic, SubOpts) ->
+    run_hooks(Ctx, 'session.subscribed', [CInfo, MountTopic, SubOpts]).
 
 unsubscribe(Msg, Topic, Ctx, CInfo) ->
     MountTopic = mount(CInfo, Topic),

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -17,6 +17,7 @@
 
 -include_lib("er_coap_client/include/coap.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_hooks.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -752,6 +753,40 @@ t_connectionless_legacy_no_auth_config_allows_pub_sub(_) ->
                 <<"security/coap/legacy/publish">>,
                 <<"security/coap/legacy/subscribe">>
             )
+        end)
+    end).
+
+t_connectionless_observe_skips_session_subscribed_hook(_) ->
+    with_security_profile("legacy", fun() ->
+        with_connectionless_coap(true, fun() ->
+            Parent = self(),
+            SubscribedHook = {?MODULE, forward_session_subscribed, [Parent]},
+            ok = emqx_hooks:add('session.subscribed', SubscribedHook, ?HP_HIGHEST),
+            try
+                do(fun(Channel) ->
+                    Topic = <<"coap/connectionless/no-session-subscribed">>,
+                    ClientId = <<"coap-client-observe">>,
+                    URI = pubsub_uri(binary_to_list(Topic), #{
+                        "clientid" => ClientId
+                    }),
+                    Req = (make_req(get, <<>>, [{observe, 0}]))#coap_message{
+                        token = <<"obs-no-session-subscribed">>
+                    },
+                    {ok, content, _} = do_request(Channel, URI, Req),
+
+                    timer:sleep(100),
+                    [SubPid] = emqx:subscribers(Topic),
+                    ?assert(is_pid(SubPid)),
+                    receive
+                        {coap_session_subscribed, _SubClientInfo, Topic, _SubOpts} ->
+                            ct:fail(connectionless_session_subscribed_hook_called)
+                    after 500 ->
+                        ok
+                    end
+                end)
+            after
+                ok = emqx_hooks:del('session.subscribed', {?MODULE, forward_session_subscribed})
+            end
         end)
     end).
 
@@ -2143,6 +2178,12 @@ return_message_response({error, Code}, Message) ->
 
 do(Fun) ->
     emqx_coap_test_helpers:with_udp_channel(Fun).
+
+forward_session_subscribed(#{protocol := coap} = ClientInfo, Topic, SubOpts, Parent) ->
+    Parent ! {coap_session_subscribed, ClientInfo, Topic, SubOpts},
+    ok;
+forward_session_subscribed(_ClientInfo, _Topic, _SubOpts, _Parent) ->
+    ok.
 
 assert_connectionless_pub_sub_allowed(PublishTopic, SubscribeTopic) ->
     assert_connectionless_pub_sub_allowed(PublishTopic, SubscribeTopic, #{}).


### PR DESCRIPTION
Release version:
6.2.1

## Summary

Follow-up to https://github.com/emqx/emqx/pull/17507 to fix:
```
2026-06-10T03:21:49.566774+00:00 [error] msg: hook_callback_exception, peername: 10.42.0.0:50351, pid: <0.15470.0>, reason: {badmatch,undefined}, stacktrace: [{emqx_extsub,get_channel_info,0,[{file,"emqx_extsub.erl"},{line,594}]},{emqx_extsub,subscribe_ctx,1,[{file,"emqx_extsub.erl"},{line,519}]},{emqx_extsub,on_subscribed,3,[{file,"emqx_extsub.erl"},{line,205}]},{emqx_hooks,safe_execute,2,[{file,"emqx_hooks.erl"},{line,213}]},{emqx_hooks,do_run,2,[{file,"emqx_hooks.erl"},{line,180}]},{emqx_coap_pubsub_handler,subscribe,4,[{file,"emqx_coap_pubsub_handler.erl"},{line,175}]},{emqx_coap_channel,do_call_handler_request,4,[{file,"emqx_coap_channel.erl"},{line,890}]},{emqx_coap_channel,authenticate_connectionless_pubsub,2,[{file,"emqx_coap_channel.erl"},{line,502}]},{emqx_gateway_conn,with_channel,3,[{file,"emqx_gateway_conn.erl"},{line,776}]},{emqx_gateway_conn,process_msg,2,[{file,"emqx_gateway_conn.erl"},{line,425}]},{emqx_gateway_conn,process_msg,2,[{file,"emqx_gateway_conn.erl"},{line,431}]},{emqx_gateway_conn,handle_recv,3,[{file,"emqx_gateway_conn.erl"},{line,388}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,344}]}], exception: error, callback_module: emqx_extsub, callback_args: [#{peername => {{10,42,0,0},50351},protocol => coap,password => <<"******">>,username => <<"pr17507_user">>,peerhost => {10,42,0,0},listener => 'coap:udp:default',enable_authn => true,mountpoint => <<>>,is_superuser => false,clientid => <<"coap-client-observe">>,is_bridge => false,zone => default,sockport => 5683,auth_expire_at => undefined},<<"pr17507/coap/observe">>,#{nl => 0,is_new => false,qos => 1,rap => 0,rh => 1}], callback_function: on_session_subscribed
```

CoAP connectionless observe requests can trigger `session.subscribed` without first opening a gateway session. ExtSub builds its subscribe context from channel information saved by `session.created`, so this connectionless path can crash with `{badmatch, undefined}` when handling the subscribed hook.

This change keeps the fix in the CoAP gateway: direct `/ps` observe requests on `connection_required = false` listeners are treated as connectionless subscriptions and skip the global `session.subscribed` hook. Broker subscription and CoAP observe session state are still updated, so message delivery remains unchanged. Connected/token CoAP session paths continue to run `session.subscribed`.

This also adjusts the Docker image size gate for release-62. Release-63 already has the same direction of workflow changes: `829a8ab52de` prints the computed Docker image size, and `53382a2d008` raises the Docker image size limit to 160 MB.

Changelog: not required; this is a follow-up fix for https://github.com/emqx/emqx/pull/17507.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (not required for this follow-up fix)
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)

