### PR TITLE
fix(dashboard_sso): upgrade esaml for XXE protection

### DIFF
--- a/apps/emqx_dashboard_sso/mix.exs
+++ b/apps/emqx_dashboard_sso/mix.exs
@@ -26,7 +26,7 @@ defmodule EMQXDashboardSso.MixProject do
       {:emqx_ctl, in_umbrella: true},
       {:emqx_ldap, in_umbrella: true},
       {:emqx_dashboard, in_umbrella: true},
-      {:esaml, github: "emqx/esaml", tag: "v1.1.3"},
+      {:esaml, github: "emqx/esaml", tag: "v1.1.5"},
       {:oidcc, github: "emqx/oidcc", tag: "v3.2.0-1", manager: :rebar3},
     ]
   end

--- a/apps/emqx_dashboard_sso/rebar.config
+++ b/apps/emqx_dashboard_sso/rebar.config
@@ -4,6 +4,6 @@
 {deps, [
     {emqx_ldap, {path, "../../apps/emqx_ldap"}},
     {emqx_dashboard, {path, "../../apps/emqx_dashboard"}},
-    {esaml, {git, "https://github.com/emqx/esaml", {tag, "v1.1.3"}}},
+    {esaml, {git, "https://github.com/emqx/esaml", {tag, "v1.1.5"}}},
     {oidcc, {git, "https://github.com/emqx/oidcc.git", {tag, "v3.2.0-1"}}}
 ]}.

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
@@ -1,0 +1,71 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_dashboard_sso_saml_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("esaml/include/esaml.hrl").
+
+-define(SAML_HTTP_REDIRECT_BINDING,
+    <<"urn:oasis:names:tc:SAML:2.0:bindings:URL-Encoding:DEFLATE">>
+).
+
+all() ->
+    [
+        t_callback_rejects_xxe_response,
+        t_callback_rejects_deflate_xxe_response
+    ].
+
+t_callback_rejects_xxe_response(Config) ->
+    assert_callback_rejects_xxe_response(Config, undefined).
+
+t_callback_rejects_deflate_xxe_response(Config) ->
+    assert_callback_rejects_xxe_response(Config, ?SAML_HTTP_REDIRECT_BINDING).
+
+assert_callback_rejects_xxe_response(Config, SAMLEncoding) ->
+    SecretPath = filename:join(?config(priv_dir, Config), "xxe-secret.txt"),
+    Secret = <<"emqx_xxe_secret">>,
+    ok = file:write_file(SecretPath, Secret),
+
+    Body = saml_callback_body(SecretPath, SAMLEncoding),
+    SP = #esaml_sp{
+        consume_uri = "https://127.0.0.1:18083/api/v5/sso/saml/acs",
+        metadata_uri = "https://127.0.0.1:18083/api/v5/sso/saml/metadata",
+        idp_signs_envelopes = false,
+        idp_signs_assertions = false
+    },
+    State = #{sp => SP, dashboard_addr => <<"https://127.0.0.1:18083">>},
+
+    {error, Reason} = emqx_dashboard_sso_saml:callback(#{body => Body}, State),
+    ?assertMatch(<<"Access denied, assertion failed validation:\n{bad_decode,", _/binary>>, Reason),
+    ?assertEqual(nomatch, binary:match(Reason, Secret)).
+
+saml_callback_body(SecretPath, SAMLEncoding) ->
+    Xml = iolist_to_binary([
+        <<"<?xml version=\"1.0\"?>">>,
+        <<"<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file://">>,
+        SecretPath,
+        <<"\">]>\n">>,
+        <<"<samlp:Response ">>,
+        <<"xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" ">>,
+        <<"xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ">>,
+        <<"Version=\"2.0\" IssueInstant=\"2026-01-01T00:00:00Z\">">>,
+        <<"<saml:Issuer>&xxe;</saml:Issuer>">>,
+        <<"</samlp:Response>">>
+    ]),
+    Payload =
+        case SAMLEncoding of
+            undefined -> base64:encode(Xml);
+            ?SAML_HTTP_REDIRECT_BINDING -> base64:encode(zlib:zip(Xml))
+        end,
+    Query =
+        case SAMLEncoding of
+            undefined -> [{<<"SAMLResponse">>, Payload}];
+            _ -> [{<<"SAMLEncoding">>, SAMLEncoding}, {<<"SAMLResponse">>, Payload}]
+        end,
+    iolist_to_binary(uri_string:compose_query(Query)).

--- a/changes/ee/fix-17539.en.md
+++ b/changes/ee/fix-17539.en.md
@@ -1,0 +1,1 @@
+Upgraded the `esaml` dependency to `v1.1.5` to disable XML entity expansion when parsing SAML responses and metadata, preventing crafted SAML XML from expanding external or custom entities during SAML SSO processing.


### PR DESCRIPTION
Release version:
5.8.11

## Summary

This PR updates r58 to consume `emqx/esaml` `v1.1.5` for https://github.com/emqx/emqx-dev-team-tasks/issues/87.

- Upgrade `esaml` from `v1.1.3` to `v1.1.5` in `emqx_dashboard_sso`.
- Add SAML callback regression coverage for external XML entity payloads in both normal and DEFLATE encodings.
- Verified with `make ct-suite SUITE=apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl`: 2 ok, 0 failed.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
