### PR TITLE
test(pulsar): de-flake t_rule_action async-mode metrics assert

### DIFF
--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_SUITE.erl
@@ -559,18 +559,24 @@ t_rule_action(TCConfig) when is_list(TCConfig) ->
         #{payload := Payload} = Context,
         Consumed = receive_consumed(),
         ?assertMatch([#{<<"payload">> := Payload}], Consumed),
-        ?assertMatch(
-            {200, #{
-                <<"metrics">> := #{
-                    <<"matched">> := 1,
-                    <<"success">> := 1,
-                    <<"failed">> := 0,
-                    <<"dropped">> := 0,
-                    <<"late_reply">> := 0,
-                    <<"received">> := 0
-                }
-            }},
-            get_action_metrics_api(TCConfig)
+        %% Async producer mode bumps `inflight' synchronously but `success'
+        %% only after Pulsar's ACK is received. Poll until counters settle.
+        ?retry(
+            _Sleep = 200,
+            _Attempts = 25,
+            ?assertMatch(
+                {200, #{
+                    <<"metrics">> := #{
+                        <<"matched">> := 1,
+                        <<"success">> := 1,
+                        <<"failed">> := 0,
+                        <<"dropped">> := 0,
+                        <<"late_reply">> := 0,
+                        <<"received">> := 0
+                    }
+                }},
+                get_action_metrics_api(TCConfig)
+            )
         )
     end,
     Opts = #{


### PR DESCRIPTION
## Summary

The async producer mode bumps the \`inflight\` counter synchronously but \`success\` only after Pulsar acknowledges. The post-publish assertion in \`t_rule_action\` read the metrics before the ACK landed, leaving \`success=0, inflight=1\` on a path that expected \`success=1, inflight=0\`.

Wrap the metrics assertion in \`?retry\` to poll until counters settle. Mirrors the convention already used 10+ times elsewhere in this suite.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking