### PR TITLE
feat: expose certificate SAN to client attributes

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -348,11 +348,12 @@ set_peercert_infos(PeerCert, ClientInfo, Zone) ->
     ClientId = PeercetAs(peer_cert_as_clientid),
     ClientInfo#{username => Username, clientid => ClientId, dn => DN, cn => CN}.
 
-%% Reject control characters (0x00-0x1F, 0x7F-0x9F) in CN / DN. Mirrors the
-%% byte-class check `emqx_frame:validate_utf8/1` applies to MQTT-ingested
-%% clientid/username/password. Closes a CRLF-injection primitive where bytes
-%% sourced from a PROXY-Protocol v2 SSL TLV could be smuggled into outbound
-%% HTTP authn/authz/bridge requests via `${cert_common_name}` / `${cert_subject}`.
+%% Reject control characters (0x00-0x1F, 0x7F-0x9F) in peer certificate strings.
+%% Mirrors the byte-class check `emqx_frame:validate_utf8/1` applies to
+%% MQTT-ingested clientid/username/password. Closes a CRLF-injection primitive
+%% where bytes sourced from a peer certificate or PROXY-Protocol v2 SSL TLV could
+%% be smuggled into outbound HTTP authn/authz/bridge requests via
+%% `${cert_common_name}` / `${cert_subject}` / `${cert_san.*}`.
 validate_peercert_string(_Field, undefined, _Source) ->
     ok;
 validate_peercert_string(Field, Value, Source) when is_binary(Value) ->
@@ -2152,7 +2153,7 @@ check_connect(ConnPkt, #channel{clientinfo = #{zone := Zone}}) ->
 %%--------------------------------------------------------------------
 %% Enrich Client Info
 
-enrich_client(ConnPkt, Channel = #channel{clientinfo = ClientInfo}) ->
+enrich_client(ConnPkt, Channel = #channel{clientinfo = ClientInfo, conninfo = ConnInfo}) ->
     Pipe = emqx_utils:pipeline(
         [
             fun set_username/2,
@@ -2160,7 +2161,9 @@ enrich_client(ConnPkt, Channel = #channel{clientinfo = ClientInfo}) ->
             fun maybe_username_as_clientid/2,
             fun maybe_assign_clientid/2,
             %% attr init should happen after clientid and username assign
-            fun maybe_set_client_initial_attrs/2,
+            fun(NConnPkt, NClientInfo) ->
+                maybe_set_client_initial_attrs(NConnPkt, NClientInfo, ConnInfo)
+            end,
             %% clientid override should happen after client_attrs is initialized
             fun maybe_override_clientid/2
         ],
@@ -2218,7 +2221,7 @@ maybe_assign_clientid(#mqtt_packet_connect{clientid = ClientId}, ClientInfo) ->
 get_client_attrs_init_config(Zone) ->
     get_mqtt_conf(Zone, client_attrs_init, []).
 
-maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo) ->
+maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo, ConnInfo) ->
     case get_client_attrs_init_config(Zone) of
         [] ->
             {ok, ClientInfo};
@@ -2226,7 +2229,8 @@ maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo) ->
             UserProperty = get_user_property_as_map(ConnPkt),
             Password = get_connect_password(ConnPkt),
             RenderCtx = client_attrs_init_render_ctx(
-                ClientInfo#{user_property => UserProperty, password => Password}
+                ClientInfo#{user_property => UserProperty, password => Password},
+                ConnInfo
             ),
             Attrs0 = maps:get(client_attrs, ClientInfo, #{}),
             Attrs1 = initialize_client_attrs(Inits, RenderCtx),
@@ -2236,15 +2240,47 @@ maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo) ->
 get_connect_password(#mqtt_packet_connect{password = Password}) ->
     Password.
 
-client_attrs_init_render_ctx(#{cn := CN} = Ctx) ->
+client_attrs_init_render_ctx(Ctx, ConnInfo) ->
+    client_attrs_init_render_ctx_cn(add_cert_san_render_ctx(Ctx, ConnInfo)).
+
+client_attrs_init_render_ctx_cn(#{cn := CN} = Ctx) ->
     client_attrs_init_render_ctx_dn(Ctx#{cert_common_name => CN});
-client_attrs_init_render_ctx(Ctx) ->
+client_attrs_init_render_ctx_cn(Ctx) ->
     client_attrs_init_render_ctx_dn(Ctx).
 
 client_attrs_init_render_ctx_dn(#{dn := DN} = Ctx) ->
     Ctx#{cert_subject => DN};
 client_attrs_init_render_ctx_dn(Ctx) ->
     Ctx.
+
+add_cert_san_render_ctx(Ctx, ConnInfo) ->
+    PeerCert = maps:get(peercert, ConnInfo, undefined),
+    CertSAN = esockd_peercert:subject_alt_names(PeerCert),
+    ok = validate_cert_san(CertSAN, PeerCert),
+    Ctx#{cert_san => cert_san_render_ctx(CertSAN)}.
+
+validate_cert_san(nosan, _Source) ->
+    ok;
+validate_cert_san(CertSAN, Source) when is_map(CertSAN) ->
+    maps:foreach(
+        fun(NameType, Values) ->
+            lists:foreach(
+                fun(Value) ->
+                    validate_peercert_string({cert_san, NameType}, Value, Source)
+                end,
+                Values
+            )
+        end,
+        CertSAN
+    ).
+
+cert_san_render_ctx(nosan) ->
+    empty_cert_san_render_ctx();
+cert_san_render_ctx(CertSAN) when is_map(CertSAN) ->
+    maps:merge(empty_cert_san_render_ctx(), CertSAN).
+
+empty_cert_san_render_ctx() ->
+    #{dns => [], ip => [], email => [], uri => []}.
 
 initialize_client_attrs(Inits, #{clientid := ClientId} = ClientInfo) ->
     lists:foldl(

--- a/apps/emqx/test/emqx_client_cert_san_SUITE.erl
+++ b/apps/emqx/test/emqx_client_cert_san_SUITE.erl
@@ -1,0 +1,222 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_client_cert_san_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/asserts.hrl").
+
+all() ->
+    [
+        t_cert_san_as_client_attrs,
+        t_invalid_cert_san_rejected,
+        t_empty_cert_san_do_not_set_attr
+    ].
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            {emqx,
+                "listeners.tcp.default.enable = false\n"
+                "listeners.ssl.default.enable = false\n"
+                "listeners.ws.default.enable = false\n"
+                "listeners.wss.default.enable = false\n"}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(apps, Config)).
+
+init_per_testcase(_TestCase, Config) ->
+    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], []),
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], []),
+    ok.
+
+t_cert_san_as_client_attrs(Config) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    {Port, SslOpts, ListenerConf} = start_san_listener(
+        ?FUNCTION_NAME,
+        Config,
+        [
+            {dns, "example.com"},
+            {dns, "www.example.com"},
+            {ip, {192, 168, 1, 100}},
+            {ip, {16#2001, 16#0db8, 0, 0, 0, 0, 0, 1}},
+            {email, "ops@example.com"},
+            {uri, "spiffe://example.com/client"}
+        ]
+    ),
+    {ok, DNS} = emqx_variform:compile("nth(1, cert_san.dns)"),
+    {ok, AllDNS} = emqx_variform:compile("join_to_string(',', cert_san.dns)"),
+    {ok, IP} = emqx_variform:compile("nth(1, cert_san.ip)"),
+    {ok, IPv6} = emqx_variform:compile("nth(2, cert_san.ip)"),
+    {ok, Email} = emqx_variform:compile("nth(1, cert_san.email)"),
+    {ok, URI} = emqx_variform:compile("nth(1, cert_san.uri)"),
+    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], [
+        #{expression => DNS, set_as_attr => <<"san_dns">>},
+        #{expression => AllDNS, set_as_attr => <<"san_dns_all">>},
+        #{expression => IP, set_as_attr => <<"san_ip">>},
+        #{expression => IPv6, set_as_attr => <<"san_ipv6">>},
+        #{expression => Email, set_as_attr => <<"san_email">>},
+        #{expression => URI, set_as_attr => <<"san_uri">>}
+    ]),
+    try
+        {ok, Client} = emqtt:start_link([
+            {host, "127.0.0.1"},
+            {clientid, ClientId},
+            {port, Port},
+            {ssl, true},
+            {ssl_opts, SslOpts}
+        ]),
+        {ok, _} = emqtt:connect(Client),
+        ChanInfo = get_chan_info(ClientId),
+        ?assertMatch(
+            #{
+                clientinfo := #{
+                    client_attrs := #{
+                        <<"san_dns">> := <<"example.com">>,
+                        <<"san_dns_all">> := <<"example.com,www.example.com">>,
+                        <<"san_ip">> := <<"192.168.1.100">>,
+                        <<"san_ipv6">> := <<"2001:db8::1">>,
+                        <<"san_email">> := <<"ops@example.com">>,
+                        <<"san_uri">> := <<"spiffe://example.com/client">>
+                    }
+                }
+            },
+            ChanInfo
+        ),
+        #{clientinfo := ClientInfo} = ChanInfo,
+        ?assertNot(maps:is_key(cert_san, ClientInfo)),
+        emqtt:disconnect(Client)
+    after
+        stop_san_listener(?FUNCTION_NAME, ListenerConf)
+    end.
+
+t_invalid_cert_san_rejected(Config) ->
+    process_flag(trap_exit, true),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    {Port, SslOpts, ListenerConf} = start_san_listener(
+        ?FUNCTION_NAME,
+        Config,
+        [{dns, "tenant-a\r\nX-Override-Result: allow"}]
+    ),
+    {ok, DNS} = emqx_variform:compile("nth(1, cert_san.dns)"),
+    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], [
+        #{expression => DNS, set_as_attr => <<"san_dns">>}
+    ]),
+    try
+        {ok, Client} = emqtt:start_link([
+            {host, "127.0.0.1"},
+            {clientid, ClientId},
+            {port, Port},
+            {ssl, true},
+            {ssl_opts, SslOpts}
+        ]),
+        case catch emqtt:connect(Client) of
+            {error, _} ->
+                ok;
+            {'EXIT', _} ->
+                ok;
+            {ok, _} ->
+                emqtt:disconnect(Client),
+                ct:fail(invalid_cert_san_accepted)
+        end
+    after
+        stop_san_listener(?FUNCTION_NAME, ListenerConf)
+    end.
+
+t_empty_cert_san_do_not_set_attr(Config) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    {Port, SslOpts, ListenerConf} = start_san_listener(?FUNCTION_NAME, Config, []),
+    {ok, DNS} = emqx_variform:compile("nth(1, cert_san.dns)"),
+    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], [
+        #{expression => DNS, set_as_attr => <<"san_dns">>}
+    ]),
+    try
+        {ok, Client} = emqtt:start_link([
+            {host, "127.0.0.1"},
+            {clientid, ClientId},
+            {port, Port},
+            {ssl, true},
+            {ssl_opts, SslOpts}
+        ]),
+        {ok, _} = emqtt:connect(Client),
+        ChanInfo = get_chan_info(ClientId),
+        ?assertMatch(#{clientinfo := #{client_attrs := #{}}}, ChanInfo),
+        #{clientinfo := ClientInfo} = ChanInfo,
+        ?assertNot(maps:is_key(cert_san, ClientInfo)),
+        emqtt:disconnect(Client)
+    after
+        stop_san_listener(?FUNCTION_NAME, ListenerConf)
+    end.
+
+start_san_listener(Name, Config, ClientSANList) ->
+    CertDir = filename:join(?config(priv_dir, Config), atom_to_list(Name)),
+    ok = filelib:ensure_dir(filename:join(CertDir, "dummy")),
+    CertKeyRoot = emqx_cth_tls:gen_cert(#{key => ec, issuer => root}),
+    CertKeyServer = emqx_cth_tls:gen_cert(#{
+        key => ec,
+        issuer => CertKeyRoot,
+        subject => #{name => "localhost"},
+        extensions => #{subject_alt_name => [{ip, {127, 0, 0, 1}}]}
+    }),
+    ClientExtensions =
+        case ClientSANList of
+            [] -> #{};
+            [_ | _] -> #{subject_alt_name => ClientSANList}
+        end,
+    CertKeyClient = emqx_cth_tls:gen_cert(#{
+        key => ec,
+        issuer => CertKeyRoot,
+        subject => #{name => "san-client"},
+        extensions => ClientExtensions
+    }),
+    {CACertFile, _} = emqx_cth_tls:write_cert(CertDir, "ca", CertKeyRoot),
+    {ServerCertFile, ServerKeyFile} = emqx_cth_tls:write_cert(CertDir, "server", CertKeyServer),
+    {ClientCertFile, ClientKeyFile} = emqx_cth_tls:write_cert(CertDir, "client", CertKeyClient),
+    Port = emqx_common_test_helpers:select_free_port(ssl),
+    ListenerConf = #{
+        enable => true,
+        bind => {{127, 0, 0, 1}, Port},
+        mountpoint => <<>>,
+        zone => default,
+        tcp_options => #{active_n => 100},
+        ssl_options => #{
+            cacertfile => CACertFile,
+            certfile => ServerCertFile,
+            keyfile => ServerKeyFile,
+            verify => verify_peer,
+            fail_if_no_peer_cert => true
+        }
+    },
+    ok = emqx_config:put_listener_conf(ssl, Name, [], ListenerConf),
+    ok = emqx_listeners:start_listener(ssl, Name, ListenerConf),
+    SslOpts =
+        emqx_common_test_helpers:ssl_verify_fun_allow_any_host() ++
+            [
+                {cacertfile, CACertFile},
+                {certfile, ClientCertFile},
+                {keyfile, ClientKeyFile}
+            ],
+    {Port, SslOpts, ListenerConf}.
+
+stop_san_listener(Name, ListenerConf) ->
+    _ = emqx_listeners:stop_listener(ssl, Name, ListenerConf),
+    ok.
+
+get_chan_info(ClientId) ->
+    ?retry(
+        3_000,
+        100,
+        #{} = emqx_cm:get_chan_info(ClientId)
+    ).

