### PR TITLE
fix(deps): bump brod to 4.5.5

### DIFF
--- a/changes/ee/fix-17568.en.md
+++ b/changes/ee/fix-17568.en.md
@@ -1,6 +1,3 @@
 Upgraded the Kafka client library `brod` to 4.5.5.
 
-This release includes two fixes that affect Kafka producer and consumer integrations:
-
-- Consumer group: respect the broker-assigned member ID when the join response carries the `member_id_required` error code (returned by older Kafka brokers, e.g. 2.2.0, that do not support static member instance IDs). Previously the member ID was discarded on error, preventing the retry from succeeding.
-- Client: break a deadlock between `brod_client` and the producers supervisor that could stall partition discovery when client metadata refresh and producer startup interleaved.
+Consumer group: respect the broker-assigned member ID when the join response carries the `member_id_required` error code (returned by older Kafka brokers, e.g. 2.2.0, that do not support static member instance IDs). Previously the member ID was discarded on error, preventing the retry from succeeding.

--- a/changes/ee/fix-17568.en.md
+++ b/changes/ee/fix-17568.en.md
@@ -1,0 +1,6 @@
+Upgraded the Kafka client library `brod` to 4.5.5.
+
+This release includes two fixes that affect Kafka producer and consumer integrations:
+
+- Consumer group: respect the broker-assigned member ID when the join response carries the `member_id_required` error code (returned by older Kafka brokers, e.g. 2.2.0, that do not support static member instance IDs). Previously the member ID was discarded on error, preventing the retry from succeeding.
+- Client: break a deadlock between `brod_client` and the producers supervisor that could stall partition discovery when client metadata refresh and producer startup interleaved.

--- a/mix.exs
+++ b/mix.exs
@@ -281,7 +281,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:kafka_protocol),
     do: {:kafka_protocol, "4.3.2", override: true}
 
-  def common_dep(:brod), do: {:brod, "4.5.4"}
+  def common_dep(:brod), do: {:brod, "4.5.5"}
   ## TODO: remove `mix.exs` from `wolff` and remove this override
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.10", override: true}


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Bumps the Kafka client library `brod` from 4.5.4 to 4.5.5 in the umbrella `mix.exs` pin.

User-visible upstream fix picked up:

- `fix(consumer-group): handle member_id_required error` — `brod` now remembers the member ID returned by the broker when the join response carries the `member_id_required` error code (e.g. against Kafka 2.2.0, which does not support static member instance IDs), so the retry can succeed instead of looping with a fresh empty ID.

The release also contains a `brod_client <-> producers_sup` deadlock fix, but EMQX does not use brod's producer, so that one is not user-visible from EMQX.

No EMQX code changes — the `brod` API is unchanged.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)