### PR TITLE
test(prom): de-flake t_listener_shutdown_count

### DIFF
--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -356,33 +356,38 @@ t_stats_auth_api(_) ->
     request_stats(Headers, Auth),
     ok.
 
+emqtt_connect(ClientId) ->
+    {ok, C0} = emqtt:start_link(#{clientid => ClientId}),
+    %% temp unlink to avoid self (tester) exit due to server_unavailable race
+    unlink(C0),
+    try emqtt:connect(C0) of
+        {ok, _} ->
+            %% link again
+            link(C0),
+            {ok, C0}
+    catch
+        exit:{shutdown, server_unavailable} ->
+            ct:sleep(100),
+            emqtt_connect(ClientId)
+    end.
+
 %% Simple smoke test for verifying reason code labels in `emqx_client_disconnected_reason'
 %% counter metric.
 t_listener_shutdown_count(_Config) ->
-    ConnectRetry = fun Retry(ClientId) ->
-        {ok, C0} = emqtt:start_link(#{clientid => ClientId}),
-        try emqtt:connect(C0) of
-            {ok, _} -> {ok, C0}
-        catch
-            exit:{shutdown, server_unavailable} ->
-                ct:sleep(1),
-                Retry(ClientId)
-        end
-    end,
     ClientId1 = fresh_clientid(?FUNCTION_NAME),
-    {ok, C1} = ConnectRetry(ClientId1),
+    {ok, C1} = emqtt_connect(ClientId1),
     %% Takeover
     unlink(C1),
-    {ok, C2} = ConnectRetry(ClientId1),
+    {ok, C2} = emqtt_connect(ClientId1),
     %% Kick
     unlink(C2),
     ok = emqx_cm:kick_session(ClientId1),
     %% Normal disconnect
     ClientId2 = fresh_clientid(?FUNCTION_NAME),
-    {ok, C3} = ConnectRetry(ClientId2),
+    {ok, C3} = emqtt_connect(ClientId2),
     ok = emqtt:stop(C3),
     %% Disconnect with reason code
-    {ok, C4} = ConnectRetry(ClientId2),
+    {ok, C4} = emqtt_connect(ClientId2),
     ok = emqtt:disconnect(C4, ?RC_IMPLEMENTATION_SPECIFIC_ERROR),
     OnlyDisconnectStats = fun(Stats0) ->
         Stats = lists:filter(


### PR DESCRIPTION
## Summary

\`ConnectRetry\` uses \`emqtt:start_link/1\` per attempt. When the broker rejects CONNECT with \`server_unavailable\` (open-session throttle), the emqtt process exits with \`{shutdown, server_unavailable}\`. The \`try/catch\` handled the synchronous exit from \`gen_statem:call\`, but the async link signal would still kill the test process before the retry could fire.

Fix is to unlink before emqtt:connect and link again once connected.


## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking