### PR TITLE
fix(oracle): handle prepare checks and large text binds

### DIFF
--- a/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
+++ b/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
@@ -180,6 +180,29 @@ sql_insert_template_with_inconsistent_datatype() ->
 sql_create_table() ->
     "CREATE TABLE mqtt_test (topic VARCHAR2(255), msgid VARCHAR2(64), payload NCLOB, retain NUMBER(1))".
 
+sql_eec_1322_insert_template() ->
+    "INSERT INTO t_mqtt_msgs(msgid, sender, topic, qos, retain, arrived, payload) VALUES(\n"
+    "  ${id},\n"
+    "  ${clientid},\n"
+    "  ${topic},\n"
+    "  ${qos},\n"
+    "  ${flags.retain},\n"
+    "  TO_TIMESTAMP('1970-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS') + "
+    "NUMTODSINTERVAL(${timestamp}/1000, 'SECOND'),\n"
+    "  ${payload}\n"
+    ")".
+
+sql_create_eec_1322_table() ->
+    "CREATE TABLE t_mqtt_msgs ("
+    "msgid VARCHAR2(64), "
+    "sender VARCHAR2(64), "
+    "topic VARCHAR2(255), "
+    "qos NUMBER(1), "
+    "retain NUMBER(1), "
+    "payload NCLOB, "
+    "arrived TIMESTAMP"
+    ")".
+
 sql_drop_table() ->
     "BEGIN\n"
     "        EXECUTE IMMEDIATE 'DROP TABLE mqtt_test';\n"
@@ -192,8 +215,75 @@ sql_drop_table() ->
     "            END IF;\n"
     "     END;".
 
+sql_drop_eec_1322_table() ->
+    "BEGIN\n"
+    "        EXECUTE IMMEDIATE 'DROP TABLE t_mqtt_msgs';\n"
+    "     EXCEPTION\n"
+    "        WHEN OTHERS THEN\n"
+    "            IF SQLCODE = -942 THEN\n"
+    "                NULL;\n"
+    "            ELSE\n"
+    "                RAISE;\n"
+    "            END IF;\n"
+    "     END;".
+
 sql_check_table_exist() ->
     "SELECT COUNT(*) FROM user_tables WHERE table_name = 'MQTT_TEST'".
