### PR TITLE
fix(prometheus): redact authorization headers in config api responses

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.app.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.app.src
@@ -2,7 +2,7 @@
 {application, emqx_prometheus, [
     {description, "Prometheus for EMQX"},
     % strict semver, bump manually!
-    {vsn, "5.2.12"},
+    {vsn, "5.2.13"},
     {modules, []},
     {registered, [emqx_prometheus_sup]},
     {applications, [kernel, stdlib, prometheus, emqx, emqx_auth, emqx_resource, emqx_management]},

--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -220,11 +220,13 @@ setting(get, _Params) ->
             true -> Raw;
             false -> emqx_prometheus_config:to_recommend_type(Raw)
         end,
-    {200, Conf};
+    {200, emqx_utils:redact(Conf)};
 setting(put, #{body := Body}) ->
-    case emqx_prometheus_config:update(Body) of
+    Raw = emqx:get_raw_config([<<"prometheus">>], #{}),
+    Deobfuscated = emqx_utils:deobfuscate(Body, Raw),
+    case emqx_prometheus_config:update(Deobfuscated) of
         {ok, NewConfig} ->
-            {200, NewConfig};
+            {200, emqx_utils:redact(NewConfig)};
         {error, Reason} ->
             Message = list_to_binary(io_lib:format("Update config failed ~p", [Reason])),
             {500, 'INTERNAL_ERROR', Message}

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -97,7 +97,7 @@ t_legacy_prometheus_api(_) ->
             <<"push_gateway">> :=
                 #{
                     <<"enable">> := true,
-                    <<"headers">> := #{<<"Authorization">> := <<"some-authz-tokens">>},
+                    <<"headers">> := #{<<"Authorization">> := <<"******">>},
                     <<"interval">> := <<"1s">>,
                     <<"job_name">> := <<"${cluster_name}~${name}~${host}">>,
                     <<"url">> := <<"http://127.0.0.1:9091">>
@@ -189,6 +189,10 @@ t_prometheus_api(_) ->
             #{<<"url">> := Url, <<"enable">> := Enable} = PushGateway,
         <<"collectors">> := Collector
     } = Conf,
+    ?assertEqual(
+        #{<<"Authorization">> => <<"******">>},
+        maps:get(<<"headers">>, PushGateway)
+    ),
     Pid = erlang:whereis(emqx_prometheus),
     ?assertEqual(Enable, undefined =/= Pid, {Url, Pid}),
 

--- a/changes/ee/fix-17652.en.md
+++ b/changes/ee/fix-17652.en.md
@@ -1,0 +1,3 @@
+Fixed a security issue where the Prometheus configuration API returned stored
+`Authorization` header values in push gateway headers. The API now redacts these
+values in responses.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/248

Release version:
5.10.4

## Summary

Redact sensitive header values from the Prometheus configuration API responses.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
