### PR TITLE
chore(deps): bump brod to 4.5.5

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -5,7 +5,7 @@
     {wolff, "4.1.10"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
-    {brod, "4.5.4"},
+    {brod, "4.5.5"},
     {snappyer, "1.2.10"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -5,7 +5,7 @@
     {wolff, "4.1.10"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
-    {brod, "4.5.4"},
+    {brod, "4.5.5"},
     {snappyer, "1.2.10"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -5,7 +5,7 @@
     {wolff, "4.1.10"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
-    {brod, "4.5.4"},
+    {brod, "4.5.5"},
     {snappyer, "1.2.10"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},

--- a/changes/ee/fix-17567.en.md
+++ b/changes/ee/fix-17567.en.md
@@ -1,0 +1,3 @@
+Upgraded Kafka client library `brod` from 4.5.4 to 4.5.5.
+
+Fixed Kafka consumer group join failures against Kafka 2.2.0, where the broker returns `member_id_required` and brod previously discarded the assigned member ID instead of using it for the retry.

--- a/mix.exs
+++ b/mix.exs
@@ -287,7 +287,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:kafka_protocol),
     do: {:kafka_protocol, "4.3.2", override: true}
 
-  def common_dep(:brod), do: {:brod, "4.5.4"}
+  def common_dep(:brod), do: {:brod, "4.5.5"}
   ## TODO: remove `mix.exs` from `wolff` and remove this override
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.10", override: true}


### PR DESCRIPTION
Release version: 5.8.11

## Summary

Bump Kafka client library `brod` from 4.5.4 to 4.5.5.

Fixes Kafka consumer group join failures against Kafka 2.2.0, where the broker returns `member_id_required` and brod previously discarded the assigned member ID instead of using it for the retry.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)