### PR TITLE
feat(authn): fail closed on authentication backend failures

### DIFF
--- a/apps/emqx/src/emqx_access_control.erl
+++ b/apps/emqx/src/emqx_access_control.erl
@@ -74,6 +74,18 @@ end).
 
 -define(DEFAULT_AUTH_RESULT_PT_KEY, {?MODULE, default_authn_result}).
 
+-define(IS_AUTH_ERROR(Result),
+    (Result =:= client_identifier_not_valid orelse
+        Result =:= bad_username_or_password orelse
+        Result =:= bad_clientid_or_password orelse
+        Result =:= not_authorized orelse
+        Result =:= server_unavailable orelse
+        Result =:= server_busy orelse
+        Result =:= banned orelse
+        Result =:= bad_authentication_method orelse
+        Result =:= quota_exceeded)
+).
+
 -ifdef(TEST).
 -define(DEFAULT_AUTH_RESULT, ok).
 -else.
@@ -89,7 +101,7 @@ end).
     | {ok, authn_result(), authn_data()}
     | {continue, authn_cache()}
     | {continue, authn_data(), authn_cache()}
-    | {error, not_authorized}.
+    | {error, emqx_types:auth_result()}.
 authenticate(Credential) ->
     %% pre-hook quick authentication or
     %% if auth backend returning nothing but just 'ok'
@@ -112,9 +124,13 @@ authenticate(Credential) ->
                 {ok, AuthResult, _AuthData} = OkResult ->
                     on_authentication_complete_success(Credential, AuthResult, ok),
                     OkResult;
-                {error, Reason} = Error ->
+                {error, Reason} = Error when ?IS_AUTH_ERROR(Reason) ->
                     on_authentication_complete_error(Credential, Reason),
                     Error;
+                {error, Reason} ->
+                    %% Unknown error, treat as not_authorized
+                    on_authentication_complete_error(Credential, Reason),
+                    {error, not_authorized};
                 {continue, _AuthCache} = IncompleteResult ->
                     IncompleteResult;
                 {continue, _AuthData, _AuthCache} = IncompleteResult ->
@@ -384,6 +400,7 @@ on_authentication_complete_error(Credential, Reason) ->
         ]
     ),
     inc_authn_metrics(error).
