### PR TITLE
docs: refresh upgrade paths matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,36 +163,52 @@ _build/emqx/rel/emqx/bin/emqx console
 
 ## Rolling Upgrade Paths Since 5.0
 
-Below is the matrix supported rolling upgrade paths since 5.0.
+Below are the matrices of supported rolling upgrade paths since 5.0.
+Tables are split for readability; the late-v5 versions (5.8 – 5.10) appear in both.
 
-- Version numbers end with `?` e.g. `6.0?` are future releases.
+- Version numbers end with `?` e.g. `6.3?` are future releases.
 - ✅: Supported, or planed to support.
-- ⚠️:  May experience issues, require manual resolution.
+- ⚠️:  Supported, but with limitations.
 - ❌: Not supported.
-- 🔄: Tentative support for future versions.
+- 🔄: Tentative full support for future versions.
 
 See release notes for detailed information.
 
-| From\To  | 5.1  | 5.2  | 5.3  | 5.4  | 5.5  | 5.6  | 5.7  | 5.8  | 5.9   | 5.10? | 6.0?  |
-|----------|------|------|------|------|------|------|------|------|-------|-------|-------|
-| 5.0      | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ⚠️[1]  | ❌[2] | ❌[2] |
-| 5.1      | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅    | ❌[2] | ❌[2] |
-| 5.2      |      | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅    | ❌[2] | ❌[2] |
-| 5.3      |      |      | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅    | ❌[2] | ❌[2] |
-| 5.4      |      |      |      | ✅   | ✅   | ⚠️    | ✅   | ✅   | ✅    | ✅    | 🔄    |
-| 5.5      |      |      |      |      | ✅   | ⚠️    | ✅   | ✅   | ✅    | ✅    | 🔄    |
-| 5.6      |      |      |      |      |      | ✅   | ✅   | ✅   | ✅    | ✅    | 🔄    |
-| 5.7      |      |      |      |      |      |      | ✅   | ✅   | ✅    | ✅    | 🔄    |
-| 5.8      |      |      |      |      |      |      |      | ✅   | ⚠️[3] | ⚠️[3] | 🔄    |
-| 5.9      |      |      |      |      |      |      |      |      | ✅    | ✅    | ✅    |
-| 5.10?    |      |      |      |      |      |      |      |      |       | ✅    | ✅    |
-| 6.0?     |      |      |      |      |      |      |      |      |       |       | ✅    |
+### Within v5 (5.0 – 5.10)
+
+| From\To | 5.1  | 5.2  | 5.3  | 5.4  | 5.5  | 5.6  | 5.7  | 5.8  | 5.9   | 5.10  |
+|---------|------|------|------|------|------|------|------|------|-------|-------|
+| 5.0     | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ⚠️[1]  | ❌[2] |
+| 5.1     | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅    | ❌[2] |
+| 5.2     |      | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅    | ❌[2] |
+| 5.3     |      |      | ✅   | ✅   | ✅   | ✅   | ✅   | ✅   | ✅    | ❌[2] |
+| 5.4     |      |      |      | ✅   | ✅   | ⚠️    | ✅   | ✅   | ✅    | ✅    |
+| 5.5     |      |      |      |      | ✅   | ⚠️    | ✅   | ✅   | ✅    | ✅    |
+| 5.6     |      |      |      |      |      | ✅   | ✅   | ✅   | ✅    | ✅    |
+| 5.7     |      |      |      |      |      |      | ✅   | ✅   | ✅    | ✅    |
+| 5.8     |      |      |      |      |      |      |      | ✅   | ⚠️[3]  | ⚠️[3]  |
+| 5.9     |      |      |      |      |      |      |      |      | ✅    | ✅    |
+| 5.10    |      |      |      |      |      |      |      |      |       | ✅    |
 
 - [1] Old limiter configs should be deleted from the config files (`etc/emqx.conf` and `data/configs/cluster-override.conf`) before upgrade.
 - [2] Pre-5.4 routing table will be deleted. Upgrade to 5.9 first, then perform a full-cluster restart (not rolling) before upgrade to 5.10 or later.
 - [3] Opentelemetry headers configuration support was introduced in 5.8.7. This release date is later than 5.9.0 and 5.10.0.
       5.8 versions running 5.8.7 or later require a rolling upgrade to version 5.9.1 or 5.10.1.
       Alternatively, remove the header configuration for OpenTelemetry integration during the upgrade.
+
+### Into v6 (5.8 – 6.3?)
+
+| From\To | 5.8  | 5.9   | 5.10  | 6.0   | 6.1   | 6.2  | 6.3?  |
+|---------|------|-------|-------|-------|-------|------|-------|
+| 5.8     | ✅   | ⚠️[3]  | ⚠️[3]  | ⚠️[4]  | ⚠️[4]  | ⚠️[4] | ⚠️[4]  |
+| 5.9     |      | ✅    | ✅    | ⚠️[4]  | ⚠️[4]  | ⚠️[4] | ⚠️[4]  |
+| 5.10    |      |       | ✅    | ⚠️[4]  | ⚠️[4]  | ⚠️[4] | ⚠️[4]  |
+| 6.0     |      |       |       | ✅    | ✅    | ✅   | ✅    |
+| 6.1     |      |       |       |       | ✅    | ✅   | ✅    |
+| 6.2     |      |       |       |       |       | ✅   | ✅    |
+| 6.3?    |      |       |       |       |       |      | ✅    |
+
+- [4] Durable session states will be lost after upgraded from v5 to v6. After clients reconnect, the sessions created in the new nodes will appear to be clean.
 
 ## License
 


### PR DESCRIPTION
Port of #17682 from \`release-58\` to \`release-60\`.

## Summary

Split the rolling-upgrade matrix in the README into two tables (within-v5 5.0..5.10 and into-v6 5.8..6.3?) for readability. Drop the v5 rows that no longer need a v6 transition column on this branch (5.4..5.7 row tails); the late-v5 rows are kept in the second table so 5.8/5.9/5.10 → v6 paths remain visible. Footnote [3] is defined once under Table 1 and referenced in both tables.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking