### PR TITLE
feat(authn,jwt): harden JWKS TLS verification

### DIFF
--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -51,7 +51,8 @@ Returns policy depending on the current security profile.
     (authz_backend_failure) -> ignore | deny;
     (dashboard_unchanged_default_credentials) -> allow | deny;
     (access_control_hook_failure) -> ignore | interrupt;
-    (outbound_tls_verify) -> verify_none | verify_peer.
+    (outbound_tls_verify) -> verify_none | verify_peer;
+    (authn_jwt_missing) -> ignore | deny.
 policy(mqtt_default_bind) ->
     case profile() of
         legacy -> any;
@@ -91,6 +92,11 @@ policy(outbound_tls_verify) ->
     case profile() of
         legacy -> verify_none;
         hardened -> verify_peer
+    end;
+policy(authn_jwt_missing) ->
+    case profile() of
+        legacy -> ignore;
+        hardened -> deny
     end.
 
 -doc """

--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -50,7 +50,8 @@ Returns policy depending on the current security profile.
     (authn_backend_failure) -> ignore | deny;
     (authz_backend_failure) -> ignore | deny;
     (dashboard_unchanged_default_credentials) -> allow | deny;
-    (access_control_hook_failure) -> ignore | interrupt.
+    (access_control_hook_failure) -> ignore | interrupt;
+    (outbound_tls_verify) -> verify_none | verify_peer.
 policy(mqtt_default_bind) ->
     case profile() of
         legacy -> any;
@@ -85,6 +86,11 @@ policy(access_control_hook_failure) ->
     case profile() of
         legacy -> ignore;
         hardened -> interrupt
+    end;
+policy(outbound_tls_verify) ->
+    case profile() of
+        legacy -> verify_none;
+        hardened -> verify_peer
     end.
 
 -doc """

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -45,6 +45,7 @@ t_legacy(_) ->
     ?assertEqual(legacy, emqx_security_profile:profile()),
     ?assertEqual(ignore, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(ignore, emqx_security_profile:policy(authz_backend_failure)),
+    ?assertEqual(verify_none, emqx_security_profile:policy(outbound_tls_verify)),
 
     %% Full defaults
     ?assertEqual({{0, 0, 0, 0}, 1883}, emqx:get_config([listeners, tcp, default, bind])),
@@ -83,6 +84,7 @@ t_hardened(_) ->
     ?assertEqual(hardened, emqx_security_profile:profile()),
     ?assertEqual(deny, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(deny, emqx_security_profile:policy(authz_backend_failure)),
+    ?assertEqual(verify_peer, emqx_security_profile:policy(outbound_tls_verify)),
 
     %% Full defaults are secure in hardened profile
     ?assertEqual({{127, 0, 0, 1}, 1883}, emqx:get_config([listeners, tcp, default, bind])),

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -46,6 +46,7 @@ t_legacy(_) ->
     ?assertEqual(ignore, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(ignore, emqx_security_profile:policy(authz_backend_failure)),
     ?assertEqual(verify_none, emqx_security_profile:policy(outbound_tls_verify)),
+    ?assertEqual(ignore, emqx_security_profile:policy(authn_jwt_missing)),
 
     %% Full defaults
     ?assertEqual({{0, 0, 0, 0}, 1883}, emqx:get_config([listeners, tcp, default, bind])),
@@ -85,6 +86,7 @@ t_hardened(_) ->
     ?assertEqual(deny, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(deny, emqx_security_profile:policy(authz_backend_failure)),
     ?assertEqual(verify_peer, emqx_security_profile:policy(outbound_tls_verify)),
+    ?assertEqual(deny, emqx_security_profile:policy(authn_jwt_missing)),
 
     %% Full defaults are secure in hardened profile
     ?assertEqual({{127, 0, 0, 1}, 1883}, emqx:get_config([listeners, tcp, default, bind])),

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_schema_tests.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_schema_tests.erl
@@ -141,6 +141,21 @@ jwt_on_missing_jwt_explicit_test() ->
         check(jwt_jwks_config_on_missing_jwt(deny))
     ).
 
+jwt_jwks_max_fail_count_test() ->
+    ok = ensure_schema_load(),
+    ?assertMatch(
+        {ok, #{authentication := [#{max_fail_count := 5}]}},
+        check(jwt_jwks_config())
+    ),
+    ?assertMatch(
+        {ok, #{authentication := [#{max_fail_count := 2}]}},
+        check(jwt_jwks_config_max_fail_count(2))
+    ),
+    ?assertMatch(
+        ?ERR(_),
+        check(jwt_jwks_config_max_fail_count(0))
+    ).
+
 union_member_selector_redis_test_() ->
     ok = ensure_schema_load(),
     [
@@ -222,6 +237,19 @@ jwt_jwks_config_on_missing_jwt(OnMissingJWT) ->
     ]
     """,
     io_lib:format(C, [atom_to_list(OnMissingJWT)]).
+
+jwt_jwks_config_max_fail_count(MaxFailCount) ->
+    C = """
+    [
+        {
+            mechanism = jwt,
+            use_jwks = true,
+            endpoint = "https://127.0.0.1/jwks.json"
+            max_fail_count = ~B
+        }
+    ]
+    """,
+    io_lib:format(C, [MaxFailCount]).
 
 jwt_jwks_config_with_ssl() ->
     """

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_schema_tests.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_schema_tests.erl
@@ -67,6 +67,48 @@ union_member_selector_jwt_test_() ->
         end}
     ].
 
+jwt_jwks_ssl_verify_default_test_() ->
+    ok = ensure_schema_load(),
+    [
+        {"legacy", fun() ->
+            emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+                ?assertMatch(
+                    {ok, #{authentication := [#{ssl := #{verify := verify_none}}]}},
+                    check(jwt_jwks_config())
+                )
+            end)
+        end},
+        {"hardened", fun() ->
+            emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+                ?assertMatch(
+                    {ok, #{authentication := [#{ssl := #{verify := verify_peer}}]}},
+                    check(jwt_jwks_config())
+                )
+            end)
+        end}
+    ].
+
+jwt_jwks_ssl_verify_omitted_test_() ->
+    ok = ensure_schema_load(),
+    [
+        {"legacy", fun() ->
+            emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+                ?assertMatch(
+                    {ok, #{authentication := [#{ssl := #{verify := verify_none}}]}},
+                    check(jwt_jwks_config_with_ssl())
+                )
+            end)
+        end},
+        {"hardened", fun() ->
+            emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+                ?assertMatch(
+                    {ok, #{authentication := [#{ssl := #{verify := verify_peer}}]}},
+                    check(jwt_jwks_config_with_ssl())
+                )
+            end)
+        end}
+    ].
+
 union_member_selector_redis_test_() ->
     ok = ensure_schema_load(),
     [
@@ -124,6 +166,31 @@ check(HoconConf) ->
         #{roots => emqx_authn_schema:global_auth_fields()},
         ["authentication= ", HoconConf]
     ).
+
+jwt_jwks_config() ->
+    """
+    [
+        {
+            mechanism = jwt,
+            use_jwks = true,
+            endpoint = "https://127.0.0.1/jwks.json"
+        }
+    ]
+    """.
+
+jwt_jwks_config_with_ssl() ->
+    """
+    [
+        {
+            mechanism = jwt,
+            use_jwks = true,
+            endpoint = "https://127.0.0.1/jwks.json",
+            ssl = {
+                enable = true
+            }
+        }
+    ]
+    """.
 
 ensure_schema_load() ->
     _ = emqx_conf_schema:roots(),

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_schema_tests.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_schema_tests.erl
@@ -109,6 +109,38 @@ jwt_jwks_ssl_verify_omitted_test_() ->
         end}
     ].
 
+jwt_on_missing_jwt_default_test_() ->
+    ok = ensure_schema_load(),
+    [
+        {"legacy", fun() ->
+            emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+                ?assertMatch(
+                    {ok, #{authentication := [#{on_missing_jwt := ignore}]}},
+                    check(jwt_jwks_config())
+                )
+            end)
+        end},
+        {"hardened", fun() ->
+            emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+                ?assertMatch(
+                    {ok, #{authentication := [#{on_missing_jwt := deny}]}},
+                    check(jwt_jwks_config())
+                )
+            end)
+        end}
+    ].
+
+jwt_on_missing_jwt_explicit_test() ->
+    ok = ensure_schema_load(),
+    ?assertMatch(
+        {ok, #{authentication := [#{on_missing_jwt := ignore}]}},
+        check(jwt_jwks_config_on_missing_jwt(ignore))
+    ),
+    ?assertMatch(
+        {ok, #{authentication := [#{on_missing_jwt := deny}]}},
+        check(jwt_jwks_config_on_missing_jwt(deny))
+    ).
+
 union_member_selector_redis_test_() ->
     ok = ensure_schema_load(),
     [
@@ -177,6 +209,19 @@ jwt_jwks_config() ->
         }
     ]
     """.
+
+jwt_jwks_config_on_missing_jwt(OnMissingJWT) ->
+    C = """
+    [
+        {
+            mechanism = jwt,
+            use_jwks = true,
+            endpoint = "https://127.0.0.1/jwks.json"
+            on_missing_jwt = ~s
+        }
+    ]
+    """,
+    io_lib:format(C, [atom_to_list(OnMissingJWT)]).
 
 jwt_jwks_config_with_ssl() ->
     """

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwks_client.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwks_client.erl
@@ -10,7 +10,7 @@
 -include_lib("jose/include/jose_jwk.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--define(MAX_FAIL_COUNT, 5).
+-define(DEFAULT_MAX_FAIL_COUNT, 5).
 
 -export([
     start_link/1,
@@ -116,16 +116,19 @@ code_change(_OldVsn, State, _Extra) ->
 %% Internal functions
 %%--------------------------------------------------------------------
 
-handle_options(#{
-    endpoint := Endpoint,
-    headers := Headers,
-    refresh_interval := RefreshInterval0,
-    ssl := SSLOpts
-}) ->
+handle_options(
+    #{
+        endpoint := Endpoint,
+        headers := Headers,
+        refresh_interval := RefreshInterval0,
+        ssl := SSLOpts
+    } = Opts
+) ->
     #{
         endpoint => Endpoint,
         headers => to_httpc_headers(Headers),
         refresh_interval => limit_refresh_interval(RefreshInterval0),
+        max_fail_count => maps:get(max_fail_count, Opts, ?DEFAULT_MAX_FAIL_COUNT),
         ssl_opts => emqx_tls_lib:to_client_opts(SSLOpts),
         jwks => undefined,
         failure_count => 0,
@@ -166,10 +169,12 @@ refresh_jwks(
         end,
     ensure_expiry_timer(NState).
 
-record_jwks_refresh_failure(#{failure_count := FailureCount0} = State) ->
+record_jwks_refresh_failure(
+    #{failure_count := FailureCount0, max_fail_count := MaxFailCount} = State
+) ->
     FailureCount = FailureCount0 + 1,
     State1 = State#{failure_count := FailureCount},
-    case FailureCount >= ?MAX_FAIL_COUNT of
+    case FailureCount >= MaxFailCount of
         true ->
             State1#{jwks := undefined};
         false ->
@@ -185,8 +190,9 @@ limit_refresh_interval(Interval) ->
     Interval.
 
 to_httpc_headers(Headers) ->
-    UserHeaders = [{binary_to_list(bin(K)), V} || {K, V} <- maps:to_list(Headers)] ++
-        [{"connection", "close"}],
+    UserHeaders =
+        [{binary_to_list(bin(K)), V} || {K, V} <- maps:to_list(Headers)] ++
+            [{"connection", "close"}],
     ensure_te_header(UserHeaders).
 
 %% Inets versions prior to 9.4.2 (OTP 28.1) emit an RFC 2616-violating

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwks_client.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwks_client.erl
@@ -10,6 +10,8 @@
 -include_lib("jose/include/jose_jwk.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
+-define(MAX_FAIL_COUNT, 5).
+
 -export([
     start_link/1,
     stop/1
@@ -79,12 +81,12 @@ handle_info(
                     endpoint => Endpoint,
                     reason => Reason
                 }),
-                State1;
+                record_jwks_refresh_failure(State1);
             {StatusLine, Headers, Body} ->
                 try
                     JWK = jose_jwk:from(emqx_utils_json:decode(Body)),
                     {_, JWKS} = JWK#jose_jwk.keys,
-                    State1#{jwks := JWKS}
+                    State1#{jwks := JWKS, failure_count := 0}
                 catch
                     _:_ ->
                         ?SLOG(warning, #{
@@ -94,7 +96,7 @@ handle_info(
                             headers => Headers,
                             body => Body
                         }),
-                        State1
+                        record_jwks_refresh_failure(State1)
                 end
         end,
     {noreply, NewState};
@@ -125,7 +127,8 @@ handle_options(#{
         headers => to_httpc_headers(Headers),
         refresh_interval => limit_refresh_interval(RefreshInterval0),
         ssl_opts => emqx_tls_lib:to_client_opts(SSLOpts),
-        jwks => [],
+        jwks => undefined,
+        failure_count => 0,
         request_id => undefined
     }.
 
@@ -156,12 +159,22 @@ refresh_jwks(
                     http_opts => HTTPOpts,
                     reason => Reason
                 }),
-                State;
+                record_jwks_refresh_failure(State);
             {ok, RequestID} ->
                 ?tp(debug, jwks_endpoint_request_ok, #{request_id => RequestID}),
                 State#{request_id := RequestID}
         end,
     ensure_expiry_timer(NState).
+
+record_jwks_refresh_failure(#{failure_count := FailureCount0} = State) ->
+    FailureCount = FailureCount0 + 1,
+    State1 = State#{failure_count := FailureCount},
+    case FailureCount >= ?MAX_FAIL_COUNT of
+        true ->
+            State1#{jwks := undefined};
+        false ->
+            State1
+    end.
 
 ensure_expiry_timer(State = #{refresh_interval := Interval}) ->
     State#{refresh_timer => erlang:send_after(timer:seconds(Interval), self(), refresh_jwks)}.
@@ -172,7 +185,8 @@ limit_refresh_interval(Interval) ->
     Interval.
 
 to_httpc_headers(Headers) ->
-    UserHeaders = [{binary_to_list(bin(K)), V} || {K, V} <- maps:to_list(Headers)],
+    UserHeaders = [{binary_to_list(bin(K)), V} || {K, V} <- maps:to_list(Headers)] ++
+        [{"connection", "close"}],
     ensure_te_header(UserHeaders).
 
 %% Inets versions prior to 9.4.2 (OTP 28.1) emit an RFC 2616-violating

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
@@ -80,26 +80,39 @@ authenticate(#{auth_method := _}, _) ->
 authenticate(
     Credential,
     #{
+        from := From,
+        on_missing_jwt := OnMissingJWT
+    } = State
+) ->
+    case maps:get(From, Credential, undefined) of
+        undefined ->
+            missing_jwt(OnMissingJWT);
+        JWT ->
+            do_authenticate(JWT, Credential, State)
+    end.
+
+do_authenticate(
+    JWT,
+    Credential,
+    #{
         verify_claims := VerifyClaims0,
         disconnect_after_expire := DisconnectAfterExpire,
         jwk := JWK,
-        acl_claim_name := AclClaimName,
-        from := From
+        acl_claim_name := AclClaimName
     }
 ) ->
-    JWT = maps:get(From, Credential),
     %% XXX: Only supports single public key
     JWKs = [JWK],
     VerifyClaims = render_expected(VerifyClaims0, Credential),
     verify(JWT, JWKs, VerifyClaims, AclClaimName, DisconnectAfterExpire);
-authenticate(
+do_authenticate(
+    JWT,
     Credential,
     #{
         verify_claims := VerifyClaims0,
         disconnect_after_expire := DisconnectAfterExpire,
         resource_id := ResourceId,
-        acl_claim_name := AclClaimName,
-        from := From
+        acl_claim_name := AclClaimName
     }
 ) ->
     case emqx_resource:simple_sync_query(ResourceId, get_jwks) of
@@ -109,8 +122,9 @@ authenticate(
                 reason => Reason
             }),
             emqx_authn_utils:backend_failure_result();
+        {ok, undefined} ->
+            emqx_authn_utils:backend_failure_result();
         {ok, JWKs} ->
-            JWT = maps:get(From, Credential),
             VerifyClaims = render_expected(VerifyClaims0, Credential),
             verify(JWT, JWKs, VerifyClaims, AclClaimName, DisconnectAfterExpire)
     end.
@@ -130,6 +144,7 @@ create_authn_hmac_based(#{
     secret_base64_encoded := Base64Encoded,
     verify_claims := VerifyClaims,
     disconnect_after_expire := DisconnectAfterExpire,
+    on_missing_jwt := OnMissingJWT,
     acl_claim_name := AclClaimName,
     from := From,
     enable := Enable
@@ -143,6 +158,7 @@ create_authn_hmac_based(#{
                 jwk => JWK,
                 verify_claims => handle_verify_claims(VerifyClaims),
                 disconnect_after_expire => DisconnectAfterExpire,
+                on_missing_jwt => OnMissingJWT,
                 acl_claim_name => AclClaimName,
                 from => From,
                 enable => Enable
@@ -154,6 +170,7 @@ create_authn_public_key(
         public_key := PublicKey,
         verify_claims := VerifyClaims,
         disconnect_after_expire := DisconnectAfterExpire,
+        on_missing_jwt := OnMissingJWT,
         acl_claim_name := AclClaimName,
         from := From,
         enable := Enable
@@ -169,6 +186,7 @@ create_authn_public_key(
             jwk => JWK,
             verify_claims => handle_verify_claims(VerifyClaims),
             disconnect_after_expire => DisconnectAfterExpire,
+            on_missing_jwt => OnMissingJWT,
             acl_claim_name => AclClaimName,
             from => From,
             enable => Enable
@@ -180,12 +198,13 @@ create_authn_public_key_with_jwks(
     #{
         verify_claims := VerifyClaims,
         disconnect_after_expire := DisconnectAfterExpire,
+        on_missing_jwt := OnMissingJWT,
         acl_claim_name := AclClaimName,
         from := From
     } = Config
 ) ->
     ResourceConfig = emqx_authn_utils:cleanup_resource_config(
-        [verify_claims, disconnect_after_expire, acl_claim_name, from], Config
+        [verify_claims, disconnect_after_expire, on_missing_jwt, acl_claim_name, from], Config
     ),
     State = emqx_authn_utils:init_state(
         Config,
@@ -193,6 +212,7 @@ create_authn_public_key_with_jwks(
             resource_id => ResourceId,
             verify_claims => handle_verify_claims(VerifyClaims),
             disconnect_after_expire => DisconnectAfterExpire,
+            on_missing_jwt => OnMissingJWT,
             acl_claim_name => AclClaimName,
             from => From
         }
@@ -239,9 +259,6 @@ render_expected([{Name, ExpectedTemplate} | More], Variables) ->
     Expected = emqx_auth_template:render_str(ExpectedTemplate, Variables),
     [{Name, Expected} | render_expected(More, Variables)].
 
-verify(undefined, _, _, _, _) ->
-    %% No value in `From` field, where we expect a JWT token
-    ignore;
 verify(JWT, JWKs, VerifyClaims, AclClaimName, DisconnectAfterExpire) ->
     case do_verify(JWT, JWKs, VerifyClaims) of
         {ok, Extra} ->
@@ -259,6 +276,9 @@ verify(JWT, JWKs, VerifyClaims, AclClaimName, DisconnectAfterExpire) ->
             ?TRACE_AUTHN_PROVIDER("invalid_jwt_claims", #{jwt => JWT, claims => Claims}),
             {error, bad_username_or_password}
     end.
+
+missing_jwt(ignore) -> ignore;
+missing_jwt(deny) -> {error, bad_username_or_password}.
 
 extra_to_auth_data(Extra, JWT, AclClaimName, DisconnectAfterExpire) ->
     IsSuperuser = emqx_authn_utils:is_superuser(Extra),

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt_schema.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt_schema.erl
@@ -99,6 +99,7 @@ fields(jwt_jwks) ->
             )},
         {pool_size, fun emqx_connector_schema_lib:pool_size/1},
         {refresh_interval, fun refresh_interval/1},
+        {max_fail_count, fun max_fail_count/1},
         {ssl,
             sc(hoconsc:ref(jwks_client_ssl_opts), #{
                 default => #{
@@ -158,11 +159,16 @@ endpoint(desc) -> ?DESC(?FUNCTION_NAME);
 endpoint(required) -> true;
 endpoint(_) -> undefined.
 
-refresh_interval(type) -> integer();
+refresh_interval(type) -> pos_integer();
 refresh_interval(desc) -> ?DESC(?FUNCTION_NAME);
 refresh_interval(default) -> 300;
-refresh_interval(validator) -> [fun(I) -> I > 0 end];
 refresh_interval(_) -> undefined.
+
+max_fail_count(type) -> pos_integer();
+max_fail_count(desc) -> ?DESC(?FUNCTION_NAME);
+max_fail_count(default) -> 5;
+max_fail_count(importance) -> ?IMPORTANCE_HIDDEN;
+max_fail_count(_) -> undefined.
 
 verify_claims(type) ->
     %% user input is a map, converted to a list of {binary(), validated_value_type()}

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt_schema.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt_schema.erl
@@ -132,6 +132,7 @@ common_fields() ->
             default => <<"acl">>,
             desc => ?DESC(acl_claim_name)
         }},
+        {on_missing_jwt, fun on_missing_jwt/1},
         {verify_claims, fun verify_claims/1},
         {disconnect_after_expire, fun disconnect_after_expire/1},
         {from, fun from/1}
@@ -199,6 +200,11 @@ disconnect_after_expire(type) -> boolean();
 disconnect_after_expire(desc) -> ?DESC(?FUNCTION_NAME);
 disconnect_after_expire(default) -> true;
 disconnect_after_expire(_) -> undefined.
+
+on_missing_jwt(type) -> hoconsc:enum([deny, ignore]);
+on_missing_jwt(desc) -> ?DESC(?FUNCTION_NAME);
+on_missing_jwt(default) -> atom_to_binary(emqx_security_profile:policy(authn_jwt_missing));
+on_missing_jwt(_) -> undefined.
 
 do_check_verify_claims([]) ->
     true;

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt_schema.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt_schema.erl
@@ -99,12 +99,19 @@ fields(jwt_jwks) ->
             )},
         {pool_size, fun emqx_connector_schema_lib:pool_size/1},
         {refresh_interval, fun refresh_interval/1},
-        {ssl, #{
-            type => hoconsc:ref(emqx_schema, "ssl_client_opts"),
-            default => #{<<"enable">> => false},
-            desc => ?DESC("ssl")
-        }}
-    ] ++ common_fields().
+        {ssl,
+            sc(hoconsc:ref(jwks_client_ssl_opts), #{
+                default => #{
+                    <<"enable">> => false,
+                    <<"verify">> => emqx_security_profile:policy(outbound_tls_verify)
+                },
+                desc => ?DESC("ssl")
+            })}
+    ] ++ common_fields();
+fields(jwks_client_ssl_opts) ->
+    emqx_schema:client_ssl_opts_schema(#{
+        verify => emqx_security_profile:policy(outbound_tls_verify)
+    }).
 
 desc(jwt_hmac) ->
     ?DESC(jwt_hmac);
@@ -112,6 +119,8 @@ desc(jwt_public_key) ->
     ?DESC(jwt_public_key);
 desc(jwt_jwks) ->
     ?DESC(jwt_jwks);
+desc(jwks_client_ssl_opts) ->
+    ?DESC("ssl");
 desc(undefined) ->
     undefined.
 

--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -54,6 +54,7 @@ t_hmac_based(_) ->
         secret_base64_encoded => false,
         verify_claims => [{<<"username">>, <<"${username}">>}],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         enable => true
     },
     {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config),
@@ -166,6 +167,49 @@ t_hmac_based(_) ->
     ?assertEqual(ok, emqx_authn_jwt:destroy(State3)),
     ok.
 
+t_on_missing_jwt(_) ->
+    Config = #{
+        mechanism => jwt,
+        from => password,
+        acl_claim_name => <<"acl">>,
+        use_jwks => false,
+        algorithm => 'hmac-based',
+        secret => <<"abcdef">>,
+        secret_base64_encoded => false,
+        verify_claims => [],
+        disconnect_after_expire => false,
+        enable => true,
+        on_missing_jwt => ignore
+    },
+    Credential = #{username => <<"myuser">>},
+
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config#{on_missing_jwt => ignore}),
+        ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential, State)),
+        ?assertEqual(ok, emqx_authn_jwt:destroy(State))
+    end),
+
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config#{on_missing_jwt => deny}),
+        ?assertEqual(
+            {error, bad_username_or_password},
+            emqx_authn_jwt:authenticate(Credential, State)
+        ),
+        ?assertEqual(ok, emqx_authn_jwt:destroy(State))
+    end),
+
+    {ok, IgnoreState} = emqx_authn_jwt:create(?AUTHN_ID, Config#{on_missing_jwt => ignore}),
+    ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential, IgnoreState)),
+    ?assertEqual(ok, emqx_authn_jwt:destroy(IgnoreState)),
+
+    {ok, DenyState} = emqx_authn_jwt:create(?AUTHN_ID, Config#{on_missing_jwt => deny}),
+    ?assertEqual(
+        {error, bad_username_or_password},
+        emqx_authn_jwt:authenticate(Credential, DenyState)
+    ),
+    ?assertEqual(ok, emqx_authn_jwt:destroy(DenyState)),
+    ok.
+
 t_public_key(_) ->
     PublicKey = test_rsa_key(public),
     PrivateKey = test_rsa_key(private),
@@ -178,6 +222,7 @@ t_public_key(_) ->
         public_key => PublicKey,
         verify_claims => [],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         enable => true
     },
     {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config),
