### PR TITLE
fix(tls): resolve file:// passwords during SSL config validation

### DIFF
--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -368,7 +368,7 @@ ensure_ssl_file(Dir, KeyPath, SSL, MaybePem, Opts) ->
 
 do_ensure_ssl_file(Dir, RawDir, KeyPath, SSL, MaybePem, DryRun) ->
     Type = keypath_to_type(KeyPath),
-    Password = maps:get(password, SSL, maps:get(<<"password">>, SSL, undefined)),
+    Password = resolve_password(maps:get(password, SSL, maps:get(<<"password">>, SSL, undefined))),
     case is_pem(MaybePem) of
         true ->
             maybe
@@ -397,6 +397,15 @@ keypath_to_type(KeyPath) when is_list(KeyPath) ->
         _ ->
             undefined
     end.
+
+%% @doc Wrap a raw `<<"file://...">>' binary into a secret closure so that
+%% `emqx_secret:unwrap/1' at the use site resolves it to the file contents.
+%% Pre-config-update validation runs before the schema converter, so the
+%% password value in `RawConf' may still be a literal `file://' string here.
+resolve_password(<<"file://", _/binary>> = Bin) ->
+    emqx_schema_secret:convert_secret(Bin, #{});
+resolve_password(Other) ->
+    Other.
 
 is_valid_string(Empty) when Empty == <<>>; Empty == "" -> false;
 is_valid_string(String) when is_list(String) ->
@@ -574,7 +583,7 @@ do_drop_invalid_certs([], SSL) ->
     SSL;
 do_drop_invalid_certs([KeyPath | KeyPaths], SSL) ->
     Type = keypath_to_type(KeyPath),
-    Password = maps:get(password, SSL, maps:get(<<"password">>, SSL, undefined)),
+    Password = resolve_password(maps:get(password, SSL, maps:get(<<"password">>, SSL, undefined))),
     case emqx_utils_maps:deep_get(KeyPath, SSL, undefined) of
         undefined ->
             do_drop_invalid_certs(KeyPaths, SSL);

--- a/apps/emqx/test/emqx_tls_lib_tests.erl
+++ b/apps/emqx/test/emqx_tls_lib_tests.erl
@@ -943,6 +943,91 @@ password_file_test() ->
     ?assertEqual(T, PasswordResolved),
     ok.
 
+%% Reproduce https://github.com/emqx/emqx/issues/17523:
+%% `emqx ctl conf load --merge' runs `ensure_ssl_files_in_mutable_certs_dir' on
+%% RawConf BEFORE the schema converter wraps the password, so the password may
+%% still be a literal `<<"file://...">>' binary at validation time. The library
+%% must resolve it from disk, not treat the URL as the passphrase.
+ensure_ssl_files_resolves_file_url_password_test_() ->
+    {setup, setup_ssl_files(), fun cleanup_ssl_files/1, fun ensure_ssl_files_file_url_cases/1}.
+
+ensure_ssl_files_file_url_cases(Context) ->
+    #{
+        key := EncKey,
+        keyfile_path := KeyfilePath,
+        cert := Cert,
+        cacert := Cacert,
+        password := Password,
+        temp_dir := TmpDir
+    } = Context,
+    PwdFile = filename:join(TmpDir, "pwd.txt"),
+    ok = file:write_file(PwdFile, [Password, $\n]),
+    FileUrlBin = iolist_to_binary(["file://", PwdFile]),
+    [
+        {"raw file:// password resolved from PEM contents",
+            ?_test(
+                ?assertMatch(
+                    {ok, _},
+                    emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir("/tmp", #{
+                        <<"keyfile">> => EncKey,
+                        <<"certfile">> => Cert,
+                        <<"cacertfile">> => Cacert,
+                        <<"password">> => FileUrlBin
+                    })
+                )
+            )},
+        {"raw file:// password resolved from keyfile path",
+            ?_test(
+                ?assertMatch(
+                    {ok, _},
+                    emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir("/tmp", #{
+                        <<"keyfile">> => KeyfilePath,
+                        <<"certfile">> => Cert,
+                        <<"cacertfile">> => Cacert,
+                        <<"password">> => FileUrlBin
+                    })
+                )
+            )},
+        {"raw file:// password with wrong content fails as bad password",
+            ?_test(begin
+                WrongPwdFile = filename:join(TmpDir, "wrong-pwd.txt"),
+                ok = file:write_file(WrongPwdFile, <<"not-the-password">>),
+                WrongUrl = iolist_to_binary(["file://", WrongPwdFile]),
+                ?assertMatch(
+                    {error, #{
+                        reason := bad_password_or_invalid_keyfile,
+                        which_option := <<"keyfile">>
+                    }},
+                    emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir("/tmp", #{
+                        <<"keyfile">> => EncKey,
+                        <<"certfile">> => Cert,
+                        <<"cacertfile">> => Cacert,
+                        <<"password">> => WrongUrl
+                    })
+                )
+            end)},
+        {"raw file:// password pointing at non-existent file",
+            ?_test(begin
+                Missing = filename:join(TmpDir, "no-such-pwd-file"),
+                MissingUrl = iolist_to_binary(["file://", Missing]),
+                %% The secret-loader throw is currently swallowed by the
+                %% wrapping ?catching in der_decode_file; the user sees a
+                %% bad-password error rather than failed_to_read_secret_file.
+                ?assertMatch(
+                    {error, #{
+                        reason := bad_password_or_invalid_keyfile,
+                        which_option := <<"keyfile">>
+                    }},
+                    emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir("/tmp", #{
+                        <<"keyfile">> => EncKey,
+                        <<"certfile">> => Cert,
+                        <<"cacertfile">> => Cacert,
+                        <<"password">> => MissingUrl
+                    })
+                )
+            end)}
+    ].
+
 to_server_opts_test() ->
     VersionsAll = [tlsv1, 'tlsv1.1', 'tlsv1.2', 'tlsv1.3'],
     Versions13Only = ['tlsv1.3'],

--- a/changes/ee/fix-17540.en.md
+++ b/changes/ee/fix-17540.en.md
@@ -1,0 +1,4 @@
+Fixed a bug where setting `password = "file://..."` on an SSL listener caused
+config validation to fail with `bad_password_or_invalid_keyfile` when the
+keyfile was encrypted. The `file://` reference is now resolved during
+validation, not only at runtime.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.3, 6.2.2

## Summary

Fixes https://github.com/emqx/emqx/issues/17523.

\`emqx ctl conf load --merge\` runs \`emqx_listeners:pre_config_update\` →
\`emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir\` on RawConf **before** the
HOCON schema converter wraps secret-typed fields. With an encrypted keyfile
and \`password = \"file:///path/to/secret\"\`, the literal binary
\`<<\"file:///path/to/secret\">>\` was handed to \`public_key:pem_entry_decode\`
as the passphrase, so validation failed with
\`bad_password_or_invalid_keyfile\`. A literal in-line password worked, and
the runtime path worked too (the schema converter resolves \`file://\` once
HOCON checks complete) — only the pre-config-update validation pass was
broken.

\`apps/emqx/src/emqx_tls_lib.erl\` now wraps a raw \`<<\"file://...\">>\` binary
into the same secret closure \`emqx_schema_secret:convert_secret/2\` would
produce, so \`emqx_secret:unwrap\` at the use site reads the file. Already
wrapped funs, plain in-line passwords, and \`undefined\` pass through
unchanged. The helper is applied at both extraction sites
(\`do_ensure_ssl_file\` and \`do_drop_invalid_certs\`).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)