### PR TITLE
fix(pgsql): serialize raw batch queries when prepares are disabled

### DIFF
--- a/apps/emqx_postgresql/mix.exs
+++ b/apps/emqx_postgresql/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXPostgresql.MixProject do
   def project do
     [
       app: :emqx_postgresql,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -364,7 +364,7 @@ on_query(
             data => Data
         }
     ),
-    Res = on_sql_query(InstId, PoolName, QueryType, NameOrSQL2, Data),
+    Res = on_sql_query(InstId, PoolName, QueryType, NameOrSQL2, Data, State),
     ?tp(postgres_bridge_connector_on_query_return, #{instance_id => InstId, result => Res}),
     handle_result(Res).
 
@@ -395,7 +395,7 @@ on_batch_query(
                     data => Rows
                 }
             ),
-            case on_sql_query(InstId, PoolName, execute_batch, StatementTemplate, Rows) of
+            case on_sql_query(InstId, PoolName, execute_batch, StatementTemplate, Rows, State) of
                 {error, _Error} = Result ->
                     handle_result(Result);
                 {_Column, Results} ->
@@ -471,14 +471,9 @@ get_templated_statement(Key, #{prepares := PrepStatements}) ->
     BinKey = to_bin(Key),
     {ok, maps:get(BinKey, PrepStatements)}.
 
-on_sql_query(InstId, PoolName, Type, NameOrSQL, Data) ->
-    %% query calls equery, which is not atomic and can interleave with other equery calls
-    Handover =
-        case Type of
-            query -> handover;
-            _ -> no_handover
-        end,
-    try ecpool:pick_and_do(PoolName, {?MODULE, Type, [NameOrSQL, Data]}, Handover) of
+on_sql_query(InstId, PoolName, Type, NameOrSQL, Data, State) ->
+    ApplyMode = apply_mode(Type, State),
+    try ecpool:pick_and_do(PoolName, {?MODULE, Type, [NameOrSQL, Data]}, ApplyMode) of
         {error, Reason} ->
             ?tp(
                 pgsql_connector_query_return,
@@ -525,6 +520,21 @@ on_sql_query(InstId, PoolName, Type, NameOrSQL, Data) ->
             }),
             {error, {unrecoverable_error, invalid_request}}
     end.