@@ -215,6 +260,7 @@ t_bad_public_keys(_) ->
         algorithm => 'public-key',
         verify_claims => [],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         enable => true
     },
 
@@ -266,6 +312,7 @@ t_jwt_in_username(_) ->
         secret_base64_encoded => false,
         verify_claims => [],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         enable => true
     },
     {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config),
@@ -290,6 +337,7 @@ t_complex_template(_) ->
         secret_base64_encoded => false,
         verify_claims => [{<<"id">>, <<"${username}-${clientid}">>}],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         enable => true
     },
     {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config),
@@ -331,6 +379,7 @@ t_jwks_renewal(_Config) ->
         ssl => #{enable => false},
         verify_claims => [],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         use_jwks => true,
         endpoint => "https://127.0.0.1:" ++ integer_to_list(?JWKS_PORT + 1) ++ ?JWKS_PATH,
         headers => #{<<"Accept">> => <<"application/json">>},
@@ -349,9 +398,13 @@ t_jwks_renewal(_Config) ->
 
     ok = snabbkaffe:stop(),
 
-    ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential0, State0)),
     ?assertEqual(
-        ignore, emqx_authn_jwt:authenticate(Credential0#{password => <<"badpassword">>}, State0)
+        {error, not_authorized},
+        emqx_authn_jwt:authenticate(Credential0, State0)
+    ),
+    ?assertEqual(
+        {error, not_authorized},
+        emqx_authn_jwt:authenticate(Credential0#{password => <<"badpassword">>}, State0)
     ),
 
     ClientSSLOpts = client_ssl_opts(),
@@ -373,9 +426,13 @@ t_jwks_renewal(_Config) ->
 
     ok = snabbkaffe:stop(),
 
-    ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential0, State1)),
     ?assertEqual(
-        ignore, emqx_authn_jwt:authenticate(Credential0#{password => <<"badpassword">>}, State0)
+        {error, not_authorized},
+        emqx_authn_jwt:authenticate(Credential0, State1)
+    ),
+    ?assertEqual(
+        {error, not_authorized},
+        emqx_authn_jwt:authenticate(Credential0#{password => <<"badpassword">>}, State0)
     ),
 
     GoodConfig = BadConfig1#{
@@ -432,6 +489,7 @@ t_jwks_resource_status(_Config) ->
         ssl => client_ssl_opts(),
         verify_claims => [],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         use_jwks => true,
         endpoint => "https://127.0.0.1:" ++ integer_to_list(?JWKS_PORT) ++ ?JWKS_PATH,
         headers => #{<<"Accept">> => <<"application/json">>},
@@ -463,6 +521,43 @@ t_jwks_resource_status(_Config) ->
     %% Clean up
     ok = emqx_authn_jwt:destroy(State3),
     ok = emqx_utils_http_test_server:stop().
+
+t_jwks_cache_invalidated_after_refresh_failures(_Config) ->
+    {ok, _} = emqx_utils_http_test_server:start_link(?JWKS_PORT, ?JWKS_PATH, server_ssl_opts()),
+    on_exit(fun() -> ok = emqx_utils_http_test_server:stop() end),
+    ok = emqx_utils_http_test_server:set_handler(fun jwks_handler/2),
+    ok = snabbkaffe:start_trace(),
+
+    Opts = #{
+        endpoint => "https://127.0.0.1:" ++ integer_to_list(?JWKS_PORT) ++ ?JWKS_PATH,
+        headers => #{<<"Accept">> => <<"application/json">>},
+        refresh_interval => 1000,
+        ssl => client_ssl_opts()
+    },
+    {{ok, Pid}, {ok, _}} = ?wait_async_action(
+        emqx_authn_jwks_client:start_link(Opts),
+        #{?snk_kind := jwks_endpoint_response},
+        5_000
+    ),
+    on_exit(fun() -> emqx_authn_jwks_client:stop(Pid) end),
+    ?assertMatch({ok, [_ | _]}, emqx_authn_jwks_client:get_jwks(Pid)),
+
+    ok = emqx_utils_http_test_server:set_handler(fun invalid_jwks_handler/2),
+    lists:foreach(
+        fun(_) ->
+            force_jwks_refresh(Pid),
+            ?assertMatch({ok, [_ | _]}, emqx_authn_jwks_client:get_jwks(Pid))
+        end,
+        lists:seq(1, 4)
+    ),
+
+    force_jwks_refresh(Pid),
+    ?assertEqual({ok, undefined}, emqx_authn_jwks_client:get_jwks(Pid)),
+
+    ok = emqx_utils_http_test_server:set_handler(fun jwks_handler/2),
+    force_jwks_refresh(Pid),
+    ?assertMatch({ok, [_ | _]}, emqx_authn_jwks_client:get_jwks(Pid)),
+    ok = snabbkaffe:stop().
 
 t_jwks_custom_headers(_Config) ->
     {ok, _} = emqx_utils_http_test_server:start_link(?JWKS_PORT, ?JWKS_PATH, server_ssl_opts()),
@@ -728,6 +823,7 @@ t_jwks_config_update(_Config) ->
         ssl => client_ssl_opts(),
         verify_claims => [],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         use_jwks => true,
         endpoint => "https://127.0.0.1:" ++ integer_to_list(?JWKS_PORT + 1) ++ ?JWKS_PATH,
         headers => #{<<"Accept">> => <<"application/json">>},
@@ -746,7 +842,10 @@ t_jwks_config_update(_Config) ->
     ok = snabbkaffe:stop(),
 
     %% The authentication should fail, because the `from` is set to `username` in settings
-    ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential, State0)),
+    ?assertEqual(
+        {error, not_authorized},
+        emqx_authn_jwt:authenticate(Credential, State0)
+    ),
 
     %% Fix from field in the config
     ok = snabbkaffe:start_trace(),
