### PR TITLE
fix(gcp pubsub consumer): correctly clear optvars when restarting (r60)

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
@@ -11,7 +11,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 %% `ecpool_worker' API
--export([connect/1, health_check/1]).
+-export([connect/1, health_check/1, clear_optvar/1]).
 
 %% `gen_server' API
 -export([
@@ -35,7 +35,7 @@
     ack_deadline := emqx_schema:timeout_duration_s(),
     ack_retry_interval := emqx_schema:timeout_duration_ms(),
     client := emqx_bridge_gcp_pubsub_client:state(),
-    ecpool_worker_id => non_neg_integer(),
+    ecpool_worker_id := non_neg_integer(),
     forget_interval := duration(),
     namespace := emqx_bridge_v2:maybe_namespace(),
     hookpoints := [binary()],
@@ -54,12 +54,11 @@
     ack_timer := undefined | reference(),
     async_workers := #{pid() => reference()},
     client := emqx_bridge_gcp_pubsub_client:state(),
+    connector_resource_id := binary(),
     ecpool_worker_id := non_neg_integer(),
     forget_interval := duration(),
     namespace := emqx_bridge_v2:maybe_namespace(),
     hookpoints := [binary()],
-    connector_resource_id := binary(),
-    source_resource_id := binary(),
     pending_acks := #{message_id() => ack_id()},
     project_id := emqx_bridge_gcp_pubsub_client:project_id(),
     pull_max_messages := non_neg_integer(),
@@ -70,6 +69,7 @@
     %% between acknlowledging a message and receiving a duplicate pulled message, we need
     %% to keep the seen message IDs for a while...
     seen_message_ids := sets:set(message_id()),
+    source_resource_id := binary(),
     subscription_id := subscription_id(),
     topic := emqx_bridge_gcp_pubsub_client:topic()
 }.
@@ -136,14 +136,19 @@ get_subscription(WorkerPid) ->
 %% `ecpool' health check
 %%-------------------------------------------------------------------------------------------------
 
--spec health_check(pid()) -> subscription_ok | topic_not_found | timeout.
-health_check(WorkerPid) ->
-    case optvar:read(?OPTVAR_SUB_OK(WorkerPid), ?HEALTH_CHECK_TIMEOUT) of
+-spec health_check(integer()) -> subscription_ok | topic_not_found | timeout.
+health_check(WorkerId) ->
+    case optvar:read(?OPTVAR_SUB_OK(WorkerId), ?HEALTH_CHECK_TIMEOUT) of
         {ok, Status} ->
             Status;
         timeout ->
             timeout
     end.
+
+-spec clear_optvar(integer()) -> ok.
+clear_optvar(WorkerId) ->
+    optvar:unset(?OPTVAR_SUB_OK(WorkerId)),
+    ok.
 
 %%-------------------------------------------------------------------------------------------------
 %% `ecpool' API
@@ -159,6 +164,7 @@ connect(Opts0) ->
         forget_interval := ForgetInterval,
         hookpoints := Hookpoints,
         namespace := Namespace,
+        ecpool_worker_id := WorkerId,
         connector_resource_id := ConnectorResId,
         source_resource_id := SourceResId,
         project_id := ProjectId,
@@ -174,6 +180,7 @@ connect(Opts0) ->
         %% bridge during `on_get_status', since we have handed it over to the pull
         %% workers.
         client => Client,
+        ecpool_worker_id => WorkerId,
         forget_interval => ForgetInterval,
         hookpoints => Hookpoints,
         namespace => Namespace,
@@ -211,9 +218,12 @@ handle_continue(?ensure_subscription, State0) ->
         already_exists ->
             {noreply, State0, {continue, ?patch_subscription}};
         continue ->
-            #{source_resource_id := SourceResId} = State0,
+            #{
+                source_resource_id := SourceResId,
+                ecpool_worker_id := WorkerId
+            } = State0,
             ?MODULE:pull_async(self()),
-            optvar:set(?OPTVAR_SUB_OK(self()), subscription_ok),
+            optvar:set(?OPTVAR_SUB_OK(WorkerId), subscription_ok),
             clear_unhealthy_status(State0),
             ?tp(
                 debug,
@@ -235,9 +245,12 @@ handle_continue(?patch_subscription, State0) ->
     ?tp(gcp_pubsub_consumer_worker_patch_subscription_enter, #{}),
     case patch_subscription(State0) of
         ok ->
-            #{source_resource_id := SourceResId} = State0,
+            #{
+                source_resource_id := SourceResId,
+                ecpool_worker_id := WorkerId
+            } = State0,
             ?MODULE:pull_async(self()),
-            optvar:set(?OPTVAR_SUB_OK(self()), subscription_ok),
+            optvar:set(?OPTVAR_SUB_OK(WorkerId), subscription_ok),
             clear_unhealthy_status(State0),
             ?tp(
                 debug,
@@ -315,16 +328,20 @@ terminate({error, Reason}, State) when
     Reason =:= permission_denied
 ->
     #{
+        ecpool_worker_id := WorkerId,
         source_resource_id := SourceResId,
         topic := _Topic
     } = State,
-    optvar:unset(?OPTVAR_SUB_OK(self())),
+    clear_optvar(WorkerId),
     emqx_bridge_gcp_pubsub_impl_consumer:mark_as_unhealthy(SourceResId, Reason),
     ?tp(gcp_pubsub_consumer_worker_terminate, #{reason => {error, Reason}, topic => _Topic}),
     ok;
-terminate(_Reason, _State) ->
-    optvar:unset(?OPTVAR_SUB_OK(self())),
-    ?tp(gcp_pubsub_consumer_worker_terminate, #{reason => _Reason, topic => maps:get(topic, _State)}),
+terminate(_Reason, State) ->
+    #{
+        ecpool_worker_id := WorkerId
+    } = State,
+    clear_optvar(WorkerId),
+    ?tp(gcp_pubsub_consumer_worker_terminate, #{reason => _Reason, topic => maps:get(topic, State)}),
     ok.
 
 %%-------------------------------------------------------------------------------------------------

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
@@ -214,6 +214,7 @@ handle_continue(?ensure_subscription, State0) ->
             #{source_resource_id := SourceResId} = State0,
             ?MODULE:pull_async(self()),
             optvar:set(?OPTVAR_SUB_OK(self()), subscription_ok),
+            clear_unhealthy_status(State0),
             ?tp(
                 debug,
                 "gcp_pubsub_consumer_worker_subscription_ready",
@@ -237,6 +238,7 @@ handle_continue(?patch_subscription, State0) ->
             #{source_resource_id := SourceResId} = State0,
             ?MODULE:pull_async(self()),
             optvar:set(?OPTVAR_SUB_OK(self()), subscription_ok),
+            clear_unhealthy_status(State0),
             ?tp(
                 debug,
                 "gcp_pubsub_consumer_worker_subscription_ready",
@@ -787,6 +789,11 @@ add_if_present(FromKey, Message, ToKey, Map) ->
 forget_message_ids_after(MsgIds0, Timeout) ->
     MsgIds = sets:from_list(MsgIds0, [{version, 2}]),
     _ = erlang:send_after(Timeout, self(), {forget_message_ids, MsgIds}),
+    ok.
+
+clear_unhealthy_status(State) ->
+    #{source_resource_id := SourceResId} = State,
+    emqx_bridge_gcp_pubsub_impl_consumer:clear_one_unhealthy(SourceResId),
     ok.
 
 to_bin(A) when is_atom(A) -> atom_to_binary(A);

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -305,7 +305,10 @@ start_consumers(ConnectorResId, SourceResId, Client, ProjectId, SourceConfig) ->
         emqx_resource_pool:start(SourceResId, emqx_bridge_gcp_pubsub_consumer_worker, ConsumerOpts)
     of
         ok ->
-            State = #{pool_name => SourceResId},
+            State = #{
+                pool_name => SourceResId,
+                pool_size => PoolSize
+            },
             {ok, State};
         {error, Reason} ->
             {error, Reason}
@@ -321,7 +324,10 @@ stop_consumers(ConnectorState) ->
     ).
 
 stop_consumers1(SourceState) ->
-    #{pool_name := PoolName} = SourceState,
+    #{
+        pool_name := PoolName,
+        pool_size := PoolSize
+    } = SourceState,
     _ = log_when_error(
         fun() ->
             ok = emqx_resource_pool:stop(PoolName)
@@ -330,6 +336,12 @@ stop_consumers1(SourceState) ->
             msg => "failed_to_stop_pull_worker_pool",
             pool_name => PoolName
         }
+    ),
+    lists:foreach(
+        fun(WorkerId) ->
+            emqx_bridge_gcp_pubsub_consumer_worker:clear_optvar(WorkerId)
+        end,
+        lists:seq(1, PoolSize)
     ),
     ok.
 
@@ -374,7 +386,9 @@ get_client_status(Client) ->
     ?status_connected | ?status_connecting.
 check_workers(SourceResId, Client) ->
     Opts = #{
-        check_fn => fun emqx_bridge_gcp_pubsub_consumer_worker:health_check/1,
+        check_fn => fun(#{id := WorkerId}) ->
+            emqx_bridge_gcp_pubsub_consumer_worker:health_check(WorkerId)
+        end,
         run_on => independent,
         is_success_fn => fun
             (subscription_ok) -> false;

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -25,6 +25,7 @@
 -export([
     mark_as_unhealthy/2,
     clear_unhealthy/1,
+    clear_one_unhealthy/1,
     check_if_unhealthy/1
 ]).
 
@@ -162,6 +163,7 @@ on_add_channel(ConnectorResId, ConnectorState0, SourceResId, SourceConfig) ->
     {ok, connector_state()}.
 on_remove_channel(_ConnectorResId, ConnectorState0, SourceResId) ->
     #{installed_sources := InstalledSources0} = ConnectorState0,
+    clear_one_unhealthy(SourceResId),
     case maps:take(SourceResId, InstalledSources0) of
         {SourceState, InstalledSources} ->
             stop_consumers1(SourceState),
@@ -215,12 +217,17 @@ mark_as_unhealthy(SourceResId, Reason) ->
     optvar:set(?OPTVAR_UNHEALTHY(SourceResId), Reason),
     ok.
 
+clear_one_unhealthy(SourceResId) ->
+    optvar:unset(?OPTVAR_UNHEALTHY(SourceResId)),
+    ?tp(gcp_pubsub_consumer_clear_unhealthy, #{source_res_id => SourceResId}),
+    ok.
+
 -spec clear_unhealthy(connector_state()) -> ok.
 clear_unhealthy(ConnectorState) ->
     #{installed_sources := InstalledSources} = ConnectorState,
     maps:foreach(
         fun(SourceResId, _SourceState) ->
-            optvar:unset(?OPTVAR_UNHEALTHY(SourceResId))
+            clear_one_unhealthy(SourceResId)
         end,
         InstalledSources
     ),
@@ -272,6 +279,7 @@ start_consumers(ConnectorResId, SourceResId, Client, ProjectId, SourceConfig) ->
     ConsumerOpts = maps:to_list(ConsumerConfig),
     ReqOpts = #{request_ttl => RequestTTL},
     PubsubTopics = [PubsubTopic],
+    clear_one_unhealthy(SourceResId),
     case validate_pubsub_topics(PubsubTopics, Client, ReqOpts) of
         ok ->
             ok;

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -367,6 +367,7 @@ get_client_status(Client) ->
 check_workers(SourceResId, Client) ->
     Opts = #{
         check_fn => fun emqx_bridge_gcp_pubsub_consumer_worker:health_check/1,
+        run_on => independent,
         is_success_fn => fun
             (subscription_ok) -> false;
             (_) -> true

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -24,7 +24,6 @@
 %% health check API
 -export([
     mark_as_unhealthy/2,
-    clear_unhealthy/1,
     clear_one_unhealthy/1,
     check_if_unhealthy/1
 ]).
@@ -76,6 +75,9 @@
     "provided service account has the correct permissions configured."
 ).
 
+%% Allocatable resources
+-define(worker_pool, worker_pool).
+
 %%-------------------------------------------------------------------------------------------------
 %% `emqx_resource' API
 %%-------------------------------------------------------------------------------------------------
@@ -121,10 +123,9 @@ on_start(ConnectorResId, Config0) ->
     end.
 
 -spec on_stop(resource_id(), connector_state()) -> ok | {error, term()}.
-on_stop(ConnectorResId, ConnectorState) ->
+on_stop(ConnectorResId, _ConnectorState) ->
     ?tp(gcp_pubsub_consumer_stop_enter, #{}),
-    clear_unhealthy(ConnectorState),
-    ok = stop_consumers(ConnectorState),
+    clear_resources(ConnectorResId),
     emqx_bridge_gcp_pubsub_client:stop(ConnectorResId).
 
 -spec on_get_status(resource_id(), connector_state()) ->
@@ -163,10 +164,9 @@ on_add_channel(ConnectorResId, ConnectorState0, SourceResId, SourceConfig) ->
     {ok, connector_state()}.
 on_remove_channel(_ConnectorResId, ConnectorState0, SourceResId) ->
     #{installed_sources := InstalledSources0} = ConnectorState0,
-    clear_one_unhealthy(SourceResId),
     case maps:take(SourceResId, InstalledSources0) of
         {SourceState, InstalledSources} ->
-            stop_consumers1(SourceState),
+            clear_one_resource(SourceResId, SourceState),
             ok;
         error ->
             InstalledSources = InstalledSources0
@@ -222,16 +222,21 @@ clear_one_unhealthy(SourceResId) ->
     ?tp(gcp_pubsub_consumer_clear_unhealthy, #{source_res_id => SourceResId}),
     ok.
 
--spec clear_unhealthy(connector_state()) -> ok.
-clear_unhealthy(ConnectorState) ->
-    #{installed_sources := InstalledSources} = ConnectorState,
+clear_resources(ConnResId) ->
     maps:foreach(
-        fun(SourceResId, _SourceState) ->
-            clear_one_unhealthy(SourceResId)
+        fun
+            ({?worker_pool, SourceResId}, Data) ->
+                clear_one_resource(SourceResId, Data);
+            (_, _) ->
+                ok
         end,
-        InstalledSources
-    ),
-    ?tp(gcp_pubsub_consumer_clear_unhealthy, #{}),
+        emqx_resource:get_allocated_resources(ConnResId)
+    ).
+
+clear_one_resource(SourceResId, Data) ->
+    #{pool_size := PoolSize} = Data,
+    stop_consumers1(SourceResId, PoolSize),
+    clear_one_unhealthy(SourceResId),
     ok.
 
 -spec check_if_unhealthy(source_resource_id()) ->
@@ -301,6 +306,12 @@ start_consumers(ConnectorResId, SourceResId, Client, ProjectId, SourceConfig) ->
             %% topic when upserting their subscription.
             ok
     end,
+    ok = emqx_resource:allocate_resource(
+        ConnectorResId,
+        ?MODULE,
+        {?worker_pool, SourceResId},
+        #{pool_size => PoolSize}
+    ),
     case
         emqx_resource_pool:start(SourceResId, emqx_bridge_gcp_pubsub_consumer_worker, ConsumerOpts)
     of
@@ -314,27 +325,14 @@ start_consumers(ConnectorResId, SourceResId, Client, ProjectId, SourceConfig) ->
             {error, Reason}
     end.
 
-stop_consumers(ConnectorState) ->
-    #{installed_sources := InstalledSources} = ConnectorState,
-    maps:foreach(
-        fun(_SourceResId, SourceState) ->
-            stop_consumers1(SourceState)
-        end,
-        InstalledSources
-    ).
-
-stop_consumers1(SourceState) ->
-    #{
-        pool_name := PoolName,
-        pool_size := PoolSize
-    } = SourceState,
+stop_consumers1(SourceResId, PoolSize) ->
     _ = log_when_error(
         fun() ->
-            ok = emqx_resource_pool:stop(PoolName)
+            ok = emqx_resource_pool:stop(SourceResId)
         end,
         #{
             msg => "failed_to_stop_pull_worker_pool",
-            pool_name => PoolName
+            pool_name => SourceResId
         }
     ),
     lists:foreach(

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -2137,3 +2137,47 @@ t_create_via_http_json_object_service_account(TCConfig) ->
     }),
     assert_persisted_service_account_json_is_binary(TCConfig),
     ok.
