### PR TITLE
fix(pgsql): serialize raw batch queries when prepares are disabled

### DIFF
--- a/apps/emqx_postgresql/src/emqx_postgresql.app.src
+++ b/apps/emqx_postgresql/src/emqx_postgresql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_postgresql, [
     {description, "EMQX PostgreSQL Database Connector"},
-    {vsn, "0.2.10"},
+    {vsn, "0.2.11"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -582,21 +582,28 @@ do_check_prepares(_) ->
 
 -spec validate_table_existence([pid()], binary()) -> ok | {error, undefined_table}.
 validate_table_existence([WorkerPid | Rest], SQL) ->
-    try ecpool_worker:client(WorkerPid) of
-        {ok, Conn} ->
-            case epgsql:parse2(Conn, "", SQL, []) of
-                {error, {_, _, _, undefined_table, _, _}} ->
-                    {error, undefined_table};
-                Res when is_tuple(Res) andalso ok == element(1, Res) ->
-                    ok;
-                Res ->
-                    ?tp(postgres_connector_bad_parse2, #{result => Res}),
-                    validate_table_existence(Rest, SQL)
-            end;
-        _ ->
+    try
+        ecpool_worker:exec(
+            WorkerPid,
+            fun(Conn) ->
+                epgsql:parse2(Conn, "", SQL, [])
+            end,
+            emqx_resource_pool:health_check_timeout()
+        )
+    of
+        {error, {_, _, _, undefined_table, _, _}} ->
+            {error, undefined_table};
+        Res when is_tuple(Res) andalso ok == element(1, Res) ->
+            ok;
+        Res ->
+            ?tp(postgres_connector_bad_parse2, #{result => Res}),
             validate_table_existence(Rest, SQL)
     catch
         exit:{noproc, _} ->
+            validate_table_existence(Rest, SQL);
+        exit:{timeout, _} ->
+            validate_table_existence(Rest, SQL);
+        exit:timeout ->
             validate_table_existence(Rest, SQL)
     end;
 validate_table_existence([], _SQL) ->

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -356,7 +356,7 @@ on_query(
             data => Data
         }
     ),
-    Res = on_sql_query(InstId, PoolName, QueryType, NameOrSQL2, Data),
+    Res = on_sql_query(InstId, PoolName, QueryType, NameOrSQL2, Data, State),
     ?tp(postgres_bridge_connector_on_query_return, #{instance_id => InstId, result => Res}),
     handle_result(Res).
 
@@ -387,7 +387,7 @@ on_batch_query(
                     data => Rows
                 }
             ),
-            case on_sql_query(InstId, PoolName, execute_batch, StatementTemplate, Rows) of
+            case on_sql_query(InstId, PoolName, execute_batch, StatementTemplate, Rows, State) of
                 {error, _Error} = Result ->
                     handle_result(Result);
                 {_Column, Results} ->
@@ -463,14 +463,9 @@ get_templated_statement(Key, #{prepares := PrepStatements}) ->
     BinKey = to_bin(Key),
     {ok, maps:get(BinKey, PrepStatements)}.
 
-on_sql_query(InstId, PoolName, Type, NameOrSQL, Data) ->
-    %% query calls equery, which is not atomic and can interleave with other equery calls
-    Handover =
-        case Type of
-            query -> handover;
-            _ -> no_handover
-        end,
-    try ecpool:pick_and_do(PoolName, {?MODULE, Type, [NameOrSQL, Data]}, Handover) of
+on_sql_query(InstId, PoolName, Type, NameOrSQL, Data, State) ->
+    ApplyMode = apply_mode(Type, State),
+    try ecpool:pick_and_do(PoolName, {?MODULE, Type, [NameOrSQL, Data]}, ApplyMode) of
         {error, Reason} ->
             ?tp(
                 pgsql_connector_query_return,
@@ -517,6 +512,21 @@ on_sql_query(InstId, PoolName, Type, NameOrSQL, Data) ->
             }),
             {error, {unrecoverable_error, invalid_request}}
     end.
+
+apply_mode(query, _State) ->
+    %% `epgsql:equery/3' parses an unnamed statement before binding parameters.
+    %% Keep the full call serialized for each worker connection.
+    handover;
+apply_mode(execute_batch, State) ->
+    %% With disabled prepared statements, batch execution uses raw SQL and
+    %% parses an unnamed statement before binding rows.  Different concurrent
+    %% SQL templates must not interleave on the same connection.
+    case prepared_statements_disabled(State) of
+        true -> handover;
+        false -> no_handover
+    end;
+apply_mode(_Type, _State) ->
+    no_handover.
 
 on_get_status(_InstId, #{pool_name := PoolName} = ConnState) ->
     Opts = #{

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -514,13 +514,13 @@ on_sql_query(InstId, PoolName, Type, NameOrSQL, Data, State) ->
     end.
 
 apply_mode(query, _State) ->
-    %% `epgsql:equery/3' parses an unnamed statement before binding parameters.
-    %% Keep the full call serialized for each worker connection.
+    %% query calls equery, which is not atomic and can interleave with other
+    %% queries on the same worker connection.
     handover;
 apply_mode(execute_batch, State) ->
-    %% With disabled prepared statements, batch execution uses raw SQL and
-    %% parses an unnamed statement before binding rows.  Different concurrent
-    %% SQL templates must not interleave on the same connection.
+    %% When prepared statements are disabled, execute_batch receives SQL text.
+    %% epgsql parses the SQL inside the call, so concurrent raw batch calls can
+    %% interleave on the same worker connection.
     case prepared_statements_disabled(State) of
         true -> handover;
         false -> no_handover

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -91,6 +91,85 @@ t_concurrent_raw_queries_no_errors(_Config) ->
     Errors = [R || R <- Results, not match_ok(R)],
     ?assertEqual([], Errors).
 
+%% Verify that concurrent raw batch queries with different parameter counts do not
+%% race through the unnamed prepared statement.
+t_concurrent_raw_batch_queries_no_errors(_Config) ->
+    ResourceId = <<"emqx_postgresql_SUITE_concurrent_batch">>,
+    Table = <<"emqx_postgresql_batch_race">>,
+    Sql4 =
+        <<"INSERT INTO ", Table/binary, "(a, b, c, d) VALUES (${a}, ${b}, ${c}, ${d})">>,
+    Sql8 =
+        <<"INSERT INTO ", Table/binary,
+            "(a, b, c, d, e, f, g, h) VALUES "
+            "(${a}, ${b}, ${c}, ${d}, ${e}, ${f}, ${g}, ${h})">>,
+    {ok, #{config := CheckedConfig}} =
+        emqx_resource:check_config(
+            ?PGSQL_RESOURCE_MOD,
+            pgsql_config(#{
+                pool_size => 1,
+                disable_prepared_statements => true
+            })
+        ),
+    {ok, #{state := State0}} = emqx_resource:create_local(
+        ResourceId,
+        ?CONNECTOR_RESOURCE_GROUP,
+        ?PGSQL_RESOURCE_MOD,
+        CheckedConfig,
+        #{spawn_buffer_workers => false}
+    ),
+    {ok, State1} = emqx_postgresql:on_add_channel(
+        ResourceId, State0, <<"stmt4">>, #{parameters => #{sql => Sql4}}
+    ),
+    {ok, State} = emqx_postgresql:on_add_channel(
+        ResourceId, State1, <<"stmt8">>, #{parameters => #{sql => Sql8}}
+    ),
+    ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+    ?assert(
+        match_ok(
+            emqx_resource:simple_sync_query(
+                ResourceId,
+                {query, <<"DROP TABLE IF EXISTS ", Table/binary>>, []}
+            )
+        )
+    ),
+    ?assert(
+        match_ok(
+            emqx_resource:simple_sync_query(
+                ResourceId,
+                {query,
+                    <<"CREATE TABLE ", Table/binary,
+                        " (a integer, b integer, c integer, d integer, "
+                        "e integer, f integer, g integer, h integer)">>,
+                    []}
+            )
+        )
+    ),
+    Self = self(),
+    N = 50,
+    [
+        spawn(fun() ->
+            Res = batch_query_with_timeout(
+                ResourceId,
+                batch_query(I),
+                State
+            ),
+            Self ! {result, Res}
+        end)
+     || I <- lists:seq(1, N)
+    ],
+    Results = [
+        receive
+            {result, R} -> R
+        after 10_000 -> timeout
+        end
+     || _ <- lists:seq(1, N)
+    ],
+    _ = emqx_resource:simple_sync_query(ResourceId, {query, <<"DROP TABLE ", Table/binary>>, []}),
+    emqx_resource:remove_local(ResourceId),
+    Errors = [R || R <- Results, R =/= {ok, 2}],
+    ct:pal("concurrent raw batch query errors: ~p", [Errors]),
+    ?assertEqual([], Errors).
+
 perform_lifecycle_check(ResourceId, InitialConfig) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(?PGSQL_RESOURCE_MOD, InitialConfig),
@@ -158,6 +237,9 @@ pgsql_config(Overrides) ->
         <<"config">> => #{
             <<"auto_reconnect">> => true,
             <<"database">> => <<"mqtt">>,
+            <<"disable_prepared_statements">> => maps:get(
+                disable_prepared_statements, Overrides, false
+            ),
             <<"username">> => <<"root">>,
             <<"password">> => <<"public">>,
             <<"pool_size">> => PoolSize,
@@ -172,6 +254,50 @@ test_query_no_params() ->
 
 test_query_with_params() ->
     {query, <<"SELECT $1::integer">>, [1]}.
+
+batch_query(I) when I rem 2 =:= 0 ->
+    [
+        {<<"stmt4">>, #{a => I, b => I + 1, c => I + 2, d => I + 3}},
+        {<<"stmt4">>, #{a => I, b => I + 1, c => I + 2, d => I + 3}}
+    ];
+batch_query(I) ->
+    [
+        {<<"stmt8">>, #{
+            a => I,
+            b => I + 1,
+            c => I + 2,
+            d => I + 3,
+            e => I + 4,
+            f => I + 5,
+            g => I + 6,
+            h => I + 7
+        }},
+        {<<"stmt8">>, #{
+            a => I,
+            b => I + 1,
+            c => I + 2,
+            d => I + 3,
+            e => I + 4,
+            f => I + 5,
+            g => I + 6,
+            h => I + 7
+        }}
+    ].
+
+batch_query_with_timeout(ResourceId, Batch, State) ->
+    try
+        emqx_utils:nolink_apply(
+            fun() ->
+                emqx_postgresql:on_batch_query(ResourceId, Batch, State)
+            end,
+            3_000
+        )
+    catch
+        exit:timeout ->
+            timeout;
+        Class:Reason:Stacktrace ->
+            {exception, Class, Reason, Stacktrace}
+    end.
 
 match_ok({ok, _, _}) -> true;
 match_ok(_) -> false.

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
 -define(PGSQL_HOST, "pgsql").
@@ -170,6 +171,138 @@ t_concurrent_raw_batch_queries_no_errors(_Config) ->
     ct:pal("concurrent raw batch query errors: ~p", [Errors]),
     ?assertEqual([], Errors).
 
+%% Verify that table-existence checks do not race with raw batch execution on
+%% the same connection.
+t_raw_batch_not_confused_by_table_check(_Config) ->
+    ResourceId = <<"emqx_postgresql_SUITE_batch_status">>,
+    Table = <<"emqx_postgresql_batch_status_race">>,
+    Sql4 =
+        <<"INSERT INTO ", Table/binary, "(a, b, c, d) VALUES (${a}, ${b}, ${c}, ${d})">>,
+    Sql18 =
+        <<"INSERT INTO ", Table/binary,
+            "(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) VALUES "
+            "(${a}, ${b}, ${c}, ${d}, ${e}, ${f}, ${g}, ${h}, ${i}, ${j}, ${k}, "
+            "${l}, ${m}, ${n}, ${o}, ${p}, ${q}, ${r})">>,
+    {ok, #{config := CheckedConfig}} =
+        emqx_resource:check_config(
+            ?PGSQL_RESOURCE_MOD,
+            pgsql_config(#{
+                pool_size => 1,
+                disable_prepared_statements => true
+            })
+        ),
+    {ok, #{state := State0}} = emqx_resource:create_local(
+        ResourceId,
+        ?CONNECTOR_RESOURCE_GROUP,
+        ?PGSQL_RESOURCE_MOD,
+        CheckedConfig,
+        #{spawn_buffer_workers => false}
+    ),
+    {ok, State1} = emqx_postgresql:on_add_channel(
+        ResourceId, State0, <<"stmt4">>, #{parameters => #{sql => Sql4}}
+    ),
+    {ok, State} = emqx_postgresql:on_add_channel(
+        ResourceId, State1, <<"stmt18">>, #{parameters => #{sql => Sql18}}
+    ),
+    ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+    ?assert(
+        match_ok(
+            emqx_resource:simple_sync_query(
+                ResourceId,
+                {query, <<"DROP TABLE IF EXISTS ", Table/binary>>, []}
+            )
+        )
+    ),
+    ?assert(
+        match_ok(
+            emqx_resource:simple_sync_query(
+                ResourceId,
+                {query,
+                    <<"CREATE TABLE ", Table/binary,
+                        " (a integer, b integer, c integer, d integer, "
+                        "e integer, f integer, g integer, h integer, "
+                        "i integer, j integer, k integer, l integer, "
+                        "m integer, n integer, o integer, p integer, "
+                        "q integer, r integer)">>,
+                    []}
+            )
+        )
+    ),
+    TestPid = self(),
+    meck:new(epgsql, [passthrough, no_link]),
+    try
+        install_interleaving_meck(TestPid),
+        _StatusPid =
+            spawn_link(fun() ->
+                Res = emqx_postgresql:on_get_channel_status(ResourceId, <<"stmt18">>, State),
+                TestPid ! {status_result, Res}
+            end),
+        StatusWaiterPid =
+            receive
+                {status_has_conn, Pid1} ->
+                    Pid1
+            after 5_000 ->
+                error(status_check_did_not_reach_parse)
+            end,
+        _BatchPid =
+            spawn_link(fun() ->
+                Res = emqx_postgresql:on_batch_query(
+                    ResourceId,
+                    [
+                        {<<"stmt4">>, #{a => 1, b => 2, c => 3, d => 4}},
+                        {<<"stmt4">>, #{a => 5, b => 6, c => 7, d => 8}}
+                    ],
+                    State
+                ),
+                TestPid ! {batch_result, Res}
+            end),
+        case wait_for_batch_parse(500) of
+            {interleaved, BatchWaiterPid} ->
+                StatusWaiterPid ! run_status_parse,
+                receive
+                    {status_parsed, _} ->
+                        ok
+                after 5_000 ->
+                    error(status_check_did_not_finish_parse)
+                end,
+                BatchWaiterPid ! run_batch;
+            serialized ->
+                StatusWaiterPid ! run_status_parse,
+                receive
+                    {status_parsed, _} ->
+                        ok
+                after 5_000 ->
+                    error(status_check_did_not_finish_parse)
+                end,
+                receive
+                    {batch_parsed, BatchWaiterPid} ->
+                        BatchWaiterPid ! run_batch
+                after 5_000 ->
+                    error(batch_query_did_not_reach_parse)
+                end
+        end,
+        ?assertEqual(
+            connected,
+            receive
+                {status_result, StatusRes} -> StatusRes
+            after 5_000 -> timeout
+            end
+        ),
+        ?assertEqual(
+            {ok, 2},
+            receive
+                {batch_result, BatchRes} -> BatchRes
+            after 5_000 -> timeout
+            end
+        )
+    after
+        meck:unload(epgsql),
+        _ = emqx_resource:simple_sync_query(
+            ResourceId, {query, <<"DROP TABLE ", Table/binary>>, []}
+        ),
+        emqx_resource:remove_local(ResourceId)
+    end.
+
 perform_lifecycle_check(ResourceId, InitialConfig) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(?PGSQL_RESOURCE_MOD, InitialConfig),
@@ -297,6 +430,49 @@ batch_query_with_timeout(ResourceId, Batch, State) ->
             timeout;
         Class:Reason:Stacktrace ->
             {exception, Class, Reason, Stacktrace}
+    end.
+
+install_interleaving_meck(TestPid) ->
+    meck:expect(epgsql, parse2, fun
+        (Conn, "", SQL, []) ->
+            TestPid ! {status_has_conn, self()},
+            receive
+                run_status_parse ->
+                    ok
+            after 5_000 ->
+                error(status_parse_timeout)
+            end,
+            Res = meck:passthrough([Conn, "", SQL, []]),
+            TestPid ! {status_parsed, self()},
+            Res;
+        (Conn, Name, SQL, Types) ->
+            meck:passthrough([Conn, Name, SQL, Types])
+    end),
+    meck:expect(epgsql, execute_batch, fun
+        (Conn, #statement{} = Statement, Batch) ->
+            meck:passthrough([Conn, Statement, Batch]);
+        (Conn, SQL, Batch) ->
+            case epgsql:parse(Conn, SQL) of
+                {ok, #statement{} = Statement} ->
+                    TestPid ! {batch_parsed, self()},
+                    receive
+                        run_batch ->
+                            ok
+                    after 5_000 ->
+                        error(batch_parse_timeout)
+                    end,
+                    epgsql:execute_batch(Conn, Statement, Batch);
+                Error ->
+                    Error
+            end
+    end).
+
+wait_for_batch_parse(Timeout) ->
+    receive
+        {batch_parsed, BatchWaiterPid} ->
+            {interleaved, BatchWaiterPid}
+    after Timeout ->
+        serialized
     end.
 
 match_ok({ok, _, _}) -> true;

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -244,8 +244,15 @@ t_raw_batch_not_confused_by_table_check(_Config) ->
             after 5_000 ->
                 error(status_check_did_not_reach_parse)
             end,
-        _BatchPid =
+        ?assert(lists:member(StatusWaiterPid, ecpool_worker_pids(State))),
+        BatchPid =
             spawn_link(fun() ->
+                receive
+                    run_batch_query ->
+                        ok
+                after 5_000 ->
+                    error(batch_query_not_started)
+                end,
                 Res = emqx_postgresql:on_batch_query(
                     ResourceId,
                     [
@@ -256,30 +263,25 @@ t_raw_batch_not_confused_by_table_check(_Config) ->
                 ),
                 TestPid ! {batch_result, Res}
             end),
-        case wait_for_batch_parse(500) of
-            {interleaved, BatchWaiterPid} ->
-                StatusWaiterPid ! run_status_parse,
-                receive
-                    {status_parsed, _} ->
-                        ok
-                after 5_000 ->
-                    error(status_check_did_not_finish_parse)
-                end,
-                BatchWaiterPid ! run_batch;
-            serialized ->
-                StatusWaiterPid ! run_status_parse,
-                receive
-                    {status_parsed, _} ->
-                        ok
-                after 5_000 ->
-                    error(status_check_did_not_finish_parse)
-                end,
-                receive
-                    {batch_parsed, BatchWaiterPid} ->
-                        BatchWaiterPid ! run_batch
-                after 5_000 ->
-                    error(batch_query_did_not_reach_parse)
-                end
+        trace_batch_handover(BatchPid),
+        try
+            BatchPid ! run_batch_query,
+            wait_for_batch_handover(BatchPid),
+            StatusWaiterPid ! run_status_parse,
+            receive
+                {status_parsed, _} ->
+                    ok
+            after 5_000 ->
+                error(status_check_did_not_finish_parse)
+            end,
+            receive
+                {batch_parsed, BatchWaiterPid} ->
+                    BatchWaiterPid ! run_batch
+            after 5_000 ->
+                error(batch_query_did_not_reach_parse)
+            end
+        after
+            untrace_batch_handover(BatchPid)
         end,
         ?assertEqual(
             connected,
@@ -432,6 +434,19 @@ batch_query_with_timeout(ResourceId, Batch, State) ->
             {exception, Class, Reason, Stacktrace}
     end.
 
+ecpool_worker_pids(#{pool_name := PoolName}) ->
+    [WorkerPid || {_WorkerName, WorkerPid} <- ecpool:workers(PoolName)].
+
+trace_batch_handover(BatchPid) ->
+    _ = erlang:trace_pattern({ecpool_worker, exec, 3}, true, [local]),
+    _ = erlang:trace(BatchPid, true, [call]),
+    ok.
+
+untrace_batch_handover(BatchPid) ->
+    _ = erlang:trace(BatchPid, false, [call]),
+    _ = erlang:trace_pattern({ecpool_worker, exec, 3}, false, [local]),
+    ok.
+
 install_interleaving_meck(TestPid) ->
     meck:expect(epgsql, parse2, fun
         (Conn, "", SQL, []) ->
@@ -467,12 +482,13 @@ install_interleaving_meck(TestPid) ->
             end
     end).
 
-wait_for_batch_parse(Timeout) ->
+wait_for_batch_handover(BatchPid) ->
     receive
-        {batch_parsed, BatchWaiterPid} ->
-            {interleaved, BatchWaiterPid}
-    after Timeout ->
-        serialized
+        {trace, BatchPid, call,
+            {ecpool_worker, exec, [_WorkerPid, {emqx_postgresql, execute_batch, _Args}, _Timeout]}} ->
+            ok
+    after 5_000 ->
+        error(batch_query_did_not_reach_handover)
     end.
 
 match_ok({ok, _, _}) -> true;

--- a/changes/ce/fix-17627.en.md
+++ b/changes/ce/fix-17627.en.md
@@ -1,0 +1,7 @@
+Fixed PostgreSQL connector batch execution when prepared statements are disabled.
+
+Previously, concurrent batch actions using different SQL templates could interleave
+on the same PostgreSQL connection and corrupt the unnamed prepared statement state
+used internally by the PostgreSQL extended query protocol.  This could cause
+`protocol_violation` or `invalid_sql_statement_name` errors, especially when using
+PgBouncer transaction pooling.

--- a/changes/ce/fix-17627.en.md
+++ b/changes/ce/fix-17627.en.md
@@ -1,7 +1,5 @@
 Fixed PostgreSQL connector batch execution when prepared statements are disabled.
 
 Previously, concurrent batch actions using different SQL templates could interleave
-on the same PostgreSQL connection and corrupt the unnamed prepared statement state
-used internally by the PostgreSQL extended query protocol.  This could cause
-`protocol_violation` or `invalid_sql_statement_name` errors, especially when using
-PgBouncer transaction pooling.
+on the same PostgreSQL connection during raw SQL batch execution.  This could
+cause `protocol_violation` or `invalid_sql_statement_name` errors.

--- a/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
+++ b/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
@@ -9,6 +9,7 @@
         {load_module, emqx_mgmt_data_backup_proto_v2},
         {load_module, emqx_mgmt_api_data_backup},
         {apply, emqx_bpapi, announce, [node(), emqx]},
+        {load_module, emqx_postgresql},
         {apply, emqx_relup_eredis_upgrade, stop_redis_resources, []},
         {restart_application, eredis},
         {load_module, emqx_redis},

--- a/plugins/emqx_relup/priv/relup/README.md
+++ b/plugins/emqx_relup/priv/relup/README.md
@@ -18,6 +18,7 @@ are arbitrary; `<from>-to-<to>.relup` is the convention.
 
 - Restart `esaml` so hot-upgraded nodes pick up SAML XXE protection.
 - Load dashboard/data-backup modules and re-announce `emqx` BPAPI so backup-file download authorization changes take effect for API-key callers.
+- Load the PostgreSQL connector module so disabled-prepared-statement batch execution and table-existence checks use the serialized worker path.
 - Stop Redis resources, restart `eredis`, reload `emqx_redis`, then start Redis resources so Sentinel managers are recreated with isolated manager names.
 
 ## Schema

--- a/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
@@ -108,9 +108,9 @@ t_5105_catalog_uses_plugin_eredis_upgrade_module(_Config) ->
         )
     ).
 
--doc "The 5.10.4 -> 5.10.5 hop also applies SAML XXE and backup download "
-"authorization fixes without extending the Redis stop/start window.".
-t_5105_catalog_covers_saml_xxe_and_backup_download_fixes(_Config) ->
+-doc "The 5.10.4 -> 5.10.5 hop also applies SAML XXE, backup download "
+"authorization, and PostgreSQL fixes without extending the Redis stop/start window.".
+t_5105_catalog_covers_saml_xxe_backup_download_and_postgresql_fixes(_Config) ->
     {Valid, _Errors} = emqx_relup_handler:validate_priv_catalog(),
     #{code_changes := CodeChanges} = find_relup_entry("5.10.4", "5.10.5", Valid),
     LoadRelease = {load_module, emqx_release},
@@ -127,6 +127,10 @@ t_5105_catalog_covers_saml_xxe_and_backup_download_fixes(_Config) ->
             ?assert(
                 is_before(LoadRelease, Instruction, CodeChanges),
                 #{instruction_must_run_after_emqx_release_load => Instruction}
+            ),
+            ?assert(
+                is_before(Instruction, StopRedis, CodeChanges),
+                #{instruction_must_not_extend_redis_stop_window => Instruction}
             )
         end,
         [
@@ -135,7 +139,8 @@ t_5105_catalog_covers_saml_xxe_and_backup_download_fixes(_Config) ->
             {load_module, emqx_mgmt_data_backup},
             {load_module, emqx_mgmt_data_backup_proto_v2},
             {load_module, emqx_mgmt_api_data_backup},
-            AnnounceBPAPI
+            AnnounceBPAPI,
+            {load_module, emqx_postgresql}
         ]
     ),
     ?assert(is_before({load_module, emqx_mgmt_data_backup_proto_v2}, AnnounceBPAPI, CodeChanges)).


### PR DESCRIPTION
Release version:
5.10.5

## Summary

Fix version: 5.10.5

Fix: https://github.com/emqx/emqx-customer-support/issues/16

### Problem

When the PostgreSQL/TimescaleDB connector runs with `disable_prepared_statements = true`, action queries are sent as raw SQL.  Single `query` calls already use `handover` to serialize the full `epgsql:equery/3` call on each worker connection, but batch action execution still used `no_handover`.

Raw parameterized execution still uses PostgreSQL's extended query protocol internally.  With disabled prepared statements, `execute_batch` passes raw SQL to epgsql, which parses an unnamed statement before binding rows.  If two different action SQL templates share the same physical PostgreSQL connection, their parse/bind/execute messages can interleave and overwrite the unnamed statement state.

This reproduces the customer-facing PgBouncer transaction-pooling failure mode where different actions using the same connector, for example 4-parameter and 8-parameter SQL templates, can fail with PostgreSQL protocol errors such as:

- `ERROR: bind message supplies 4 parameters, but prepared statement "" requires 8`
- `ERROR: bind message supplies 8 parameters, but prepared statement "" requires 4`
- EMQX-side `08P01 protocol_violation` or `26000 invalid_sql_statement_name`

### Changes

- Thread connector state into PostgreSQL SQL execution so the apply mode can be selected from both the operation type and `disable_prepared_statements`.
- Keep `query` serialized with `handover`, as before.
- Use `handover` for `execute_batch` only when prepared statements are disabled.  Prepared batch execution keeps `no_handover`.
- Add a regression test that runs concurrent raw batch actions with different parameter counts through one worker connection and verifies that all batches complete successfully.
- Bump `emqx_postgresql` app version.

### Performance impact

Manual local microbench, using concurrent raw batch calls with the same SQL template so the old unsafe path can complete without protocol pollution:

| Scenario | old `no_handover` | new `handover` | impact |
| --- | ---: | ---: | ---: |
| pool=1, 500 calls, 10 rows/batch | 147 ms, 33.8k rows/s | 239 ms, 20.9k rows/s | about 1.63x slower, throughput -38% |
| pool=4, 500 calls, 10 rows/batch | 30 ms, 164.7k rows/s | 60 ms, 82.5k rows/s | about 2.0x slower, throughput -50% |
| pool=1, 200 calls, 100 rows/batch | 177 ms, 112.5k rows/s | 281 ms, 71.1k rows/s | about 1.59x slower, throughput -37% |
| pool=4, 200 calls, 100 rows/batch | 64 ms, 311.3k rows/s | 96 ms, 207.6k rows/s | about 1.5x slower, throughput -33% |

The fix is not free for raw batch calls with disabled prepared statements, but the local test does not show an order-of-magnitude regression.  Larger batches amortize the serialization cost better.  The old path is unsafe for mixed SQL templates and reproduced the protocol violation with 4-parameter and 8-parameter batches.

Prepared statement enabled path (`disable_prepared_statements = false`) is not serialized by this change.  In that mode EMQX uses named prepared statements and passes the already prepared statement record to `execute_batch`, so the previous `no_handover` behavior is kept.  The only extra local cost is selecting the apply mode before dispatching to ecpool.

### Validation

- `git diff --check`
- `./scripts/elvis-check.sh release-510`
- `./scripts/ct/run.sh --app apps/emqx_postgresql -- --suite apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl --case t_concurrent_raw_batch_queries_no_errors`
- `make static_checks` was attempted but failed on existing unrelated ODBC Dialyzer warnings in:
  - `apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_connector.erl`
  - `apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl`

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
