### PR TITLE
fix(s3, s3tables): limit amount of data returned during health checks

### DIFF
--- a/apps/emqx_s3/src/emqx_s3_client.erl
+++ b/apps/emqx_s3/src/emqx_s3_client.erl
@@ -109,7 +109,8 @@ get_status(S3ClientConfig) ->
         {error, Reason} ->
             {?status_disconnected, emqx_s3_utils:map_error_details(Reason)};
         AWSConfig ->
-            try erlcloud_s3:list_buckets(AWSConfig) of
+            Opts = #{max_buckets => 1},
+            try erlcloud_s3:list_buckets(Opts, AWSConfig) of
                 Props when is_list(Props) ->
                     ?status_connected
             catch

--- a/changes/ee/fix-17595.en.md
+++ b/changes/ee/fix-17595.en.md
@@ -1,0 +1,1 @@
+Limited the amount of data returned during Connector health checks of S3 and S3Tables integrations.  This only has observable effects if the list of existing buckets was really large, in which case the health check will take far less time to execute.

--- a/mix.exs
+++ b/mix.exs
@@ -291,7 +291,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:erlavro),
     do: {:erlavro, github: "emqx/erlavro", tag: "2.10.2-emqx-3", override: true}
 
-  def common_dep(:erlcloud), do: {:erlcloud, github: "emqx/erlcloud", tag: "3.8.3.0"}
+  def common_dep(:erlcloud), do: {:erlcloud, github: "emqx/erlcloud", tag: "3.8.3.2"}
 
   # transitive dependency of pulsar-client-erl, and direct dep in s3tables bridge
   def common_dep(:murmerl3),


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/17411

Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
