### PR TITLE
feat(plugins): gate the plugin framework as an EMQX feature

### DIFF
--- a/apps/emqx_machine/src/emqx_machine_features.erl
+++ b/apps/emqx_machine/src/emqx_machine_features.erl
@@ -59,7 +59,6 @@ core_apps() ->
         emqx_ctl,
         emqx_bpapi,
         emqx_license,
-        emqx_plugins,
         emqx_durable_storage,
         emqx_ds_backends,
         emqx_ds_builtin_local,
@@ -145,6 +144,10 @@ known_features() ->
         },
         multi_tenancy => #{
             apps => [emqx_mt],
+            deps => []
+        },
+        plugins => #{
+            apps => [emqx_plugins],
             deps => []
         },
         ai => #{

--- a/apps/emqx_machine/test/emqx_machine_features_tests.erl
+++ b/apps/emqx_machine/test/emqx_machine_features_tests.erl
@@ -281,6 +281,7 @@ test_individual_feature_specific_assertions(Feature) when
     Feature == metrics;
     Feature == cluster_link;
     Feature == multi_tenancy;
+    Feature == plugins;
     Feature == mqtt_extensions;
     Feature == ai;
     Feature == file_transfer;

--- a/apps/emqx_management/mix.exs
+++ b/apps/emqx_management/mix.exs
@@ -28,7 +28,7 @@ defmodule EMQXManagement.MixProject do
       {:emqx_setopts, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_dashboard, in_umbrella: true, runtime: false},
-      {:emqx_plugins, in_umbrella: true},
+      {:emqx_plugins, in_umbrella: true, runtime: false},
       {:emqx_ctl, in_umbrella: true},
       :minirest,
       :emqx_http_lib

--- a/apps/emqx_management/src/emqx_mgmt_api_features.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_features.erl
@@ -109,7 +109,8 @@ example_features_list() ->
                         <<"multi_tenancy">>,
                         <<"ai">>,
                         <<"metrics">>,
-                        <<"mqtt_extensions">>
+                        <<"mqtt_extensions">>,
+                        <<"plugins">>
                     ],
                     bundled => []
                 }

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -70,18 +70,26 @@ api_spec() ->
 scopes() -> ?SCOPE_SYSTEM.
 
 paths() ->
-    [
-        "/plugins",
-        "/plugins/:name",
-        "/plugins/install",
-        "/plugins/:name/:action",
-        "/plugins/:name/config",
-        "/plugins/:name/config/download",
-        "/plugins/:name/config/upload",
-        "/plugins/:name/schema",
-        "/plugins/:name/move",
-        "/plugins/cluster_sync"
-    ].
+    %% The plugin framework is a gated feature: when it is not in the active
+    %% `EMQX_FEATURES' preset, `emqx_plugins' is not started and these routes
+    %% must not be registered.
+    case emqx_machine_features:is_umbrella_application_enabled(emqx_plugins) of
+        false ->
+            [];
+        true ->
+            [
+                "/plugins",
+                "/plugins/:name",
+                "/plugins/install",
+                "/plugins/:name/:action",
+                "/plugins/:name/config",
+                "/plugins/:name/config/download",
+                "/plugins/:name/config/upload",
+                "/plugins/:name/schema",
+                "/plugins/:name/move",
+                "/plugins/cluster_sync"
+            ]
+    end.
 
 schema("/plugins") ->
     #{
@@ -905,6 +913,30 @@ update_plugin_schema_exposes_param_error_test() ->
             }
         }
     } = schema("/plugins/:name/:action").
+
+paths_gated_by_feature_test_() ->
+    {foreach, fun setup_feature_env/0, fun clear_feature_env/1, [
+        {"enabled when plugins feature is on", fun() ->
+            os:putenv("EMQX_FEATURES", "plugins"),
+            emqx_machine_features:clear_features(),
+            ?assertMatch([_ | _], paths())
+        end},
+        {"empty when plugins feature is off", fun() ->
+            os:putenv("EMQX_FEATURES", "dashboard"),
+            emqx_machine_features:clear_features(),
+            ?assertEqual([], paths())
+        end}
+    ]}.
+
+setup_feature_env() ->
+    os:getenv("EMQX_FEATURES").
+
+clear_feature_env(Prev) ->
+    case Prev of
+        false -> os:unsetenv("EMQX_FEATURES");
+        _ -> os:putenv("EMQX_FEATURES", Prev)
+    end,
+    emqx_machine_features:clear_features().
 
 -endif.
 

--- a/apps/emqx_plugins/src/emqx_plugins_api_endpoint.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_api_endpoint.erl
@@ -15,6 +15,9 @@
 -include_lib("emqx/include/emqx_config.hrl").
 -include_lib("emqx_utils/include/emqx_http_api.hrl").
 -include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
 
 -define(DEFAULT_TIMEOUT, 5000).
 
@@ -24,7 +27,15 @@ api_spec() ->
 scopes() -> ?SCOPE_SYSTEM.
 
 paths() ->
