### PR TITLE
test(lwm2m): clean up channels after test cases

### DIFF
--- a/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
+++ b/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
@@ -183,7 +183,8 @@ groups() ->
             case141_channel_blockwise_server_paths,
             case142_clear_blockwise_downlink,
             case143_blockwise_busy_no_context,
-            case144_blockwise_consume_only
+            case144_blockwise_consume_only,
+            case147_cleanup_lwm2m_channels
         ]}
     ].
 
@@ -248,6 +249,7 @@ init_per_testcase(TestCase, Config) ->
 
 end_per_testcase(_AllTestCase, Config) ->
     timer:sleep(300),
+    cleanup_lwm2m_channels(),
     gen_udp:close(?config(sock, Config)),
     emqtt:disconnect(?config(emqx_c, Config)),
     snabbkaffe:stop(),
@@ -5993,6 +5995,52 @@ case144_blockwise_consume_only(_Config) ->
     #{return := {_Outs, _Session2}} =
         emqx_lwm2m_session:handle_protocol_in({response, {Ctx, Resp}}, WithContext, Session1),
     ok.
+
+case147_cleanup_lwm2m_channels(_Config) ->
+    ClientId = <<"cleanup-test-client">>,
+    Parent = self(),
+    Pid = spawn_link(fun() -> fake_lwm2m_channel(Parent, ClientId) end),
+    ok = emqx_gateway_cm:register_channel(lwm2m, ClientId, Pid, #{conn_mod => ?MODULE}),
+    ?assertMatch([Pid], emqx_gateway_cm_registry:lookup_channels(lwm2m, ClientId)),
+
+    cleanup_lwm2m_channels(),
+
+    receive
+        {fake_channel_kicked, ClientId, kick} ->
+            ok
+    after 1000 ->
+        ct:fail(fake_lwm2m_channel_was_not_kicked)
+    end,
+    ?assertEqual([], emqx_gateway_cm_registry:lookup_channels(lwm2m, ClientId)).
+
+fake_lwm2m_channel(Parent, ClientId) ->
+    receive
+        {gateway_cm_call, kick} ->
+            emqx_gateway_cm:connection_closed(lwm2m, ClientId),
+            emqx_gateway_cm:unregister_channel(lwm2m, ClientId),
+            Parent ! {fake_channel_kicked, ClientId, kick}
+    end.
+
+call(Pid, Action, _Timeout) ->
+    Pid ! {gateway_cm_call, Action},
+    ok.
+
+cleanup_lwm2m_channels() ->
+    lists:foreach(
+        fun({ClientId, ChanPid}) ->
+            _ = emqx_gateway_cm:kick_session(lwm2m, ClientId, ChanPid)
+        end,
+        lwm2m_channels()
+    ),
+    ?retry(100, 20, ?assertEqual([], lwm2m_channels())).
+
+lwm2m_channels() ->
+    Tab = emqx_gateway_cm:tabname(chan, lwm2m),
+    try ets:tab2list(Tab) of
+        Channels -> Channels
+    catch
+        error:badarg -> []
+    end.
 
 capture_with_context(Pid) ->
     fun


### PR DESCRIPTION
Release version:
6.1.2

Fix flaky tets:
```
emqx_lwm2m_SUITE:std_register failed on line 6328
Reason: {badmatch,{coap_message,ack,{ok,changed},18,<<>>,#{},<<>>}}
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Testing apps.emqx_gateway_lwm2m.emqx_lwm2m_SUITE: *** FAILED test case 21 of 103 ***
%%% emqx_lwm2m_SUITE ==> test_grp_0_register.case09_auto_observe_list_no_intersection: FAILED
%%% emqx_lwm2m_SUITE ==> {{badmatch,{coap_message,ack,{ok,changed},18,<<>>,#{},<<>>}},
 [{emqx_lwm2m_SUITE,std_register,5,
                    [{file,"test/emqx_lwm2m_SUITE.erl"},{line,6328}]},
  {emqx_lwm2m_SUITE,case09_auto_observe_list_no_intersection,1,
                    [{file,"test/emqx_lwm2m_SUITE.erl"},{line,1463}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1796}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1305}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1237}]}]}
```
## Summary

The LwM2M tests create UDP clients per test case, but closing the client UDP socket does not explicitly close the gateway-side LwM2M channel. If the OS reuses the same UDP peer port in a later test, the next REGISTER packet can be routed to the previous channel and be handled as a reregister, returning `2.04 Changed` instead of the expected `2.01 Created`.

This change makes `emqx_lwm2m_SUITE:end_per_testcase/2` explicitly kick all LwM2M gateway channels before closing the test UDP socket. It also adds `case147_cleanup_lwm2m_channels` to cover that the cleanup helper kicks a registered channel and waits for the channel registry to become empty.

Validated with:

- `make ct-suite SUITE=apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl PROFILE=emqx-enterprise TESTCASE=case147_cleanup_lwm2m_channels`
- `make ct-suite SUITE=apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl PROFILE=emqx-enterprise GROUP=test_grp_0_register`
- `./scripts/erlfmt -c apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl`
- `git diff --check`
- `./scripts/apps-version-check.exs`

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log is not required because this is a test-only stability fix
- [x] Schema changes are not included
