### PR TITLE
test(mqtt): de-flake t_message_expiry_interval for QoS>0

### DIFF
--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -110,7 +110,36 @@ message_expiry_interval_init(Tag) ->
     emqtt:subscribe(CControl, <<"t/a">>, 1),
     emqtt:subscribe(CVerify, <<"t/a">>, 1),
     emqtt:stop(CVerify),
+    %% Wait until the broker has fully processed Client-Verify's DISCONNECT and
+    %% moved its (retained) session into the `disconnected` state before any
+    %% message is published. Until then the channel is still `connected`, so a
+    %% delivered QoS>0 message is placed into the session's inflight window
+    %% instead of the mqueue. Inflight messages are replayed verbatim on resume,
+    %% bypassing the mqueue's Message-Expiry-Interval check -- which made the
+    %% expiry assertions race (most visibly for QoS=2, whose longer publish
+    %% handshake widens the window).
+    ok = wait_until_session_disconnected(<<"Client-Verify-", Tag/binary>>),
     {CPublish, CControl}.
+
+wait_until_session_disconnected(ClientId) ->
+    wait_until_session_disconnected(ClientId, 100).
+
+wait_until_session_disconnected(ClientId, 0) ->
+    error({session_still_connected, ClientId});
+wait_until_session_disconnected(ClientId, N) ->
+    case emqx_cm:lookup_channels(ClientId) of
+        [_ | _] = Pids ->
+            case lists:any(fun emqx_cm:is_channel_connected/1, Pids) of
+                false -> ok;
+                true -> retry_until_session_disconnected(ClientId, N)
+            end;
+        [] ->
+            retry_until_session_disconnected(ClientId, N)
+    end.
+
+retry_until_session_disconnected(ClientId, N) ->
+    ct:sleep(50),
+    wait_until_session_disconnected(ClientId, N - 1).
 
 message_expiry_interval_exipred(CPublish, CControl, QoS, Tag) ->
     ct:pal("~p ~p", [?FUNCTION_NAME, QoS]),


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Test-only de-flake of `emqx_mqtt_SUITE:t_message_expiry_interval` (no user-facing change).

`message_expiry_interval_init` stops `Client-Verify` and the test publishes immediately afterwards. The broker may not have processed the DISCONNECT yet, so the channel is still `connected` when the message is delivered. A connected session places a QoS>0 message into its **inflight** window (`emqx_session_mem:deliver_msg`) instead of the **mqueue** (the `disconnected` branch of `emqx_channel:handle_deliver`). On resume, `emqx_session_mem:replay/2` resends inflight messages verbatim, **bypassing** the `is_expired` check that `dequeue` applies to mqueue messages — so an already-expired message gets delivered and the test fails with `should_have_expired`.

QoS=0 always lands in the mqueue (expiry-checked), which is why only QoS>0 flaked — most often QoS=2, whose longer PUBLISH/PUBREL handshake widens the race window relative to the disconnect.

Fix: after stopping `Client-Verify`, wait until the broker reports its session as disconnected before publishing, so the queued message deterministically lands in the mqueue and is subject to the expiry check.

Validated by looping `t_message_expiry_interval` 20× and `t_message_not_expiry_interval` 10× locally, all green.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
