### PR TITLE
test(bridge_mqtt): de-flake t_reconnect drain

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_action_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_action_SUITE.erl
@@ -340,6 +340,25 @@ get_emqtt_clients(PoolName) ->
         ecpool:workers(PoolName)
     ).
 
+%% Collect N `'DOWN'' messages from monitors already set up by the caller,
+%% waiting up to `Timeout' total for them all to arrive. Fails the test if
+%% fewer than N arrive within the timeout. Unlike `emqx_utils:drain_down/1'
+%% (which uses `after 0' and races mailbox arrival), this actually waits.
+wait_for_downs(N, Timeout) ->
+    Deadline = erlang:monotonic_time(millisecond) + Timeout,
+    wait_for_downs(N, Deadline, []).
+
+wait_for_downs(0, _Deadline, Acc) ->
+    lists:reverse(Acc);
+wait_for_downs(N, Deadline, Acc) ->
+    Remaining = max(0, Deadline - erlang:monotonic_time(millisecond)),
+    receive
+        {'DOWN', _MRef, process, Pid, _Reason} ->
+            wait_for_downs(N - 1, Deadline, [Pid | Acc])
+    after Remaining ->
+        ct:fail({timeout_waiting_for_downs, #{missing => N, got => lists:reverse(Acc)}})
+    end.
+
 start_publisher(Topic, Interval, CtrlPid) ->
     spawn_link(fun() -> publisher(Topic, 1, Interval, CtrlPid) end).
 
@@ -724,7 +743,10 @@ t_reconnect(TCConfig) ->
             lists:foreach(fun(Pid) -> monitor(process, Pid) end, ChanPids),
             ct:pal("kicking ~p (leaving 1 client alive)", [ClientIds]),
             {204, _} = emqx_bridge_v2_testlib:kick_clients_http(ClientIds),
-            DownPids = emqx_utils:drain_down(PoolSize - 1),
+            %% `emqx_utils:drain_down/1' returns whatever is already in the
+            %% mailbox (`after 0'), so it races the kick propagation. Wait
+            %% with a generous timeout for the expected count to arrive.
+            DownPids = wait_for_downs(PoolSize - 1, 5_000),
             ?assertEqual(lists:sort(ChanPids), lists:sort(DownPids)),
             %% Recovery
             ct:pal("clients kicked; waiting for recovery..."),


### PR DESCRIPTION
## Summary

\`emqx_utils:drain_down/1\` returns whatever is already in the mailbox (\`after 0\`) and does not wait. After \`kick_clients_http\`, the test process called \`drain_down(2)\` before both DOWN signals had propagated through \`emqx_cm\` + channel teardown, leaving \`DownPids\` with only the one already-arrived pid:

\`\`\`
expected: [Pid1, Pid2]
got: [Pid1]
\`\`\`

Replace \`drain_down/1\` with a local \`wait_for_downs/2\` helper that polls the mailbox until N DOWNs arrive or a 5s deadline elapses (then fails loudly with a useful message).

The second \`drain_down\` use in this suite (line 820) ignores its return value and is left as-is.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking