### PR TITLE
chore: merge 6.0.3 tag (dashboard 2.0.3-1) back to release-60

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include env.sh
 
 # Dashboard version
 # from https://github.com/emqx/emqx-dashboard5
-export EMQX_DASHBOARD_VERSION ?= 2.0.3
+export EMQX_DASHBOARD_VERSION ?= 2.0.3-1
 
 export EMQX_REL_FORM ?= tgz
 export QUICER_TLS_VER ?= sys


### PR DESCRIPTION
The `6.0.3` tag was re-cut to include the dashboard version bump `2.0.3` → `2.0.3-1` (from #17611), cherry-picked on top of the original release commit (the tag was force-updated `383c5d45` → `d6d76350`).

Because `release-60` had already advanced past the tag (the gbt32960 fix #17604), the new tag commit is not a fast-forward of the branch. This PR merges the re-cut tag commit back into `release-60` so the `6.0.3` tag is an ancestor of the release branch and the dashboard bump is present on the branch.

Supersedes #17611 (its change is included via the tagged commit).