### PR TITLE
test(mqtt v5): forward-port duplicate clientid stabilization to release-62

### DIFF
--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -571,14 +571,17 @@ t_connect_keepalive_timeout(Config) ->
 t_connect_duplicate_clientid(Config) ->
     ConnFun = ?config(conn_fun, Config),
     process_flag(trap_exit, true),
+    %% generate fresh clientid on each run to avoid throttling
+    N = erlang:unique_integer(),
+    ClientId = <<"t_connect_duplicate_clientid", (integer_to_binary(N))/binary>>,
     {ok, Client1} = emqtt:start_link([
-        {clientid, <<"t_connect_duplicate_clientid">>},
+        {clientid, ClientId},
         {proto_ver, v5}
         | Config
     ]),
     {ok, _} = emqtt:ConnFun(Client1),
     {ok, Client2} = emqtt:start_link([
-        {clientid, <<"t_connect_duplicate_clientid">>},
+        {clientid, ClientId},
         {proto_ver, v5}
         | Config
     ]),
@@ -596,8 +599,11 @@ t_connect_duplicate_clientid(Config) ->
 
 t_connack_session_present(Config) ->
     ConnFun = ?config(conn_fun, Config),
+    %% generate fresh clientid on each run to avoid throttling
+    N = erlang:unique_integer(),
+    ClientId = <<"t_connect_duplicate_clientid", (integer_to_binary(N))/binary>>,
     {ok, Client1} = emqtt:start_link([
-        {clientid, <<"t_connect_duplicate_clientid">>},
+        {clientid, ClientId},
         {proto_ver, v5},
         {properties, #{'Session-Expiry-Interval' => 7200}},
         {clean_start, true}
@@ -609,7 +615,7 @@ t_connack_session_present(Config) ->
     ok = emqtt:disconnect(Client1),
 
     {ok, Client2} = emqtt:start_link([
-        {clientid, <<"t_connect_duplicate_clientid">>},
+        {clientid, ClientId},
         {proto_ver, v5},
         {properties, #{'Session-Expiry-Interval' => 7200}},
         {clean_start, false}


### PR DESCRIPTION
Release version: 6.2.x

## Summary

Forward-port of [`68e28741b3`](https://github.com/emqx/emqx/commit/68e28741b3) (\"test(mqtt v5): attempt to stabilize flaky test\") from release-61. The fix did not propagate via sync PR yet, and the flake was hit again in release-63 CI.

The test was using a fixed clientid `<<"t_connect_duplicate_clientid">>` shared across runs, which collided with the clientid-throttle in \`emqx_cm\` and produced \`{server_busy, THROTTLED}\` on rapid re-runs. This patch generates a fresh clientid per run via \`erlang:unique_integer/0\`.

Cherry-pick is clean (matches release-61 byte-for-byte for this case and for \`t_connack_session_present\`).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [x] Schema changes are backward compatible or intentionally breaking