### PR TITLE
fix(authn_api): redact provider secrets in authenticator creation response

### DIFF
--- a/apps/emqx_auth/mix.exs
+++ b/apps/emqx_auth/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuth.MixProject do
   def project do
     [
       app: :emqx_auth,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
@@ -990,7 +990,10 @@ create_authenticator(ConfKeyPath, ChainName, Config) ->
             raw_config := AuthenticatorsConfig
         }} ->
             {ok, AuthenticatorConfig} = find_config(ID, AuthenticatorsConfig),
-            {200, maps:put(id, ID, convert_certs(fill_defaults(AuthenticatorConfig)))};
+            {200,
+                maps:put(
+                    id, ID, convert_certs(emqx_utils:redact(fill_defaults(AuthenticatorConfig)))
+                )};
         {error, {_PrePostConfigUpdate, ?CONFIG, Reason}} ->
             serialize_error(Reason);
         {error, Reason} ->

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
@@ -111,6 +111,50 @@ t_authenticator_fail(_) ->
         )
     ).
 
+t_create_authenticator_redacts_secrets(_) ->
+    JWTConfig = emqx_authn_test_lib:jwt_example(),
+    {ok, 200, JWTRes} = request(
+        post,
+        uri([?CONF_NS]),
+        JWTConfig
+    ),
+    ?assertMatch(
+        #{<<"id">> := <<"jwt">>, <<"secret">> := <<"******">>},
+        emqx_utils_json:decode(JWTRes)
+    ),
+
+    HTTPConfig0 = emqx_authn_test_lib:http_example(),
+    HTTPConfig = HTTPConfig0#{
+        headers => #{
+            <<"content-type">> => <<"application/json">>,
+            <<"authorization">> => <<"Bearer secret-token">>
+        },
+        body => #{
+            <<"username">> => <<"${username}">>,
+            <<"password">> => <<"secret-password">>
+        }
+    },
+    {ok, 200, HTTPRes} = request(
+        post,
+        uri([?CONF_NS]),
+        HTTPConfig
+    ),
+    ?assertMatch(
+        #{
+            <<"id">> := <<"password_based:http">>,
+            <<"headers">> := #{
+                <<"content-type">> := <<"application/json">>,
+                <<"authorization">> := <<"******">>
+            },
+            <<"body">> := #{
+                <<"username">> := <<"${username}">>,
+                <<"password">> := <<"******">>
+            }
+        },
+        emqx_utils_json:decode(HTTPRes)
+    ),
+    ok.
+
 t_authenticator_position(_) ->
     test_authenticator_position([]).
 

--- a/changes/ee/fix-17654.en.md
+++ b/changes/ee/fix-17654.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where creating an authenticator via `POST /authentication` returned the new authenticator config without redacting provider secrets (such as JWT HMAC secrets, HTTP `Authorization` headers, and request body passwords). The creation response now applies the same redaction as the list and get endpoints.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/247

Release version: 6.0.3

## Summary

Redact secrets in `POST /authentication`. The deprecated listener-authenticator creation path is also covered.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
