### PR TITLE
Implement security profiles and fail-closed behavior for authz

### DIFF
--- a/apps/emqx/mix.exs
+++ b/apps/emqx/mix.exs
@@ -6,7 +6,7 @@ defmodule EMQX.MixProject do
   def project do
     [
       app: :emqx,
-      version: "6.2.1",
+      version: "6.2.2",
       build_path: "../../_build",
       erlc_paths: erlc_paths(),
       erlc_options: [

--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -47,6 +47,7 @@ Returns policy depending on the current security profile.
     (mqtt_default_bind) -> loopback | any;
     (dashboard_http_default_bind) -> loopback | any;
     (authn_not_configured) -> allow | deny;
+    (authz_backend_failure) -> ignore | deny;
     (dashboard_unchanged_default_credentials) -> allow | deny.
 policy(mqtt_default_bind) ->
     case profile() of
@@ -61,6 +62,11 @@ policy(dashboard_http_default_bind) ->
 policy(authn_not_configured) ->
     case profile() of
         legacy -> allow;
+        hardened -> deny
+    end;
+policy(authz_backend_failure) ->
+    case profile() of
+        legacy -> ignore;
         hardened -> deny
     end;
 policy(dashboard_unchanged_default_credentials) ->

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -77,6 +77,7 @@
 ]).
 
 -export([clear_screen/0]).
+-export([set_security_profile/1, with_security_profile/2, clear_security_profile/0]).
 -export([with_mock/4, with_mock/5, with_mocks/2, with_mocks/3]).
 -export([
     on_exit/1,
@@ -120,6 +121,7 @@
 -export([seed_defaults_for_all_roots_namespaced_cluster/2]).
 
 -define(CERTS_PATH(CertName), filename:join(["etc", "certs", CertName])).
+-define(SECURITY_PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 -define(MQTT_SSL_CLIENT_CERTS, [
     {keyfile, ?CERTS_PATH("client-key.pem")},
@@ -1772,6 +1774,24 @@ capture_io_format(Fn) ->
             error(timeout)
         end,
     {Result, format_io_requests(Prints)}.
+
+with_security_profile(Profile, Fun) ->
+    set_security_profile(Profile),
+    try
+        Fun()
+    after
+        clear_security_profile()
+    end.
+
+set_security_profile(Profile) ->
+    os:putenv(?SECURITY_PROFILE_ENV_VAR, Profile),
+    emqx_security_profile:clear_profile(),
+    ok.
+
+clear_security_profile() ->
+    os:unsetenv(?SECURITY_PROFILE_ENV_VAR),
+    emqx_security_profile:clear_profile(),
+    ok.
 
 gl_sink(Owner, Acc) ->
     receive

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -27,26 +27,23 @@ end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(apps, Config)).
 
 init_per_testcase(t_legacy, Config) ->
-    os:putenv(?PROFILE_ENV_VAR, "legacy"),
-    emqx_security_profile:clear_profile(),
+    emqx_common_test_helpers:set_security_profile("legacy"),
     Config;
 init_per_testcase(t_hardened, Config) ->
-    os:putenv(?PROFILE_ENV_VAR, "hardened"),
-    emqx_security_profile:clear_profile(),
+    emqx_common_test_helpers:set_security_profile("hardened"),
     Config;
 init_per_testcase(_, Config) ->
     Config.
 
 end_per_testcase(_, _Config) ->
-    os:unsetenv(?PROFILE_ENV_VAR),
-    emqx_security_profile:clear_profile(),
-    ok.
+    emqx_common_test_helpers:clear_security_profile().
 
 t_legacy(_) ->
     {ok, _} = emqx:update_config([listeners], #{}),
 
     %% verify the mode itself
     ?assertEqual(legacy, emqx_security_profile:profile()),
+    ?assertEqual(ignore, emqx_security_profile:policy(authz_backend_failure)),
 
     %% Full defaults
     ?assertEqual({{0, 0, 0, 0}, 1883}, emqx:get_config([listeners, tcp, default, bind])),
@@ -83,6 +80,7 @@ t_hardened(_) ->
 
     %% verify the mode itself
     ?assertEqual(hardened, emqx_security_profile:profile()),
+    ?assertEqual(deny, emqx_security_profile:policy(authz_backend_failure)),
 
     %% Full defaults are secure in hardened profile
     ?assertEqual({{127, 0, 0, 1}, 1883}, emqx:get_config([listeners, tcp, default, bind])),

--- a/apps/emqx_auth/mix.exs
+++ b/apps/emqx_auth/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuth.MixProject do
   def project do
     [
       app: :emqx_auth,
-      version: "6.2.1",
+      version: "6.2.2",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
@@ -528,7 +528,6 @@ do_authorize(
                         Res
                 catch
                     Class:Reason:Stacktrace ->
-                        ok = inc_metrics(Type, nomatch),
                         ?SLOG(warning, #{
                             msg => "unexpected_error_in_authorize",
                             exception => Class,
@@ -536,7 +535,10 @@ do_authorize(
                             stacktrace => Stacktrace,
                             authorize_type => Type
                         }),
-                        error
+                        Res = emqx_authz_utils:backend_failure_result(),
+                        ok = inc_metrics(Type, Res),
+                        ok = log_trace(Res, Type, Module, Username, Topic, Action),
+                        Res
                 end,
             ?EXT_TRACE_ADD_ATTRS(#{'authz.result' => format_result(Result0)}),
             Result0
@@ -545,8 +547,6 @@ do_authorize(
     ),
 
     case Result of
-        error ->
-            do_authorize(Client, Action, Topic, SourceStates);
         nomatch ->
             do_authorize(Client, Action, Topic, SourceStates);
         ignore ->

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
@@ -610,8 +610,6 @@ log_trace(Res, Type, Module, Username, Topic, PubSub) ->
             })
     end.
 
-format_result(error) ->
-    error;
 format_result(nomatch) ->
     nomatch;
 format_result(ignore) ->

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
@@ -125,6 +125,12 @@ injected_fields(AuthzSchemaMods) ->
 
 authz_fields() ->
     [
+        {ignore_backend_failures,
+            hoconsc:mk(boolean(), #{
+                default => false,
+                desc => ?DESC(ignore_backend_failures),
+                importance => ?IMPORTANCE_HIDDEN
+            })},
         {builtin_record_count_refresh_interval,
             hoconsc:mk(emqx_schema:timeout_duration_ms(), #{
                 default => <<"1h">>,

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
@@ -4,8 +4,6 @@
 
 -module(emqx_authz_utils).
 
--feature(maybe_expr, enable).
-
 -include("emqx_authz.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
 
@@ -18,6 +16,7 @@
     update_config/2,
     vars_for_rule_query/2,
     authorize_with_row/6,
+    authz_backend_failure_policy/0,
     backend_failure_result/0,
     init_state/2,
     cleanup_resource_config/2
@@ -201,9 +200,21 @@ authorize_with_row(Type, Client, Action, Topic, ColumnNames, Row) ->
 
 -spec backend_failure_result() -> ignore | {matched, deny}.
 backend_failure_result() ->
-    case emqx_security_profile:policy(authz_backend_failure) of
+    case authz_backend_failure_policy() of
         ignore -> ignore;
         deny -> {matched, deny}
+    end.
+
+-spec authz_backend_failure_policy() -> ignore | deny.
+authz_backend_failure_policy() ->
+    case emqx_security_profile:policy(authz_backend_failure) of
+        deny ->
+            case emqx:get_config([authorization, ignore_backend_failures], false) of
+                true -> ignore;
+                false -> deny
+            end;
+        ignore ->
+            ignore
     end.
 
 -spec init_state(emqx_authz_source:source(), map()) -> emqx_authz_source:source_state().

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
@@ -18,6 +18,7 @@
     update_config/2,
     vars_for_rule_query/2,
     authorize_with_row/6,
+    backend_failure_result/0,
     init_state/2,
     cleanup_resource_config/2
 ]).
@@ -178,7 +179,7 @@ cached_simple_sync_query(CacheKey, ResourceID, Query) ->
     emqx_types:topic(),
     [binary()] | undefined,
     [binary()] | map()
-) -> nomatch | {matched, allow | deny | ignore}.
+) -> ignore | nomatch | {matched, allow | deny | ignore}.
 authorize_with_row(Type, Client, Action, Topic, ColumnNames, Row) ->
     try
         maybe
@@ -190,12 +191,19 @@ authorize_with_row(Type, Client, Action, Topic, ColumnNames, Row) ->
                 nomatch;
             {error, Reason0} ->
                 log_match_rule_error(Type, Row, Reason0),
-                nomatch
+                backend_failure_result()
         end
     catch
         throw:Reason1 ->
             log_match_rule_error(Type, Row, Reason1),
-            nomatch
+            backend_failure_result()
+    end.
+
+-spec backend_failure_result() -> ignore | {matched, deny}.
+backend_failure_result() ->
+    case emqx_security_profile:policy(authz_backend_failure) of
+        ignore -> ignore;
+        deny -> {matched, deny}
     end.
 
 -spec init_state(emqx_authz_source:source(), map()) -> emqx_authz_source:source_state().

--- a/apps/emqx_auth/src/emqx_authz/sources/emqx_authz_client_info.erl
+++ b/apps/emqx_auth/src/emqx_authz/sources/emqx_authz_client_info.erl
@@ -57,7 +57,7 @@ destroy(_Source) -> ok.
 %%        all => [TopicFilter]
 %%    }
 %%
-%% v2: (rules are checked in sequence, passthrough when no match)
+%% v2: (rules are checked in sequence, passthrough when no rules match)
 %%
 %%    [{
 %%        Permission :: emqx_authz_rule:permission_resolution(),

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
@@ -24,8 +24,6 @@
 ).
 -define(CONF_ROOT, ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_ATOM).
 -define(NOT_SUPERUSER, #{is_superuser => false}).
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
-
 -define(assertAuthSuccessForUser(User),
     ?assertMatch(
         {ok, _},
@@ -578,16 +576,16 @@ t_authn_not_configured_missing_chain(Config) when is_list(Config) ->
     ok = cleanup_authn_not_configured_chains(),
     ClientInfo = authn_not_configured_clientinfo(),
 
-    with_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         ?assertMatch({ok, _}, emqx_access_control:authenticate(ClientInfo))
     end),
-    with_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         ?assertEqual({error, not_authorized}, emqx_access_control:authenticate(ClientInfo))
     end),
     ok;
 t_authn_not_configured_missing_chain({'end', _Config}) ->
     ok = cleanup_authn_not_configured_chains(),
-    clear_security_profile().
+    emqx_common_test_helpers:clear_security_profile().
 
 t_authn_not_configured_empty_chain({'init', Config}) ->
     Config;
@@ -604,17 +602,17 @@ t_authn_not_configured_empty_chain(Config) when is_list(Config) ->
     {ok, _} = ?AUTHN:create_authenticator(ListenerID, AuthenticatorConfig),
     ClientInfo = authn_not_configured_clientinfo(),
 
-    with_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         ?assertMatch({ok, _}, emqx_access_control:authenticate(ClientInfo))
     end),
-    with_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         ?assertEqual({error, not_authorized}, emqx_access_control:authenticate(ClientInfo))
     end),
     ok;
 t_authn_not_configured_empty_chain({'end', _Config}) ->
     ok = cleanup_authn_not_configured_chains(),
     ok = ?AUTHN:deregister_provider({password_based, built_in_database}),
-    clear_security_profile().
+    emqx_common_test_helpers:clear_security_profile().
 
 %%=================================================================================
 %% Helpers fns
@@ -628,20 +626,6 @@ authn_not_configured_clientinfo() ->
         username => <<"bad">>,
         password => <<"any">>
     }.
-
-with_profile(Profile, Fun) ->
-    os:putenv(?PROFILE_ENV_VAR, Profile),
-    emqx_security_profile:clear_profile(),
-    try
-        Fun()
-    after
-        clear_security_profile()
-    end.
-
-clear_security_profile() ->
-    os:unsetenv(?PROFILE_ENV_VAR),
-    emqx_security_profile:clear_profile(),
-    ok.
 
 cleanup_authn_not_configured_chains() ->
     _ = ?AUTHN:delete_chain('tcp:default'),

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
@@ -472,6 +472,26 @@ t_pre_config_update_crash(_) ->
     ),
     ok = meck:unload(emqx_authz_fake_source).
 
+t_authorizer_crash_legacy_continues_chain(_) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        {Result, Calls} = authorize_with_crashing_http_and_allowing_redis(),
+        ?assertEqual(
+            allow,
+            Result
+        ),
+        ?assertEqual([http, redis], Calls)
+    end).
+
+t_authorizer_crash_hardened_denies_and_aborts_chain(_) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        {Result, Calls} = authorize_with_crashing_http_and_allowing_redis(),
+        ?assertEqual(
+            deny,
+            Result
+        ),
+        ?assertEqual([http], Calls)
+    end).
+
 t_get_enabled_authzs_none_enabled(_Config) ->
     ?assertEqual([], emqx_authz:get_enabled_authzs()).
 
@@ -824,3 +844,44 @@ t_mount_prefix_for_authz(_TCConfig) ->
     ),
     snabbkaffe:stop(),
     ok.
+
+authorize_with_crashing_http_and_allowing_redis() ->
+    TestPid = self(),
+    Ref = make_ref(),
+    ok = meck:new(emqx_authz_fake_source, [passthrough]),
+    try
+        ok = meck:expect(
+            emqx_authz_fake_source,
+            authorize,
+            fun
+                (_Client, _Action, _Topic, #{type := http}) ->
+                    TestPid ! {Ref, http},
+                    error(fake_authz_crash);
+                (_Client, _Action, _Topic, #{type := redis}) ->
+                    TestPid ! {Ref, redis},
+                    {matched, allow};
+                (Client, Action, Topic, Source) ->
+                    meck:passthrough([Client, Action, Topic, Source])
+            end
+        ),
+        {ok, _} = emqx_authz:update(?CMD_REPLACE, [?SOURCE_HTTP, ?SOURCE_REDIS]),
+        Result = emqx_access_control:authorize(
+            emqx_authz_test_lib:base_client_info(),
+            ?AUTHZ_PUBLISH,
+            <<"t">>
+        ),
+        {Result, collect_authz_calls(Ref)}
+    after
+        ok = meck:unload(emqx_authz_fake_source)
+    end.
+
+collect_authz_calls(Ref) ->
+    collect_authz_calls(Ref, []).
+
+collect_authz_calls(Ref, Acc) ->
+    receive
+        {Ref, Type} ->
+            collect_authz_calls(Ref, [Type | Acc])
+    after 0 ->
+        lists:reverse(Acc)
+    end.

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
@@ -492,6 +492,20 @@ t_authorizer_crash_hardened_denies_and_aborts_chain(_) ->
         ?assertEqual([http], Calls)
     end).
 
+t_authz_backend_failure_policy_override(_) ->
+    on_exit(fun() ->
+        {ok, _} = emqx:update_config([authorization, ignore_backend_failures], false)
+    end),
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        {ok, _} = emqx:update_config([authorization, ignore_backend_failures], false),
+        ?assertEqual(deny, emqx_authz_utils:authz_backend_failure_policy()),
+        ?assertEqual({matched, deny}, emqx_authz_utils:backend_failure_result()),
+
+        {ok, _} = emqx:update_config([authorization, ignore_backend_failures], true),
+        ?assertEqual(ignore, emqx_authz_utils:authz_backend_failure_policy()),
+        ?assertEqual(ignore, emqx_authz_utils:backend_failure_result())
+    end).
+
 t_get_enabled_authzs_none_enabled(_Config) ->
     ?assertEqual([], emqx_authz:get_enabled_authzs()).
 

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_file_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_file_SUITE.erl
@@ -12,8 +12,6 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
-
 -define(RAW_SOURCE, #{
     <<"type">> => <<"file">>,
     <<"enable">> => true,
@@ -216,14 +214,14 @@ t_security_profile(_Config) ->
         <<"rules">> => <<"{allow, {security_profile, legacy}, all, [\"t/#\"]}.">>
     }),
 