--- a/apps/emqx/test/emqx_cth_tls.erl
+++ b/apps/emqx/test/emqx_cth_tls.erl
@@ -37,7 +37,12 @@
     {_From :: calendar:date(), _To :: calendar:date()}.
 
 -type cert_extensions() :: #{
-    subject_alt_name => string(),
+    subject_alt_name => [
+        {dns, string()}
+        | {ip, inet:ip_address()}
+        | {email, string()}
+        | {uri, string()}
+    ],
     basic_constraints => false | ca | _PathLenContraint :: pos_integer(),
     key_usage => false | certsign
 }.
@@ -281,8 +286,22 @@ extension(key_usage, certsign) ->
         }
     ].
 
-subject_alt_name({ip, IPAddr}) when tuple_size(IPAddr) == 4 ->
-    {iPAddress, tuple_to_list(IPAddr)}.
+subject_alt_name({dns, Name}) ->
+    {dNSName, Name};
+subject_alt_name({ip, IPAddr}) ->
+    {iPAddress, ip_address_bytes(IPAddr)};
+subject_alt_name({email, Email}) ->
+    {rfc822Name, Email};
+subject_alt_name({uri, URI}) ->
+    {uniformResourceIdentifier, URI}.
+
+ip_address_bytes({A, B, C, D}) ->
+    [A, B, C, D];
+ip_address_bytes({A, B, C, D, E, F, G, H}) ->
+    lists:append([integer_to_2bytes(I) || I <- [A, B, C, D, E, F, G, H]]).
+
+integer_to_2bytes(I) ->
+    [I bsr 8, I band 16#ff].
 
 default_validity() ->
     {shift_date(date(), -1), shift_date(date(), +7)}.

--- a/changes/ee/feat-17603.en.md
+++ b/changes/ee/feat-17603.en.md
@@ -1,0 +1,1 @@
+Added support for extracting subject alternative names from directly connected TLS client certificates into MQTT client attributes with `cert_san.dns`, `cert_san.ip`, `cert_san.email`, and `cert_san.uri` in `mqtt.client_attrs_init`.

--- a/mix.exs
+++ b/mix.exs
@@ -178,7 +178,7 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.0", override: true}
-  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.16.3", override: true}
+  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.0", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.9", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1910,6 +1910,12 @@ client_attrs_init_expression {
     - `cert_common_name`: Alias of `cn`.
     - `dn`: Client's TLS certificate distinguished name (the subject).
     - `cert_subject`: Alias of `dn`.
+    For directly connected TLS clients, the subject alternative names in the client certificate
+    can be used:
+    - `cert_san.dns`: DNS names in the client certificate.
+    - `cert_san.ip`: IP addresses in the client certificate.
+    - `cert_san.email`: Email addresses in the client certificate.
+    - `cert_san.uri`: URIs in the client certificate.
     - `peersni`: TLS server name indication sent by the client.
 
     You can read more about variform expressions in EMQX docs."""


### PR DESCRIPTION
Fix: https://emqx.atlassian.net/browse/EMQX-15299
Release version:
6.3.0

## Summary

- Bumped `esockd` to 5.17.0 to use `esockd_peercert:subject_alt_names/1` for peer certificate SAN extraction.
- Exposed `cert_san.dns`, `cert_san.ip`, `cert_san.email`, and `cert_san.uri` to `mqtt.client_attrs_init`; no-SAN values render as empty lists for client attribute extraction.
- Adds `cert_san` only to the transient `client_attrs_init` render context when client attribute initialization is configured, and keeps `cert_san` out of the stored `clientinfo`.
- Validates extracted SAN string values with the existing peer certificate string guard before exposing them to `client_attrs_init`.
- Added an mTLS Common Test suite that generates SAN-bearing client certificates and verifies DNS, IPv4, IPv6, email, URI, empty-SAN, and invalid-SAN cases end to end.
- Added changelog entry `changes/ee/feat-17603.en.md`.

Local checks run:
- `make ct-suite SUITE=apps/emqx/test/emqx_client_cert_san_SUITE.erl PROFILE=emqx-enterprise`
- `./scripts/erlfmt -c apps/emqx/src/emqx_channel.erl apps/emqx/src/emqx_types.erl apps/emqx/test/emqx_cth_tls.erl apps/emqx/test/emqx_client_cert_san_SUITE.erl`
- `mix compile`
- `mix format --check-formatted mix.exs`
- `./scripts/apps-version-check.exs`
- `git diff --check`

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)