### PR TITLE
fix(relup): cover SAML XXE and backup download fixes

### DIFF
--- a/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
+++ b/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
@@ -3,6 +3,12 @@
     target_version => "5.10.5",
     code_changes => [
         {load_module, emqx_release},
+        {restart_application, esaml},
+        {load_module, emqx_dashboard},
+        {load_module, emqx_mgmt_data_backup},
+        {load_module, emqx_mgmt_data_backup_proto_v2},
+        {load_module, emqx_mgmt_api_data_backup},
+        {apply, emqx_bpapi, announce, [node(), emqx]},
         {apply, emqx_relup_eredis_upgrade, stop_redis_resources, []},
         {restart_application, eredis},
         {load_module, emqx_redis},

--- a/plugins/emqx_relup/priv/relup/README.md
+++ b/plugins/emqx_relup/priv/relup/README.md
@@ -8,9 +8,17 @@ are arbitrary; `<from>-to-<to>.relup` is the convention.
 
 ## Supported Upgrade Paths
 
-| From | To | Purpose |
+| From | To | Changes |
 |---|---|---|
-| 5.10.4 | 5.10.5 | Restart Redis resources around the eredis upgrade so Sentinel managers are recreated with isolated manager names. |
+| 5.10.4 | 5.10.5 | [5.10.4-5.10.5](#5104-5105) |
+
+## Changes
+
+### 5.10.4-5.10.5
+
+- Restart `esaml` so hot-upgraded nodes pick up SAML XXE protection.
+- Load dashboard/data-backup modules and re-announce `emqx` BPAPI so backup-file download authorization changes take effect for API-key callers.
+- Stop Redis resources, restart `eredis`, reload `emqx_redis`, then start Redis resources so Sentinel managers are recreated with isolated manager names.
 
 ## Schema
 
@@ -23,6 +31,7 @@ are arbitrary; `<from>-to-<to>.relup` is the convention.
         {load_module, emqx_release},
         {load_module, another_module},
         {update, emqx_other, {advanced, ExtraTerm}},
+        {apply, emqx_bpapi, announce, [node(), emqx]},
         {restart_application, emqx_something}
     ],
     post_upgrade_callbacks => [

--- a/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
@@ -108,6 +108,38 @@ t_5105_catalog_uses_plugin_eredis_upgrade_module(_Config) ->
         )
     ).
 
+-doc "The 5.10.4 -> 5.10.5 hop also applies SAML XXE and backup download "
+"authorization fixes without extending the Redis stop/start window.".
+t_5105_catalog_covers_saml_xxe_and_backup_download_fixes(_Config) ->
+    {Valid, _Errors} = emqx_relup_handler:validate_priv_catalog(),
+    #{code_changes := CodeChanges} = find_relup_entry("5.10.4", "5.10.5", Valid),
+    LoadRelease = {load_module, emqx_release},
+    StopRedis = {apply, emqx_relup_eredis_upgrade, stop_redis_resources, []},
+    StartRedis = {apply, emqx_relup_eredis_upgrade, start_redis_resources, []},
+    AnnounceBPAPI = {apply, emqx_bpapi, announce, [node(), emqx]},
+    ?assert(is_before(StopRedis, StartRedis, CodeChanges)),
+    lists:foreach(
+        fun(Instruction) ->
+            ?assert(
+                lists:member(Instruction, CodeChanges),
+                #{missing_instruction => Instruction}
+            ),
+            ?assert(
+                is_before(LoadRelease, Instruction, CodeChanges),
+                #{instruction_must_run_after_emqx_release_load => Instruction}
+            )
+        end,
+        [
+            {restart_application, esaml},
+            {load_module, emqx_dashboard},
+            {load_module, emqx_mgmt_data_backup},
+            {load_module, emqx_mgmt_data_backup_proto_v2},
+            {load_module, emqx_mgmt_api_data_backup},
+            AnnounceBPAPI
+        ]
+    ),
+    ?assert(is_before({load_module, emqx_mgmt_data_backup_proto_v2}, AnnounceBPAPI, CodeChanges)).
+
 %%==============================================================================
 %% Helpers
 %%==============================================================================
@@ -134,6 +166,19 @@ find_relup_entry(FromVsn, TargetVsn, Entries) ->
         Entries
     ),
     Entry.
+
+is_before(Earlier, Later, List) ->
+    index_of(Earlier, List) < index_of(Later, List).
+
+index_of(Item, List) ->
+    index_of(Item, List, 1).
+
+index_of(Item, [Item | _], Index) ->
+    Index;
+index_of(Item, [_ | Rest], Index) ->
+    index_of(Item, Rest, Index + 1);
+index_of(Item, [], _Index) ->
+    error({not_found, Item}).
 
 cleanup_test_catalog_entries() ->
     Dir = filename:join([code:priv_dir(emqx_relup), "relup"]),


### PR DESCRIPTION
Release version:
5.10.5

## Summary

- Restart `esaml` during the 5.10.4 -> 5.10.5 relup so hot-upgraded nodes pick up the SAML XXE protection.
- Load the dashboard/data-backup modules and re-announce the `emqx` BPAPI so hot-upgraded nodes pick up the backup-file download authorization changes for API-key callers.
- Keep these instructions before the existing Redis stop/start window and add catalog coverage for the ordering.
- Checks run: focused relup CT, full `plugins/emqx_relup-ct`, `git diff --check`, and `./scripts/elvis-check.sh release-510`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (N/A, relup catalog/test only)
- [x] Schema changes are backward compatible or intentionally breaking (N/A)