-    with_security_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         ?assertEqual(
             allow,
             emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t/1">>)
         )
     end),
 
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         ?assertEqual(
             deny,
             emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t/1">>)
@@ -363,13 +361,3 @@ setup_config(SpecialParams) ->
 
 stop_apps(Apps) ->
     lists:foreach(fun application:stop/1, Apps).
-
-with_security_profile(Profile, Fun) ->
-    os:putenv(?PROFILE_ENV_VAR, Profile),
-    emqx_security_profile:clear_profile(),
-    try
-        Fun()
-    after
-        os:unsetenv(?PROFILE_ENV_VAR),
-        emqx_security_profile:clear_profile()
-    end.

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_rule_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_rule_SUITE.erl
@@ -11,8 +11,6 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx_placeholder.hrl").
 
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
-
 -define(CLIENT_INFO_BASE, #{
     clientid => <<"test">>,
     username => <<"test">>,
@@ -691,7 +689,7 @@ t_match(_) ->
 
 t_security_profile_condition(_) ->
     Rule = emqx_authz_rule:compile({allow, {security_profile, legacy}, all, all}),
-    with_security_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         ?assertEqual(
             {matched, allow},
             emqx_authz_rule:match(
@@ -702,7 +700,7 @@ t_security_profile_condition(_) ->
             )
         )
     end),
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         ?assertEqual(
             nomatch,
             emqx_authz_rule:match(
@@ -846,15 +844,5 @@ client_info() ->
 
 client_info(Overrides) ->
     maps:merge(?CLIENT_INFO_BASE, Overrides).
-
-with_security_profile(Profile, Fun) ->
-    os:putenv(?PROFILE_ENV_VAR, Profile),
-    emqx_security_profile:clear_profile(),
-    try
-        Fun()
-    after
-        os:unsetenv(?PROFILE_ENV_VAR),
-        emqx_security_profile:clear_profile()
-    end.
 
 bin(X) -> iolist_to_binary(X).

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_test_lib.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_test_lib.erl
@@ -112,15 +112,18 @@ client_info(Overrides) ->
     maps:merge(base_client_info(), Overrides).
 
 run_checks(#{checks := Checks} = Case) ->
-    _ = setup_default_permission(Case),
-    ClientInfoOverrides = maps:get(client_info, Case, #{}),
-    ClientInfo = client_info(ClientInfoOverrides),
-    lists:foreach(
-        fun(Check) ->
-            run_check(ClientInfo, Check)
-        end,
-        Checks
-    ).
+    SecurityProfile = atom_to_list(maps:get(security_profile, Case, legacy)),
+    emqx_common_test_helpers:with_security_profile(SecurityProfile, fun() ->
+        _ = setup_default_permission(Case),
+        ClientInfoOverrides = maps:get(client_info, Case, #{}),
+        ClientInfo = client_info(ClientInfoOverrides),
+        lists:foreach(
+            fun(Check) ->
+                run_check(ClientInfo, Check)
+            end,
+            Checks
+        )
+    end).
 
 run_check(ClientInfo, Fun) when is_function(Fun, 0) ->
     run_check(ClientInfo, Fun());

--- a/apps/emqx_auth_http/src/emqx_authz_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authz_http.erl
@@ -96,10 +96,10 @@ authorize(
                                 content_type => ContentType,
                                 body => Body
                             }),
-                            nomatch;
+                            emqx_authz_utils:backend_failure_result();
                         {error, Reason} ->
                             ?tp(error, bad_authz_http_response, #{reason => Reason}),
-                            nomatch;
+                            emqx_authz_utils:backend_failure_result();
                         Result ->
                             {matched, Result}
                     end;
@@ -116,14 +116,14 @@ authorize(
                         resource => ResourceId,
                         reason => Reason
                     }),
-                    ignore
+                    emqx_authz_utils:backend_failure_result()
             end;
         {error, Reason} ->
             ?SLOG(error, #{
                 msg => "http_request_generation_failed",
                 reason => Reason
             }),
-            ignore
+            emqx_authz_utils:backend_failure_result()
     end.
 
 format_for_api(#{<<"headers">> := Headers} = Source) ->

--- a/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
@@ -14,7 +14,6 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(HTTP_PATH, "/authz/[...]").
-
 -define(AUTHZ_HTTP_RESP(Result, Req),
     cowboy_req:reply(
         200,
@@ -513,6 +512,48 @@ t_bad_response_content_type(TCConfig) ->
         end
     ).
 
+t_bad_response_content_type_legacy_ignores(TCConfig) ->
+    ClientInfo = #{
+        clientid => <<"client id">>,
+        username => <<"user name">>,
+        peerhost => {127, 0, 0, 1},
+        protocol => <<"MQTT">>,
+        mountpoint => <<"MOUNTPOINT">>,
+        zone => default,
+        listener => 'tcp:default',
+        cn => ?PH_CERT_CN_NAME,
+        dn => ?PH_CERT_SUBJECT
+    },
+    ok = setup_bad_response_content_type(TCConfig),
+    {ok, _} = emqx:update_config([authorization, no_match], allow),
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ?assertEqual(
+            allow,
+            emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t">>)
+        )
+    end).
+
+t_bad_response_content_type_hardened_denies(TCConfig) ->
+    ClientInfo = #{
+        clientid => <<"client id">>,
+        username => <<"user name">>,
+        peerhost => {127, 0, 0, 1},
+        protocol => <<"MQTT">>,
+        mountpoint => <<"MOUNTPOINT">>,
+        zone => default,
+        listener => 'tcp:default',
+        cn => ?PH_CERT_CN_NAME,
+        dn => ?PH_CERT_SUBJECT
+    },
+    ok = setup_bad_response_content_type(TCConfig),
+    {ok, _} = emqx:update_config([authorization, no_match], allow),
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ?assertEqual(
+            deny,
+            emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t">>)
+        )
+    end).
+
 %% Checks that we bump the correct metrics when we receive an error response
 t_bad_response(TCConfig) ->
     ok = setup_handler_and_config(
@@ -928,3 +969,26 @@ get_status_api() ->
 
 http_port_bin(TCConfig) ->
     integer_to_binary(?config(http_port, TCConfig)).
+
+setup_bad_response_content_type(TCConfig) ->
+    setup_handler_and_config(
+        TCConfig,
+        fun(Req0, State) ->
+            {ok, _PostVars, Req1} = cowboy_req:read_urlencoded_body(Req0),
+            Req = cowboy_req:reply(
+                200,
+                #{<<"content-type">> => <<"text/csv">>},
+                "hi",
+                Req1
+            ),
+            {ok, Req, State}
+        end,
+        #{
+            <<"method">> => <<"post">>,
+            <<"body">> => #{<<"username">> => <<"${username}">>},
+            <<"headers">> => #{
+                <<"accept">> => <<"text/plain">>,
+                <<"content-type">> => <<"application/json">>
+            }
+        }
+    ).

--- a/apps/emqx_auth_ldap/docker-ct
+++ b/apps/emqx_auth_ldap/docker-ct
@@ -1,1 +1,2 @@
+toxiproxy
 ldap

--- a/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
@@ -87,7 +87,7 @@ authorize(
                         reason => Reason,
                         ldap_entry => Entry
                     }),
-                    nomatch
+                    emqx_authz_utils:backend_failure_result()
             end;
         {error, Reason} ->
             ?SLOG(error, #{
@@ -95,7 +95,7 @@ authorize(
                 reason => emqx_utils:redact(Reason),
                 resource_id => ResourceId
             }),
-            nomatch
+            emqx_authz_utils:backend_failure_result()
     end.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_auth_ldap/test/emqx_authz_ldap_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authz_ldap_SUITE.erl
@@ -12,6 +12,9 @@
 
 -define(LDAP_HOST, "ldap").
 -define(LDAP_DEFAULT_PORT, 389).
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "ldap_tcp").
 
 all() ->
     emqx_authz_test_lib:all_with_table_case(?MODULE, t_run_case, cases()).
