### PR TITLE
fix(bridge_mongodb): connect to MongoDB 8.0+ requiring auth

### DIFF
--- a/.ci/docker-compose-file/.env
+++ b/.ci/docker-compose-file/.env
@@ -1,6 +1,10 @@
 MYSQL_TAG=8
 REDIS_TAG=7.0
 MONGO_TAG=5
+# Single-node TCP MongoDB is pinned to 8 to cover authenticated connections
+# (issue #17505). Other topologies stay on 5 because their init scripts still
+# use the legacy `mongo` shell, which MongoDB removed in 6.0.
+MONGO_TAG_SINGLE_TCP=8
 PGSQL_TAG=13
 LDAP_TAG=2.4.50
 INFLUXDB_TAG=2.5.0

--- a/.ci/docker-compose-file/docker-compose-mongo-single-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-mongo-single-tcp.yaml
@@ -1,7 +1,7 @@
 services:
   mongo_server:
     container_name: mongo
-    image: public.ecr.aws/docker/library/mongo:${MONGO_TAG}
+    image: public.ecr.aws/docker/library/mongo:${MONGO_TAG_SINGLE_TCP}
     restart: always
     networks:
       - emqx_bridge
@@ -15,7 +15,7 @@ services:
       --bind_ip_all
 
   mongo_single_setup:
-    image: public.ecr.aws/docker/library/mongo:${MONGO_TAG}
+    image: public.ecr.aws/docker/library/mongo:${MONGO_TAG_SINGLE_TCP}
     container_name: mongo_single_setup
     networks:
       - emqx_bridge
@@ -26,18 +26,16 @@ services:
       - /bin/bash
       - -c
       - |
-        while ! mongo --host mongo --eval 'db.runCommand("ping").ok' --quiet > /dev/null 2>&1; do
+        while ! mongosh --host mongo --quiet --eval 'db.runCommand({ping: 1}).ok' > /dev/null 2>&1; do
             sleep 1
         done
-        cat <<EOF >cmds.js
-          use mqtt
-          db.createRole({role: "role1", privileges: [], roles: []})
-          db.createUser({user: "user1", pwd: "abc123", roles: [{role: "role1", db: "mqtt"}]})
+        mongosh --host mongo -u emqx -p passw0rd --authenticationDatabase admin --quiet <<'EOF'
+        db.getSiblingDB("mqtt").createRole({role: "role1", privileges: [], roles: []})
+        db.getSiblingDB("mqtt").createUser({user: "user1", pwd: "abc123", roles: [{role: "role1", db: "mqtt"}]})
         EOF
-        mongo --host mongo -u emqx -p passw0rd < cmds.js
 
   mongo_single_setup_done:
-    image: public.ecr.aws/docker/library/mongo:${MONGO_TAG}
+    image: public.ecr.aws/docker/library/mongo:${MONGO_TAG_SINGLE_TCP}
     networks:
       - emqx_bridge
     restart: no

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -102,6 +102,7 @@ jobs:
         env:
           DOCKER_CT_RUNNER_IMAGE: ${{ inputs.builder }}
           MONGO_TAG: "5"
+          MONGO_TAG_SINGLE_TCP: "8"
           MYSQL_TAG: "8"
           PGSQL_TAG: "13"
           REDIS_TAG: "7.0"

--- a/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
@@ -13,7 +13,6 @@
 -include_lib("common_test/include/ct.hrl").
 
 -define(MONGO_HOST, "mongo").
--define(MONGO_CLIENT, 'emqx_authn_mongo_SUITE_client').
 
 -define(PATH, [authentication]).
 
@@ -25,14 +24,19 @@ init_per_testcase(_TestCase, Config) ->
         [authentication],
         ?GLOBAL
     ),
-    {ok, _} = mc_worker_api:connect(mongo_config()),
-    ok = init_seeds(),
-    Config.
+    %% Address the seeding connection by pid: the driver keys the negotiated
+    %% wire protocol by pid, so a registered name would resolve to the
+    %% legacy-protocol default, which MongoDB 5.1+ rejects. The pid
+    %% auto-negotiates OP_MSG on every supported server.
+    {ok, Client} = mc_worker_api:connect(mongo_config()),
+    ok = init_seeds(Client),
+    [{mongo_client, Client} | Config].
 
-end_per_testcase(_TestCase, _Config) ->
+end_per_testcase(_TestCase, Config) ->
+    Client = ?config(mongo_client, Config),
     ok = emqx_authn_test_lib:enable_node_cache(false),
-    ok = drop_seeds(),
-    ok = mc_worker_api:disconnect(?MONGO_CLIENT).
+    ok = drop_seeds(Client),
+    ok = mc_worker_api:disconnect(Client).
 
 init_per_suite(Config) ->
     case emqx_common_test_helpers:is_tcp_server_available(?MONGO_HOST, ?MONGO_DEFAULT_PORT) of
@@ -98,8 +102,24 @@ t_authenticate(_Config) ->
             ct:pal("test_user_auth sample: ~p", [Sample]),
             test_user_auth(Sample)
         end,
-        user_seeds()
+        applicable_user_seeds()
     ).
+
+%% The legacy-protocol seed only applies to MongoDB servers that still support
+%% the legacy OP_QUERY opcodes (removed in MongoDB 5.1, wire protocol 14).
+applicable_user_seeds() ->
+    case mongo_supports_legacy_protocol(?MONGO_HOST, ?MONGO_DEFAULT_PORT) of
+        true ->
+            user_seeds();
+        false ->
+            [
+                Seed
+             || Seed <- user_seeds(),
+                maps:get(
+                    <<"use_legacy_protocol">>, maps:get(config_params, Seed, #{}), undefined
+                ) =/= <<"true">>
+            ]
+    end.
 
 test_user_auth(#{
     credentials := Credentials0,
@@ -124,8 +144,9 @@ test_user_auth(#{
         ?GLOBAL
     ).
 
-t_destroy(_Config) ->
-    ok = init_seeds(),
+t_destroy(Config) ->
+    Client = ?config(mongo_client, Config),
+    ok = init_seeds(Client),
     AuthConfig = raw_mongo_auth_config(),
 
     {ok, _} = emqx:update_config(
@@ -161,10 +182,11 @@ t_destroy(_Config) ->
         )
     ),
 
-    ok = drop_seeds().
+    ok = drop_seeds(Client).
 
-t_update(_Config) ->
-    ok = init_seeds(),
+t_update(Config) ->
+    Client = ?config(mongo_client, Config),
+    ok = init_seeds(Client),
     CorrectConfig = raw_mongo_auth_config(),
     IncorrectConfig =
         CorrectConfig#{<<"filter">> => #{<<"wrongfield">> => <<"wrongvalue">>}},
@@ -197,9 +219,10 @@ t_update(_Config) ->
             protocol => mqtt
         }
     ),
-    ok = drop_seeds().
+    ok = drop_seeds(Client).
 
-t_is_superuser(_Config) ->
+t_is_superuser(TCConfig) ->
+    Client = ?config(mongo_client, TCConfig),
     Config = raw_mongo_auth_config(),
     {ok, _} = emqx:update_config(
         ?PATH,
@@ -221,10 +244,10 @@ t_is_superuser(_Config) ->
         {true, true}
     ],
 
-    lists:foreach(fun test_is_superuser/1, Checks).
+    lists:foreach(fun(Check) -> test_is_superuser(Client, Check) end, Checks).
 
-test_is_superuser({Value, ExpectedValue}) ->
-    {true, _} = mc_worker_api:delete(?MONGO_CLIENT, <<"users">>, #{}),
+test_is_superuser(Client, {Value, ExpectedValue}) ->
+    {true, _} = mc_worker_api:delete(Client, <<"users">>, #{}),
 
     UserData = #{
         username => <<"user">>,
@@ -233,7 +256,7 @@ test_is_superuser({Value, ExpectedValue}) ->
         is_superuser => Value
     },
 
-    ok = create_user(UserData),
+    ok = create_user(Client, UserData),
 
     Credentials = #{
         listener => 'tcp:default',
@@ -247,8 +270,9 @@ test_is_superuser({Value, ExpectedValue}) ->
         emqx_access_control:authenticate(Credentials)
     ).
 
