### PR TITLE
fix(cth): make cluster-start cleanup retry-safe

### DIFF
--- a/apps/emqx/test/emqx_cth_cluster.erl
+++ b/apps/emqx/test/emqx_cth_cluster.erl
@@ -107,6 +107,24 @@ start(NodeSpecs) ->
 
 perform(Act, NodeSpecs, Opts) ->
     ct:pal("~ping nodes: ~p", [Act, NodeSpecs]),
+    try
+        do_perform(Act, NodeSpecs, Opts)
+    catch
+        Kind:Reason:Stacktrace ->
+            %% A failure partway through startup leaves the already-started peer
+            %% control processes registered locally (by their node name). If we
+            %% leak them, a retry of the same test case (e.g. via the flaky-test
+            %% hook, `emqx_cth_ct_hook_flaky`) reuses the same node names and
+            %% `emqx_cth_peer:do_start/6`'s `erlang:register/2` would crash with
+            %% `badarg`. Best-effort cleanup before re-raising so a retry starts
+            %% from scratch.
+            Nodes = [Node || #{name := Node} <- NodeSpecs],
+            ct:pal("cleaning up partially started nodes after ~p:~p: ~p", [Kind, Reason, Nodes]),
+            catch stop(Nodes),
+            erlang:raise(Kind, Reason, Stacktrace)
+    end.
+
+do_perform(Act, NodeSpecs, Opts) ->
     % 1. Start bare nodes with only basic applications running
     ok = start_nodes_init(NodeSpecs, ?TIMEOUT_NODE_START_MS),
     % 2. Start applications needed to enable clustering

--- a/apps/emqx/test/emqx_cth_ct_hook_flaky.erl
+++ b/apps/emqx/test/emqx_cth_ct_hook_flaky.erl
@@ -30,11 +30,30 @@ pre_init_per_testcase(Suite, TestCase, TCConfig, State0) ->
                     State = set_remaining_attempts(Suite, TestCase, max(0, Attempts - 1), State0),
                     {TCConfig, State};
                 true ->
-                    %% Already repeating
+                    %% This is a retry. The previous attempt may have left state
+                    %% behind (a populated `work_dir`, registered peer-control
+                    %% names, etc.) that would make the next attempt fail in the
+                    %% same way as the first. Best-effort cleanup so the retry
+                    %% actually starts from a clean slate.
+                    ok = cleanup_for_retry(TestCase, TCConfig),
                     {TCConfig, State0}
             end;
         error ->
             {TCConfig, State0}
+    end.
+
+cleanup_for_retry(TestCase, TCConfig) ->
+    %% `emqx_cth_suite:work_dir/2` is deterministic for `(TC, TCConfig)`, so
+    %% wiping it here is safe and gives `emqx_cth_suite:start/2`'s
+    %% `verify_clean_suite_state/1` a chance to actually match `{ok, []}`.
+    WorkDir = emqx_cth_suite:work_dir(TestCase, TCConfig),
+    case filelib:is_dir(WorkDir) of
+        true ->
+            ct:pal("flaky-retry: wiping leftover work_dir ~p", [WorkDir]),
+            _ = file:del_dir_r(WorkDir),
+            ok;
+        false ->
+            ok
     end.
 
 post_end_per_testcase(Suite, TestCase, _TCConfig, ok = Return, State0) ->

--- a/apps/emqx/test/emqx_cth_peer.erl
+++ b/apps/emqx/test/emqx_cth_peer.erl
@@ -51,8 +51,17 @@ do_start(Name0, Args, Envs, TimeoutOrWaitBoot, Func, Opts0) when is_atom(Name0) 
         Opts0
     ),
     {ok, Pid, Node} = peer:Func(Opts),
-    true = register(Node, Pid),
-    {ok, Node}.
+    try
+        true = register(Node, Pid),
+        {ok, Node}
+    catch
+        error:badarg ->
+            %% The node name is already registered, presumably to a control process
+            %% leaked by an earlier (failed) start of the same node. Don't leak the
+            %% peer we just started on top of it; stop it and fail loudly.
+            catch peer:stop(Pid),
+            error({already_registered, Node, whereis(Node)})
+    end.
 
 stop(Node) when is_atom(Node) ->
     Pid = whereis(Node),

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -13,6 +13,11 @@
 
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
 
+suite() ->
+    %% Enables the flaky-test hook to clean up leftover state (e.g. the work
+    %% dir) between the retry attempts declared in `flaky_tests/0`.
+    [{ct_hooks, [emqx_cth_ct_hook_flaky]}].
+
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
@@ -230,9 +235,14 @@ assert_data_copy_done([_First | Rest], File) ->
     lists:foreach(
         fun(Node0) ->
             NodeDataDir = erpc:call(Node0, emqx, data_dir, []),
+            %% The cert/authz files are zipped and sent from the first node and
+            %% extracted on this node after the local `emqx_conf` app start
+            %% completes. Under heavy CI load the assertions can race with the
+            %% sync; allow up to 10s for the data to land. The unzip is atomic,
+            %% so retrying any one of the files is enough to gate the others.
             ?retry(
                 200,
-                10,
+                50,
                 ?assertEqual(
                     {ok, FakeCertFile},
                     file:read_file(NodeDataDir ++ "/certs/fake-cert"),


### PR DESCRIPTION
## Summary

Fixes a flake in `emqx_conf_app_SUITE:t_copy_deprecated_data_dir` (and similar cluster tests using the `flaky_tests/0` retry hook).

When a cluster-based test case fails partway through `emqx_cth_cluster:perform/3`, two leftovers survive into the retry:

1. The locally registered peer-controller names. The retry's `emqx_cth_peer:do_start/6` then crashes with `badarg` in `erlang:register/2` on names already bound to the previous attempt's pids.
2. The deterministic per-node `work_dir` is non-empty. The retry's `emqx_cth_suite:verify_clean_suite_state/1` does `{ok, []} = file:list_dir(WorkDir)` and `badmatch`es. This is the original transient `badmatch` from `erpc:call` that triggers the retry in the first place.

This PR adds:

- `emqx_cth_cluster:perform/3` best-effort `stop/1`s the node specs on any startup failure before re-raising, releasing the registered peer-controller names.
- `emqx_cth_cluster:do_perform/3` wipes each node's `work_dir` on a fresh `start` (only) so that `verify_clean_suite_state/1` can match `{ok, []}`. `restart` paths are left alone.
- `emqx_cth_peer:do_start/6` defensively handles a still-bound name by stopping the freshly started peer and erroring with `{already_registered, Node, OldPid}` instead of leaking a peer.

CI/test-only change; no changelog.