@@ -114,6 +117,68 @@ t_node_cache(_Config) ->
         emqx_auth_cache:metrics(?AUTHZ_CACHE)
     ).
 
+%% mqttuser0011 user has malformed ACL records
+%% so they should be denied in hardened mode
+t_invalid_acl_rules_legacy_ignores(_Config) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ok = setup_authz_source(),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        ?assertEqual(
+            allow,
+            emqx_access_control:authorize(
+                #{username => <<"mqttuser0011">>},
+                ?AUTHZ_PUBLISH,
+                <<"t">>
+            )
+        )
+    end).
+
+t_invalid_acl_rules_hardened_denies(_Config) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ok = setup_authz_source(),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        ?assertEqual(
+            deny,
+            emqx_access_control:authorize(
+                #{username => <<"mqttuser0011">>},
+                ?AUTHZ_PUBLISH,
+                <<"t">>
+            )
+        )
+    end).
+
+t_conn_error_legacy_ignores(_Config) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        setup_config(#{<<"server">> => <<"toxiproxy:389">>}),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                allow,
+                emqx_access_control:authorize(
+                    #{username => <<"mqttuser0001">>},
+                    ?AUTHZ_PUBLISH,
+                    <<"mqttuser0001/pub/1">>
+                )
+            )
+        end)
+    end).
+
+t_conn_error_hardened_denies(_Config) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        setup_config(#{<<"server">> => <<"toxiproxy:389">>}),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                deny,
+                emqx_access_control:authorize(
+                    #{username => <<"mqttuser0001">>},
+                    ?AUTHZ_PUBLISH,
+                    <<"mqttuser0001/pub/1">>
+                )
+            )
+        end)
+    end).
+
 %%------------------------------------------------------------------------------
 %% Case
 %%------------------------------------------------------------------------------
@@ -199,3 +264,12 @@ setup_config(SpecialParams) ->
 
 ldap_server() ->
     iolist_to_binary(io_lib:format("~s:~B", [?LDAP_HOST, ?LDAP_DEFAULT_PORT])).
+
+with_failure(FailureType, Fun) ->
+    emqx_common_test_helpers:with_failure(
+        FailureType,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        Fun
+    ).

--- a/apps/emqx_auth_ldap/test/emqx_authz_ldap_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authz_ldap_SUITE.erl
@@ -83,6 +83,7 @@ t_node_cache(_Config) ->
         %% but we just test that the filter's vars are used for caching
         <<"filter">> => <<"(objectClass=${cert_common_name})">>
     }),
+    ok = emqx_authz_test_lib:reset_node_cache(),
     ok = emqx_authz_test_lib:enable_node_cache(true),
 
     %% Subscribe to twice, should hit cache the second time

--- a/apps/emqx_auth_mongodb/docker-ct
+++ b/apps/emqx_auth_mongodb/docker-ct
@@ -1,1 +1,2 @@
+toxiproxy
 mongo

--- a/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
@@ -54,7 +54,7 @@ authorize(
                 msg => "mongo_authorize_error",
                 reason => EncodeError
             }),
-            nomatch
+            emqx_authz_utils:backend_failure_result()
     end.
 
 %%--------------------------------------------------------------------
@@ -103,7 +103,7 @@ authorize_with_filter(RenderedFilter, Client, Action, Topic, #{
                 options => Options,
                 resource_id => ResourceId
             }),
-            nomatch;
+            emqx_authz_utils:backend_failure_result();
         {ok, Rows} ->
             Rules = lists:flatmap(fun parse_rule/1, Rows),
             do_authorize(Client, Action, Topic, Rules)

--- a/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
@@ -15,6 +15,9 @@
 
 -define(MONGO_HOST, "mongo").
 -define(MONGO_CLIENT, 'emqx_authz_mongo_SUITE_client').
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "mongo_single_tcp").
 
 all() ->
     [
@@ -129,6 +132,80 @@ t_node_cache(_Config) ->
         #{hits := #{value := 1}, misses := #{value := 2}},
         emqx_auth_cache:metrics(?AUTHZ_CACHE)
     ).
+
+t_render_filter_failure_legacy_ignores(Config) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ok = setup_authz_source(#{
+            filter => #{<<"username">> => <<"${username}">>},
+            use_legacy_protocol => ?config(use_legacy_protocol, Config)
+        }),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        ?assertEqual(
+            allow,
+            emqx_access_control:authorize(
+                #{username => <<255>>},
+                ?AUTHZ_PUBLISH,
+                <<"a">>
+            )
+        )
+    end).
+
+t_render_filter_failure_hardened_denies(Config) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ok = setup_authz_source(#{
+            filter => #{<<"username">> => <<"${username}">>},
+            use_legacy_protocol => ?config(use_legacy_protocol, Config)
+        }),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        ?assertEqual(
+            deny,
+            emqx_access_control:authorize(
+                #{username => <<255>>},
+                ?AUTHZ_PUBLISH,
+                <<"a">>
+            )
+        )
+    end).
+
+t_resource_failure_legacy_ignores(Config) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ok = setup_authz_source(#{
+            filter => #{<<"username">> => <<"${username}">>},
+            use_legacy_protocol => ?config(use_legacy_protocol, Config),
+            settings => #{<<"server">> => <<"toxiproxy:27017">>}
+        }),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                allow,
+                emqx_access_control:authorize(
+                    emqx_authz_test_lib:base_client_info(),
+                    ?AUTHZ_PUBLISH,
+                    <<"a">>
+                )
+            )
+        end)
+    end).
+
+t_resource_failure_hardened_denies(Config) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ok = setup_authz_source(#{
+            filter => #{<<"username">> => <<"${username}">>},
+            use_legacy_protocol => ?config(use_legacy_protocol, Config),
+            settings => #{<<"server">> => <<"toxiproxy:27017">>}
+        }),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                deny,
+                emqx_access_control:authorize(
+                    emqx_authz_test_lib:base_client_info(),
+                    ?AUTHZ_PUBLISH,
+                    <<"a">>
+                )
+            )
+        end)
+    end).
 
 %%------------------------------------------------------------------------------
 %% Cases
@@ -512,6 +589,15 @@ mongo_config() ->
         {password, mongo_password()},
         {register, ?MONGO_CLIENT}
     ].
+
+with_failure(FailureType, Fun) ->
+    emqx_common_test_helpers:with_failure(
+        FailureType,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        Fun
+    ).
 
 mongo_authsource() ->
     iolist_to_binary(os:getenv("MONGO_AUTHSOURCE", "admin")).

--- a/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
@@ -71,7 +71,7 @@ authorize(
                 params => RenderedArgs,
                 resource_id => ResourceId
             }),
-            nomatch
+            emqx_authz_utils:backend_failure_result()
     end.
 
 %%--------------------------------------------------------------------
@@ -105,6 +105,8 @@ do_authorize(Client, Action, Topic, ColumnNames, [Row | Tail]) ->
     case emqx_authz_utils:authorize_with_row(mysql, Client, Action, Topic, ColumnNames, Row) of
         nomatch ->
             do_authorize(Client, Action, Topic, ColumnNames, Tail);
+        ignore ->
+            ignore;
         {matched, Permission} ->
             {matched, Permission}
     end.

--- a/apps/emqx_auth_mysql/test/emqx_authz_mysql_SUITE.erl
+++ b/apps/emqx_auth_mysql/test/emqx_authz_mysql_SUITE.erl
@@ -15,6 +15,9 @@
 
 -define(MYSQL_HOST, "mysql").
 -define(MYSQL_RESOURCE, <<"emqx_authz_mysql_SUITE">>).
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "mysql_tcp").
 
 -define(TABLE_TESTS, [t_run_case, t_run_case_with_disable_prepared_statements]).
 
@@ -89,6 +92,7 @@ t_create_invalid(_Config) ->
     [_] = emqx_authz:lookup_states().
 
 t_node_cache(_Config) ->
