### PR TITLE
fix(swagger): require ?DESC ref for operation summary derivation

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -624,6 +624,12 @@ generate_method_desc(Spec, Options) ->
     enforce_method_desc_policy(Spec),
     trans_tags(trans_summary(Spec, Spec, Options)).
 
+trans_summary(Spec = #{summary := ?DESC(_, _) = Struct}, _Hocon, Options) ->
+    %% Explicit i18n summary ref wins over auto-derivation from the
+    %% desc/description ref.  This is the escape hatch for operations
+    %% that need a static title but render their description dynamically.
+    Summary = resolve_i18n(<<"label">>, Struct, Options),
+    Spec#{summary => Summary};
 trans_summary(Spec = #{summary := _}, Hocon, Options) ->
     forbidden_summary_ref(Spec),
     trans_summary(maps:remove(summary, Spec), Hocon, Options);
@@ -753,22 +759,31 @@ forbidden_summary_ref(_Spec) ->
 -dialyzer({nowarn_function, forbidden_summary_ref/1}).
 missing_i18n_ref(Text) ->
     error({missing_i18n_ref, Text}).
-%% In production, explicit operation summary is forbidden. Summary must be
-%% derived from the same ?DESC(...) reference used by desc/description.
+%% In production, operation summary must be an i18n ?DESC(...) reference, never a
+%% literal binary.  A literal would bypass i18n and force every consumer (Redoc,
+%% SDK generators) to render the source-language string verbatim.
 forbidden_summary_ref(Spec) ->
     error({forbidden_summary_ref, Spec}).
 -endif.
 
 %% Policy for operation docs:
-%% 1) Tagged endpoint methods must not define summary in source.
-%% 2) Tagged endpoint methods must define desc/description so summary can be
-%%    derived from i18n label and description from i18n desc.
+%% 1) Tagged endpoint methods may declare `summary => ?DESC(M, S)' explicitly.
+%%    A literal binary summary is forbidden — i18n must flow through ?DESC.
+%% 2) Tagged endpoint methods without an explicit summary must define
+%%    desc/description as a ?DESC(...) ref so summary can be auto-derived
+%%    from the i18n `label' entry and description from the `desc' entry.
+%%    A raw binary description is forbidden because it leaves the operation
+%%    without a summary, and Redoc would fall back to truncating the
+%%    description as the title.
+enforce_method_desc_policy(#{tags := _, summary := ?DESC(_, _)}) ->
+    ok;
 enforce_method_desc_policy(#{tags := _, summary := _} = Spec) ->
     forbidden_summary_ref(Spec);
 enforce_method_desc_policy(#{tags := _} = Spec) ->
     case desc_struct(Spec) of
+        ?DESC(_, _) -> ok;
         undefined -> missing_i18n_ref(missing_operation_description);
-        _ -> ok
+        _ -> missing_i18n_ref(missing_desc_ref_for_summary)
     end;
 enforce_method_desc_policy(_Spec) ->
     ok.

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -310,7 +310,14 @@ production_api_modules() ->
     %% `reboot_apps/0' is the canonical EMQX umbrella business-app list
     %% and lets us load each one explicitly here.
     Apps = emqx_machine_boot:reboot_apps(),
-    lists:foreach(fun ensure_loaded/1, Apps),
+    AlreadyLoaded = [App || {App, _, _} <- application:loaded_applications()],
+    NewlyLoaded = [App || App <- Apps, ensure_loaded(App, AlreadyLoaded)],
+    %% `cth_suite' unloads the apps it started; we only need to
+    %% unload the ones we just loaded ourselves, so other code that
+    %% relies on the original load state isn't surprised.
+    emqx_common_test_helpers:on_exit(
+        fun() -> lists:foreach(fun application:unload/1, NewlyLoaded) end
+    ),
     AllModules = lists:flatten([app_modules(App) || App <- Apps]),
     [
         M
@@ -319,11 +326,22 @@ production_api_modules() ->
         implements_minirest_api(M)
     ].
 
-ensure_loaded(App) ->
-    case application:load(App) of
-        ok -> ok;
-        {error, {already_loaded, _}} -> ok;
-        {error, Other} -> ct:pal("Skip ~p: ~p", [App, Other])
+%% Returns true when this call actually loaded the app (so the caller
+%% knows to undo it later).
+ensure_loaded(App, AlreadyLoaded) ->
+    case lists:member(App, AlreadyLoaded) of
+        true ->
+            false;
+        false ->
+            case application:load(App) of
+                ok ->
+                    true;
+                {error, {already_loaded, _}} ->
+                    false;
+                {error, Other} ->
+                    ct:pal("Skip ~p: ~p", [App, Other]),
+                    false
+            end
     end.
 
 app_modules(App) ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -279,6 +279,114 @@ t_swagger_json(_Config) ->
     ?assertEqual([], BadTags, {non_string_tags_in_openapi_spec, BadTags}),
     ok.
 
+-doc """
+Every tagged operation in every production API module must carry a
+non-empty binary `summary'.  Without it, Redoc falls back to the first
+~50 chars of the description for the sidebar title and operation header,
+which silently truncates a complete sentence (e.g. `GET /banned' once
+surfaced "List all currently banned client IDs, usernames an").
+
+This guard is paired with the boot-time enforcement in
+`emqx_dashboard_swagger:enforce_method_desc_policy/1' so a future
+regression cannot ship even if the boot check is loosened.
+
+We walk production API modules directly via
+`emqx_dashboard_swagger:spec/2' instead of the live `/api-docs/swagger.json'
+spec, because the test build profile bundles test-SUITE modules into the
+dashboard app's module list and they pollute the live spec with
+intentionally permissive synthetic operations.
+""".
+t_swagger_summary_required(_Config) ->
+    Modules = production_api_modules(),
+    ?assert(length(Modules) > 30, {too_few_api_modules, length(Modules)}),
+    Missing = lists:flatmap(fun module_missing_summaries/1, Modules),
+    ?assertEqual([], Missing, {ops_missing_summary, Missing}).
+
+production_api_modules() ->
+    Apps = [App || {App, _, _} <- application:loaded_applications(), is_emqx_app(App)],
+    AllModules = lists:flatten([app_modules(App) || App <- Apps]),
+    [
+        M
+     || M <- AllModules,
+        not is_suite_module(M),
+        implements_minirest_api(M)
+    ].
+
+is_emqx_app(App) ->
+    case atom_to_list(App) of
+        "emqx" ++ _ -> true;
+        _ -> false
+    end.
+
+app_modules(App) ->
+    case application:get_key(App, modules) of
+        {ok, Modules} -> Modules;
+        undefined -> []
+    end.
+
+is_suite_module(Module) ->
+    case lists:reverse(atom_to_list(Module)) of
+        "ETIUS_" ++ _ -> true;
+        _ -> false
+    end.
+
+implements_minirest_api(Module) ->
+    try
+        Attrs = Module:module_info(attributes),
+        Behaviours =
+            proplists:get_all_values(behaviour, Attrs) ++
+                proplists:get_all_values(behavior, Attrs),
+        lists:member(minirest_api, lists:flatten(Behaviours))
+    catch
+        _:_ -> false
+    end.
+
+module_missing_summaries(Module) ->
+    try
+        {ApiSpec, _Components} = emqx_dashboard_swagger:spec(Module, #{check_schema => false}),
+        lists:flatmap(
+            fun({Path, MethodSpecs, _Refs, _Extras}) ->
+                missing_in_path(Module, Path, MethodSpecs)
+            end,
+            ApiSpec
+        )
+    catch
+        Class:Reason:Stack ->
+            ct:pal(
+                "Failed to introspect spec for ~p:~n~p:~p~n~p",
+                [Module, Class, Reason, Stack]
+            ),
+            [{Module, spec_introspection_failed, {Class, Reason}}]
+    end.
+
+missing_in_path(Module, Path, MethodSpecs) when is_map(MethodSpecs) ->
+    maps:fold(
+        fun(Method, OpSpec, Acc) ->
+            case is_op_spec(OpSpec) andalso has_tags(OpSpec) of
+                true ->
+                    case maps:get(summary, OpSpec, maps:get(<<"summary">>, OpSpec, undefined)) of
+                        S when is_binary(S), byte_size(S) > 0 ->
+                            Acc;
+                        Other ->
+                            [{Module, Path, Method, Other} | Acc]
+                    end;
+                false ->
+                    Acc
+            end
+        end,
+        [],
+        MethodSpecs
+    );
+missing_in_path(_Module, _Path, _Other) ->
+    [].
+
+is_op_spec(Spec) when is_map(Spec) -> true;
+is_op_spec(_) -> false.
+
+has_tags(#{tags := Tags}) -> is_list(Tags) andalso Tags =/= [];
+has_tags(#{<<"tags">> := Tags}) -> is_list(Tags) andalso Tags =/= [];
+has_tags(_) -> false.
+
 collect_non_string_tags(#{<<"paths">> := Paths}) ->
     maps:fold(
         fun(Path, Methods, Acc) ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -303,7 +303,14 @@ t_swagger_summary_required(_Config) ->
     ?assertEqual([], Missing, {ops_missing_summary, Missing}).
 
 production_api_modules() ->
-    Apps = [App || {App, _, _} <- application:loaded_applications(), is_emqx_app(App)],
+    %% Use `emqx_machine_boot:reboot_apps/0' rather than
+    %% `application:loaded_applications/0': the latter only sees apps
+    %% the SUITE happens to have loaded, so a future init_per_suite
+    %% trimming could silently shrink coverage to a handful of apps.
+    %% `reboot_apps/0' is the canonical EMQX umbrella business-app list
+    %% and lets us load each one explicitly here.
+    Apps = emqx_machine_boot:reboot_apps(),
+    lists:foreach(fun ensure_loaded/1, Apps),
     AllModules = lists:flatten([app_modules(App) || App <- Apps]),
     [
         M
@@ -312,10 +319,11 @@ production_api_modules() ->
         implements_minirest_api(M)
     ].
 
-is_emqx_app(App) ->
-    case atom_to_list(App) of
-        "emqx" ++ _ -> true;
-        _ -> false
+ensure_loaded(App) ->
+    case application:load(App) of
+        ok -> ok;
+        {error, {already_loaded, _}} -> ok;
+        {error, Other} -> ct:pal("Skip ~p: ~p", [App, Other])
     end.
 
 app_modules(App) ->

--- a/changes/ee/fix-17559.en.md
+++ b/changes/ee/fix-17559.en.md
@@ -1,1 +1,0 @@
-Tightened API spec generation to require an i18n description reference for every documented operation, so Redoc-rendered API documentation always has a proper title instead of falling back to a truncated description string. Any operation missing a `?DESC` reference now fails the build with a clear error.

--- a/changes/ee/fix-17559.en.md
+++ b/changes/ee/fix-17559.en.md
@@ -1,0 +1,1 @@
+Tightened API spec generation to require an i18n description reference for every documented operation, so Redoc-rendered API documentation always has a proper title instead of falling back to a truncated description string. Any operation missing a `?DESC` reference now fails the build with a clear error.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.3, 6.2.2

## Summary

OpenAPI operations in EMQX rely on a `?DESC(...)` reference in their
`description` field — the swagger generator resolves that reference's
`.label` to produce the operation's `summary`.  Without a summary,
Redoc falls back to the first ~50 characters of the description as the
sidebar / header title, which silently truncates the sentence (e.g.
older builds rendered `GET /banned` as
`List all currently banned client IDs, usernames an`).

The pre-existing boot-time check in
`emqx_dashboard_swagger:enforce_method_desc_policy/1` only caught two
classes of regression: a tagged operation with no description at all,
and a `?DESC` ref whose i18n entry was missing.  A tagged operation
whose `description` was a raw binary slipped through unnoticed: no
summary got derived, and the redoc-side truncation appeared at runtime.

This PR:

- Tightens `enforce_method_desc_policy/1` so a tagged operation must
  either declare `summary => ?DESC(M, S)` explicitly, or carry a
  `?DESC` `desc`/`description` ref that summary can be auto-derived
  from.  Raw binary descriptions on tagged ops now fail at boot with
  `{missing_i18n_ref, missing_desc_ref_for_summary}`.
- Teaches `trans_summary/3` to honour an explicit `summary => ?DESC(...)`
  ref, so operations with genuinely dynamic descriptions (e.g.
  `emqx_mgmt_api_configs` paths that interpolate the requested config
  root) can still pin a static, i18n-driven title.  Literal binary
  summaries remain forbidden in production.
- Adds a CT case `t_swagger_summary_required` that walks every
  production API module via `emqx_dashboard_swagger:spec/2` and asserts
  every tagged operation has a non-empty binary `summary`.  The check
  bypasses the live `/api-docs/swagger.json` endpoint because the test
  build profile bundles test-SUITE modules into the dashboard app's
  module list, polluting the live spec with intentionally permissive
  synthetic operations.

No source-level offenders were found in `release-60`; the existing
operations are all `?DESC`-clean and the user-reported truncation must
have been observed on an older deployment.  The change is a forward
guard against regressions.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to \`changes/ee/fix-17559.en.md\`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)