### PR TITLE
fix(emqx_agent): redact AI provider API keys in plugin API

### DIFF
--- a/plugins/emqx_agent/src/emqx_agent_api.erl
+++ b/plugins/emqx_agent/src/emqx_agent_api.erl
@@ -130,7 +130,8 @@ normalize_plugin_response(Status) when is_integer(Status) ->
 %%--------------------------------------------------------------------
 
 '/agent/providers'(get, _Params) ->
-    ?OK(emqx_ai_completion_config:get_providers_raw()).
+    Providers = [emqx_utils:redact(P) || P <- emqx_ai_completion_config:get_providers_raw()],
+    ?OK(Providers).
 
 %%--------------------------------------------------------------------
 %% Handler — UI

--- a/plugins/emqx_agent/test/emqx_agent_api_SUITE.erl
+++ b/plugins/emqx_agent/test/emqx_agent_api_SUITE.erl
@@ -34,6 +34,7 @@ init_per_suite(Config) ->
             emqx,
             emqx_conf,
             emqx_resource,
+            emqx_ai_completion,
             emqx_agent,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
@@ -77,6 +78,29 @@ t_ui_returns_html(_Config) ->
 
     {ok, 200, CompatAppJs} = api_get([agent, ui, assets, <<"app.js">>]),
     ?assertEqual(AppJs, CompatAppJs).
+
+%%--------------------------------------------------------------------
+%% AI Providers
+%%--------------------------------------------------------------------
+
+t_providers_are_redacted(Config) ->
+    Id = ?config(tc_id, Config),
+    ProviderName = <<"test-provider-", Id/binary>>,
+    Provider = #{
+        <<"name">> => ProviderName,
+        <<"type">> => <<"openai">>,
+        <<"api_key">> => <<"super-secret-key">>,
+        <<"base_url">> => <<"https://api.openai.com/v1">>
+    },
+    ok = emqx_ai_completion_config:update_providers_raw({add, Provider}),
+    try
+        {ok, 200, [Response]} = api_get([agent, providers]),
+        ?assertEqual(ProviderName, maps:get(<<"name">>, Response)),
+        ?assertEqual(<<"openai">>, maps:get(<<"type">>, Response)),
+        ?assertEqual(<<"******">>, maps:get(<<"api_key">>, Response))
+    after
+        _ = emqx_ai_completion_config:update_providers_raw({delete, ProviderName})
+    end.
 
 %%--------------------------------------------------------------------
 %% Tools — individual type tests


### PR DESCRIPTION
Fixes emqx/emqx-dev-team-tasks#242

Release version: 6.3.0

## Summary

Redact providers in the `emqx_agent` plugin API 

## PR Checklist

- [x] The changes are covered with new or existing tests
~~- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~ -- not a released feature
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
