### PR TITLE
fix(management): align log outputs CLI with config

### DIFF
--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_cli_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_cli_SUITE.erl
@@ -291,13 +291,21 @@ t_list_cards(TCConfig) ->
         ?CAPTURE(list_cards(["--status", "offline"], TCConfig))
     ),
     C = start_client(#{clientid => Id1}),
-    ?assertMatch(
-        {ok, [[#{<<"name">> := Id2}]]},
-        ?CAPTURE(list_cards(["--status", "offline"], TCConfig))
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            {ok, [[#{<<"name">> := Id2}]]},
+            ?CAPTURE(list_cards(["--status", "offline"], TCConfig))
+        )
     ),
-    ?assertMatch(
-        {ok, [[#{<<"name">> := Id1}]]},
-        ?CAPTURE(list_cards(["--status", "online"], TCConfig))
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            {ok, [[#{<<"name">> := Id1}]]},
+            ?CAPTURE(list_cards(["--status", "online"], TCConfig))
+        )
     ),
     emqtt:stop(C),
 

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -15,6 +15,7 @@
 
 -define(DATA_BACKUP_OPTS, #{print_fun => fun emqx_ctl:print/2}).
 -define(EXCLUSIVE_TAB, emqx_exclusive_subscription).
+-define(LOG_UPDATE_OPTS, #{rawconf_with_defaults => true, override_to => cluster}).
 
 -export([load/0]).
 
@@ -633,6 +634,36 @@ log(["primary-level", Level]) ->
             emqx_ctl:print("[error] invalid level: ~p~n", [Level])
     end,
     emqx_ctl:print("~ts~n", [emqx_logger:get_primary_log_level()]);
+log(["outputs", "list"]) ->
+    LogConf = emqx_conf:get_raw([log], #{}),
+    lists:foreach(fun print_log_output/1, log_outputs(LogConf)),
+    ok;
+log(["outputs", "set-level", Name, Level]) ->
+    case emqx_utils:safe_to_existing_atom(Level) of
+        {ok, _} ->
+            case log_output_path(Name, <<"level">>, emqx_conf:get_raw([log], #{})) of
+                {ok, Path, OutputName} ->
+                    update_log_output_level(Path, unicode:characters_to_binary(Level), OutputName);
+                {error, Reason} ->
+                    emqx_ctl:print("[error] ~ts~n", [Reason])
+            end;
+        _ ->
+            emqx_ctl:print("[error] invalid level: ~p~n", [Level])
+    end;
+log(["outputs", "enable", Name]) ->
+    case log_output_path(Name, <<"enable">>, emqx_conf:get_raw([log], #{})) of
+        {ok, Path, OutputName} ->
+            update_log_output(Path, true, OutputName);
+        {error, Reason} ->
+            emqx_ctl:print("[error] ~ts~n", [Reason])
+    end;
+log(["outputs", "disable", Name]) ->
+    case log_output_path(Name, <<"enable">>, emqx_conf:get_raw([log], #{})) of
+        {ok, Path, OutputName} ->
+            update_log_output(Path, false, OutputName);
+        {error, Reason} ->
+            emqx_ctl:print("[error] ~ts~n", [Reason])
+    end;
 log(["handlers", "list"]) ->
     _ = [
         emqx_ctl:print(
@@ -699,12 +730,112 @@ log(_) ->
             {"log set-level <Level>", "Set the overall log level"},
             {"log primary-level", "Show the primary log level now"},
             {"log primary-level <Level>", "Set the primary log level"},
-            {"log handlers list", "Show log handlers"},
-            {"log handlers start <HandlerId>", "Start a log handler"},
-            {"log handlers stop  <HandlerId>", "Stop a log handler"},
-            {"log handlers set-level <HandlerId> <Level>", "Set log level of a log handler"}
+            {"log outputs list", "Show configured log outputs"},
+            {"log outputs enable <name>", "Enable console, file, or a file handler name"},
+            {"log outputs disable <name>", "Disable console, file, or a file handler name"},
+            {"log outputs set-level <name> <Level>",
+                "Set log level for console, file, or a file handler name"}
         ]
     ).
+
+log_outputs(LogConf) ->
+    Console = maps:get(<<"console">>, LogConf, #{}),
+    Files = maps:get(<<"file">>, LogConf, #{}),
+    [
+        #{
+            name => <<"console">>,
+            level => maps:get(<<"level">>, Console, undefined),
+            destination => <<"console">>,
+            status => output_status(Console)
+        }
+        | [
+            #{
+                name => log_file_output_name(Name),
+                level => maps:get(<<"level">>, FileConf, undefined),
+                destination => maps:get(<<"path">>, FileConf, <<>>),
+                status => output_status(FileConf)
+            }
+         || {Name, FileConf} <- lists:sort(maps:to_list(Files))
+        ]
+    ].
+
+log_file_output_name(<<"default">>) ->
+    <<"file">>;
+log_file_output_name(Name) ->
+    Name.
+
+output_status(#{<<"enable">> := true}) ->
+    <<"enabled">>;
+output_status(_) ->
+    <<"disabled">>.
+
+print_log_output(#{
+    name := Name,
+    level := Level,
+    destination := Destination,
+    status := Status
+}) ->
+    emqx_ctl:print(
+        "LogOutput(name=~ts, level=~ts, destination=~ts, status=~ts)~n",
+        [Name, fmt_cli(Level), fmt_cli(Destination), Status]
+    ).
+
+log_output_path("console", Field, _LogConf) ->
+    {ok, [<<"console">>, Field], <<"console">>};
+log_output_path("file", Field, _LogConf) ->
+    {ok, [<<"file">>, <<"default">>, Field], <<"file">>};
+log_output_path("default", Field, _LogConf) ->
+    {ok, [<<"file">>, <<"default">>, Field], <<"file">>};
+log_output_path(Name, Field, LogConf) ->
+    NameBin = unicode:characters_to_binary(Name),
+    Files = maps:get(<<"file">>, LogConf, #{}),
+    case maps:is_key(NameBin, Files) of
+        true ->
+            {ok, [<<"file">>, NameBin, Field], NameBin};
+        false ->
+            {error, iolist_to_binary(io_lib:format("unknown log output: ~ts", [Name]))}
+    end.
+
+update_log_output(Path, Enable, OutputName) ->
+    LogConf0 = emqx_conf:get_raw([log], #{}),
+    LogConf = emqx_utils_maps:deep_put(Path, LogConf0, Enable),
+    case emqx_conf:update([log], LogConf, ?LOG_UPDATE_OPTS) of
+        {ok, _} ->
+            emqx_ctl:print("log output ~ts ~ts~n", [
+                OutputName,
+                case Enable of
+                    true -> <<"enabled">>;
+                    false -> <<"disabled">>
+                end
+            ]),
+            ok;
+        {error, Reason} = Error ->
+            emqx_ctl:print("[error] failed to update log output ~ts: ~0p~n", [OutputName, Reason]),
+            Error
+    end.
+
+update_log_output_level(Path, Level, OutputName) ->
+    LogConf0 = emqx_conf:get_raw([log], #{}),
+    LogConf = emqx_utils_maps:deep_put(Path, LogConf0, Level),
+    case emqx_conf:update([log], LogConf, ?LOG_UPDATE_OPTS) of
+        {ok, _} ->
+            emqx_ctl:print("log output ~ts level set to ~ts~n", [OutputName, Level]),
+            ok;
+        {error, Reason} = Error ->
+            emqx_ctl:print("[error] failed to update log output ~ts level: ~0p~n", [
+                OutputName, Reason
+            ]),
+            Error
+    end.
+
+fmt_cli(undefined) ->
+    <<"">>;
+fmt_cli(Value) when is_binary(Value) ->
+    Value;
+fmt_cli(Value) when is_atom(Value) ->
+    atom_to_binary(Value, utf8);
+fmt_cli(Value) ->
+    iolist_to_binary(io_lib:format("~0p", [Value])).
 
 %%--------------------------------------------------------------------
 %% @doc Trace Command

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1425,26 +1425,38 @@ t_subscribe_shared_topic(Config) ->
     ),
 
     %% assert subscription
-    ?assertMatch(
-        [
-            {_, #share{group = <<"group">>, topic = <<"testtopic">>}},
-            {_, <<"t/#">>}
-        ],
-        ets:tab2list(?SUBSCRIPTION)
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            [
+                #share{group = <<"group">>, topic = <<"testtopic">>},
+                <<"t/#">>
+            ],
+            lists:sort([Topic || {_, Topic} <- ets:tab2list(?SUBSCRIPTION)])
+        )
     ),
 
-    ?assertMatch(
-        [
-            {{#share{group = <<"group">>, topic = <<"testtopic">>}, _}, #{
-                nl := 0, qos := 1, rh := 1, rap := 0
-            }},
-            {{<<"t/#">>, _}, #{nl := 0, qos := 1, rh := 1, rap := 0}}
-        ],
-        ets:tab2list(?SUBOPTION)
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            [
+                {{#share{group = <<"group">>, topic = <<"testtopic">>}, _}, #{
+                    nl := 0, qos := 1, rh := 1, rap := 0
+                }},
+                {{<<"t/#">>, _}, #{nl := 0, qos := 1, rh := 1, rap := 0}}
+            ],
+            lists:sort(ets:tab2list(?SUBOPTION))
+        )
     ),
-    ?assertMatch(
-        [{emqx_shared_subscription, <<"group">>, <<"testtopic">>, _}],
-        ets:tab2list(emqx_shared_subscription)
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            [{emqx_shared_subscription, <<"group">>, <<"testtopic">>, _}],
+            ets:tab2list(emqx_shared_subscription)
+        )
     ),
 
     %% assert subscription virtual

--- a/apps/emqx_management/test/emqx_mgmt_cli_log_outputs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_log_outputs_SUITE.erl
@@ -13,16 +13,22 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
+    DashboardPort = emqx_common_test_helpers:select_free_port(tcp),
     Apps = emqx_cth_suite:start(
         [
             {emqx_conf, #{config => listeners_conf()}},
             emqx_modules,
-            emqx_management
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard(dashboard_conf(DashboardPort))
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     ok = emqx_mgmt_cli:load(),
-    [{apps, Apps} | Config].
+    [
+        {apps, Apps},
+        {api_host, "http://127.0.0.1:" ++ integer_to_list(DashboardPort)}
+        | Config
+    ].
 
 end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(apps, Config)).
@@ -131,6 +137,36 @@ t_update_cluster_config(_Config) ->
         ?assertMatch({ok, _}, logger:get_handler_config(new))
     end).
 
+t_http_api_cli_roundtrip(Config) ->
+    Host = ?config(api_host, Config),
+    with_log_conf_restore(fun() ->
+        {ok, Log0} = http_get_log_config(Host),
+        Log1 = emqx_utils_maps:deep_put([<<"file">>, <<"default">>, <<"enable">>], Log0, false),
+        {ok, #{}} = http_update_log_config(Host, Log1),
+
+        {ok, Output} = capture_ctl(fun() ->
+            emqx_ctl:run_command(["log", "outputs", "list"])
+        end),
+        ?assertMatch(
+            match,
+            re:run(Output, <<"LogOutput\\(name=file[^\\n]*status=disabled">>, [{capture, none}])
+        ),
+
+        ok = emqx_ctl:run_command(["log", "outputs", "enable", "file"]),
+        {ok, Log2} = http_get_log_config(Host),
+        ?assertEqual(
+            true,
+            emqx_utils_maps:deep_get([<<"file">>, <<"default">>, <<"enable">>], Log2)
+        ),
+
+        ok = emqx_ctl:run_command(["log", "outputs", "set-level", "file", "error"]),
+        {ok, Log3} = http_get_log_config(Host),
+        ?assertEqual(
+            <<"error">>,
+            emqx_utils_maps:deep_get([<<"file">>, <<"default">>, <<"level">>], Log3)
+        )
+    end).
+
 t_hide_legacy_handlers_usage(_Config) ->
     {ok, Output} = capture_ctl(fun() ->
         emqx_ctl:run_command(["log"])
@@ -157,6 +193,20 @@ capture_ctl(Fun) ->
     {Res, Prints} = emqx_common_test_helpers:capture_io_format(Fun),
     {Res, iolist_to_binary(Prints)}.
 
+http_get_log_config(Host) ->
+    Path = emqx_mgmt_api_test_util:api_path(Host, ["configs", "log"]),
+    case emqx_mgmt_api_test_util:simple_request(get, Path, []) of
+        {200, Log} -> {ok, Log};
+        Error -> Error
+    end.
+
+http_update_log_config(Host, Log) ->
+    Path = emqx_mgmt_api_test_util:api_path(Host, ["configs", "log"]),
+    case emqx_mgmt_api_test_util:simple_request(put, Path, Log) of
+        {200, Resp} -> {ok, Resp};
+        Error -> Error
+    end.
+
 listeners_conf() ->
     #{
         listeners =>
@@ -172,3 +222,14 @@ select_free_listener_port(wss) ->
     emqx_common_test_helpers:select_free_port(tcp);
 select_free_listener_port(Type) ->
     emqx_common_test_helpers:select_free_port(Type).
+
+dashboard_conf(Port) ->
+    io_lib:format(
+        """
+        dashboard {
+            listeners.http { enable = true, bind = ~B }
+            password_expired_time = "86400s"
+        }
+        """,
+        [Port]
+    ).

--- a/apps/emqx_management/test/emqx_mgmt_cli_log_outputs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_log_outputs_SUITE.erl
@@ -1,0 +1,174 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_mgmt_cli_log_outputs_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            {emqx_conf, #{config => listeners_conf()}},
+            emqx_modules,
+            emqx_management
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    ok = emqx_mgmt_cli:load(),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    ok = emqx_cth_suite:stop(?config(apps, Config)).
+
+t_list_tracks_config(_Config) ->
+    with_log_conf_restore(fun() ->
+        Log0 = emqx_conf:get_raw([log], #{}),
+        Log1 = emqx_utils_maps:deep_put(
+            [<<"file">>, <<"default">>, <<"enable">>], Log0, false
+        ),
+        {ok, _} = update_log_conf(Log1),
+
+        {ok, Output} = capture_ctl(fun() ->
+            emqx_ctl:run_command(["log", "outputs", "list"])
+        end),
+
+        ?assertMatch(match, re:run(Output, <<"LogOutput\\(name=file">>, [{capture, none}])),
+        ?assertMatch(match, re:run(Output, <<"status=disabled">>, [{capture, none}]))
+    end).
+
+t_update_cluster_config(_Config) ->
+    with_log_conf_restore(fun() ->
+        ok = emqx_ctl:run_command(["log", "outputs", "disable", "file"]),
+        ?assertEqual(
+            false,
+            emqx_utils_maps:deep_get(
+                [<<"file">>, <<"default">>, <<"enable">>],
+                emqx_conf:get_raw([log], #{})
+            )
+        ),
+        ?assertEqual({error, {not_found, default}}, logger:get_handler_config(default)),
+
+        ok = emqx_ctl:run_command(["log", "outputs", "enable", "file"]),
+        ?assertEqual(
+            true,
+            emqx_utils_maps:deep_get(
+                [<<"file">>, <<"default">>, <<"enable">>],
+                emqx_conf:get_raw([log], #{})
+            )
+        ),
+        ?assertMatch({ok, _}, logger:get_handler_config(default)),
+
+        ok = emqx_ctl:run_command(["log", "outputs", "set-level", "file", "error"]),
+        ?assertEqual(
+            <<"error">>,
+            emqx_utils_maps:deep_get(
+                [<<"file">>, <<"default">>, <<"level">>],
+                emqx_conf:get_raw([log], #{})
+            )
+        ),
+        ?assertMatch({ok, #{level := error}}, logger:get_handler_config(default)),
+
+        ok = emqx_ctl:run_command(["log", "outputs", "disable", "console"]),
+        ?assertEqual(
+            false,
+            emqx_utils_maps:deep_get([<<"console">>, <<"enable">>], emqx_conf:get_raw([log], #{}))
+        ),
+        ?assertEqual({error, {not_found, console}}, logger:get_handler_config(console)),
+
+        ok = emqx_ctl:run_command(["log", "outputs", "enable", "console"]),
+        ?assertEqual(
+            true,
+            emqx_utils_maps:deep_get([<<"console">>, <<"enable">>], emqx_conf:get_raw([log], #{}))
+        ),
+        ?assertMatch({ok, _}, logger:get_handler_config(console)),
+
+        Log0 = emqx_conf:get_raw([log], #{}),
+        DefaultFile = emqx_utils_maps:deep_get([<<"file">>, <<"default">>], Log0),
+        NamedFile = DefaultFile#{
+            <<"enable">> => true,
+            <<"path">> => <<"log/emqx-test-new.log">>
+        },
+        {ok, _} = update_log_conf(
+            emqx_utils_maps:deep_put([<<"file">>, <<"new">>], Log0, NamedFile)
+        ),
+        ?assertMatch({ok, _}, logger:get_handler_config(new)),
+
+        ok = emqx_ctl:run_command(["log", "outputs", "set-level", "new", "debug"]),
+        ?assertEqual(
+            <<"debug">>,
+            emqx_utils_maps:deep_get(
+                [<<"file">>, <<"new">>, <<"level">>],
+                emqx_conf:get_raw([log], #{})
+            )
+        ),
+        ?assertMatch({ok, #{level := debug}}, logger:get_handler_config(new)),
+
+        ok = emqx_ctl:run_command(["log", "outputs", "disable", "new"]),
+        ?assertEqual(
+            false,
+            emqx_utils_maps:deep_get(
+                [<<"file">>, <<"new">>, <<"enable">>],
+                emqx_conf:get_raw([log], #{})
+            )
+        ),
+        ?assertEqual({error, {not_found, new}}, logger:get_handler_config(new)),
+
+        ok = emqx_ctl:run_command(["log", "outputs", "enable", "new"]),
+        ?assertEqual(
+            true,
+            emqx_utils_maps:deep_get(
+                [<<"file">>, <<"new">>, <<"enable">>],
+                emqx_conf:get_raw([log], #{})
+            )
+        ),
+        ?assertMatch({ok, _}, logger:get_handler_config(new))
+    end).
+
+t_hide_legacy_handlers_usage(_Config) ->
+    {ok, Output} = capture_ctl(fun() ->
+        emqx_ctl:run_command(["log"])
+    end),
+    ?assertMatch(match, re:run(Output, <<"log outputs list">>, [{capture, none}])),
+    ?assertMatch(match, re:run(Output, <<"log outputs enable <name>">>, [{capture, none}])),
+    ?assertMatch(
+        match, re:run(Output, <<"log outputs set-level <name> <Level>">>, [{capture, none}])
+    ),
+    ?assertEqual(nomatch, re:run(Output, <<"log handlers list">>, [{capture, none}])).
+
+with_log_conf_restore(Fun) ->
+    Log0 = emqx_conf:get_raw([log], #{}),
+    try
+        Fun()
+    after
+        _ = update_log_conf(Log0)
+    end.
+
+update_log_conf(Log) ->
+    emqx_conf:update([log], Log, #{rawconf_with_defaults => true, override_to => cluster}).
+
+capture_ctl(Fun) ->
+    {Res, Prints} = emqx_common_test_helpers:capture_io_format(Fun),
+    {Res, iolist_to_binary(Prints)}.
+
+listeners_conf() ->
+    #{
+        listeners =>
+            maps:from_list([
+                {Type, #{default => #{bind => select_free_listener_port(Type)}}}
+             || Type <- [tcp, ssl, ws, wss]
+            ])
+    }.
+
+select_free_listener_port(ws) ->
+    emqx_common_test_helpers:select_free_port(tcp);
+select_free_listener_port(wss) ->
+    emqx_common_test_helpers:select_free_port(tcp);
+select_free_listener_port(Type) ->
+    emqx_common_test_helpers:select_free_port(Type).

--- a/changes/ee/fix-17602.en.md
+++ b/changes/ee/fix-17602.en.md
@@ -1,0 +1,1 @@
+Added config-backed `emqx ctl log outputs` commands so CLI changes to logger outputs stay consistent with logger configuration managed by the HTTP API and Dashboard.


### PR DESCRIPTION
Fix: https://github.com/emqx/emqx-customer-support/issues/11
Release version:
6.3.x (release-63)

## Summary

This PR adds config-backed `emqx ctl log outputs` commands so logger output changes made through CLI and HTTP API/Dashboard use the same cluster logger configuration path.

Key changes:

* Adds `log outputs list`, `enable`, `disable`, and `set-level` commands for `console`, the default `file` output, and configured named file handlers.
* Keeps the legacy `log handlers ...` commands callable for compatibility, but removes them from `log` usage output.
* Adds CT coverage for CLI/API config parity, named file handlers, level updates, and hidden legacy usage.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
