### PR TITLE
feat(auth): log per-backend attribution on authn/authz rejection

### DIFF
--- a/apps/emqx/src/emqx_log_throttler.erl
+++ b/apps/emqx/src/emqx_log_throttler.erl
@@ -176,6 +176,8 @@ schedule_refresh(PeriodMs) ->
     erlang:send_after(PeriodMs, ?MODULE, refresh).
 
 new_throttler(Msg) when
+    Msg =:= authenticator_rejection;
+    Msg =:= authorization_source_denied;
     Msg =:= async_send_error;
     Msg =:= unrecoverable_resource_error;
     Msg =:= buffer_worker_dropped_expired_messages;

--- a/apps/emqx/test/emqx_cth_log_capture.erl
+++ b/apps/emqx/test/emqx_cth_log_capture.erl
@@ -1,0 +1,61 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_cth_log_capture).
+
+-moduledoc """
+Test helper to capture structured log reports emitted while running a function.
+
+Installs a temporary `logger` handler that forwards report-style log events at or
+above a given level to the calling process, runs the provided function, and
+returns the captured reports in emission order.
+""".
+
+%% API
+-export([capture/1, capture/2]).
+
+%% logger handler callback
+-export([log/2]).
+
+-define(HANDLER_ID, ?MODULE).
+
+-doc "Same as `capture(warning, Fun)`.".
+-spec capture(fun(() -> term())) -> [map()].
+capture(Fun) ->
+    capture(warning, Fun).
+
+-doc """
+Run `Fun' while capturing log reports at or above `Level', returning the captured
+reports (the `Data' maps passed to `?SLOG'/`?TRACE') in emission order.
+""".
+-spec capture(logger:level(), fun(() -> term())) -> [map()].
+capture(Level, Fun) ->
+    ok = logger:add_handler(?HANDLER_ID, ?MODULE, #{
+        level => Level,
+        config => #{test_pid => self()},
+        filter_default => log,
+        filters => []
+    }),
+    PrevLevel = emqx_logger:get_primary_log_level(),
+    ok = emqx_logger:set_primary_log_level(Level),
+    try
+        _ = Fun(),
+        collect([])
+    after
+        ok = emqx_logger:set_primary_log_level(PrevLevel),
+        ok = logger:remove_handler(?HANDLER_ID)
+    end.
+
+%% @private logger handler callback.
+log(#{msg := {report, Report}}, #{config := #{test_pid := Pid}}) when is_map(Report) ->
+    Pid ! {?MODULE, Report},
+    ok;
+log(_Event, _Config) ->
+    ok.
+
+collect(Acc) ->
+    receive
+        {?MODULE, Report} -> collect([Report | Acc])
+    after 200 -> lists:reverse(Acc)
+    end.

--- a/apps/emqx_auth/include/emqx_authn_chains.hrl
+++ b/apps/emqx_auth/include/emqx_authn_chains.hrl
@@ -23,6 +23,12 @@
 -define(TRACE_AUTHN(Msg, Meta), ?TRACE_AUTHN(debug, Msg, Meta)).
 -define(TRACE_AUTHN(Level, Msg, Meta), ?TRACE(Level, ?AUTHN_TRACE_TAG, Msg, Meta)).
 
+%% Throttled AUTHN trace, keyed by `Key' (e.g. authenticator id) so that a
+%% rejection storm on one authenticator does not suppress logs from another.
+-define(TRACE_AUTHN_THROTTLE(Level, Key, Msg, Meta),
+    ?TRACE_THROTTLE(Level, Key, ?AUTHN_TRACE_TAG, Msg, Meta)
+).
+
 %% config root name all auth providers have to agree on.
 -define(EMQX_AUTHENTICATION_CONFIG_ROOT_NAME, "authentication").
 -define(EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_ATOM, authentication).

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
@@ -798,7 +798,7 @@ do_authenticate(_ChainName, [], _) ->
     {ok, {error, not_authorized}};
 do_authenticate(
     ChainName,
-    [#authenticator{id = ID, provider = _Module} = Authenticator | More],
+    [#authenticator{id = ID, provider = Module} = Authenticator | More],
     Credential
 ) ->
     MetricsID = metrics_id(ChainName, ID),
@@ -819,7 +819,7 @@ do_authenticate(
             'client.username' => maps:get(username, Credential, undefined),
             'authn.authenticator' => ID,
             'authn.chain' => ChainName,
-            'authn.module' => _Module
+            'authn.module' => Module
         }),
         fun() ->
             try authenticate_with_provider(Authenticator, Credential) of
@@ -840,7 +840,12 @@ do_authenticate(
                         {ok, _, _} ->
                             emqx_metrics_worker:inc(authn_metrics, MetricsID, success),
                             ?EXT_TRACE_ADD_ATTRS(#{'authn.result' => ok});
-                        {error, _} ->
+                        {error, ErrReason} ->
+                            ?TRACE_AUTHN_THROTTLE(warning, ID, authenticator_rejection, #{
+                                authenticator => ID,
+                                provider => Module,
+                                reason => ErrReason
+                            }),
                             emqx_metrics_worker:inc(authn_metrics, MetricsID, failed),
                             ?EXT_TRACE_ADD_ATTRS(#{'authn.result' => error}),
                             ?EXT_TRACE_SET_STATUS_ERROR();

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
@@ -669,13 +669,18 @@ log_trace(Res, Type, Module, Username, Topic, PubSub) ->
                 action => emqx_access_control:format_action(PubSub)
             });
         {matched, deny} ->
-            ?TRACE("AUTHZ", "authorization_matched_deny", #{
-                authorize_type => Type,
-                module => Module,
-                username => Username,
-                topic => Topic,
-                action => emqx_access_control:format_action(PubSub)
-            })
+            %% Emit at warning level (throttled per source type) so that operators
+            %% get per-source attribution for denials by default, without having to
+            %% enable a client trace first.
+            ?TRACE_THROTTLE(
+                warning, bin(Type), "AUTHZ", authorization_source_denied, #{
+                    authorize_type => Type,
+                    module => Module,
+                    username => Username,
+                    topic => Topic,
+                    action => emqx_access_control:format_action(PubSub)
+                }
+            )
     end.
 
 format_result(nomatch) ->

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
@@ -287,6 +287,86 @@ t_authenticate({'end', Config}) ->
     ?AUTHN:deregister_provider(?config(authn_type)),
     ok.
 
+-doc "A per-authenticator rejection is logged at warning level with the authenticator id.".
+t_authenticate_rejection_log({init, Config}) ->
+    [
+        {listener_id, 'tcp:default'},
+        {authn_type, {password_based, built_in_database}}
+        | Config
+    ];
+t_authenticate_rejection_log(Config) when is_list(Config) ->
+    ListenerID = ?config(listener_id),
+    AuthNType = ?config(authn_type),
+    ok = register_provider(AuthNType, ?MODULE),
+    AuthenticatorConfig = #{
+        mechanism => password_based,
+        backend => built_in_database,
+        enable => true
+    },
+    {ok, _} = ?AUTHN:create_authenticator(ListenerID, AuthenticatorConfig),
+    ClientInfo = #{
+        zone => default,
+        listener => ListenerID,
+        protocol => mqtt,
+        username => <<"bad">>,
+        password => <<"any">>
+    },
+    Logs = capture_warnings(fun() ->
+        ?assertEqual(
+            {error, bad_username_or_password},
+            emqx_access_control:authenticate(ClientInfo)
+        )
+    end),
+    ?assertMatch(
+        [
+            #{
+                msg := authenticator_rejection,
+                authenticator := <<"password_based:built_in_database">>,
+                provider := _,
+                reason := bad_username_or_password
+            }
+            | _
+        ],
+        [M || #{msg := authenticator_rejection} = M <- Logs]
+    );
+t_authenticate_rejection_log({'end', Config}) ->
+    ?AUTHN:delete_chain(?config(listener_id)),
+    ?AUTHN:deregister_provider(?config(authn_type)),
+    ok.
+
+%% Logger handler callback used by capture_warnings/1.
+log(#{msg := {report, Report}}, #{config := #{test_pid := Pid}}) when is_map(Report) ->
+    Pid ! {captured_log, Report},
+    ok;
+log(_Event, _Config) ->
+    ok.
+
+%% Install a temporary logger handler that forwards warning reports to the test
+%% process, run `Fun', and return the captured reports in emission order.
+capture_warnings(Fun) ->
+    HandlerId = test_capture_handler,
+    ok = logger:add_handler(HandlerId, ?MODULE, #{
+        level => warning,
+        config => #{test_pid => self()},
+        filter_default => log,
+        filters => []
+    }),
+    PrevLevel = emqx_logger:get_primary_log_level(),
+    ok = emqx_logger:set_primary_log_level(warning),
+    try
+        _ = Fun(),
+        collect_captured([])
+    after
+        ok = emqx_logger:set_primary_log_level(PrevLevel),
+        ok = logger:remove_handler(HandlerId)
+    end.
+
+collect_captured(Acc) ->
+    receive
+        {captured_log, Report} -> collect_captured([Report | Acc])
+    after 200 -> lists:reverse(Acc)
+    end.
+
 t_update_config({init, Config}) ->
     Global = 'mqtt:global',
     AuthNType1 = {password_based, built_in_database},

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
@@ -311,7 +311,7 @@ t_authenticate_rejection_log(Config) when is_list(Config) ->
         username => <<"bad">>,
         password => <<"any">>
     },
