### PR TITLE
test(prometheus_api): deflake t_listener_shutdown_count

### DIFF
--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -355,9 +355,6 @@ t_stats_auth_api(_) ->
 %% Simple smoke test for verifying reason code labels in `emqx_client_disconnected_reason'
 %% counter metric.
 t_listener_shutdown_count(_Config) ->
-    ClientId1 = fresh_clientid(?FUNCTION_NAME),
-    {ok, C1} = emqtt:start_link(#{clientid => ClientId1}),
-    {ok, _} = emqtt:connect(C1),
     ConnectRetry = fun Retry(ClientId) ->
         {ok, C0} = emqtt:start_link(#{clientid => ClientId}),
         try emqtt:connect(C0) of
@@ -368,6 +365,8 @@ t_listener_shutdown_count(_Config) ->
                 Retry(ClientId)
         end
     end,
+    ClientId1 = fresh_clientid(?FUNCTION_NAME),
+    {ok, C1} = ConnectRetry(ClientId1),
     %% Takeover
     unlink(C1),
     {ok, C2} = ConnectRetry(ClientId1),
@@ -600,4 +599,8 @@ get_stats(Format, Mode) ->
     end.
 
 fresh_clientid(TestCase) ->
-    iolist_to_binary([atom_to_binary(TestCase), integer_to_binary(erlang:monotonic_time())]).
+    iolist_to_binary([
+        atom_to_binary(TestCase),
+        "-",
+        integer_to_binary(erlang:unique_integer([positive, monotonic]))
+    ]).


### PR DESCRIPTION
Release version:
6.0.3

## Summary

Deflakes `emqx_prometheus_api_SUITE:t_listener_shutdown_count`, observed failing on a release-63 push:

```
%%% emqx_prometheus_api_SUITE ==> t_listener_shutdown_count: FAILED
%%% emqx_prometheus_api_SUITE ==> {'EXIT',{shutdown,server_unavailable}}
```

A previous fix wrapped every connect in the case in a `server_unavailable` retry helper — except the very first one, which stayed unguarded and could still fail when the client-id registration throttle (`clientid_registration_throttled`) rejected the connect. This change moves the `ConnectRetry` helper above the first connect and routes it through the same retry, removing the asymmetry.

It also changes `fresh_clientid/1` to use `erlang:unique_integer([positive, monotonic])` (guaranteed unique within the VM) instead of `erlang:monotonic_time/0` (only monotonically non-decreasing), and adds a hyphen separator for readability in logs.

Test-only change. Will be forward-synced to release-61/62/63.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)