### PR TITLE
test(mqtt): de-flake t_offline_message_queueing

### DIFF
--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -228,7 +228,12 @@ t_offline_message_queueing(_) ->
     ok = emqtt:publish(C2, <<"TopicA/B">>, <<"qos 0">>, 0),
     {ok, _} = emqtt:publish(C2, <<"Topic/C">>, <<"qos 1">>, 1),
     {ok, _} = emqtt:publish(C2, <<"TopicA/C">>, <<"qos 2">>, 2),
-    timer:sleep(10),
+    %% Wait until all three messages have been dispatched into c1's offline
+    %% session mqueue before tearing down the publisher. The publish calls can
+    %% return before dispatch reaches the subscriber: QoS 0 has no broker ack at
+    %% all, and the QoS 1/2 acks are sent before the broker drives the dispatch
+    %% to subscribers. A fixed sleep here races the disconnect on slow runners.
+    ?WAIT(?assertEqual(3, proplists:get_value(mqueue_len, emqx_cm:get_chan_stats(<<"c1">>))), 30),
     emqtt:disconnect(C2),
 
     {ok, C3} = emqtt:start_link([{clean_start, false}, {clientid, <<"c1">>}]),


### PR DESCRIPTION
## Problem

`emqx_client_SUITE:t_offline_message_queueing` intermittently fails on CI with `length(recv_msgs(3))` returning 2 instead of 3 (e.g. [this run](https://github.com/emqx/emqx/actions/runs/28011117330/job/82906325297?pr=17684)).

The test publishes QoS 0/1/2 messages to an offline session's mqueue, then `timer:sleep(10)` before disconnecting the publisher and resuming the session. That sleep races the dispatch-to-mqueue chain:

- the QoS 0 publish has no broker-side ack at all;
- the QoS 1/2 acks are sent **before** the broker drives dispatch to subscribers.

So all three publish calls can return before the messages land in the offline mqueue. Under load on CI runners, 10ms loses the race.

## Fix

Replace the fixed sleep with a deterministic wait on the offline session's `mqueue_len` via `emqx_cm:get_chan_stats/1`, reusing the suite's existing `?WAIT` retry macro. This blocks until all three messages are actually enqueued before tearing down the publisher — removing the race rather than widening the window, and keeping the test fast.

## Validation

- 30/30 green locally (`gen_tcp_listener.mqttv4.t_offline_message_queueing`).
- `make fmt-diff` and elvis clean.