### PR TITLE
fix(redis): isolate Sentinel managers per resource

### DIFF
--- a/apps/emqx_redis/mix.exs
+++ b/apps/emqx_redis/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXRedis.MixProject do
     UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
-      {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.8.12"}
+      {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.9.0"}
     ])
   end
 end

--- a/apps/emqx_redis/src/emqx_redis.erl
+++ b/apps/emqx_redis/src/emqx_redis.erl
@@ -124,7 +124,8 @@ on_start(InstId, Config0) ->
     }),
     Config = config(Config0),
     #{pool_size := PoolSize, ssl := SSL, redis_type := Type} = Config,
-    Options = ssl_options(SSL) ++ [{sentinel, maps:get(sentinel, Config, undefined)}],
+    BaseOptions = ssl_options(SSL) ++ [{sentinel, maps:get(sentinel, Config, undefined)}],
+    Options = runtime_options(Type, InstId, BaseOptions),
     Opts =
         [
             {username, maps:get(username, Config, undefined)},
@@ -138,7 +139,7 @@ on_start(InstId, Config0) ->
     State = #{pool_name => InstId, type => Type},
     ok = emqx_resource:allocate_resource(InstId, ?MODULE, type, Type),
     ok = emqx_resource:allocate_resource(InstId, ?MODULE, pool_name, InstId),
-    case validate_sentinel_connection(Type, InstId, Config, Options) of
+    case validate_sentinel_connection(Type, InstId, Config, BaseOptions) of
         ok ->
             do_start(Type, InstId, Opts, State);
         {error, Reason} ->
@@ -159,8 +160,17 @@ do_start(_Type, InstId, Opts, State) ->
         ok ->
             {ok, State};
         {error, Reason} ->
+            ok = stop_sentinel_manager(State),
             {error, Reason}
     end.
+
+runtime_options(sentinel, InstId, Options) ->
+    [{sentinel_manager_ref, sentinel_manager_ref(InstId)} | Options];
+runtime_options(_Type, _InstId, Options) ->
+    Options.
+
+sentinel_manager_ref(InstId) ->
+    {?MODULE, InstId}.
 
 validate_sentinel_connection(sentinel, InstId, Config, Options) ->
     Servers = servers(Config),
@@ -252,21 +262,29 @@ on_stop(InstId, _State) ->
     }),
     Resources = emqx_resource:get_allocated_resources(InstId),
     ok = stop_sentinel_validation_client(Resources),
-    Res =
-        case Resources of
-            #{pool_name := PoolName, type := cluster} ->
-                case eredis_cluster:stop_pool(PoolName) of
-                    {error, not_found} -> ok;
-                    ok -> ok;
-                    Error -> Error
-                end;
-            #{pool_name := PoolName, type := _} ->
-                emqx_resource_pool:stop(PoolName);
-            _ ->
-                ok
-        end,
+    Res = stop_pool(Resources),
+    ok = stop_sentinel_manager(Resources),
     ?tp("redis_connector_stop", #{instance_id => InstId}),
     Res.
+
+stop_pool(Resources) ->
+    case Resources of
+        #{pool_name := PoolName, type := cluster} ->
+            case eredis_cluster:stop_pool(PoolName) of
+                {error, not_found} -> ok;
+                ok -> ok;
+                Error -> Error
+            end;
+        #{pool_name := PoolName, type := _} ->
+            emqx_resource_pool:stop(PoolName);
+        _ ->
+            ok
+    end.
+
+stop_sentinel_manager(#{pool_name := PoolName, type := sentinel}) ->
+    eredis:stop_sentinel_manager(sentinel_manager_ref(PoolName));
+stop_sentinel_manager(_Resources) ->
+    ok.
 
 on_query(InstId, {cmd, _} = Query, State) ->
     do_query(InstId, Query, State);

--- a/apps/emqx_redis/test/emqx_redis_SUITE.erl
+++ b/apps/emqx_redis/test/emqx_redis_SUITE.erl
@@ -153,6 +153,76 @@ t_sentinel_auth_master_auth_sentinel_auth(_Config) ->
         sentinel_auth => password
     }).
 
