### PR TITLE
fix(session): drop expired in-flight messages at takeover

### DIFF
--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -785,18 +785,38 @@ filter_remote_pendings(ClientInfo, Session, Pendings) ->
 
 -spec replay(emqx_types:clientinfo(), session()) ->
     {ok, replies(), session()}.
-replay(ClientInfo, Session) ->
-    PubsResend = lists:map(
-        fun
-            ({PacketId, #inflight_data{phase = wait_comp}}) ->
-                {pubrel, PacketId};
-            ({PacketId, #inflight_data{message = Msg}}) ->
-                {PacketId, without_inflight_insert_ts(emqx_message:set_flag(dup, true, Msg))}
-        end,
-        emqx_inflight:to_list(Session#session.inflight)
-    ),
-    {ok, More, Session1} = dequeue(ClientInfo, Session),
+replay(ClientInfo = #{zone := Zone}, Session = #session{inflight = Inflight}) ->
+    {PubsResend, Inflight1} = replay_inflight(ClientInfo, Zone, Inflight),
+    {ok, More, Session1} = dequeue(ClientInfo, Session#session{inflight = Inflight1}),
     {ok, append(PubsResend, More), Session1}.
+
+%% Resend inflight messages to the resuming channel, dropping any that have
+%% expired their `Message-Expiry-Interval` while the client was disconnected.
+%% This mirrors the expiry check `dequeue/4` applies to queued messages, so an
+%% expired message is treated the same whether it sat in the inflight set or the
+%% mqueue at takeover time.
+replay_inflight(ClientInfo, Zone, Inflight) ->
+    {Resends, Inflight1} = lists:foldl(
+        fun
+            ({PacketId, #inflight_data{phase = wait_comp}}, {Acc, IFL}) ->
+                %% Post-PUBREC, awaiting PUBCOMP: the message was already
+                %% delivered and acked by the receiver, so the QoS-2 handshake
+                %% must be completed regardless of the original message expiry.
+                {[{pubrel, PacketId} | Acc], IFL};
+            ({PacketId, #inflight_data{message = Msg}}, {Acc, IFL}) ->
+                case emqx_message:is_expired(Msg, Zone) of
+                    true ->
+                        _ = emqx_session_events:handle_event(ClientInfo, {expired, Msg}),
+                        {Acc, emqx_inflight:delete(PacketId, IFL)};
+                    false ->
+                        Msg1 = without_inflight_insert_ts(emqx_message:set_flag(dup, true, Msg)),
+                        {[{PacketId, Msg1} | Acc], IFL}
+                end
+        end,
+        {[], Inflight},
+        emqx_inflight:to_list(Inflight)
+    ),
+    {lists:reverse(Resends), Inflight1}.
 
 -spec dedup([emqx_types:message()], [emqx_types:message()]) ->
     [emqx_types:message()].

--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -248,6 +248,66 @@ t_puback_not_lost_on_disconnect(_) ->
     ?assertNot(lists:member(<<"1">>, Msgs1)),
     emqtt:stop(C1).
 
+-doc "An inflight (sent-but-unacked) QoS>0 message that expired while the client was disconnected is dropped at takeover instead of being redelivered.".
+t_inflight_expired_dropped_on_takeover(_) ->
+    ClientId = <<"inflight_expired_drop">>,
+    {ok, CPub} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, <<"inflight_expired_pub">>}
+    ]),
+    {ok, _} = emqtt:connect(CPub),
+    %% Subscriber with a persistent in-mem session, manual acking so the broker
+    %% keeps the delivered message in its inflight set awaiting PUBACK.
+    {ok, C0} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, ClientId},
+        {auto_ack, false},
+        {clean_start, false},
+        {properties, #{'Session-Expiry-Interval' => 360}}
+    ]),
+    {ok, _} = emqtt:connect(C0),
+    {ok, _, [1]} = emqtt:subscribe(C0, <<"t/a">>, 1),
+    %% Publish a QoS-1 message that expires in 1s.
+    _ = emqtt:publish(
+        CPub,
+        <<"t/a">>,
+        #{'Message-Expiry-Interval' => 1},
+        <<"inflight, will expire">>,
+        [{qos, 1}]
+    ),
+    %% The message reaches the subscriber and enters the session inflight set,
+    %% but we deliberately do NOT acknowledge it.
+    receive
+        {publish, #{client_pid := C0, topic := <<"t/a">>}} ->
+            ok
+    after 2000 ->
+        ct:fail(should_receive_publish)
+    end,
+    %% Disconnect (keep the session); the un-acked message stays in inflight.
+    ok = emqtt:disconnect(C0),
+    ?retry(100, 20, [] =:= emqx_cm:lookup_channels(ClientId)),
+    %% Sleep well past Message-Expiry-Interval (1s) with a wide margin so the
+    %% wall-clock-based expiry check at takeover is not racy on slow CI.
+    ct:sleep(2000),
+    %% Resume the session, triggering takeover/replay of the inflight set.
+    {ok, C1} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, ClientId},
+        {auto_ack, true},
+        {clean_start, false},
+        {properties, #{'Session-Expiry-Interval' => 360}}
+    ]),
+    {ok, _} = emqtt:connect(C1),
+    %% The expired inflight message must NOT be redelivered.
+    receive
+        {publish, #{client_pid := C1, topic := <<"t/a">>}} ->
+            ct:fail(should_have_expired)
+    after 500 ->
+        ok
+    end,
+    emqtt:stop(C1),
+    emqtt:stop(CPub).
+
 drain_messages(C) ->
     receive
         {publish, #{topic := <<"t/1">>, payload := IBin, client_pid := C}} ->

--- a/changes/ee/fix-17698.en.md
+++ b/changes/ee/fix-17698.en.md
@@ -1,0 +1,3 @@
+Stopped delivering expired QoS 1 / QoS 2 messages to a client after it reconnects and takes over its previous session.
+
+Previously, the `Message-Expiry-Interval` was only checked for messages waiting in the session queue. A message that had already been sent to the client but not yet acknowledged (in-flight) when the client disconnected was redelivered on reconnect even if it had since expired. The expiry check is now applied to in-flight messages at session takeover as well, so an expired message is dropped regardless of whether it was queued or in-flight. Operators may observe new `delivery.dropped` events with reason `expired` for such messages.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.1, 6.2.0

## Summary

`emqx_session_mem:replay/2` resent every in-flight message verbatim at session
takeover, while `dequeue/4` already dropped queued messages whose
`Message-Expiry-Interval` had elapsed. Because of this asymmetry, an expired
QoS 1 / QoS 2 message that was **in-flight** (sent but not yet acknowledged) when
the client disconnected was redelivered on reconnect, whereas the same message
would have been dropped had it still been in the session queue.

This applies the same expiry check to in-flight messages in `replay/2`
(`apps/emqx/src/emqx_session_mem.erl`). Expired entries are removed from the
in-flight set and emit the `{expired, Msg}` session event (firing the
`delivery.dropped` hook with reason `expired`), mirroring the queue path.
`wait_comp` entries (post-PUBREC) are preserved so the QoS-2 second-half
handshake (PUBREL/PUBCOMP) still completes — the message was already delivered
and acknowledged once, so expiry of the original message must not abort it.

New CT case `t_inflight_expired_dropped_on_takeover` covers the in-flight path;
it fails against the old code and passes with the fix (verified, plus 10x loop).
Existing `t_message_expiry_interval` (queue path) and
`t_puback_not_lost_on_disconnect` (non-expired in-flight replay) still pass.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)