### PR TITLE
feat(gcp): support file-based secrets for service account creds

### DIFF
--- a/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_connector_schema.erl
+++ b/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_connector_schema.erl
@@ -87,12 +87,10 @@ fields(connector_config) ->
             )},
         emqx_connector_schema:ehttpc_max_inactive_sc(),
         {service_account_json,
-            mk(
-                binary(),
+            emqx_schema_secret:mk(
                 #{
                     required => true,
                     validator => fun emqx_bridge_gcp_pubsub:service_account_json_validator/1,
-                    sensitive => true,
                     desc => ?DESC(emqx_bridge_gcp_pubsub, "service_account_json")
                 }
             )}

--- a/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
+++ b/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
@@ -104,7 +104,7 @@ callback_mode() ->
 on_start(ConnResId, ConnConfig0) ->
     ConnConfig1 = maps:update_with(
         service_account_json,
-        fun(X) -> emqx_utils_json:decode(X) end,
+        fun emqx_bridge_gcp_pubsub:decode_service_account_json/1,
         ConnConfig0
     ),
     {Transport, HostPort} = emqx_bridge_gcp_pubsub_client:get_transport(bigquery),

--- a/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
+++ b/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
@@ -59,6 +59,7 @@ groups() ->
 init_per_suite(TCConfig) ->
     Server = render_str("${host}:${port}", #{host => ?PROXY_HOST, port => ?PORT}),
     os:putenv("BIGQUERY_EMULATOR_HOST", Server),
+    WorkDir = emqx_cth_suite:work_dir(TCConfig),
     Apps = emqx_cth_suite:start(
         [
             emqx,
@@ -69,9 +70,10 @@ init_per_suite(TCConfig) ->
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],
-        #{work_dir => emqx_cth_suite:work_dir(TCConfig)}
+        #{work_dir => WorkDir}
     ),
     [
+        {work_dir, WorkDir},
         {apps, Apps},
         {proxy_host, ?PROXY_HOST},
         {proxy_port, ?PROXY_PORT},
@@ -456,6 +458,18 @@ get_action_api(TCConfig) ->
         emqx_bridge_v2_testlib:get_action_api(TCConfig)
     ).
 
+mk_service_account_file(TCConfig, Content) ->
+    Filename = filename:join(
+        ?config(work_dir, TCConfig),
+        lists:flatten([
+            binary_to_list(?config(connector_name, TCConfig)),
+            integer_to_list(erlang:unique_integer()),
+            ".json"
+        ])
+    ),
+    ok = file:write_file(Filename, Content),
+    Filename.
+
 %%------------------------------------------------------------------------------
 %% Test cases
 %%------------------------------------------------------------------------------
@@ -465,6 +479,15 @@ t_start_stop(TCConfig) when is_list(TCConfig) ->
 
 t_on_get_status(TCConfig) when is_list(TCConfig) ->
     emqx_bridge_v2_testlib:t_on_get_status(TCConfig).
+
+t_on_get_status_with_service_account_file_secret(TCConfig) ->
+    ServiceAccountJSON = ?config(service_account_json, TCConfig),
+    Filename = mk_service_account_file(TCConfig, emqx_utils_json:encode(ServiceAccountJSON)),
+    FileRef = iolist_to_binary(["file://", Filename]),
+    emqx_bridge_v2_testlib:t_on_get_status([
+        {connector_overrides, #{<<"service_account_json">> => FileRef}}
+        | TCConfig
+    ]).
 
 t_rule_action() ->
     [{matrix, true}].
@@ -492,6 +515,26 @@ t_rule_action(TCConfig) when is_list(TCConfig) ->
         post_publish_fn => PostPublishFn
     },
     emqx_bridge_v2_testlib:t_rule_action(TCConfig, Opts).
+
+t_file_secret_service_account_json(TCConfig) when is_list(TCConfig) ->
+    ConnectorName = ?config(connector_name, TCConfig),
+    ServiceAccountJSON = ?config(service_account_json, TCConfig),
+    Filename = mk_service_account_file(TCConfig, emqx_utils_json:encode(ServiceAccountJSON)),
+    FileRef = iolist_to_binary(["file://", Filename]),
+    {201, _} = create_connector_api(TCConfig, #{<<"service_account_json">> => FileRef}),
+    {ok, Hocon} = hocon:files([application:get_env(emqx, cluster_hocon_file, undefined)]),
+    ?assertEqual(
+        FileRef,
+        emqx_utils_maps:deep_get(
+            [
+                <<"connectors">>,
+                ?CONNECTOR_TYPE_BIN,
+                ConnectorName,
+                <<"service_account_json">>
+            ],
+            Hocon
+        )
+    ).
 
 %% Checks that we mark the resource as unhealthy if the dataset does not exist at channel
 %% creation time.

--- a/apps/emqx_bridge_gcp_pubsub/mix.exs
+++ b/apps/emqx_bridge_gcp_pubsub/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeGcpPubsub.MixProject do
   def project do
     [
       app: :emqx_bridge_gcp_pubsub,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
@@ -18,7 +18,8 @@
 ]).
 -export([
     service_account_json_validator/1,
-    service_account_json_converter/2
+    service_account_json_converter/2,
+    decode_service_account_json/1
 ]).
 
 -export([upgrade_raw_conf/1]).
@@ -82,13 +83,11 @@ fields(connector_config) ->
                 }
             )},
         {service_account_json,
-            sc(
-                binary(),
+            emqx_schema_secret:mk(
                 #{
                     required => true,
                     validator => fun ?MODULE:service_account_json_validator/1,
                     converter => fun ?MODULE:service_account_json_converter/2,
-                    sensitive => true,
                     desc => ?DESC("service_account_json")
                 }
             )}