+t_sentinel_resources_do_not_share_sentinel_state(_Config) ->
+    catch eredis_sentinel:stop(),
+    ResourceId1 = <<"emqx_redis_SUITE_sentinel_isolation_noauth">>,
+    ResourceId2 = <<"emqx_redis_SUITE_sentinel_isolation_auth">>,
+    Config1 = redis_config_sentinel_auth_matrix(
+        ?REDIS_SENTINEL_S_NO_AUTH_M_NO_AUTH_HOST,
+        none,
+        none
+    ),
+    Config2 = redis_config_sentinel_auth_matrix(
+        ?REDIS_SENTINEL_S_NO_AUTH_M_AUTH_HOST,
+        password,
+        none
+    ),
+    {ok, #{config := CheckedConfig1}} = emqx_resource:check_config(?REDIS_RESOURCE_MOD, Config1),
+    {ok, #{config := CheckedConfig2}} = emqx_resource:check_config(?REDIS_RESOURCE_MOD, Config2),
+    try
+        {ok, #{status := connected}} = emqx_resource:create_local(
+            ResourceId1,
+            ?CONNECTOR_RESOURCE_GROUP,
+            ?REDIS_RESOURCE_MOD,
+            CheckedConfig1,
+            #{spawn_buffer_workers => true}
+        ),
+        ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId1)),
+        ?assertEqual({ok, <<"PONG">>}, emqx_resource:query(ResourceId1, {cmd, [<<"PING">>]})),
+        {ok, #{status := connected}} = emqx_resource:create_local(
+            ResourceId2,
+            ?CONNECTOR_RESOURCE_GROUP,
+            ?REDIS_RESOURCE_MOD,
+            CheckedConfig2,
+            #{spawn_buffer_workers => true}
+        ),
+        ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId2)),
+        ?assertEqual({ok, <<"PONG">>}, emqx_resource:query(ResourceId2, {cmd, [<<"PING">>]}))
+    after
+        catch emqx_resource:remove_local(ResourceId1),
+        catch emqx_resource:remove_local(ResourceId2),
+        catch eredis_sentinel:stop()
+    end.
+
+t_sentinel_manager_removed_when_resource_removed(_Config) ->
+    ResourceId = <<"emqx_redis_SUITE_sentinel_manager_cleanup">>,
+    ManagerName = sentinel_manager_name(ResourceId),
+    Config = redis_config_sentinel_auth_matrix(
+        ?REDIS_SENTINEL_S_NO_AUTH_M_NO_AUTH_HOST,
+        none,
+        none
+    ),
+    {ok, #{config := CheckedConfig}} = emqx_resource:check_config(?REDIS_RESOURCE_MOD, Config),
+    try
+        ?assertEqual(undefined, eredis_sentinel_registry:whereis_name(ManagerName)),
+        {ok, #{status := connected}} = emqx_resource:create_local(
+            ResourceId,
+            ?CONNECTOR_RESOURCE_GROUP,
+            ?REDIS_RESOURCE_MOD,
+            CheckedConfig,
+            #{spawn_buffer_workers => true}
+        ),
+        ManagerPid = wait_until_sentinel_manager_started(ManagerName),
+        ?assert(is_process_alive(ManagerPid)),
+        ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+
+        ?assertEqual(ok, emqx_resource:remove_local(ResourceId)),
+        wait_until_sentinel_manager_stopped(ManagerName, ManagerPid)
+    after
+        catch emqx_resource:remove_local(ResourceId),
+        catch eredis_sentinel:stop(ManagerName)
+    end.
+
 t_sentinel_dry_run_rejects_stale_sentinel_auth(_Config) ->
     ResourceId = <<"emqx_redis_SUITE_sentinel_dry_run_auth">>,
     GoodConfig = redis_config_sentinel_auth_matrix(
@@ -363,6 +433,37 @@ run_sentinel_auth_matrix_case(#{
         )
     after
         catch emqx_resource:remove_local(ResourceId)
+    end.
+
+sentinel_manager_name(ResourceId) ->
+    {eredis_sentinel, {?REDIS_RESOURCE_MOD, ResourceId}}.
+
+wait_until_sentinel_manager_started(ManagerName) ->
+    wait_until_sentinel_manager_started(ManagerName, 20).
+
+wait_until_sentinel_manager_started(ManagerName, 0) ->
+    ct:fail({sentinel_manager_not_started, ManagerName});
+wait_until_sentinel_manager_started(ManagerName, Retries) ->
+    case eredis_sentinel_registry:whereis_name(ManagerName) of
+        Pid when is_pid(Pid) ->
+            Pid;
+        undefined ->
+            timer:sleep(100),
+            wait_until_sentinel_manager_started(ManagerName, Retries - 1)
+    end.
+
+wait_until_sentinel_manager_stopped(ManagerName, ManagerPid) ->
+    wait_until_sentinel_manager_stopped(ManagerName, ManagerPid, 20).
+
+wait_until_sentinel_manager_stopped(ManagerName, ManagerPid, 0) ->
+    ct:fail({sentinel_manager_not_stopped, ManagerName, ManagerPid});
+wait_until_sentinel_manager_stopped(ManagerName, ManagerPid, Retries) ->
+    case {eredis_sentinel_registry:whereis_name(ManagerName), is_process_alive(ManagerPid)} of
+        {undefined, false} ->
+            ok;
+        _ ->
+            timer:sleep(100),
+            wait_until_sentinel_manager_stopped(ManagerName, ManagerPid, Retries - 1)
     end.
 
 -define(REDIS_CONFIG_BASE(MaybeSentinel, MaybeDatabase),

--- a/changes/ce/fix-17579.en.md
+++ b/changes/ce/fix-17579.en.md
@@ -1,0 +1,1 @@
+Fixed Redis Sentinel connectors to use isolated Sentinel managers per resource and clean them up when resources stop, avoiding shared Sentinel state across connectors.


### PR DESCRIPTION
Fix: https://github.com/emqx/emqx-dev-team-tasks/issues/156
Backports the Redis Sentinel manager isolation part of https://github.com/emqx/emqx/pull/17538 to release-60.

Release version:
6.0.3

## Summary

- Gives each Redis Sentinel connector resource its own runtime Sentinel manager by passing a per-resource `sentinel_manager_ref` to `eredis`.
- Stops the per-resource Sentinel manager when the Redis resource stops or fails during startup, avoiding leaked or shared Sentinel state between connectors.
- Updates `emqx_redis` to consume `eredis_cluster` `0.9.0`, which depends on `eredis` `1.3.0`.
- Adds regression CT coverage for Sentinel resource isolation and Sentinel manager cleanup on resource removal.
- The release-510 relup changes from the source PR are intentionally not included because this release-60 port only needs the Redis runtime fix.
- Checked with `./scripts/erlfmt -c apps/emqx_redis/src/emqx_redis.erl apps/emqx_redis/test/emqx_redis_SUITE.erl`, `mix format --check-formatted apps/emqx_redis/mix.exs`, `git diff --check`, `./scripts/apps-version-check.exs`, `PROFILE=emqx-enterprise ./mix compile`, `emqx_redis_SUITE` (`11 ok, 0 failed`), and `emqx_redis_command_SUITE` (`2 ok, 0 failed`).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/fix-17579.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
