### PR TITLE
fix(mongodb): bump driver to v3.1.2 for MongoDB 8.0 compatibility

### DIFF
--- a/apps/emqx_mongodb/mix.exs
+++ b/apps/emqx_mongodb/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXMongodb.MixProject do
     [
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
-      {:mongodb, github: "emqx/mongodb-erlang", tag: "v3.0.25"}
+      {:mongodb, github: "emqx/mongodb-erlang", tag: "v3.1.2"}
     ]
   end
 end

--- a/apps/emqx_mongodb/rebar.config
+++ b/apps/emqx_mongodb/rebar.config
@@ -4,5 +4,5 @@
 {deps, [
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
-    {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.1.0"}}}
+    {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.1.2"}}}
 ]}.

--- a/changes/ce/fix-17597.en.md
+++ b/changes/ce/fix-17597.en.md
@@ -1,1 +1,0 @@
-Fixed a connection failure to MongoDB 8.0+ when authentication is required. The driver previously queried `buildInfo` before authentication to pick the auth mechanism; MongoDB 8.0 restricted that command to authenticated callers. The driver now skips the probe and uses SCRAM-SHA-1 directly, which all supported MongoDB versions accept.

--- a/changes/ce/fix-17597.en.md
+++ b/changes/ce/fix-17597.en.md
@@ -1,0 +1,1 @@
+Fixed a connection failure to MongoDB 8.0+ when authentication is required. The driver previously queried `buildInfo` before authentication to pick the auth mechanism; MongoDB 8.0 restricted that command to authenticated callers. The driver now skips the probe and uses SCRAM-SHA-1 directly, which all supported MongoDB versions accept.

--- a/changes/ee/fix-17597.en.md
+++ b/changes/ee/fix-17597.en.md
@@ -1,0 +1,1 @@
+Fixed a connection failure to MongoDB 8.0+ when authentication is required. The driver previously queried `buildInfo` before authentication to pick the auth mechanism; MongoDB 8.0 restricted that command to authenticated callers. The driver now skips the probe and uses SCRAM-SHA-1 directly, which all supported MongoDB versions accept.


### PR DESCRIPTION
Release version: 5.8.11

## Summary

Fixes a connection failure to MongoDB 8.0+ when authentication is required (#17505).

The `mongodb-erlang` driver's `mc_worker_logic:get_version/3` issued a `buildInfo` command **before** SCRAM authentication, to choose between SCRAM-SHA-1 (server > 2.7) and the legacy MONGODB-CR mechanism. MongoDB 8.0 restricted `buildInfo` to authenticated callers, so the pre-auth probe fails and the connection process crashes. MONGODB-CR was removed in MongoDB 4.0, so the probe only ever selected the SCRAM-SHA-1 path on any supported server.

The driver fix (emqx/mongodb-erlang#58, tag `v3.1.2`) skips the probe and always uses SCRAM-SHA-1. This PR bumps the EMQX dep pin to `v3.1.2`.

### Notes for reviewers / release management

- **Unifies a pre-existing dep-pin discrepancy.** Before this change `apps/emqx_mongodb/rebar.config` pinned `v3.1.0` while `apps/emqx_mongodb/mix.exs` pinned `v3.0.25`, i.e. the rebar3 (canonical) and mix (elixir variant) build paths used different driver commits. Both are now bumped to `v3.1.2`. The only `mc_worker_logic.erl` change between those tags is the buildInfo fix; the `v3.0.25 -> v3.1.x` delta (drop of the `pbkdf2` dep in favour of `crypto:pbkdf2_hmac`, poolboy pinned to the emqx fork tag `1.5.2`) is safe on the OTP 26 builder used by release-58.
- **Hot-upgrade.** The fix is a single stateless dep beam (`mc_worker_logic.beam`); the exported arity and return type are unchanged and there are no call-site changes, so running workers (already past auth) are unaffected and new connections pick up the fix. The next 5.8.x relup catalog should include a `{load_module, mc_worker_logic}` instruction so existing nodes get the fixed module on hot-patch. There is no pending (non-example) `.relup` file in this branch to append to, and the next patch version is not yet fixed — flagging for release management to add the hop when the relup is cut.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)