+    ok = emqx_authz_test_lib:reset_node_cache(),
     Case = #{
         name => cache_publish,
         setup => [
@@ -135,6 +139,38 @@ t_node_cache(_Config) ->
         #{hits := #{value := 1}, misses := #{value := 2}},
         emqx_auth_cache:metrics(?AUTHZ_CACHE)
     ).
+
+t_conn_error_legacy_ignores(_Config) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ok = setup_conn_error_source(),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                allow,
+                emqx_access_control:authorize(
+                    emqx_authz_test_lib:base_client_info(),
+                    ?AUTHZ_PUBLISH,
+                    <<"a">>
+                )
+            )
+        end)
+    end).
+
+t_conn_error_hardened_denies(_Config) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ok = setup_conn_error_source(),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                deny,
+                emqx_access_control:authorize(
+                    emqx_authz_test_lib:base_client_info(),
+                    ?AUTHZ_PUBLISH,
+                    <<"a">>
+                )
+            )
+        end)
+    end).
 
 %%------------------------------------------------------------------------------
 %% Cases
@@ -511,6 +547,23 @@ cases() ->
             checks => [
                 {deny, ?AUTHZ_PUBLISH, <<"a">>}
             ]
+        },
+        #{
+            name => invalid_rule_hardened_fail_closed,
+            security_profile => hardened,
+            default_permission => allow,
+            setup => [
+                """
+                CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255),
+                permission VARCHAR(255), action VARCHAR(255))
+                """,
+                %% 'permit' is invalid value for action
+                "INSERT INTO acl(username, topic, permission, action) VALUES('username', 'a', 'permit', 'publish')"
+            ],
+            query => <<"SELECT permission, action, topic FROM acl WHERE username = ${username}">>,
+            checks => [
+                {deny, ?AUTHZ_PUBLISH, <<"a">>}
+            ]
         }
     ].
 
@@ -533,6 +586,12 @@ setup_authz_source(#{query := Query}, SpecialParams) ->
             <<"query">> => Query
         }
     ).
+
+setup_conn_error_source() ->
+    ok = q(
+        "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), permission VARCHAR(255), action VARCHAR(255))"
+    ),
+    setup_config(#{<<"server">> => <<"toxiproxy:3306">>}).
 
 raw_mysql_authz_config() ->
     #{
@@ -571,6 +630,15 @@ setup_config(SpecialParams) ->
     emqx_authz_test_lib:setup_config(
         raw_mysql_authz_config(),
         SpecialParams
+    ).
+
+with_failure(FailureType, Fun) ->
+    emqx_common_test_helpers:with_failure(
+        FailureType,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        Fun
     ).
 
 mysql_config() ->

--- a/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
@@ -68,7 +68,7 @@ authorize(
                 params => RenderedParams,
                 resource_id => ResourceId
             }),
-            nomatch
+            emqx_authz_utils:backend_failure_result()
     end.
 
 %%--------------------------------------------------------------------
@@ -99,6 +99,8 @@ do_authorize(Client, Action, Topic, ColumnNames, [Row | Tail]) ->
     case emqx_authz_utils:authorize_with_row(postgresql, Client, Action, Topic, ColumnNames, Row) of
         nomatch ->
             do_authorize(Client, Action, Topic, ColumnNames, Tail);
+        ignore ->
+            ignore;
         {matched, Permission} ->
             {matched, Permission}
     end.

--- a/apps/emqx_auth_postgresql/test/emqx_authz_postgresql_SUITE.erl
+++ b/apps/emqx_auth_postgresql/test/emqx_authz_postgresql_SUITE.erl
@@ -13,6 +13,9 @@
 
 -define(PGSQL_HOST, "pgsql").
 -define(PGSQL_RESOURCE, <<"emqx_authz_pgsql_SUITE">>).
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "pgsql_tcp").
 
 -define(TABLE_TESTS, [t_run_case, t_run_case_with_disable_prepared_statements]).
 
@@ -137,6 +140,38 @@ t_node_cache(_Config) ->
         #{hits := #{value := 1}, misses := #{value := 2}},
         emqx_auth_cache:metrics(?AUTHZ_CACHE)
     ).
+
+t_conn_error_legacy_ignores(_Config) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ok = setup_conn_error_source(),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                allow,
+                emqx_access_control:authorize(
+                    emqx_authz_test_lib:base_client_info(),
+                    ?AUTHZ_PUBLISH,
+                    <<"a">>
+                )
+            )
+        end)
+    end).
+
+t_conn_error_hardened_denies(_Config) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ok = setup_conn_error_source(),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                deny,
+                emqx_access_control:authorize(
+                    emqx_authz_test_lib:base_client_info(),
+                    ?AUTHZ_PUBLISH,
+                    <<"a">>
+                )
+            )
+        end)
+    end).
 
 %%------------------------------------------------------------------------------
 %% Cases
@@ -490,6 +525,23 @@ cases() ->
             checks => [
                 {deny, ?AUTHZ_PUBLISH, <<"a">>}
             ]
+        },
+        #{
+            name => invalid_rule_hardened_fail_closed,
+            security_profile => hardened,
+            default_permission => allow,
+            setup => [
+                """
+                CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255),
+                permission VARCHAR(255), action VARCHAR(255))
+                """,
+                %% 'permit' is invalid value for action
+                "INSERT INTO acl(username, topic, permission, action) VALUES('username', 'a', 'permit', 'publish')"
+            ],
+            query => <<"SELECT permission, action, topic FROM acl WHERE username = ${username}">>,
+            checks => [
+                {deny, ?AUTHZ_PUBLISH, <<"a">>}
+            ]
         }
         %% TODO: add case for unknown variables after fixing EMQX-10400
     ].
@@ -512,6 +564,12 @@ setup_authz_source(#{query := Query}, SpecialParams) ->
             <<"query">> => Query
         }
     ).
+
+setup_conn_error_source() ->
+    {ok, _, _} = q(
+        "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), permission VARCHAR(255), action VARCHAR(255))"
+    ),
+    setup_config(#{<<"server">> => <<"toxiproxy:5432">>}).
 
 raw_pgsql_authz_config() ->
     #{
@@ -544,6 +602,15 @@ setup_config(SpecialParams) ->
     emqx_authz_test_lib:setup_config(
         raw_pgsql_authz_config(),
         SpecialParams
+    ).
+
+with_failure(FailureType, Fun) ->
+    emqx_common_test_helpers:with_failure(
+        FailureType,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        Fun
     ).
 
 pgsql_config() ->

--- a/apps/emqx_auth_redis/docker-ct
+++ b/apps/emqx_auth_redis/docker-ct
@@ -1,1 +1,2 @@
+toxiproxy
 redis

--- a/apps/emqx_auth_redis/src/emqx_authz_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authz_redis.erl
@@ -65,7 +65,7 @@ authorize(
                 cmd => Cmd,
                 resource_id => ResourceId
             }),
-            nomatch
+            emqx_authz_utils:backend_failure_result()
     end.
 
 %%--------------------------------------------------------------------
@@ -111,6 +111,8 @@ do_authorize(Client, Action, Topic, [TopicFilterRaw, RuleEncoded | Tail], ACLCom
             of
                 nomatch ->
                     do_authorize(Client, Action, Topic, Tail, ACLCompatibilityMode);
+                ignore ->
+                    ignore;
                 {matched, Permission} ->
                     {matched, Permission}
             end;

--- a/apps/emqx_auth_redis/test/emqx_authz_redis_SUITE.erl
+++ b/apps/emqx_auth_redis/test/emqx_authz_redis_SUITE.erl
@@ -14,6 +14,9 @@
 
 -define(REDIS_HOST, "redis").
 -define(REDIS_RESOURCE, <<"emqx_authz_redis_SUITE">>).
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "redis_single_tcp").
 
 all() ->
     emqx_authz_test_lib:all_with_table_case(?MODULE, t_run_case, cases()).
@@ -161,6 +164,44 @@ t_node_cache(_Config) ->
         emqx_auth_cache:metrics(?AUTHZ_CACHE)
     ).
 
+t_resource_failure_legacy_ignores(_Config) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ok = setup_config(#{
+            <<"server">> => <<"toxiproxy:6379">>,
+            <<"cmd">> => <<"HGETALL acl:${username}">>
+        }),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                allow,
+                emqx_access_control:authorize(
+                    emqx_authz_test_lib:base_client_info(),
+                    ?AUTHZ_PUBLISH,
+                    <<"a">>
+                )
+            )
+        end)
+    end).
+
+t_resource_failure_hardened_denies(_Config) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ok = setup_config(#{
+            <<"server">> => <<"toxiproxy:6379">>,
+            <<"cmd">> => <<"HGETALL acl:${username}">>
+        }),
+        {ok, _} = emqx:update_config([authorization, no_match], allow),
+        with_failure(down, fun() ->
+            ?assertEqual(
+                deny,
+                emqx_access_control:authorize(
+                    emqx_authz_test_lib:base_client_info(),
+                    ?AUTHZ_PUBLISH,
+                    <<"a">>
+                )
+            )
+        end)
+    end).
+
 %%------------------------------------------------------------------------------
 %% Cases
 %%------------------------------------------------------------------------------
@@ -214,6 +255,23 @@ cases() ->
                 {deny, ?AUTHZ_PUBLISH, <<"a">>},
                 {deny, ?AUTHZ_PUBLISH, <<"b">>},
                 {deny, ?AUTHZ_PUBLISH, <<"c">>},
+                {deny, ?AUTHZ_PUBLISH(1, true), <<"d">>}
+            ]
+        },
+        #{
+            name => invalid_rule_hardened_fail_closed,
+            security_profile => hardened,
+            default_permission => allow,
+            setup => [
+                [
+                    "HMSET",
+                    "acl:username",
+                    "d",
+                    emqx_utils_json:encode(#{qos => 1, retain => true})
+                ]
+            ],
+            cmd => "HGETALL acl:${username}",
+            checks => [
                 {deny, ?AUTHZ_PUBLISH(1, true), <<"d">>}
             ]
         },
@@ -462,6 +520,15 @@ q(Command) ->
     emqx_resource:simple_sync_query(
         ?REDIS_RESOURCE,
         {cmd, Command}
+    ).
+
+with_failure(FailureType, Fun) ->
+    emqx_common_test_helpers:with_failure(
+        FailureType,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        Fun
     ).
 
 redis_config() ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -27,7 +27,6 @@
 
 -define(BASE_PATH, "/api/v5").
 -define(CAPTURE(Expr), emqx_common_test_helpers:capture_io_format(fun() -> Expr end)).
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 -define(OVERVIEWS, [
     "alarms",
@@ -66,7 +65,7 @@ init_per_test_case(_, Config) ->
     Config.
 
 end_per_test_case(t_default_public_password_login_security_profile, _Config) ->
-    clear_security_profile(),
+    emqx_common_test_helpers:clear_security_profile(),
     mnesia:clear_table(?ADMIN);
 end_per_test_case(_Case, _Config) ->
     ok.
@@ -210,14 +209,14 @@ t_default_public_password_login_security_profile(_TCConfig) ->
         Username, PublicPassword, ?ROLE_SUPERUSER, <<"public password test">>, #{}
     ),
 
-    with_security_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         ?assertMatch(
             {ok, {{_, 200, _}, _, _}},
             login_api(Username, PublicPassword)
         )
     end),
 
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         {ok, {{_, 401, _}, _, Body}} = login_api(Username, PublicPassword),
         #{
             <<"code">> := <<"BAD_USERNAME_OR_PWD">>,
@@ -685,20 +684,6 @@ login_api(Username, Password) ->
         [],
         [{body_format, binary}]
     ).
-
-with_security_profile(Profile, Fun) ->
-    os:putenv(?PROFILE_ENV_VAR, Profile),
-    emqx_security_profile:clear_profile(),
-    try
-        Fun()
-    after
-        clear_security_profile()
-    end.
-
-clear_security_profile() ->
-    os:unsetenv(?PROFILE_ENV_VAR),
-    emqx_security_profile:clear_profile(),
-    ok.
 
 api_path(Parts) ->
     ?HOST ++ filename:join([?BASE_PATH | Parts]).

--- a/apps/emqx_dashboard/test/emqx_dashboard_listener_config_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_listener_config_SUITE.erl
@@ -11,8 +11,6 @@
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("common_test/include/ct.hrl").
 
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
-
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
@@ -30,7 +28,7 @@ init_per_testcase(TestCase, Config) ->
 end_per_testcase(_TestCase, Config) ->
     Apps = ?config(apps, Config),
     emqx_cth_suite:stop(Apps),
-    clear_security_profile(),
+    emqx_common_test_helpers:clear_security_profile(),
     ok.
 
 t_change_i18n_lang(_Config) ->
@@ -54,7 +52,7 @@ change_i18n_lang(Lang) ->
     ok.
 
 assert_http_default_bind(Profile, Inet6, ExpectedBind, ExpectedInetOpt) ->
-    set_security_profile(Profile),
+    emqx_common_test_helpers:set_security_profile(Profile),
     {ok, _} = emqx:update_config([dashboard, listeners], #{
         <<"http">> => #{
             <<"enable">> => true,
@@ -72,14 +70,4 @@ assert_http_default_bind(Profile, Inet6, ExpectedBind, ExpectedInetOpt) ->
     SocketOpts = maps:get(socket_opts, RanchOpts),
     ?assert(lists:member(ExpectedInetOpt, SocketOpts)),
     ?assertEqual(false, lists:keymember(bind, 1, SocketOpts)),
-    ok.
-
-set_security_profile(Profile) ->
-    os:putenv(?PROFILE_ENV_VAR, Profile),
-    emqx_security_profile:clear_profile(),
-    ok.
-
-clear_security_profile() ->
-    os:unsetenv(?PROFILE_ENV_VAR),
-    emqx_security_profile:clear_profile(),
     ok.

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -27,7 +27,6 @@
 -define(PS_PREFIX, "coap://127.0.0.1/ps").
 -define(MQTT_PREFIX, "coap://127.0.0.1/mqtt").
 -define(OBSERVE_NOTIFICATION_QUEUE_MAX_LEN, 100).
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -91,16 +90,6 @@ update_coap_with_mountpoint(Mp) ->
         coap,
         Conf#{<<"mountpoint">> => Mp}
     ).
-
-with_security_profile(Profile, Fun) ->
-    os:putenv(?PROFILE_ENV_VAR, Profile),
-    emqx_security_profile:clear_profile(),
-    try
-        Fun()
-    after
-        os:unsetenv(?PROFILE_ENV_VAR),
-        emqx_security_profile:clear_profile()
-    end.
 
 with_connectionless_coap(EnableAuthn, Fun) ->
     OldConf = emqx:get_raw_config([gateway, coap]),