-    ["/plugin_api/:plugin/[...]"].
+    %% The plugin framework is a gated feature: when it is not in the active
+    %% `EMQX_FEATURES' preset, `emqx_plugins' is not started and this gateway
+    %% route must not be registered.
+    case emqx_machine_features:is_umbrella_application_enabled(emqx_plugins) of
+        false ->
+            [];
+        true ->
+            ["/plugin_api/:plugin/[...]"]
+    end.
 
 schema("/plugin_api/:plugin/[...]") ->
     #{
@@ -172,3 +183,31 @@ request_namespace(#{auth_meta := #{namespace := ?global_ns}}) ->
     ?global_ns;
 request_namespace(_Request) ->
     ?global_ns.
+
+-ifdef(TEST).
+
+paths_gated_by_feature_test_() ->
+    {foreach, fun setup_feature_env/0, fun clear_feature_env/1, [
+        {"enabled when plugins feature is on", fun() ->
+            os:putenv("EMQX_FEATURES", "plugins"),
+            emqx_machine_features:clear_features(),
+            ?assertMatch([_ | _], paths())
+        end},
+        {"empty when plugins feature is off", fun() ->
+            os:putenv("EMQX_FEATURES", "dashboard"),
+            emqx_machine_features:clear_features(),
+            ?assertEqual([], paths())
+        end}
+    ]}.
+
+setup_feature_env() ->
+    os:getenv("EMQX_FEATURES").
+
+clear_feature_env(Prev) ->
+    case Prev of
+        false -> os:unsetenv("EMQX_FEATURES");
+        _ -> os:putenv("EMQX_FEATURES", Prev)
+    end,
+    emqx_machine_features:clear_features().
+
+-endif.

--- a/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
@@ -19,6 +19,10 @@ init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
             emqx_conf,
+            %% `emqx_plugins' must be started for the `/plugin_api/*' gateway routes
+            %% to be registered: the `plugins' feature gates the route list, and the
+            %% API module is only discovered when its app is loaded.
+            emqx_plugins,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],

--- a/changes/ee/feat-17407.en.md
+++ b/changes/ee/feat-17407.en.md
@@ -19,6 +19,7 @@ The available features are:
 - `ai`: AI features (A2A registry, AI completion).
 - `metrics`: Prometheus metrics exporting.
 - `mqtt_extensions`: MQTT extensions: delayed publish, topic rewrite, auto subscribe, slow subs, message queue, streams.
+- `plugins`: Plugin framework for installing and managing third-party plugins.
 
 The following features cannot be enabled by themselves and are only enabled when using the full preset:
 

--- a/scripts/test/test_emqx_boot.py
+++ b/scripts/test/test_emqx_boot.py
@@ -517,6 +517,7 @@ KNOWN_FEATURES = {
     "gateways": {},
     "cluster_link": {},
     "multi_tenancy": {},
+    "plugins": {},
     "ai": {},
     "metrics": {},
     "file_transfer": {},


### PR DESCRIPTION
Release version:
6.3.0

## Summary

Promotes `emqx_plugins` from an always-on core application to a gated feature, so a regulated deployment can forbid the plugin framework entirely via `EMQX_FEATURES`.

When the `plugins` feature is not in the active preset:
1. `emqx_plugins` is not started.
2. The plugin REST APIs (`/api/v5/plugins/*` and `/api/v5/plugin_api/*`) are not registered.
3. The dashboard hides the plugin management UI (it already keys off `/api/v5/features`).

The default `full` preset keeps the feature enabled, so default deployments are unaffected. Operators running a custom `EMQX_FEATURES` list who want the plugin framework must add `plugins` to that list.

### Key changes
* `apps/emqx_machine/src/emqx_machine_features.erl` — moved `emqx_plugins` out of `core_apps/0` into a new `plugins` feature in `known_features/0`.
* `apps/emqx_management/mix.exs` — made the `emqx_plugins` dependency `runtime: false`. Otherwise `application:ensure_all_started/2` (used at boot by `emqx_machine_boot`) would force-start `emqx_plugins` as an OTP dependency of the always-on `emqx_management` app, defeating the gate. This mirrors how `emqx_dashboard`/`emqx_conf` are already declared.
* `apps/emqx_management/src/emqx_mgmt_api_plugins.erl` and `apps/emqx_plugins/src/emqx_plugins_api_endpoint.erl` — gated `paths/0` on the feature so the routes are not registered when the feature is off (empty swagger spec ⇒ 404).

### Why gate `paths/0` rather than filter the dashboard's app list
The plugin **management** API module (`emqx_mgmt_api_plugins`) is compiled into `emqx_management`, which belongs to the always-on `dashboard` feature. `minirest_api:find_api_modules/1` discovers API modules from each app's module list, so filtering `emqx_dashboard:apps/0` by feature would still expose `/plugins/*`. Gating `paths/0` is the minimal change that removes both API surfaces without relocating release-stable modules.

### Behavior change to call out
Operators who run with a custom `EMQX_FEATURES` value and explicitly list every feature they want will need to add `plugins` to keep the plugin framework. The default preset is `full`, so default deployments are unaffected.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)