+
 on_authentication_complete_success(Credential, Result, Type) ->
     emqx_hooks:run(
         'client.check_authn_complete',

--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -47,6 +47,7 @@ Returns policy depending on the current security profile.
     (mqtt_default_bind) -> loopback | any;
     (dashboard_http_default_bind) -> loopback | any;
     (authn_not_configured) -> allow | deny;
+    (authn_backend_failure) -> ignore | deny;
     (authz_backend_failure) -> ignore | deny;
     (dashboard_unchanged_default_credentials) -> allow | deny;
     (access_control_hook_failure) -> ignore | interrupt.
@@ -63,6 +64,11 @@ policy(dashboard_http_default_bind) ->
 policy(authn_not_configured) ->
     case profile() of
         legacy -> allow;
+        hardened -> deny
+    end;
+policy(authn_backend_failure) ->
+    case profile() of
+        legacy -> ignore;
         hardened -> deny
     end;
 policy(authz_backend_failure) ->

--- a/apps/emqx/src/emqx_types.erl
+++ b/apps/emqx/src/emqx_types.erl
@@ -50,6 +50,10 @@
 ]).
 
 -export_type([
+    auth_result/0
+]).
+
+-export_type([
     connack/0,
     subopts/0,
     reason_code/0,
@@ -204,7 +208,8 @@
     | server_unavailable
     | server_busy
     | banned
-    | bad_authentication_method.
+    | bad_authentication_method
+    | quota_exceeded.
 
 -type packet_type() :: ?RESERVED..?AUTH.
 -type connack() :: ?CONNACK_ACCEPT..?CONNACK_AUTH.

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -43,6 +43,7 @@ t_legacy(_) ->
 
     %% verify the mode itself
     ?assertEqual(legacy, emqx_security_profile:profile()),
+    ?assertEqual(ignore, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(ignore, emqx_security_profile:policy(authz_backend_failure)),
 
     %% Full defaults
@@ -80,6 +81,7 @@ t_hardened(_) ->
 
     %% verify the mode itself
     ?assertEqual(hardened, emqx_security_profile:profile()),
+    ?assertEqual(deny, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(deny, emqx_security_profile:policy(authz_backend_failure)),
 
     %% Full defaults are secure in hardened profile

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
@@ -843,17 +843,27 @@ do_authenticate(
                             Stacktrace
                         )
                     ),
-                    emqx_metrics_worker:inc(authn_metrics, MetricsID, nomatch),
-                    with_provider_failed
+                    FailureResult = emqx_authn_utils:backend_failure_result(),
+                    inc_failure_metric(MetricsID, FailureResult),
+                    maybe_stop_on_failure(FailureResult)
             end
         end,
         []
     ),
     case Result of
-        with_provider_failed -> do_authenticate(ChainName, More, Credential);
         ignore -> do_authenticate(ChainName, More, Credential);
         {stop, _} -> Result
     end.
+
+inc_failure_metric(MetricsID, ignore) ->
+    emqx_metrics_worker:inc(authn_metrics, MetricsID, nomatch);
+inc_failure_metric(MetricsID, {error, _}) ->
+    emqx_metrics_worker:inc(authn_metrics, MetricsID, failed).
+
+maybe_stop_on_failure(ignore) ->
+    ignore;
+maybe_stop_on_failure({error, _} = Error) ->
+    {stop, Error}.
 
 maybe_add_stacktrace('throw', Data, _Stacktrace) ->
     Data;
@@ -861,21 +871,28 @@ maybe_add_stacktrace(_, Data, Stacktrace) ->
     Data#{stacktrace => Stacktrace}.
 
 check_precondition(undefined, _) ->
-    true;
+    {ok, true};
 check_precondition(Precondition, Credential0) ->
     Credential = emqx_auth_template:rename_client_info_vars(Credential0),
     case emqx_variform:render(Precondition, Credential) of
         {ok, <<"true">>} ->
-            true;
+            {ok, true};
         Other ->
             Other
     end.
 
 authenticate_with_provider(#authenticator{precondition = Precondition} = A, Credential) ->
     case check_precondition(Precondition, Credential) of
-        true ->
+        {ok, true} ->
             do_authenticate_with_provider(A, Credential);
-        Other ->
+        {error, _} = Error ->
+            ?TRACE_AUTHN("precondition_error", #{
+                authenticator => A#authenticator.id,
+                expression => emqx_variform:decompile(Precondition),
+                result => Error
+            }),
+            emqx_authn_utils:backend_failure_result();
+        {ok, Other} ->
             ?TRACE_AUTHN("precondition_not_met", #{
                 authenticator => A#authenticator.id,
                 expression => emqx_variform:decompile(Precondition),

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_schema.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_schema.erl
@@ -220,6 +220,12 @@ enable(_) -> undefined.
 
 fields("settings") ->
     [
+        {"ignore_backend_failures",
+            hoconsc:mk(boolean(), #{
+                default => false,
+                desc => ?DESC(ignore_backend_failures),
+                importance => ?IMPORTANCE_LOW
+            })},
         {"node_cache",
             ?HOCON(
                 ?R_REF(emqx_auth_cache_schema, config),
@@ -229,7 +235,7 @@ fields("settings") ->
                     default => emqx_auth_cache_schema:default_config()
                 }
             )},
-        {builtin_record_count_refresh_interval,
+        {"builtin_record_count_refresh_interval",
             hoconsc:mk(emqx_schema:timeout_duration_ms(), #{
                 default => <<"1h">>,
                 importance => ?IMPORTANCE_HIDDEN

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
@@ -25,6 +25,8 @@
     make_resource_id/1,
     without_password/1,
     to_bool/1,
+    backend_failure_result/0,
+    authn_backend_failure_policy/0,
     cached_simple_sync_query/3
 ]).
 
@@ -214,6 +216,25 @@ to_bool(_) ->
 
 cached_simple_sync_query(CacheKey, ResourceID, Query) ->
     emqx_auth_utils:cached_simple_sync_query(?AUTHN_CACHE, CacheKey, ResourceID, Query).
+
+-spec backend_failure_result() -> ignore | {error, not_authorized}.
+backend_failure_result() ->
+    case authn_backend_failure_policy() of
+        ignore -> ignore;
+        deny -> {error, not_authorized}
+    end.
+
+-spec authn_backend_failure_policy() -> ignore | deny.
+authn_backend_failure_policy() ->
+    case emqx_security_profile:policy(authn_backend_failure) of
+        deny ->
+            case emqx:get_config([authentication_settings, ignore_backend_failures], false) of
+                true -> ignore;
+                false -> deny
+            end;
+        ignore ->
+            ignore
+    end.
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
@@ -36,10 +36,19 @@
     owner_id => OWNER_ID
 }).
 
+-type authn_provider_state() :: #{resource_id => binary(), enable => boolean(), _ => _}.
+-type resource_config() :: map().
+-type mechanism() :: atom() | binary().
+-type backend() :: atom() | binary().
+-type template_var() :: emqx_template:varname() | {var_namespace, emqx_template:varname()}.
+-type used_template_vars() :: [template_var()].
+
 %%--------------------------------------------------------------------
 %% APIs
 %%--------------------------------------------------------------------
 
+-spec create_resource(module(), resource_config(), authn_provider_state(), mechanism(), backend()) ->
+    ok | {error, term()}.
 create_resource(Module, ResourceConfig, #{resource_id := ResourceId} = State, Mechanism, Backend) ->
     maybe
         OwnerId = owner_id(Mechanism, Backend),
@@ -54,6 +63,8 @@ create_resource(Module, ResourceConfig, #{resource_id := ResourceId} = State, Me
         ok = start_resource_if_enabled(State, Mechanism, Backend)
     end.
 
+-spec update_resource(module(), resource_config(), authn_provider_state(), mechanism(), backend()) ->
+    ok | {error, term()}.
 update_resource(Module, ResourceConfig, #{resource_id := ResourceId} = State, Mechanism, Backend) ->
     maybe
         OwnerId = owner_id(Mechanism, Backend),
@@ -64,6 +75,7 @@ update_resource(Module, ResourceConfig, #{resource_id := ResourceId} = State, Me
         start_resource_if_enabled(State, Mechanism, Backend)
     end.
 
+-spec start_resource_if_enabled(authn_provider_state(), mechanism(), backend()) -> ok.
 start_resource_if_enabled(#{resource_id := ResourceId, enable := true}, Mechanism, Backend) ->
     case emqx_resource:start(ResourceId) of
         ok ->
@@ -83,6 +95,7 @@ start_resource_if_enabled(#{resource_id := ResourceId, enable := true}, Mechanis
 start_resource_if_enabled(#{resource_id := _ResourceId, enable := false}, _Mechanism, _Backend) ->
     ok.
 
+-spec init_state(map(), map()) -> authn_provider_state().
 init_state(#{enable := Enable} = _Source, Values) ->
     maps:merge(
         #{
@@ -91,16 +104,23 @@ init_state(#{enable := Enable} = _Source, Values) ->
         Values
     ).
 
+-spec cleanup_resource_config(list(atom()), resource_config()) -> resource_config().
 cleanup_resource_config(WithoutFields, Config) ->
     maps:without([enable] ++ WithoutFields, Config).
 
+-spec parse_deep(term()) -> {used_template_vars(), emqx_template:t()}.
 parse_deep(Template) -> emqx_auth_template:parse_deep(Template, ?AUTHN_DEFAULT_ALLOWED_VARS).
 
+-spec parse_str(unicode:chardata()) -> {used_template_vars(), emqx_template:t()}.
 parse_str(Template) -> emqx_auth_template:parse_str(Template, ?AUTHN_DEFAULT_ALLOWED_VARS).
 
+-spec parse_sql(emqx_template_sql:raw_statement_template(), emqx_template_sql:sql_parameters()) ->
+    {used_template_vars(), emqx_template_sql:statement(), emqx_template_sql:row_template()}.
 parse_sql(Template, ReplaceWith) ->
     emqx_auth_template:parse_sql(Template, ReplaceWith, ?AUTHN_DEFAULT_ALLOWED_VARS).
 
+-spec check_password_from_selected_map(atom(), #{binary() => term()}, binary() | undefined) ->
+    {error, bad_username_or_password} | ok.
 check_password_from_selected_map(_Algorithm, _Selected, undefined) ->
     {error, bad_username_or_password};
 check_password_from_selected_map(Algorithm, Selected, Password) ->
@@ -124,16 +144,19 @@ check_password_from_selected_map(Algorithm, Selected, Password) ->
             end
     end.
 
+-spec is_superuser(#{binary() => term()}) -> #{is_superuser => boolean()}.
 is_superuser(#{<<"is_superuser">> := Value}) ->
     #{is_superuser => to_bool(Value)};
 is_superuser(#{}) ->
     #{is_superuser => false}.
 
+-spec client_attrs(#{binary() => term()}) -> #{client_attrs => map()}.
 client_attrs(#{<<"client_attrs">> := Attrs}) ->
     #{client_attrs => drop_invalid_attr(Attrs)};
 client_attrs(_) ->
     #{client_attrs => #{}}.
 
+-spec clientid_override(#{binary() => term()}) -> #{clientid_override => term()}.
 clientid_override(#{<<"clientid_override">> := Value}) when
     is_binary(Value) andalso Value /= <<"">>
 ->
@@ -141,45 +164,35 @@ clientid_override(#{<<"clientid_override">> := Value}) when
 clientid_override(_) ->
     #{}.
 
-drop_invalid_attr(Map) when is_map(Map) ->
-    maps:from_list(do_drop_invalid_attr(maps:to_list(Map))).
-
-do_drop_invalid_attr([]) ->
-    [];
-do_drop_invalid_attr([{K, V} | More]) ->
-    case emqx_utils:is_restricted_str(K) of
-        true ->
-            [{iolist_to_binary(K), iolist_to_binary(V)} | do_drop_invalid_attr(More)];
-        false ->
-            ?SLOG(debug, #{msg => "invalid_client_attr_dropped", attr_name => K}, #{
-                tag => "AUTHN"
-            }),
-            do_drop_invalid_attr(More)
-    end.
-
+-spec ensure_apps_started(term()) -> ok.
 ensure_apps_started(bcrypt) ->
     {ok, _} = application:ensure_all_started(bcrypt),
     ok;
 ensure_apps_started(_) ->
     ok.
 
+-spec bin(atom() | binary() | list()) -> binary().
 bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
 bin(L) when is_list(L) -> iolist_to_binary(L);
 bin(X) when is_binary(X) -> X.
 
+-spec cleanup_resources() -> ok.
 cleanup_resources() ->
     lists:foreach(
         fun emqx_resource:remove_local/1,
         emqx_resource:list_group_instances(?AUTHN_RESOURCE_GROUP)
     ).
 
+-spec make_resource_id(term()) -> emqx_resource:resource_id().
 make_resource_id(Name) ->
     NameBin = bin([<<"authn:">>, bin(Name)]),
     emqx_resource:generate_id(NameBin).
 
+-spec without_password(map()) -> map().
 without_password(Credential) ->
     without_password(Credential, [password, <<"password">>]).
 
+-spec to_bool(term()) -> boolean().
 to_bool(<<"true">>) ->
     true;
 to_bool(true) ->
@@ -214,6 +227,11 @@ to_bool(MaybeBinInt) when is_binary(MaybeBinInt) ->
 to_bool(_) ->
     false.
 
+-spec cached_simple_sync_query(
+    emqx_auth_cache:cache_key(),
+    emqx_resource:resource_id(),
+    _Request :: term()
+) -> term().
 cached_simple_sync_query(CacheKey, ResourceID, Query) ->
     emqx_auth_utils:cached_simple_sync_query(?AUTHN_CACHE, CacheKey, ResourceID, Query).
 
@@ -252,3 +270,19 @@ without_password(Credential, [Name | Rest]) ->
 
 owner_id(Mechanism, Backend) ->
     bin([bin(Mechanism), ":", bin(Backend)]).
+
+drop_invalid_attr(Map) when is_map(Map) ->
+    maps:from_list(do_drop_invalid_attr(maps:to_list(Map))).
+
+do_drop_invalid_attr([]) ->
+    [];
+do_drop_invalid_attr([{K, V} | More]) ->
+    case emqx_utils:is_restricted_str(K) of
+        true ->
+            [{iolist_to_binary(K), iolist_to_binary(V)} | do_drop_invalid_attr(More)];
+        false ->
+            ?SLOG(debug, #{msg => "invalid_client_attr_dropped", attr_name => K}, #{
+                tag => "AUTHN"
+            }),
+            do_drop_invalid_attr(More)
+    end.

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
@@ -41,16 +41,23 @@
 %% Callbacks
 %%------------------------------------------------------------------------------
 
-create(_AuthenticatorID, _Config) ->
-    {ok, #{mark => 1}}.
+create(_AuthenticatorID, Config) ->
+    {ok, #{mark => 1, config => Config}}.
 
-update(_Config, _State) ->
-    {ok, #{mark => 2}}.
+update(Config, _State) ->
+    {ok, #{mark => 2, config => Config}}.
 
 authenticate(#{username := <<"good">>}, _State) ->
     {ok, #{is_superuser => true}};
 authenticate(#{username := <<"ignore">>}, _State) ->
     ignore;
+authenticate(
+    #{username := <<"backend_failure">>},
+    #{config := #{backend := built_in_database}}
+) ->
+    emqx_authn_utils:backend_failure_result();
+authenticate(#{username := <<"backend_failure">>}, _State) ->
+    {ok, #{is_superuser => true}};
 authenticate(#{username := <<"emqx_authn_ignore_for_hook_good">>}, _State) ->
     ignore;
 authenticate(#{username := <<"emqx_authn_ignore_for_hook_bad">>}, _State) ->
@@ -614,6 +621,46 @@ t_authn_not_configured_empty_chain({'end', _Config}) ->
     ok = ?AUTHN:deregister_provider({password_based, built_in_database}),
     emqx_common_test_helpers:clear_security_profile().
 
+t_authn_backend_failure_legacy_continues_chain({'init', Config}) ->
+    setup_backend_failure_chain(),
+    Config;
+t_authn_backend_failure_legacy_continues_chain(Config) when is_list(Config) ->
+    ClientInfo = backend_failure_clientinfo(),
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ?assertEqual({ok, #{is_superuser => true}}, emqx_access_control:authenticate(ClientInfo))
+    end),
+    ok;
+t_authn_backend_failure_legacy_continues_chain({'end', _Config}) ->
+    cleanup_backend_failure_chain().
+
+t_authn_backend_failure_hardened_aborts_chain({'init', Config}) ->
+    setup_backend_failure_chain(),
+    Config;
+t_authn_backend_failure_hardened_aborts_chain(Config) when is_list(Config) ->
+    ClientInfo = backend_failure_clientinfo(),
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ?assertEqual({error, not_authorized}, emqx_access_control:authenticate(ClientInfo))
+    end),
+    ok;
+t_authn_backend_failure_hardened_aborts_chain({'end', _Config}) ->
+    cleanup_backend_failure_chain().
+
+t_authn_backend_failure_policy_override({'init', Config}) ->
+    Config;
+t_authn_backend_failure_policy_override(Config) when is_list(Config) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        {ok, _} = emqx:update_config([authentication_settings, ignore_backend_failures], false),
+        ?assertEqual(deny, emqx_authn_utils:authn_backend_failure_policy()),
+        ?assertEqual({error, not_authorized}, emqx_authn_utils:backend_failure_result()),
+
+        {ok, _} = emqx:update_config([authentication_settings, ignore_backend_failures], true),
+        ?assertEqual(ignore, emqx_authn_utils:authn_backend_failure_policy()),
+        ?assertEqual(ignore, emqx_authn_utils:backend_failure_result())
+    end);
+t_authn_backend_failure_policy_override({'end', _Config}) ->
+    {ok, _} = emqx:update_config([authentication_settings, ignore_backend_failures], false),
+    emqx_common_test_helpers:clear_security_profile().
+
 %%=================================================================================
 %% Helpers fns
 %%=================================================================================
@@ -631,6 +678,40 @@ cleanup_authn_not_configured_chains() ->
     _ = ?AUTHN:delete_chain('tcp:default'),
     _ = ?AUTHN:delete_chain('mqtt:global'),
     ok.
+
+backend_failure_clientinfo() ->
+    #{
+        zone => default,
+        listener => 'tcp:default',
+        protocol => mqtt,
+        username => <<"backend_failure">>,
+        password => <<"any">>
+    }.
+
+setup_backend_failure_chain() ->
+    ListenerID = 'tcp:default',
+    AuthNType1 = {password_based, built_in_database},
+    AuthNType2 = {password_based, mysql},
+    ok = register_provider(AuthNType1, ?MODULE),
+    ok = register_provider(AuthNType2, ?MODULE),
+    {ok, _} = ?AUTHN:create_authenticator(ListenerID, #{
+        mechanism => password_based,
+        backend => built_in_database,
+        enable => true
+    }),
+    {ok, _} = ?AUTHN:create_authenticator(ListenerID, #{
+        mechanism => password_based,
+        backend => mysql,
+        enable => true
+    }),
+    ok.
+
+cleanup_backend_failure_chain() ->
+    ok = ?AUTHN:delete_chain('tcp:default'),
+    ok = ?AUTHN:deregister_provider({password_based, built_in_database}),
+    ok = ?AUTHN:deregister_provider({password_based, mysql}),
+    {ok, _} = emqx:update_config([authentication_settings, ignore_backend_failures], false),
+    emqx_common_test_helpers:clear_security_profile().
 
 hook(Priority) ->
     ok = emqx_hooks:put(

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_test_lib.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_test_lib.erl
@@ -79,6 +79,23 @@ enable_node_cache(Enable) ->
     emqx_auth_cache:reset(?AUTHN_CACHE),
     ok.
 
+add_permissive_builtin_authenticator(Path, Chain, Username, Password) ->
+    Config = #{
+        <<"mechanism">> => <<"password_based">>,
+        <<"backend">> => <<"built_in_database">>,
+        <<"password_hash_algorithm">> => #{
+            <<"name">> => <<"plain">>,
+            <<"salt_position">> => <<"disable">>
+        }
+    },
+    {ok, _} = emqx:update_config(Path, {create_authenticator, Chain, Config}),
+    {ok, _} = emqx_authn_chains:add_user(
+        Chain,
+        <<"password_based:built_in_database">>,
+        #{user_id => Username, password => Password}
+    ),
+    ok.
+
 -doc """
 Checks that, if an authentication backend returns the `clientid_override` attribute, it's
 used to override.

--- a/apps/emqx_auth_http/src/emqx_authn_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_http.erl
@@ -203,7 +203,7 @@ handle_response(Headers, Body) ->
         {ok, NBody} ->
             body_to_auth_data(NBody);
         {error, _Reason} ->
-            ignore
+            emqx_authn_utils:backend_failure_result()
     end.
 
 body_to_auth_data(Body) ->
@@ -215,7 +215,7 @@ body_to_auth_data(Body) ->
         <<"ignore">> ->
             ignore;
         _ ->
-            ignore
+            emqx_authn_utils:backend_failure_result()
     end.
 
 extract_auth_data(Source, Body) ->

--- a/apps/emqx_auth_http/src/emqx_authn_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_http.erl
@@ -95,11 +95,11 @@ authenticate(
                 {ok, 200, Headers, Body} ->
                     handle_response(Headers, Body);
                 {ok, _StatusCode, _Headers} = Response ->
-                    ignore;
+                    emqx_authn_utils:backend_failure_result();
                 {ok, _StatusCode, _Headers, _Body} = Response ->
-                    ignore;
+                    emqx_authn_utils:backend_failure_result();
                 {error, _Reason} ->
-                    ignore
+                    emqx_authn_utils:backend_failure_result()
             end;
         {error, Reason} ->
             ?TRACE_AUTHN_PROVIDER(
@@ -107,7 +107,7 @@ authenticate(
                 "generate_http_request_failed",
                 #{reason => Reason, credential => emqx_authn_utils:without_password(Credential)}
             ),
-            ignore
+            emqx_authn_utils:backend_failure_result()
     end.
 
 destroy(#{resource_id := ResourceId}) ->

--- a/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
@@ -79,9 +79,11 @@ groups() ->
 
 init_per_suite(TCConfig) ->
     emqx_utils:interactive_load(emqx_variform_bif),
-    Apps = emqx_cth_suite:start([cowboy, emqx, emqx_conf, emqx_auth, emqx_auth_http], #{
-        work_dir => ?config(priv_dir, TCConfig)
-    }),
+    Apps = emqx_cth_suite:start(
+        [cowboy, emqx, emqx_conf, emqx_auth, emqx_auth_mnesia, emqx_auth_http], #{
+            work_dir => ?config(priv_dir, TCConfig)
+        }
+    ),
     [{apps, Apps} | TCConfig].
 
 end_per_suite(TCConfig) ->
@@ -178,6 +180,22 @@ t_authenticate(TCConfig) ->
         end,
         samples()
     ).
+
+t_backend_failure_legacy_ignores(TCConfig) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ?assertEqual(
+            {ok, #{is_superuser => false}},
+            authenticate_with_unexpected_status(TCConfig)
+        )
+    end).
+
+t_backend_failure_hardened_denies(TCConfig) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ?assertEqual(
+            {error, not_authorized},
+            authenticate_with_unexpected_status(TCConfig)
+        )
+    end).
 
 test_user_auth(
     TCConfig,
@@ -1478,6 +1496,24 @@ samples() ->
             result => {error, not_authorized}
         }
     ].
+
+unexpected_status_handler() ->
+    fun(Req0, State) ->
+        Req = cowboy_req:reply(500, Req0),
+        {ok, Req, State}
+    end.
+
+authenticate_with_unexpected_status(TCConfig) ->
+    AuthConfig = raw_http_auth_config(TCConfig),
+    {ok, _} = emqx:update_config(?PATH, {create_authenticator, ?GLOBAL, AuthConfig}),
+    ok = emqx_utils_http_test_server:set_handler(unexpected_status_handler()),
+    ok = emqx_authn_test_lib:add_permissive_builtin_authenticator(
+        ?PATH,
+        ?GLOBAL,
+        maps:get(username, ?CREDENTIALS),
+        maps:get(password, ?CREDENTIALS)
+    ),
+    emqx_access_control:authenticate(?CREDENTIALS).
 
 uri_encode(T) ->
     emqx_http_lib:uri_encode(to_list(T)).

--- a/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
@@ -197,6 +197,30 @@ t_backend_failure_hardened_denies(TCConfig) ->
         )
     end).
 
+t_malformed_response_legacy_ignores(TCConfig) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ?assertEqual(
+            {ok, #{is_superuser => false}},
+            authenticate_with_http_handler(TCConfig, invalid_json_handler())
+        ),
+        ?assertEqual(
+            {ok, #{is_superuser => false}},
+            authenticate_with_http_handler(TCConfig, invalid_result_handler())
+        )
+    end).
+
+t_malformed_response_hardened_denies(TCConfig) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ?assertEqual(
+            {error, not_authorized},
+            authenticate_with_http_handler(TCConfig, invalid_json_handler())
+        ),
+        ?assertEqual(
+            {error, not_authorized},
+            authenticate_with_http_handler(TCConfig, invalid_result_handler())
+        )
+    end).
+
 test_user_auth(
     TCConfig,
     #{
@@ -1503,17 +1527,47 @@ unexpected_status_handler() ->
         {ok, Req, State}
     end.
 
+invalid_json_handler() ->
+    fun(Req0, State) ->
+        Req = cowboy_req:reply(
+            200,
+            #{<<"content-type">> => <<"application/json">>},
+            <<"not-json">>,
+            Req0
+        ),
+        {ok, Req, State}
+    end.
+
+invalid_result_handler() ->
+    fun(Req0, State) ->
+        Req = cowboy_req:reply(
+            200,
+            #{<<"content-type">> => <<"application/json">>},
+            emqx_utils_json:encode(#{result => unexpected}),
+            Req0
+        ),
+        {ok, Req, State}
+    end.
+
 authenticate_with_unexpected_status(TCConfig) ->
+    authenticate_with_http_handler(TCConfig, unexpected_status_handler()).
+
+authenticate_with_http_handler(TCConfig, Handler) ->
     AuthConfig = raw_http_auth_config(TCConfig),
     {ok, _} = emqx:update_config(?PATH, {create_authenticator, ?GLOBAL, AuthConfig}),
-    ok = emqx_utils_http_test_server:set_handler(unexpected_status_handler()),
+    ok = emqx_utils_http_test_server:set_handler(Handler),
     ok = emqx_authn_test_lib:add_permissive_builtin_authenticator(
         ?PATH,
         ?GLOBAL,
         maps:get(username, ?CREDENTIALS),
         maps:get(password, ?CREDENTIALS)
     ),
-    emqx_access_control:authenticate(?CREDENTIALS).
+    Result = emqx_access_control:authenticate(?CREDENTIALS),
+    emqx_authn_test_lib:delete_authenticators(
+        [authentication],
+        ?GLOBAL
+    ),
+    Result.
 
 uri_encode(T) ->
     emqx_http_lib:uri_encode(to_list(T)).

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
@@ -108,7 +108,7 @@ authenticate(
                 resource => ResourceId,
                 reason => Reason
             }),
-            ignore;
+            emqx_authn_utils:backend_failure_result();
         {ok, JWKs} ->
             JWT = maps:get(From, Credential),
             VerifyClaims = render_expected(VerifyClaims0, Credential),
@@ -252,7 +252,7 @@ verify(JWT, JWKs, VerifyClaims, AclClaimName, DisconnectAfterExpire) ->
         {error, invalid_signature} ->
             %% it's a invalid token, so it's ok to log
             ?TRACE_AUTHN_PROVIDER("invalid_jwt_signature", #{jwks => JWKs, jwt => JWT}),
-            ignore;
+            emqx_authn_utils:backend_failure_result();
         {error, {claims, Claims}} ->
             %% it's a invalid token, so it's ok to log
             ?TRACE_AUTHN_PROVIDER("invalid_jwt_claims", #{jwt => JWT, claims => Claims}),

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
@@ -240,6 +240,7 @@ render_expected([{Name, ExpectedTemplate} | More], Variables) ->
     [{Name, Expected} | render_expected(More, Variables)].
 
 verify(undefined, _, _, _, _) ->
+    %% No value in `From` field, where we expect a JWT token
     ignore;
 verify(JWT, JWKs, VerifyClaims, AclClaimName, DisconnectAfterExpire) ->
     case do_verify(JWT, JWKs, VerifyClaims) of

--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -24,7 +24,7 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_jwt], #{
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mnesia, emqx_auth_jwt], #{
         work_dir => emqx_cth_suite:work_dir(Config)
     }),
     [{apps, Apps} | Config].
@@ -34,6 +34,7 @@ end_per_suite(Config) ->
     ok.
 
 end_per_testcase(_TestCase, _Config) ->
+    emqx_authn_test_lib:delete_authenticators([authentication], 'mqtt:global'),
     emqx_common_test_helpers:call_janitor(),
     ok.
 
@@ -194,6 +195,16 @@ t_public_key(_) ->
 
     ?assertEqual(ok, emqx_authn_jwt:destroy(State)),
     ok.
+
+t_invalid_signature_legacy_ignores(_) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ?assertEqual({ok, #{is_superuser => false}}, authenticate_with_invalid_signature())
+    end).
+
+t_invalid_signature_hardened_denies(_) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ?assertEqual({error, not_authorized}, authenticate_with_invalid_signature())
+    end).
 
 t_bad_public_keys(_) ->
     BaseConfig = #{
@@ -1173,6 +1184,35 @@ read_until_headers(Sock, Acc) ->
         _ ->
             Acc
     end.
+
+authenticate_with_invalid_signature() ->
+    Secret = <<"abcdef">>,
+    Config = #{
+        <<"mechanism">> => <<"jwt">>,
+        <<"from">> => <<"password">>,
+        <<"acl_claim_name">> => <<"acl">>,
+        <<"use_jwks">> => false,
+        <<"algorithm">> => <<"hmac-based">>,
+        <<"secret">> => Secret,
+        <<"secret_base64_encoded">> => false,
+        <<"verify_claims">> => #{},
+        <<"disconnect_after_expire">> => false,
+        <<"enable">> => true
+    },
+    Payload = #{<<"username">> => <<"myuser">>, <<"exp">> => erlang:system_time(second) + 60},
+    BadJWS = generate_jws('hmac-based', Payload, <<"bad_secret">>),
+    Credentials = #{
+        username => <<"myuser">>,
+        password => BadJWS,
+        listener => 'tcp:default',
+        protocol => mqtt
+    },
+    Chain = 'mqtt:global',
+    {ok, _} = emqx:update_config([authentication], {create_authenticator, Chain, Config}),
+    ok = emqx_authn_test_lib:add_permissive_builtin_authenticator(
+        [authentication], Chain, maps:get(username, Credentials), maps:get(password, Credentials)
+    ),
+    emqx_access_control:authenticate(Credentials).
 
 jwks_handler(Req0, State) ->
     JWK = jose_jwk:from_pem_file(test_rsa_key(public)),

--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap_bind.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap_bind.erl
@@ -90,7 +90,7 @@ do_authenticate(
                 timeout => Timeout,
                 reason => Reason
             }),
-            ignore
+            emqx_authn_utils:backend_failure_result()
     end.
 
 format_authentication_result(

--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap_hash.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap_hash.erl
@@ -65,7 +65,7 @@ authenticate(
                 timeout => Timeout,
                 reason => Reason
             }),
-            ignore
+            emqx_authn_utils:backend_failure_result()
     end.
 
 do_authenticate(Password, Entry, #{resource_id := ResourceId} = State) ->

--- a/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
@@ -13,6 +13,9 @@
 
 -define(LDAP_HOST, "ldap").
 -define(LDAP_DEFAULT_PORT, 389).
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "ldap_tcp").
 
 -define(PATH, [authentication]).
 -define(AUTHN_ID, <<"password_based:ldap">>).
@@ -37,7 +40,7 @@ end_per_testcase(_, Config) ->
 
 init_per_suite(Config) ->
     _ = application:load(emqx_conf),
-    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_ldap], #{
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mnesia, emqx_auth_ldap], #{
         work_dir => ?config(priv_dir, Config)
     }),
     [{apps, Apps} | Config].
@@ -167,14 +170,16 @@ t_authenticate(_Config) ->
         fun(Sample) ->
             test_user_auth(Sample)
         end,
-        user_seeds()
+        cases()
     ).
 
-test_user_auth(#{
-    credentials := Credentials0,
-    config_params := SpecificConfigParams,
-    result := ExpectedResult
-}) ->
+test_user_auth(
+    #{
+        credentials := Credentials0,
+        config_params := SpecificConfigParams,
+        result := ExpectedResult
+    } = Sample
+) ->
     AuthConfig = maps:merge(raw_ldap_auth_config(), SpecificConfigParams),
 
     ct:pal("test_user_auth~ncredentials: ~p~nconfig: ~p~nresult: ~p", [
@@ -190,7 +195,11 @@ test_user_auth(#{
         protocol => mqtt
     },
 
-    ActualAuthResult0 = emqx_access_control:authenticate(Credentials),
+    ActualAuthResult0 = run(
+        Sample,
+        Credentials,
+        fun() -> emqx_access_control:authenticate(Credentials) end
+    ),
     ActualAuthResult = filter_expected_fields(ExpectedResult, ActualAuthResult0),
     ?assertEqual(ExpectedResult, ActualAuthResult),
 
@@ -357,7 +366,7 @@ raw_ldap_auth_config() ->
         <<"pool_size">> => 8
     }.
 
-user_seeds() ->
+cases() ->
     New4 = fun(Username, Password, Result, Params) ->
         #{
             credentials => #{
@@ -384,6 +393,24 @@ user_seeds() ->
     [
         %% Not exists
         New(<<"notexists">>, <<"notexists">>, {error, not_authorized}),
+        maps:merge(
+            New4(
+                <<"mqttuser0001">>,
+                <<"mqttuser0001">>,
+                {ok, #{is_superuser => false}},
+                #{<<"server">> => <<"toxiproxy:389">>}
+            ),
+            #{add_permissive => true, backend_failure => true, security_profile => legacy}
+        ),
+        maps:merge(
+            New4(
+                <<"mqttuser0001">>,
+                <<"mqttuser0001">>,
+                {error, not_authorized},
+                #{<<"server">> => <<"toxiproxy:389">>}
+            ),
+            #{add_permissive => true, backend_failure => true, security_profile => hardened}
+        ),
         %% Wrong Password
         New(<<"mqttuser0001">>, <<"wrongpassword">>, {error, bad_username_or_password}),
         %% Disabled
@@ -427,6 +454,36 @@ user_seeds() ->
 
 ldap_server() ->
     iolist_to_binary(io_lib:format("~s:~B", [?LDAP_HOST, ?LDAP_DEFAULT_PORT])).
+
+run(Sample, Credentials, Auth) ->
+    run([failure, profile, permissive_auth], Sample, Credentials, Auth).
+
+run([failure | Rest], #{backend_failure := true} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_failure(
+        down,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        fun() -> run(Rest, Sample, Credentials, Auth) end
+    );
+run([failure | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([profile | Rest], #{security_profile := Profile} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_security_profile(atom_to_list(Profile), fun() ->
+        run(Rest, Sample, Credentials, Auth)
+    end);
+run([profile | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], #{add_permissive := true} = Sample, Credentials, Auth) ->
+    #{username := Username, password := Password} = Credentials,
+    ok = emqx_authn_test_lib:add_permissive_builtin_authenticator(
+        ?PATH, ?GLOBAL, Username, Password
+    ),
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([], _Sample, _Credentials, Auth) ->
+    Auth().
 
 filter_expected_fields({ok, Expected}, {ok, Actual}) ->
     {ok, maps:with(maps:keys(Expected), Actual)};

--- a/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
@@ -71,7 +71,7 @@ authenticate(
             ?TRACE_AUTHN_PROVIDER(error, "mongodb_render_filter_failed", #{
                 reason => EncodeError
             }),
-            ignore
+            emqx_authn_utils:backend_failure_result()
     end.
 
 authenticate_with_filter(
@@ -99,7 +99,7 @@ authenticate_with_filter(
                 filter => Filter,
                 reason => Reason
             }),
-            ignore;
+            emqx_authn_utils:backend_failure_result();
         {ok, Doc} ->
             case check_password(Password, Doc, State) of
                 ok ->
@@ -112,7 +112,7 @@ authenticate_with_filter(
                         document => Doc,
                         password_hash_field => PasswordHashField
                     }),
-                    ignore;
+                    emqx_authn_utils:backend_failure_result();
                 {error, Reason} ->
                     {error, Reason}
             end

--- a/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
@@ -13,6 +13,9 @@
 -include_lib("common_test/include/ct.hrl").
 
 -define(MONGO_HOST, "mongo").
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "mongo_single_tcp").
 
 -define(PATH, [authentication]).
 
@@ -39,9 +42,11 @@ end_per_testcase(_TestCase, Config) ->
     ok = mc_worker_api:disconnect(Client).
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mongodb], #{
-        work_dir => ?config(priv_dir, Config)
-    }),
+    Apps = emqx_cth_suite:start(
+        [emqx, emqx_conf, emqx_auth, emqx_auth_mnesia, emqx_auth_mongodb], #{
+            work_dir => ?config(priv_dir, Config)
+        }
+    ),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
@@ -97,30 +102,32 @@ t_authenticate(_Config) ->
             ct:pal("test_user_auth sample: ~p", [Sample]),
             test_user_auth(Sample)
         end,
-        applicable_user_seeds()
+        applicable_cases()
     ).
 
 %% The legacy-protocol seed only applies to MongoDB servers that still support
 %% the legacy OP_QUERY opcodes (removed in MongoDB 5.1, wire protocol 14).
-applicable_user_seeds() ->
+applicable_cases() ->
     case mongo_supports_legacy_protocol(?MONGO_HOST, ?MONGO_DEFAULT_PORT) of
         true ->
-            user_seeds();
+            cases();
         false ->
             [
                 Seed
-             || Seed <- user_seeds(),
+             || Seed <- cases(),
                 maps:get(
                     <<"use_legacy_protocol">>, maps:get(config_params, Seed, #{}), undefined
                 ) =/= <<"true">>
             ]
     end.
 
-test_user_auth(#{
-    credentials := Credentials0,
-    config_params := SpecificConfigParams,
-    result := Result
-}) ->
+test_user_auth(
+    #{
+        credentials := Credentials0,
+        config_params := SpecificConfigParams,
+        result := Result
+    } = Sample
+) ->
     AuthConfig = maps:merge(raw_mongo_auth_config(), SpecificConfigParams),
 
     {ok, _} = emqx:update_config(
@@ -132,7 +139,8 @@ test_user_auth(#{
         listener => 'tcp:default',
         protocol => mqtt
     },
-    ?assertEqual(Result, emqx_access_control:authenticate(Credentials)),
+    Auth = fun() -> ?assertEqual(Result, emqx_access_control:authenticate(Credentials)) end,
+    run(Sample, Credentials, Auth),
 
     emqx_authn_test_lib:delete_authenticators(
         [authentication],
@@ -367,7 +375,7 @@ raw_mongo_auth_config() ->
         <<"use_legacy_protocol">> => <<"auto">>
     }.
 
-user_seeds() ->
+cases() ->
     PlainSeed =
         #{
             data => #{
@@ -387,6 +395,72 @@ user_seeds() ->
         PlainSeed#{config_params => #{<<"use_legacy_protocol">> => <<"auto">>}},
         PlainSeed#{config_params => #{<<"use_legacy_protocol">> => <<"true">>}},
         PlainSeed#{config_params => #{<<"use_legacy_protocol">> => <<"false">>}},
+        #{
+            data => #{
+                username => <<"backend_failure_legacy">>,
+                password_hash => <<"backend_failure_legacy">>,
+                salt => <<"">>,
+                is_superuser => <<"1">>
+            },
+            credentials => #{
+                username => <<"backend_failure_legacy">>,
+                password => <<"backend_failure_legacy">>
+            },
+            config_params => #{<<"server">> => <<"toxiproxy:27017">>},
+            add_permissive => true,
+            backend_failure => true,
+            security_profile => legacy,
+            result => {ok, #{is_superuser => false}}
+        },
+        #{
+            data => #{
+                username => <<"backend_failure_hardened">>,
+                password_hash => <<"backend_failure_hardened">>,
+                salt => <<"">>,
+                is_superuser => <<"1">>
+            },
+            credentials => #{
+                username => <<"backend_failure_hardened">>,
+                password => <<"backend_failure_hardened">>
+            },
+            config_params => #{<<"server">> => <<"toxiproxy:27017">>},
+            add_permissive => true,
+            backend_failure => true,
+            security_profile => hardened,
+            result => {error, not_authorized}
+        },
+        #{
+            data => #{
+                username => <<"render_failure_legacy">>,
+                password_hash => <<"render_failure_legacy">>,
+                salt => <<"">>,
+                is_superuser => <<"1">>
+            },
+            credentials => #{
+                username => <<255>>,
+                password => <<"render_failure_legacy">>
+            },
+            config_params => #{<<"filter">> => #{<<"username">> => <<"${username}">>}},
+            add_permissive => true,
+            security_profile => legacy,
+            result => {ok, #{is_superuser => false}}
+        },
+        #{
+            data => #{
+                username => <<"render_failure_hardened">>,
+                password_hash => <<"render_failure_hardened">>,
+                salt => <<"">>,
+                is_superuser => <<"1">>
+            },
+            credentials => #{
+                username => <<255>>,
+                password => <<"render_failure_hardened">>
+            },
+            config_params => #{<<"filter">> => #{<<"username">> => <<"${username}">>}},
+            add_permissive => true,
+            security_profile => hardened,
+            result => {error, not_authorized}
+        },
         #{
             data => #{
                 username => <<"md5">>,
@@ -534,7 +608,7 @@ user_seeds() ->
     ].
 
 init_seeds(Client) ->
-    Users = [Values || #{data := Values} <- user_seeds()],
+    Users = [Values || #{data := Values} <- cases()],
     ok = lists:foreach(fun(User) -> create_user(Client, User) end, Users),
     ok.
 
@@ -545,6 +619,36 @@ create_user(Client, User) ->
 drop_seeds(Client) ->
     {true, _} = mc_worker_api:delete(Client, <<"users">>, #{}),
     ok.
+
+run(Sample, Credentials, Auth) ->
+    run([failure, profile, permissive_auth], Sample, Credentials, Auth).
+
+run([failure | Rest], #{backend_failure := true} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_failure(
+        down,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        fun() -> run(Rest, Sample, Credentials, Auth) end
+    );
+run([failure | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([profile | Rest], #{security_profile := Profile} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_security_profile(atom_to_list(Profile), fun() ->
+        run(Rest, Sample, Credentials, Auth)
+    end);
+run([profile | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], #{add_permissive := true} = Sample, Credentials, Auth) ->
+    #{username := Username, password := Password} = Credentials,
+    ok = emqx_authn_test_lib:add_permissive_builtin_authenticator(
+        ?PATH, ?GLOBAL, Username, Password
+    ),
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([], _Sample, _Credentials, Auth) ->
+    Auth().
 
 mongo_server() ->
     iolist_to_binary(io_lib:format("~s", [?MONGO_HOST])).

--- a/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
@@ -100,7 +100,7 @@ authenticate(
                 timeout => Timeout,
                 reason => Reason
             }),
-            ignore
+            emqx_authn_utils:backend_failure_result()
     end.
 
 create_state(

--- a/apps/emqx_auth_mysql/test/emqx_authn_mysql_SUITE.erl
+++ b/apps/emqx_auth_mysql/test/emqx_authn_mysql_SUITE.erl
@@ -14,6 +14,9 @@
 
 -define(MYSQL_HOST, "mysql").
 -define(MYSQL_RESOURCE, <<"emqx_authn_mysql_SUITE">>).
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "mysql_tcp").
 
 -define(PATH, [authentication]).
 -define(ResourceID, <<"password_based:mysql">>).
@@ -39,7 +42,7 @@ end_per_testcase(_TestCase, _Config) ->
     ok.
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mysql], #{
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mnesia, emqx_auth_mysql], #{
         work_dir => ?config(priv_dir, Config)
     }),
     {ok, _} = emqx_resource:create_local(
@@ -106,14 +109,16 @@ t_authenticate(_Config) ->
             ct:pal("test_user_auth sample: ~p", [Sample]),
             test_user_auth(Sample)
         end,
-        user_seeds()
+        cases()
     ).
 
-test_user_auth(#{
-    credentials := Credentials0,
-    config_params := SpecificConfigParams,
-    result := Result
-}) ->
+test_user_auth(
+    #{
+        credentials := Credentials0,
+        config_params := SpecificConfigParams,
+        result := Result
+    } = Sample
+) ->
     AuthConfig = maps:merge(raw_mysql_auth_config(), SpecificConfigParams),
 
     {ok, _} = emqx:update_config(
@@ -126,7 +131,8 @@ test_user_auth(#{
         protocol => mqtt
     },
 
-    ?assertEqual(Result, emqx_access_control:authenticate(Credentials)),
+    Auth = fun() -> ?assertEqual(Result, emqx_access_control:authenticate(Credentials)) end,
+    run(Sample, Credentials, Auth),
 
     emqx_authn_test_lib:delete_authenticators(
         [authentication],
@@ -318,7 +324,7 @@ raw_mysql_auth_config() ->
         <<"server">> => mysql_server()
     }.
 
-user_seeds() ->
+cases() ->
     [
         #{
             data => #{
@@ -333,6 +339,42 @@ user_seeds() ->
             },
             config_params => #{},
             result => {ok, #{is_superuser => true}}
+        },
+
+        #{
+            data => #{
+                username => "backend_failure_legacy",
+                password_hash => "backend_failure_legacy",
+                salt => "",
+                is_superuser_str => "1"
+            },
+            credentials => #{
+                username => <<"backend_failure_legacy">>,
+                password => <<"backend_failure_legacy">>
+            },
+            config_params => #{<<"server">> => <<"toxiproxy:3306">>},
+            add_permissive => true,
+            backend_failure => true,
+            security_profile => legacy,
+            result => {ok, #{is_superuser => false}}
+        },
+
+        #{
+            data => #{
+                username => "backend_failure_hardened",
+                password_hash => "backend_failure_hardened",
+                salt => "",
+                is_superuser_str => "1"
+            },
+            credentials => #{
+                username => <<"backend_failure_hardened">>,
+                password => <<"backend_failure_hardened">>
+            },
+            config_params => #{<<"server">> => <<"toxiproxy:3306">>},
+            add_permissive => true,
+            backend_failure => true,
+            security_profile => hardened,
+            result => {error, not_authorized}
         },
 
         #{
@@ -563,7 +605,7 @@ init_seeds() ->
         fun(#{data := Values}) ->
             create_user(Values)
         end,
-        user_seeds()
+        cases()
     ).
 
 create_user(Values) ->
@@ -598,6 +640,36 @@ q(Sql, Params) ->
 
 drop_seeds() ->
     ok = q("DROP TABLE IF EXISTS users").
+
+run(Sample, Credentials, Auth) ->
+    run([failure, profile, permissive_auth], Sample, Credentials, Auth).
+
+run([failure | Rest], #{backend_failure := true} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_failure(
+        down,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        fun() -> run(Rest, Sample, Credentials, Auth) end
+    );
+run([failure | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([profile | Rest], #{security_profile := Profile} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_security_profile(atom_to_list(Profile), fun() ->
+        run(Rest, Sample, Credentials, Auth)
+    end);
+run([profile | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], #{add_permissive := true} = Sample, Credentials, Auth) ->
+    #{username := Username, password := Password} = Credentials,
+    ok = emqx_authn_test_lib:add_permissive_builtin_authenticator(
+        ?PATH, ?GLOBAL, Username, Password
+    ),
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([], _Sample, _Credentials, Auth) ->
+    Auth().
 
 mysql_server() ->
     iolist_to_binary(io_lib:format("~s", [?MYSQL_HOST])).

--- a/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
@@ -105,7 +105,7 @@ authenticate(
                 params => Params,
                 reason => Reason
             }),
-            ignore
+            emqx_authn_utils:backend_failure_result()
     end.
 
 create_state(

--- a/apps/emqx_auth_postgresql/test/emqx_authn_postgresql_SUITE.erl
+++ b/apps/emqx_auth_postgresql/test/emqx_authn_postgresql_SUITE.erl
@@ -13,6 +13,9 @@
 
 -define(PGSQL_HOST, "pgsql").
 -define(PGSQL_RESOURCE, <<"emqx_authn_postgresql_SUITE">>).
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "pgsql_tcp").
 -define(ResourceID, <<"password_based:postgresql">>).
 
 -define(PATH, [authentication]).
@@ -39,9 +42,11 @@ end_per_testcase(_TestCase, _Config) ->
     ok.
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_postgresql], #{
-        work_dir => ?config(priv_dir, Config)
-    }),
+    Apps = emqx_cth_suite:start(
+        [emqx, emqx_conf, emqx_auth, emqx_auth_mnesia, emqx_auth_postgresql], #{
+            work_dir => ?config(priv_dir, Config)
+        }
+    ),
     {ok, _} = emqx_resource:create_local(
         ?PGSQL_RESOURCE,
         ?AUTHN_RESOURCE_GROUP,
@@ -121,14 +126,16 @@ t_authenticate(_Config) ->
             ct:pal("test_user_auth sample: ~p", [Sample]),
             test_user_auth(Sample)
         end,
-        user_seeds()
+        cases()
     ).
 
-test_user_auth(#{
-    credentials := Credentials0,
-    config_params := SpecificConfigParams,
-    result := Result
-}) ->
+test_user_auth(
+    #{
+        credentials := Credentials0,
+        config_params := SpecificConfigParams,
+        result := Result
+    } = Sample
+) ->
     AuthConfig = maps:merge(raw_pgsql_auth_config(), SpecificConfigParams),
 
     {ok, _} = emqx:update_config(
@@ -141,7 +148,8 @@ test_user_auth(#{
         protocol => mqtt
     },
 
-    ?assertEqual(Result, emqx_access_control:authenticate(Credentials)),
+    Auth = fun() -> ?assertEqual(Result, emqx_access_control:authenticate(Credentials)) end,
+    run(Sample, Credentials, Auth),
 
     emqx_authn_test_lib:delete_authenticators(
         [authentication],
@@ -159,7 +167,7 @@ t_authenticate_disabled_prepared_statements(_Config) ->
             ct:pal("test_user_auth sample: ~p", [Sample]),
             test_user_auth(Sample)
         end,
-        user_seeds()
+        cases()
     ).
 
 t_destroy(_Config) ->
@@ -408,7 +416,7 @@ raw_pgsql_auth_config() ->
         <<"server">> => pgsql_server()
     }.
 
-user_seeds() ->
+cases() ->
     [
         #{
             data => #{
@@ -423,6 +431,42 @@ user_seeds() ->
             },
             config_params => #{},
             result => {ok, #{is_superuser => true}}
+        },
+
+        #{
+            data => #{
+                username => "backend_failure_legacy",
+                password_hash => "backend_failure_legacy",
+                salt => "",
+                is_superuser_str => "1"
+            },
+            credentials => #{
+                username => <<"backend_failure_legacy">>,
+                password => <<"backend_failure_legacy">>
+            },
+            config_params => #{<<"server">> => <<"toxiproxy:5432">>},
+            add_permissive => true,
+            backend_failure => true,
+            security_profile => legacy,
+            result => {ok, #{is_superuser => false}}
+        },
+
+        #{
+            data => #{
+                username => "backend_failure_hardened",
+                password_hash => "backend_failure_hardened",
+                salt => "",
+                is_superuser_str => "1"
+            },
+            credentials => #{
+                username => <<"backend_failure_hardened">>,
+                password => <<"backend_failure_hardened">>
+            },
+            config_params => #{<<"server">> => <<"toxiproxy:5432">>},
+            add_permissive => true,
+            backend_failure => true,
+            security_profile => hardened,
+            result => {error, not_authorized}
         },
 
         #{
@@ -633,7 +677,7 @@ init_seeds() ->
         fun(#{data := Values}) ->
             ok = create_user(Values)
         end,
-        user_seeds()
+        cases()
     ).
 
 create_user(Values) ->
@@ -675,6 +719,36 @@ q(Sql, Params) ->
 drop_seeds() ->
     {ok, _, _} = q("DROP TABLE IF EXISTS users"),
     ok.
+
+run(Sample, Credentials, Auth) ->
+    run([failure, profile, permissive_auth], Sample, Credentials, Auth).
+
+run([failure | Rest], #{backend_failure := true} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_failure(
+        down,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        fun() -> run(Rest, Sample, Credentials, Auth) end
+    );
+run([failure | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([profile | Rest], #{security_profile := Profile} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_security_profile(atom_to_list(Profile), fun() ->
+        run(Rest, Sample, Credentials, Auth)
+    end);
+run([profile | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], #{add_permissive := true} = Sample, Credentials, Auth) ->
+    #{username := Username, password := Password} = Credentials,
+    ok = emqx_authn_test_lib:add_permissive_builtin_authenticator(
+        ?PATH, ?GLOBAL, Username, Password
+    ),
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([], _Sample, _Credentials, Auth) ->
+    Auth().
 
 pgsql_server() ->
     iolist_to_binary(io_lib:format("~s", [?PGSQL_HOST])).

--- a/apps/emqx_auth_redis/src/emqx_authn_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authn_redis.erl
@@ -95,6 +95,7 @@ authenticate(
                         keys => NKey,
                         fields => Fields
                     }),
+                    %% The entry does not actually exist, not a error, so ignore.
                     ignore
             end;
         {error, Reason} ->

--- a/apps/emqx_auth_redis/src/emqx_authn_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authn_redis.erl
@@ -105,7 +105,7 @@ authenticate(
                 fields => Fields,
                 reason => Reason
             }),
-            ignore
+            emqx_authn_utils:backend_failure_result()
     end.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_auth_redis/test/emqx_authn_redis_SUITE.erl
+++ b/apps/emqx_auth_redis/test/emqx_authn_redis_SUITE.erl
@@ -14,6 +14,9 @@
 
 -define(REDIS_HOST, "redis").
 -define(REDIS_RESOURCE, <<"emqx_authn_redis_SUITE">>).
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "redis_single_tcp").
 
 -define(PATH, [authentication]).
 -define(ResourceID, <<"password_based:redis">>).
@@ -35,7 +38,7 @@ end_per_testcase(_TestCase, _Config) ->
     ok.
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_redis], #{
+    Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_mnesia, emqx_auth_redis], #{
         work_dir => ?config(priv_dir, Config)
     }),
     {ok, _} = emqx_resource:create_local(
@@ -161,7 +164,7 @@ t_authenticate(_Config) ->
             ct:pal("test_user_auth sample: ~p", [Sample]),
             test_user_auth(Sample)
         end,
-        user_seeds()
+        cases()
     ).
 
 test_user_auth(
@@ -186,7 +189,8 @@ test_user_auth(
         protocol => mqtt
     },
 
-    ?assertEqual(Result, emqx_access_control:authenticate(Credentials)),
+    Auth = fun() -> ?assertEqual(Result, emqx_access_control:authenticate(Credentials)) end,
+    run(Config, Credentials, Auth),
 
     case maps:get(redis_result, Config, undefined) of
         undefined ->
@@ -407,7 +411,7 @@ raw_redis_auth_config() ->
         <<"server">> => redis_server()
     }.
 
-user_seeds() ->
+cases() ->
     [
         #{
             data => #{
@@ -422,6 +426,40 @@ user_seeds() ->
             key => <<"mqtt_user:plain">>,
             config_params => #{},
             result => {ok, #{is_superuser => true}}
+        },
+        #{
+            data => #{
+                password_hash => <<"backend_failure_legacy">>,
+                salt => <<"">>,
+                is_superuser => <<"1">>
+            },
+            credentials => #{
+                username => <<"backend_failure_legacy">>,
+                password => <<"backend_failure_legacy">>
+            },
+            key => <<"mqtt_user:backend_failure_legacy">>,
+            config_params => #{<<"server">> => <<"toxiproxy:6379">>},
+            add_permissive => true,
+            backend_failure => true,
+            security_profile => legacy,
+            result => {ok, #{is_superuser => false}}
+        },
+        #{
+            data => #{
+                password_hash => <<"backend_failure_hardened">>,
+                salt => <<"">>,
+                is_superuser => <<"1">>
+            },
+            credentials => #{
+                username => <<"backend_failure_hardened">>,
+                password => <<"backend_failure_hardened">>
+            },
+            key => <<"mqtt_user:backend_failure_hardened">>,
+            config_params => #{<<"server">> => <<"toxiproxy:6379">>},
+            add_permissive => true,
+            backend_failure => true,
+            security_profile => hardened,
+            result => {error, not_authorized}
         },
         #{
             data => #{
@@ -691,7 +729,7 @@ init_seeds() ->
         fun(#{key := UserKey, data := Values}) ->
             create_user(UserKey, Values)
         end,
-        user_seeds()
+        cases()
     ).
 
 create_user(UserKey, Values) ->
@@ -713,8 +751,38 @@ drop_seeds() ->
         fun(#{key := UserKey}) ->
             q(["DEL", UserKey])
         end,
-        user_seeds()
+        cases()
     ).
+
+run(Sample, Credentials, Auth) ->
+    run([failure, profile, permissive_auth], Sample, Credentials, Auth).
+
+run([failure | Rest], #{backend_failure := true} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_failure(
+        down,
+        ?PROXY_NAME,
+        ?PROXY_HOST,
+        ?PROXY_PORT,
+        fun() -> run(Rest, Sample, Credentials, Auth) end
+    );
+run([failure | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([profile | Rest], #{security_profile := Profile} = Sample, Credentials, Auth) ->
+    emqx_common_test_helpers:with_security_profile(atom_to_list(Profile), fun() ->
+        run(Rest, Sample, Credentials, Auth)
+    end);
+run([profile | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], #{add_permissive := true} = Sample, Credentials, Auth) ->
+    #{username := Username, password := Password} = Credentials,
+    ok = emqx_authn_test_lib:add_permissive_builtin_authenticator(
+        ?PATH, ?GLOBAL, Username, Password
+    ),
+    run(Rest, Sample, Credentials, Auth);
+run([permissive_auth | Rest], Sample, Credentials, Auth) ->
+    run(Rest, Sample, Credentials, Auth);
+run([], _Sample, _Credentials, Auth) ->
+    Auth().
 
 redis_server() ->
     iolist_to_binary(io_lib:format("~s", [?REDIS_HOST])).

--- a/apps/emqx_gcp_device/src/emqx_gcp_device_authn.erl
+++ b/apps/emqx_gcp_device/src/emqx_gcp_device_authn.erl
@@ -97,7 +97,7 @@ check_jwt(ClientInfo, DeviceId) ->
                 reason => "key not found",
                 client => ClientInfo
             }),
-            ignore;
+            emqx_authn_utils:backend_failure_result();
         Keys ->
             case any_key_matches(Keys, ClientInfo) of
                 true ->

--- a/apps/emqx_gcp_device/test/emqx_gcp_device_SUITE.erl
+++ b/apps/emqx_gcp_device/test/emqx_gcp_device_SUITE.erl
@@ -18,7 +18,14 @@ all() ->
 
 init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
-        [emqx, emqx_conf, emqx_auth, emqx_gcp_device, {emqx_retainer, "retainer {enable = true}"}],
+        [
+            emqx,
+            emqx_conf,
+            emqx_auth,
+            emqx_auth_mnesia,
+            emqx_gcp_device,
+            {emqx_retainer, "retainer {enable = true}"}
+        ],
         #{
             work_dir => ?config(priv_dir, Config)
         }
@@ -148,6 +155,16 @@ t_no_keys(_Config) ->
         keys()
     ),
     ok.
+
+t_no_keys_legacy_ignores(_Config) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ?assertEqual({ok, #{is_superuser => false}}, authenticate_with_no_keys())
+    end).
+
+t_no_keys_hardened_denies(_Config) ->
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ?assertEqual({error, not_authorized}, authenticate_with_no_keys())
+    end).
 
 t_expired_keys(_Config) ->
     lists:foreach(
@@ -384,6 +401,19 @@ key_data(Filename) ->
 
 generate_jws(Payload, KeyType, PrivateKeyName) ->
     emqx_gcp_device_test_helpers:generate_jws(Payload, KeyType, PrivateKeyName).
+
+authenticate_with_no_keys() ->
+    [{DeviceId, KeyType, PrivateKeyName, _PublicKey} | _] = keys(),
+    ClientId = gcp_client_id(DeviceId),
+    Payload = #{<<"exp">> => erlang:system_time(second) + 3600},
+    JWT = generate_jws(Payload, KeyType, PrivateKeyName),
+    Credentials = (client_info(ClientId, JWT))#{username => ClientId},
+    Config = #{<<"mechanism">> => <<"gcp_device">>, <<"enable">> => true},
+    {ok, _} = emqx:update_config([authentication], {create_authenticator, ?GLOBAL, Config}),
+    ok = emqx_authn_test_lib:add_permissive_builtin_authenticator(
+        [authentication], ?GLOBAL, maps:get(username, Credentials), maps:get(password, Credentials)
+    ),
+    emqx_access_control:authenticate(Credentials).
 
 clear_data() ->
     emqx_gcp_device_test_helpers:clear_data(),

--- a/changes/ee/feat-17674.en.md
+++ b/changes/ee/feat-17674.en.md
@@ -1,0 +1,1 @@
+Authentication backends now fail closed in hardened security profile when backend failures or malformed backend responses occur. Legacy behavior can be preserved with `authentication_settings.ignore_backend_failures`.

--- a/rel/i18n/emqx_authn_schema.hocon
+++ b/rel/i18n/emqx_authn_schema.hocon
@@ -198,4 +198,9 @@ authentication_cache.desc:
 authentication_cache.label:
 """Authentication Cache"""
 
+ignore_backend_failures.desc:
+"""Ignore authentication backend failures in hardened security profile and continue to the next authenticator in the chain."""
+ignore_backend_failures.label:
+"""Ignore Backend Failures"""
+
 }


### PR DESCRIPTION
Release version:
6.2.0

Fixes emqx/emqx-dev-team-tasks#84

## Summary

Authentication backend failures now follow security-profile policy. Legacy mode preserves fall-through behavior, while hardened mode fails closed when backend failures or malformed backend responses occur.

Added `authentication_settings.ignore_backend_failures` to preserve legacy-style backend failure handling in hardened mode when explicitly configured.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
