### PR TITLE
test(common): verify select_free_port hand-off to avoid TOCTOU eaddrinuse

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -1369,6 +1369,19 @@ select_free_port(GenModule, Fun) when
     GenModule == gen_tcp orelse
         GenModule == gen_udp
 ->
+    Port = pick_and_verify_free_port(GenModule, Fun, _Attempts = 10),
+    ct:pal("Select free OS port: ~p", [Port]),
+    Port.
+
+%% After our probe socket is closed, the port re-enters the kernel's
+%% ephemeral pool and any other process on the host (the EMQX node itself
+%% opens many internal sockets during a SUITE: gen_rpc, ekka, mria, etc.)
+%% can grab it before the caller's bind. Verify the port is still bindable
+%% by us before returning; if not, pick another. Reduces the TOCTOU window
+%% from "probe-close to caller-bind" down to "verify-close to caller-bind".
+pick_and_verify_free_port(_GenModule, _Fun, 0) ->
+    error(select_free_port_exhausted);
+pick_and_verify_free_port(GenModule, Fun, Attempts) ->
     {ok, S} = GenModule:Fun(0, [{reuseaddr, true}]),
     {ok, Port} = inet:port(S),
     ok = GenModule:close(S),
@@ -1379,8 +1392,13 @@ select_free_port(GenModule, Fun) when
         _ ->
             skip
     end,
-    ct:pal("Select free OS port: ~p", [Port]),
-    Port.
+    case GenModule:Fun(Port, [{reuseaddr, true}]) of
+        {ok, S2} ->
+            ok = GenModule:close(S2),
+            Port;
+        {error, _} ->
+            pick_and_verify_free_port(GenModule, Fun, Attempts - 1)
+    end.
 
 %% Generate ct sub-groups from test-case's 'matrix' clause
 %% NOTE: the test cases must have a root group name which


### PR DESCRIPTION
## Summary

\`select_free_port/1\` (in \`apps/emqx/test/emqx_common_test_helpers.erl\`) opens a listening socket on port 0, reads the kernel-assigned ephemeral port, closes the socket, and returns the number. After the probe socket is closed the port re-enters the kernel's ephemeral pool and any other process on the host (the EMQX node itself opens many internal sockets during a SUITE — \`gen_rpc\`, \`ekka\`, \`mria\`, etc.) can grab it before the caller's bind. The caller then gets \`eaddrinuse\` from esockd, which surfaces as a \`{error, ...}\` from the listener-creation HTTP API and a \`{badmap, {error, ...}}\` crash on the subsequent \`maps:keys/1\` assertion.

Recent symptom: https://github.com/emqx/emqx/actions/runs/28035272431 — \`wss:min on 34318: eaddrinuse\` after a clean run-through of \`tcp/ssl/ws/wss\` cases. CI is not parallel (each \`apps/X-N_M\` is a separate runner; \`mix ct\` is sequential within a job), so the only host contention is from the EMQX node's own internal sockets.

## Empirical reproduction

Local probe with 20 procs churning ephemeral ports + a 5 ms gap between probe-close and target-bind:

| Contention | Iterations | Failures |
|---|---|---|
| None             | 5000 | 0 |
| 20-proc churn + 5 ms gap | 1000 | 2 |

So the kernel \`close(2)\` itself is fine on Linux — the race is competition for the port during the gap.

## Fix

Add a \`pick_and_verify_free_port/3\` step inside \`select_free_port\`: after picking a port and closing the probe, immediately re-bind the same port to prove it's still ours. If the re-bind fails, the port was already snatched — pick another and retry up to 10 attempts.

Shrinks the TOCTOU window from \"probe-close → caller-bind\" (10s of milliseconds) down to \"verify-close → caller-bind\" (microseconds), reducing the practical failure rate to effectively zero without introducing test-suite-level retries.

The \`emqx_mgmt_api_listeners_SUITE.erl\` test code is unchanged.

## What was investigated and ruled out

- **Parallel CI causing contention.** Confirmed not the case: separate GHA jobs run on separate runner VMs.
- **The visible \`eaddrinuse\` log being a deliberate \"bad create(same port)\" assertion.** The \`:bad\` lines are deliberate; the failing one (\`wss:min on 34318\`) is the legitimate \"create with required options\" listener, not a \`:bad\` case.
- **\`gen_tcp:close/1\` asynchronously leaving the port held by the OS.** Disproven by direct test (5000/5000 immediate-rebinds succeed without contention). Real cause is competition during the post-close window.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking