### PR TITLE
feat(authz): forbid topic-filter characters in authz topic interpolation

### DIFF
--- a/apps/emqx_auth/src/emqx_auth_template.erl
+++ b/apps/emqx_auth/src/emqx_auth_template.erl
@@ -23,6 +23,7 @@
     render_urlencoded_str/2,
     render_sql_params/2,
     render_strict/2,
+    render_strict/3,
     escape_disallowed_placeholders_str/2,
     rename_client_info_vars/1
 ]).
@@ -305,7 +306,10 @@ render_var(_Name, Value) ->
     Value.
 
 render_strict(Topic, ClientInfo) ->
-    emqx_template:render_strict(Topic, rename_client_info_vars(ClientInfo)).
+    render_strict(Topic, ClientInfo, #{}).
+
+render_strict(Topic, ClientInfo, Opts) ->
+    emqx_template:render_strict(Topic, rename_client_info_vars(ClientInfo), Opts).
 
 first_present_kv([Key | Keys], Map) ->
     case Map of

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_rule.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_rule.erl
@@ -522,23 +522,34 @@ topic_template_allow() ->
 
 validate_topic_template_value(Name, Value, TopicTemplateAllow) ->
     Rendered = emqx_template:to_string(Value),
-    ok = do_validate_topic_template_value(
-        Name, unicode:characters_to_list(Rendered), TopicTemplateAllow
-    ),
+    ok = do_validate_topic_template_value(Name, Rendered, TopicTemplateAllow),
     Rendered.
 
+%% emqx_template:to_string/1 returns either a binary or a unicode character list
+%% we directly handle both cases to avoid additional conversions.
+do_validate_topic_template_value(_Name, <<>>, _TopicTemplateAllow) ->
+    ok;
+do_validate_topic_template_value(Name, <<Char, Rest/binary>>, TopicTemplateAllow) when
+    Char =:= $/ orelse Char =:= $# orelse Char =:= $+
+->
+    check_special_char(Name, Char, Rest, TopicTemplateAllow);
+do_validate_topic_template_value(Name, <<_Char, Rest/binary>>, TopicTemplateAllow) ->
+    do_validate_topic_template_value(Name, Rest, TopicTemplateAllow);
 do_validate_topic_template_value(_Name, [], _TopicTemplateAllow) ->
     ok;
 do_validate_topic_template_value(Name, [Char | Rest], TopicTemplateAllow) when
     Char =:= $/ orelse Char =:= $# orelse Char =:= $+
 ->
+    check_special_char(Name, Char, Rest, TopicTemplateAllow);
+do_validate_topic_template_value(Name, [_Char | Rest], TopicTemplateAllow) ->
+    do_validate_topic_template_value(Name, Rest, TopicTemplateAllow);
+do_validate_topic_template_value(Name, InvalidUnicode, _TopicTemplateAllow) ->
+    throw({invalid_value_substituted_in_topic, {Name, InvalidUnicode}}).
+
+check_special_char(Name, Char, Rest, TopicTemplateAllow) ->
     case maps:get(Char, TopicTemplateAllow) of
         true ->
             do_validate_topic_template_value(Name, Rest, TopicTemplateAllow);
         false ->
             throw({invalid_char_in_value_substituted_in_topic, {Name, Char}})
-    end;
-do_validate_topic_template_value(Name, [_Char | Rest], TopicTemplateAllow) ->
-    do_validate_topic_template_value(Name, Rest, TopicTemplateAllow);
-do_validate_topic_template_value(Name, InvalidUnicode, _TopicTemplateAllow) ->
-    throw({invalid_value_substituted_in_topic, {Name, InvalidUnicode}}).
+    end.

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_rule.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_rule.erl
@@ -346,13 +346,19 @@ matches(Client, Action, Topic, [{Permission, Cond, ActionCond, TopicCond} | Tail
 -spec match(emqx_types:clientinfo(), action(), emqx_types:topic(), rule()) ->
     {matched, allow} | {matched, deny} | nomatch.
 match(Client, Action, Topic, {Permission, Cond, ActionCond, TopicCond}) ->
-    case
+    try
         match_action(Action, ActionCond) andalso
             match_condition(Client, Cond) andalso
             match_topics(Client, Topic, TopicCond)
     of
         true -> {matched, Permission};
         _ -> nomatch
+    catch
+        throw:_Reason ->
+            case emqx_authz_utils:authz_backend_failure_policy() of
+                ignore -> nomatch;
+                deny -> {matched, deny}
+            end
     end.
 
 -spec match_action(action(), action_condition()) -> boolean().
@@ -481,7 +487,14 @@ match_topic(Topic, TopicFilter) ->
 
 render_topic(Topic, ClientInfo) ->
     try
-        bin(emqx_auth_template:render_strict(Topic, ClientInfo))
+        TopicTemplateAllow = topic_template_allow(),
+        bin(
+            emqx_auth_template:render_strict(Topic, ClientInfo, #{
+                var_trans => fun(Name, Value) ->
+                    validate_topic_template_value(Name, Value, TopicTemplateAllow)
+                end
+            })
+        )
     catch
         error:Reason ->
             ?SLOG(debug, #{
@@ -489,5 +502,43 @@ render_topic(Topic, ClientInfo) ->
                 template => Topic,
                 reason => Reason
             }),
-            error
+            case emqx_security_profile:policy(authz_backend_failure) of
+                ignore -> error;
+                deny -> throw({cannot_render_topic_template, Reason})
+            end
     end.
+
+topic_template_allow() ->
+    AllowMap = emqx:get_config([authorization, topic_template_allow], #{
+        plus => false,
+        hash => false,
+        slash => false
+    }),
+    #{
+        $+ => maps:get(plus, AllowMap, false),
+        $# => maps:get(hash, AllowMap, false),
+        $/ => maps:get(slash, AllowMap, false)
+    }.
+
+validate_topic_template_value(Name, Value, TopicTemplateAllow) ->
+    Rendered = emqx_template:to_string(Value),
+    ok = do_validate_topic_template_value(
+        Name, unicode:characters_to_list(Rendered), TopicTemplateAllow
+    ),
+    Rendered.
+
+do_validate_topic_template_value(_Name, [], _TopicTemplateAllow) ->
+    ok;
+do_validate_topic_template_value(Name, [Char | Rest], TopicTemplateAllow) when
+    Char =:= $/ orelse Char =:= $# orelse Char =:= $+
+->
+    case maps:get(Char, TopicTemplateAllow) of
+        true ->
+            do_validate_topic_template_value(Name, Rest, TopicTemplateAllow);
+        false ->
+            throw({invalid_char_in_value_substituted_in_topic, {Name, Char}})
+    end;
+do_validate_topic_template_value(Name, [_Char | Rest], TopicTemplateAllow) ->
+    do_validate_topic_template_value(Name, Rest, TopicTemplateAllow);
+do_validate_topic_template_value(Name, InvalidUnicode, _TopicTemplateAllow) ->
+    throw({invalid_value_substituted_in_topic, {Name, InvalidUnicode}}).

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
@@ -65,6 +65,27 @@ namespace() -> undefined.
 %% "authorization"
 fields(?CONF_NS) ->
     emqx_schema:authz_fields() ++ authz_fields();
