### PR TITLE
feat(mt): per-namespace counters for dropped messages and deliveries

### DIFF
--- a/apps/emqx_mt/mix.exs
+++ b/apps/emqx_mt/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMT.MixProject do
   def project do
     [
       app: :emqx_mt,
-      version: "6.1.1",
+      version: "6.1.2",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_mt/src/emqx_mt_hookcb.erl
+++ b/apps/emqx_mt/src/emqx_mt_hookcb.erl
@@ -12,7 +12,9 @@
     on_authenticate/2,
     on_post_authn/1,
     on_api_actor_will_be_created/2,
-    on_namespace_resource_pre_create/2
+    on_namespace_resource_pre_create/2,
+    on_message_dropped/3,
+    on_delivery_dropped/3
 ]).
 
 -include_lib("emqx/include/emqx.hrl").
@@ -27,6 +29,8 @@
 -define(POST_AUTHN_HOOK, {?MODULE, on_post_authn, []}).
 -define(LIMITER_HOOK, {emqx_mt_limiter, adjust_limiter, []}).
 -define(USER_CREATION_HOOK, {?MODULE, on_api_actor_will_be_created, []}).
+-define(MSG_DROPPED_HOOK, {?MODULE, on_message_dropped, []}).
+-define(DELIVERY_DROPPED_HOOK, {?MODULE, on_delivery_dropped, []}).
 
 register_hooks() ->
     ok = emqx_hooks:add('session.created', ?SESSION_HOOK, ?HP_HIGHEST),
@@ -39,6 +43,10 @@ register_hooks() ->
         {?MODULE, on_namespace_resource_pre_create, []},
         ?HP_HIGHEST
     ),
+    %% Drop-event hooks run at the lowest priority so any higher-priority
+    %% handlers (filters, rule-engine, etc.) have already executed.
+    ok = emqx_hooks:add('message.dropped', ?MSG_DROPPED_HOOK, ?HP_LOWEST),
+    ok = emqx_hooks:add('delivery.dropped', ?DELIVERY_DROPPED_HOOK, ?HP_LOWEST),
     ok.
 
 unregister_hooks() ->
@@ -50,6 +58,8 @@ unregister_hooks() ->
     ok = emqx_hooks:del(
         'namespace.resource_pre_create', {?MODULE, on_namespace_resource_pre_create}
     ),
+    ok = emqx_hooks:del('message.dropped', ?MSG_DROPPED_HOOK),
+    ok = emqx_hooks:del('delivery.dropped', ?DELIVERY_DROPPED_HOOK),
     ok.
 
 on_session_created(
@@ -202,3 +212,68 @@ on_namespace_resource_pre_create(#{?namespace := Namespace}, ResCtx) when is_bin
         false ->
             {stop, ResCtx#{exists := false}}
     end.
+
+%%--------------------------------------------------------------------
+%% Drop-event hooks
+%%--------------------------------------------------------------------
+
+%% @doc `message.dropped' hook: bump per-namespace `messages.dropped' counters.
+%%
+%% Notes:
+%%   * Reason `no_subscribers' is the only one that has a dedicated
+%%     fine-grained global counter ticked at the call site
+%%     (`emqx_broker:inc_dropped_cnt/1'); we mirror it per-namespace.
+%%   * The `messages.dropped.await_pubrel_timeout' counter is incremented
+%%     globally only via the bulk path in `emqx_session_events:expired_rel/1',
+%%     which carries a count but no `#message{}', so the hook does not fire
+%%     there and the per-namespace counter for that reason is not bumped.
+on_message_dropped(Msg, _Info, Reason) ->
+    inc_ns(ns_from_msg(Msg), drop_metric_names('messages.dropped', Reason)).
+
+%% @doc `delivery.dropped' hook: bump per-namespace `delivery.dropped' counters.
+on_delivery_dropped(ClientInfo, Msg, Reason) ->
+    inc_ns(
+        ns_from_clientinfo(ClientInfo, Msg),
+        drop_metric_names('delivery.dropped', Reason)
+    ).
+
+%% Build the list of per-namespace counter names to bump for a given
+%% drop event. We always bump the umbrella counter, plus a reason-specific
+%% counter when one exists in `emqx_prometheus:message_metric_meta/0' /
+%% `delivery_metric_meta/0'.
+drop_metric_names('messages.dropped', no_subscribers) ->
+    ['messages.dropped', 'messages.dropped.no_subscribers'];
+drop_metric_names('messages.dropped', _OtherReason) ->
+    ['messages.dropped'];
+drop_metric_names('delivery.dropped', expired) ->
+    ['delivery.dropped', 'delivery.dropped.expired'];
+drop_metric_names('delivery.dropped', no_local) ->
+    ['delivery.dropped', 'delivery.dropped.no_local'];
+drop_metric_names('delivery.dropped', qos0_msg) ->
+    ['delivery.dropped', 'delivery.dropped.qos0_msg'];
+drop_metric_names('delivery.dropped', queue_full) ->
+    ['delivery.dropped', 'delivery.dropped.queue_full'];
+drop_metric_names('delivery.dropped', too_large) ->
+    ['delivery.dropped', 'delivery.dropped.too_large'];
+drop_metric_names('delivery.dropped', _OtherReason) ->
+    ['delivery.dropped'].
+
+ns_from_msg(#message{headers = #{client_attrs := #{?CLIENT_ATTR_NAME_TNS := Ns}}}) when
+    is_binary(Ns)
+->
+    Ns;
+ns_from_msg(_) ->
+    undefined.
+
+ns_from_clientinfo(#{client_attrs := #{?CLIENT_ATTR_NAME_TNS := Ns}}, _Msg) when is_binary(Ns) ->
+    Ns;
+ns_from_clientinfo(_, Msg) ->
+    ns_from_msg(Msg).
+
+inc_ns(undefined, _Names) ->
+    ok;
+inc_ns(Ns, Names) when is_binary(Ns) ->
+    lists:foreach(
+        fun(Name) -> _ = emqx_metrics:inc_safe(Ns, Name) end,
+        Names
+    ).

--- a/apps/emqx_mt/src/emqx_mt_hookcb.erl
+++ b/apps/emqx_mt/src/emqx_mt_hookcb.erl
@@ -223,10 +223,13 @@ on_namespace_resource_pre_create(#{?namespace := Namespace}, ResCtx) when is_bin
 %%   * Reason `no_subscribers' is the only one that has a dedicated
 %%     fine-grained global counter ticked at the call site
 %%     (`emqx_broker:inc_dropped_cnt/1'); we mirror it per-namespace.
-%%   * The `messages.dropped.await_pubrel_timeout' counter is incremented
-%%     globally only via the bulk path in `emqx_session_events:expired_rel/1',
-%%     which carries a count but no `#message{}', so the hook does not fire
-%%     there and the per-namespace counter for that reason is not bumped.
+%%   * QoS2 PUBREL await-timeout drops bump the global
+%%     `messages.dropped.await_pubrel_timeout' counter via
+%%     `emqx_session_events:inc_await_pubrel_timeout/1' but do not fire the
+%%     `message.dropped' hook (the event carries only a count, not the
+%%     `#message{}'s). So the per-namespace counter for that reason stays at
+%%     zero until the upstream gap is closed. Tracked in
+%%     https://github.com/emqx/emqx/issues/17663.
 on_message_dropped(Msg, _Info, Reason) ->
     inc_ns(ns_from_msg(Msg), drop_metric_names('messages.dropped', Reason)).
 

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -1679,3 +1679,218 @@ authn_inject_tag(#{username := <<"user_bad">>}, _Acc) ->
     {stop, {ok, #{is_superuser => false, client_attrs => #{<<"tag">> => <<"ghost">>}}}};
 authn_inject_tag(_ClientInfo, Acc) ->
     {ok, Acc}.
+
+%%------------------------------------------------------------------------------
+%% Per-namespace counters for dropped messages and dropped deliveries
+%%------------------------------------------------------------------------------
+
+-doc """
+`messages.dropped' is bumped per-namespace when a publish from a namespaced
+client matches no subscribers.  Both the umbrella counter and the
+`no_subscribers' fine-grained counter must move; the global counters move
+by the same amount; counters belonging to other namespaces stay at zero.
+""".
+t_namespaced_metrics_dropped_no_subscribers({init, Config}) ->
+    Namespace = <<"explicit_ns_dropped_no_subs">>,
+    ok = emqx_mt_config:create_managed_ns(Namespace),
+    reset_global_metrics(),
+    [{explicit_ns, Namespace} | Config];
+t_namespaced_metrics_dropped_no_subscribers({'end', Config}) ->
+    Namespace = ?config(explicit_ns, Config),
+    ok = emqx_mt_config:delete_managed_ns(Namespace),
+    ?retry(250, 10, ?assertNot(emqx_mt_state:is_tombstoned(Namespace))),
+    reset_global_metrics(),
+    delete_all_namespaces(),
+    ok;
+t_namespaced_metrics_dropped_no_subscribers(Config) when is_list(Config) ->
+    Namespace = ?config(explicit_ns, Config),
+    ClientId = ?NEW_CLIENTID(),
+    Pid = connect(ClientId, Namespace),
+    %% Fresh state.
+    ?assertEqual(0, emqx_metrics:val_global('messages.dropped')),
+    ?assertEqual(0, emqx_metrics:val(Namespace, 'messages.dropped')),
+    ?assertEqual(0, emqx_metrics:val_global('messages.dropped.no_subscribers')),
+    ?assertEqual(0, emqx_metrics:val(Namespace, 'messages.dropped.no_subscribers')),
+    %% Publish QoS 1 to a topic with no subscribers.
+    {ok, _} = emqtt:publish(Pid, <<"no_one_here">>, <<"hey">>, [{qos, 1}]),
+    %% Both umbrella and fine-grained counter move on the namespace, mirroring
+    %% the global counters.
+    ?retry(
+        100,
+        10,
+        ?assertEqual(
+            {1, 1, 1, 1},
+            {
+                emqx_metrics:val_global('messages.dropped'),
+                emqx_metrics:val(Namespace, 'messages.dropped'),
+                emqx_metrics:val_global('messages.dropped.no_subscribers'),
+                emqx_metrics:val(Namespace, 'messages.dropped.no_subscribers')
+            }
+        )
+    ),
+    ok = emqtt:stop(Pid),
+    ok.
+
+-doc """
+`messages.dropped' from a client without a tenant-namespace must only move
+the global counters; per-namespace counters are not touched (no Ns to attach
+to).
+""".
+t_namespaced_metrics_dropped_no_subscribers_implicit({init, Config}) ->
+    Namespace = <<"explicit_ns_dropped_implicit">>,
+    ok = emqx_mt_config:create_managed_ns(Namespace),
+    reset_global_metrics(),
+    [{explicit_ns, Namespace} | Config];
+t_namespaced_metrics_dropped_no_subscribers_implicit({'end', Config}) ->
+    Namespace = ?config(explicit_ns, Config),
+    ok = emqx_mt_config:delete_managed_ns(Namespace),
+    ?retry(250, 10, ?assertNot(emqx_mt_state:is_tombstoned(Namespace))),
+    reset_global_metrics(),
+    delete_all_namespaces(),
+    ok;
+t_namespaced_metrics_dropped_no_subscribers_implicit(Config) when is_list(Config) ->
+    Namespace = ?config(explicit_ns, Config),
+    ClientId = ?NEW_CLIENTID(),
+    %% Username does not match an existing namespace, so client has no tns.
+    Pid = connect(ClientId, <<"no_such_tenant">>),
+    ?assertEqual(0, emqx_metrics:val_global('messages.dropped')),
+    ?assertEqual(0, emqx_metrics:val(Namespace, 'messages.dropped')),
+    {ok, _} = emqtt:publish(Pid, <<"no_one_here">>, <<"hey">>, [{qos, 1}]),
+    ?retry(
+        100,
+        10,
+        ?assertEqual(1, emqx_metrics:val_global('messages.dropped'))
+    ),
+    %% Per-namespace counter stays at zero — the publish does not belong to
+    %% any namespace.
+    ?assertEqual(0, emqx_metrics:val(Namespace, 'messages.dropped')),
+    ?assertEqual(0, emqx_metrics:val(Namespace, 'messages.dropped.no_subscribers')),
+    ok = emqtt:stop(Pid),
+    ok.
+
+-doc """
+`delivery.dropped' is bumped per-namespace for the `no_local' reason when a
+namespaced client publishes to a topic to which it itself is subscribed with
+`no local' set.
+""".
+t_namespaced_metrics_delivery_dropped_no_local({init, Config}) ->
+    Namespace = <<"explicit_ns_no_local">>,
+    ok = emqx_mt_config:create_managed_ns(Namespace),
+    reset_global_metrics(),
+    [{explicit_ns, Namespace} | Config];
+t_namespaced_metrics_delivery_dropped_no_local({'end', Config}) ->
+    Namespace = ?config(explicit_ns, Config),
+    ok = emqx_mt_config:delete_managed_ns(Namespace),
+    ?retry(250, 10, ?assertNot(emqx_mt_state:is_tombstoned(Namespace))),
+    reset_global_metrics(),
+    delete_all_namespaces(),
+    ok;
+t_namespaced_metrics_delivery_dropped_no_local(Config) when is_list(Config) ->
+    Namespace = ?config(explicit_ns, Config),
+    ClientId = ?NEW_CLIENTID(),
+    Pid = connect(ClientId, Namespace),
+    ?assertEqual(0, emqx_metrics:val_global('delivery.dropped')),
+    ?assertEqual(0, emqx_metrics:val(Namespace, 'delivery.dropped')),
+    ?assertEqual(0, emqx_metrics:val_global('delivery.dropped.no_local')),
+    ?assertEqual(0, emqx_metrics:val(Namespace, 'delivery.dropped.no_local')),
+    Topic = <<"self_loop">>,
+    {ok, _, [2]} = emqtt:subscribe(Pid, #{}, [{Topic, [{nl, true}, {qos, 2}]}]),
+    ok = emqtt:publish(Pid, Topic, <<"will be dropped">>, [{qos, 0}]),
+    %% Both umbrella and fine-grained counter move on the namespace, mirroring
+    %% the global counters.
+    ?retry(
+        100,
+        10,
+        ?assertEqual(
+            {1, 1, 1, 1},
+            {
+                emqx_metrics:val_global('delivery.dropped'),
+                emqx_metrics:val(Namespace, 'delivery.dropped'),
+                emqx_metrics:val_global('delivery.dropped.no_local'),
+                emqx_metrics:val(Namespace, 'delivery.dropped.no_local')
+            }
+        )
+    ),
+    ok = emqtt:stop(Pid),
+    ok.
+
+-doc """
+Verifies that `delivery_data_ns' is included in the per-namespace metric map
+returned by `emqx_prometheus:fetch_namespaced_metrics_v1/2', and that the
+rendered Prometheus text exposes `emqx_delivery_dropped' families labelled
+with the originating namespace.
+""".
+t_namespaced_metrics_prometheus_delivery_dropped({init, TCConfig}) ->
+    Nodes = mk_cluster(?FUNCTION_NAME, #{n => 1}, TCConfig),
+    ?ON_ALL(Nodes, begin
+        meck:new(emqx_license_checker, [non_strict, passthrough, no_link]),
+        meck:expect(emqx_license_checker, expiry_epoch, fun() -> 1859673600 end)
+    end),
+    [{nodes, Nodes} | TCConfig];
+t_namespaced_metrics_prometheus_delivery_dropped({'end', _TCConfig}) ->
+    ok;
+t_namespaced_metrics_prometheus_delivery_dropped(TCConfig) when is_list(TCConfig) ->
+    [N | _] = ?config(nodes, TCConfig),
+    Namespace = <<"prom_delivery_ns">>,
+    ok = ?ON(N, emqx_mt_config:create_managed_ns(Namespace)),
+
+    %% Provision an authn entry so the client can connect with this namespace.
+    ?ON(N, begin
+        {ok, _} = emqx_authn_chains:add_user(
+            'mqtt:global',
+            <<"password_based:built_in_database">>,
+            #{user_id => Namespace, namespace => Namespace, password => Namespace}
+        )
+    end),
+
+    %% Connect and trigger a no_local delivery drop.
+    Port = emqx_mt_api_SUITE:get_mqtt_tcp_port(N),
+    ClientId = ?NEW_CLIENTID(),
+    Opts0 = #{
+        clientid => ClientId,
+        username => Namespace,
+        password => Namespace,
+        port => Port
+    },
+    Opts1 = connect_opts_of(TCConfig),
+    Opts = maps:merge(Opts1, Opts0),
+    C1 = connect(Opts),
+    Topic = <<"self_loop">>,
+    {ok, _, [2]} = emqtt:subscribe(C1, #{}, [{Topic, [{nl, true}, {qos, 2}]}]),
+    ok = emqtt:publish(C1, Topic, <<"will be dropped">>, [{qos, 0}]),
+
+    %% The fetched map must include the new key.
+    ?assertMatch(
+        {_, #{delivery_data_ns := _}},
+        ?ON(N, emqx_prometheus:fetch_namespaced_metrics_v1(Namespace, ?PROM_DATA_MODE__NODE))
+    ),
+
+    %% The Prometheus text must contain the delivery_dropped family labelled
+    %% with the namespace, with non-zero values.
+    NsLabel = #{<<"node">> => atom_to_binary(N), <<"namespace">> => Namespace},
+    ?retry(
+        200,
+        25,
+        begin
+            {200, Metrics} =
+                get_prometheus_ns_stats(
+                    Namespace, ?PROM_DATA_MODE__ALL_NODES_UNAGGREGATED, prometheus
+                ),
+            ?assertMatch(
+                #{
+                    <<"emqx_delivery_dropped">> := #{NsLabel := 1},
+                    <<"emqx_delivery_dropped_no_local">> := #{NsLabel := 1}
+                },
+                Metrics,
+                #{
+                    sample =>
+                        maps:with(
+                            [<<"emqx_delivery_dropped">>, <<"emqx_delivery_dropped_no_local">>],
+                            Metrics
+                        )
+                }
+            )
+        end
+    ),
+    ok = emqtt:stop(C1),
+    ok.

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -246,6 +246,7 @@ collect_mf(?PROMETHEUS_NS_STATS_REGISTRY, Callback) ->
 
     ok = add_collect_family(Callback, packet_metric_ns_meta(), ?MG(packet_data_ns, RawData)),
     ok = add_collect_family(Callback, message_metric_ns_meta(), ?MG(message_data_ns, RawData)),
+    ok = add_collect_family(Callback, delivery_metric_ns_meta(), ?MG(delivery_data_ns, RawData)),
     ok = add_collect_family(Callback, session_metric_ns_meta(), ?MG(session_metric_ns, RawData)),
     ok = add_collect_family(Callback, authz_metric_ns_meta(), ?MG(authz_metric_ns, RawData)),
     ok = add_collect_family(Callback, authn_metric_ns_meta(), ?MG(authn_metric_ns, RawData)),
@@ -423,7 +424,8 @@ get_namespace_pd() ->
 fetch_namespaced_metrics_v1(Namespace, Mode) ->
     {node(), #{
         packet_data_ns => metric_data_ns(Namespace, packet_metric_ns_meta(), Mode),
-        message_data_ns => metric_data_ns(Namespace, message_metric_ns_meta(), Mode)
+        message_data_ns => metric_data_ns(Namespace, message_metric_ns_meta(), Mode),
+        delivery_data_ns => metric_data_ns(Namespace, delivery_metric_ns_meta(), Mode)
     }}.
 
 -spec fetch_cluster_wide_namespaced_metrics(all | emqx_config:namespace(), _Mode) -> map().
@@ -1070,6 +1072,9 @@ delivery_metric_meta() ->
         {emqx_delivery_dropped_queue_full, counter, 'delivery.dropped.queue_full'},
         {emqx_delivery_dropped_expired, counter, 'delivery.dropped.expired'}
     ].
+
+delivery_metric_ns_meta() ->
+    delivery_metric_meta().
 
 %%==========
 %% Client

--- a/changes/ee/feat-17665.en.md
+++ b/changes/ee/feat-17665.en.md
@@ -1,0 +1,1 @@
+Added per-namespace counters for dropped messages and dropped deliveries in the multi-tenancy app. The new metrics are exposed via the Prometheus scrape endpoint alongside the existing per-namespace metric families. Operators can now diagnose drop rates per tenant without resorting to log inspection.

--- a/changes/ee/feat-17665.en.md
+++ b/changes/ee/feat-17665.en.md
@@ -1,1 +1,3 @@
-Added per-namespace counters for dropped messages and dropped deliveries in the multi-tenancy app. The new metrics are exposed via the Prometheus scrape endpoint alongside the existing per-namespace metric families. Operators can now diagnose drop rates per tenant without resorting to log inspection.
+Added per-namespace counters for dropped messages and dropped deliveries in the multi-tenancy app. These are exposed at `/api/v5/prometheus/namespaced_stats` with a `namespace` label, alongside the existing per-namespace metric families. Operators can now diagnose drop rates per tenant from Prometheus without resorting to log inspection.
+
+Known limitation: QoS2 PUBREL await-timeout drops do not yet have per-namespace attribution because that drop path bumps the global counter without firing the `message.dropped` hook. Tracked separately.


### PR DESCRIPTION
Release version: 6.1.3, 6.2.2

## Summary

Adds per-namespace counters for `messages.dropped` and `delivery.dropped`
events in the multi-tenancy app, and exposes them via the existing
Prometheus namespaced-metrics endpoint.

Known gap: `emqx_session_events:inc_await_pubrel_timeout/1` (bulk
PUBREL-expiry) does not fire `'message.dropped'`, so the per-namespace
`messages.dropped.await_pubrel_timeout` counter is not bumped on that
path. Closing it requires touching `emqx_session_events`; left for a
follow-up.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)