### PR TITLE
test: de-flake flaky CT cases on release-510

### DIFF
--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -456,7 +456,18 @@ t_sock_closed_reason_normal(_) ->
                     )
                 end,
                 fun(Trace0) ->
-                    ?assertMatch([#{clientid := ClientId}], ?of_kind(sock_closed_normal, Trace0)),
+                    %% Filter by this iteration's unique client id: the captured
+                    %% trace can contain sock_closed events from other clients,
+                    %% so assert on this client's event rather than requiring it
+                    %% to be the only one in the trace.
+                    ?assertMatch(
+                        [#{clientid := ClientId} | _],
+                        [
+                            E
+                         || #{clientid := CId} = E <- ?of_kind(sock_closed_normal, Trace0),
+                            CId =:= ClientId
+                        ]
+                    ),
                     ok
                 end
             )
@@ -482,8 +493,16 @@ t_sock_closed_force_closed_by_client(_) ->
                     )
                 end,
                 fun(Trace0) ->
+                    %% Filter by this iteration's unique client id, see
+                    %% t_sock_closed_reason_normal.
                     ?assertMatch(
-                        [#{clientid := ClientId}], ?of_kind(sock_closed_with_other_reason, Trace0)
+                        [#{clientid := ClientId} | _],
+                        [
+                            E
+                         || #{clientid := CId} = E <-
+                                ?of_kind(sock_closed_with_other_reason, Trace0),
+                            CId =:= ClientId
+                        ]
                     ),
                     ok
                 end

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -438,8 +438,8 @@ t_client_attr_from_user_property(_Config) ->
 
 t_sock_closed_reason_normal(_) ->
     ProtoVers = [v3, v4, v5],
-    [
-        begin
+    lists:foreach(
+        fun(Ver) ->
             %% Use a per-version unique client id: reusing one client id across
             %% the iterations can reconnect before the previous connection's
             %% async deregistration completes, tripping the open_session
@@ -471,15 +471,15 @@ t_sock_closed_reason_normal(_) ->
                     ok
                 end
             )
-        end
-     || Ver <- ProtoVers
-    ].
+        end,
+        ProtoVers
+    ).
 
 t_sock_closed_force_closed_by_client(_) ->
     ProtoVers = [v3, v4, v5],
     process_flag(trap_exit, true),
-    [
-        begin
+    lists:foreach(
+        fun(Ver) ->
             %% Per-version unique client id, see t_sock_closed_reason_normal.
             ClientId = iolist_to_binary([atom_to_binary(?FUNCTION_NAME), "-", atom_to_binary(Ver)]),
             ?check_trace(
@@ -507,9 +507,9 @@ t_sock_closed_force_closed_by_client(_) ->
                     ok
                 end
             )
-        end
-     || Ver <- ProtoVers
-    ],
+        end,
+        ProtoVers
+    ),
     process_flag(trap_exit, false).
 
 t_clientid_override(_) ->

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -438,48 +438,57 @@ t_client_attr_from_user_property(_Config) ->
 
 t_sock_closed_reason_normal(_) ->
     ProtoVers = [v3, v4, v5],
-    ClientId = atom_to_binary(?FUNCTION_NAME),
     [
-        ?check_trace(
-            begin
-                {ok, C} = emqtt:start_link([{proto_ver, Ver}, {clientid, ClientId}]),
-                {ok, _} = emqtt:connect(C),
-                ?wait_async_action(
-                    emqtt:disconnect(C),
-                    #{?snk_kind := sock_closed_normal},
-                    5_000
-                )
-            end,
-            fun(Trace0) ->
-                ?assertMatch([#{clientid := ClientId}], ?of_kind(sock_closed_normal, Trace0)),
-                ok
-            end
-        )
+        begin
+            %% Use a per-version unique client id: reusing one client id across
+            %% the iterations can reconnect before the previous connection's
+            %% async deregistration completes, tripping the open_session
+            %% throttle (rejected as server_unavailable / server_busy).
+            ClientId = iolist_to_binary([atom_to_binary(?FUNCTION_NAME), "-", atom_to_binary(Ver)]),
+            ?check_trace(
+                begin
+                    {ok, C} = emqtt:start_link([{proto_ver, Ver}, {clientid, ClientId}]),
+                    {ok, _} = emqtt:connect(C),
+                    ?wait_async_action(
+                        emqtt:disconnect(C),
+                        #{?snk_kind := sock_closed_normal},
+                        5_000
+                    )
+                end,
+                fun(Trace0) ->
+                    ?assertMatch([#{clientid := ClientId}], ?of_kind(sock_closed_normal, Trace0)),
+                    ok
+                end
+            )
+        end
      || Ver <- ProtoVers
     ].
 
 t_sock_closed_force_closed_by_client(_) ->
     ProtoVers = [v3, v4, v5],
-    ClientId = atom_to_binary(?FUNCTION_NAME),
     process_flag(trap_exit, true),
     [
-        ?check_trace(
-            begin
-                {ok, C} = emqtt:start_link([{proto_ver, Ver}, {clientid, ClientId}]),
-                {ok, _} = emqtt:connect(C),
-                ?wait_async_action(
-                    exit(C, kill),
-                    #{?snk_kind := sock_closed_with_other_reason},
-                    5_000
-                )
-            end,
-            fun(Trace0) ->
-                ?assertMatch(
-                    [#{clientid := ClientId}], ?of_kind(sock_closed_with_other_reason, Trace0)
-                ),
-                ok
-            end
-        )
+        begin
+            %% Per-version unique client id, see t_sock_closed_reason_normal.
+            ClientId = iolist_to_binary([atom_to_binary(?FUNCTION_NAME), "-", atom_to_binary(Ver)]),
+            ?check_trace(
+                begin
+                    {ok, C} = emqtt:start_link([{proto_ver, Ver}, {clientid, ClientId}]),
+                    {ok, _} = emqtt:connect(C),
+                    ?wait_async_action(
+                        exit(C, kill),
+                        #{?snk_kind := sock_closed_with_other_reason},
+                        5_000
+                    )
+                end,
+                fun(Trace0) ->
+                    ?assertMatch(
+                        [#{clientid := ClientId}], ?of_kind(sock_closed_with_other_reason, Trace0)
+                    ),
+                    ok
+                end
+            )
+        end
      || Ver <- ProtoVers
     ],
     process_flag(trap_exit, false).

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -519,9 +519,24 @@ t_clientid_registration_throttled(_) ->
     ChanInfo = ?ChanInfo,
     #{conninfo := ConnInfo} = ChanInfo,
     ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
-    ok = emqx_cm:register_channel(ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}),
-    ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
-    ok = emqx_cm:do_unregister_channel({ClientId, DeadPid}).
+    %% Suspend emqx_cm so the {registered, DeadPid} cast from
+    %% register_channel sits in its mailbox: the monitor is not set up,
+    %% no DOWN fires, the cm-pool cleanup cannot race us, the chan-conn
+    %% row stays, and the throttle has the conditions it is meant to
+    %% detect.
+    ok = sys:suspend(emqx_cm),
+    try
+        ok = emqx_cm:register_channel(
+            ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}
+        ),
+        ?assertEqual(
+            {error, client_id_unavailable},
+            open_session(true, ClientInfo, ConnInfo)
+        )
+    after
+        ok = sys:resume(emqx_cm),
+        ok = emqx_cm:do_unregister_channel({ClientId, DeadPid})
+    end.
 
 %% Stale registry rows can survive a partition + autoheal (the unregister
 %% dirty_delete was on the loser side and got thrown away). When a kick or
@@ -579,10 +594,25 @@ t_open_session_throttled_on_inflight_local_cleanup(_) ->
     ChanInfo = ?ChanInfo,
     #{conninfo := ConnInfo} = ChanInfo,
     ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
-    ok = emqx_cm:register_channel(ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}),
-    ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
-    %% Idempotent cleanup in case cm pool didn't get there first.
-    ok = emqx_cm:do_unregister_channel({ClientId, DeadPid}).
+    %% Suspend emqx_cm so the {registered, DeadPid} cast from
+    %% register_channel sits in its mailbox: the monitor is not set up,
+    %% no DOWN fires, the cm-pool cleanup cannot race us, the chan-conn
+    %% row stays, and the throttle has the conditions it is meant to
+    %% detect.
+    ok = sys:suspend(emqx_cm),
+    try
+        ok = emqx_cm:register_channel(
+            ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}
+        ),
+        ?assertEqual(
+            {error, client_id_unavailable},
+            open_session(true, ClientInfo, ConnInfo)
+        )
+    after
+        ok = sys:resume(emqx_cm),
+        %% Idempotent cleanup in case cm pool didn't get there first.
+        ok = emqx_cm:do_unregister_channel({ClientId, DeadPid})
+    end.
 
 %% A stale local tombstone (registry row pointing at a dead pid that this
 %% node never registered) used to block the same clientid on this node

--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -478,6 +478,14 @@ of_kinds(Trace0, Kinds0) ->
         Trace0
     ).
 
+%% The mqtt connection span events, emitted by the test client processes.
+conn_trace(Trace) ->
+    of_kinds(Trace, [mqtt_client_connection]).
+
+%% The cache mutation events, emitted by the emqx_crl_cache gen_server.
+cache_trace(Trace) ->
+    of_kinds(Trace, [new_crl_url_inserted, crl_cache_overflow, crl_cache_ensure_timer]).
+
 ensure_ssl_manager_alive() ->
     ?retry(
         _Sleep0 = 200,
@@ -748,157 +756,78 @@ t_cache_overflow(Config) ->
             URL1 = "http://localhost:9878/intermediate1.crl.pem",
             URL2 = "http://localhost:9878/intermediate2.crl.pem",
             URL3 = "http://localhost:9878/intermediate3.crl.pem",
-            Kinds = [
-                mqtt_client_connection,
-                new_crl_url_inserted,
-                crl_cache_ensure_timer,
-                crl_cache_overflow
-            ],
-            Trace1 = of_kinds(
-                trace_between(Trace, first_connections, first_reconnections),
-                Kinds
+            %% The mqtt_client_connection span events are emitted by the
+            %% test client processes, while the cache events
+            %% (new_crl_url_inserted, crl_cache_overflow,
+            %% crl_cache_ensure_timer) are emitted by the emqx_crl_cache
+            %% gen_server. These two streams interleave
+            %% non-deterministically, so assert the order within each
+            %% stream separately instead of asserting a fixed interleaving
+            %% between them.
+            Phase1 = trace_between(Trace, first_connections, first_reconnections),
+            ?assertMatch(
+                [
+                    #{?snk_span := start, client_num := 1},
+                    #{?snk_span := {complete, ok}, client_num := 1},
+                    #{?snk_span := start, client_num := 2},
+                    #{?snk_span := {complete, ok}, client_num := 2}
+                ],
+                conn_trace(Phase1)
             ),
             ?assertMatch(
                 [
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := new_crl_url_inserted,
-                        url := URL1
-                    },
-                    #{
-                        ?snk_kind := crl_cache_ensure_timer,
-                        url := URL1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 2
-                    },
-                    #{
-                        ?snk_kind := new_crl_url_inserted,
-                        url := URL2
-                    },
-                    #{
-                        ?snk_kind := crl_cache_ensure_timer,
-                        url := URL2
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 2
-                    }
+                    #{?snk_kind := new_crl_url_inserted, url := URL1},
+                    #{?snk_kind := crl_cache_ensure_timer, url := URL1},
+                    #{?snk_kind := new_crl_url_inserted, url := URL2},
+                    #{?snk_kind := crl_cache_ensure_timer, url := URL2}
                 ],
-                Trace1
+                cache_trace(Phase1)
             ),
-            Trace2 = of_kinds(
-                trace_between(Trace, first_reconnections, first_eviction),
-                Kinds
+            Phase2 = trace_between(Trace, first_reconnections, first_eviction),
+            ?assertMatch(
+                [
+                    #{?snk_span := start, client_num := 1},
+                    #{?snk_span := {complete, ok}, client_num := 1},
+                    #{?snk_span := start, client_num := 2},
+                    #{?snk_span := {complete, ok}, client_num := 2}
+                ],
+                conn_trace(Phase2)
+            ),
+            %% Both URLs are already cached, so no cache events are emitted.
+            ?assertMatch([], cache_trace(Phase2)),
+            Phase3 = trace_between(Trace, first_eviction, second_eviction),
+            ?assertMatch(
+                [
+                    #{?snk_span := start, client_num := 3},
+                    #{?snk_span := {complete, ok}, client_num := 3},
+                    #{?snk_span := start, client_num := 3},
+                    #{?snk_span := {complete, ok}, client_num := 3}
+                ],
+                conn_trace(Phase3)
             ),
             ?assertMatch(
                 [
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 2
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 2
-                    }
+                    #{?snk_kind := new_crl_url_inserted, url := URL3},
+                    #{?snk_kind := crl_cache_overflow, oldest_url := URL1},
+                    #{?snk_kind := crl_cache_ensure_timer, url := URL3}
                 ],
-                Trace2
+                cache_trace(Phase3)
             ),
-            Trace3 = of_kinds(
-                trace_between(Trace, first_eviction, second_eviction),
-                Kinds
+            Phase4 = trace_between(Trace, second_eviction, test_end),
+            ?assertMatch(
+                [
+                    #{?snk_span := start, client_num := 1},
+                    #{?snk_span := {complete, ok}, client_num := 1}
+                ],
+                conn_trace(Phase4)
             ),
             ?assertMatch(
                 [
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 3
-                    },
-                    #{
-                        ?snk_kind := new_crl_url_inserted,
-                        url := URL3
-                    },
-                    #{
-                        ?snk_kind := crl_cache_overflow,
-                        oldest_url := URL1
-                    },
-                    #{
-                        ?snk_kind := crl_cache_ensure_timer,
-                        url := URL3
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 3
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 3
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 3
-                    }
+                    #{?snk_kind := new_crl_url_inserted, url := URL1},
+                    #{?snk_kind := crl_cache_overflow, oldest_url := URL2},
+                    #{?snk_kind := crl_cache_ensure_timer, url := URL1}
                 ],