+fields(topic_template_allow) ->
+    [
+        {plus,
+            hoconsc:mk(boolean(), #{
+                default => false,
+                desc => ?DESC(topic_template_allow_plus),
+                importance => ?IMPORTANCE_HIDDEN
+            })},
+        {hash,
+            hoconsc:mk(boolean(), #{
+                default => false,
+                desc => ?DESC(topic_template_allow_hash),
+                importance => ?IMPORTANCE_HIDDEN
+            })},
+        {slash,
+            hoconsc:mk(boolean(), #{
+                default => false,
+                desc => ?DESC(topic_template_allow_slash),
+                importance => ?IMPORTANCE_HIDDEN
+            })}
+    ];
 fields("metrics_status_fields") ->
     [
         {"resource_metrics", ?HOCON(?R_REF("resource_metrics"), #{desc => ?DESC("metrics")})},
@@ -130,6 +151,16 @@ authz_fields() ->
                 default => false,
                 desc => ?DESC(ignore_backend_failures),
                 importance => ?IMPORTANCE_LOW
+            })},
+        {topic_template_allow,
+            hoconsc:mk(?R_REF(topic_template_allow), #{
+                default => #{
+                    <<"plus">> => false,
+                    <<"hash">> => false,
+                    <<"slash">> => false
+                },
+                desc => ?DESC(topic_template_allow),
+                importance => ?IMPORTANCE_HIDDEN
             })},
         {builtin_record_count_refresh_interval,
             hoconsc:mk(emqx_schema:timeout_duration_ms(), #{

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_source_http_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_source_http_SUITE.erl
@@ -62,6 +62,7 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     emqx_cth_suite:stop(?config(suite_apps, Config)),
     meck:unload(emqx_resource),
+    meck:unload(emqx_authz_file),
     ok.
 
 init_per_testcase(t_api, Config) ->

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_sources_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_sources_SUITE.erl
@@ -134,6 +134,7 @@ end_per_suite(Config) ->
     _ = emqx_common_test_http:delete_default_app(),
     emqx_cth_suite:stop(?config(suite_apps, Config)),
     meck:unload(emqx_resource),
+    meck:unload(emqx_authz_file),
     ok.
 
 init_per_testcase(t_api, Config) ->

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_rule_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_rule_SUITE.erl
@@ -712,6 +712,24 @@ t_security_profile_condition(_) ->
         )
     end).
 