@@ -787,6 +886,7 @@ t_jwks_verify_hostname(Config) ->
         ssl => SSLOpts,
         verify_claims => [],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         use_jwks => true,
         endpoint => <<"https://www.googleapis.com/oauth2/v3/certs">>,
         headers => #{<<"Accept">> => <<"application/json">>},
@@ -820,6 +920,7 @@ t_verify_claims(_) ->
         secret_base64_encoded => false,
         verify_claims => [{<<"foo">>, <<"bar">>}],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         enable => true
     },
     {ok, State0} = emqx_authn_jwt:create(?AUTHN_ID, Config0),
@@ -912,6 +1013,7 @@ t_verify_claim_clientid(_) ->
         secret_base64_encoded => false,
         verify_claims => [{<<"cl">>, <<"${clientid}">>}],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         enable => true
     },
     {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config),
@@ -946,6 +1048,7 @@ t_verify_claim_aud(_) ->
         secret_base64_encoded => false,
         verify_claims => [{<<"aud">>, <<"myapp">>}],
         disconnect_after_expire => false,
+        on_missing_jwt => ignore,
         enable => true
     },
     {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config),
@@ -1301,6 +1404,15 @@ jwks_handler(Req0, State) ->
     ),
     {ok, Req, State}.
 
+invalid_jwks_handler(Req0, State) ->
+    Req = cowboy_req:reply(
+        200,
+        #{<<"content-type">> => <<"application/json">>},
+        <<"not-a-jwks">>,
+        Req0
+    ),
+    {ok, Req, State}.
+
 jwks_handler_spy() ->
     TestPid = self(),
     fun(Req, State) ->
