### PR TITLE
test(bigquery): de-flake dataset/table setup against emulator

### DIFF
--- a/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
+++ b/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
@@ -304,10 +304,7 @@ do_create_dataset(Dataset, TCConfig) ->
         <<"datasetReference">> => #{<<"datasetId">> => Dataset}
     }),
     on_exit(fun() -> do_delete_dataset(Dataset, TCConfig) end),
-    {ok, _} = emqx_bridge_gcp_pubsub_client:query_sync(
-        ?PREPARED_REQUEST(Method, Path, Body),
-        Client
-    ),
+    {ok, _} = query_sync_with_retry(?PREPARED_REQUEST(Method, Path, Body), Client),
     ct:pal("dataset ~s created", [Dataset]),
     ok.
 
@@ -349,12 +346,24 @@ do_create_table(Dataset, Table, TCConfig) ->
         }
     }),
     on_exit(fun() -> do_delete_table(Dataset, Table, TCConfig) end),
-    {ok, _} = emqx_bridge_gcp_pubsub_client:query_sync(
-        ?PREPARED_REQUEST(Method, Path, Body),
-        Client
-    ),
+    {ok, _} = query_sync_with_retry(?PREPARED_REQUEST(Method, Path, Body), Client),
     ct:pal("table ~s created", [Table]),
     ok.
+
+%% The bigquery emulator (goccy/bigquery-emulator) intermittently drops its
+%% internal SQL connection and replies `500 "sql: connection is already
+%% closed"' to the next request. That made dataset/table setup in
+%% init_per_testcase fail (and skip the whole case). Retry such transient
+%% failures; a 409 means a previous retried attempt already succeeded.
+query_sync_with_retry(Request, Client) ->
+    ?retry(
+        _Sleep = 300,
+        _Attempts = 10,
+        case emqx_bridge_gcp_pubsub_client:query_sync(Request, Client) of
+            {ok, Result} -> {ok, Result};
+            {error, #{status_code := 409}} -> {ok, already_exists}
+        end
+    ).
 
 do_delete_table(Dataset, Table, TCConfig) ->
     ProjectId = get_value(project_id, TCConfig),


### PR DESCRIPTION
The bigquery emulator intermittently drops its SQL connection and replies `500 "sql: connection is already closed"`, which made `init_per_testcase` (dataset/table creation) fail and skip the case — reported as a CI failure under `--ci`. Add a retry helper for the setup `query_sync` calls.

Fixes a flake seen e.g. in https://github.com/emqx/emqx/actions/runs/27834828134/job/82382375876 (surfaced on the r63→master sync PR #17658). The code originates on release-60 (earliest branch with the bigquery bridge), so fixing here propagates forward via the sync chain.