### PR TITLE
test(stomp): wait for previous session to drain in t_subscribe_inuse

### DIFF
--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -322,7 +322,10 @@ t_subscribe_inuse(_) ->
         fun(Sock) ->
             Setup(Sock),
             %% assert subscription stats
-            [#{clientid := ClientId}] = clients(),
+            %% the previous connection's session may still be draining
+            %% asynchronously after its socket was closed, so retry until
+            %% exactly one client is listed
+            [#{clientid := ClientId}] = ?retry(100, 30, [_] = clients()),
             {error, ErrMsg} = create_subscription(ClientId, <<"/queue/bar">>, UsedSubId),
             ?assertEqual(<<"Subscription id 0 is in used">>, ErrMsg),
 
@@ -333,7 +336,10 @@ t_subscribe_inuse(_) ->
         fun(Sock) ->
             Setup(Sock),
             %% assert subscription stats
-            [#{clientid := ClientId}] = clients(),
+            %% the previous connection's session may still be draining
+            %% asynchronously after its socket was closed, so retry until
+            %% exactly one client is listed
+            [#{clientid := ClientId}] = ?retry(100, 30, [_] = clients()),
             {error, ErrMsg} = create_subscription(ClientId, UsedTopic, <<"1">>),
             ?assertEqual(<<"Topic /queue/foo already in subscribed">>, ErrMsg),
 


### PR DESCRIPTION
## Summary

`t_subscribe_inuse` calls `with_connection/1` four times sequentially. After
each call the client-side socket is closed, but the gateway's STOMP channel
process tears down the session asynchronously, so the next `with_connection/1`
can start before the previous client has been unregistered from `emqx_cm`.
The strict-singleton match `[#{clientid := ClientId}] = clients()` then fails
when two sessions are briefly listed.

Wrap the two listing matches in `?retry(100, 30, ...)` so they wait up to
3 seconds for exactly one client to be listed.

Verified with 18 consecutive green runs of `t_subscribe_inuse` in a tight
loop (plus a full-suite run, 20/20 green). Test-only change.