### PR TITLE
fix(frame): make MQTT v5 user-property parsing O(N) instead of O(N^2)

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -555,7 +555,7 @@ parse_properties(Bin, ?MQTT_PROTO_V5, StrictMode) ->
     {Len, Rest} = parse_variable_byte_integer(Bin),
     case Rest of
         <<PropsBin:Len/binary, Rest1/binary>> ->
-            {parse_property(PropsBin, #{}, StrictMode), Rest1};
+            {finalize_user_property(parse_property(PropsBin, #{}, StrictMode)), Rest1};
         _ ->
             ?PARSE_ERR(#{
                 cause => user_property_not_enough_bytes,
@@ -620,10 +620,11 @@ parse_property(<<16#25, Val, Bin/binary>>, Props, StrictMode) ->
     parse_property(Bin, Props#{'Retain-Available' => Val}, StrictMode);
 parse_property(<<16#26, Bin/binary>>, Props, StrictMode) ->
     {Pair, Rest} = parse_utf8_pair(Bin, StrictMode),
+    %% Accumulate in reverse order to keep this O(1) per entry; the list is
+    %% reversed back to wire order in parse_properties/3 once parsing finishes.
     case maps:find('User-Property', Props) of
         {ok, UserProps} ->
-            UserProps1 = lists:append(UserProps, [Pair]),
-            parse_property(Rest, Props#{'User-Property' := UserProps1}, StrictMode);
+            parse_property(Rest, Props#{'User-Property' := [Pair | UserProps]}, StrictMode);
         error ->
             parse_property(Rest, Props#{'User-Property' => [Pair]}, StrictMode)
     end;
@@ -638,6 +639,13 @@ parse_property(<<16#2A, Val, Bin/binary>>, Props, StrictMode) ->
 parse_property(<<Property:8, _Rest/binary>>, _Props, _StrictMode) ->
     ?PARSE_ERR(#{cause => invalid_property_code, property_code => Property}).
 %% TODO: invalid property in specific packet.
+
+%% Restore wire order for the 'User-Property' list, which parse_property/3
+%% accumulates in reverse to keep per-entry cost constant.
+finalize_user_property(#{'User-Property' := UserProps} = Props) ->
+    Props#{'User-Property' := lists:reverse(UserProps)};
+finalize_user_property(Props) ->
+    Props.
 
 parse_variable_byte_integer(Bin) ->
     parse_variable_byte_integer(Bin, 1, 0).

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -55,6 +55,7 @@ groups() ->
             t_serialize_parse_v3_connect,
             t_serialize_parse_v4_connect,
             t_serialize_parse_v5_connect,
+            t_parse_many_user_properties_is_linear,
             t_serialize_parse_connect_without_clientid,
             t_serialize_parse_connect_with_will,
             t_serialize_parse_connect_with_malformed_will,
@@ -245,6 +246,48 @@ t_serialize_parse_v5_connect(_) ->
         }
     ),
     ?assertEqual(Packet, parse_serialize(Packet)).
+
+%% A CONNECT packet carrying a large number of MQTT v5 'User-Property' entries must
+%% parse in time linear to the number of entries. Builds a raw CONNECT frame with
+%% 50k empty user-properties (5 bytes each, ~250 KB, well under max_packet_size) and
+%% asserts the parse finishes quickly while preserving the count and wire order.
+t_parse_many_user_properties_is_linear(_) ->
+    N = 50_000,
+    %% Each user-property on the wire: 0x26 + 2-byte empty key + value tagged
+    %% with its 1-based index so wire order can be asserted after parsing.
+    Props = iolist_to_binary([
+        begin
+            V = integer_to_binary(I),
+            <<16#26, 0:16, (byte_size(V)):16, V/binary>>
+        end
+     || I <- lists:seq(1, N)
+    ]),
+    PropsSection = <<(encode_vbi(byte_size(Props)))/binary, Props/binary>>,
+    %% Variable header: protocol name + level + connect flags + keepalive + props.
+    VarHeader = <<4:16, "MQTT", ?MQTT_PROTO_V5:8, 2:8, 60:16, PropsSection/binary>>,
+    %% Empty client id payload.
+    Body = <<VarHeader/binary, 0:16>>,
+    Frame = <<16#10, (encode_vbi(byte_size(Body)))/binary, Body/binary>>,
+    ParseState = emqx_frame:initial_parse_state(#{strict_mode => true}),
+    T0 = erlang:monotonic_time(millisecond),
+    {ok, Packet, <<>>, _} = emqx_frame:parse(Frame, ParseState),
+    Elapsed = erlang:monotonic_time(millisecond) - T0,
+    #mqtt_packet{variable = #mqtt_packet_connect{properties = ParsedProps}} = Packet,
+    UserProps = maps:get('User-Property', ParsedProps),
+    ?assertEqual(N, length(UserProps)),
+    %% Order must follow the wire: first entry has value <<"1">>, last <<"50000">>.
+    ?assertEqual({<<>>, <<"1">>}, hd(UserProps)),
+    ?assertEqual({<<>>, integer_to_binary(N)}, lists:last(UserProps)),
+    %% Generous threshold: the point is that 50k entries is now feasible at all,
+    %% not a microbenchmark. The old quadratic path took seconds here.
+    ?assert(Elapsed < 2000, #{elapsed_ms => Elapsed}),
+    ok.
+
+%% Encode an unsigned integer as an MQTT variable byte integer.
+encode_vbi(N) when N < 16#80 ->
+    <<N>>;
+encode_vbi(N) ->
+    <<1:1, (N rem 16#80):7, (encode_vbi(N div 16#80))/binary>>.
 
 t_serialize_parse_connect_without_clientid(_) ->
     Bin = <<16, 12, 0, 4, 77, 81, 84, 84, 4, 2, 0, 60, 0, 0>>,

--- a/changes/ce/fix-17573.en.md
+++ b/changes/ce/fix-17573.en.md
@@ -1,0 +1,3 @@
+Reduced MQTT v5 user-property parsing cost from quadratic to linear.
+
+Previously a CONNECT, PUBLISH or SUBSCRIBE packet carrying many user-properties caused super-linear scheduler time on the owning connection process, because each parsed property was appended to the end of the accumulated list. Parsing now scales linearly with the number of entries while preserving their wire order.

--- a/changes/ce/fix-17573.en.md
+++ b/changes/ce/fix-17573.en.md
@@ -1,3 +1,0 @@
-Reduced MQTT v5 user-property parsing cost from quadratic to linear.
-
-Previously a CONNECT, PUBLISH or SUBSCRIBE packet carrying many user-properties caused super-linear scheduler time on the owning connection process, because each parsed property was appended to the end of the accumulated list. Parsing now scales linearly with the number of entries while preserving their wire order.

--- a/changes/ee/fix-17573.en.md
+++ b/changes/ee/fix-17573.en.md
@@ -1,0 +1,3 @@
+Reduced MQTT v5 user-property parsing cost from quadratic to linear.
+
+Previously a CONNECT, PUBLISH or SUBSCRIBE packet carrying many user-properties caused super-linear scheduler time on the owning connection process, because each parsed property was appended to the end of the accumulated list. Parsing now scales linearly with the number of entries while preserving their wire order.


### PR DESCRIPTION
Release version: 5.8.11

## Summary

Make MQTT v5 `User-Property` parsing scale linearly with the number of entries.

Previously each parsed user-property was appended to the end of the accumulated list via `lists:append/2`, making the parse of a single packet quadratic in the number of user-properties. A CONNECT/PUBLISH/SUBSCRIBE packet carrying many user-properties therefore consumed super-linear scheduler time on the owning connection process.

The parser now prepends each entry (O(1) per entry) and reverses the `'User-Property'` list once when the property map is finalized, preserving wire order. Added a regression test that parses a CONNECT frame with 50k user-properties and asserts both the linear-time behaviour and that count/order are preserved.

Internal tracker: https://github.com/emqx/emqx-dev-team-tasks/issues/142

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
