### PR TITLE
docs(backup_sync): clarify unsupported sensitive tables

### DIFF
--- a/plugins/emqx_backup_sync/README.md
+++ b/plugins/emqx_backup_sync/README.md
@@ -53,9 +53,11 @@ sync {
 }
 ```
 
-The configured API key must be allowed to access Data Backup endpoints on the
-primary cluster. `primary.api_key` and `primary.api_secret` can be set directly
-or as `file://` paths, for example `file:///etc/emqx/backup-sync-api-key`.
+The configured API key must be created on the primary cluster beforehand and
+must be allowed to access Data Backup endpoints. API keys cannot create or
+manage other API keys through the Dashboard API. `primary.api_key` and
+`primary.api_secret` can be set directly or as `file://` paths, for example
+`file:///etc/emqx/backup-sync-api-key`.
 
 Supported `sync.root_keys` values are `connectors`, `actions`, `sources`,
 `rule_engine`, `listeners`, `schema_registry`, `authentication`, and
@@ -70,9 +72,12 @@ By default, synchronization also includes the `banned`, `builtin_authn`, and
 `builtin_authz` table sets. These selected table sets are replaced on the
 secondary cluster. Set `sync.table_sets = []` when configuration-only
 synchronization is required. Supported `sync.table_sets` values are `banned`,
-`builtin_authn`, `builtin_authz`, `builtin_retainer`, `psk`, and `mt`. The
-primary Data Backup API does not include `dashboard_users` or `api_keys` when
-called with an API key.
+`builtin_authn`, `builtin_authz`, `builtin_retainer`, `psk`, and `mt`.
+
+Dashboard users and API keys are intentionally not supported by this plugin.
+The primary Data Backup API does not include `dashboard_users` or `api_keys`
+when called with an API key, and API-key callers cannot download or import
+backup archives that contain those table sets.
 
 ## CLI
 


### PR DESCRIPTION
Release version:
5.10.5

## Summary

This PR updates the EMQX Backup Sync README to clarify that the configured primary API key must be created ahead of time and that API keys cannot create or manage other API keys through the Dashboard API.

It also documents that Backup Sync intentionally does not support synchronizing Dashboard Users or API Keys. API-key Data Backup exports exclude `dashboard_users` and `api_keys`, and API-key callers cannot download or import backup archives that contain those table sets.

Checks run: `git diff --check`; `git show --check --stat --oneline HEAD`.

## PR Checklist

- ~The changes are covered with new or existing tests~
- ~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~
- ~Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)~