+
+sql_check_table_exist(TableName) ->
+    "SELECT COUNT(*) FROM user_tables WHERE table_name = '" ++ TableName ++ "'".
+
+sql_drop_probe_audit_table() ->
+    "BEGIN\n"
+    "        EXECUTE IMMEDIATE 'DROP TABLE mqtt_probe_audit';\n"
+    "     EXCEPTION\n"
+    "        WHEN OTHERS THEN\n"
+    "            IF SQLCODE = -942 THEN\n"
+    "                NULL;\n"
+    "            ELSE\n"
+    "                RAISE;\n"
+    "            END IF;\n"
+    "     END;".
+
+sql_drop_probe_trigger() ->
+    "BEGIN\n"
+    "        EXECUTE IMMEDIATE 'DROP TRIGGER mqtt_probe_trigger';\n"
+    "     EXCEPTION\n"
+    "        WHEN OTHERS THEN\n"
+    "            IF SQLCODE = -4080 THEN\n"
+    "                NULL;\n"
+    "            ELSE\n"
+    "                RAISE;\n"
+    "            END IF;\n"
+    "     END;".
+
+sql_create_probe_audit_table() ->
+    "CREATE TABLE mqtt_probe_audit (marker VARCHAR2(64))".
+
+sql_create_probe_trigger() ->
+    "CREATE OR REPLACE TRIGGER mqtt_probe_trigger\n"
+    "BEFORE INSERT ON mqtt_test\n"
+    "DECLARE\n"
+    "    PRAGMA AUTONOMOUS_TRANSACTION;\n"
+    "BEGIN\n"
+    "    INSERT INTO mqtt_probe_audit(marker) VALUES ('prepare');\n"
+    "    COMMIT;\n"
+    "END;".
+
+sql_drop_prepare_probe_table() ->
+    "BEGIN\n"
+    "        EXECUTE IMMEDIATE 'DROP TABLE mqtt_prepare_probe';\n"
+    "     EXCEPTION\n"
+    "        WHEN OTHERS THEN\n"
+    "            IF SQLCODE = -942 THEN\n"
+    "                NULL;\n"
+    "            ELSE\n"
+    "                RAISE;\n"
+    "            END IF;\n"
+    "     END;".
+
+sql_create_prepare_probe_table() ->
+    "CREATE TABLE mqtt_prepare_probe (id NUMBER)".
 
 new_jamdb_connection(Config) ->
     JamdbOpts = [
@@ -218,6 +308,16 @@ reset_table(Config) ->
     end,
     ok.
 
+reset_eec_1322_table(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_eec_1322_table_if_exists(Conn),
+        {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_create_eec_1322_table())
+    after
+        close_jamdb_connection(Conn)
+    end,
+    ok.
+
 drop_table_if_exists(Conn) when is_pid(Conn) ->
     {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_table()),
     ok;
@@ -229,6 +329,75 @@ drop_table_if_exists(Config) ->
         close_jamdb_connection(Conn)
     end,
     ok.
+
+drop_eec_1322_table_if_exists(Conn) when is_pid(Conn) ->
+    {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_eec_1322_table()),
+    ok;
+drop_eec_1322_table_if_exists(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_eec_1322_table_if_exists(Conn)
+    after
+        close_jamdb_connection(Conn)
+    end,
+    ok.
+
+create_probe_audit_objects(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_probe_audit_objects(Conn),
+        {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_create_probe_audit_table()),
+        {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_create_probe_trigger())
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+drop_probe_audit_objects(Conn) when is_pid(Conn) ->
+    {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_probe_trigger()),
+    {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_probe_audit_table()),
+    ok;
+drop_probe_audit_objects(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_probe_audit_objects(Conn)
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+drop_prepare_probe_table(Conn) when is_pid(Conn) ->
+    {ok, [{proc_result, 0, _}]} = jamdb_oracle:sql_query(Conn, sql_drop_prepare_probe_table()),
+    ok;
+drop_prepare_probe_table(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        ok = drop_prepare_probe_table(Conn)
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+scan_probe_audit_table(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        jamdb_oracle:sql_query(Conn, "select count(*) from mqtt_probe_audit")
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+count_eec_1322_rows(Config) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        jamdb_oracle:sql_query(Conn, "select count(*) from t_mqtt_msgs")
+    after
+        close_jamdb_connection(Conn)
+    end.
+
+count_user_table(Config, TableName) ->
+    {ok, Conn} = new_jamdb_connection(Config),
+    try
+        jamdb_oracle:sql_query(Conn, sql_check_table_exist(TableName))
+    after
+        close_jamdb_connection(Conn)
+    end.
 
 oracle_config(TestCase, _ConnectionType, Config) ->
     UniqueNum = integer_to_binary(erlang:unique_integer()),
@@ -365,6 +534,9 @@ probe_bridge_api(Config, Overrides) ->
         Error ->
             Error
     end.
+
+large_json_payload() ->
+    emqx_utils_json:encode(#{<<"msg">> => binary:copy(<<"a">>, 5000)}).
 
 create_rule_and_action_http(Config) ->
     OracleName = ?config(oracle_name, Config),
@@ -720,6 +892,95 @@ t_probe_with_inconsistent_datatype(Config) ->
         #{<<"sql">> => sql_insert_template_with_inconsistent_datatype()}
     ),
     ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes0).
+
+t_prepare_does_not_execute_user_sql(Config) ->
+    reset_table(Config),
+    create_probe_audit_objects(Config),
+    on_exit(fun() -> drop_probe_audit_objects(Config) end),
+    ?assertMatch({ok, _}, create_bridge_api(Config)),
+    _ = emqx_bridge_testlib:get_bridge_api(Config),
+    ?assertMatch(
+        {ok, [{result_set, _, _, [[{0}]]}]},
+        scan_probe_audit_table(Config)
+    ),
+    ok.
+
+t_prepare_rejects_ddl_without_executing(Config) ->
+    drop_prepare_probe_table(Config),
+    on_exit(fun() -> drop_prepare_probe_table(Config) end),
+    ?assertMatch(
+        {ok, _},
+        create_bridge_api(Config, #{<<"sql">> => sql_create_prepare_probe_table()})
+    ),
+    ?assertMatch(
+        {ok, [{result_set, _, _, [[{0}]]}]},
+        count_user_table(Config, "MQTT_PREPARE_PROBE")
+    ),
+    ?retry(
+        _Sleep = 1_000,
+        _Attempts = 20,
+        begin
+            {ok, #{<<"status_reason">> := StatusReason}} =
+                emqx_bridge_testlib:get_bridge_api(Config),
+            ?assertNotEqual(nomatch, binary:match(StatusReason, <<"unsupported_sql_statement">>))
+        end
+    ),
+    ok.
+
+t_eec_1322_large_payload_after_small_payload(Config) ->
+    reset_eec_1322_table(Config),
+    on_exit(fun() -> drop_eec_1322_table_if_exists(Config) end),
+    ?assertMatch(
+        {ok, _},
+        create_bridge_api(Config, #{<<"sql">> => sql_eec_1322_insert_template()})
+    ),
+    BridgeId = bridge_id(Config),
+    SmallPayload = emqx_utils_json:encode(#{<<"msg">> => <<"heelo">>}),
+    LargePayload = large_json_payload(),
+    BaseParams = #{
+        clientid => <<"client1">>,
+        topic => <<"mqtt/eec1322">>,
+        qos => 0,
+        flags => #{retain => false},
+        timestamp => erlang:system_time(millisecond)
+    },
+    ?check_trace(
+        begin
+            emqx_bridge:send_message(BridgeId, BaseParams#{
+                id => integer_to_binary(erlang:unique_integer()),
+                payload => SmallPayload
+            }),
+            ?retry(
+                _Sleep1 = 500,
+                _Attempts1 = 60,
+                ?assertMatch(
+                    {ok, [{result_set, _, _, [[{1}]]}]},
+                    count_eec_1322_rows(Config)
+                )
+            ),
+            emqx_bridge:send_message(BridgeId, BaseParams#{
+                id => integer_to_binary(erlang:unique_integer()),
+                payload => LargePayload
+            }),
+            ?retry(
+                _Sleep2 = 500,
+                _Attempts2 = 60,
+                ?assertMatch(
+                    {ok, [{result_set, _, _, [[{2}]]}]},
+                    count_eec_1322_rows(Config)
+                )
+            ),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertEqual(
+                [],
+                [Event || #{error := _} = Event <- ?of_kind(oracle_connector_query_return, Trace)]
+            ),
+            ok
+        end
+    ),
+    ok.
 
 t_on_get_status(Config) ->
     ProxyPort = ?config(proxy_port, Config),

--- a/apps/emqx_oracle/mix.exs
+++ b/apps/emqx_oracle/mix.exs
@@ -23,7 +23,7 @@ defmodule EMQXOracle.MixProject do
 
   def deps() do
     [
-      {:jamdb_oracle, github: "emqx/jamdb_oracle", tag: "0.4.9.5", manager: :rebar3},
+      {:jamdb_oracle, github: "emqx/jamdb_oracle", tag: "0.4.9.7", manager: :rebar3},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true}
     ]

--- a/apps/emqx_oracle/rebar.config
+++ b/apps/emqx_oracle/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {jamdb_oracle, {git, "https://github.com/emqx/jamdb_oracle", {tag, "0.4.9.5"}}},
+    {jamdb_oracle, {git, "https://github.com/emqx/jamdb_oracle", {tag, "0.4.9.7"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.

--- a/apps/emqx_oracle/src/emqx_oracle.app.src
+++ b/apps/emqx_oracle/src/emqx_oracle.app.src
@@ -1,6 +1,6 @@
 {application, emqx_oracle, [
     {description, "EMQX Enterprise Oracle Database Connector"},
-    {vsn, "0.2.7"},
+    {vsn, "0.2.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_oracle/src/emqx_oracle.erl
+++ b/apps/emqx_oracle/src/emqx_oracle.erl
@@ -14,6 +14,10 @@
 -define(UNHEALTHY_TARGET_MSG,
     "Oracle table is invalid. Please check if the table exists in Oracle Database."
 ).
+-define(UNSUPPORTED_SQL_STATEMENT_MSG,
+    "unsupported_sql_statement: DDL, DCL, and transaction control statements are not supported "
+    "in Oracle Action SQL templates."
+).
 
 -define(DEFAULT_ROLE, normal).
 -define(SYSDBA_ROLE, sysdba).
@@ -51,6 +55,12 @@
     oracle_host_options/0
 ]).
 
+-ifdef(TEST).
+-export([
+    sql_has_parse_side_effect/1
+]).
+-endif.
+
 -define(ORACLE_DEFAULT_PORT, 1521).
 -define(SYNC_QUERY_MODE, no_handover).
 -define(DEFAULT_POOL_SIZE, 8).
@@ -61,12 +71,15 @@
 }).
 
 -type prepares() :: #{atom() => binary()}.
+-type prepare_state() ::
+    prepares()
+    | {error, _Reason :: term(), prepares()}.
 -type params_tokens() :: #{atom() => list()}.
 
 -type state() ::
     #{
         pool_name := binary(),
-        prepare_sql := prepares(),
+        prepare_sql := prepare_state(),
         params_tokens := params_tokens(),
         batch_params_tokens := params_tokens()
     }.
@@ -191,6 +204,8 @@ on_get_channel_status(
         {error, undefined_table} ->
             %% return new state indicating that we are connected but the target table is not created
             {?status_disconnected, {unhealthy_target, ?UNHEALTHY_TARGET_MSG}};
+        {error, unsupported_sql_statement} ->
+            {?status_disconnected, {unhealthy_target, ?UNSUPPORTED_SQL_STATEMENT_MSG}};
         {error, _Reason} ->
             %% do not log error, it is logged in prepare_sql_to_conn
             ?status_connecting
@@ -355,10 +370,10 @@ do_check_prepares(
     _ChannelId,
     _PoolName,
     #{
-        prepare_sql := {error, _Prepares}
+        prepare_sql := {error, Reason, _Prepares}
     } = _State
 ) ->
-    {error, undefined_table};
+    {error, Reason};
 do_check_prepares(
     ChannelId,
     PoolName,
@@ -377,8 +392,12 @@ do_check_prepares(
                 case ecpool_worker:client(WorkerPid) of
                     {ok, Conn} ->
                         case check_if_table_exists(Conn, SQL, Tokens) of
-                            {error, undefined_table} -> {error, undefined_table};
-                            _ -> ok
+                            {error, undefined_table} ->
+                                {error, undefined_table};
+                            {error, unsupported_sql_statement} ->
+                                {error, unsupported_sql_statement};
+                            _ ->
+                                ok
                         end;
                     _ ->
                         ok
@@ -457,8 +476,11 @@ init_prepare(PoolName, State = #{prepare_sql := Prepares, params_tokens := Token
             },
             ?SLOG(error, LogMeta),
             %% mark the prepare_sql as failed
-            State#{prepare_sql => {error, Prepares}}
+            State#{prepare_sql => {error, prepare_error_reason(Error), Prepares}}
     end.
+
+prepare_error_reason({error, Reason}) ->
+    Reason.
 
 do_sql_query(Conn, Req) ->
     try
@@ -526,75 +548,147 @@ prepare_sql_to_conn(Conn, [{Key, SQL} | PrepareList], TokensMap, Statements) whe
 get_reconnect_callback_signature([[{ChannelId, _Template}]]) ->
     ChannelId.
 
-check_if_table_exists(Conn, SQL, Tokens0) ->
-    % Discard nested tokens for checking if table exist. As payload here is defined as
-    % a single string, it would fail if Token is, for instance, ${payload.msg}, causing
-    % bridge probe to fail.
-    Tokens = lists:map(
-        fun
-            ({var, [Token | _DiscardedDeepTokens]}) ->
-                {var, [Token]};
-            (Token) ->
-                Token
-        end,
-        Tokens0
-    ),
-    {Event, _Headers} = emqx_rule_events:eventmsg_publish(
-        emqx_message:make(<<"t/opic">>, "test query")
-    ),
-    SqlQuery = "begin " ++ binary_to_list(SQL) ++ "; rollback; end;",
-    Params = emqx_placeholder:proc_sql(Tokens, Event),
-    case do_sql_query(Conn, {SqlQuery, Params}) of
+check_if_table_exists(Conn, SQL, _Tokens0) ->
+    case sql_has_parse_side_effect(SQL) of
+        true ->
+            {error, unsupported_sql_statement};
+        false ->
+            check_if_sql_parseable(Conn, SQL, 1)
+    end.
+
+check_if_sql_parseable(Conn, SQL, Retries) ->
+    ParseSQL =
+        "declare "
+        "  c integer; "
+        "begin "
+        "  c := dbms_sql.open_cursor; "
+        "  dbms_sql.parse(c, :1, dbms_sql.native); "
+        "  dbms_sql.close_cursor(c); "
+        "exception "
+        "  when others then "
+        "    if dbms_sql.is_open(c) then "
+        "      dbms_sql.close_cursor(c); "
+        "    end if; "
+        "    raise; "
+        "end;",
+    case do_sql_query(Conn, {ParseSQL, [binary_to_list(SQL)]}) of
         {ok, [{proc_result, 0, _Description}]} ->
             ok;
-        {ok, [{proc_result, 942, _Description}]} ->
-            %% Target table is not created
+        {ok, [{proc_result, RetCode, _Description}]} when
+            RetCode =:= 904; RetCode =:= 942
+        ->
+            %% ORA-00904: invalid identifier
+            %% ORA-00942: table or view does not exist
             {error, undefined_table};
+        {ok, [{proc_result, 1013, _Description}]} when Retries > 0 ->
+            %% ORA-01013: user requested cancel of current operation
+            check_if_sql_parseable(Conn, SQL, Retries - 1);
         {ok, [{proc_result, _, Description}]} ->
-            % only the last result is returned, so we need to check on description if it
-            % contains the "Table doesn't exist" error as it can not be the last one.
-            % (for instance, the ORA-06550 can be the result value when table does not exist)
-            ErrorCodes =
-                case re:run(Description, <<"(ORA-[0-9]+)">>, [global, {capture, first, binary}]) of
-                    {match, OraCodes} -> OraCodes;
-                    _ -> []
-                end,
-            OraMap = maps:from_keys([ErrorCode || [ErrorCode] <- ErrorCodes], true),
-            case OraMap of
-                _ when is_map_key(<<"ORA-00942">>, OraMap) ->
-                    % ORA-00942: table or view does not exist
-                    {error, undefined_table};
-                _ when is_map_key(<<"ORA-00932">>, OraMap) ->
-                    % ORA-00932: inconsistent datatypes
-                    % There is a some type inconsistency with table definition but
-                    % table does exist. Probably this inconsistency was caused by
-                    % token discarding in this test query.
-                    ok;
-                _ when is_map_key(<<"ORA-01400">>, OraMap) ->
-                    % ORA-01400: cannot insert NULL into (string)
-                    % There is a some type inconsistency with table definition but
-                    % table does exist. Probably this inconsistency was caused by
-                    % token discarding in this test query.
-                    ok;
-                _ when is_map_key(<<"ORA-01013">>, OraMap) ->
-                    % ORA-01013: user requested cancel of current operation
-                    % This error is returned when the query is canceled by the user.
-                    ok;
-                _ when is_map_key(<<"ORA-12899">>, OraMap) ->
-                    % ORA-12899: value too large for column
-                    % This error is returned when the value is too large for the column.
-                    ok;
-                _ ->
-                    {error, Description}
-            end;
-        {error, {noproc, _}} ->
+            handle_parse_error_description(Description);
+        {error, {noproc, _}} when Retries > 0 ->
             %% See Note [jamdb oracle race condition]
-            check_if_table_exists(Conn, SQL, Tokens0);
-        {error, socket, closed} ->
-            check_if_table_exists(Conn, SQL, Tokens0);
+            check_if_sql_parseable(Conn, SQL, Retries - 1);
+        {error, socket, closed} when Retries > 0 ->
+            check_if_sql_parseable(Conn, SQL, Retries - 1);
         Reason ->
             {error, Reason}
     end.
+
+handle_parse_error_description(Description) ->
+    case oracle_error_codes(Description) of
+        #{<<"ORA-00904">> := true} ->
+            {error, undefined_table};
+        #{<<"ORA-00942">> := true} ->
+            {error, undefined_table};
+        #{<<"ORA-01013">> := true} ->
+            ok;
+        _ ->
+            {error, Description}
+    end.
+
+oracle_error_codes(Description) ->
+    case
+        re:run(iolist_to_binary(Description), <<"(ORA-[0-9]+)">>, [
+            global,
+            {capture, first, binary}
+        ])
+    of
+        {match, OraCodes} ->
+            maps:from_keys([ErrorCode || [ErrorCode] <- OraCodes], true);
+        nomatch ->
+            #{}
+    end.
+
+sql_has_parse_side_effect(SQL) ->
+    case first_sql_token(SQL) of
+        <<"alter">> -> true;
+        <<"analyze">> -> true;
+        <<"associate">> -> true;
+        <<"audit">> -> true;
+        <<"comment">> -> true;
+        <<"commit">> -> true;
+        <<"create">> -> true;
+        <<"disassociate">> -> true;
+        <<"drop">> -> true;
+        <<"explain">> -> true;
+        <<"flashback">> -> true;
+        <<"grant">> -> true;
+        <<"lock">> -> true;
+        <<"noaudit">> -> true;
+        <<"purge">> -> true;
+        <<"rename">> -> true;
+        <<"revoke">> -> true;
+        <<"rollback">> -> true;
+        <<"savepoint">> -> true;
+        <<"set">> -> true;
+        <<"truncate">> -> true;
+        _ -> false
+    end.
+
+first_sql_token(SQL) ->
+    take_sql_token(skip_sql_prefix(to_bin(SQL)), <<>>).
+
+skip_sql_prefix(<<C, Rest/binary>>) when
+    C =:= $\s; C =:= $\t; C =:= $\n; C =:= $\r; C =:= $\f; C =:= $\v
+->
+    skip_sql_prefix(Rest);
+skip_sql_prefix(<<"--", Rest/binary>>) ->
+    skip_sql_prefix(skip_line_comment(Rest));
+skip_sql_prefix(<<"/*", Rest/binary>>) ->
+    skip_sql_prefix(skip_block_comment(Rest));
+skip_sql_prefix(SQL) ->
+    SQL.
+
+skip_line_comment(<<"\n", Rest/binary>>) ->
+    Rest;
+skip_line_comment(<<"\r", Rest/binary>>) ->
+    Rest;
+skip_line_comment(<<_, Rest/binary>>) ->
+    skip_line_comment(Rest);
+skip_line_comment(<<>>) ->
+    <<>>.
+
+skip_block_comment(<<"*/", Rest/binary>>) ->
+    Rest;
+skip_block_comment(<<_, Rest/binary>>) ->
+    skip_block_comment(Rest);
+skip_block_comment(<<>>) ->
+    <<>>.
+
+take_sql_token(<<C, Rest/binary>>, Acc) when
+    (C >= $A andalso C =< $Z) orelse
+        (C >= $a andalso C =< $z) orelse
+        (C >= $0 andalso C =< $9) orelse
+        C =:= $_
+->
+    take_sql_token(Rest, <<Acc/binary, (lower_ascii(C))>>);
+take_sql_token(_Rest, Acc) ->
+    Acc.
+
+lower_ascii(C) when C >= $A, C =< $Z ->
+    C + 32;
+lower_ascii(C) ->
+    C.
 
 to_bin(Bin) when is_binary(Bin) ->
     Bin;

--- a/apps/emqx_oracle/test/emqx_oracle_tests.erl
+++ b/apps/emqx_oracle/test/emqx_oracle_tests.erl
@@ -1,0 +1,15 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_oracle_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+sql_has_parse_side_effect_test_() ->
+    [
+        ?_assert(emqx_oracle:sql_has_parse_side_effect(<<"CREATE TABLE t(id NUMBER)">>)),
+        ?_assert(emqx_oracle:sql_has_parse_side_effect(<<"  /* c */ DROP TABLE t">>)),
+        ?_assert(emqx_oracle:sql_has_parse_side_effect(<<"-- c\nROLLBACK">>)),
+        ?_assertNot(emqx_oracle:sql_has_parse_side_effect(<<"INSERT INTO t(id) VALUES (:1)">>)),
+        ?_assertNot(emqx_oracle:sql_has_parse_side_effect(<<" /* c */ SELECT * FROM t">>))
+    ].

--- a/changes/ee/fix-17605.en.md
+++ b/changes/ee/fix-17605.en.md
@@ -1,0 +1,1 @@
+Fixed Oracle action prepare/status checks to parse action SQL without executing it, and reject unsupported top-level DDL/DCL/TCL statements. Also improved support for text payloads over 4000 bytes when the payload placeholder is the last bind parameter.


### PR DESCRIPTION
Release version:
5.8.12

Fix version:
5.8.12

Fix: [EEC-1322](https://emqx.atlassian.net/browse/EEC-1322)

Driver PR: [emqx/jamdb_oracle#9](https://github.com/emqx/jamdb_oracle/pull/9), released as `emqx/jamdb_oracle@0.4.9.7`.

## Summary

Ported #17605 to release-58.

This PR fixes two Oracle action issues found while reproducing EEC-1322.

First, Oracle action prepare checks used to validate SQL templates by executing the rendered user SQL inside an anonymous PL/SQL block followed by rollback. In the reproduced prepare-check case, creating an Oracle action with a normal `INSERT` template fired a `BEFORE INSERT` trigger and wrote audit rows before any MQTT message was published. The prepare check now uses `DBMS_SQL.PARSE` so it validates SQL syntax and object references without running the action SQL. Top-level DDL, DCL, and transaction-control statements are rejected during prepare.

Second, the runtime write path could fail after payload size changed from small text to large text. The driver used cursor and bind metadata that had been prepared for smaller values, which could surface as Oracle errors such as `ORA-01461`, `ORA-01013`, or a closed socket. This backport bumps `emqx/jamdb_oracle` to `0.4.9.7` for that runtime fix.

The release-58 coverage adds Oracle bridge regression cases for prepare side effects, DDL rejection, and small-then-large writes to `t_mqtt_msgs`, plus EUnit coverage for the prepare-side-effect statement filter. The Oracle CT cases compile locally but skip on this host because no Oracle service is configured; EUnit, version checks, compile, and static checks passed.

## Expected Side Effects

- Oracle action SQL templates that start with DDL, DCL, or transaction-control statements are rejected during prepare. This is intentional because those are not safe action templates.
- The same SQL text may use more than one cached cursor when payload sizes produce different bind formats. This avoids reusing an incompatible cursor, and the existing cursor limit still bounds the cache.
- The driver intentionally does not rewrite SQL or reorder user placeholders. Oracle's native LOB bind restrictions still apply, so users should place large `CLOB`/`NCLOB` bind placeholders after non-LOB placeholders when Oracle requires it.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)


[EEC-1322]: https://emqx.atlassian.net/browse/EEC-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