### PR TITLE
fix(gbt32960): route downstream command responses to upstream/response

### DIFF
--- a/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
+++ b/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
@@ -760,7 +760,9 @@ transform(Frame = ?CMD(Cmd), Mountpoint) ->
             ?CMD_PLATFORM_LOGIN -> <<"upstream/plogin">>;
             ?CMD_PLATFORM_LOGOUT -> <<"upstream/plogout">>;
             ?CMD_ACTIVATION -> <<"upstream/activation">>;
-            %CMD_HEARTBEAT, CMD_SCHOOL_TIME ...
+            ?CMD_PARAM_QUERY -> <<"upstream/response">>;
+            ?CMD_PARAM_SETTING -> <<"upstream/response">>;
+            ?CMD_TERMINAL_CTRL -> <<"upstream/response">>;
             _ -> <<"upstream/transparent">>
         end,
     Topic = emqx_mountpoint:mount(Mountpoint, Suffix),

--- a/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
+++ b/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
@@ -1689,3 +1689,74 @@ t_case25_param_query_2025(_Config) ->
         }
     } = emqx_utils_json:decode(PubedMsg),
     ok.
+
+t_case26_param_query_ack_fe(_Config) ->
+    {ok, Socket} = login_first(),
+
+    Req = #{
+        <<"Action">> => <<"Query">>,
+        <<"Total">> => 2,
+        <<"Ids">> => [<<"0x01">>, <<"0x02">>]
+    },
+    Topic = <<"gbt32960/1G1BL52P7TR115520/dnstream">>,
+    emqx:publish(emqx_message:make(Topic, emqx_utils_json:encode(Req))),
+    timer:sleep(200),
+    {ok, _Packet} = gen_tcp:recv(Socket, 0, 500),
+
+    Time = <<17, 2, 2, 11, 12, 12>>,
+    Info = <<2, 1, 6000:?WORD, 2, 10:?WORD>>,
+    Resp = encode(
+        ?CMD_PARAM_QUERY, ?ACK_IS_CMD, <<"1G1BL52P7TR115520">>, <<Time/binary, Info/binary>>
+    ),
+    gen_tcp:send(Socket, Resp),
+    timer:sleep(200),
+    {<<"gbt32960/1G1BL52P7TR115520/upstream/response">>, _PubedMsg} = get_published_msg(),
+    ok.
+
+t_case27_param_setting_ack_fe(_Config) ->
+    {ok, Socket} = login_first(),
+
+    Req = #{
+        <<"Action">> => <<"Setting">>,
+        <<"Total">> => 2,
+        <<"Params">> => [
+            #{<<"0x01">> => 5000},
+            #{<<"0x02">> => 200}
+        ]
+    },
+    Topic = <<"gbt32960/1G1BL52P7TR115520/dnstream">>,
+    emqx:publish(emqx_message:make(Topic, emqx_utils_json:encode(Req))),
+    timer:sleep(200),
+    {ok, _Packet} = gen_tcp:recv(Socket, 0, 500),
+
+    Time = <<17, 2, 2, 11, 12, 12>>,
+    Info = <<2, 1, 5000:?WORD, 2, 200:?WORD>>,
+    Resp = encode(
+        ?CMD_PARAM_SETTING, ?ACK_IS_CMD, <<"1G1BL52P7TR115520">>, <<Time/binary, Info/binary>>
+    ),
+    gen_tcp:send(Socket, Resp),
+    timer:sleep(200),
+    {<<"gbt32960/1G1BL52P7TR115520/upstream/response">>, _PubedMsg} = get_published_msg(),
+    ok.
+
+t_case28_terminal_ctrl_ack_fe(_Config) ->
+    {ok, Socket} = login_first(),
+
+    Req = #{
+        <<"Action">> => <<"Control">>,
+        <<"Command">> => "0x02"
+    },
+    Topic = <<"gbt32960/1G1BL52P7TR115520/dnstream">>,
+    emqx:publish(emqx_message:make(Topic, emqx_utils_json:encode(Req))),
+    timer:sleep(200),
+    {ok, _Packet} = gen_tcp:recv(Socket, 0, 500),
+
+    Time = <<17, 2, 2, 11, 12, 12>>,
+    Info = <<2>>,
+    Resp = encode(
+        ?CMD_TERMINAL_CTRL, ?ACK_IS_CMD, <<"1G1BL52P7TR115520">>, <<Time/binary, Info/binary>>
+    ),
+    gen_tcp:send(Socket, Resp),
+    timer:sleep(200),
+    {<<"gbt32960/1G1BL52P7TR115520/upstream/response">>, _PubedMsg} = get_published_msg(),
+    ok.

--- a/changes/ce/fix-17604.en.md
+++ b/changes/ce/fix-17604.en.md
@@ -1,0 +1,1 @@
+Fixed GBT32960 gateway routing: vehicle responses to downstream commands (Parameter Query, Parameter Setting, Terminal Control) are now correctly published to `upstream/response` instead of `upstream/transparent`.


### PR DESCRIPTION
## Summary

Fixes: [EMQX-15313](https://emqx.atlassian.net/browse/EMQX-15313)

Vehicle responses to platform downstream commands (Parameter Query 0x80, Parameter Setting 0x81, Terminal Control 0x82) were incorrectly routed to `upstream/transparent` when the vehicle response frame used `ack=0xFE`.

**Root cause:** `transform/2` in `emqx_gbt32960_channel.erl` has two clauses:
1. Matches frames with `ack=0xFE`, routes by CMD. CMD 0x80-0xBF fell through to `_ -> upstream/transparent` catch-all
2. Matches response ack codes (0x01-0x07) → `upstream/response`

Since `transform/2` is only called from `handle_in` (vehicle→platform), CMD 0x80-0xBF in this context is always a response to a platform command and should route to `upstream/response`.

**Fix:** Added explicit case branches for these three CMDs in the first clause.

## Changes

- `src/emqx_gbt32960_channel.erl` — added 3 case branches
- `test/emqx_gbt32960_SUITE.erl` — added 3 test cases (t_case26-28) covering ack=0xFE responses

## Notes

- Target release: **6.0.4** — please do not merge yet.

[EMQX-15313]: https://emqx.atlassian.net/browse/EMQX-15313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