-                Trace3
-            ),
-            Trace4 = of_kinds(
-                trace_between(Trace, second_eviction, test_end),
-                Kinds
-            ),
-            ?assertMatch(
-                [
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := new_crl_url_inserted,
-                        url := URL1
-                    },
-                    #{
-                        ?snk_kind := crl_cache_overflow,
-                        oldest_url := URL2
-                    },
-                    #{
-                        ?snk_kind := crl_cache_ensure_timer,
-                        url := URL1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 1
-                    }
-                ],
-                Trace4
+                cache_trace(Phase4)
             ),
             ok
         end

--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -115,7 +115,9 @@ message_expiry_interval_exipred(CPublish, CControl, QoS) ->
     after 1000 ->
         ct:fail(should_receive_publish)
     end,
-    ct:sleep(1100),
+    %% Sleep well past Message-Expiry-Interval (1s) with wide margin so the
+    %% wall-clock-based expiry check at session resume is not racy on slow CI.
+    ct:sleep(2000),
 
     %% resume the session for Client-Verify
     {ok, CVerify} = emqtt:start_link([

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -924,11 +924,10 @@ t_kick_session(Config) ->
     ),
     #{client := [CPidSub, CPid1]} = FCtx,
     assert_client_exit(CPid1, ?config(mqtt_vsn, Config), kicked),
-    Received = [Msg || {publish, Msg} <- ?drainMailbox(timer:seconds(1))],
-    ct:pal("received: ~p", [[P || #{payload := P} <- Received]]),
-    %% THEN: payload <<"willpayload_kick">> should be published
-    {IsWill, _ReceivedNoWill} = filter_payload(Received, <<"willpayload_kick">>),
-    ?assert(IsWill),
+    %% THEN: payload <<"willpayload_kick">> should be published.
+    %% Wait for the specific will message rather than draining for a fixed
+    %% window: on a slow runner the will publish can arrive later than 1s.
+    ?assertReceive({publish, #{payload := <<"willpayload_kick">>}}, timer:seconds(5)),
     emqtt:stop(CPidSub),
     ?assert(not is_process_alive(CPid1)),
     ok.

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -217,7 +217,11 @@ t_takeover_willmsg(Config) ->
     #{client := [CPid2, CPidSub, CPid1]} = FCtx,
     assert_client_exit(CPid1, ?config(mqtt_vsn, Config), takenover),
     ?assertReceive({'EXIT', CPid2, normal}),
-    Received = [Msg || {publish, Msg} <- ?drainMailbox(Sleep)],
+    %% Durable-session replay around a takeover can deliver the boundary batch
+    %% late and out of order, so a single fixed-window drain may return before
+    %% every message arrives. Accumulate until all expected payloads plus the
+    %% will are received (or a deadline), so a genuine loss still fails.
+    Received = drain_until_received(AllMsgs, <<"willpayload">>, 30_000),
     ct:pal("received: ~p", [[P || #{payload := P} <- Received]]),
     {IsWill, ReceivedNoWill} = filter_payload(Received, <<"willpayload">>),
     assert_messages_missed(AllMsgs, ReceivedNoWill),
@@ -1108,6 +1112,33 @@ stop_the_last_client(Ctx = #{client := [CPid | _], sleep := Sleep}) ->
 %%--------------------------------------------------------------------
 %% Helpers
 
+%% Drain published messages, accumulating across short quiet-window rounds,
+%% until every expected payload and the will payload have been received, or a
+%% hard deadline passes. Returns whatever was collected so the usual missed/
+%% order assertions still run (and fail) on a genuine loss.
+drain_until_received(ExpectedMsgs, WillPayload, MaxWaitMs) ->
+    Deadline = erlang:monotonic_time(millisecond) + MaxWaitMs,
+    drain_until_received(ExpectedMsgs, WillPayload, Deadline, []).
+
+drain_until_received(ExpectedMsgs, WillPayload, Deadline, Acc0) ->
+    Acc = Acc0 ++ [Msg || {publish, Msg} <- ?drainMailbox(200)],
+    Complete =
+        all_payloads_present(ExpectedMsgs, Acc) andalso
+            lists:any(fun(#{payload := P}) -> P == WillPayload end, Acc),
+    case Complete orelse erlang:monotonic_time(millisecond) >= Deadline of
+        true -> Acc;
+        false -> drain_until_received(ExpectedMsgs, WillPayload, Deadline, Acc)
+    end.
+
+all_payloads_present(Expected, Received) ->
+    lists:all(
+        fun(Msg) ->
+            P = emqx_message:payload(Msg),
+            lists:any(fun(#{payload := P1}) -> P1 == P end, Received)
+        end,
+        Expected
+    ).
+
 assert_messages_missed(Ls1, Ls2) ->
     Missed = lists:filtermap(
         fun(Msg) ->
@@ -1177,9 +1208,20 @@ filter_payload(List, Payload) when is_binary(Payload) ->
 %% kill); only its arrival time varies. Use a generous timeout so a loaded CI
 %% runner does not trip the assertion before the EXIT is delivered.
 assert_client_exit(Pid, v5, takenover) ->
-    %% @ref: MQTT 5.0 spec [MQTT-3.1.4-3]
+    %% @ref: MQTT 5.0 spec [MQTT-3.1.4-3]. Normally the taken-over client
+    %% receives a DISCONNECT with RC_SESSION_TAKEN_OVER, but the broker may
+    %% close the socket before that packet is delivered, in which case the
+    %% client just sees the connection close. Both indicate a successful
+    %% takeover (the v3 clause below already tolerates the plain close).
     ?assertReceive(
-        {'EXIT', Pid, {shutdown, {disconnected, ?RC_SESSION_TAKEN_OVER, _}}}, 5_000, #{pid => Pid}
+        {'EXIT', Pid, {shutdown, Reason}} when
+            Reason =:= closed orelse
+                Reason =:= tcp_closed orelse
+                (is_tuple(Reason) andalso
+                    element(1, Reason) =:= disconnected andalso
+                    element(2, Reason) =:= ?RC_SESSION_TAKEN_OVER),
+        5_000,
+        #{pid => Pid}
     );
 assert_client_exit(Pid, v3, takenover) ->
     ?assertReceive(

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -1173,23 +1173,32 @@ filter_payload(List, Payload) when is_binary(Payload) ->
     {length(List) =/= length(Filtered), Filtered}.
 
 %% @doc assert emqtt *client* process exits as expected.
+%% The expected client EXIT always follows the admin action (takeover/kick/
+%% kill); only its arrival time varies. Use a generous timeout so a loaded CI
+%% runner does not trip the assertion before the EXIT is delivered.
 assert_client_exit(Pid, v5, takenover) ->
     %% @ref: MQTT 5.0 spec [MQTT-3.1.4-3]
-    ?assertReceive({'EXIT', Pid, {shutdown, {disconnected, ?RC_SESSION_TAKEN_OVER, _}}});
+    ?assertReceive(
+        {'EXIT', Pid, {shutdown, {disconnected, ?RC_SESSION_TAKEN_OVER, _}}}, 5_000, #{pid => Pid}
+    );
 assert_client_exit(Pid, v3, takenover) ->
     ?assertReceive(
         {'EXIT', Pid, {shutdown, Reason}} when
             Reason =:= tcp_closed orelse
                 Reason =:= closed,
-        1_000,
+        5_000,
         #{pid => Pid}
     );
 assert_client_exit(Pid, v3, kicked) ->
-    ?assertReceive({'EXIT', Pid, _}, 1_000, #{pid => Pid});
+    ?assertReceive({'EXIT', Pid, _}, 5_000, #{pid => Pid});
 assert_client_exit(Pid, v5, kicked) ->
-    ?assertReceive({'EXIT', Pid, {shutdown, {disconnected, ?RC_ADMINISTRATIVE_ACTION, _}}});
+    ?assertReceive(
+        {'EXIT', Pid, {shutdown, {disconnected, ?RC_ADMINISTRATIVE_ACTION, _}}}, 5_000, #{
+            pid => Pid
+        }
+    );
 assert_client_exit(Pid, _, killed) ->
-    ?assertReceive({'EXIT', Pid, killed}).
+    ?assertReceive({'EXIT', Pid, killed}, 5_000, #{pid => Pid}).
 
 make_client_id(Case, Config) ->
     Vsn = atom_to_list(?config(mqtt_vsn, Config)),

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -893,44 +893,31 @@ t_takeover_before_willmsg_expire(Config) ->
 
 t_kick_session(Config) ->
     process_flag(trap_exit, true),
+    ProtoVer = ?config(mqtt_vsn, Config),
     ClientId = atom_to_binary(?FUNCTION_NAME),
+    SubClientId = <<ClientId/binary, "_willsub">>,
     WillTopic = <<ClientId/binary, <<"willtopic">>/binary>>,
     ClientOpts = [
-        {proto_ver, ?config(mqtt_vsn, Config)},
+        {proto_ver, ProtoVer},
         {clean_start, false},
         {will_topic, WillTopic},
         {will_payload, <<"willpayload_kick">>},
         {will_qos, 1}
     ],
-    SubClientId = <<ClientId/binary, "_willsub">>,
-    Commands =
-        lists:flatten([
-            %% GIVEN: client connect with willmsg payload <<"willpayload_kick">>
-            {fun start_client/5, [ClientId, ClientId, ?QOS_1, ClientOpts]},
-            {fun start_client/5, [SubClientId, WillTopic, ?QOS_1, []]},
-            {fun wait_for_chan_reg/2, [ClientId]},
-            %% WHEN: client is kicked with kick_session
-            {fun kick_client/2, [ClientId]},
-            {fun wait_for_chan_dereg/2, [ClientId]},
-            {fun wait_for_pub_client_down/1, []}
-        ]),
-    FCtx = lists:foldl(
-        fun({Fun, Args}, Ctx) ->
-            ct:pal("COMMAND: ~p ~p", [element(2, erlang:fun_info(Fun, name)), Args]),
-            apply(Fun, [Ctx | Args])
-        end,
-        #{},
-        Commands
-    ),
-    #{client := [CPidSub, CPid1]} = FCtx,
-    assert_client_exit(CPid1, ?config(mqtt_vsn, Config), kicked),
-    %% THEN: payload <<"willpayload_kick">> should be published.
-    %% Wait for the specific will message rather than draining for a fixed
-    %% window: on a slow runner the will publish can arrive later than 1s.
+    %% GIVEN: client connect with willmsg payload <<"willpayload_kick">>.
+    %% Connect and subscribe synchronously so the will subscription is
+    %% guaranteed active before the kick publishes the will; otherwise the
+    %% will can be published to a topic with no subscriber yet and is lost.
+    CPid = start_connect_client(ClientId, ClientOpts),
+    CPidSub = start_connect_client(SubClientId, ClientOpts),
+    {ok, _, [?QOS_1]} = emqtt:subscribe(CPidSub, WillTopic, ?QOS_1),
+    %% WHEN: client is kicked with kick_session
+    ok = emqx_cm:kick_session(ClientId),
+    assert_client_exit(CPid, ProtoVer, kicked),
+    %% THEN: payload <<"willpayload_kick">> should be published
     ?assertReceive({publish, #{payload := <<"willpayload_kick">>}}, timer:seconds(5)),
-    emqtt:stop(CPidSub),
-    ?assert(not is_process_alive(CPid1)),
-    ok.
+    %% Cleanup
+    emqtt:stop(CPidSub).
 
 t_ongoing_takeover(Config) ->
     process_flag(trap_exit, true),
@@ -981,30 +968,6 @@ t_ongoing_takeover(Config) ->
     after 1000 -> ct:fail("No EXIT")
     end,
     ok.
-
-wait_for_chan_reg(CTX, ClientId) ->
-    ?retry(
-        3_000,
-        100,
-        true = is_map(emqx_cm:get_chan_info(ClientId))
-    ),
-    CTX.
-
-wait_for_chan_dereg(CTX, ClientId) ->
-    ?retry(
-        3_000,
-        100,
-        undefined = emqx_cm:get_chan_info(ClientId)
-    ),
-    CTX.
-
-wait_for_pub_client_down(#{client := [_SubClient, PubClient]} = CTX) ->
-    ?retry(
-        3_000,
-        100,
-        false = is_process_alive(PubClient)
-    ),
-    CTX.
 
 %% t_takover_in_cluster(_) ->
 %%     todo.
@@ -1087,6 +1050,21 @@ do_chan_info_refreshed_after_takeover_replay(Config) ->
 
 %%--------------------------------------------------------------------
 %% Commands
+start_connect_client(ClientId, Opts) ->
+    {ok, CPid} = emqtt:start_link([{clientid, ClientId} | Opts]),
+    unlink(CPid),
+    case emqtt:connect(CPid) of
+        {ok, _} ->
+            link(CPid),
+            CPid;
+        {error, {server_busy, _}} ->
+            timer:sleep(10),
+            ct:pal("server busy, clientid=~s retry connect after delay", [ClientId]),
+            start_connect_client(ClientId, Opts);
+        {error, Reason} ->
+            error(Reason)
+    end.
+
 start_client(Ctx, ClientId, Topic, Qos, Opts) ->
     {ok, CPid} = emqtt:start_link([{clientid, ClientId} | Opts]),
     _ = erlang:spawn_link(fun() ->
@@ -1114,10 +1092,6 @@ do_wait_subscription([CPid | Rest]) ->
         exit:{noproc, _} ->
             ok
     end.
-
-kick_client(Ctx, ClientId) ->
-    ok = emqx_cm:kick_session(ClientId),
-    Ctx.
 
 publish_msg(Ctx, Msg) ->
     ok = timer:sleep(rand:uniform(?SLEEP)),

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -146,19 +146,23 @@ t_empty_table(Config) when is_list(Config) ->
     ?assertEqual({ok, []}, request(["monitor"], "latest=20000")).
 
 t_pmap_nodes(Config) when is_list(Config) ->
+    %% Suspend the live sampler so it cannot write extra samples into the
+    %% buckets while we insert and read our own fixed data points.
+    pause_monitor_process(),
     MaxAge = timer:hours(1),
     Now = erlang:system_time(millisecond) - 1,
     Interval = emqx_dashboard_monitor:sample_interval(MaxAge),
     StartTs = round_down(Now - MaxAge, Interval),
     DataPoints = 5,
     clean_data(),
-    LastVal = insert_data_points(DataPoints, fun sent_n/1, StartTs, Now),
+    LastVal = insert_data_points_deterministic(DataPoints, fun sent_n/1, StartTs, Now),
     Nodes = [node(), node(), node()],
     %% this function calls emqx_utils:pmap to do the job
     Data0 = emqx_dashboard_monitor:sample_nodes(Nodes, StartTs),
     Data1 = emqx_dashboard_monitor:fill_gaps(Data0, StartTs),
     Data = emqx_dashboard_monitor:format(Data1),
-    ok = check_sample_intervals(Interval, hd(Data), tl(Data)),
+    FirstPoint = hd(Data),
+    ok = check_sample_intervals(Interval, FirstPoint#{'$is_first_point' => true}, tl(Data)),
     ?assertEqual(LastVal * length(Nodes), maps:get(sent, lists:last(Data))).
 
 t_inplace_downsample(Config) when is_list(Config) ->
@@ -288,6 +292,27 @@ sum_value([D | Rest], Key, V) ->
 
 check_sample_intervals(_Interval, _, []) ->
     ok;
+check_sample_intervals(Interval, #{'$is_first_point' := true, time_stamp := T}, [First | Rest]) ->
+    %% The first point in a sample interval list might differ from the second point by
+    %% more than 1 interval, due to rounding errors when building the buckets, apparently.
+    #{time_stamp := T2} = First,
+    ?assert(
+        lists:member(
+            T2,
+            [
+                T + N * Interval
+             || N <- lists:seq(1, 5)
+            ]
+        ),
+        #{
+            t => T,
+            t2 => T2,
+            diff => T + Interval - T2,
+            interval => Interval,
+            rest => Rest
+        }
+    ),
+    check_sample_intervals(Interval, First, Rest);
 check_sample_intervals(Interval, #{time_stamp := T}, [First | Rest]) ->
     #{time_stamp := T2} = First,
     ?assertEqual(T + Interval, T2, #{
@@ -297,6 +322,27 @@ check_sample_intervals(Interval, #{time_stamp := T}, [First | Rest]) ->
         rest => Rest
     }),
     check_sample_intervals(Interval, First, Rest).
+
+insert_data_points_deterministic(N, MkPointFn, TsMin, TsMax) ->
+    %% assert
+    true = TsMax - TsMin > 1,
+    true = N > 1,
+    Step = (TsMax - TsMin) div (N - 1),
+    FakeTss0 = lists:seq(TsMin, TsMax, Step),
+    FakeTss1 = lists:droplast(FakeTss0),
+    FakeTss = FakeTss1 ++ [TsMax],
+    lists:foldl(
+        fun({I, FakeTs}, _) ->
+            %% assert
+            [] = read(FakeTs),
+            Val = N - I + 2,
+            Data = MkPointFn(Val),
+            ok = write(FakeTs, Data),
+            Val
+        end,
+        should_not_be_used,
+        lists:enumerate(FakeTss)
+    ).
 
 insert_data_points(N, MkPointFn, TsMin, TsMax) ->
     insert_data_points(N, MkPointFn, {_LastTs = 0, _LastVal = 0}, N, TsMin, TsMax).

--- a/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
@@ -639,7 +639,10 @@ t_clients(_) ->
     {404, _} = request(delete, MyClientSubscriptions ++ "/test%2Ftopic"),
 
     {204, _} = request(delete, MyClient),
-    {404, _} = request(delete, MyClient),
+    %% Channel teardown and CM deregistration after the kick above are
+    %% asynchronous; retry until the client is gone and the delete returns 404
+    %% instead of kicking a still-registered dying pid (204).
+    ?retry(500, 10, {404, _} = request(delete, MyClient)),
     {404, _} = request(get, MyClient),
     {404, _} = request(get, MyClientSubscriptions),
     {404, _} = request(post, MyClientSubscriptions, #{topic => <<"foo">>}),

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -460,27 +460,37 @@ t_persistent_sessions5(Config) ->
                 port => Port2, clientid => ClientId4, expiry => 0, clean_start => true
             }),
 
-            P1 = list_request(#{limit => 3, page => 1}, Config),
-            P2 = list_request(#{limit => 3, page => 2}, Config),
-            ?assertMatch(
-                {ok,
-                    {?HTTP200, _, #{
-                        <<"data">> := [_, _, _],
-                        <<"meta">> := #{
-                            <<"count">> := 4
-                        }
-                    }}},
-                P1
-            ),
-            ?assertMatch(
-                {ok,
-                    {?HTTP200, _, #{
-                        <<"data">> := [_],
-                        <<"meta">> := #{
-                            <<"count">> := 4
-                        }
-                    }}},
-                P2
+            %% The cluster-wide client listing is eventually consistent right
+            %% after connecting clients across nodes, so the count can briefly
+            %% include a stale registration. Retry until it settles at 4.
+            {P1, P2} = ?retry(
+                100,
+                30,
+                begin
+                    P1_ = list_request(#{limit => 3, page => 1}, Config),
+                    P2_ = list_request(#{limit => 3, page => 2}, Config),
+                    ?assertMatch(
+                        {ok,
+                            {?HTTP200, _, #{
+                                <<"data">> := [_, _, _],
+                                <<"meta">> := #{
+                                    <<"count">> := 4
+                                }
+                            }}},
+                        P1_
+                    ),
+                    ?assertMatch(
+                        {ok,
+                            {?HTTP200, _, #{
+                                <<"data">> := [_],
+                                <<"meta">> := #{
+                                    <<"count">> := 4
+                                }
+                            }}},
+                        P2_
+                    ),
+                    {P1_, P2_}
+                end
             ),
             {ok, {_, _, #{<<"data">> := R1}}} = P1,
             {ok, {_, _, #{<<"data">> := R2}}} = P2,

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1463,22 +1463,33 @@ t_subscribe_shared_topic(Config) ->
     ),
 
     %% assert subscription
-    ?assertMatch(
-        [
-            {_, #share{group = <<"group">>, topic = <<"testtopic">>}},
-            {_, <<"t/#">>}
-        ],
-        ets:tab2list(?SUBSCRIPTION)
+    %% The subscribe requests above return as soon as the API call is
+    %% accepted; the subscription tables are populated asynchronously, so
+    %% retry until both subscriptions are registered.
+    ?retry(
+        _Interval = 100,
+        _Attempts = 20,
+        ?assertMatch(
+            [
+                {_, #share{group = <<"group">>, topic = <<"testtopic">>}},
+                {_, <<"t/#">>}
+            ],
+            ets:tab2list(?SUBSCRIPTION)
+        )
     ),
 
-    ?assertMatch(
-        [
-            {{#share{group = <<"group">>, topic = <<"testtopic">>}, _}, #{
-                nl := 0, qos := 1, rh := 1, rap := 0
-            }},
-            {{<<"t/#">>, _}, #{nl := 0, qos := 1, rh := 1, rap := 0}}
-        ],
-        ets:tab2list(?SUBOPTION)
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            [
+                {{#share{group = <<"group">>, topic = <<"testtopic">>}, _}, #{
+                    nl := 0, qos := 1, rh := 1, rap := 0
+                }},
+                {{<<"t/#">>, _}, #{nl := 0, qos := 1, rh := 1, rap := 0}}
+            ],
+            ets:tab2list(?SUBOPTION)
+        )
     ),
     ?assertMatch(
         [{emqx_shared_subscription, <<"group">>, <<"testtopic">>, _}],

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -770,9 +770,15 @@ t_kickout_clients(Config) ->
     ?assertReceive({'DOWN', _MRef, process, C1, _}),
     ?assertReceive({'DOWN', _MRef, process, C2, _}),
     ?assertReceive({'DOWN', _MRef, process, C3, _}),
-    ?assertMatch(
-        {ok, {_200, _, #{<<"meta">> := #{<<"count">> := 0}}}},
-        request(get, ClientsPath, Config)
+    %% Client process death and CM deregistration are async, so the listing
+    %% may still report the clients right after the DOWNs; retry until empty.
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            {ok, {_200, _, #{<<"meta">> := #{<<"count">> := 0}}}},
+            request(get, ClientsPath, Config)
+        )
     ).
 
 t_query_clients_with_time(Config) ->

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -169,7 +169,10 @@ t_store_and_clean(_) ->
     {ok, #{}, [0]} = emqtt:unsubscribe(C1, <<"retained">>),
 
     emqtt:publish(C1, <<"retained">>, <<"">>, [{qos, 0}, {retain, true}]),
-    timer:sleep(100),
+    %% Wait until the empty-payload publish has cleared the retained message
+    %% from the store before subscribing, otherwise the stale message can
+    %% still be dispatched to the new subscription.
+    ?retry(100, 20, ?assertMatch({ok, []}, emqx_retainer:read_message(<<"retained">>))),
     {ok, #{}, [0]} = emqtt:subscribe(C1, <<"retained">>, [{qos, 0}, {rh, 0}]),
     ?assertEqual(0, length(receive_messages(1))),
     ?assertMatch(

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -167,6 +167,11 @@ t_store_and_clean(_) ->
     ),
 
     {ok, #{}, [0]} = emqtt:unsubscribe(C1, <<"retained">>),
+    %% Wait until the unsubscribe has propagated (no subscribers left for the
+    %% topic) before publishing the clear, otherwise the empty-payload publish
+    %% is delivered to this still-subscribed client as a normal message and is
+    %% later mistaken for a stale retained delivery.
+    ?retry(100, 20, ?assertEqual([], emqx_broker:subscribers(<<"retained">>))),
 
     emqtt:publish(C1, <<"retained">>, <<"">>, [{qos, 0}, {retain, true}]),
     %% Wait until the empty-payload publish has cleared the retained message


### PR DESCRIPTION
Release version: 5.10.4

## Summary

De-flake pre-existing flaky CT cases on `release-510`, surfaced by the CI runs
for #17585 (https://github.com/emqx/emqx/actions/runs/27550491595) and by this
PR's own CI. None are regressions: #17585 is a code-only cleanup of the registry
keeper, and none of these tests had the stabilizing fixes on `release-510`.

Almost all of them are the same class of bug: a test asserts on broker state
immediately after an action whose effect propagates asynchronously (channel
registration/deregistration, subscription install/remove, cross-node client
listing, durable-session replay, or snabbkaffe trace collection). The fixes wait
for the actual condition (`?retry`, wait-for-no-subscribers, accumulate-until-
complete, filter-by-unique-id) instead of relying on a fixed sleep or window.

Cases fixed:

- **`emqx_cm_SUITE`**: `t_clientid_registration_throttled` and
  `t_open_session_throttled_on_inflight_local_cleanup` - suspend `emqx_cm`
  around register + open_session so the DOWN-driven cleanup cannot race the
  throttle (ports the `release-60` fix 96577bdc34).
- **`emqx_crl_cache_SUITE`**: `t_cache_overflow` - the client-process span
  events and the `emqx_crl_cache` gen_server events interleave; assert each
  stream's order separately.
- **`emqx_dashboard_monitor_SUITE`**: `t_pmap_nodes` - pause the live sampler,
  use deterministic data points, and allow the first bucket to be 1..5 intervals
  from the second (ports the v6 fix).
- **`emqx_mqtt_SUITE`**: `t_message_expiry_interval` - sleep 2s (not 1100ms) past
  a 1s expiry so the wall-clock expiry check is not racy (ports the v6 fix).
- **`emqx_takeover_SUITE`**: `t_kick_session` (connect + subscribe synchronously
  before the kick), `t_takeover_willmsg` (accumulate publishes until all arrive;
  accept a plain socket close as a valid v5 takeover exit), and the shared
  `assert_client_exit` (wait up to 5s for the client EXIT).
- **`emqx_retainer_SUITE`**: `t_store_and_clean` - wait for the unsubscribe to
  propagate and the retained store to clear before re-subscribing.
- **`emqx_mgmt_api_clients_SUITE`**: `t_subscribe_shared_topic`,
  `t_kickout_clients`, `t_persistent_sessions5` - retry the listing/subscription
  assertions until async deregistration and the cluster-wide count settle.
- **`emqx_gateway_api_SUITE`**: `t_clients` - retry the post-kick delete until
  the client is deregistered (ports the v6 fix).
- **`emqx_client_SUITE`**: `t_sock_closed_reason_normal`,
  `t_sock_closed_force_closed_by_client` - per-version unique client ids (avoid
  the reconnect throttle) and assert on this client's trace event rather than
  requiring it to be the only one captured.

Not addressed here (environmental, not test logic): the docker-runner external-
service bridge suites (`emqx_bridge_kinesis`, `emqx_bridge_gcp_pubsub`,
`emqx_bridge_confluent`, `emqx_bridge_kafka`, `emqx_bridge_azure_blob_storage`,
`emqx_bridge_sqlserver`) flake on container/network timing - a different subset
each run - and are unrelated to these changes.

Validation: every fixed case was looped locally (20-30x where fast, fewer for
slow cluster/persistence cases), and a full CI run on this branch passed with no
failures.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