-t_node_cache(_Config) ->
-    ok = create_user(#{
+t_node_cache(TCConfig) ->
+    Client = ?config(mongo_client, TCConfig),
+    ok = create_user(Client, #{
         username => <<"node_cache_user">>, password_hash => <<"password">>, salt => <<"">>
     }),
     Config = raw_mongo_auth_config(),
@@ -290,11 +314,12 @@ Checks that, if an authentication backend returns the `clientid_override` attrib
 used to override.
 """.
 t_clientid_override(TCConfig) when is_list(TCConfig) ->
+    Client = ?config(mongo_client, TCConfig),
     OverriddenClientId = <<"overridden_clientid">>,
     Username = <<"overriden_clientid">>,
     Password = <<"password">>,
     MkConfigFn = fun() ->
-        ok = create_user(#{
+        ok = create_user(Client, #{
             username => Username,
             password_hash => Password,
             salt => <<"">>,
@@ -513,17 +538,17 @@ user_seeds() ->
         }
     ].
 
-init_seeds() ->
+init_seeds(Client) ->
     Users = [Values || #{data := Values} <- user_seeds()],
-    ok = lists:foreach(fun create_user/1, Users),
+    ok = lists:foreach(fun(User) -> create_user(Client, User) end, Users),
     ok.
 
-create_user(User) ->
-    {{true, _}, _} = mc_worker_api:insert(?MONGO_CLIENT, <<"users">>, [User]),
+create_user(Client, User) ->
+    {{true, _}, _} = mc_worker_api:insert(Client, <<"users">>, [User]),
     ok.
 
-drop_seeds() ->
-    {true, _} = mc_worker_api:delete(?MONGO_CLIENT, <<"users">>, #{}),
+drop_seeds(Client) ->
+    {true, _} = mc_worker_api:delete(Client, <<"users">>, #{}),
     ok.
 
 mongo_server() ->
@@ -536,9 +561,29 @@ mongo_config() ->
         {port, ?MONGO_DEFAULT_PORT},
         {auth_source, mongo_authsource()},
         {login, mongo_username()},
-        {password, mongo_password()},
-        {register, ?MONGO_CLIENT}
+        {password, mongo_password()}
     ].
+
+%% MongoDB 5.1 removed the legacy OP_QUERY opcodes (wire protocol version 14),
+%% so the legacy-protocol seeds only apply to servers reporting wire version 13
+%% (MongoDB 5.0) or below. `isMaster` is answered before authentication, so no
+%% credentials are required to probe the running server.
+mongo_supports_legacy_protocol(Host, Port) ->
+    %% Force the modern OP_MSG protocol for the probe itself: the legacy
+    %% OP_QUERY opcodes the probe is checking for are exactly what newer servers
+    %% reject, so a legacy probe connection would fail on them.
+    {ok, Conn} = mc_worker_api:connect([
+        {database, <<"admin">>},
+        {host, Host},
+        {port, Port},
+        {use_legacy_protocol, false}
+    ]),
+    try
+        {true, Info} = mc_worker_api:command(Conn, {<<"isMaster">>, 1}),
+        maps:get(<<"maxWireVersion">>, Info, 0) =< 13
+    after
+        mc_worker_api:disconnect(Conn)
+    end.
 
 mongo_authsource() ->
     iolist_to_binary(os:getenv("MONGO_AUTHSOURCE", "admin")).

--- a/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
@@ -14,7 +14,6 @@
 -include_lib("emqx/include/emqx_placeholder.hrl").
 
 -define(MONGO_HOST, "mongo").
--define(MONGO_CLIENT, 'emqx_authz_mongo_SUITE_client').
 
 all() ->
     [
@@ -45,7 +44,12 @@ init_per_suite(Config) ->
                 ],
                 #{work_dir => ?config(priv_dir, Config)}
             ),
-            [{suite_apps, Apps} | Config];
+            [
+                {suite_apps, Apps},
+                {mongo_supports_legacy_protocol,
+                    mongo_supports_legacy_protocol(?MONGO_HOST, ?MONGO_DEFAULT_PORT)}
+                | Config
+            ];
         false ->
             {skip, no_mongo}
     end.
@@ -66,30 +70,50 @@ end_per_group(_Group, _Config) ->
     ok.
 
 init_per_testcase(_TestCase, Config) ->
-    {ok, _} = mc_worker_api:connect(mongo_config()),
-    ok = emqx_authz_test_lib:reset_authorizers(),
-    Config.
+    %% The forced-legacy cases only run against MongoDB servers that still
+    %% support the legacy OP_QUERY opcodes (removed in MongoDB 5.1).
+    case
+        ?config(use_legacy_protocol, Config) =:= true andalso
+            not proplists:get_value(mongo_supports_legacy_protocol, Config, true)
+    of
+        true ->
+            {skip, mongo_server_dropped_legacy_protocol};
+        false ->
+            %% Address the seeding connection by pid: the driver keys the
+            %% negotiated wire protocol by pid, so a registered name would
+            %% resolve to the legacy-protocol default, which MongoDB 5.1+
+            %% rejects. The pid auto-negotiates OP_MSG on every supported server.
+            {ok, Client} = mc_worker_api:connect(mongo_config()),
+            ok = emqx_authz_test_lib:reset_authorizers(),
+            [{mongo_client, Client} | Config]
+    end.
 
-end_per_testcase(_TestCase, _Config) ->
+end_per_testcase(_TestCase, Config) ->
+    Client = ?config(mongo_client, Config),
     ok = emqx_authz_test_lib:enable_node_cache(false),
-    ok = reset_samples(),
-    ok = mc_worker_api:disconnect(?MONGO_CLIENT).
+    ok = reset_samples(Client),
+    ok = mc_worker_api:disconnect(Client).
 
 %%------------------------------------------------------------------------------
 %% Testcases
 %%------------------------------------------------------------------------------
 
 t_run_case(Config) ->
-    run_test(?config(test_case, Config), ?config(use_legacy_protocol, Config)).
+    run_test(
+        ?config(mongo_client, Config),
+        ?config(test_case, Config),
+        ?config(use_legacy_protocol, Config)
+    ).
 
-run_test(#{name := extended_query_with_order_skip_limit}, true) ->
+run_test(_Client, #{name := extended_query_with_order_skip_limit}, true) ->
     ok;
-run_test(Case, UseLegacyProtocol) ->
-    ok = setup_source_data(Case),
+run_test(Client, Case, UseLegacyProtocol) ->
+    ok = setup_source_data(Client, Case),
     ok = setup_authz_source(Case#{use_legacy_protocol => UseLegacyProtocol}),
     ok = emqx_authz_test_lib:run_checks(Case).
 
-t_node_cache(_Config) ->
+t_node_cache(Config) ->
+    Client = ?config(mongo_client, Config),
     ok = emqx_authz_test_lib:reset_node_cache(),
     Case = #{
         name => cache_publish,
@@ -106,7 +130,7 @@ t_node_cache(_Config) ->
         use_legacy_protocol => <<"auto">>,
         checks => []
     },
-    ok = setup_source_data(Case),
+    ok = setup_source_data(Client, Case),
     ok = setup_authz_source(Case),
     ok = emqx_authz_test_lib:enable_node_cache(true),
 
@@ -464,12 +488,12 @@ cases() ->
 %% Helpers
 %%------------------------------------------------------------------------------
 
-reset_samples() ->
-    {true, _} = mc_worker_api:delete(?MONGO_CLIENT, <<"acl">>, #{}),
+reset_samples(Client) ->
+    {true, _} = mc_worker_api:delete(Client, <<"acl">>, #{}),
     ok.
 
-setup_source_data(#{records := Records}) ->
-    {{true, _}, _} = mc_worker_api:insert(?MONGO_CLIENT, <<"acl">>, Records),
+setup_source_data(Client, #{records := Records}) ->
+    {{true, _}, _} = mc_worker_api:insert(Client, <<"acl">>, Records),
     ok.
 
 setup_authz_source(#{filter := Filter, use_legacy_protocol := UseLegacyProtocol} = Case) ->
@@ -515,9 +539,29 @@ mongo_config() ->
         {port, ?MONGO_DEFAULT_PORT},
         {auth_source, mongo_authsource()},
         {login, mongo_username()},
-        {password, mongo_password()},
-        {register, ?MONGO_CLIENT}
+        {password, mongo_password()}
     ].
+
+%% MongoDB 5.1 removed the legacy OP_QUERY opcodes (wire protocol version 14),
+%% so the legacy-protocol cases only apply to servers reporting wire version 13
+%% (MongoDB 5.0) or below. `isMaster` is answered before authentication, so no
+%% credentials are required to probe the running server.
+mongo_supports_legacy_protocol(Host, Port) ->
+    %% Force the modern OP_MSG protocol for the probe itself: the legacy
+    %% OP_QUERY opcodes the probe is checking for are exactly what newer servers
+    %% reject, so a legacy probe connection would fail on them.
+    {ok, Conn} = mc_worker_api:connect([
+        {database, <<"admin">>},
+        {host, Host},
+        {port, Port},
+        {use_legacy_protocol, false}
+    ]),
+    try
+        {true, Info} = mc_worker_api:command(Conn, {<<"isMaster">>, 1}),
+        maps:get(<<"maxWireVersion">>, Info, 0) =< 13
+    after
+        mc_worker_api:disconnect(Conn)
+    end.
 
 mongo_authsource() ->
     iolist_to_binary(os:getenv("MONGO_AUTHSOURCE", "admin")).

--- a/apps/emqx_bridge_mongodb/test/emqx_bridge_mongodb_SUITE.erl
+++ b/apps/emqx_bridge_mongodb/test/emqx_bridge_mongodb_SUITE.erl
@@ -398,6 +398,29 @@ start_client() ->
 unique_payload() ->
     integer_to_binary(erlang:unique_integer()).
 
+%% MongoDB 5.1 removed the legacy OP_QUERY opcodes (wire protocol version 14),
+%% so forcing the legacy protocol only works against servers reporting wire
+%% version 13 (MongoDB 5.0) or below. `isMaster` is answered before
+%% authentication, so no credentials are required to probe the running server.
+mongo_supports_legacy_protocol() ->
+    Host = os:getenv("MONGO_SINGLE_HOST", "mongo"),
+    Port = list_to_integer(os:getenv("MONGO_SINGLE_PORT", "27017")),
+    %% Force the modern OP_MSG protocol for the probe itself: the legacy
+    %% OP_QUERY opcodes the probe is checking for are exactly what newer servers
+    %% reject, so a legacy probe connection would fail on them.
+    {ok, Conn} = mc_worker_api:connect([
+        {database, <<"admin">>},
+        {host, Host},
+        {port, Port},
+        {use_legacy_protocol, false}
+    ]),
+    try
+        {true, Info} = mc_worker_api:command(Conn, {<<"isMaster">>, 1}),
+        maps:get(<<"maxWireVersion">>, Info, 0) =< 13
+    after
+        mc_worker_api:disconnect(Conn)
+    end.
+
 get_worker_pids(TCConfig) ->
     ConnResId = emqx_bridge_v2_testlib:connector_resource_id(TCConfig),
     %% abusing health check api a bit...
@@ -560,6 +583,14 @@ t_get_status_server_selection_too_short(TCConfig) ->
     ok.
 
 t_use_legacy_protocol_option(TCConfig) ->
+    case mongo_supports_legacy_protocol() of
+        false ->
+            {skip, mongo_server_dropped_legacy_protocol};
+        true ->
+            do_t_use_legacy_protocol_option(TCConfig)
+    end.
+
+do_t_use_legacy_protocol_option(TCConfig) ->
     {201, #{<<"status">> := <<"connected">>}} =
         create_connector_api(TCConfig, #{<<"use_legacy_protocol">> => true}),
     WorkerPids0 = get_worker_pids(TCConfig),

--- a/apps/emqx_mongodb/mix.exs
+++ b/apps/emqx_mongodb/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXMongodb.MixProject do
     UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
-      {:mongodb, github: "emqx/mongodb-erlang", tag: "v3.1.1"}
+      {:mongodb, github: "emqx/mongodb-erlang", tag: "v3.1.2"}
     ])
   end
 end

--- a/changes/ee/fix-17598.en.md
+++ b/changes/ee/fix-17598.en.md
@@ -1,0 +1,1 @@
+Fixed a connection failure to MongoDB 8.0+ when authentication is required. The driver previously queried `buildInfo` before authentication to pick the auth mechanism; MongoDB 8.0 restricted that command to authenticated callers. The driver now skips the probe and uses SCRAM-SHA-1 directly, which all supported MongoDB versions accept.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.3, 6.2.2

## Summary

Fixes #17505 — connections to MongoDB 8.0+ fail when authentication is required.

The mongodb-erlang driver runs the `buildInfo` command *before* SCRAM
authentication, in `mc_worker_logic:get_version/3`, to choose between
SCRAM-SHA-1 and the legacy MONGODB-CR mechanism. MongoDB 8.0 restricted
`buildInfo` to authenticated callers, so this pre-auth probe now fails
and the connection can never be established.

### Fix

Bumps the `mongodb` dependency in `apps/emqx_mongodb/mix.exs` from
`v3.1.1` to `v3.1.2`. The new tag patches `get_version/3` to return the
constant `3.0` instead of probing the server. That probe only ever
selected between SCRAM-SHA-1 (version > 2.7) and MONGODB-CR; MongoDB 4.0
removed MONGODB-CR entirely, so the legacy branch was dead code.
Returning `3.0` deterministically selects the SCRAM-SHA-1 path, which all
supported MongoDB versions accept.

Driver PR: https://github.com/emqx/mongodb-erlang/pull/57

### CI coverage (MongoDB 8)

To actually exercise the fix and prevent regression, the single-node TCP
MongoDB CI instance is bumped to 8.0 (new `MONGO_TAG_SINGLE_TCP`; the
replica-set / sharded / single-TLS instances stay on 5 since their init
scripts still use the legacy `mongo` shell). That instance's init script
is ported from `mongo` (removed in MongoDB 6.0) to `mongosh`, validated
end-to-end against a real `mongo:8` container.

MongoDB 5.1 removed the legacy OP_QUERY opcodes, so the suites that force
`use_legacy_protocol = true` (`emqx_authz_mongodb_SUITE`,
`emqx_authn_mongodb_SUITE`, `emqx_bridge_mongodb_SUITE`) can only run
against MongoDB <= 5.0. They are gated behind a runtime wire-version
probe (`isMaster.maxWireVersion <= 13`) so they skip on the 8.0 instance
and still run wherever a legacy-capable server is available.

### Hot-upgrade note (for release management)

The fix was kept minimal on purpose so it can ship as a hot patch:
- `get_version/3` keeps its exported arity; the call site in
  `mc_worker.erl` is unchanged.
- `mc_worker_logic` is a stateless helper — a single hot-loadable
  `mc_worker_logic.beam`, no state migration. Workers already past auth
  are unaffected; new connections pick up the fix.

**The next `.relup` hop catalog entry (`plugins/emqx_relup/priv/relup/`)
should add `{load_module, mc_worker_logic}` to its `code_changes`** so an
in-place upgrade reloads the patched beam. No `.relup` file exists yet
for the upcoming hop, so this is flagged here rather than authored in
this PR (the `{from, target}` versions aren't decided here).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
