### PR TITLE
feat(emqx_relup): add data/patches preflight check to relup upgrade

### DIFF
--- a/changes/ee/feat-17593.en.md
+++ b/changes/ee/feat-17593.en.md
@@ -1,0 +1,4 @@
+Added `--force` flag to `emqx ctl relup upgrade`. By default, the
+upgrade now refuses to proceed if `data/patches/` contains any
+`*.beam` hot-patch files (which would shadow modules from the upgrade
+target). Pass `--force` to keep the patches and proceed anyway.

--- a/plugins/emqx_relup/README.md
+++ b/plugins/emqx_relup/README.md
@@ -25,10 +25,17 @@ CLI on each node.
    - `<tarball>.sha256` - sha256 digest of the tarball. The
      `sha256sum` output format (`<digest>  <filename>`) is accepted.
 
-4. **Trigger the upgrade.** `emqx ctl relup upgrade <TarballPath>`
+4. **Trigger the upgrade.** `emqx ctl relup upgrade <TarballPath> [--force]`
    on each node. The handler:
    - Verifies `<TarballPath>.sha256` against the tarball's actual
      digest - refuses to extract on mismatch.
+   - Refuses if `data/patches/` contains any `*.beam`. Those would
+     shadow modules from the upgrade target (the patches dir is
+     prepended to the code path via `vm.args -pa`), so if the new
+     release already supersedes a hot-patched module, the stale beam
+     would silently keep running. Delete the patches first, or pass
+     `--force` if you intend them to remain applied on top of the
+     target.
    - Extracts the tarball and reads `REL_VSN` from
      `releases/emqx_vars`.
    - Looks up the matching `{from, target}` hop in

--- a/plugins/emqx_relup/src/emqx_relup_cli.erl
+++ b/plugins/emqx_relup/src/emqx_relup_cli.erl
@@ -3,14 +3,9 @@
 -export([cmd/1]).
 
 cmd(["upgrade", TarballPath]) ->
