### PR TITLE
fix(jt808): bind authcode to registered phone

### DIFF
--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -239,7 +239,12 @@ handle_in(Frame = ?MSG(MType), Channel = #channel{conn_state = ConnState}) when
     do_handle_in(Frame, Channel#channel{conn_state = connecting});
 handle_in(Frame, Channel = #channel{conn_state = connected}) ->
     ?SLOG(debug, #{msg => "recv_frame", frame => Frame}),
-    do_handle_in(Frame, Channel);
+    case check_connected_frame_phone(Frame, Channel) of
+        ok ->
+            do_handle_in(Frame, Channel);
+        {error, Reason} ->
+            handle_invalid_frame_phone(Frame, Reason, Channel)
+    end;
 handle_in(Frame = ?MSG(MType), Channel) when
     MType =:= ?MC_DEREGISTER
 ->
@@ -308,7 +313,8 @@ do_handle_in(Frame = ?MSG(?MC_AUTH), Channel0) ->
         {ok, _NFrame, Channel} ->
             case authenticate(Frame, Channel) of
                 true ->
-                    NChannel = process_connect(Frame, ensure_connected(Channel)),
+                    NChannel0 = normalize_authenticated_phone(Frame, Channel),
+                    NChannel = process_connect(Frame, ensure_connected(NChannel0)),
                     authack({0, MsgSn, NChannel});
                 false ->
                     authack({1, MsgSn, Channel})
@@ -860,8 +866,14 @@ get_msg_ack(?MC_DRIVER_ID_REPORT, _MsgSn) ->
 get_msg_ack(MsgId, MsgSn) ->
     error({invalid_message_type, MsgId, MsgSn}).
 
-build_frame_header(MsgId, #channel{clientinfo = #{phone := Phone}, msg_sn = TxMsgSn}) ->
+build_frame_header(MsgId, #channel{clientinfo = ClientInfo, msg_sn = TxMsgSn}) ->
+    Phone = frame_header_phone(ClientInfo),
     build_frame_header(MsgId, 0, Phone, TxMsgSn).
+
+frame_header_phone(#{authenticated_phone := Phone}) ->
+    Phone;
+frame_header_phone(#{phone := Phone}) ->
+    Phone.
 
 build_frame_header(MsgId, Encrypt, Phone, TxMsgSn) ->
     #{
@@ -908,10 +920,14 @@ is_driver_id_req_exist(#channel{inflight = Inflight}) ->
     Key = get_msg_ack(?MC_DRIVER_ID_REPORT, none),
     emqx_inflight:contain(Key, Inflight).
 
-register_(Frame, Channel0) ->
+register_(Frame = #{<<"header">> := #{<<"phone">> := Phone}}, Channel0) ->
     case emqx_jt808_auth:register(Frame, Channel0#channel.auth) of
         {ok, AuthCode} ->
-            {ok, Channel0#channel{authcode = AuthCode}};
+            ClientInfo = maps:remove(
+                authenticated_phone,
+                (Channel0#channel.clientinfo)#{registered_phone => Phone}
+            ),
+            {ok, Channel0#channel{authcode = AuthCode, clientinfo = ClientInfo}};
         {error, Reason} ->
             ?SLOG(error, #{msg => "register_failed", reason => Reason}),
             ResCode =
@@ -922,22 +938,75 @@ register_(Frame, Channel0) ->
             {error, ResCode}
     end.
 
-authenticate(_AuthFrame, #channel{authcode = anonymous}) ->
-    true;
-authenticate(AuthFrame, #channel{authcode = undefined, auth = Auth}) ->
+authenticate(AuthFrame, Channel = #channel{authcode = anonymous}) ->
+    auth_phone_matches(AuthFrame, Channel);
+authenticate(AuthFrame, Channel = #channel{authcode = undefined, auth = Auth}) ->
     %% Try request authentication server
-    case emqx_jt808_auth:authenticate(AuthFrame, Auth) of
-        {ok, #{auth_result := IsAuth}} ->
-            IsAuth;
-        {error, Reason} ->
-            ?SLOG(error, #{msg => "request_auth_server_failed", reason => Reason}),
+    case auth_phone_matches(AuthFrame, Channel) of
+        true ->
+            case emqx_jt808_auth:authenticate(AuthFrame, Auth) of
+                {ok, #{auth_result := IsAuth}} ->
+                    IsAuth;
+                {error, Reason} ->
+                    ?SLOG(error, #{msg => "request_auth_server_failed", reason => Reason}),
+                    false
+            end;
+        false ->
             false
     end;
 authenticate(
-    #{<<"body">> := #{<<"code">> := InCode}},
-    #channel{authcode = AuthCode}
+    AuthFrame = #{<<"body">> := #{<<"code">> := InCode}},
+    Channel = #channel{authcode = AuthCode}
 ) ->
-    InCode == AuthCode.
+    InCode == AuthCode andalso auth_phone_matches(AuthFrame, Channel).
+
+auth_phone_matches(
+    #{<<"header">> := #{<<"phone">> := Phone}},
+    #channel{clientinfo = ClientInfo}
+) ->
+    case maps:get(registered_phone, ClientInfo, undefined) of
+        undefined -> true;
+        Phone -> true;
+        _RegisteredPhone -> false
+    end.
+
+normalize_authenticated_phone(
+    #{<<"header">> := #{<<"phone">> := Phone}},
+    Channel = #channel{clientinfo = ClientInfo0, conninfo = ConnInfo}
+) ->
+    ClientInfo = maps:without(
+        [registered_phone, authenticated_phone],
+        ClientInfo0#{phone => Phone, clientid => Phone}
+    ),
+    Channel#channel{
+        clientinfo = ClientInfo,
+        conninfo = ConnInfo#{clientid => Phone}
+    }.
+
+check_connected_frame_phone(
+    #{<<"header">> := #{<<"phone">> := Phone}},
+    #channel{clientinfo = #{phone := Phone}}
+) ->
+    ok;
+check_connected_frame_phone(
+    #{<<"header">> := #{<<"phone">> := Phone}},
+    #channel{clientinfo = #{phone := AuthenticatedPhone}}
+) ->
+    {error, #{expected_phone => AuthenticatedPhone, received_phone => Phone}};
+check_connected_frame_phone(_Frame, _Channel) ->
+    ok.
+
+handle_invalid_frame_phone(Frame, Reason, Channel = #channel{clientinfo = ClientInfo}) ->
+    case maps:get(ignore_unsupported_frames, ClientInfo, ?IGNORE_UNSUPPORTED_FRAMES) of
+        true ->
+            ?SLOG(warning, #{
+                msg => "ignore_frame_with_unexpected_phone", reason => Reason, frame => Frame
+            }),
+            {ok, Channel};
+        false ->
+            ?SLOG(error, #{msg => "disconnect_client", reason => Reason, frame => Frame}),
+            {shutdown, unexpected_frame, Channel}
+    end.
 
 enrich_conninfo(
     #{<<"header">> := #{<<"phone">> := Phone}},
@@ -982,7 +1051,8 @@ enrich_clientinfo(
     },
     Channel = #channel{clientinfo = ClientInfo}
 ) ->
-    NClientInfo = maybe_fix_mountpoint(ClientInfo#{
+    NClientInfo0 = maps:remove(authenticated_phone, ClientInfo),
+    NClientInfo = maybe_fix_mountpoint(NClientInfo0#{
         phone => Phone,
         clientid => Phone,
         manufacturer => Manu,
@@ -995,8 +1065,7 @@ enrich_clientinfo(
     Channel = #channel{clientinfo = ClientInfo}
 ) ->
     NClientInfo = ClientInfo#{
-        phone => Phone,
-        clientid => Phone
+        authenticated_phone => Phone
     },
     {ok, Channel#channel{clientinfo = NClientInfo}}.
 

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -33,12 +33,16 @@
 -define(PROTO_REG_REGISTRY_PATH, "/jt808/registry").
 
 -define(JT808_PHONE, "000123456789").
+-define(JT808_VICTIM_PHONE, "000123456790").
+-define(JT808_VICTIM_PHONE_BCD, <<16#00, 16#01, 16#23, 16#45, 16#67, 16#90>>).
 %% <<"jt808/000123456789/">>
 -define(JT808_MOUNTPOINT, "jt808/" ?JT808_PHONE "/").
 %% <<"jt808/000123456789/000123456789/up">>
 -define(JT808_UP_TOPIC, <<?JT808_MOUNTPOINT, ?JT808_PHONE, "/up">>).
 %% <<"jt808/000123456789/000123456789/dn">>
 -define(JT808_DN_TOPIC, <<?JT808_MOUNTPOINT, ?JT808_PHONE, "/dn">>).
+%% <<"jt808/000123456790/000123456790/dn">>
+-define(JT808_VICTIM_DN_TOPIC, <<"jt808/" ?JT808_VICTIM_PHONE "/" ?JT808_VICTIM_PHONE "/dn">>).
 
 %% erlfmt-ignore
 -define(CONF_DEFAULT, <<"
@@ -98,7 +102,10 @@ end_per_suite(_Config) ->
 init_per_testcase(Case = t_case_invalid_auth_reg_server, Config) ->
     Apps = boot_apps(Case, ?CONF_INVALID_AUTH_SERVER, Config),
     [{suite_apps, Apps} | Config];
-init_per_testcase(Case = t_case02_anonymous_register_and_auth, Config) ->
+init_per_testcase(Case, Config) when
+    Case =:= t_case02_anonymous_register_and_auth;
+    Case =:= t_jt808_reject_anonymous_auth_with_unregistered_phone
+->
     Apps = boot_apps(Case, ?CONF_ANONYMOUS, Config),
     [{suite_apps, Apps} | Config];
 init_per_testcase(Case, Config) when
@@ -169,10 +176,25 @@ do_escape(<<16#7d, Rest/binary>>, Acc) ->
 do_escape(<<C, Rest/binary>>, Acc) ->
     do_escape(Rest, <<Acc/binary, C:8>>).
 
+unescape_packet(Packet) ->
+    unescape_packet(Packet, <<>>).
+
+unescape_packet(<<>>, Acc) ->
+    Acc;
+unescape_packet(<<16#7d, 16#02, Rest/binary>>, Acc) ->
+    unescape_packet(Rest, <<Acc/binary, 16#7e>>);
+unescape_packet(<<16#7d, 16#01, Rest/binary>>, Acc) ->
+    unescape_packet(Rest, <<Acc/binary, 16#7d>>);
+unescape_packet(<<C, Rest/binary>>, Acc) ->
+    unescape_packet(Rest, <<Acc/binary, C:8>>).
+
 client_regi_procedure(Socket) ->
     client_regi_procedure(Socket, <<"123456">>).
 
 client_regi_procedure(Socket, ExpectedAuthCode) ->
+    client_regi_procedure(Socket, ExpectedAuthCode, <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>).
+
+client_regi_procedure(Socket, ExpectedAuthCode, PhoneBCD) ->
     %
     % send REGISTER
     %
@@ -185,7 +207,6 @@ client_regi_procedure(Socket, ExpectedAuthCode) ->
     RegisterPacket =
         <<58:?WORD, 59:?WORD, Manuf/binary, Model/binary, DevId/binary, Color, Plate/binary>>,
     MsgId = ?MC_REGISTER,
-    PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
     MsgSn = 78,
     Size = size(RegisterPacket),
     Header =
@@ -194,7 +215,7 @@ client_regi_procedure(Socket, ExpectedAuthCode) ->
     S1 = gen_packet(Header, RegisterPacket),
 
     ok = gen_tcp:send(Socket, S1),
-    {ok, Packet} = gen_tcp:recv(Socket, 0, 500),
+    {ok, Packet} = gen_tcp:recv(Socket, 0, 5000),
 
     AckPacket = <<MsgSn:?WORD, 0, ExpectedAuthCode/binary>>,
     Size2 = size(AckPacket),
@@ -208,6 +229,37 @@ client_regi_procedure(Socket, ExpectedAuthCode) ->
     ?LOGT("Packet=~p", [binary_to_hex_string(Packet)]),
     ?assertEqual(S2, Packet),
     {ok, ExpectedAuthCode}.
+
+client_register_expect_result(Socket, PhoneBCD, ExpectedResult) ->
+    ?LOGT("start register procedure expecting result ~p", [ExpectedResult]),
+    Manuf = <<"examp">>,
+    Model = <<"33333333333333333", 0, 0, 0>>,
+    DevId = <<"123456", 0>>,
+    Color = 3,
+    Plate = <<"ujvl239">>,
+    RegisterPacket =
+        <<58:?WORD, 59:?WORD, Manuf/binary, Model/binary, DevId/binary, Color, Plate/binary>>,
+    MsgId = ?MC_REGISTER,
+    MsgSn = 78,
+    Size = size(RegisterPacket),
+    Header =
+        <<MsgId:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size), PhoneBCD/binary,
+            MsgSn:?WORD>>,
+
+    ok = gen_tcp:send(Socket, gen_packet(Header, RegisterPacket)),
+    {ok, Packet} = gen_tcp:recv(Socket, 0, 500),
+    assert_register_result(Packet, PhoneBCD, ExpectedResult).
+
+assert_register_result(Packet, ExpectedPhoneBCD, ExpectedResult) ->
+    <<16#7E, Inner/binary>> = Packet,
+    InnerSize = byte_size(Inner) - 1,
+    <<Escaped:InnerSize/binary, 16#7E>> = Inner,
+    Unescaped = unescape_packet(Escaped),
+    <<?MS_REGISTER_ACK:?WORD, _Attrs:?WORD, Phone:6/binary, _RespMsgSn:?WORD, _Seq:?WORD, Result:8,
+        _Crc:8>> = Unescaped,
+    ?assertEqual(ExpectedPhoneBCD, Phone),
+    ?assertEqual(ExpectedResult, Result),
+    ok.
 
 client_auth_procedure(Socket, AuthCode) ->
     ?LOGT("start auth procedure", []),
@@ -241,6 +293,39 @@ client_auth_procedure(Socket, AuthCode) ->
     ?assert(lists:member(?JT808_DN_TOPIC, emqx:topics())),
 
     ?LOGT("============= auth procedure success ===============", []).
+
+client_auth_expect_result(Socket, AuthCode, PhoneBCD, ExpectedResult) ->
+    ?LOGT("start auth procedure expecting result ~p", [ExpectedResult]),
+    MsgId = ?MC_AUTH,
+    MsgSn = 78,
+    Size = size(AuthCode),
+    Header =
+        <<MsgId:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size), PhoneBCD/binary,
+            MsgSn:?WORD>>,
+    S1 = gen_packet(Header, AuthCode),
+
+    ok = gen_tcp:send(Socket, S1),
+    {ok, Packet} = gen_tcp:recv(Socket, 0, 500),
+    assert_auth_result(Packet, ExpectedResult).
+
+assert_auth_result(Packet, ExpectedResult) ->
+    <<16#7E, Inner/binary>> = Packet,
+    InnerSize = byte_size(Inner) - 1,
+    <<Escaped:InnerSize/binary, 16#7E>> = Inner,
+    Unescaped = unescape_packet(Escaped),
+    <<?MS_GENERAL_RESPONSE:?WORD, _Attrs:?WORD, _Phone:6/binary, _RespMsgSn:?WORD, _Seq:?WORD,
+        ?MC_AUTH:?WORD, Result:8, _Crc:8>> = Unescaped,
+    ?assertEqual(ExpectedResult, Result),
+    ok.
+
+send_event_report(Socket, PhoneBCD, EventReportId, MsgSn) ->
+    MsgBody = <<EventReportId>>,
+    MsgId = ?MC_EVENT_REPORT,
+    Size = size(MsgBody),
+    Header =
+        <<MsgId:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size), PhoneBCD/binary,
+            MsgSn:?WORD>>,
+    ok = gen_tcp:send(Socket, gen_packet(Header, MsgBody)).
 
 client_send_general_response(Socket, MsgId3, MsgSn3, PhoneBCD) ->
     GenAckPacket4 = <<MsgSn3:?WORD, MsgId3:?WORD, 0>>,
@@ -388,6 +473,59 @@ t_case02_anonymous_register_and_auth(_) ->
     ?assertEqual(AuthCode, DefaultAuthCode),
 
     ok = client_auth_procedure(Socket, AuthCode),
+
+    ok = gen_tcp:close(Socket).
+
+t_jt808_reject_auth_with_unregistered_phone(_) ->
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+
+    {ok, AuthCode} = client_regi_procedure(Socket),
+    ok = client_auth_expect_result(Socket, AuthCode, ?JT808_VICTIM_PHONE_BCD, 1),
+    ?assertNot(lists:member(?JT808_VICTIM_DN_TOPIC, emqx:topics())),
+
+    ok = gen_tcp:close(Socket).
+
+t_jt808_reject_anonymous_auth_with_unregistered_phone(_) ->
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+
+    DefaultAuthCode = <<"anonymous">>,
+    {ok, AuthCode} = client_regi_procedure(Socket, DefaultAuthCode),
+    ok = client_auth_expect_result(Socket, AuthCode, ?JT808_VICTIM_PHONE_BCD, 1),
+    ?assertNot(lists:member(?JT808_VICTIM_DN_TOPIC, emqx:topics())),
+
+    ok = gen_tcp:close(Socket).
+
+t_jt808_reject_connected_frame_with_other_phone(_) ->
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+    {ok, AuthCode} = client_regi_procedure(Socket),
+    ok = client_auth_procedure(Socket, AuthCode),
+
+    ok = emqx:subscribe(?JT808_UP_TOPIC),
+    ok = send_event_report(Socket, ?JT808_VICTIM_PHONE_BCD, 98, 79),
+    {error, timeout} = gen_tcp:recv(Socket, 0, 500),
+    {error, timeout} = receive_msg(),
+
+    ok = gen_tcp:close(Socket).
+
+t_jt808_register_ack_uses_register_phone_after_failed_auth(_) ->
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+
+    {ok, AuthCode} = client_regi_procedure(Socket),
+    ok = client_auth_expect_result(Socket, AuthCode, ?JT808_VICTIM_PHONE_BCD, 1),
+    emqx_jt808_auth_http_test_server:set_handler(
+        fun(Req0 = #{method := <<"POST">>, path := <<?PROTO_REG_REGISTRY_PATH>>}, State) ->
+            Req = cowboy_req:reply(
+                200,
+                #{<<"content-type">> => <<"application/json">>},
+                emqx_utils_json:encode(#{code => 1}),
+                Req0
+            ),
+            {ok, Req, State}
+        end
+    ),
+    ok = client_register_expect_result(
+        Socket, <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>, 1
+    ),
 
     ok = gen_tcp:close(Socket).
 
@@ -680,9 +818,14 @@ t_case08_dl_0x8500_vehicle_ctrl(_Config) ->
     ?assertEqual(S3, Packet3),
 
     % client send "client answer"
-    CtrlAck =
-        <<126, 5, 0, 0, 30, 1, 136, 118, 99, 137, 114, 1, 244, 0, 7, 0, 0, 0, 0, 0, 4, 0, 0, 1, 49,
-            122, 103, 6, 147, 104, 81, 0, 24, 0, 0, 0, 121, 23, 16, 32, 18, 3, 25, 69, 126>>,
+    CtrlAckBody =
+        <<0, 7, 0, 0, 0, 0, 0, 4, 0, 0, 1, 49, 122, 103, 6, 147, 104, 81, 0, 24, 0, 0, 0, 121, 23,
+            16, 32, 18, 3, 25>>,
+    CtrlAckSize = size(CtrlAckBody),
+    CtrlAckHeader =
+        <<?MC_VEHICLE_CTRL_ACK:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3,
+            ?MSG_SIZE(CtrlAckSize), PhoneBCD/binary, 500:?WORD>>,
+    CtrlAck = gen_packet(CtrlAckHeader, CtrlAckBody),
     ?LOGT("S4 = ~p", [CtrlAck]),
 
     ok = gen_tcp:send(Socket, CtrlAck),
@@ -697,7 +840,7 @@ t_case08_dl_0x8500_vehicle_ctrl(_Config) ->
                     <<"len">> => 30,
                     <<"msg_id">> => 1280,
                     <<"msg_sn">> => 500,
-                    <<"phone">> => <<"018876638972">>
+                    <<"phone">> => <<"000123456789">>
                 },
             <<"body">> =>
                 #{
@@ -2722,7 +2865,6 @@ t_case_dl_invalid_msg(_Config) ->
     {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
     {ok, AuthCode} = client_regi_procedure(Socket),
     ok = client_auth_procedure(Socket, AuthCode),
-    PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
 
     DlCommand = #{
         %% missing msg_id
@@ -2988,10 +3130,16 @@ raw_jt808_config() ->
     }.
 
 unsupported_frame_packet() ->
-    <<126, 2, 5, 0, 128, 1, 137, 112, 19, 0, 64, 1, 98, 72, 66, 77, 54, 48, 49, 67, 86, 77, 48, 49,
-        49, 77, 50, 50, 48, 50, 53, 45, 48, 49, 45, 49, 55, 253, 255, 2, 0, 255, 127, 0, 128, 80,
-        17, 1, 54, 69, 67, 56, 48, 48, 77, 0, 0, 0, 0, 0, 0, 0, 0, 0, 56, 54, 56, 48, 49, 57, 48,
-        55, 51, 55, 48, 52, 51, 56, 48, 52, 54, 48, 49, 49, 51, 56, 55, 49, 49, 48, 49, 53, 55, 52,
-        56, 57, 56, 54, 49, 49, 50, 52, 50, 51, 51, 48, 56, 49, 51, 49, 53, 55, 57, 53, 0, 0, 76,
-        67, 48, 68, 55, 52, 67, 52, 49, 80, 48, 50, 49, 49, 50, 54, 48, 4, 20, 164, 132, 0, 0, 0, 0,
-        66, 126>>.
+    PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
+    MsgBody =
+        <<72, 66, 77, 54, 48, 49, 67, 86, 77, 48, 49, 49, 77, 50, 50, 48, 50, 53, 45, 48, 49, 45,
+            49, 55, 253, 255, 2, 0, 255, 127, 0, 128, 80, 17, 1, 54, 69, 67, 56, 48, 48, 77, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 56, 54, 56, 48, 49, 57, 48, 55, 51, 55, 48, 52, 51, 56, 48, 52, 54,
+            48, 49, 49, 51, 56, 55, 49, 49, 48, 49, 53, 55, 52, 56, 57, 56, 54, 49, 49, 50, 52, 50,
+            51, 51, 48, 56, 49, 51, 49, 53, 55, 57, 53, 0, 0, 76, 67, 48, 68, 55, 52, 67, 52, 49,
+            80, 48, 50, 49, 49, 50, 54, 48, 4, 20, 164, 132, 0, 0, 0, 0>>,
+    Size = size(MsgBody),
+    Header =
+        <<16#0205:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size),
+            PhoneBCD/binary, 16#0162:?WORD>>,
+    gen_packet(Header, MsgBody).

--- a/changes/ee/fix-17581.en.md
+++ b/changes/ee/fix-17581.en.md
@@ -1,0 +1,1 @@
+Fixed the JT/T 808 gateway to use the phone number accepted during authentication as the connection identity, rejecting mismatched registration-code authentication attempts and subsequent uplink frames with a different phone number.


### PR DESCRIPTION
Release version:
5.8.11

## Summary

Backports #17581 to release-58.

The JT/T 808 gateway now uses the phone number accepted during authentication as the connection identity. Registration remains optional; when a registration-issued authcode is present, the authentication frame must use the matching phone number before that authcode is accepted.

Temporary `registered_phone` and `authenticated_phone` values are kept in `clientinfo` while processing registration and authentication frames. After successful authentication, they are normalized back to the existing `phone` and `clientid` fields. A subsequent registration frame also clears any stale authentication phone before building the REGISTER_ACK response.

After a client is connected, uplink frames whose header phone differs from the authenticated phone are treated as invalid frames, following the existing `ignore_unsupported_frames` behavior for whether to ignore or disconnect.

Added CT coverage for default auth, anonymous auth, post-auth uplink frame phone mismatch, and REGISTER_ACK phone handling after a failed authentication attempt. Checked with `scripts/erlfmt -c apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl`, `scripts/apps-version-check.sh`, `git diff --check`, and the focused JT808 CT cases.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