-    Logs = capture_warnings(fun() ->
+    Logs = emqx_cth_log_capture:capture(fun() ->
         ?assertEqual(
             {error, bad_username_or_password},
             emqx_access_control:authenticate(ClientInfo)
@@ -333,39 +333,6 @@ t_authenticate_rejection_log({'end', Config}) ->
     ?AUTHN:delete_chain(?config(listener_id)),
     ?AUTHN:deregister_provider(?config(authn_type)),
     ok.
-
-%% Logger handler callback used by capture_warnings/1.
-log(#{msg := {report, Report}}, #{config := #{test_pid := Pid}}) when is_map(Report) ->
-    Pid ! {captured_log, Report},
-    ok;
-log(_Event, _Config) ->
-    ok.
-
-%% Install a temporary logger handler that forwards warning reports to the test
-%% process, run `Fun', and return the captured reports in emission order.
-capture_warnings(Fun) ->
-    HandlerId = test_capture_handler,
-    ok = logger:add_handler(HandlerId, ?MODULE, #{
-        level => warning,
-        config => #{test_pid => self()},
-        filter_default => log,
-        filters => []
-    }),
-    PrevLevel = emqx_logger:get_primary_log_level(),
-    ok = emqx_logger:set_primary_log_level(warning),
-    try
-        _ = Fun(),
-        collect_captured([])
-    after
-        ok = emqx_logger:set_primary_log_level(PrevLevel),
-        ok = logger:remove_handler(HandlerId)
-    end.
-
-collect_captured(Acc) ->
-    receive
-        {captured_log, Report} -> collect_captured([Report | Acc])
-    after 200 -> lists:reverse(Acc)
-    end.
 
 t_update_config({init, Config}) ->
     Global = 'mqtt:global',

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
@@ -551,6 +551,58 @@ t_precondition_render_error_skips_source(_Config) ->
         end
     ).
 
+t_source_denied_logged_at_warning(_Config) ->
+    Source = ?SOURCE_FILE(<<"{deny, all}.">>),
+    {ok, _} = emqx_authz:update(?CMD_REPLACE, [Source]),
+    ClientInfo = emqx_authz_test_lib:base_client_info(),
+    Logs = capture_warnings(fun() ->
+        deny = emqx_access_control:authorize(ClientInfo, ?AUTHZ_SUBSCRIBE, <<"t">>)
+    end),
+    ?assertMatch(
+        [
+            #{
+                msg := authorization_source_denied,
+                authorize_type := file,
+                module := emqx_authz_file
+            }
+            | _
+        ],
+        [M || #{msg := authorization_source_denied} = M <- Logs]
+    ).
+
+%% Logger handler callback used by capture_warnings/1.
+log(#{msg := {report, Report}}, #{config := #{test_pid := Pid}}) when is_map(Report) ->
+    Pid ! {captured_log, Report},
+    ok;
+log(_Event, _Config) ->
+    ok.
+
+%% Install a temporary logger handler that forwards warning reports to the test
+%% process, run `Fun', and return the captured reports in emission order.
+capture_warnings(Fun) ->
+    HandlerId = test_capture_handler,
+    ok = logger:add_handler(HandlerId, ?MODULE, #{
+        level => warning,
+        config => #{test_pid => self()},
+        filter_default => log,
+        filters => []
+    }),
+    PrevLevel = emqx_logger:get_primary_log_level(),
+    ok = emqx_logger:set_primary_log_level(warning),
+    try
+        _ = Fun(),
+        collect_captured([])
+    after
+        ok = emqx_logger:set_primary_log_level(PrevLevel),
+        ok = logger:remove_handler(HandlerId)
+    end.
+
+collect_captured(Acc) ->
+    receive
+        {captured_log, Report} -> collect_captured([Report | Acc])
+    after 200 -> lists:reverse(Acc)
+    end.
+
 t_precondition_skips_source(_Config) ->
     ClientInfo = #{
         username => <<"u">>,

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
@@ -551,11 +551,12 @@ t_precondition_render_error_skips_source(_Config) ->
         end
     ).
 
+-doc "A source matching deny is logged at warning level with the source type and module.".
 t_source_denied_logged_at_warning(_Config) ->
     Source = ?SOURCE_FILE(<<"{deny, all}.">>),
     {ok, _} = emqx_authz:update(?CMD_REPLACE, [Source]),
     ClientInfo = emqx_authz_test_lib:base_client_info(),
-    Logs = capture_warnings(fun() ->
+    Logs = emqx_cth_log_capture:capture(fun() ->
         deny = emqx_access_control:authorize(ClientInfo, ?AUTHZ_SUBSCRIBE, <<"t">>)
     end),
     ?assertMatch(
@@ -569,39 +570,6 @@ t_source_denied_logged_at_warning(_Config) ->
         ],
         [M || #{msg := authorization_source_denied} = M <- Logs]
     ).
-
-%% Logger handler callback used by capture_warnings/1.
-log(#{msg := {report, Report}}, #{config := #{test_pid := Pid}}) when is_map(Report) ->
-    Pid ! {captured_log, Report},
-    ok;
-log(_Event, _Config) ->
-    ok.
-
-%% Install a temporary logger handler that forwards warning reports to the test
-%% process, run `Fun', and return the captured reports in emission order.
-capture_warnings(Fun) ->
-    HandlerId = test_capture_handler,
-    ok = logger:add_handler(HandlerId, ?MODULE, #{
-        level => warning,
-        config => #{test_pid => self()},
-        filter_default => log,
-        filters => []
-    }),
-    PrevLevel = emqx_logger:get_primary_log_level(),
-    ok = emqx_logger:set_primary_log_level(warning),
-    try
-        _ = Fun(),
-        collect_captured([])
-    after
-        ok = emqx_logger:set_primary_log_level(PrevLevel),
-        ok = logger:remove_handler(HandlerId)
-    end.
-
-collect_captured(Acc) ->
-    receive
-        {captured_log, Report} -> collect_captured([Report | Acc])
-    after 200 -> lists:reverse(Acc)
-    end.
 
 t_precondition_skips_source(_Config) ->
     ClientInfo = #{

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -105,7 +105,9 @@
 -define(LOG_THROTTLING_MSGS, [
     async_send_error,
     authentication_failure,
+    authenticator_rejection,
     authorization_permission_denied,
+    authorization_source_denied,
     buffer_worker_dropped_expired_messages,
     cannot_deliver_from_topic_due_to_quota_exceeded,
     cannot_publish_to_topic_due_to_not_authorized,

--- a/changes/ee/feat-17671.en.md
+++ b/changes/ee/feat-17671.en.md
@@ -1,0 +1,5 @@
+Authentication and authorization rejection logs now include per-backend attribution.
+
+When EMQX rejects a client because an authenticator returns an error, it now emits a warning log identifying the authenticator id and provider that produced the rejection. When an authorization source denies an operation, the denial is now logged at warning level (previously only visible under a client trace) with the source type, module, topic and action.
+
+This makes it possible to tell which backend produced a decision in deployments with multiple authenticators or authorization sources, without having to enable a client trace first. The new logs are throttled per authenticator and per authorization source to avoid log floods.


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Adds per-backend attribution to authentication and authorization rejection logs (issue #17661). In multi-backend deployments operators previously could not tell which authenticator or authorization source produced a rejection.

Changes:
- `emqx_authn_chains:do_authenticate/3` — when a per-authenticator step returns `{error, Reason}`, emit a `warning` log `authenticator_rejection` with the authenticator id, provider module and reason. Previously only the OTel span attribute was set and no log was emitted at this point.
- `emqx_authz:log_trace/6` — the `{matched, deny}` outcome is now logged at `warning` level (`authorization_source_denied`) with the source type and module. Previously this was only visible at `debug` level under a client trace.
- Both new logs are throttled (per authenticator id and per source type respectively) and registered in `log.throttling.msgs`, consistent with the existing `authentication_failure` / `authorization_permission_denied` aggregate logs.

Most relevant files: `apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl`, `apps/emqx_auth/src/emqx_authz/emqx_authz.erl`, `apps/emqx_conf/src/emqx_conf_schema.erl`, `apps/emqx/src/emqx_log_throttler.erl`.

The final aggregate `authentication_failure` log emitted from `emqx_channel` is left unchanged; threading the failing authenticator id all the way back up is out of scope for this PR.

Closes #17661

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