-    case emqx_relup_main:upgrade(TarballPath) of
-        ok ->
-            emqx_ctl:print("upgrade complete~n");
-        {error, Reason} ->
-            emqx_ctl:print("upgrade failed, reason: ~p~n", [Reason]);
-        {error_vm_restarted, Reason} ->
-            emqx_ctl:print("upgrade failed, emqx restarted, reason: ~p~n", [Reason])
-    end;
+    do_upgrade(TarballPath, #{});
+cmd(["upgrade", TarballPath, "--force"]) ->
+    do_upgrade(TarballPath, #{force => true});
 cmd(["list-supported-paths"]) ->
     case emqx_relup_handler:list_supported_paths() of
         [] ->
@@ -45,11 +40,14 @@ cmd(["logs-clear"]) ->
     emqx_ctl:print("cleared all upgrade logs~n");
 cmd(_) ->
     emqx_ctl:usage([
-        {"relup upgrade <TarballPath>",
+        {"relup upgrade <TarballPath> [--force]",
             "Upgrade using the EMQX target tarball at <TarballPath>.\n"
             "A `<TarballPath>.sha256` sidecar must sit next to it.\n"
             "Target version is read from the tarball's\n"
-            "`releases/emqx_vars` (`REL_VSN`)."},
+            "`releases/emqx_vars` (`REL_VSN`).\n"
+            "Refuses to proceed if `data/patches/` contains any\n"
+            "`*.beam` (they would shadow the target's modules). Pass\n"
+            "--force to keep the patches and proceed anyway."},
         {"relup list-supported-paths", "List the {From, Target} hops the priv catalog supports."},
         {"relup status",
             "Print the current upgrade state of this node:\n"
@@ -63,6 +61,16 @@ cmd(_) ->
             "one row per attempt, oldest first."},
         {"relup logs-clear", "Wipe this node's upgrade log table."}
     ]).
+
+do_upgrade(TarballPath, Opts) ->
+    case emqx_relup_main:upgrade(TarballPath, Opts) of
+        ok ->
+            emqx_ctl:print("upgrade complete~n");
+        {error, Reason} ->
+            emqx_ctl:print("upgrade failed, reason: ~p~n", [Reason]);
+        {error_vm_restarted, Reason} ->
+            emqx_ctl:print("upgrade failed, emqx restarted, reason: ~p~n", [Reason])
+    end.
 
 print_log(#{
     started_at := Started,

--- a/plugins/emqx_relup/src/emqx_relup_handler.erl
+++ b/plugins/emqx_relup/src/emqx_relup_handler.erl
@@ -30,6 +30,10 @@ list_supported_paths() ->
 
 check_and_unpack(CurrVsn, RootDir, #{tarball := TarFile} = Opts) ->
     try
+        ok = assert_patches_dir_clean(
+            filename:join([emqx:data_dir(), "patches"]),
+            maps:get(force, Opts, false)
+        ),
         {ok, UnpackDir} = unpack_release(TarFile),
         TargetVsn = read_rel_vsn(UnpackDir),
         ok = assert_no_duplicate_pending(RootDir, TargetVsn),
@@ -121,6 +125,37 @@ assert_not_same_vsn(TargetVsn, TargetVsn) ->
     throw(make_error(already_upgraded_to_target_vsn, #{vsn => TargetVsn}));
 assert_not_same_vsn(_CurrVsn, _TargetVsn) ->
     ok.
+
+-doc """
+`data/patches/` is prepended to the code path at boot (`vm.args -pa`),
+so any `.beam` left there will shadow modules loaded from the upgrade
+target. If the operator forgot to clear out a hot-patch that the new
+release already supersedes, the upgrade would silently keep running the
+stale beam. Refuse by default; `--force` is the override for operators
+who deliberately want the patches to stay on top of the new release.
+""".
+assert_patches_dir_clean(_PatchesDir, true) ->
+    ok;
+assert_patches_dir_clean(PatchesDir, false) ->
+    case filelib:wildcard(filename:join(PatchesDir, "*.beam")) of
+        [] ->
+            ok;
+        Files ->
+            throw(
+                make_error(patches_dir_not_empty, #{
+                    dir => bin(PatchesDir),
+                    files => [bin(filename:basename(F)) || F <- Files],
+                    hint =>
+                        <<
+                            "hot-patch beam files in this dir will shadow modules "
+                            "from the upgrade target. Delete them if the target "
+                            "already contains those fixes; re-run with --force if "
+                            "you intend the patches to remain applied on top of "
+                            "the target."
+                        >>
+                })
+            )
+    end.
 
 check_write_permission(RootDir) ->
     SubDirs = ["relup"],

--- a/plugins/emqx_relup/src/emqx_relup_main.erl
+++ b/plugins/emqx_relup/src/emqx_relup_main.erl
@@ -14,7 +14,8 @@
 -export([
     load/1,
     unload/0,
-    upgrade/1
+    upgrade/1,
+    upgrade/2
 ]).
 
 -export([
@@ -75,7 +76,11 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 upgrade(TarballPath) ->
-    gen_server:call(?MODULE, {upgrade, #{tarball => TarballPath}}, infinity).
+    upgrade(TarballPath, #{}).
+
+upgrade(TarballPath, ExtraOpts) when is_map(ExtraOpts) ->
+    Opts = ExtraOpts#{tarball => TarballPath},
+    gen_server:call(?MODULE, {upgrade, Opts}, infinity).
 
 %% Called when the plugin application start
 load(_Env) ->

--- a/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
@@ -57,8 +57,14 @@ init_per_testcase(Case, Config) ->
     ok = forge_release_files(RootDir, ?CURR_VSN, default_arch()),
     [{root_dir, RootDir} | Config].
 
-end_per_testcase(_Case, _Config) ->
+end_per_testcase(_Case, Config) ->
     cleanup_test_catalog_entries(),
+    %% The patches-dir preflight reads the shared emqx:data_dir()/patches;
+    %% make sure no stale beam leaks into a later case.
+    _ = [
+        file:delete(F)
+     || F <- filelib:wildcard(filename:join(?config(patches_dir, Config), "*.beam"))
+    ],
     ok.
 
 %%==============================================================================
@@ -320,6 +326,50 @@ t_chain_relup_from_pending_marker(Config) ->
     ?assertMatch(
         {ok, #{target_vsn := ?TARGET_VSN}},
         emqx_relup_handler:check_and_unpack(?CURR_VSN, RootDir, #{tarball => Tarball})
+    ).
+
+-doc "`data/patches/` is prepended to the code path via `vm.args -pa`, so "
+"a `*.beam` left there would shadow modules from the upgrade target. The "
+"preflight refuses with `patches_dir_not_empty` by default; `force => "
+"true` skips it; an empty patches dir passes. Driven through "
+"`check_and_unpack/3` (not the `emqx_relup_main` gen_server) so the temp "
+"RootDir stays hermetic and the real install is never touched.".
+t_patches_dir_preflight(Config) ->
+    RootDir = ?config(root_dir, Config),
+    PatchesDir = ?config(patches_dir, Config),
+    Tarball = forge_target_tarball(RootDir, ?TARGET_VSN, default_arch()),
+    ok = write_sha256_sidecar(Tarball),
+    _ = write_no_op_relup(?CURR_VSN, ?TARGET_VSN),
+    StaleBeam = filename:join(PatchesDir, "stale_patch.beam"),
+    ok = file:write_file(StaleBeam, <<>>),
+    try
+        %% A stale hot-patch beam present, no force -> refuse before unpack.
+        ?assertMatch(
+            {error, #{
+                err_type := patches_dir_not_empty,
+                files := [<<"stale_patch.beam">>]
+            }},
+            emqx_relup_handler:check_and_unpack(
+                ?CURR_VSN, RootDir, #{tarball => Tarball}
+            )
+        ),
+        %% force => true skips the preflight; downstream checks still run
+        %% and (with the no-op catalog entry) the upgrade proceeds.
+        ?assertMatch(
+            {ok, #{target_vsn := ?TARGET_VSN}},
+            emqx_relup_handler:check_and_unpack(
+                ?CURR_VSN, RootDir, #{tarball => Tarball, force => true}
+            )
+        )
+    after
+        ok = file:delete(StaleBeam)
+    end,
+    %% Empty patches dir -> preflight passes without force.
+    ?assertMatch(
+        {ok, #{target_vsn := ?TARGET_VSN}},
+        emqx_relup_handler:check_and_unpack(
+            ?CURR_VSN, RootDir, #{tarball => Tarball}
+        )
     ).
 
 %%==============================================================================


### PR DESCRIPTION
Release version: 5.10.4

## Summary

Backports the `data/patches/` preflight check from the v6 `emqx_relup`
plugin (release-60+) to release-510.

`data/patches/` is prepended to the code path at boot (`vm.args -pa`),
so any `*.beam` left there shadows modules loaded from the upgrade
target. If an operator leaves a hot-patch that the new release already
supersedes, the upgrade would silently keep running the stale beam.

Changes:
- `emqx ctl relup upgrade <TarballPath>` now refuses to proceed when
  `data/patches/` contains any `*.beam`, returning
  `patches_dir_not_empty` with the offending file names and a hint.
- New `--force` flag (`emqx ctl relup upgrade <TarballPath> --force`)
  skips the preflight for operators who deliberately want the patches
  to remain applied on top of the target.
- `emqx_relup_main:upgrade/2` API and a `do_upgrade/2` CLI helper carry
  the opts map through.
- Plugin README step 4 documents the new behaviour.
- New CT case `t_patches_dir_preflight` in
  `emqx_relup_round_trip_SUITE` covers refuse / `--force` skip / empty
  dir passes.

Out of scope (intentionally not ported from r60): the
`check_otp_comaptibility` typo fix, the `pending_vm_restart` /
`maybe_restart_vm` VM-restart sequencing change, and the
`restart_application` instruction reshape.

Triggered by a docs review request to document this preflight:
https://github.com/emqx/emqx-docs/pull/3587#discussion_r3411667618

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