+
+apply_mode(query, _State) ->
+    %% query calls equery, which is not atomic and can interleave with other
+    %% queries on the same worker connection.
+    handover;
+apply_mode(execute_batch, State) ->
+    %% When prepared statements are disabled, execute_batch receives SQL text.
+    %% epgsql parses the SQL inside the call, so concurrent raw batch calls can
+    %% interleave on the same worker connection.
+    case prepared_statements_disabled(State) of
+        true -> handover;
+        false -> no_handover
+    end;
+apply_mode(_Type, _State) ->
+    no_handover.
 
 on_get_status(_InstId, #{pool_name := PoolName} = ConnState) ->
     Opts = #{
@@ -580,21 +590,28 @@ do_check_prepares(_) ->
 
 -spec validate_table_existence([pid()], binary()) -> ok | {error, undefined_table}.
 validate_table_existence([WorkerPid | Rest], SQL) ->
-    try ecpool_worker:client(WorkerPid) of
-        {ok, Conn} ->
-            case epgsql:parse2(Conn, "", SQL, []) of
-                {error, {_, _, _, undefined_table, _, _}} ->
-                    {error, undefined_table};
-                Res when is_tuple(Res) andalso ok == element(1, Res) ->
-                    ok;
-                Res ->
-                    ?tp(postgres_connector_bad_parse2, #{result => Res}),
-                    validate_table_existence(Rest, SQL)
-            end;
-        _ ->
+    try
+        ecpool_worker:exec(
+            WorkerPid,
+            fun(Conn) ->
+                epgsql:parse2(Conn, "", SQL, [])
+            end,
+            emqx_resource_pool:health_check_timeout()
+        )
+    of
+        {error, {_, _, _, undefined_table, _, _}} ->
+            {error, undefined_table};
+        Res when is_tuple(Res) andalso ok == element(1, Res) ->
+            ok;
+        Res ->
+            ?tp(postgres_connector_bad_parse2, #{result => Res}),
             validate_table_existence(Rest, SQL)
     catch
         exit:{noproc, _} ->
+            validate_table_existence(Rest, SQL);
+        exit:{timeout, _} ->
+            validate_table_existence(Rest, SQL);
+        exit:timeout ->
             validate_table_existence(Rest, SQL)
     end;
 validate_table_existence([], _SQL) ->

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
@@ -120,6 +121,219 @@ t_concurrent_raw_queries_no_errors(_Config) ->
     Errors = [R || R <- Results, not match_ok(R)],
     ?assertEqual([], Errors).
 
+%% Verify that concurrent raw batch queries with different parameter counts do not
+%% race through the unnamed prepared statement.
+t_concurrent_raw_batch_queries_no_errors(_Config) ->
+    ResourceId = <<"emqx_postgresql_SUITE_concurrent_batch">>,
+    Table = <<"emqx_postgresql_batch_race">>,
+    Sql4 =
+        <<"INSERT INTO ", Table/binary, "(a, b, c, d) VALUES (${a}, ${b}, ${c}, ${d})">>,
+    Sql8 =
+        <<"INSERT INTO ", Table/binary,
+            "(a, b, c, d, e, f, g, h) VALUES "
+            "(${a}, ${b}, ${c}, ${d}, ${e}, ${f}, ${g}, ${h})">>,
+    {ok, #{config := CheckedConfig}} =
+        emqx_resource:check_config(
+            ?PGSQL_RESOURCE_MOD,
+            pgsql_config(#{
+                pool_size => 1,
+                disable_prepared_statements => true
+            })
+        ),
+    {ok, #{state := State0}} = emqx_resource:create_local(
+        ResourceId,
+        ?CONNECTOR_RESOURCE_GROUP,
+        ?PGSQL_RESOURCE_MOD,
+        CheckedConfig,
+        #{spawn_buffer_workers => false}
+    ),
+    {ok, State1} = emqx_postgresql:on_add_channel(
+        ResourceId, State0, <<"stmt4">>, #{parameters => #{sql => Sql4}}
+    ),
+    {ok, State} = emqx_postgresql:on_add_channel(
+        ResourceId, State1, <<"stmt8">>, #{parameters => #{sql => Sql8}}
+    ),
+    ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+    ?assert(
+        match_ok(
+            emqx_resource:simple_sync_query(
+                ResourceId,
+                {query, <<"DROP TABLE IF EXISTS ", Table/binary>>, []}
+            )
+        )
+    ),
+    ?assert(
+        match_ok(
+            emqx_resource:simple_sync_query(
+                ResourceId,
+                {query,
+                    <<"CREATE TABLE ", Table/binary,
+                        " (a integer, b integer, c integer, d integer, "
+                        "e integer, f integer, g integer, h integer)">>,
+                    []}
+            )
+        )
+    ),
+    Self = self(),
+    N = 50,
+    [
+        spawn(fun() ->
+            Res = batch_query_with_timeout(
+                ResourceId,
+                batch_query(I),
+                State
+            ),
+            Self ! {result, Res}
+        end)
+     || I <- lists:seq(1, N)
+    ],
+    Results = [
+        receive
+            {result, R} -> R
+        after 10_000 -> timeout
+        end
+     || _ <- lists:seq(1, N)
+    ],
+    _ = emqx_resource:simple_sync_query(ResourceId, {query, <<"DROP TABLE ", Table/binary>>, []}),
+    emqx_resource:remove_local(ResourceId),
+    Errors = [R || R <- Results, R =/= {ok, 2}],
+    ct:pal("concurrent raw batch query errors: ~p", [Errors]),
+    ?assertEqual([], Errors).
+
+%% Verify that table-existence checks do not race with raw batch execution on
+%% the same connection.
+t_raw_batch_not_confused_by_table_check(_Config) ->
+    ResourceId = <<"emqx_postgresql_SUITE_batch_status">>,
+    Table = <<"emqx_postgresql_batch_status_race">>,
+    Sql4 =
+        <<"INSERT INTO ", Table/binary, "(a, b, c, d) VALUES (${a}, ${b}, ${c}, ${d})">>,
+    Sql18 =
+        <<"INSERT INTO ", Table/binary,
+            "(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) VALUES "
+            "(${a}, ${b}, ${c}, ${d}, ${e}, ${f}, ${g}, ${h}, ${i}, ${j}, ${k}, "
+            "${l}, ${m}, ${n}, ${o}, ${p}, ${q}, ${r})">>,
+    {ok, #{config := CheckedConfig}} =
+        emqx_resource:check_config(
+            ?PGSQL_RESOURCE_MOD,
+            pgsql_config(#{
+                pool_size => 1,
+                disable_prepared_statements => true
+            })
+        ),
+    {ok, #{state := State0}} = emqx_resource:create_local(
+        ResourceId,
+        ?CONNECTOR_RESOURCE_GROUP,
+        ?PGSQL_RESOURCE_MOD,
+        CheckedConfig,
+        #{spawn_buffer_workers => false}
+    ),
+    {ok, State1} = emqx_postgresql:on_add_channel(
+        ResourceId, State0, <<"stmt4">>, #{parameters => #{sql => Sql4}}
+    ),
+    {ok, State} = emqx_postgresql:on_add_channel(
+        ResourceId, State1, <<"stmt18">>, #{parameters => #{sql => Sql18}}
+    ),
+    ?assertEqual({ok, connected}, emqx_resource:health_check(ResourceId)),
+    ?assert(
+        match_ok(
+            emqx_resource:simple_sync_query(
+                ResourceId,
+                {query, <<"DROP TABLE IF EXISTS ", Table/binary>>, []}
+            )
+        )
+    ),
+    ?assert(
+        match_ok(
+            emqx_resource:simple_sync_query(
+                ResourceId,
+                {query,
+                    <<"CREATE TABLE ", Table/binary,
+                        " (a integer, b integer, c integer, d integer, "
+                        "e integer, f integer, g integer, h integer, "
+                        "i integer, j integer, k integer, l integer, "
+                        "m integer, n integer, o integer, p integer, "
+                        "q integer, r integer)">>,
+                    []}
+            )
+        )
+    ),
+    TestPid = self(),
+    meck:new(epgsql, [passthrough, no_link]),
+    try
+        install_interleaving_meck(TestPid),
+        _StatusPid =
+            spawn_link(fun() ->
+                Res = emqx_postgresql:on_get_channel_status(ResourceId, <<"stmt18">>, State),
+                TestPid ! {status_result, Res}
+            end),
+        StatusWaiterPid =
+            receive
+                {status_has_conn, Pid1} ->
+                    Pid1
+            after 5_000 ->
+                error(status_check_did_not_reach_parse)
+            end,
+        ?assert(lists:member(StatusWaiterPid, ecpool_worker_pids(State))),
+        BatchPid =
+            spawn_link(fun() ->
+                receive
+                    run_batch_query ->
+                        ok
+                after 5_000 ->
+                    error(batch_query_not_started)
+                end,
+                Res = emqx_postgresql:on_batch_query(
+                    ResourceId,
+                    [
+                        {<<"stmt4">>, #{a => 1, b => 2, c => 3, d => 4}},
+                        {<<"stmt4">>, #{a => 5, b => 6, c => 7, d => 8}}
+                    ],
+                    State
+                ),
+                TestPid ! {batch_result, Res}
+            end),
+        trace_batch_handover(BatchPid),
+        try
+            BatchPid ! run_batch_query,
+            wait_for_batch_handover(BatchPid),
+            StatusWaiterPid ! run_status_parse,
+            receive
+                {status_parsed, _} ->
+                    ok
+            after 5_000 ->
+                error(status_check_did_not_finish_parse)
+            end,
+            receive
+                {batch_parsed, BatchWaiterPid} ->
+                    BatchWaiterPid ! run_batch
+            after 5_000 ->
+                error(batch_query_did_not_reach_parse)
+            end
+        after
+            untrace_batch_handover(BatchPid)
+        end,
+        ?assertEqual(
+            connected,
+            receive
+                {status_result, StatusRes} -> StatusRes
+            after 5_000 -> timeout
+            end
+        ),
+        ?assertEqual(
+            {ok, 2},
+            receive
+                {batch_result, BatchRes} -> BatchRes
+            after 5_000 -> timeout
+            end
+        )
+    after
+        meck:unload(epgsql),
+        _ = emqx_resource:simple_sync_query(
+            ResourceId, {query, <<"DROP TABLE ", Table/binary>>, []}
+        ),
+        emqx_resource:remove_local(ResourceId)
+    end.
+
 perform_lifecycle_check(ResourceId, InitialConfig) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(?PGSQL_RESOURCE_MOD, InitialConfig),
@@ -191,6 +405,9 @@ pgsql_config(Overrides) ->
         <<"config">> => #{
             <<"auto_reconnect">> => true,
             <<"database">> => <<"mqtt">>,
+            <<"disable_prepared_statements">> => maps:get(
+                disable_prepared_statements, Overrides, false
+            ),
             <<"username">> => <<"root">>,
             <<"password">> => <<"public">>,
             <<"pool_size">> => PoolSize,
@@ -208,6 +425,107 @@ test_query_with_params() ->
 
 test_query_application_name() ->
     {query, <<"SELECT current_setting('application_name')">>}.
+
+batch_query(I) when I rem 2 =:= 0 ->
+    [
+        {<<"stmt4">>, #{a => I, b => I + 1, c => I + 2, d => I + 3}},
+        {<<"stmt4">>, #{a => I, b => I + 1, c => I + 2, d => I + 3}}
+    ];
+batch_query(I) ->
+    [
+        {<<"stmt8">>, #{
+            a => I,
+            b => I + 1,
+            c => I + 2,
+            d => I + 3,
+            e => I + 4,
+            f => I + 5,
+            g => I + 6,
+            h => I + 7
+        }},
+        {<<"stmt8">>, #{
+            a => I,
+            b => I + 1,
+            c => I + 2,
+            d => I + 3,
+            e => I + 4,
+            f => I + 5,
+            g => I + 6,
+            h => I + 7
+        }}
+    ].
+
+batch_query_with_timeout(ResourceId, Batch, State) ->
+    try
+        emqx_utils:nolink_apply(
+            fun() ->
+                emqx_postgresql:on_batch_query(ResourceId, Batch, State)
+            end,
+            3_000
+        )
+    catch
+        exit:timeout ->
+            timeout;
+        Class:Reason:Stacktrace ->
+            {exception, Class, Reason, Stacktrace}
+    end.
+
+ecpool_worker_pids(#{pool_name := PoolName}) ->
+    [WorkerPid || {_WorkerName, WorkerPid} <- ecpool:workers(PoolName)].
+
+trace_batch_handover(BatchPid) ->
+    _ = erlang:trace_pattern({ecpool_worker, exec, 3}, true, [local]),
+    _ = erlang:trace(BatchPid, true, [call]),
+    ok.
+
+untrace_batch_handover(BatchPid) ->
+    _ = erlang:trace(BatchPid, false, [call]),
+    _ = erlang:trace_pattern({ecpool_worker, exec, 3}, false, [local]),
+    ok.
+
+install_interleaving_meck(TestPid) ->
+    meck:expect(epgsql, parse2, fun
+        (Conn, "", SQL, []) ->
+            TestPid ! {status_has_conn, self()},
+            receive
+                run_status_parse ->
+                    ok
+            after 5_000 ->
+                error(status_parse_timeout)
+            end,
+            Res = meck:passthrough([Conn, "", SQL, []]),
+            TestPid ! {status_parsed, self()},
+            Res;
+        (Conn, Name, SQL, Types) ->
+            meck:passthrough([Conn, Name, SQL, Types])
+    end),
+    meck:expect(epgsql, execute_batch, fun
+        (Conn, #statement{} = Statement, Batch) ->
+            meck:passthrough([Conn, Statement, Batch]);
+        (Conn, SQL, Batch) ->
+            case epgsql:parse(Conn, SQL) of
+                {ok, #statement{} = Statement} ->
+                    TestPid ! {batch_parsed, self()},
+                    receive
+                        run_batch ->
+                            ok
+                    after 5_000 ->
+                        error(batch_parse_timeout)
+                    end,
+                    epgsql:execute_batch(Conn, Statement, Batch);
+                Error ->
+                    Error
+            end
+    end).
+
+wait_for_batch_handover(BatchPid) ->
+    receive
+        {trace, BatchPid, call,
+            {ecpool_worker, exec, [_WorkerPid, {emqx_postgresql, execute_batch, _Args}, _Timeout]}} ->
+            ok
+    after 5_000 ->
+        error(batch_query_did_not_reach_handover)
+    end.
 
 match_ok({ok, _, _}) -> true;
 match_ok(_) -> false.

--- a/changes/ee/fix-17681.en.md
+++ b/changes/ee/fix-17681.en.md
@@ -1,0 +1,3 @@
+Fixed PostgreSQL connector batch writes when prepared statements are disabled.
+
+Previously, concurrent batches on the same connection could interleave raw SQL parsing and fail with PostgreSQL protocol errors. Table-existence checks are also serialized through the connector worker to avoid interleaving with batch execution.


### PR DESCRIPTION
Release version:
6.0.4

## Summary
Fix version: 6.0.4
Fix: https://github.com/emqx/emqx-customer-support/issues/16

Ports #17627 to release-60.

When PostgreSQL prepared statements are disabled, batch execution receives raw SQL text. Running those raw batch calls with `no_handover` can interleave parse and execute work on one worker connection, so concurrent batches with different parameter shapes may fail with PostgreSQL `protocol_violation`. Table existence checks also called `epgsql:parse2/4` directly on the worker client, which can interleave with query execution on the same connection.

This change uses `handover` for raw `query` calls and for `execute_batch` when prepared statements are disabled, while keeping the prepared batch path on `no_handover`. It also runs table existence checks through `ecpool_worker:exec/3`, adds regression coverage for concurrent raw batch execution and table-check interleaving, bumps `emqx_postgresql` to `6.0.4`, and adds `changes/ee/fix-17681.en.md`.

Local checks run before publishing: `git diff --check`, `./scripts/erlfmt -c apps/emqx_postgresql/src/emqx_postgresql.erl apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl`, `mix format --check-formatted apps/emqx_postgresql/mix.exs`, `./scripts/apps-version-check.exs`, `mix compile --force`, `./scripts/ct/run.sh --app apps/emqx_postgresql`, and `./scripts/elvis-check.sh release-60`. `make static_checks` passed Xref, then stopped on existing ODBC Dialyzer findings in Snowflake and SQLServer connector modules unrelated to this PostgreSQL diff.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)