### PR TITLE
test(kafka_token_cache): fix flaky t_smoke_cache_concurrency

### DIFF
--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_token_cache_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_token_cache_SUITE.erl
@@ -122,9 +122,20 @@ Smoke test for cache concurrency (if not cached, linearizes refresh calls to pro
 """.
 t_smoke_cache_concurrency(_TCConfig) ->
     RefreshFn = mk_fetch_success(),
+    %% N.B. Register the cleanup once, from the main test process.  Calling `on_exit/1`
+    %% from inside the `pmap` workers would make each worker spawn its own janitor (the
+    %% janitor lookup is keyed on the per-process dictionary), and each janitor would run
+    %% `unregister` when its worker exits, deleting the cache mid-batch and forcing extra
+    %% refreshes.
+    on_exit(fun() -> emqx_bridge_kafka_token_cache:unregister(?client_id) end),
     Responses =
         [OneResponse | _] =
-        emqx_utils:pmap(fun(_) -> get_or_refresh(RefreshFn) end, lists:seq(1, 10)),
+        emqx_utils:pmap(
+            fun(_) ->
+                emqx_bridge_kafka_token_cache:get_or_refresh(?client_id, RefreshFn)
+            end,
+            lists:seq(1, 10)
+        ),
     ?assertMatch([OneResponse], lists:usort(Responses)),
     ?assertNotReceive({fetched, #{times_called := N}} when N > 1),
     ok.


### PR DESCRIPTION
Fixes flaky CT case `emqx_bridge_kafka_token_cache_SUITE:t_smoke_cache_concurrency`.

Release version:
6.1.2

## Summary

Same root cause and fix as #17574 (which fixes the descendant of this test on
release-63, where the token cache was refactored into `emqx_connector_jwt_token_cache`).
On release-61/62 the test still lives in the kafka bridge.

The concurrency smoke test spawned its 10 parallel callers via `emqx_utils:pmap`,
and the per-call test helper registered an `on_exit/1` cleanup from inside each
`pmap` worker process. `emqx_common_test_helpers:on_exit/1` looks up its janitor
through the per-process dictionary, which is empty in each freshly spawned worker.
So every worker spawned its own janitor (owned by that worker). When a worker
finished and exited, its janitor ran the `unregister` callback, deleting the
freshly-cached token from the ETS table mid-batch. Subsequent queued refresh
calls then saw a cache miss and re-fetched, producing more than one distinct
token and failing the linearization assertion.

The fix is test-side only: register the `unregister` cleanup once from the main
test process and call the cache module directly inside `pmap`, so the cache is
not cleared while the batch is still in flight. Production linearization in
`emqx_bridge_kafka_token_cache` is correct and unchanged.

Most relevant file: `apps/emqx_bridge_kafka/test/emqx_bridge_kafka_token_cache_SUITE.erl`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
