### PR TITLE
test(bridge_mqtt): fix flaky t_resubscribe_on_fast_failure

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
@@ -933,8 +933,10 @@ t_resubscribe_on_fast_failure(TCConfig) when is_list(TCConfig) ->
     ct:pal("Restarting source node (1)"),
     {ok, SRef0} = snabbkaffe:subscribe(
         ?match_event(#{?snk_kind := "mqtt_source_reconnected"}),
-        %% 2 sources with 3 workers each
-        2 * PoolSize,
+        %% Each cluster node runs its own connector pool, and every worker re-runs the
+        %% reconnect callback for both sources.  We must wait for ALL of them, otherwise
+        %% a node whose SUBSCRIBE hasn't completed yet will silently drop the publish.
+        NumNodes * 2 * PoolSize,
         %% Timeout
         30_000
     ),
@@ -1000,8 +1002,8 @@ t_resubscribe_on_fast_failure(TCConfig) when is_list(TCConfig) ->
     ct:pal("Restarting source node (2)"),
     {ok, SRef1} = snabbkaffe:subscribe(
         ?match_event(#{?snk_kind := "mqtt_source_reconnected"}),
-        %% 1 source with 3 workers each
-        1 * PoolSize,
+        %% Only one source remains now, but still one pool per cluster node.
+        NumNodes * 1 * PoolSize,
         %% Timeout
         30_000
     ),


### PR DESCRIPTION
Release version: 6.1.2

## Summary

Fixes the flaky `emqx_bridge_mqtt_source_SUITE:t_resubscribe_on_fast_failure`.

The test runs on a 3-node cluster, and each node runs its own MQTT connector pool. When the source broker is restarted, every worker on every node re-runs its reconnect callback for each source channel, emitting a `"mqtt_source_reconnected"` snabbkaffe event:

```
NumNodes * num_sources * pool_size
```

The test only waited for `num_sources * pool_size` events (the comment even said "2 sources with 3 workers each" — it forgot the cluster dimension). Once that many events arrived it published immediately. Any cluster node whose `SUBSCRIBE` to the source broker had not yet completed silently dropped the QoS-1 publish, so fewer republishes than `NumNodes` were produced and `?assertReceivePublish` hit an empty mailbox.

The fix waits for the reconnect events from **all** cluster nodes (`NumNodes * ...`) before publishing, in both restart phases of the test.

Test-only change; no user-facing behavior is affected.

Verified by looping the previously-failing variant (`cluster.proto_v3.clean_start`) — consistently green.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
