### PR TITLE
build(deps): upgrade jiffy 1.1.2 -> 2.0.1

### DIFF
--- a/changes/ee/perf-17583.en.md
+++ b/changes/ee/perf-17583.en.md
@@ -1,0 +1,3 @@
+Improved JSON encoding and decoding performance.
+
+As part of this change, floating-point numbers in JSON output are now formatted consistently with the Erlang/OTP standard, which may differ slightly from previous releases (for example, switching to scientific notation a little earlier).

--- a/mix.exs
+++ b/mix.exs
@@ -190,7 +190,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ehttpc),
     do: {:ehttpc, github: "emqx/ehttpc", tag: "0.7.3", override: true}
 
-  def common_dep(:jiffy), do: {:jiffy, "1.1.2", override: true}
+  def common_dep(:jiffy), do: {:jiffy, "2.0.1", override: true}
 
   def common_dep(:grpc),
     do:


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Upgrade the `jiffy` JSON library from 1.1.2 to 2.0.1, chosen for performance and compatibility.

jiffy 2.0 brings substantial encode/decode performance improvements (SIMD ASCII/UTF-8 scan-ahead, Ryu float formatting matching OTP, ffc.h number parsing) while keeping the full API surface EMQX relies on:
- functions: `encode/1,2`, `decode/1,2`
- types: `json_value/0`, `encode_options/0`, `decode_options/0` (used in `emqx_utils_json`)
- options: `uescape`, `pretty`, `force_utf8` (encode) and `return_maps`, `return_trailer`, `dedupe_keys`, `copy_strings` (decode)

Only `mix.exs` changes — it is the sole jiffy pin on this branch (the former `rebar.config` pins are gone).

Verified locally: the NIF builds under OTP 27/28, `emqx_utils_json_SUITE` passes, and an `emqx_utils_json` encode/decode smoke test (roundtrip, floats, `uescape`, `force_utf8`, `pretty`, ejson proplist form) behaves as before.

Note: jiffy 2.0 uses Ryu for float encoding (now consistent with Erlang/OTP), so JSON floating-point output can differ slightly from 1.x (e.g. switching to scientific notation a little earlier). Captured in the changelog.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)