### PR TITLE
test(jwt_cache): fix flaky t_smoke_cache_concurrency

### DIFF
--- a/apps/emqx_connector_jwt/test/emqx_connector_jwt_token_cache_SUITE.erl
+++ b/apps/emqx_connector_jwt/test/emqx_connector_jwt_token_cache_SUITE.erl
@@ -124,9 +124,22 @@ Smoke test for cache concurrency (if not cached, linearizes refresh calls to pro
 """.
 t_smoke_cache_concurrency(_TCConfig) ->
     RefreshFn = mk_fetch_success(),
+    %% N.B. Register the cleanup once, from the main test process.  Calling `on_exit/1`
+    %% from inside the `pmap` workers would make each worker spawn its own janitor (the
+    %% janitor lookup is keyed on the per-process dictionary), and each janitor would run
+    %% `unregister` when its worker exits, deleting the cache mid-batch and forcing extra
+    %% refreshes.
+    on_exit(fun() -> emqx_connector_jwt_token_cache:unregister(?MODULE, ?client_id) end),
     Responses =
         [OneResponse | _] =
-        emqx_utils:pmap(fun(_) -> get_or_refresh(RefreshFn) end, lists:seq(1, 10)),
+        emqx_utils:pmap(
+            fun(_) ->
+                emqx_connector_jwt_token_cache:get_or_refresh(
+                    ?MODULE, ?tab, ?client_id, RefreshFn
+                )
+            end,
+            lists:seq(1, 10)
+        ),
     ?assertMatch([OneResponse], lists:usort(Responses)),
     ?assertNotReceive({fetched, #{times_called := N}} when N > 1),
     ok.


### PR DESCRIPTION
Fixes flaky CT case `emqx_connector_jwt_token_cache_SUITE:t_smoke_cache_concurrency`.

## Summary

The concurrency smoke test spawned its 10 parallel callers via `emqx_utils:pmap`,
and the per-call test helper registered an `on_exit/1` cleanup from inside each
`pmap` worker process.

`emqx_common_test_helpers:on_exit/1` looks up its janitor through the
per-process dictionary, which is empty in each freshly spawned `pmap` worker.
So every worker spawned its own janitor (linked to and owned by that worker).
When a worker finished and exited, its janitor ran the `unregister` callback,
deleting the freshly-cached token from the ETS table mid-batch. Subsequent
queued `#register_refresh` calls then saw a cache miss and re-fetched, producing
more than one distinct token (e.g. `<<"1">>` and `<<"2">>`) and failing the
linearization assertion.

The fix is test-side only: register the `unregister` cleanup once from the main
test process and call the cache module directly inside `pmap`, so the cache is
not cleared while the batch is still in flight. Production linearization in
`emqx_connector_jwt_token_cache` is correct and unchanged.

Validated by running the case 30x in a loop (all green) and the full suite (8/8 ok).

Most relevant file: `apps/emqx_connector_jwt/test/emqx_connector_jwt_token_cache_SUITE.erl`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
