### PR TITLE
fix(authz): show backend failure override

### DIFF
--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
@@ -129,7 +129,7 @@ authz_fields() ->
             hoconsc:mk(boolean(), #{
                 default => false,
                 desc => ?DESC(ignore_backend_failures),
-                importance => ?IMPORTANCE_HIDDEN
+                importance => ?IMPORTANCE_LOW
             })},
         {builtin_record_count_refresh_interval,
             hoconsc:mk(emqx_schema:timeout_duration_ms(), #{


### PR DESCRIPTION
Follow up to #17564

## Summary

Unhide `authorization.ignore_backend_failures` setting