### PR TITLE
feat(auth): implement fail closed for access control hooks

### DIFF
--- a/apps/emqx/src/emqx_access_control.erl
+++ b/apps/emqx/src/emqx_access_control.erl
@@ -319,9 +319,13 @@ format_retain_flag(false) ->
 
 run_hooks(Name, Args, Acc) when Name == 'client.authenticate'; Name == 'client.authorize' ->
     ok = emqx_metrics:inc_global(Name),
-    {Time, Value} = timer:tc(
-        fun() -> emqx_hooks:run_fold(Name, Args, Acc) end
-    ),
+    {Time, Value} =
+        case emqx_security_profile:policy(access_control_hook_failure) of
+            ignore ->
+                timer:tc(fun() -> {ok, emqx_hooks:run_fold(Name, Args, Acc)} end);
+            interrupt ->
+                timer:tc(fun() -> emqx_hooks:run_fold_strict(Name, Args, Acc) end)
+        end,
     try
         emqx_metrics_worker:observe_hist(
             ?ACCESS_CONTROL_METRICS_WORKER,
@@ -333,7 +337,15 @@ run_hooks(Name, Args, Acc) when Name == 'client.authenticate'; Name == 'client.a
         _:_ ->
             ok
     end,
-    Value.
+    case Value of
+        {ok, Result} -> Result;
+        {error, _Reason} -> fail_close_result(Name)
+    end.
+
+fail_close_result('client.authenticate') ->
+    ignore;
+fail_close_result('client.authorize') ->
+    #{result => deny, from => default_on_fail}.
 
 -compile({inline, [inc_authz_metrics/1]}).
 inc_authz_metrics(allow) ->

--- a/apps/emqx/src/emqx_hooks.erl
+++ b/apps/emqx/src/emqx_hooks.erl
@@ -27,6 +27,8 @@
     run/3,
     run_fold/3,
     run_fold/4,
+    run_fold_strict/3,
+    run_fold_strict/4,
     lookup/1
 ]).
 
@@ -70,6 +72,7 @@
 -type hookpoint() :: atom() | binary().
 -type action() :: {module(), atom(), [term()] | undefined}.
 -type filter() :: {module(), atom(), [term()] | undefined}.
