### PR TITLE
fix(oracle): handle prepare checks and large text binds

### DIFF
--- a/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
+++ b/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
@@ -209,6 +209,61 @@ sql_drop_table() ->
 sql_check_table_exist() ->
     "SELECT COUNT(*) FROM user_tables WHERE table_name = 'MQTT_TEST'".
 
+sql_check_table_exist(TableName) ->
+    "SELECT COUNT(*) FROM user_tables WHERE table_name = '" ++ TableName ++ "'".
+
+sql_drop_probe_audit_table() ->
+    "BEGIN\n"
+    "        EXECUTE IMMEDIATE 'DROP TABLE mqtt_probe_audit';\n"
+    "     EXCEPTION\n"
+    "        WHEN OTHERS THEN\n"
+    "            IF SQLCODE = -942 THEN\n"
+    "                NULL;\n"
+    "            ELSE\n"
+    "                RAISE;\n"
+    "            END IF;\n"
+    "     END;".
+
+sql_drop_probe_trigger() ->
+    "BEGIN\n"
+    "        EXECUTE IMMEDIATE 'DROP TRIGGER mqtt_probe_trigger';\n"
+    "     EXCEPTION\n"
+    "        WHEN OTHERS THEN\n"
+    "            IF SQLCODE = -4080 THEN\n"
+    "                NULL;\n"
+    "            ELSE\n"
+    "                RAISE;\n"
+    "            END IF;\n"
+    "     END;".
+
+sql_create_probe_audit_table() ->
+    "CREATE TABLE mqtt_probe_audit (marker VARCHAR2(64))".
+
+sql_create_probe_trigger() ->
+    "CREATE OR REPLACE TRIGGER mqtt_probe_trigger\n"
+    "BEFORE INSERT ON mqtt_test\n"
+    "DECLARE\n"
+    "    PRAGMA AUTONOMOUS_TRANSACTION;\n"
+    "BEGIN\n"
+    "    INSERT INTO mqtt_probe_audit(marker) VALUES ('prepare');\n"
+    "    COMMIT;\n"
+    "END;".
+
+sql_drop_prepare_probe_table() ->
+    "BEGIN\n"
+    "        EXECUTE IMMEDIATE 'DROP TABLE mqtt_prepare_probe';\n"
+    "     EXCEPTION\n"
+    "        WHEN OTHERS THEN\n"
+    "            IF SQLCODE = -942 THEN\n"
+    "                NULL;\n"
+    "            ELSE\n"
+    "                RAISE;\n"
+    "            END IF;\n"
+    "     END;".
+
+sql_create_prepare_probe_table() ->
+    "CREATE TABLE mqtt_prepare_probe (id NUMBER)".
+
 new_jamdb_connection(Config) ->
     JamdbOpts = [
         {host, get_config(oracle_host, Config, "toxiproxy.emqx.net")},
@@ -244,10 +299,59 @@ drop_table_if_exists(Config) ->
     end,
     ok.
 
+create_probe_audit_objects(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_probe_audit_objects(Conn),
+        {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_create_probe_audit_table()),
+        {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_create_probe_trigger())
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+drop_probe_audit_objects(Conn) when is_pid(Conn) ->
+    {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_probe_trigger()),
+    {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_probe_audit_table()),
+    ok;
+drop_probe_audit_objects(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_probe_audit_objects(Conn)
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+drop_prepare_probe_table(Conn) when is_pid(Conn) ->
+    {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_prepare_probe_table()),
+    ok;
+drop_prepare_probe_table(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_prepare_probe_table(Conn)
+    after
+        close_jamdb_connection(Conn)
+    end.
+
 scan_table(TCConfig) ->
     {ok, Conn} = new_jamdb_connection(TCConfig),
     try
         jamdb_oracle:sql_query(Conn, "select * from mqtt_test")
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+scan_probe_audit_table(TCConfig) ->
+    {ok, Conn} = new_jamdb_connection(TCConfig),
+    try
+        jamdb_oracle:sql_query(Conn, "select count(*) from mqtt_probe_audit")
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+count_user_table(TCConfig, TableName) ->
+    {ok, Conn} = new_jamdb_connection(TCConfig),
+    try
+        jamdb_oracle:sql_query(Conn, sql_check_table_exist(TableName))
     after
         close_jamdb_connection(Conn)
     end.
@@ -372,6 +476,38 @@ t_probe_with_inconsistent_datatype(TCConfig) ->
             #{<<"parameters">> => #{<<"sql">> => sql_insert_template_with_inconsistent_datatype()}}
         )
     ).
+
+t_prepare_does_not_execute_user_sql(TCConfig) ->
+    create_probe_audit_objects(TCConfig),
+    on_exit(fun() -> drop_probe_audit_objects(TCConfig) end),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{}),
+    ?assertMatch(
+        {ok, [{result_set, _, _, [[{0}]]}]},
+        scan_probe_audit_table(TCConfig)
+    ),
+    ok.
+
+t_prepare_rejects_ddl_without_executing(TCConfig) ->
+    drop_prepare_probe_table(TCConfig),
+    on_exit(fun() -> drop_prepare_probe_table(TCConfig) end),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{<<"sql">> => sql_create_prepare_probe_table()}
+    }),
+    ?assertMatch(
+        {ok, [{result_set, _, _, [[{0}]]}]},
+        count_user_table(TCConfig, "MQTT_PREPARE_PROBE")
+    ),
+    ?retry(
+        _Sleep = 1_000,
+        _Attempts = 20,
+        begin
+            {200, #{<<"status_reason">> := StatusReason}} = get_action_api(TCConfig),
+            ?assertNotEqual(nomatch, binary:match(StatusReason, <<"unsupported_sql_statement">>))
+        end
+    ),
+    ok.
 
 t_no_sid_nor_service_name(TCConfig0) ->
     TCConfig = emqx_bridge_v2_testlib:proplist_update(

--- a/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
+++ b/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
@@ -194,9 +194,44 @@ sql_insert_template_with_inconsistent_datatype() ->
 sql_create_table() ->
     "CREATE TABLE mqtt_test (topic VARCHAR2(255), msgid VARCHAR2(64), payload NCLOB, retain NUMBER(1))".
 
+sql_eec_1322_insert_template() ->
+    "INSERT INTO t_mqtt_msgs(msgid, sender, topic, qos, retain, arrived, payload) VALUES(\n"
+    "  ${id},\n"
+    "  ${clientid},\n"
+    "  ${topic},\n"
+    "  ${qos},\n"
+    "  ${flags.retain},\n"
+    "  TO_TIMESTAMP('1970-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS') + "
+    "NUMTODSINTERVAL(${timestamp}/1000, 'SECOND'),\n"
+    "  ${payload}\n"
+    ")".
+
+sql_create_eec_1322_table() ->
+    "CREATE TABLE t_mqtt_msgs ("
+    "msgid VARCHAR2(64), "
+    "sender VARCHAR2(64), "
+    "topic VARCHAR2(255), "
+    "qos NUMBER(1), "
+    "retain NUMBER(1), "
+    "payload NCLOB, "
+    "arrived TIMESTAMP"
+    ")".
+
 sql_drop_table() ->
     "BEGIN\n"
     "        EXECUTE IMMEDIATE 'DROP TABLE mqtt_test';\n"
+    "     EXCEPTION\n"
+    "        WHEN OTHERS THEN\n"
+    "            IF SQLCODE = -942 THEN\n"
+    "                NULL;\n"
+    "            ELSE\n"
+    "                RAISE;\n"
+    "            END IF;\n"
+    "     END;".
+
+sql_drop_eec_1322_table() ->
+    "BEGIN\n"
+    "        EXECUTE IMMEDIATE 'DROP TABLE t_mqtt_msgs';\n"
     "     EXCEPTION\n"
     "        WHEN OTHERS THEN\n"
     "            IF SQLCODE = -942 THEN\n"
@@ -287,6 +322,16 @@ reset_table(Config) ->
     end,
     ok.
 
+reset_eec_1322_table(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_eec_1322_table_if_exists(Conn),
+        {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_create_eec_1322_table())
+    after
+        close_jamdb_connection(Conn)
+    end,
+    ok.
+
 drop_table_if_exists(Conn) when is_pid(Conn) ->
     {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_table()),
     ok;
@@ -294,6 +339,18 @@ drop_table_if_exists(Config) ->
     {ok, Conn} = new_jamdb_connection(Config),
     try
         ok = drop_table_if_exists(Conn)
+    after
+        close_jamdb_connection(Conn)
+    end,
+    ok.
+
+drop_eec_1322_table_if_exists(Conn) when is_pid(Conn) ->
+    {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_eec_1322_table()),
+    ok;
+drop_eec_1322_table_if_exists(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_eec_1322_table_if_exists(Conn)
     after
         close_jamdb_connection(Conn)
     end,
@@ -348,6 +405,25 @@ scan_probe_audit_table(TCConfig) ->
         close_jamdb_connection(Conn)
     end.
 
+count_eec_1322_rows(TCConfig) ->
+    {ok, Conn} = new_jamdb_connection(TCConfig),
+    try
+        jamdb_oracle:sql_query(Conn, "select count(*) from t_mqtt_msgs")
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+scan_one_eec_1322_row(TCConfig) ->
+    {ok, Conn} = new_jamdb_connection(TCConfig),
+    try
+        jamdb_oracle:sql_query(
+            Conn,
+            "select sender, topic, qos, retain, payload from t_mqtt_msgs where rownum = 1"
+        )
+    after
+        close_jamdb_connection(Conn)
+    end.
+
 count_user_table(TCConfig, TableName) ->
     {ok, Conn} = new_jamdb_connection(TCConfig),
     try
@@ -381,6 +457,9 @@ start_client() ->
 
 unique_payload() ->
     integer_to_binary(erlang:unique_integer()).
+
+large_json_payload() ->
+    emqx_utils_json:encode(#{<<"msg">> => binary:copy(<<"a">>, 5000)}).
 
 simple_create_rule_api(TCConfig) ->
     emqx_bridge_v2_testlib:simple_create_rule_api(TCConfig).
@@ -417,6 +496,115 @@ t_rule_action(TCConfig) when is_list(TCConfig) ->
         post_publish_fn => PostPublishFn
     },
     emqx_bridge_v2_testlib:t_rule_action(TCConfig, Opts).
+
+t_eec_1322_t_mqtt_msgs_write_path() ->
+    [{matrix, true}].
+t_eec_1322_t_mqtt_msgs_write_path(matrix) ->
+    [[?with_batch]];
+t_eec_1322_t_mqtt_msgs_write_path(TCConfig) when is_list(TCConfig) ->
+    reset_eec_1322_table(TCConfig),
+    on_exit(fun() -> drop_eec_1322_table_if_exists(TCConfig) end),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{<<"sql">> => sql_eec_1322_insert_template()}
+    }),
+    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    Clients = [start_client() || _ <- lists:seq(1, 10)],
+    Payload = emqx_utils_json:encode(#{<<"msg">> => <<"heelo">>}),
+    TopicStr = str(Topic),
+    MessagesPerClient = 10,
+    PublishCount = length(Clients) * MessagesPerClient,
+    ?check_trace(
+        begin
+            lists:foreach(
+                fun(C) ->
+                    lists:foreach(
+                        fun(_) ->
+                            emqtt:publish(C, Topic, Payload)
+                        end,
+                        lists:seq(1, MessagesPerClient)
+                    )
+                end,
+                Clients
+            ),
+            ?retry(
+                _Sleep = 500,
+                _Attempts = 60,
+                ?assertMatch(
+                    {ok, [{result_set, _, _, [[{PublishCount}]]}]},
+                    count_eec_1322_rows(TCConfig)
+                )
+            ),
+            ?assertMatch(
+                {ok, [{result_set, _, _, [[_, TopicStr, {0}, {0}, "{\"msg\":\"heelo\"}"]]}]},
+                scan_one_eec_1322_row(TCConfig)
+            ),
+            ?assertMatch(
+                {200, #{<<"status">> := <<"connected">>}},
+                get_action_api(TCConfig)
+            ),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertEqual(
+                [],
+                [Event || #{error := _} = Event <- ?of_kind(oracle_connector_query_return, Trace)]
+            ),
+            ok
+        end
+    ),
+    ok.
+
+t_eec_1322_large_payload_after_small_payload() ->
+    [{matrix, true}].
+t_eec_1322_large_payload_after_small_payload(matrix) ->
+    [[?with_batch]];
+t_eec_1322_large_payload_after_small_payload(TCConfig) when is_list(TCConfig) ->
+    reset_eec_1322_table(TCConfig),
+    on_exit(fun() -> drop_eec_1322_table_if_exists(TCConfig) end),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{<<"sql">> => sql_eec_1322_insert_template()}
+    }),
+    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    SmallPayload = emqx_utils_json:encode(#{<<"msg">> => <<"heelo">>}),
+    LargePayload = large_json_payload(),
+    ?check_trace(
+        begin
+            emqtt:publish(C, Topic, SmallPayload),
+            ?retry(
+                _Sleep1 = 500,
+                _Attempts1 = 60,
+                ?assertMatch(
+                    {ok, [{result_set, _, _, [[{1}]]}]},
+                    count_eec_1322_rows(TCConfig)
+                )
+            ),
+            emqtt:publish(C, Topic, LargePayload),
+            ?retry(
+                _Sleep2 = 500,
+                _Attempts2 = 60,
+                ?assertMatch(
+                    {ok, [{result_set, _, _, [[{2}]]}]},
+                    count_eec_1322_rows(TCConfig)
+                )
+            ),
+            ?assertMatch(
+                {200, #{<<"status">> := <<"connected">>}},
+                get_action_api(TCConfig)
+            ),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertEqual(
+                [],
+                [Event || #{error := _} = Event <- ?of_kind(oracle_connector_query_return, Trace)]
+            ),
+            ok
+        end
+    ),
+    ok.
 
 t_update_with_invalid_prepare(TCConfig) ->
     Opts = #{
@@ -482,6 +670,8 @@ t_prepare_does_not_execute_user_sql(TCConfig) ->
     on_exit(fun() -> drop_probe_audit_objects(TCConfig) end),
     {201, _} = create_connector_api(TCConfig, #{}),
     {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{}),
+    #{topic := _Topic} = simple_create_rule_api(TCConfig),
+    _ = get_action_api(TCConfig),
     ?assertMatch(
         {ok, [{result_set, _, _, [[{0}]]}]},
         scan_probe_audit_table(TCConfig)

--- a/apps/emqx_oracle/mix.exs
+++ b/apps/emqx_oracle/mix.exs
@@ -23,7 +23,7 @@ defmodule EMQXOracle.MixProject do
 
   def deps() do
     UMP.deps([
-      {:jamdb_oracle, github: "emqx/jamdb_oracle", tag: "0.4.9.6", manager: :rebar3},
+      {:jamdb_oracle, github: "emqx/jamdb_oracle", tag: "0.4.9.7", manager: :rebar3},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true}
     ])

--- a/apps/emqx_oracle/mix.exs
+++ b/apps/emqx_oracle/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXOracle.MixProject do
   def project do
     [
       app: :emqx_oracle,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_oracle/src/emqx_oracle.erl
+++ b/apps/emqx_oracle/src/emqx_oracle.erl
@@ -14,6 +14,10 @@
 -define(UNHEALTHY_TARGET_MSG,
     "Oracle table is invalid. Please check if the table exists in Oracle Database."
 ).
+-define(UNSUPPORTED_SQL_STATEMENT_MSG,
+    "unsupported_sql_statement: DDL, DCL, and transaction control statements are not supported "
+    "in Oracle Action SQL templates."
+).
 
 -define(DEFAULT_ROLE, normal).
 -define(SYSDBA_ROLE, sysdba).
@@ -63,6 +67,10 @@
 }).
 
 -type prepares() :: #{atom() => binary()}.
+-type prepare_state() ::
+    prepares()
+    | {error, _Reason :: term(), prepares()}
+    | {error, prepares()}.
 -type params_tokens() :: #{atom() => list()}.
 
 -type state() ::
@@ -70,7 +78,7 @@
         pool_name := binary(),
         installed_channels := map(),
         health_check_timeout := timeout(),
-        prepare_sql := prepares(),
+        prepare_sql := prepare_state(),
         params_tokens := params_tokens(),
         batch_params_tokens := params_tokens()
     }.
@@ -197,6 +205,8 @@ on_get_channel_status(
         {error, undefined_table} ->
             %% return new state indicating that we are connected but the target table is not created
             {?status_disconnected, {unhealthy_target, ?UNHEALTHY_TARGET_MSG}};
+        {error, unsupported_sql_statement} ->
+            {?status_disconnected, {unhealthy_target, ?UNSUPPORTED_SQL_STATEMENT_MSG}};
         {error, _Reason} ->
             %% do not log error, it is logged in prepare_sql_to_conn
             ?status_connecting
@@ -365,6 +375,14 @@ do_check_prepares(
     _ChannelId,
     _PoolName,
     #{
+        prepare_sql := {error, Reason, _Prepares}
+    } = _State
+) ->
+    {error, Reason};
+do_check_prepares(
+    _ChannelId,
+    _PoolName,
+    #{
         prepare_sql := {error, _Prepares}
     } = _State
 ) ->
@@ -387,8 +405,12 @@ do_check_prepares(
                 case ecpool_worker:client(WorkerPid) of
                     {ok, Conn} ->
                         case check_if_table_exists(Conn, SQL, Tokens) of
-                            {error, undefined_table} -> {error, undefined_table};
-                            _ -> ok
+                            {error, undefined_table} ->
+                                {error, undefined_table};
+                            {error, unsupported_sql_statement} ->
+                                {error, unsupported_sql_statement};
+                            _ ->
+                                ok
                         end;
                     _ ->
                         ok
@@ -479,8 +501,11 @@ init_prepare(PoolName, State = #{prepare_sql := Prepares, params_tokens := Token
             },
             ?SLOG(error, LogMeta),
             %% mark the prepare_sql as failed
-            State#{prepare_sql => {error, Prepares}}
+            State#{prepare_sql => {error, prepare_error_reason(Error), Prepares}}
     end.
+
+prepare_error_reason({error, Reason}) ->
+    Reason.
 
 prepare_sql(Prepares, PoolName, TokensMap) when is_map(Prepares) ->
     prepare_sql(maps:to_list(Prepares), PoolName, TokensMap);
@@ -536,78 +561,147 @@ prepare_sql_to_conn(Conn, [{Key, SQL} | PrepareList], TokensMap, Statements) whe
 get_reconnect_callback_signature([[{ChannelId, _Template}]]) ->
     ChannelId.
 
-check_if_table_exists(Conn, SQL, Tokens0) ->
-    % Discard nested tokens for checking if table exist. As payload here is defined as
-    % a single string, it would fail if Token is, for instance, ${payload.msg}, causing
-    % bridge probe to fail.
-    Tokens = lists:map(
-        fun
-            ({var, [Token | _DiscardedDeepTokens]}) ->
-                {var, [Token]};
-            (Token) ->
-                Token
-        end,
-        Tokens0
-    ),
-    {Event, _Headers} = emqx_rule_events:eventmsg_publish(
-        emqx_message:make(<<"t/opic">>, "test query")
-    ),
-    SqlQuery = "begin " ++ binary_to_list(SQL) ++ "; rollback; end;",
-    Params = emqx_placeholder:proc_sql(Tokens, Event),
-    case do_sql_query(Conn, {SqlQuery, Params}) of
+check_if_table_exists(Conn, SQL, _Tokens0) ->
+    case sql_has_parse_side_effect(SQL) of
+        true ->
+            {error, unsupported_sql_statement};
+        false ->
+            check_if_sql_parseable(Conn, SQL, 1)
+    end.
+
+check_if_sql_parseable(Conn, SQL, Retries) ->
+    ParseSQL =
+        "declare "
+        "  c integer; "
+        "begin "
+        "  c := dbms_sql.open_cursor; "
+        "  dbms_sql.parse(c, :1, dbms_sql.native); "
+        "  dbms_sql.close_cursor(c); "
+        "exception "
+        "  when others then "
+        "    if dbms_sql.is_open(c) then "
+        "      dbms_sql.close_cursor(c); "
+        "    end if; "
+        "    raise; "
+        "end;",
+    case do_sql_query(Conn, {ParseSQL, [binary_to_list(SQL)]}) of
         {ok, [{proc_result, 0, _Description}]} ->
             ok;
-        {ok, [{proc_result, 942, _Description}]} ->
-            %% Target table is not created
+        {ok, [{proc_result, RetCode, _Description}]} when
+            RetCode =:= 904; RetCode =:= 942
+        ->
+            %% ORA-00904: invalid identifier
+            %% ORA-00942: table or view does not exist
             {error, undefined_table};
-        {ok, [{proc_result, 1013, _Description}]} ->
-            %% "ORA-01013: user requested cancel of current operation"
-            check_if_table_exists(Conn, SQL, Tokens0);
-        {ok, [{proc_result, _, Description}]} ->
-            % only the last result is returned, so we need to check on description if it
-            % contains the "Table doesn't exist" error as it can not be the last one.
-            % (for instance, the ORA-06550 can be the result value when table does not exist)
-            ErrorCodes =
-                case re:run(Description, <<"(ORA-[0-9]+)">>, [global, {capture, first, binary}]) of
-                    {match, OraCodes} -> OraCodes;
-                    _ -> []
-                end,
-            OraMap = maps:from_keys([ErrorCode || [ErrorCode] <- ErrorCodes], true),
-            case OraMap of
-                _ when is_map_key(<<"ORA-00942">>, OraMap) ->
-                    % ORA-00942: table or view does not exist
-                    {error, undefined_table};
-                _ when is_map_key(<<"ORA-00932">>, OraMap) ->
-                    % ORA-00932: inconsistent datatypes
-                    % There is a some type inconsistency with table definition but
-                    % table does exist. Probably this inconsistency was caused by
-                    % token discarding in this test query.
-                    ok;
-                _ when is_map_key(<<"ORA-01400">>, OraMap) ->
-                    % ORA-01400: cannot insert NULL into (string)
-                    % There is a some type inconsistency with table definition but
-                    % table does exist. Probably this inconsistency was caused by
-                    % token discarding in this test query.
-                    ok;
-                _ when is_map_key(<<"ORA-01013">>, OraMap) ->
-                    % ORA-01013: user requested cancel of current operation
-                    % This error is returned when the query is canceled by the user.
-                    ok;
-                _ when is_map_key(<<"ORA-12899">>, OraMap) ->
-                    % ORA-12899: value too large for column
-                    % This error is returned when the value is too large for the column.
-                    ok;
-                _ ->
-                    {error, Description}
-            end;
-        {error, {noproc, _}} ->
+        {ok, [{proc_result, 1013, _Description}]} when Retries > 0 ->
+            %% ORA-01013: user requested cancel of current operation
+            check_if_sql_parseable(Conn, SQL, Retries - 1);
+        {ok, [{proc_result, _RetCode, Description}]} ->
+            handle_parse_error_description(Description);
+        {error, {noproc, _}} when Retries > 0 ->
             %% See Note [jamdb oracle race condition]
-            check_if_table_exists(Conn, SQL, Tokens0);
-        {error, socket, closed} ->
-            check_if_table_exists(Conn, SQL, Tokens0);
+            check_if_sql_parseable(Conn, SQL, Retries - 1);
+        {error, socket, closed} when Retries > 0 ->
+            check_if_sql_parseable(Conn, SQL, Retries - 1);
         Reason ->
             {error, Reason}
     end.
+
+handle_parse_error_description(Description) ->
+    case oracle_error_codes(Description) of
+        #{<<"ORA-00904">> := true} ->
+            {error, undefined_table};
+        #{<<"ORA-00942">> := true} ->
+            {error, undefined_table};
+        #{<<"ORA-01013">> := true} ->
+            ok;
+        _ ->
+            {error, Description}
+    end.
+
+oracle_error_codes(Description) ->
+    case
+        re:run(iolist_to_binary(Description), <<"(ORA-[0-9]+)">>, [
+            global,
+            {capture, first, binary}
+        ])
+    of
+        {match, OraCodes} ->
+            maps:from_keys([ErrorCode || [ErrorCode] <- OraCodes], true);
+        nomatch ->
+            #{}
+    end.
+
+sql_has_parse_side_effect(SQL) ->
+    case first_sql_token(SQL) of
+        <<"alter">> -> true;
+        <<"analyze">> -> true;
+        <<"associate">> -> true;
+        <<"audit">> -> true;
+        <<"comment">> -> true;
+        <<"commit">> -> true;
+        <<"create">> -> true;
+        <<"disassociate">> -> true;
+        <<"drop">> -> true;
+        <<"explain">> -> true;
+        <<"flashback">> -> true;
+        <<"grant">> -> true;
+        <<"lock">> -> true;
+        <<"noaudit">> -> true;
+        <<"purge">> -> true;
+        <<"rename">> -> true;
+        <<"revoke">> -> true;
+        <<"rollback">> -> true;
+        <<"savepoint">> -> true;
+        <<"set">> -> true;
+        <<"truncate">> -> true;
+        _ -> false
+    end.
+
+first_sql_token(SQL) ->
+    take_sql_token(skip_sql_prefix(to_bin(SQL)), <<>>).
+
+skip_sql_prefix(<<C, Rest/binary>>) when
+    C =:= $\s; C =:= $\t; C =:= $\n; C =:= $\r; C =:= $\f; C =:= $\v
+->
+    skip_sql_prefix(Rest);
+skip_sql_prefix(<<"--", Rest/binary>>) ->
+    skip_sql_prefix(skip_line_comment(Rest));
+skip_sql_prefix(<<"/*", Rest/binary>>) ->
+    skip_sql_prefix(skip_block_comment(Rest));
+skip_sql_prefix(SQL) ->
+    SQL.
+
+skip_line_comment(<<"\n", Rest/binary>>) ->
+    Rest;
+skip_line_comment(<<"\r", Rest/binary>>) ->
+    Rest;
+skip_line_comment(<<_, Rest/binary>>) ->
+    skip_line_comment(Rest);
+skip_line_comment(<<>>) ->
+    <<>>.
+
+skip_block_comment(<<"*/", Rest/binary>>) ->
+    Rest;
+skip_block_comment(<<_, Rest/binary>>) ->
+    skip_block_comment(Rest);
+skip_block_comment(<<>>) ->
+    <<>>.
+
+take_sql_token(<<C, Rest/binary>>, Acc) when
+    (C >= $A andalso C =< $Z) orelse
+        (C >= $a andalso C =< $z) orelse
+        (C >= $0 andalso C =< $9) orelse
+        C =:= $_
+->
+    take_sql_token(Rest, <<Acc/binary, (lower_ascii(C))>>);
+take_sql_token(_Rest, Acc) ->
+    Acc.
+
+lower_ascii(C) when C >= $A, C =< $Z ->
+    C + 32;
+lower_ascii(C) ->
+    C.
 
 to_bin(Bin) when is_binary(Bin) ->
     Bin;

--- a/apps/emqx_oracle/src/emqx_oracle.erl
+++ b/apps/emqx_oracle/src/emqx_oracle.erl
@@ -732,3 +732,254 @@ convert_role_to_integer(?SYSDBA_ROLE) ->
     1;
 convert_role_to_integer(_) ->
     0.
+
+%%------------------------------------------------------------------------------
+%% Tests
+%%------------------------------------------------------------------------------
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+sql_has_parse_side_effect_test_() ->
+    SideEffectSQLs = [
+        <<"ALTER TABLE t ADD c NUMBER">>,
+        <<"ANALYZE TABLE t COMPUTE STATISTICS">>,
+        <<"ASSOCIATE STATISTICS WITH TYPES t USING pkg">>,
+        <<"AUDIT SELECT TABLE">>,
+        <<"COMMENT ON TABLE t IS 'x'">>,
+        <<"COMMIT">>,
+        <<"CREATE TABLE t(id NUMBER)">>,
+        <<"DISASSOCIATE STATISTICS FROM TYPES t">>,
+        <<"DROP TABLE t">>,
+        <<"EXPLAIN PLAN FOR SELECT * FROM t">>,
+        <<"FLASHBACK TABLE t TO BEFORE DROP">>,
+        <<"GRANT SELECT ON t TO u">>,
+        <<"LOCK TABLE t IN EXCLUSIVE MODE">>,
+        <<"NOAUDIT SELECT TABLE">>,
+        <<"PURGE TABLE t">>,
+        <<"RENAME t TO t2">>,
+        <<"REVOKE SELECT ON t FROM u">>,
+        <<"ROLLBACK">>,
+        <<"SAVEPOINT sp">>,
+        <<"SET TRANSACTION READ ONLY">>,
+        <<"TRUNCATE TABLE t">>
+    ],
+    RegularSQLs = [
+        <<"INSERT INTO t(id, payload) VALUES(:1, :2)">>,
+        <<"UPDATE t SET payload = :1 WHERE id = :2">>,
+        <<"DELETE FROM t WHERE id = :1">>,
+        <<"MERGE INTO t USING dual ON (t.id = :1) WHEN MATCHED THEN UPDATE SET c = :2">>,
+        <<"SELECT * FROM t WHERE id = :1">>,
+        <<"WITH q AS (SELECT 1 FROM dual) SELECT * FROM q">>,
+        <<"BEGIN NULL; END;">>,
+        <<>>
+    ],
+    [
+        {"statements with parse side effects are rejected", [
+            ?_assertEqual(true, sql_has_parse_side_effect(SQL))
+         || SQL <- SideEffectSQLs
+        ]},
+        {"regular action SQL statements are accepted", [
+            ?_assertEqual(false, sql_has_parse_side_effect(SQL))
+         || SQL <- RegularSQLs
+        ]},
+        ?_assertEqual(true, sql_has_parse_side_effect(create))
+    ].
+
+first_sql_token_test_() ->
+    [
+        ?_assertEqual(<<"insert">>, first_sql_token(<<" \t\nINSERT INTO t VALUES (1)">>)),
+        ?_assertEqual(<<"select">>, first_sql_token(<<"-- comment\nSELECT 1 FROM dual">>)),
+        ?_assertEqual(<<"update">>, first_sql_token(<<"-- comment\r\nUPDATE t SET c = :1">>)),
+        ?_assertEqual(<<"delete">>, first_sql_token(<<"/* block comment */ DELETE FROM t">>)),
+        ?_assertEqual(<<"merge_1">>, first_sql_token(<<"MERGE_1 INTO t USING dual">>)),
+        ?_assertEqual(<<>>, first_sql_token(<<"/* unterminated comment">>)),
+        ?_assertEqual(<<>>, first_sql_token(<<"-- only a comment">>)),
+        ?_assertEqual(<<>>, first_sql_token(<<"?">>))
+    ].
+
+check_if_table_exists_rejects_unsupported_sql_statement_test() ->
+    ?assertEqual(
+        {error, unsupported_sql_statement},
+        check_if_table_exists(undefined, <<"CREATE TABLE t(id NUMBER)">>, [])
+    ).
+
+check_if_table_exists_accepts_parseable_action_sql_test() ->
+    SQL = <<"INSERT INTO t(id, payload) VALUES(:1, :2)">>,
+    with_mocked_sql_query(
+        fun(conn, {ParseSQL, [SQLChars]}) ->
+            ?assertMatch({match, _}, re:run(ParseSQL, "dbms_sql\\.parse")),
+            ?assertEqual(binary_to_list(SQL), SQLChars),
+            {ok, [{proc_result, 0, <<>>}]}
+        end,
+        fun() ->
+            ?assertEqual(ok, check_if_table_exists(conn, SQL, []))
+        end
+    ).
+
+check_if_sql_parseable_retries_once_test() ->
+    SQL = <<"INSERT INTO t(id, payload) VALUES(:1, :2)">>,
+    with_mocked_sql_results(
+        [{error, socket, closed}, {ok, [{proc_result, 0, <<>>}]}],
+        fun() ->
+            ?assertEqual(ok, check_if_sql_parseable(conn, SQL, 1)),
+            ?assertEqual(2, get(parse_query_calls))
+        end
+    ).
+
+check_if_sql_parseable_result_test_() ->
+    SQL = <<"INSERT INTO t(id, payload) VALUES(:1, :2)">>,
+    [
+        ?_test(
+            with_mocked_sql_results(
+                [{ok, [{proc_result, 0, <<>>}]}],
+                fun() -> ?assertEqual(ok, check_if_sql_parseable(conn, SQL, 1)) end
+            )
+        ),
+        ?_test(
+            with_mocked_sql_results(
+                [{ok, [{proc_result, 904, <<>>}]}],
+                fun() ->
+                    ?assertEqual({error, undefined_table}, check_if_sql_parseable(conn, SQL, 1))
+                end
+            )
+        ),
+        ?_test(
+            with_mocked_sql_results(
+                [{ok, [{proc_result, 942, <<>>}]}],
+                fun() ->
+                    ?assertEqual({error, undefined_table}, check_if_sql_parseable(conn, SQL, 1))
+                end
+            )
+        ),
+        ?_test(
+            with_mocked_sql_results(
+                [{ok, [{proc_result, 1013, <<"ORA-01013">>}]}, {ok, [{proc_result, 0, <<>>}]}],
+                fun() -> ?assertEqual(ok, check_if_sql_parseable(conn, SQL, 1)) end
+            )
+        ),
+        ?_test(
+            with_mocked_sql_results(
+                [{ok, [{proc_result, 1013, <<"ORA-01013">>}]}],
+                fun() -> ?assertEqual(ok, check_if_sql_parseable(conn, SQL, 0)) end
+            )
+        ),
+        ?_test(
+            with_mocked_sql_results(
+                [{ok, [{proc_result, 900, <<"ORA-00942">>}]}],
+                fun() ->
+                    ?assertEqual({error, undefined_table}, check_if_sql_parseable(conn, SQL, 1))
+                end
+            )
+        ),
+        ?_test(
+            with_mocked_sql_results(
+                [{exit, {noproc, self()}}, {ok, [{proc_result, 0, <<>>}]}],
+                fun() -> ?assertEqual(ok, check_if_sql_parseable(conn, SQL, 1)) end
+            )
+        ),
+        ?_test(
+            with_mocked_sql_results(
+                [{exit, {noproc, self()}}],
+                fun() ->
+                    ?assertMatch(
+                        {error, {error, {noproc, _}}}, check_if_sql_parseable(conn, SQL, 0)
+                    )
+                end
+            )
+        ),
+        ?_test(
+            with_mocked_sql_results(
+                [{error, socket, closed}],
+                fun() ->
+                    ?assertEqual(
+                        {error, {error, socket, closed}}, check_if_sql_parseable(conn, SQL, 0)
+                    )
+                end
+            )
+        ),
+        ?_test(
+            with_mocked_sql_results(
+                [other],
+                fun() -> ?assertEqual({error, other}, check_if_sql_parseable(conn, SQL, 1)) end
+            )
+        )
+    ].
+
+with_mocked_sql_results_errors_when_sequence_is_exhausted_test() ->
+    SQL = <<"INSERT INTO t(id, payload) VALUES(:1, :2)">>,
+    ?assertError(
+        no_more_mocked_sql_results,
+        with_mocked_sql_results([], fun() -> check_if_sql_parseable(conn, SQL, 1) end)
+    ).
+
+with_mocked_sql_query(QueryFun, TestFun) ->
+    meck:new(jamdb_oracle, [passthrough, no_link]),
+    meck:expect(jamdb_oracle, sql_query, QueryFun),
+    try
+        TestFun()
+    after
+        meck:unload(jamdb_oracle)
+    end.
+
+with_mocked_sql_results(Results, TestFun) ->
+    put(parse_query_calls, 0),
+    put(parse_query_results, Results),
+    try
+        with_mocked_sql_query(
+            fun(_Conn, _Req) ->
+                Calls = get(parse_query_calls),
+                put(parse_query_calls, Calls + 1),
+                case get(parse_query_results) of
+                    [Result | Rest] ->
+                        put(parse_query_results, Rest),
+                        mock_sql_result(Result);
+                    [] ->
+                        error(no_more_mocked_sql_results)
+                end
+            end,
+            TestFun
+        )
+    after
+        erase(parse_query_calls),
+        erase(parse_query_results)
+    end.
+
+mock_sql_result({exit, Reason}) ->
+    exit(Reason);
+mock_sql_result(Result) ->
+    Result.
+
+oracle_error_codes_test_() ->
+    [
+        ?_assertEqual(
+            #{<<"ORA-00942">> => true, <<"ORA-01013">> => true},
+            oracle_error_codes([
+                <<"ORA-00942: table or view does not exist\n">>,
+                "ORA-01013: user requested cancel of current operation\n",
+                <<"ORA-00942: repeated code is de-duplicated">>
+            ])
+        ),
+        ?_assertEqual(#{}, oracle_error_codes(<<"not an oracle error">>))
+    ].
+
+handle_parse_error_description_test_() ->
+    [
+        ?_assertEqual(
+            {error, undefined_table},
+            handle_parse_error_description(<<"ORA-00904: invalid identifier">>)
+        ),
+        ?_assertEqual(
+            {error, undefined_table},
+            handle_parse_error_description(<<"ORA-00942: table or view does not exist">>)
+        ),
+        ?_assertEqual(
+            ok,
+            handle_parse_error_description(<<"ORA-01013: user requested cancel">>)
+        ),
+        ?_assertEqual(
+            {error, <<"ORA-00932: inconsistent datatypes">>},
+            handle_parse_error_description(<<"ORA-00932: inconsistent datatypes">>)
+        )
+    ].
+
+-endif.

--- a/apps/emqx_oracle/src/emqx_oracle.erl
+++ b/apps/emqx_oracle/src/emqx_oracle.erl
@@ -69,8 +69,7 @@
 -type prepares() :: #{atom() => binary()}.
 -type prepare_state() ::
     prepares()
-    | {error, _Reason :: term(), prepares()}
-    | {error, prepares()}.
+    | {error, _Reason :: term(), prepares()}.
 -type params_tokens() :: #{atom() => list()}.
 
 -type state() ::
@@ -379,14 +378,6 @@ do_check_prepares(
     } = _State
 ) ->
     {error, Reason};
-do_check_prepares(
-    _ChannelId,
-    _PoolName,
-    #{
-        prepare_sql := {error, _Prepares}
-    } = _State
-) ->
-    {error, undefined_table};
 do_check_prepares(
     ChannelId,
     PoolName,

--- a/changes/ee/fix-17605.en.md
+++ b/changes/ee/fix-17605.en.md
@@ -1,1 +1,1 @@
-Fixed an issue where Oracle action validation could cause unintended side effects by running the configured SQL instead of only validating it. Also improved Oracle action support for writing text payloads larger than 4000 bytes when the payload placeholder is the last bind parameter in the SQL template.
+Fixed Oracle action prepare/status checks to parse action SQL without executing it, and reject unsupported top-level DDL/DCL/TCL statements. Also improved support for text payloads over 4000 bytes when the payload placeholder is the last bind parameter.

--- a/changes/ee/fix-17605.en.md
+++ b/changes/ee/fix-17605.en.md
@@ -1,1 +1,1 @@
-Fixed an issue where Oracle action SQL prepare checks executed user SQL while probing the target table.  Prepare checks now parse SQL without executing it and reject unsupported DDL, DCL, and transaction-control statements.
+Fixed an issue where Oracle action validation could cause unintended side effects by running the configured SQL instead of only validating it. Also improved Oracle action support for writing text payloads larger than 4000 bytes when the payload placeholder is the last bind parameter in the SQL template.

--- a/changes/ee/fix-17605.en.md
+++ b/changes/ee/fix-17605.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where Oracle action SQL prepare checks executed user SQL while probing the target table.  Prepare checks now parse SQL without executing it and reject unsupported DDL, DCL, and transaction-control statements.


### PR DESCRIPTION
Fix version:
6.0.4, 6.1.3, 6.2.2

Fix: [EEC-1322](https://emqx.atlassian.net/browse/EEC-1322)

Driver PR: [emqx/jamdb_oracle#9](https://github.com/emqx/jamdb_oracle/pull/9), released as `emqx/jamdb_oracle@0.4.9.7`.

## Summary

This PR fixes two Oracle action issues found while reproducing EEC-1322.

First, Oracle action prepare checks used to validate SQL templates by executing the rendered user SQL inside an anonymous PL/SQL block followed by rollback. In the reproduced prepare-check case, creating an Oracle action with a normal `INSERT INTO mqtt_test ...` template fired a `BEFORE INSERT` trigger and wrote audit rows before any MQTT message was published. The prepare check now uses `DBMS_SQL.PARSE` so it validates SQL syntax and object references without running the action SQL. Top-level DDL, DCL, and transaction-control statements are rejected during prepare.

Second, the runtime write path could fail after payload size changed from small text to large text. The driver used cursor and bind metadata that had been prepared for smaller values, which could surface as Oracle errors such as `ORA-01461`, `ORA-01013`, or a closed socket. The runtime fix is in the Oracle driver, not in the EMQX connector.

`emqx_oracle` no longer rewrites or wraps user SQL for large payloads. The bumped driver now:

- includes bind format metadata in the cursor cache key, so small and large text bind shapes do not reuse an incompatible cursor;
- computes bind metadata from all rows in a batch, so a later large payload row is encoded with the correct bind format;
- derives named-bind order from the SQL text instead of relying on map iteration order;
- detects large text by encoded byte size, not Erlang list length;
- keeps normal DML and out-parameter statements on the existing driver execution path.

The EEC regression test uses a normal `t_mqtt_msgs` insert with `arrived` before `payload`, so the `NCLOB` payload bind is sent last. This verifies the size-change/cache fix without hiding Oracle's native LOB bind ordering restriction.

## Expected Side Effects

- Oracle action SQL templates that start with DDL, DCL, or transaction-control statements are rejected during prepare. This is intentional because those are not safe action templates.
- The same SQL text may use more than one cached cursor when payload sizes produce different bind formats. This avoids reusing an incompatible cursor, and the existing cursor limit still bounds the cache.
- The driver intentionally does not rewrite SQL or reorder user placeholders. Oracle's native LOB bind restrictions still apply, so users should place large `CLOB`/`NCLOB` bind placeholders after non-LOB placeholders when Oracle requires it.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)


[EEC-1322]: https://emqx.atlassian.net/browse/EEC-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