@@ -714,7 +703,7 @@ t_pubsub_unauthorized(_) ->
     end.
 
 t_connectionless_hardened_no_auth_config_rejects_pub_sub(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         with_connectionless_coap(true, fun() ->
             PublishTopic = <<"security/coap/hardened/publish">>,
             SubscribeTopic = <<"security/coap/hardened/subscribe">>,
@@ -747,7 +736,7 @@ t_connectionless_hardened_no_auth_config_rejects_pub_sub(_) ->
     end).
 
 t_connectionless_legacy_no_auth_config_allows_pub_sub(_) ->
-    with_security_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         with_connectionless_coap(true, fun() ->
             assert_connectionless_pub_sub_allowed(
                 <<"security/coap/legacy/publish">>,
@@ -757,7 +746,7 @@ t_connectionless_legacy_no_auth_config_allows_pub_sub(_) ->
     end).
 
 t_connectionless_observe_skips_session_subscribed_hook(_) ->
-    with_security_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         with_connectionless_coap(true, fun() ->
             Parent = self(),
             SubscribedHook = {?MODULE, forward_session_subscribed, [Parent]},
@@ -791,7 +780,7 @@ t_connectionless_observe_skips_session_subscribed_hook(_) ->
     end).
 
 t_connectionless_hardened_listener_authn_disabled_allows_pub_sub(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         with_connectionless_coap(false, fun() ->
             assert_connectionless_pub_sub_allowed(
                 <<"security/coap/authn-disabled/publish">>,
@@ -801,7 +790,7 @@ t_connectionless_hardened_listener_authn_disabled_allows_pub_sub(_) ->
     end).
 
 t_connectionless_hardened_authn_allows_pub_sub(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         ok = emqx_gateway_auth_ct:start_auth(authn_http),
         try
             with_connectionless_coap(true, fun() ->
@@ -822,7 +811,7 @@ t_connectionless_hardened_authn_allows_pub_sub(_) ->
     end).
 
 t_connectionless_hardened_bad_authn_rejects_pub_sub(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         ok = emqx_gateway_auth_ct:start_auth(authn_http),
         try
             with_connectionless_coap(true, fun() ->
@@ -843,7 +832,7 @@ t_connectionless_hardened_bad_authn_rejects_pub_sub(_) ->
     end).
 
 t_connectionless_hardened_authn_is_request_scoped(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         ok = emqx_gateway_auth_ct:start_auth(authn_http),
         try
             with_connectionless_coap(true, fun() ->
@@ -865,7 +854,7 @@ t_connectionless_hardened_authn_is_request_scoped(_) ->
     end).
 
 t_connectionless_mountpoint_from_authn_client_attrs(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         update_coap_with_mountpoint(<<"mp/${client_attrs.group}/">>),
         ok = meck:new(emqx_access_control, [passthrough, no_history]),
         ok = meck:expect(

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -31,8 +31,6 @@
 -define(PORT, 1884).
 
 -define(LOG(Format, Args), ct:log("TEST: " ++ Format, Args)).
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
-
 -define(MAX_PRED_TOPIC_ID, ?SN_MAX_PREDEF_TOPIC_ID).
 -define(PREDEF_TOPIC_ID1, 1).
 -define(PREDEF_TOPIC_ID2, 2).
@@ -769,24 +767,22 @@ t_publish_negqos_idle_requires_authn_in_hardened_profile(_) ->
     Topic = <<"ab">>,
     Payload = <<"idle-negqos-authn">>,
     ok = emqx:subscribe(Topic),
-    os:putenv(?PROFILE_ENV_VAR, "hardened"),
-    emqx_security_profile:clear_profile(),
     try
-        {ok, Socket} = gen_udp:open(0, [binary]),
-        ?check_trace(
-            begin
-                send_publish_msg_short_topic(Socket, 3, 1, Topic, Payload),
-                ?assertNotReceive({deliver, Topic, #message{payload = Payload}}, 500)
-            end,
-            fun(Trace0) ->
-                Trace = ?of_kind(idle_negative_qos_publish_rejected, Trace0),
-                ?assertMatch([#{return_code := ?SN_RC2_NOT_AUTHORIZE}], Trace)
-            end
-        ),
-        gen_udp:close(Socket)
+        emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+            {ok, Socket} = gen_udp:open(0, [binary]),
+            ?check_trace(
+                begin
+                    send_publish_msg_short_topic(Socket, 3, 1, Topic, Payload),
+                    ?assertNotReceive({deliver, Topic, #message{payload = Payload}}, 500)
+                end,
+                fun(Trace0) ->
+                    Trace = ?of_kind(idle_negative_qos_publish_rejected, Trace0),
+                    ?assertMatch([#{return_code := ?SN_RC2_NOT_AUTHORIZE}], Trace)
+                end
+            ),
+            gen_udp:close(Socket)
+        end)
     after
-        os:unsetenv(?PROFILE_ENV_VAR),
-        emqx_security_profile:clear_profile(),
         emqx:unsubscribe(Topic)
     end.
 
@@ -807,16 +803,14 @@ t_publish_negqos_idle_allows_authn_in_hardened_profile(_) ->
         password => <<"pw123">>,
         is_superuser => false
     }),
-    os:putenv(?PROFILE_ENV_VAR, "hardened"),
-    emqx_security_profile:clear_profile(),
     try
-        {ok, Socket} = gen_udp:open(0, [binary]),
-        send_publish_msg_short_topic(Socket, 3, 1, Topic, Payload),
-        ?assertReceive({deliver, Topic, #message{payload = Payload}}, 1000),
-        gen_udp:close(Socket)
+        emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+            {ok, Socket} = gen_udp:open(0, [binary]),
+            send_publish_msg_short_topic(Socket, 3, 1, Topic, Payload),
+            ?assertReceive({deliver, Topic, #message{payload = Payload}}, 1000),
+            gen_udp:close(Socket)
+        end)
     after
-        os:unsetenv(?PROFILE_ENV_VAR),
-        emqx_security_profile:clear_profile(),
         emqx_gateway_test_utils:delete_gateway_auth_user(<<"mqttsn">>, <<"user1">>),
         emqx_gateway_test_utils:disable_gateway_auth(<<"mqttsn">>),
         {ok, _} = emqx:update_config([authorization], OldAuthz),
@@ -833,24 +827,22 @@ t_publish_negqos_idle_rejects_bad_authn_in_hardened_profile(_) ->
         password => <<"bad-password">>,
         is_superuser => false
     }),
-    os:putenv(?PROFILE_ENV_VAR, "hardened"),
-    emqx_security_profile:clear_profile(),
     try
-        {ok, Socket} = gen_udp:open(0, [binary]),
-        ?check_trace(
-            begin
-                send_publish_msg_short_topic(Socket, 3, 1, Topic, Payload),
-                ?assertNotReceive({deliver, Topic, #message{payload = Payload}}, 500)
-            end,
-            fun(Trace0) ->
-                Trace = ?of_kind(idle_negative_qos_publish_rejected, Trace0),
-                ?assertMatch([#{return_code := ?SN_RC2_NOT_AUTHORIZE}], Trace)
-            end
-        ),
-        gen_udp:close(Socket)
+        emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+            {ok, Socket} = gen_udp:open(0, [binary]),
+            ?check_trace(
+                begin
+                    send_publish_msg_short_topic(Socket, 3, 1, Topic, Payload),
+                    ?assertNotReceive({deliver, Topic, #message{payload = Payload}}, 500)
+                end,
+                fun(Trace0) ->
+                    Trace = ?of_kind(idle_negative_qos_publish_rejected, Trace0),
+                    ?assertMatch([#{return_code := ?SN_RC2_NOT_AUTHORIZE}], Trace)
+                end
+            ),
+            gen_udp:close(Socket)
+        end)
     after
-        os:unsetenv(?PROFILE_ENV_VAR),
-        emqx_security_profile:clear_profile(),
         emqx_gateway_test_utils:delete_gateway_auth_user(<<"mqttsn">>, <<"user1">>),
         emqx_gateway_test_utils:disable_gateway_auth(<<"mqttsn">>),
         emqx:unsubscribe(Topic)

--- a/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
@@ -12,7 +12,6 @@
 -define(NKEY_ACCOUNT_PREFIX, 16#00).
 -define(NKEY_OPERATOR_PREFIX, 16#70).
 -define(NKEY_USER_PREFIX, 16#A0).
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -24,10 +23,10 @@ all() ->
 t_build_authn_ctx_and_auth_required(_Config) ->
     Disabled = mk_authn_ctx(undefined, [], undefined, false),
     ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => false}, Disabled)),
-    with_security_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => true}, Disabled))
     end),
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => false}, Disabled)),
         ?assertEqual(true, emqx_nats_authn:is_auth_required(#{enable_authn => true}, Disabled))
     end),
@@ -41,10 +40,10 @@ t_build_authn_ctx_and_auth_required(_Config) ->
         #{enable => false, trusted_operators => [<<"OP_TEST">>]},
         false
     ),
-    with_security_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         ?assertEqual(false, emqx_nats_authn:is_auth_required(#{enable_authn => true}, JWTDisabled))
     end),
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         ?assertEqual(true, emqx_nats_authn:is_auth_required(#{enable_authn => true}, JWTDisabled))
     end),
 
@@ -893,13 +892,3 @@ mutate_jwt_signature(JWT) ->
 
 replace_first_char(<<_Old, Rest/binary>>, New) ->
     <<New, Rest/binary>>.
-
-with_security_profile(Profile, Fun) ->
-    os:putenv(?PROFILE_ENV_VAR, Profile),
-    emqx_security_profile:clear_profile(),
-    try
-        Fun()
-    after
-        os:unsetenv(?PROFILE_ENV_VAR),
-        emqx_security_profile:clear_profile()
-    end.

--- a/apps/emqx_gateway_nats/test/emqx_nats_protocol_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_nats_protocol_SUITE.erl
@@ -13,7 +13,6 @@
 
 -define(NKEY_ACCOUNT_PREFIX, 16#00).
 -define(NKEY_OPERATOR_PREFIX, 16#70).
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 %%--------------------------------------------------------------------
 %% CT Callbacks
@@ -892,16 +891,6 @@ update_nats_gateway(Conf) ->
     case emqx_gateway:update(nats, Conf) of
         ok -> ok;
         {ok, _} -> ok
-    end.
-
-with_security_profile(Profile, Fun) ->
-    os:putenv(?PROFILE_ENV_VAR, Profile),
-    emqx_security_profile:clear_profile(),
-    try
-        Fun()
-    after
-        os:unsetenv(?PROFILE_ENV_VAR),
-        emqx_security_profile:clear_profile()
     end.
 
 token_auth_setup(Config, Type, Token) ->
@@ -1845,7 +1834,7 @@ t_auth_dynamic_enable_disable(Config) ->
     emqx_nats_client:stop(Client3).
 
 t_hardened_no_auth_config_rejects_anonymous_pub_sub_connect(Config) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         with_nats_no_auth_config(Config, true, fun() ->
             ClientOpts = maps:merge(?config(auth_disabled_opts, Config), #{verbose => true}),
             assert_info_auth_required(ClientOpts, true),
@@ -1856,7 +1845,7 @@ t_hardened_no_auth_config_rejects_anonymous_pub_sub_connect(Config) ->
     end).
 
 t_legacy_no_auth_config_allows_anonymous_pub_sub_connect(Config) ->
-    with_security_profile("legacy", fun() ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
         with_nats_no_auth_config(Config, true, fun() ->
             ClientOpts = maps:merge(?config(auth_disabled_opts, Config), #{verbose => true}),
             assert_info_auth_required(ClientOpts, false),
@@ -1866,7 +1855,7 @@ t_legacy_no_auth_config_allows_anonymous_pub_sub_connect(Config) ->
     end).
 
 t_hardened_listener_authn_disabled_allows_anonymous_pub_sub_connect(Config) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         with_nats_no_auth_config(Config, false, fun() ->
             ClientOpts = maps:merge(?config(auth_disabled_opts, Config), #{verbose => true}),
             assert_info_auth_required(ClientOpts, false),

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -22,7 +22,6 @@
 ).
 
 -define(HEARTBEAT, <<$\n>>).
--define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 
 -define(CONF_DEFAULT, <<
     "\n"
@@ -88,16 +87,6 @@ update_stomp_with_mountpoint(Mountpoint) ->
         stomp,
         Conf#{<<"mountpoint">> => Mountpoint}
     ).
-
-with_security_profile(Profile, Fun) ->
-    os:putenv(?PROFILE_ENV_VAR, Profile),
-    emqx_security_profile:clear_profile(),
-    try
-        Fun()
-    after
-        os:unsetenv(?PROFILE_ENV_VAR),
-        emqx_security_profile:clear_profile()
-    end.
 
 with_stomp_tcp_listener_authn(EnableAuthn, Fun) ->
     ListenerPath = [gateway, stomp, listeners, tcp, default],
@@ -235,7 +224,7 @@ t_auth_failed(_) ->
     meck:unload(emqx_access_control).
 
 t_hardened_rejects_pre_connect_send(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         Topic = <<"security/stomp/pre-connect-send">>,
         Payload = <<"blocked">>,
         emqx:subscribe(Topic),
@@ -256,7 +245,7 @@ t_hardened_rejects_pre_connect_send(_) ->
     end).
 
 t_hardened_rejects_pre_connect_subscribe(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         Topic = <<"security/stomp/pre-connect-subscribe">>,
         with_connection(fun(Sock) ->
             ok = send_subscribe_frame(Sock, 0, Topic),
@@ -267,7 +256,7 @@ t_hardened_rejects_pre_connect_subscribe(_) ->
     end).
 
 t_hardened_rejects_pre_connect_transactional_send(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         Topic = <<"security/stomp/pre-connect-transaction">>,
         Payload = <<"blocked">>,
         emqx:subscribe(Topic),
@@ -292,7 +281,7 @@ t_hardened_rejects_pre_connect_transactional_send(_) ->
     end).
 
 t_hardened_listener_authn_disabled_allows_pub_sub(_) ->
-    with_security_profile("hardened", fun() ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
         with_stomp_tcp_listener_authn(false, fun() ->
             with_connection(fun(Sock) ->
                 Topic = <<"security/stomp/authn-disabled">>,

--- a/apps/emqx_ldap/test/data/emqx.io.ldif
+++ b/apps/emqx_ldap/test/data/emqx.io.ldif
@@ -218,3 +218,14 @@ isEnabled: TRUE
 clientIdOverride: overridden_clientid
 mqttAccountName: user10
 userPassword:: e1NIQX16blNQUDBoei8wUUdzODhpaUVCNEQ4cW53T3c9
+
+## create user=mqttuser0011 with invalid ACL rule JSON
+dn:uid=mqttuser0011,ou=testdevice,dc=emqx,dc=io
+objectClass: top
+objectClass: mqttUser
+objectClass: mqttDevice
+objectClass: mqttSecurity
+uid: mqttuser0011
+isEnabled: TRUE
+mqttAclRule: {invalid-json
+userPassword: {SHA}znSPP0hz/0QGs88iiEB4D8qnwOw=

--- a/changes/ee/feat-17564.en.md
+++ b/changes/ee/feat-17564.en.md
@@ -1,0 +1,1 @@
+Added hardened security-profile behavior for authorization backend failures. In hardened mode, backend failures and invalid backend responses now fail closed; legacy mode preserves ignore/fallback behavior.

--- a/rel/i18n/emqx_authz_schema.hocon
+++ b/rel/i18n/emqx_authz_schema.hocon
@@ -129,6 +129,12 @@ It is NOT allowed to configure two or more sources of the same type."""
 sources.label:
 """sources"""
 
+ignore_backend_failures.desc:
+"""When enabled, authorization backend failures are ignored even when the active security profile would deny them."""
+
+ignore_backend_failures.label:
+"""Ignore Backend Failures"""
+
 node_metrics.desc:
 """The metrics of the resource for each node."""
 


### PR DESCRIPTION
Fixes  https://github.com/emqx/emqx-dev-team-tasks/issues/112
Addresses https://github.com/emqx/emqx-dev-team-tasks/issues/118

Release version:
6.2.2

## Summary

This PR adds security-profile-aware authorization backend failure handling. The new `authz_backend_failure` policy preserves legacy behavior by ignoring backend failures, while hardened mode fails closed by returning deny.

The policy is applied to authorization backend crashes, query/request failures, invalid backend responses, malformed rule rows, and connector failure paths across HTTP, LDAP, MongoDB, MySQL, PostgreSQL, and Redis authorizers.

**Important**: 
* fail close behaviour _not_ implemented for `emqx_authz_rules` yet. It will be implemented together with interpolation fix (#17596)
* fail close behaviour _not_ implemented for authn/authz hooks, a separate PR will follow (#17589 )

**Important**: the PR is not fully compatible because we change `nomatch` to `ignore` for legacy profile in case of failures. However, this results only in counter changes. I think `ignore` for failures is more semantically correct. `nomatch` means we have **valid set of rules** against which the principal does not match.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)