+-type context() :: term().
 
 -record(callback, {
     action :: action(),
@@ -156,7 +159,7 @@ run(HookPoint, Args) ->
     ok = emqx_hookpoints:verify_hookpoint(HookPoint),
     do_run(lookup(HookPoint), Args).
 
--spec run(hookpoint(), map(), list(Arg :: term())) -> ok.
+-spec run(hookpoint(), context(), list(Arg :: term())) -> ok.
 run(HookPoint, Ctx, Args) ->
     ok = emqx_hookpoints:verify_hookpoint(HookPoint),
     ok = stash_context(HookPoint, Ctx),
@@ -164,11 +167,12 @@ run(HookPoint, Ctx, Args) ->
     ok = unstash_context(HookPoint).
 
 %% @doc Run hooks with Accumulator.
--spec run_fold(hookpoint(), list(Arg :: term()), Acc :: term()) -> Acc :: term().
+-spec run_fold(hookpoint(), list(_Arg :: term()), Acc) -> Acc when Acc :: term().
 run_fold(HookPoint, Args, Acc) ->
     ok = emqx_hookpoints:verify_hookpoint(HookPoint),
     do_run_fold(lookup(HookPoint), Args, Acc).
 
+-spec run_fold(hookpoint(), context(), list(_Arg :: term()), Acc) -> Acc when Acc :: term().
 run_fold(HookPoint, Ctx, Args, Acc) ->
     ok = emqx_hookpoints:verify_hookpoint(HookPoint),
     ok = stash_context(HookPoint, Ctx),
@@ -176,10 +180,27 @@ run_fold(HookPoint, Ctx, Args, Acc) ->
     ok = unstash_context(HookPoint),
     Result.
 
+-spec run_fold_strict(hookpoint(), list(_Arg :: term()), Acc) -> {ok, Acc} | {error, term()} when
+    Acc :: term().
+run_fold_strict(HookPoint, Args, Acc) ->
+    ok = emqx_hookpoints:verify_hookpoint(HookPoint),
+    do_run_fold_strict(lookup(HookPoint), Args, Acc).
+
+-spec run_fold_strict(hookpoint(), context(), list(_Arg :: term()), Acc) ->
+    {ok, Acc} | {error, term()}
+when
+    Acc :: term().
+run_fold_strict(HookPoint, Ctx, Args, Acc) ->
+    ok = emqx_hookpoints:verify_hookpoint(HookPoint),
+    ok = stash_context(HookPoint, Ctx),
+    Result = do_run_fold_strict(lookup(HookPoint), Args, Acc),
+    ok = unstash_context(HookPoint),
+    Result.
+
 do_run([#callback{action = Action, filter = Filter} | Callbacks], Args) ->
     case filter_passed(Filter, Args) andalso safe_execute(Action, Args) of
         %% stop the hook chain and return
-        stop -> ok;
+        {ok, stop} -> ok;
         %% continue the hook chain, in following cases:
         %%   - the filter validation failed with 'false'
         %%   - the callback returns any term other than 'stop'
@@ -192,18 +213,39 @@ do_run_fold([#callback{action = Action, filter = Filter} | Callbacks], Args, Acc
     Args1 = Args ++ [Acc],
     case filter_passed(Filter, Args1) andalso safe_execute(Action, Args1) of
         %% stop the hook chain
-        stop -> Acc;
+        {ok, stop} -> Acc;
         %% stop the hook chain with NewAcc
-        {stop, NewAcc} -> NewAcc;
+        {ok, {stop, NewAcc}} -> NewAcc;
         %% continue the hook chain with NewAcc
-        {ok, NewAcc} -> do_run_fold(Callbacks, Args, NewAcc);
+        {ok, {ok, NewAcc}} -> do_run_fold(Callbacks, Args, NewAcc);
         %% continue the hook chain, in following cases:
         %%   - the filter validation failed with 'false'
         %%   - the callback returns any term other than 'stop' or {'stop', NewAcc}
+        %%   - the callback crashes
         _ -> do_run_fold(Callbacks, Args, Acc)
     end;
 do_run_fold([], _Args, Acc) ->
     Acc.
+
+do_run_fold_strict([#callback{action = Action, filter = Filter} | Callbacks], Args, Acc) ->
+    Args1 = Args ++ [Acc],
+    case filter_passed(Filter, Args1) andalso safe_execute(Action, Args1) of
+        %% stop on crash
+        {error, Reason} -> {error, Reason};
+        %% stop the hook chain
+        {ok, stop} -> {ok, Acc};
+        %% stop the hook chain with NewAcc
+        {ok, {stop, NewAcc}} -> {ok, NewAcc};
+        %% continue the hook chain with NewAcc
+        {ok, {ok, NewAcc}} -> do_run_fold_strict(Callbacks, Args, NewAcc);
+        %% continue the hook chain, in following cases:
+        %%   - the filter validation failed with 'false'
+        %%   - the callback returns any term other than 'stop' or {'stop', NewAcc}
+        %%   - the callback crashes
+        _ -> do_run_fold_strict(Callbacks, Args, Acc)
+    end;
+do_run_fold_strict([], _Args, Acc) ->
+    {ok, Acc}.
 
 -spec filter_passed(filter(), Args :: term()) -> true | false.
 filter_passed(undefined, _Args) -> true;
@@ -211,7 +253,7 @@ filter_passed(Filter, Args) -> execute(Filter, Args).
 
 safe_execute({M, F, A}, Args) ->
     try execute({M, F, A}, Args) of
-        Result -> Result
+        Result -> {ok, Result}
     catch
         Error:Reason:Stacktrace ->
             ?tp(error, "hook_callback_exception", #{
@@ -221,7 +263,8 @@ safe_execute({M, F, A}, Args) ->
                 callback_module => M,
                 callback_function => F,
                 callback_args => emqx_utils_redact:redact(Args ++ A)
-            })
+            }),
+            {error, Reason}
     end.
 
 %% @doc execute a function.
@@ -239,11 +282,11 @@ lookup(HookPoint) ->
 %%   thread more context down to hooks.
 %%--------------------------------------------------------------------
 
--spec context(hookpoint()) -> undefined | term().
+-spec context(hookpoint()) -> undefined | context().
 context(Name) ->
     get(?HOOK_CTX_PD_KEY(Name)).
 
--spec stash_context(hookpoint(), term()) -> ok.
+-spec stash_context(hookpoint(), context()) -> ok.
 stash_context(Name, Context) ->
     _ = put(?HOOK_CTX_PD_KEY(Name), Context),
     ok.

--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -48,7 +48,8 @@ Returns policy depending on the current security profile.
     (dashboard_http_default_bind) -> loopback | any;
     (authn_not_configured) -> allow | deny;
     (authz_backend_failure) -> ignore | deny;
-    (dashboard_unchanged_default_credentials) -> allow | deny.
+    (dashboard_unchanged_default_credentials) -> allow | deny;
+    (access_control_hook_failure) -> ignore | interrupt.
 policy(mqtt_default_bind) ->
     case profile() of
         legacy -> any;
@@ -73,6 +74,11 @@ policy(dashboard_unchanged_default_credentials) ->
     case profile() of
         legacy -> allow;
         hardened -> deny
+    end;
+policy(access_control_hook_failure) ->
+    case profile() of
+        legacy -> ignore;
+        hardened -> interrupt
     end.
 
 -doc """

--- a/apps/emqx/test/emqx_access_control_SUITE.erl
+++ b/apps/emqx/test/emqx_access_control_SUITE.erl
@@ -32,7 +32,13 @@ end_per_testcase(_, _Config) ->
     ok = emqx_hooks:del('client.authorize', {?MODULE, authz_stub}),
     ok = emqx_hooks:del('client.authorize', {?MODULE, authz_stub_cache}),
     ok = emqx_hooks:del('client.authorize', {?MODULE, authz_stub_non_cacheable}),
-    ok = emqx_hooks:del('client.authenticate', {?MODULE, quick_deny_anonymous_authn}).
+    ok = emqx_hooks:del('client.authorize', {?MODULE, crashing_authz}),
+    ok = emqx_hooks:del('client.authorize', {?MODULE, permissive_authz_stop}),
+    ok = emqx_hooks:del('client.authorize', {?MODULE, permissive_authz_ok}),
+    ok = emqx_hooks:del('client.authenticate', {?MODULE, quick_deny_anonymous_authn}),
+    ok = emqx_hooks:del('client.authenticate', {?MODULE, crashing_authn}),
+    ok = emqx_hooks:del('client.authenticate', {?MODULE, permissive_authn_stop}),
+    ok = emqx_hooks:del('client.authenticate', {?MODULE, permissive_authn_ok}).
 
 t_authenticate(_) ->
     ClientInfo = clientinfo(),
@@ -108,9 +114,72 @@ t_quick_deny_anonymous(_) ->
     ?assertMatch({error, _}, emqx_access_control:authenticate(Client5)),
     ok.
 
+t_authn_hook_crash_security_profile(_) ->
+    Cases = [
+        {"legacy", [crashing_authn, permissive_authn_stop], ok},
+        {"legacy", [permissive_authn_stop, crashing_authn], ok},
+        {"legacy", [crashing_authn, permissive_authn_ok], ok},
+        {"legacy", [permissive_authn_ok, crashing_authn], ok},
+        {"hardened", [crashing_authn, permissive_authn_stop], error},
+        {"hardened", [permissive_authn_stop, crashing_authn], ok},
+        {"hardened", [crashing_authn, permissive_authn_ok], error},
+        {"hardened", [permissive_authn_ok, crashing_authn], error}
+    ],
+    lists:foreach(fun check_authn_hook_crash_case/1, Cases).
+
+t_authz_hook_crash_security_profile(_) ->
+    Cases = [
+        {"legacy", [crashing_authz, permissive_authz_stop], allow},
+        {"legacy", [permissive_authz_stop, crashing_authz], allow},
+        {"legacy", [crashing_authz, permissive_authz_ok], allow},
+        {"legacy", [permissive_authz_ok, crashing_authz], allow},
+        {"hardened", [crashing_authz, permissive_authz_stop], deny},
+        {"hardened", [permissive_authz_stop, crashing_authz], allow},
+        {"hardened", [crashing_authz, permissive_authz_ok], deny},
+        {"hardened", [permissive_authz_ok, crashing_authz], deny}
+    ],
+    lists:foreach(fun check_authz_hook_crash_case/1, Cases).
+
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------
+
+check_authn_hook_crash_case({Profile, Hooks, Expected}) ->
+    cleanup_crash_test_hooks(),
+    emqx_common_test_helpers:with_security_profile(Profile, fun() ->
+        ok = add_crash_test_hooks('client.authenticate', ?HP_AUTHN, Hooks),
+        Result = emqx_access_control:authenticate(clientinfo()),
+        assert_authn_result(Expected, Result)
+    end),
+    cleanup_crash_test_hooks().
+
+check_authz_hook_crash_case({Profile, Hooks, Expected}) ->
+    cleanup_crash_test_hooks(),
+    emqx_common_test_helpers:with_security_profile(Profile, fun() ->
+        ok = emqx_authz_cache:empty_authz_cache(),
+        ok = add_crash_test_hooks('client.authorize', ?HP_AUTHZ, Hooks),
+        ?assertEqual(Expected, emqx_access_control:authorize(clientinfo(), ?AUTHZ_PUBLISH, <<"t">>))
+    end),
+    cleanup_crash_test_hooks().
+
+add_crash_test_hooks(HookPoint, BasePriority, [HookFirst, HookSecond]) ->
+    ok = emqx_hooks:put(HookPoint, {?MODULE, HookFirst, []}, BasePriority + 1),
+    ok = emqx_hooks:put(HookPoint, {?MODULE, HookSecond, []}, BasePriority),
+    ok.
+
+assert_authn_result(ok, Result) ->
+    ?assertMatch({ok, _}, Result);
+assert_authn_result(error, Result) ->
+    ?assertEqual({error, not_authorized}, Result).
+
+cleanup_crash_test_hooks() ->
+    ok = emqx_hooks:del('client.authenticate', {?MODULE, crashing_authn}),
+    ok = emqx_hooks:del('client.authenticate', {?MODULE, permissive_authn_stop}),
+    ok = emqx_hooks:del('client.authenticate', {?MODULE, permissive_authn_ok}),
+    ok = emqx_hooks:del('client.authorize', {?MODULE, crashing_authz}),
+    ok = emqx_hooks:del('client.authorize', {?MODULE, permissive_authz_stop}),
+    ok = emqx_hooks:del('client.authorize', {?MODULE, permissive_authz_ok}),
+    ok.
 
 authz_stub(_Client, _Action, ValidTopic, _DefaultResult, ValidTopic) -> {stop, #{result => allow}};
 authz_stub(_Client, _Action, _Topic, _DefaultResult, _ValidTopic) -> {stop, #{result => deny}}.
@@ -125,6 +194,24 @@ quick_deny_anonymous_authn(#{username := <<"badname">>}, _AuthResult) ->
     {stop, {error, not_authorized}};
 quick_deny_anonymous_authn(_ClientInfo, _AuthResult) ->
     {stop, {ok, #{is_superuser => false}}}.
+
+crashing_authn(_ClientInfo, _AuthResult) ->
+    erlang:error(authn_hook_crashed).
+
+permissive_authn_stop(_ClientInfo, _AuthResult) ->
+    {stop, {ok, #{is_superuser => false}}}.
+
+permissive_authn_ok(_ClientInfo, _AuthResult) ->
+    {ok, {ok, #{is_superuser => false}}}.
+
+crashing_authz(_ClientInfo, _Action, _Topic, _AuthzResult) ->
+    erlang:error(authz_hook_crashed).
+
+permissive_authz_stop(_ClientInfo, _Action, _Topic, _AuthzResult) ->
+    {stop, #{result => allow, from => test}}.
+
+permissive_authz_ok(_ClientInfo, _Action, _Topic, _AuthzResult) ->
+    {ok, #{result => allow, from => test}}.
 
 clientinfo() -> clientinfo(#{}).
 clientinfo(InitProps) ->

--- a/apps/emqx/test/emqx_hooks_SUITE.erl
+++ b/apps/emqx/test/emqx_hooks_SUITE.erl
@@ -21,8 +21,13 @@ init_per_testcase(_TestCase, Config) ->
             foldl_hook,
             foldl_hook2,
             foreach_hook,
+            foreach_stop_hook,
             foreach_filter1_hook,
-            foldl_filter2_hook
+            foldl_filter2_hook,
+            foldl_strict_hook,
+            foldl_crash_hook,
+            foldl_strict_crash_hook,
+            foldl_strict_context_hook
         ]
     ),
     Config.
@@ -180,6 +185,45 @@ t_run_hooks(_) ->
     ?assertEqual(3, emqx_hooks:run_fold(foldl_filter2_hook, [arg], 1)),
     ?assertEqual(2, emqx_hooks:run_fold(foldl_filter2_hook, [arg1], 1)).
 
+t_run_stops_on_stop(_) ->
+    _ = erlang:erase(hook_mark_run),
+    ok = emqx_hooks:add(foreach_stop_hook, {?MODULE, hook_stop_run, []}, 1),
+    ok = emqx_hooks:add(foreach_stop_hook, {?MODULE, hook_mark_run, []}, 0),
+    ?assertEqual(ok, emqx_hooks:run(foreach_stop_hook, [arg])),
+    ?assertEqual(undefined, erlang:get(hook_mark_run)).
+
+t_run_fold_strict(_) ->
+    ok = emqx_hooks:add(foldl_strict_hook, {?MODULE, hook_fun2, []}, 0),
+    ok = emqx_hooks:add(foldl_strict_hook, {?MODULE, hook_fun2_1, []}, 0),
+    ?assertEqual({ok, 3}, emqx_hooks:run_fold_strict(foldl_strict_hook, [arg], 1)),
+
+    ok = emqx_hooks:put(foldl_strict_hook, {?MODULE, hook_stop_new_acc, []}, 1),
+    ?assertEqual({ok, 11}, emqx_hooks:run_fold_strict(foldl_strict_hook, [arg], 1)),
+
+    ok = emqx_hooks:add(foldl_strict_crash_hook, {?MODULE, hook_crash, []}, 1),
+    ok = emqx_hooks:add(foldl_strict_crash_hook, {?MODULE, hook_fun2, []}, 0),
+    ?assertEqual(
+        {error, strict_fold_crashed},
+        emqx_hooks:run_fold_strict(foldl_strict_crash_hook, [arg], 1)
+    ).
+
+t_run_fold_ignores_crashed_callbacks(_) ->
+    ok = emqx_hooks:add(foldl_crash_hook, {?MODULE, hook_crash, []}, 1),
+    ok = emqx_hooks:add(foldl_crash_hook, {?MODULE, hook_fun2, []}, 0),
+    ?assertEqual(2, emqx_hooks:run_fold(foldl_crash_hook, [arg], 1)).
+
+t_run_fold_strict_with_context(_) ->
+    ok = emqx_hooks:add(
+        foldl_strict_context_hook,
+        {?MODULE, hook_context_fold, [foldl_strict_context_hook]},
+        0
+    ),
+    ?assertEqual(
+        {ok, [#{ctx => value}]},
+        emqx_hooks:run_fold_strict(foldl_strict_context_hook, #{ctx => value}, [arg], [])
+    ),
+    ?assertEqual(undefined, emqx_hooks:context(foldl_strict_context_hook)).
+
 t_uncovered_func(_) ->
     Pid = erlang:whereis(emqx_hooks),
     gen_server:call(Pid, test),
@@ -210,6 +254,18 @@ hook_fun8(arg, initArg) -> ok.
 
 hook_fun9(arg, Acc) -> {stop, [r9 | Acc]}.
 hook_fun10(arg, Acc) -> {stop, [r10 | Acc]}.
+
+hook_stop_run(_Arg) -> stop.
+
+hook_mark_run(_Arg) ->
+    _ = erlang:put(hook_mark_run, true),
+    ok.
+
+hook_stop_new_acc(_Arg, Acc) -> {stop, Acc + 10}.
+
+hook_crash(_Arg, _Acc) -> erlang:error(strict_fold_crashed).
+
+hook_context_fold(arg, Acc, HookPoint) -> {ok, [emqx_hooks:context(HookPoint) | Acc]}.
 
 hook_filter1(arg) -> true;
 hook_filter1(_) -> false.

--- a/changes/ee/feat-17589.en.md
+++ b/changes/ee/feat-17589.en.md
@@ -1,0 +1,1 @@
+Added hardened-profile fail-close handling for access-control hook callback failures, so crashing authentication or authorization hook callbacks deny access instead of being ignored.


### PR DESCRIPTION
https://github.com/emqx/emqx-dev-team-tasks/issues/112
Addresses https://github.com/emqx/emqx-dev-team-tasks/issues/118

Release version: 6.2.2

A complement to https://github.com/emqx/emqx/pull/17564

## Summary

This PR adds hardened-profile fail-close behavior for access-control hook callback failures.

In hardened mode, a authentication and authorization hook failures are treated as denial.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
