### PR TITLE
feat(greptimedb): add cipher_suites config for Rust NIF TLS connections

### DIFF
--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -13,7 +13,9 @@
     default_ciphers/0,
     selected_ciphers/1,
     integral_ciphers/2,
-    all_ciphers_set_cached/0
+    all_ciphers_set_cached/0,
+    cipher_to_rfc/1,
+    convert_ciphers_to_rfc/2
 ]).
 
 %% SSL files
@@ -156,6 +158,45 @@ all_ciphers_set_cached() ->
         Set ->
             Set
     end.
+
+%% @doc Convert an OpenSSL cipher name to RFC/IANA format.
+-spec cipher_to_rfc(string() | binary()) -> string().
+cipher_to_rfc(Cipher) when is_binary(Cipher) ->
+    cipher_to_rfc(binary_to_list(Cipher));
+cipher_to_rfc(Cipher) ->
+    Suite = ssl:str_to_suite(Cipher),
+    ssl:suite_to_str(Suite).
+
+%% @doc Convert a list of OpenSSL cipher names to RFC format,
+%% filtering against a supported list.
+%% Returns {Converted, Unsupported} where both lists contain
+%% original cipher name strings.
+-spec convert_ciphers_to_rfc([string() | binary()], [string() | binary()]) ->
+    {[string()], [string() | binary()]}.
+convert_ciphers_to_rfc(Ciphers, Supported) ->
+    StrSupported = lists:map(
+        fun
+            (C) when is_binary(C) -> binary_to_list(C);
+            (C) -> C
+        end,
+        Supported
+    ),
+    lists:foldr(
+        fun(Cipher, {Ok, Bad}) ->
+            try cipher_to_rfc(Cipher) of
+                Rfc ->
+                    case lists:member(Rfc, StrSupported) of
+                        true -> {[Rfc | Ok], Bad};
+                        false -> {Ok, [Cipher | Bad]}
+                    end
+            catch
+                _:_ ->
+                    {Ok, [Cipher | Bad]}
+            end
+        end,
+        {[], []},
+        Ciphers
+    ).
 
 %% @hidden Return a list of all supported ciphers.
 all_ciphers() ->

--- a/apps/emqx_bridge_emqx_tables/mix.exs
+++ b/apps/emqx_bridge_emqx_tables/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeEmqxTables.MixProject do
   def project do
     [
       app: :emqx_bridge_emqx_tables,
-      version: "6.1.0",
+      version: "6.1.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
+++ b/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
@@ -760,3 +760,121 @@ t_start_ok_ttl(TCConfig) when is_list(TCConfig) ->
         end
     ),
     ok.
+
+%%------------------------------------------------------------------------------
+%% TLS Cipher Suite Test Cases (Rust NIF)
+%%------------------------------------------------------------------------------
+
+-doc """
+Connect with a TLS 1.3 cipher suite (TLS_AES_256_GCM_SHA384).
+Verifies the cipher_suites option is forwarded to the Rust NIF layer.
+""".
+t_tls_cipher_tls13() ->
+    [{matrix, true}].
+t_tls_cipher_tls13(matrix) ->
+    [[?tls, ?sync, ?without_batch]];
+t_tls_cipher_tls13(TCConfig) when is_list(TCConfig) ->
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_connector_api(TCConfig, #{
+            <<"ssl">> => #{<<"ciphers">> => [<<"TLS_AES_256_GCM_SHA384">>]}
+        })
+    ),
+    ok.
+
+-doc """
+Connect with a TLS 1.2 cipher suite (TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384).
+""".
+t_tls_cipher_tls12() ->
+    [{matrix, true}].
+t_tls_cipher_tls12(matrix) ->
+    [[?tls, ?sync, ?without_batch]];
+t_tls_cipher_tls12(TCConfig) when is_list(TCConfig) ->
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_connector_api(TCConfig, #{
+            <<"ssl">> => #{<<"ciphers">> => [<<"ECDHE-RSA-AES256-GCM-SHA384">>]}
+        })
+    ),
+    ok.
+
+-doc """
+Connect with mixed TLS 1.2 + 1.3 cipher suites.
+""".
+t_tls_cipher_mixed() ->
+    [{matrix, true}].
+t_tls_cipher_mixed(matrix) ->
+    [[?tls, ?sync, ?without_batch]];
+t_tls_cipher_mixed(TCConfig) when is_list(TCConfig) ->
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_connector_api(TCConfig, #{
+            <<"ssl">> => #{
+                <<"ciphers">> => [
+                    <<"TLS_AES_256_GCM_SHA384">>,
+                    <<"TLS_AES_128_GCM_SHA256">>,
+                    <<"ECDHE-RSA-AES256-GCM-SHA384">>
+                ]
+            }
+        })
+    ),
+    ok.
+
+-doc """
+Empty cipher_suites list should use defaults (same as not specifying).
+""".
+t_tls_cipher_empty_default() ->
+    [{matrix, true}].
+t_tls_cipher_empty_default(matrix) ->
+    [[?tls, ?sync, ?without_batch]];
+t_tls_cipher_empty_default(TCConfig) when is_list(TCConfig) ->
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_connector_api(TCConfig, #{
+            <<"ssl">> => #{<<"ciphers">> => []}
+        })
+    ),
+    ok.
+
+-doc """
+All invalid cipher names should cause a connection failure.
+""".
+t_tls_cipher_all_invalid() ->
+    [{matrix, true}].
+t_tls_cipher_all_invalid(matrix) ->
+    [[?tls, ?sync, ?without_batch]];
+t_tls_cipher_all_invalid(TCConfig) when is_list(TCConfig) ->
+    ?assertMatch(
+        {201, #{<<"status">> := <<"disconnected">>}},
+        create_connector_api(TCConfig, #{
+            <<"ssl">> => #{
+                <<"ciphers">> => [
+                    <<"DHE-RSA-AES256-GCM-SHA384">>,
+                    <<"DHE-RSA-AES128-GCM-SHA256">>
+                ]
+            }
+        })
+    ),
+    ok.
+
+-doc """
+Mix of valid + unsupported cipher names: any unsupported cipher
+causes an immediate connection failure (fail-fast).
+""".
+t_tls_cipher_partial_invalid() ->
+    [{matrix, true}].
+t_tls_cipher_partial_invalid(matrix) ->
+    [[?tls, ?sync, ?without_batch]];
+t_tls_cipher_partial_invalid(TCConfig) when is_list(TCConfig) ->
+    ?assertMatch(
+        {201, #{<<"status">> := <<"disconnected">>}},
+        create_connector_api(TCConfig, #{
+            <<"ssl">> => #{
+                <<"ciphers">> => [
+                    <<"ECDHE-RSA-AES256-GCM-SHA384">>,
+                    <<"DHE-RSA-AES256-GCM-SHA384">>
+                ]
+            }
+        })
+    ),
+    ok.

--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
   def project do
     [
       app: :emqx_bridge_greptimedb,
-      version: "6.1.1",
+      version: "6.1.2",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_rs_impl.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_rs_impl.erl
@@ -454,7 +454,8 @@ maybe_put_tls(_ConnConfig, Opts) ->
 
 extract_tls_opts(SSLOpts) ->
     TLSCertOpts = extract_tls_cert_opts(SSLOpts),
-    maybe_put_tls_verify_opt(SSLOpts, TLSCertOpts).
+    TLSCertOpts1 = maybe_put_tls_verify_opt(SSLOpts, TLSCertOpts),
+    maybe_put_cipher_suites(SSLOpts, TLSCertOpts1).
 
 extract_tls_cert_opts(SSLOpts) ->
     TLSOpts0 = maps:fold(
@@ -491,6 +492,87 @@ maybe_put_tls_verify_opt(SSLOpts, TLSOpts) ->
                     TLSOpts
             end
     end.
+
+maybe_put_cipher_suites(SSLOpts, TLSOpts) ->
+    Ciphers = find_opt([ciphers, <<"ciphers">>], SSLOpts),
+    case Ciphers of
+        {ok, List} when is_list(List), List =/= [] ->
+            {Converted, Unsupported} = convert_ciphers_to_rfc(List),
+            case Unsupported of
+                [] ->
+                    TLSOpts#{cipher_suites => Converted};
+                _ ->
+                    throw(
+                        iolist_to_binary([
+                            "unsupported cipher suites: ",
+                            lists:join(", ", Unsupported),
+                            ". Supported: "
+                            "TLS_AES_256_GCM_SHA384, TLS_AES_128_GCM_SHA256, "
+                            "TLS_CHACHA20_POLY1305_SHA256, "
+                            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, "
+                            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, "
+                            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, "
+                            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+                        ])
+                    )
+            end;
+        _ ->
+            TLSOpts
+    end.
+
+find_opt(Keys, Map) ->
+    lists:foldl(
+        fun
+            (_K, {ok, _} = Acc) ->
+                Acc;
+            (K, Acc) ->
+                case maps:find(K, Map) of
+                    {ok, _} = Found -> Found;
+                    error -> Acc
+                end
+        end,
+        error,
+        Keys
+    ).
+
+convert_ciphers_to_rfc(Ciphers) ->
+    lists:foldr(
+        fun(Cipher, {Ok, Bad}) ->
+            case ssl_cipher_to_rfc(Cipher) of
+                {ok, RfcName} ->
+                    case lists:member(RfcName, supported_cipher_suites()) of
+                        true -> {[RfcName | Ok], Bad};
+                        false -> {Ok, [Cipher | Bad]}
+                    end;
+                error ->
+                    {Ok, [Cipher | Bad]}
+            end
+        end,
+        {[], []},
+        Ciphers
+    ).
+
+ssl_cipher_to_rfc(Cipher) when is_binary(Cipher) ->
+    ssl_cipher_to_rfc(binary_to_list(Cipher));
+ssl_cipher_to_rfc(Cipher) ->
+    try
+        Suite = ssl:str_to_suite(Cipher),
+        {ok, list_to_binary(ssl:suite_to_str(Suite))}
+    catch
+        _:_ ->
+            error
+    end.
+
+supported_cipher_suites() ->
+    [
+        <<"TLS_AES_256_GCM_SHA384">>,
+        <<"TLS_AES_128_GCM_SHA256">>,
+        <<"TLS_CHACHA20_POLY1305_SHA256">>,
+        <<"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384">>,
+        <<"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256">>,
+        <<"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384">>,
+        <<"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256">>
+    ].
 
 normalize_tls_verify(verify_none) ->
     verify_none;

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_rs_impl.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_rs_impl.erl
@@ -497,10 +497,12 @@ maybe_put_cipher_suites(SSLOpts, TLSOpts) ->
     Ciphers = find_opt([ciphers, <<"ciphers">>], SSLOpts),
     case Ciphers of
         {ok, List} when is_list(List), List =/= [] ->
-            {Converted, Unsupported} = convert_ciphers_to_rfc(List),
+            {Converted, Unsupported} = emqx_tls_lib:convert_ciphers_to_rfc(
+                List, supported_cipher_suites()
+            ),
             case Unsupported of
                 [] ->
-                    TLSOpts#{cipher_suites => Converted};
+                    TLSOpts#{cipher_suites => lists:map(fun erlang:list_to_binary/1, Converted)};
                 _ ->
                     throw(
                         iolist_to_binary([
@@ -534,34 +536,6 @@ find_opt(Keys, Map) ->
         error,
         Keys
     ).
-
-convert_ciphers_to_rfc(Ciphers) ->
-    lists:foldr(
-        fun(Cipher, {Ok, Bad}) ->
-            case ssl_cipher_to_rfc(Cipher) of
-                {ok, RfcName} ->
-                    case lists:member(RfcName, supported_cipher_suites()) of
-                        true -> {[RfcName | Ok], Bad};
-                        false -> {Ok, [Cipher | Bad]}
-                    end;
-                error ->
-                    {Ok, [Cipher | Bad]}
-            end
-        end,
-        {[], []},
-        Ciphers
-    ).
-
-ssl_cipher_to_rfc(Cipher) when is_binary(Cipher) ->
-    ssl_cipher_to_rfc(binary_to_list(Cipher));
-ssl_cipher_to_rfc(Cipher) ->
-    try
-        Suite = ssl:str_to_suite(Cipher),
-        {ok, list_to_binary(ssl:suite_to_str(Suite))}
-    catch
-        _:_ ->
-            error
-    end.
 
 supported_cipher_suites() ->
     [

--- a/changes/ee/feat-17576.en.md
+++ b/changes/ee/feat-17576.en.md
@@ -1,0 +1,2 @@
+Added TLS cipher suite configuration support for the GreptimeDB Rust NIF connector via the existing `ssl.ciphers` field. When a cipher list is specified, TLS negotiation is restricted to those suites.
+Unsupported ciphers are rejected at connector startup.

--- a/mix.exs
+++ b/mix.exs
@@ -319,7 +319,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.3-emqx.1"}
 
   def common_dep(:greptimedb_rs),
-    do: {:greptimedb_rs, github: "emqx/greptimedb-ingester-erlnif", tag: "0.1.10"}
+    do: {:greptimedb_rs, github: "emqx/greptimedb-ingester-erlnif", tag: "0.1.11"}
 
   def common_dep(:sbom), do: {:sbom, "~> 0.8", runtime: false}
 


### PR DESCRIPTION
## Summary

Add a new `cipher_suites` connector-level config field for the GreptimeDB (Rust NIF) bridge that allows users to specify TLS cipher suites using IANA naming convention.

## Changes

- **`mix.exs`**: Update `greptimedb_rs` dep to `JimMoen/feat-tls-ciphers` branch which includes cipher suite filtering support in the Rust NIF layer
- **`emqx_bridge_greptimedb_connector.erl`**: Add `cipher_suites` field to connector schema (`hoconsc:array(binary())`, default `[]`)
- **`emqx_bridge_greptimedb_rs_impl.erl`**: Forward `cipher_suites` from ConnConfig to `greptimedb_rs:start_client/1` opts
- **`emqx_bridge_greptimedb_connector.hocon`**: Add i18n description for the new field
- **`emqx_bridge_emqx_tables_SUITE.erl`**: Add 6 TLS cipher suite test cases covering TLS 1.2/1.3/mixed/empty/invalid/partial-invalid

## Why a separate field from `ssl.ciphers`?

EMQX standard `ssl.ciphers` uses OpenSSL-style names (e.g., `ECDHE-RSA-AES256-GCM-SHA384`), but `greptimedb_rs` uses a Rust TLS stack (rustls) that expects IANA-style names (e.g., `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`). These are different naming conventions, so a dedicated field avoids confusion.

## Supported cipher suites

- TLS 1.3: `TLS_AES_256_GCM_SHA384`, `TLS_AES_128_GCM_SHA256`
- TLS 1.2: `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`, `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`, `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`, `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`

When empty (default), all default cipher suites are used.

## Testing

- `emqx_bridge_greptimedb_SUITE`: 21/21 pass (existing, unchanged)
- `emqx_bridge_emqx_tables_SUITE`: 32/32 pass (26 existing + 6 new cipher tests)

## Related repos

- greptimedb-ingester-rust: [JimMoen/greptimedb-ingester-rust feat/erl-tls-ciphers](https://github.com/JimMoen/greptimedb-ingester-rust/tree/feat/erl-tls-ciphers)
- greptimedb-ingester-erlnif: [JimMoen/greptimedb-ingester-erlnif feat-tls-ciphers](https://github.com/JimMoen/greptimedb-ingester-erlnif/tree/feat-tls-ciphers)
