### PR TITLE
refactor(schema): drop unused value-injection path and edition branching

### DIFF
--- a/apps/emqx/src/emqx_schema_hooks.erl
+++ b/apps/emqx/src/emqx_schema_hooks.erl
@@ -10,22 +10,15 @@
     #{hookpoint() => [hocon_schema:field() | binary()]}.
 -callback injected_fields(term()) ->
     #{hookpoint() => [hocon_schema:field() | binary()]}.
--callback injected_values() ->
-    #{hookpoint() => term()}.
--callback injected_values(term()) ->
-    #{hookpoint() => term()}.
--optional_callbacks([injected_fields/0, injected_fields/1, injected_values/0, injected_values/1]).
+-optional_callbacks([injected_fields/0, injected_fields/1]).
 
 -export_type([hookpoint/0]).
 
 -define(HOOKPOINT_APPEND_PT_KEY(POINT_NAME), {?MODULE, fields, POINT_NAME}).
--define(HOOKPOINT_SET_PT_KEY(POINT_NAME), {?MODULE, value, POINT_NAME}).
 
 -export([
     list_injection_point/1,
     list_injection_point/2,
-    value_injection_point/1,
-    value_injection_point/2,
     inject_from_modules/1
 ]).
 
@@ -47,25 +40,11 @@ list_injection_point(PointName) ->
 list_injection_point(PointName, Default) ->
     persistent_term:get(?HOOKPOINT_APPEND_PT_KEY(PointName), Default).
 
--spec value_injection_point(hookpoint()) -> {ok, term()} | error.
-value_injection_point(PointName) ->
-    try persistent_term:get(?HOOKPOINT_SET_PT_KEY(PointName)) of
-        Val -> {ok, Val}
-    catch
-        error:badarg -> error
-    end.
-
--spec value_injection_point(hookpoint(), term()) -> term().
-value_injection_point(PointName, Default) ->
-    persistent_term:get(?HOOKPOINT_SET_PT_KEY(PointName), Default).
-
 -spec erase_injections() -> ok.
 erase_injections() ->
     lists:foreach(
         fun
             ({?HOOKPOINT_APPEND_PT_KEY(_) = Key, _}) ->
-                persistent_term:erase(Key);
-            ({?HOOKPOINT_SET_PT_KEY(_) = Key, _}) ->
                 persistent_term:erase(Key);
             (_) ->
                 ok
@@ -78,8 +57,6 @@ any_injections() ->
     lists:any(
         fun
             ({?HOOKPOINT_APPEND_PT_KEY(_), _}) ->
-                true;
-            ({?HOOKPOINT_SET_PT_KEY(_), _}) ->
                 true;
             (_) ->
                 false
@@ -95,14 +72,7 @@ inject_from_modules(Modules) ->
             #{},
             Modules
         ),
-    ok = inject_list_fields(maps:to_list(ListInjections)),
-    ValueInjections =
-        lists:foldl(
-            fun append_module_value_injections/2,
-            #{},
-            Modules
-        ),
-    ok = inject_value_fields(ValueInjections).
+    ok = inject_list_fields(maps:to_list(ListInjections)).
 
 %%--------------------------------------------------------------------
 %% Internal functions
@@ -130,15 +100,6 @@ append_module_list_injections(ModuleInjections, AllInjections) when is_map(Modul
         ModuleInjections
     ).
 
-append_module_value_injections(Module, AllInjections) when is_atom(Module) ->
-    Injections = call_if_defined(Module, injected_values, [], #{}),
-    append_module_value_injections(Injections, AllInjections);
-append_module_value_injections({Module, Options}, AllInjections) when is_atom(Module) ->
-    Injections = call_if_defined(Module, injected_values, [Options], #{}),
-    append_module_value_injections(Injections, AllInjections);
-append_module_value_injections(#{} = Injections, AllInjections) ->
-    maps:merge(AllInjections, Injections).
-
 inject_list_fields([]) ->
     ok;
 inject_list_fields([{PointName, Fields} | Rest]) ->
@@ -154,15 +115,8 @@ inject_list_fields(PointName, Fields) ->
     Key = ?HOOKPOINT_APPEND_PT_KEY(PointName),
     persistent_term:put(Key, Fields).
 
-inject_value(PointName, Value) ->
-    Key = ?HOOKPOINT_SET_PT_KEY(PointName),
-    persistent_term:put(Key, Value).
-
 any_list_injections(PointName) ->
     persistent_term:get(?HOOKPOINT_APPEND_PT_KEY(PointName), undefined) =/= undefined.
-
-inject_value_fields(Injections) ->
-    maps:foreach(fun inject_value/2, Injections).
 
 call_if_defined(Module, Function, Args, Default) ->
     %% Ensure module is loaded, especially when called from nodetool

--- a/apps/emqx_conf/src/emqx_conf_schema_inject.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema_inject.erl
@@ -7,26 +7,23 @@
 -export([schemas/0]).
 
 schemas() ->
-    schemas(emqx_release:edition()).
-
-schemas(Edition) ->
-    mria(Edition) ++
-        cluster_linking(Edition) ++
-        authn(Edition) ++
+    mria() ++
+        cluster_linking() ++
+        authn() ++
         authz() ++
-        bridges(Edition) ++
-        customized(Edition).
+        bridges() ++
+        customized().
 
-mria(ee) ->
+mria() ->
     [emqx_enterprise_schema].
 
-cluster_linking(ee) ->
+cluster_linking() ->
     [emqx_cluster_link_schema].
 
-authn(Edition) ->
-    [{emqx_authn_schema, authn_mods(Edition)}].
+authn() ->
+    [{emqx_authn_schema, authn_mods()}].
 
-authn_mods(ee) ->
+authn_mods() ->
     [
         emqx_authn_mnesia_schema,
         emqx_authn_mysql_schema,
@@ -58,7 +55,7 @@ authz_mods() ->
         emqx_authz_ldap_schema
     ].
 
-bridges(ee) ->
+bridges() ->
     [
         emqx_bridge_disk_log_connector_schema,
         emqx_bridge_mqtt_connector_schema,
@@ -66,5 +63,5 @@ bridges(ee) ->
     ].
 
 %% Add more schemas here.
-customized(_) ->
+customized() ->
     [].


### PR DESCRIPTION
Two small internal cleanups in the schema-injection area. No user-visible behaviour change.

- `emqx_schema_hooks`: remove the value-injection variant (`injected_values` callback, `value_injection_point` readers, and helpers). It had no implementations or readers anywhere in the codebase.
- `emqx_conf_schema_inject`: drop the `Edition` parameter and `(ee)` clauses. Only the `ee` edition ships, so the branching was dead code.