### PR TITLE
fix(plugins): redact dashboard credential headers from plugin api callbacks

### DIFF
--- a/apps/emqx_plugins/mix.exs
+++ b/apps/emqx_plugins/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXPlugins.MixProject do
   def project do
     [
       app: :emqx_plugins,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_plugins/src/emqx_plugins_api_endpoint.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_api_endpoint.erl
@@ -95,7 +95,7 @@ gateway(Method, Params, Request) ->
     ReqInfo = #{
         method => Method,
         query_string => QueryString,
-        headers => Headers,
+        headers => sanitize_headers(Headers),
         body => maps:get(body, Params, #{})
     },
     AuthMeta = maps:get(auth_meta, Params, #{}),
@@ -172,3 +172,6 @@ request_namespace(#{auth_meta := #{namespace := ?global_ns}}) ->
     ?global_ns;
 request_namespace(_Request) ->
     ?global_ns.
+
+sanitize_headers(Headers) ->
+    maps:without([<<"authorization">>, <<"cookie">>], Headers).

--- a/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
@@ -94,6 +94,26 @@ t_plugin_api_headers_passthrough(_Config) ->
     %% Headers should be populated from the cowboy request, not empty
     ?assert(maps:get(<<"header_count">>, Body) > 0).
 
+t_plugin_api_sensitive_headers_redacted(_Config) ->
+    ok = meck:expect(
+        emqx_plugins,
+        handle_api_call,
+        fun(<<"fake">>, #{request := ReqInfo}, _Timeout) ->
+            Headers = maps:get(headers, ReqInfo, #{}),
+            {200, #{
+                has_authorization => maps:is_key(<<"authorization">>, Headers),
+                has_cookie => maps:is_key(<<"cookie">>, Headers),
+                has_x_test => maps:is_key(<<"x-test">>, Headers)
+            }}
+        end
+    ),
+    AuthHeaders = [emqx_mgmt_api_test_util:auth_header_()],
+    ExtraHeaders = [{"cookie", "emqx_auth=secret; other=value"}, {"x-test", "1"}],
+    {200, Body} = request(get, ?SERVER ++ "/plugin_api/fake/ping", AuthHeaders ++ ExtraHeaders),
+    ?assertEqual(false, maps:get(<<"has_authorization">>, Body)),
+    ?assertEqual(false, maps:get(<<"has_cookie">>, Body)),
+    ?assertEqual(true, maps:get(<<"has_x_test">>, Body)).
+
 t_plugin_api_query_string_passthrough(_Config) ->
     ok = meck:expect(
         emqx_plugins,

--- a/changes/ee/fix-17657.en.md
+++ b/changes/ee/fix-17657.en.md
@@ -1,0 +1,1 @@
+Fixed a security issue where raw `authorization` and `cookie` headers were forwarded to plugin API callbacks. These credential-bearing headers are now redacted before reaching plugin code.


### PR DESCRIPTION
Fixes emqx/emqx-dev-team-tasks#239

Release version: 6.0.4

## Summary

Remove `authorization` and `cookie` headers from the `ReqInfo` map passed to plugin callbacks (plugins can still identify the caller through the sanitized `auth_meta`).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

