### PR TITLE
docs(session): document and test inflight-vs-queued expiry asymmetry

### DIFF
--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -785,6 +785,11 @@ filter_remote_pendings(ClientInfo, Session, Pendings) ->
 
 -spec replay(emqx_types:clientinfo(), session()) ->
     {ok, replies(), session()}.
+%% Inflight messages are resent verbatim without an expiry check, unlike the
+%% queued messages dropped on expiry by dequeue/4. This asymmetry is intentional:
+%% per [MQTT-3.3.2-5] an expired message is only deleted if onward delivery has
+%% not started; an inflight message was already sent (awaiting PUBACK/PUBREC/
+%% PUBCOMP), so its delivery must be completed regardless of Message-Expiry-Interval.
 replay(ClientInfo, Session) ->
     PubsResend = lists:map(
         fun

--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -248,6 +248,66 @@ t_puback_not_lost_on_disconnect(_) ->
     ?assertNot(lists:member(<<"1">>, Msgs1)),
     emqtt:stop(C1).
 
+-doc "An inflight (sent-but-unacked) QoS-1 message is retried at takeover even after its Message-Expiry-Interval elapsed: per [MQTT-3.3.2-5] expiry only drops messages whose onward delivery has not started.".
+t_inflight_retried_after_expiry_on_takeover(_) ->
+    ClientId = <<"inflight_retry_after_expiry">>,
+    {ok, CPub} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, <<"inflight_retry_pub">>}
+    ]),
+    {ok, _} = emqtt:connect(CPub),
+    %% Subscriber with a persistent in-mem session, manual acking so the broker
+    %% keeps the delivered message in its inflight set awaiting PUBACK.
+    {ok, C0} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, ClientId},
+        {auto_ack, false},
+        {clean_start, false},
+        {properties, #{'Session-Expiry-Interval' => 360}}
+    ]),
+    {ok, _} = emqtt:connect(C0),
+    {ok, _, [1]} = emqtt:subscribe(C0, <<"t/a">>, 1),
+    %% Publish a QoS-1 message that expires in 1s.
+    _ = emqtt:publish(
+        CPub,
+        <<"t/a">>,
+        #{'Message-Expiry-Interval' => 1},
+        <<"inflight, retried after expiry">>,
+        [{qos, 1}]
+    ),
+    %% The message reaches the subscriber and enters the session inflight set;
+    %% onward delivery has started, but we deliberately do NOT acknowledge it.
+    receive
+        {publish, #{client_pid := C0, topic := <<"t/a">>}} ->
+            ok
+    after 2000 ->
+        ct:fail(should_receive_publish)
+    end,
+    %% Disconnect (keep the session); the un-acked message stays in inflight.
+    ok = emqtt:disconnect(C0),
+    ?retry(100, 20, [] =:= emqx_cm:lookup_channels(ClientId)),
+    %% Sleep well past Message-Expiry-Interval (1s) so the message is expired.
+    ct:sleep(2000),
+    %% Resume the session, triggering takeover/replay of the inflight set.
+    {ok, C1} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, ClientId},
+        {auto_ack, true},
+        {clean_start, false},
+        {properties, #{'Session-Expiry-Interval' => 360}}
+    ]),
+    {ok, _} = emqtt:connect(C1),
+    %% Onward delivery had already started, so the message MUST still be retried
+    %% (as a DUP) despite having expired.
+    receive
+        {publish, #{client_pid := C1, topic := <<"t/a">>, dup := Dup}} ->
+            ?assertEqual(true, Dup)
+    after 2000 ->
+        ct:fail(inflight_message_not_retried)
+    end,
+    emqtt:stop(C1),
+    emqtt:stop(CPub).
+
 drain_messages(C) ->
     receive
         {publish, #{topic := <<"t/1">>, payload := IBin, client_pid := C}} ->

--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx/include/asserts.hrl").
 
 -define(STATS_KYES, [
     recv_pkt,
@@ -248,7 +249,11 @@ t_puback_not_lost_on_disconnect(_) ->
     ?assertNot(lists:member(<<"1">>, Msgs1)),
     emqtt:stop(C1).
 
--doc "An inflight (sent-but-unacked) QoS-1 message is retried at takeover even after its Message-Expiry-Interval elapsed: per [MQTT-3.3.2-5] expiry only drops messages whose onward delivery has not started.".
+-doc """
+An inflight (sent-but-unacked) QoS-1 message is retried at takeover even after
+its Message-Expiry-Interval elapsed: per [MQTT-3.3.2-5], expiry only drops
+messages whose onward delivery has not started.
+""".
 t_inflight_retried_after_expiry_on_takeover(_) ->
     ClientId = <<"inflight_retry_after_expiry">>,
     {ok, CPub} = emqtt:start_link([
@@ -277,12 +282,7 @@ t_inflight_retried_after_expiry_on_takeover(_) ->
     ),
     %% The message reaches the subscriber and enters the session inflight set;
     %% onward delivery has started, but we deliberately do NOT acknowledge it.
-    receive
-        {publish, #{client_pid := C0, topic := <<"t/a">>}} ->
-            ok
-    after 2000 ->
-        ct:fail(should_receive_publish)
-    end,
+    {publish, #{client_pid := C0}} = ?assertReceive({publish, #{topic := <<"t/a">>}}),
     %% Disconnect (keep the session); the un-acked message stays in inflight.
     ok = emqtt:disconnect(C0),
     ?retry(100, 20, [] =:= emqx_cm:lookup_channels(ClientId)),


### PR DESCRIPTION
## Summary

Documents and pins the behavior of `emqx_session_mem:replay/2`: inflight messages
are resent verbatim at session takeover while `dequeue/4` drops expired queued
messages.

The asymmetry looks like a bug (and was mistaken for one in a now-closed PR) but
is mandated by [MQTT-3.3.2-5]: an expired message is only deleted if the server
has *not* started onward delivery. An inflight message has already been sent
(awaiting PUBACK/PUBREC/PUBCOMP), so its delivery must complete regardless of
`Message-Expiry-Interval`; a still-queued message has not, so it is dropped.

Changes:
- A comment on `replay/2` explaining the invariant so the asymmetry is not
  re-mistaken for a defect.
- A regression test `t_inflight_retried_after_expiry_on_takeover` asserting that
  an inflight QoS-1 message expired during a disconnect is still retried (as a
  DUP) on reconnect — the inverse of the queued case already covered by
  `t_message_expiry_interval`.

No behavior change, no changelog (internal documentation + test only).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (N/A — no user-visible change)
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)