+t_topic_template_allow_security_profile(_) ->
+    Default = emqx_config:get([authorization, topic_template_allow]),
+    AllowAll = #{plus => true, hash => true, slash => true},
+    try
+        emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+            assert_topic_template_injection_result(nomatch)
+        end),
+        emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+            assert_topic_template_injection_result({matched, deny})
+        end),
+        emqx_config:put([authorization, topic_template_allow], AllowAll),
+        emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+            assert_topic_template_injection_result({matched, allow})
+        end)
+    after
+        emqx_config:put([authorization, topic_template_allow], Default)
+    end.
+
 t_invalid_rule(_) ->
     ?assertThrow(
         #{reason := invalid_authorization_permission},
@@ -844,5 +862,37 @@ client_info() ->
 
 client_info(Overrides) ->
     maps:merge(?CLIENT_INFO_BASE, Overrides).
+
+with_security_profile(Profile, Fun) ->
+    os:putenv(?PROFILE_ENV_VAR, Profile),
+    emqx_security_profile:clear_profile(),
+    try
+        Fun()
+    after
+        os:unsetenv(?PROFILE_ENV_VAR),
+        emqx_security_profile:clear_profile()
+    end.
+
+assert_topic_template_injection_result(Expected) ->
+    Action = #{action_type => publish, qos => 0, retain => false},
+    Cases = [
+        {#{username => <<"+">>}, <<"tenant/other/data">>, "tenant/${username}/data"},
+        {#{username => <<"#">>}, <<"tenant/other/data">>, "tenant/${username}"},
+        {#{username => <<"other/level">>}, <<"tenant/other/level/data">>, "tenant/${username}/data"}
+    ],
+    lists:foreach(
+        fun({ClientInfoOverride, Topic, TopicTemplate}) ->
+            ?assertEqual(
+                Expected,
+                emqx_authz_rule:match(
+                    client_info(ClientInfoOverride),
+                    Action,
+                    Topic,
+                    emqx_authz_rule:compile({allow, all, publish, [TopicTemplate]})
+                )
+            )
+        end,
+        Cases
+    ).
 
 bin(X) -> iolist_to_binary(X).

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_rule_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_rule_SUITE.erl
@@ -19,6 +19,8 @@
     listener => 'tcp:default'
 }).
 
+-define(PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
+
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
@@ -878,7 +880,14 @@ assert_topic_template_injection_result(Expected) ->
     Cases = [
         {#{username => <<"+">>}, <<"tenant/other/data">>, "tenant/${username}/data"},
         {#{username => <<"#">>}, <<"tenant/other/data">>, "tenant/${username}"},
-        {#{username => <<"other/level">>}, <<"tenant/other/level/data">>, "tenant/${username}/data"}
+        {
+            #{username => <<"other/level">>},
+            <<"tenant/other/level/data">>,
+            "tenant/${username}/data"
+        },
+        {#{username => "+"}, <<"tenant/other/data">>, "tenant/${username}/data"},
+        {#{username => "#"}, <<"tenant/other/data">>, "tenant/${username}"},
+        {#{username => "other/level"}, <<"tenant/other/level/data">>, "tenant/${username}/data"}
     ],
     lists:foreach(
         fun({ClientInfoOverride, Topic, TopicTemplate}) ->

--- a/changes/ee/breaking-17596.en.md
+++ b/changes/ee/breaking-17596.en.md
@@ -1,0 +1,10 @@
+Added authorization options that forbid interpolation of `/`, `+`, and `#` symbols into topic filter templates in authorization rules. The new options are:
+```
+authorization.topic_template_allow {
+    plus => false,
+    hash => false,
+    slash => false
+}
+```
+With `false`, the corresponding symbol cannot be used in a value interpolated into a topic template.
+For example, if `plus = false`, then username `bad+user` is forbidden in a rule such as `{allow, all, publish, ["userspace/${username}"]}`. The outcome depends on the active security profile: with the legacy profile the rule will not match, and with the hardened profile the action will be denied.

--- a/rel/i18n/emqx_authz_schema.hocon
+++ b/rel/i18n/emqx_authz_schema.hocon
@@ -164,6 +164,30 @@ ignore_backend_failures.desc:
 ignore_backend_failures.label:
 """Ignore Backend Failures"""
 
+topic_template_allow.desc:
+"""Controls whether client-controlled values interpolated into authorization topic templates may contain MQTT topic-filter characters."""
+
+topic_template_allow.label:
+"""Topic Template Allowed Characters"""
+
+topic_template_allow_plus.desc:
+"""Allows the plus sign (<code>+</code>) in values interpolated into authorization topic templates."""
+
+topic_template_allow_plus.label:
+"""Allow Plus"""
+
+topic_template_allow_hash.desc:
+"""Allows the hash sign (<code>#</code>) in values interpolated into authorization topic templates."""
+
+topic_template_allow_hash.label:
+"""Allow Hash"""
+
+topic_template_allow_slash.desc:
+"""Allows the slash character (<code>/</code>) in values interpolated into authorization topic templates."""
+
+topic_template_allow_slash.label:
+"""Allow Slash"""
+
 node_metrics.desc:
 """The metrics of the resource for each node."""
 


### PR DESCRIPTION
Release version: 6.3.0

Fixes emqx/emqx-dev-team-tasks#108

## Summary

This PR prevents client-controlled authorization topic-template values from being interpreted as MQTT topic-filter syntax.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