@@ -249,12 +248,12 @@ type_field_consumer() ->
 name_field() ->
     {name, mk(binary(), #{required => true, desc => ?DESC("desc_name")})}.
 
--spec service_account_json_validator(binary()) ->
+-spec service_account_json_validator(emqx_secret:t(binary())) ->
     ok
     | {error, {wrong_type, term()}}
     | {error, {missing_keys, [binary()]}}.
 service_account_json_validator(Val) ->
-    case emqx_utils_json:safe_decode(Val) of
+    case emqx_utils_json:safe_decode(emqx_secret:unwrap(Val)) of
         {ok, Map} ->
             ExpectedKeys = [
                 <<"type">>,
@@ -272,7 +271,7 @@ service_account_json_validator(Val) ->
             case {MissingKeys, Type} of
                 {[], <<"service_account">>} ->
                     ok;
-                {[], Type} ->
+                {[], _} ->
                     {error, #{wrong_type => Type}};
                 {_, _} ->
                     {error, #{missing_keys => MissingKeys}}
@@ -281,20 +280,20 @@ service_account_json_validator(Val) ->
             {error, "not a json"}
     end.
 
-service_account_json_converter(Val, #{make_serializable := true}) ->
-    case is_map(Val) of
-        true -> emqx_utils_json:encode(Val);
-        false -> Val
-    end;
-service_account_json_converter(Map, _Opts) when is_map(Map) ->
+service_account_json_converter(Map = #{}, #{make_serializable := true}) ->
     emqx_utils_json:encode(Map);
-service_account_json_converter(Val, _Opts) ->
-    case emqx_utils_json:safe_decode(Val) of
+service_account_json_converter(Map = #{}, Opts) ->
+    emqx_schema_secret:convert_secret(emqx_utils_json:encode(Map), Opts);
+service_account_json_converter(Val, Opts) ->
+    case is_binary(Val) andalso emqx_utils_json:safe_decode(Val) of
         {ok, Str} when is_binary(Str) ->
-            emqx_utils_json:decode(Str);
+            emqx_schema_secret:convert_secret(Str, Opts);
         _ ->
-            Val
+            emqx_schema_secret:convert_secret(Val, Opts)
     end.
+
+decode_service_account_json(Val) ->
+    emqx_utils_json:decode(emqx_secret:unwrap(Val)).
 
 deep_update(Path, Fun, Map) ->
     case emqx_utils_maps:deep_get(Path, Map, #{}) of

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -91,7 +91,7 @@ query_mode(_Config) -> no_queries.
     {ok, connector_state()} | {error, term()}.
 on_start(ConnectorResId, Config0) ->
     Config1 = maps:update_with(
-        service_account_json, fun(X) -> emqx_utils_json:decode(X) end, Config0
+        service_account_json, fun emqx_bridge_gcp_pubsub:decode_service_account_json/1, Config0
     ),
     {Transport, HostPort} = emqx_bridge_gcp_pubsub_client:get_transport(pubsub),
     #{hostname := Host, port := Port} = emqx_schema:parse_server(HostPort, #{

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -77,7 +77,7 @@ on_start(InstanceId, Config0) ->
         instance_id => InstanceId
     }),
     Config1 = maps:update_with(
-        service_account_json, fun(X) -> emqx_utils_json:decode(X) end, Config0
+        service_account_json, fun emqx_bridge_gcp_pubsub:decode_service_account_json/1, Config0
     ),
     {Transport, HostPort} = emqx_bridge_gcp_pubsub_client:get_transport(pubsub),
     #{hostname := Host, port := Port} = emqx_schema:parse_server(HostPort, #{

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -47,6 +47,7 @@ groups() ->
 
 init_per_suite(TCConfig) ->
     reset_proxy(),
+    WorkDir = emqx_cth_suite:work_dir(TCConfig),
     Apps = emqx_cth_suite:start(
         [
             emqx,
@@ -57,10 +58,11 @@ init_per_suite(TCConfig) ->
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],
-        #{work_dir => emqx_cth_suite:work_dir(TCConfig)}
+        #{work_dir => WorkDir}
     ),
     set_emulator_host_env(),
     [
+        {work_dir, WorkDir},
         {apps, Apps}
         | TCConfig
     ].
@@ -700,23 +702,31 @@ start_client(Opts) ->
     {ok, _} = emqtt:connect(C),
     C.
 
-assert_persisted_service_account_json_is_binary(TCConfig) ->
+persisted_service_account_json(TCConfig) ->
     #{connector_name := ConnectorName} = emqx_bridge_v2_testlib:get_common_values(TCConfig),
     %% ensure cluster.hocon has a binary encoded json string as the value
     {ok, Hocon} = hocon:files([application:get_env(emqx, cluster_hocon_file, undefined)]),
-    ?assertMatch(
-        Bin when is_binary(Bin),
-        emqx_utils_maps:deep_get(
-            [
-                <<"connectors">>,
-                <<"gcp_pubsub_producer">>,
-                ConnectorName,
-                <<"service_account_json">>
-            ],
-            Hocon
-        )
+    emqx_utils_maps:deep_get(
+        [
+            <<"connectors">>,
+            <<"gcp_pubsub_producer">>,
+            ConnectorName,
+            <<"service_account_json">>
+        ],
+        Hocon
+    ).
+
+mk_service_account_file(TCConfig, Content) ->
+    Filename = filename:join(
+        ?config(work_dir, TCConfig),
+        lists:flatten([
+            binary_to_list(?config(connector_name, TCConfig)),
+            integer_to_list(erlang:unique_integer()),
+            ".json"
+        ])
     ),
-    ok.
+    ok = file:write_file(Filename, Content),
+    Filename.
 
 %%------------------------------------------------------------------------------
 %% Test cases
@@ -731,6 +741,15 @@ t_start_stop(Config) when is_list(Config) ->
 
 t_on_get_status(Config) when is_list(Config) ->
     emqx_bridge_v2_testlib:t_on_get_status(Config).
+
+t_on_get_status_with_service_account_file_secret(TCConfig) ->
+    ServiceAccountJSON = get_config(service_account_json, TCConfig),
+    Filename = mk_service_account_file(TCConfig, emqx_utils_json:encode(ServiceAccountJSON)),
+    FileRef = iolist_to_binary(["file://", Filename]),
+    emqx_bridge_v2_testlib:t_on_get_status([
+        {connector_overrides, #{<<"service_account_json">> => FileRef}}
+        | TCConfig
+    ]).
 
 t_publish_success() ->
     [{matrix, true}].
@@ -934,6 +953,33 @@ t_not_a_json(TCConfig) ->
         )
     ),
     ok.
+
+t_file_secret_service_account_json_not_a_json(TCConfig) ->
+    Filename = mk_service_account_file(TCConfig, <<"not a json">>),
+    ?assertMatch(
+        {400, #{
+            <<"message">> := #{
+                <<"kind">> := <<"validation_error">>,
+                <<"reason">> := <<"not a json">>,
+                %% should be censored as it contains secrets
+                <<"value">> := <<"******">>
+            }
+        }},
+        create_connector_api(
+            TCConfig,
+            #{<<"service_account_json">> => iolist_to_binary(["file://", Filename])}
+        )
+    ).
+
+t_file_secret_service_account_json(TCConfig) ->
+    ServiceAccountJSON = get_config(service_account_json, TCConfig),
+    Filename = mk_service_account_file(TCConfig, emqx_utils_json:encode(ServiceAccountJSON)),
+    FileRef = iolist_to_binary(["file://", Filename]),
+    {201, _} = create_connector_api(
+        TCConfig,
+        #{<<"service_account_json">> => FileRef}
+    ),
+    ?assertEqual(FileRef, persisted_service_account_json(TCConfig)).
 
 t_not_of_service_account_type(TCConfig) ->
     JSON = emqx_bridge_gcp_pubsub_utils:generate_service_account_json(),
@@ -1874,8 +1920,7 @@ t_create_via_http_json_object_service_account(TCConfig) ->
     {201, _} = create_connector_api(TCConfig, #{
         <<"service_account_json">> => ServiceAccountJSON
     }),
-    assert_persisted_service_account_json_is_binary(TCConfig),
-    ok.
+    ?assertMatch(<<_/binary>>, persisted_service_account_json(TCConfig)).
 
 %% Check that creating an action (V2) with a non-existent topic returns an error.
 t_bad_topic(TCConfig) ->

--- a/changes/ee/feat-17594.en.md
+++ b/changes/ee/feat-17594.en.md
@@ -1,0 +1,1 @@
+Added support for configuring Google Cloud Pub/Sub and BigQuery connector `service_account_json` values with `file://` secret files, so service account credentials can be injected from external files.


### PR DESCRIPTION
Fixes: issue reported by EMQX Operator users

Release version: 6.0.3, 6.1.3, 6.2.2, 6.3.0

## Summary

This PR allows to configure `service_account_json` for GCP resources as a `file://`-backed secret.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