+
+%% original issue: source was created with a service account without the correct
+%% permissions.  later, the permissions were granted to the service account.  in the
+%% meantime, if the resource manager attempted to reinstall the source more than once, it
+%% could end up in a state where the source would not be part of its internal installed
+%% channels, and then the optvar marking the source as unhealthy would not be cleared.
+%% here, we ensure that such optvar is cleared, and the source eventually recovers once
+%% the permissions are granted.
+t_clear_stuck_unhealthy(TCConfig) ->
+    emqx_common_test_helpers:with_mock(
+        emqx_bridge_gcp_pubsub_client,
+        query_sync,
+        fun(PreparedRequest = ?PREPARED_REQUEST_PAT(Method, _Path, _Body), Client) ->
+            %% original issue: 403 when creating subscription
+            case Method =:= put of
+                true ->
+                    ct:pal("mocking response"),
+                    permission_denied_response();
+                false ->
+                    meck:passthrough([PreparedRequest, Client])
+            end
+        end,
+        fun() ->
+            {201, #{<<"status">> := <<"connected">>}} =
+                create_connector_api(TCConfig, #{}),
+            {201, #{<<"status">> := <<"disconnected">>}} =
+                create_source_api(TCConfig, #{}),
+            ?assertMatch(
+                {200, #{<<"status">> := <<"disconnected">>}},
+                get_source_api(TCConfig)
+            ),
+            ok
+        end
+    ),
+    %% now, we "grant" the permissions by removing the mock.  should recover by itself.
+    ?retry(
+        1_000,
+        10,
+        ?assertMatch(
+            {200, #{<<"status">> := <<"connected">>}},
+            get_source_api(TCConfig)
+        )
+    ),
+    ok.

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -832,7 +832,7 @@ t_start_stop(TCConfig) ->
             prop_client_stopped(),
             prop_workers_stopped(PubSubTopic),
             fun(Trace) ->
-                ?assertMatch([_], ?of_kind(gcp_pubsub_consumer_clear_unhealthy, Trace)),
+                ?assertMatch([_, _ | _], ?of_kind(gcp_pubsub_consumer_clear_unhealthy, Trace)),
                 ok
             end
         ]

--- a/apps/emqx_resource/src/emqx_resource_pool.erl
+++ b/apps/emqx_resource/src/emqx_resource_pool.erl
@@ -103,11 +103,12 @@ common_health_check_workers(PoolName, #{} = Opts) ->
     end),
     OnSuccessFn = maps:get(on_success_fn, Opts, fun() -> ?status_connected end),
     Timeout = maps:get(timeout, Opts, emqx_resource_pool:health_check_timeout()),
+    RunOn = maps:get(run_on, Opts, worker),
     Res = emqx_resource_pool:health_check_workers(
         PoolName,
         CheckFn,
         Timeout,
-        #{return_values => true}
+        #{return_values => true, run_on => RunOn}
     ),
     case Res of
         {ok, []} ->
@@ -136,6 +137,7 @@ common_health_check_workers(PoolName, #{} = Opts) ->
 
 do_health_check_workers(PoolName, CheckFunc, Timeout, Opts) ->
     ReturnValues = maps:get(return_values, Opts, false),
+    RunOn = maps:get(run_on, Opts, worker),
     Workers = [Worker || {_WorkerName, Worker} <- ecpool:workers(PoolName)],
     DoPerWorker =
         fun(Worker) ->
@@ -143,7 +145,12 @@ do_health_check_workers(PoolName, CheckFunc, Timeout, Opts) ->
                 {ok, Conn} ?= ecpool_worker:client(Worker),
                 true ?= erlang:is_process_alive(Conn),
                 try
-                    ecpool_worker:exec(Worker, CheckFunc, Timeout)
+                    case RunOn of
+                        worker ->
+                            ecpool_worker:exec(Worker, CheckFunc, Timeout);
+                        independent ->
+                            CheckFunc(Conn)
+                    end
                 catch
                     exit:{timeout, _} ->
                         {error, timeout}

--- a/apps/emqx_resource/src/emqx_resource_pool.erl
+++ b/apps/emqx_resource/src/emqx_resource_pool.erl
@@ -138,9 +138,9 @@ common_health_check_workers(PoolName, #{} = Opts) ->
 do_health_check_workers(PoolName, CheckFunc, Timeout, Opts) ->
     ReturnValues = maps:get(return_values, Opts, false),
     RunOn = maps:get(run_on, Opts, worker),
-    Workers = [Worker || {_WorkerName, Worker} <- ecpool:workers(PoolName)],
+    Workers = [{WorkerId, Worker} || {{_Name, WorkerId}, Worker} <- ecpool:workers(PoolName)],
     DoPerWorker =
-        fun(Worker) ->
+        fun({WorkerId, Worker}) ->
             maybe
                 {ok, Conn} ?= ecpool_worker:client(Worker),
                 true ?= erlang:is_process_alive(Conn),
@@ -149,7 +149,7 @@ do_health_check_workers(PoolName, CheckFunc, Timeout, Opts) ->
                         worker ->
                             ecpool_worker:exec(Worker, CheckFunc, Timeout);
                         independent ->
-                            CheckFunc(Conn)
+                            CheckFunc(#{conn => Conn, id => WorkerId})
                     end
                 catch
                     exit:{timeout, _} ->

--- a/changes/ee/fix-17625.en.md
+++ b/changes/ee/fix-17625.en.md
@@ -1,0 +1,1 @@
+Fixed an issue with GCP PubSub Consumer Source where, if a source was initially created with a service account lacking necessary permissions to create subscriptions for the configured topic, the Source would fail to become `connected` even after granting the permissions to the service account.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.3, 6.2.2

port of #17624 to 6.x

## Summary



## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
