### PR TITLE
fix(passwd): make plain password verification case-sensitive

### DIFF
--- a/apps/emqx/src/emqx_passwd.erl
+++ b/apps/emqx/src/emqx_passwd.erl
@@ -62,6 +62,10 @@ do_check_pass({bcrypt, Salt}, PasswordHash, Password) ->
         {error, _Reason} ->
             false
     end;
+do_check_pass({plain, _Salt, _SaltPosition} = HashParams, PasswordHash, Password) ->
+    %% Plaintext passwords must be compared case-sensitively.
+    Hash = hash(HashParams, Password),
+    compare_secure(Hash, PasswordHash);
 do_check_pass({_SimpleHash, _Salt, _SaltPosition} = HashParams, PasswordHash, Password) ->
     Hash = hash(HashParams, Password),
     compare_secure_caseless(Hash, PasswordHash).

--- a/apps/emqx/test/emqx_passwd_SUITE.erl
+++ b/apps/emqx/test/emqx_passwd_SUITE.erl
@@ -44,6 +44,28 @@ t_hash_data(_) ->
 
     Sha512 = emqx_passwd:hash_data(sha512, Password).
 
+t_plain_password(_) ->
+    Password = <<"password">>,
+    Salt = <<"salt">>,
+
+    ?assertEqual(Password, emqx_passwd:hash_data(plain, Password)),
+    ?assertEqual(Password, emqx_passwd:hash({plain, <<>>, disable}, Password)),
+    ?assertEqual(
+        <<Salt/binary, Password/binary>>,
+        emqx_passwd:hash({plain, Salt, prefix}, Password)
+    ),
+
+    true = emqx_passwd:check_pass({plain, <<>>, disable}, Password, Password),
+    false = emqx_passwd:check_pass({plain, <<>>, disable}, Password, <<"PASSWORD">>),
+    false = emqx_passwd:check_pass({plain, <<>>, disable}, Password, <<"Password">>),
+
+    true = emqx_passwd:check_pass(
+        {plain, Salt, prefix}, <<Salt/binary, Password/binary>>, Password
+    ),
+    false = emqx_passwd:check_pass(
+        {plain, Salt, prefix}, <<Salt/binary, Password/binary>>, <<"PASSWORD">>
+    ).
+
 t_hash(_) ->
     Password = <<"password">>,
     Salt = <<"salt">>,

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_password_hashing_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_password_hashing_SUITE.erl
@@ -174,6 +174,14 @@ hash_examples() ->
         }
     ].
 
+t_plain_password_case_sensitive(_Config) ->
+    Algorithm = #{name => plain, salt_position => disable},
+    Password = <<"password">>,
+    {Hash, Salt} = emqx_authn_password_hashing:hash(Algorithm, Password),
+    true = emqx_authn_password_hashing:check_password(Algorithm, Salt, Hash, Password),
+    false = emqx_authn_password_hashing:check_password(Algorithm, Salt, Hash, <<"PASSWORD">>),
+    false = emqx_authn_password_hashing:check_password(Algorithm, Salt, Hash, <<"Password">>).
+
 t_pbkdf2_schema(_Config) ->
     Config = fun(Iterations) ->
         #{

--- a/apps/emqx_bridge_gcp_pubsub/mix.exs
+++ b/apps/emqx_bridge_gcp_pubsub/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeGcpPubsub.MixProject do
   def project do
     [
       app: :emqx_bridge_gcp_pubsub,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/changes/ee/fix-17644.en.md
+++ b/changes/ee/fix-17644.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the `plain` password hash algorithm accepted passwords that differed only by letter case during authentication.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/128

Release version: 6.0.3

## Summary

Fixed the `plain` password hash algorithm so that passwords are compared case-sensitively. Previously both the stored password and the supplied password were lowercased before comparison, allowing authentication with case variants (e.g. `PASSWORD` for `password`).

Digest-based algorithms (`md5`, `sha`, `sha256`, `sha512`, `pbkdf2`) continue to accept hex-encoded hashes case-insensitively.

Regression tests have been added to `emqx_passwd_SUITE` and `emqx_authn_password_hashing_SUITE`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