@@ -1310,6 +1422,14 @@ jwks_handler_spy() ->
         TestPid ! {http_request, ReqMap},
         jwks_handler(Req, State)
     end.
+
+force_jwks_refresh(Pid) ->
+    {refresh_jwks, {ok, _}} = ?wait_async_action(
+        Pid ! refresh_jwks,
+        #{?snk_kind := jwks_endpoint_response},
+        5_000
+    ),
+    ok.
 
 test_rsa_key(public) ->
     data_file("public_key.pem");

--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -630,6 +630,82 @@ t_jwks_te_header_user_supplied(_Config) ->
         {_, _},
         binary:match(RequestBytes, <<"\r\nte: trailers, deflate\r\n">>)
     ),
+
+    ok.
+
+%% Verify default verify behavior for jwk fetching
+t_jwks_default_ssl_verify_profiles(_Config) ->
+    {ok, _} = emqx_utils_http_test_server:start_link(?JWKS_PORT, ?JWKS_PATH, server_ssl_opts()),
+    on_exit(fun() -> ok = emqx_utils_http_test_server:stop() end),
+    ok = emqx_utils_http_test_server:set_handler(jwks_handler_spy()),
+    ok = snabbkaffe:start_trace(),
+
+    PrivateKey = test_rsa_key(private),
+    Payload = #{<<"username">> => <<"myuser">>},
+    JWS = generate_jws('public-key', Payload, PrivateKey),
+    Credential = #{
+        username => <<"myuser">>,
+        password => JWS
+    },
+
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        Config = jwks_api_config(#{
+            <<"enable">> => true,
+            <<"cacertfile">> => cert_file("ca.crt"),
+            <<"certfile">> => cert_file("client.crt"),
+            <<"keyfile">> => cert_file("client.key"),
+            <<"server_name_indication">> => <<"authn-server-unknown-host">>
+        }),
+        %% Legacy defaults to verify_none and updates keys successfully.
+        {
+            {ok, #{raw_config := [#{<<"ssl">> := #{<<"verify">> := <<"verify_none">>}}]}},
+            {ok, #{response := {{_, 200, _}, _, _}}}
+        } = ?wait_async_action(
+            emqx_authn_api:update_config(
+                [authentication],
+                {create_authenticator, 'mqtt:global', Config}
+            ),
+            #{?snk_kind := jwks_endpoint_response},
+            5_000
+        ),
+        ?assertReceive({http_request, _}),
+        {ok, [#{provider := emqx_authn_jwt, state := State}]} =
+            emqx_authn_chains:list_authenticators('mqtt:global'),
+        ?assertMatch(
+            {ok, #{is_superuser := false}}, emqx_authn_jwt:authenticate(Credential, State)
+        ),
+        ok = delete_jwks_authenticator()
+    end),
+
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        Config = jwks_api_config(#{
+            <<"enable">> => true,
+            <<"cacertfile">> => cert_file("ca.crt"),
+            <<"certfile">> => cert_file("client.crt"),
+            <<"keyfile">> => cert_file("client.key"),
+            <<"server_name_indication">> => <<"authn-server-unknown-host">>
+        }),
+        {
+            {ok, #{raw_config := [#{<<"ssl">> := #{<<"verify">> := <<"verify_peer">>}}]}},
+            {ok, #{response := {error, _}}}
+        } = ?wait_async_action(
+            emqx_authn_api:update_config(
+                [authentication],
+                {create_authenticator, 'mqtt:global', Config}
+            ),
+            #{?snk_kind := jwks_endpoint_response},
+            5_000
+        ),
+        ?assertNotReceive({http_request, _}),
+        {ok, [#{provider := emqx_authn_jwt, state := State}]} =
+            emqx_authn_chains:list_authenticators('mqtt:global'),
+        ?assertEqual(
+            {error, not_authorized},
+            emqx_authn_jwt:authenticate(Credential, State)
+        ),
+        ok = delete_jwks_authenticator()
+    end),
+    ok = snabbkaffe:stop(),
     ok.
 
 %% @doc verify that the authenticator state is actually updated when we update its config
@@ -1265,6 +1341,27 @@ generate_jws('public-key', Payload, PrivateKey) ->
     Signed = jose_jwt:sign(JWK, Header, Payload),
     {_, JWS} = jose_jws:compact(Signed),
     JWS.
+
+jwks_api_config(SSL) ->
+    Endpoint = iolist_to_binary("https://127.0.0.1:" ++ integer_to_list(?JWKS_PORT) ++ ?JWKS_PATH),
+    #{
+        <<"mechanism">> => <<"jwt">>,
+        <<"use_jwks">> => true,
+        <<"from">> => <<"password">>,
+        <<"endpoint">> => Endpoint,
+        <<"headers">> => #{<<"Accept">> => <<"application/json">>},
+        <<"pool_size">> => 1,
+        <<"refresh_interval">> => 1_000,
+        <<"ssl">> => SSL,
+        <<"verify_claims">> => #{}
+    }.
+
+delete_jwks_authenticator() ->
+    {ok, _} = emqx_authn_api:update_config(
+        [authentication],
+        {delete_authenticator, 'mqtt:global', <<"jwt">>}
+    ),
+    ok.
 
 client_ssl_opts() ->
     #{

--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -399,11 +399,11 @@ t_jwks_renewal(_Config) ->
     ok = snabbkaffe:stop(),
 
     ?assertEqual(
-        {error, not_authorized},
+        emqx_authn_utils:backend_failure_result(),
         emqx_authn_jwt:authenticate(Credential0, State0)
     ),
     ?assertEqual(
-        {error, not_authorized},
+        emqx_authn_utils:backend_failure_result(),
         emqx_authn_jwt:authenticate(Credential0#{password => <<"badpassword">>}, State0)
     ),
 
@@ -427,11 +427,11 @@ t_jwks_renewal(_Config) ->
     ok = snabbkaffe:stop(),
 
     ?assertEqual(
-        {error, not_authorized},
+        emqx_authn_utils:backend_failure_result(),
         emqx_authn_jwt:authenticate(Credential0, State1)
     ),
     ?assertEqual(
-        {error, not_authorized},
+        emqx_authn_utils:backend_failure_result(),
         emqx_authn_jwt:authenticate(Credential0#{password => <<"badpassword">>}, State0)
     ),
 
@@ -843,7 +843,7 @@ t_jwks_config_update(_Config) ->
 
     %% The authentication should fail, because the `from` is set to `username` in settings
     ?assertEqual(
-        {error, not_authorized},
+        emqx_authn_utils:backend_failure_result(),
         emqx_authn_jwt:authenticate(Credential, State0)
     ),
 

--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -183,21 +183,6 @@ t_on_missing_jwt(_) ->
     },
     Credential = #{username => <<"myuser">>},
 
-    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
-        {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config#{on_missing_jwt => ignore}),
-        ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential, State)),
-        ?assertEqual(ok, emqx_authn_jwt:destroy(State))
-    end),
-
-    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
-        {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config#{on_missing_jwt => deny}),
-        ?assertEqual(
-            {error, bad_username_or_password},
-            emqx_authn_jwt:authenticate(Credential, State)
-        ),
-        ?assertEqual(ok, emqx_authn_jwt:destroy(State))
-    end),
-
     {ok, IgnoreState} = emqx_authn_jwt:create(?AUTHN_ID, Config#{on_missing_jwt => ignore}),
     ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential, IgnoreState)),
     ?assertEqual(ok, emqx_authn_jwt:destroy(IgnoreState)),
@@ -398,14 +383,8 @@ t_jwks_renewal(_Config) ->
 
     ok = snabbkaffe:stop(),
 
-    ?assertEqual(
-        emqx_authn_utils:backend_failure_result(),
-        emqx_authn_jwt:authenticate(Credential0, State0)
-    ),
-    ?assertEqual(
-        emqx_authn_utils:backend_failure_result(),
-        emqx_authn_jwt:authenticate(Credential0#{password => <<"badpassword">>}, State0)
-    ),
+    assert_jwks_backend_failure(Credential0, State0),
+    assert_jwks_backend_failure(Credential0#{password => <<"badpassword">>}, State0),
 
     ClientSSLOpts = client_ssl_opts(),
     BadClientSSLOpts = ClientSSLOpts#{server_name_indication => "authn-server-unknown-host"},
@@ -426,14 +405,8 @@ t_jwks_renewal(_Config) ->
 
     ok = snabbkaffe:stop(),
 
-    ?assertEqual(
-        emqx_authn_utils:backend_failure_result(),
-        emqx_authn_jwt:authenticate(Credential0, State1)
-    ),
-    ?assertEqual(
-        emqx_authn_utils:backend_failure_result(),
-        emqx_authn_jwt:authenticate(Credential0#{password => <<"badpassword">>}, State0)
-    ),
+    assert_jwks_backend_failure(Credential0, State1),
+    assert_jwks_backend_failure(Credential0#{password => <<"badpassword">>}, State0),
 
     GoodConfig = BadConfig1#{
         ssl => ClientSSLOpts,
@@ -838,10 +811,7 @@ t_jwks_config_update(_Config) ->
     ok = snabbkaffe:stop(),
 
     %% The authentication should fail, because the `from` is set to `username` in settings
-    ?assertEqual(
-        emqx_authn_utils:backend_failure_result(),
-        emqx_authn_jwt:authenticate(Credential, State0)
-    ),
+    assert_jwks_backend_failure(Credential, State0),
 
     %% Fix from field in the config
     ok = snabbkaffe:start_trace(),
@@ -1426,6 +1396,17 @@ force_jwks_refresh(Pid) ->
         5_000
     ),
     ok.
+
+assert_jwks_backend_failure(Credential, State) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential, State))
+    end),
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ?assertEqual(
+            {error, not_authorized},
+            emqx_authn_jwt:authenticate(Credential, State)
+        )
+    end).
 
 test_rsa_key(public) ->
     data_file("public_key.pem");

--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -532,6 +532,7 @@ t_jwks_cache_invalidated_after_refresh_failures(_Config) ->
         endpoint => "https://127.0.0.1:" ++ integer_to_list(?JWKS_PORT) ++ ?JWKS_PATH,
         headers => #{<<"Accept">> => <<"application/json">>},
         refresh_interval => 1000,
+        max_fail_count => 2,
         ssl => client_ssl_opts()
     },
     {{ok, Pid}, {ok, _}} = ?wait_async_action(
@@ -543,13 +544,8 @@ t_jwks_cache_invalidated_after_refresh_failures(_Config) ->
     ?assertMatch({ok, [_ | _]}, emqx_authn_jwks_client:get_jwks(Pid)),
 
     ok = emqx_utils_http_test_server:set_handler(fun invalid_jwks_handler/2),
-    lists:foreach(
-        fun(_) ->
-            force_jwks_refresh(Pid),
-            ?assertMatch({ok, [_ | _]}, emqx_authn_jwks_client:get_jwks(Pid))
-        end,
-        lists:seq(1, 4)
-    ),
+    force_jwks_refresh(Pid),
+    ?assertMatch({ok, [_ | _]}, emqx_authn_jwks_client:get_jwks(Pid)),
 
     force_jwks_refresh(Pid),
     ?assertEqual({ok, undefined}, emqx_authn_jwks_client:get_jwks(Pid)),

--- a/changes/ee/feat-17696.en.md
+++ b/changes/ee/feat-17696.en.md
@@ -1,0 +1,3 @@
+Hardened JWT authentication with JWKS by verifying the JWKS endpoint TLS certificate by default
+in the hardened security profile, rejecting presented JWTs when JWKS keys are unavailable, and
+denying missing JWT credentials in hardened mode.

--- a/rel/i18n/emqx_authn_jwt_schema.hocon
+++ b/rel/i18n/emqx_authn_jwt_schema.hocon
@@ -159,6 +159,12 @@ disconnect_after_expire.desc:
 disconnect_after_expire.label:
 """Disconnect After Expire"""
 
+on_missing_jwt.desc:
+"""Action to take when the configured JWT credential field is missing. Use <code>deny</code> to reject authentication immediately, or <code>ignore</code> to skip this authenticator and let the authentication chain continue."""
+
+on_missing_jwt.label:
+"""On Missing JWT"""
+
 jwks_headers.label:
 """HTTP Headers"""
 jwks_headers.desc:

--- a/rel/i18n/emqx_authn_jwt_schema.hocon
+++ b/rel/i18n/emqx_authn_jwt_schema.hocon
@@ -165,6 +165,12 @@ on_missing_jwt.desc:
 on_missing_jwt.label:
 """On Missing JWT"""
 
+max_fail_count.desc:
+"""Maximum number of consecutive JWKS refresh failures before cached keys are invalidated."""
+
+max_fail_count.label:
+"""Max Fail Count"""
+
 jwks_headers.label:
 """HTTP Headers"""
 jwks_headers.desc:


### PR DESCRIPTION
Release version: 6.2.0

## Summary

This hardens JWT authentication with JWKS in the hardened security profile.

Hardened mode now defaults outbound TLS verification for JWKS fetching to `verify_peer`.

We also implement missing parts of fail-closed behavior:
* JWT authenticators also get an explicit `on_missing_jwt` option. In legacy mode the default is to ignore authenticator, in hardened -- deny authn.
* JWKS authentication now fails closed when keys are unavailable.
* Fetch JWKS with `Connection: close` on JWKS fetches to avoid reusing a connection created with weaker TLS settings. A proper fix should excplicitly break connections and restart http pool. That requires changing `httpc` to a better lib, but this is out of the scope of the PR.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
