### PR TITLE
ci: add daily cron to fast-forward release-XX from dev-XX

### DIFF
--- a/.github/workflows/green_master.yaml
+++ b/.github/workflows/green_master.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           ref: ${{ matrix.ref }}
 
-      - name: run script
+      - name: rerun failed push-entrypoint runs (up to 3 attempts)
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -43,4 +43,49 @@ jobs:
         run: |
           for id in $(gh run list --branch ${{ matrix.ref }} --workflow "Push Entrypoint" --commit $(git rev-parse HEAD) --status failure --json databaseId,attempt --jq '.[] | select(.attempt < 3) | .databaseId'); do
             gh run rerun "$id" --failed
+          done
+
+      - name: alert Slack when retries are exhausted
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "SLACK_WEBHOOK_URL is unset; skipping alert."
+            exit 0
+          fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          # Only alert about runs that EXHAUSTED their retry budget within the
+          # last ~65 minutes (one cron window + buffer). Without this guard the
+          # workflow would alert every hour until a human fixes the branch.
+          SINCE=$(date -u -d '65 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          mapfile -t runs < <(gh run list \
+            --branch "${{ matrix.ref }}" \
+            --workflow "Push Entrypoint" \
+            --commit "$HEAD_SHA" \
+            --status failure \
+            --json databaseId,attempt,url,updatedAt,headSha \
+            --jq ".[] | select(.attempt >= 3 and .updatedAt >= \"$SINCE\") | @base64")
+          for r in "${runs[@]:-}"; do
+            [ -z "$r" ] && continue
+            decoded=$(echo "$r" | base64 -d)
+            run_url=$(echo "$decoded" | jq -r .url)
+            head_sha=$(echo "$decoded" | jq -r .headSha)
+            cat <<EOF > payload.json
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Push CI on \`${{ matrix.ref }}\` (${head_sha}) is still red after 3 attempts: ${run_url}"
+                }
+              }
+            ]
+          }
+          EOF
+            curl -X POST -H 'Content-type: application/json' --data @payload.json "$SLACK_WEBHOOK_URL"
           done

--- a/.github/workflows/sync-dev-to-release.yaml
+++ b/.github/workflows/sync-dev-to-release.yaml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   schedule:
-    - cron:  '0 18 * * *'
+    - cron:  '0 21 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-dev-to-release.yaml
+++ b/.github/workflows/sync-dev-to-release.yaml
@@ -1,0 +1,95 @@
+name: Fast-forward release branch from dev branch
+
+concurrency:
+  group: sync-dev-to-release-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron:  '0 18 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fast-forward:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "58"
+          - "59"
+          - "510"
+          - "60"
+          - "61"
+          - "62"
+          - "63"
+
+    env:
+      DEV_BRANCH: dev-${{ matrix.version }}
+      RELEASE_BRANCH: release-${{ matrix.version }}
+
+    defaults:
+      run:
+        shell: bash
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+
+      - name: Configure git user
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Check that the dev branch exists
+        run: |
+          set -euo pipefail
+          if ! git ls-remote --exit-code --heads origin "${DEV_BRANCH}" >/dev/null; then
+            echo "::notice::origin/${DEV_BRANCH} does not exist; skipping."
+            echo "SKIP=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Fast-forward release branch
+        if: env.SKIP != '1'
+        run: ./scripts/ff-release-from-dev.sh "${{ matrix.version }}"
+
+      - name: Send notification to Slack
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ "${NOT_FAST_FORWARD:-0}" = "1" ]; then
+            REASON="${RELEASE_BRANCH} has diverged from ${DEV_BRANCH}; rebase ${DEV_BRANCH} on top of ${RELEASE_BRANCH} (or reset ${DEV_BRANCH} to a descendant of ${RELEASE_BRANCH}) before the next run."
+          else
+            REASON="Automatic fast-forward of ${RELEASE_BRANCH} from ${DEV_BRANCH} failed."
+          fi
+          cat <<EOF > payload.json
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "${REASON} See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                }
+              }
+            ]
+          }
+          EOF
+          curl -X POST -H 'Content-type: application/json' --data @payload.json "$SLACK_WEBHOOK_URL"

--- a/scripts/ff-release-from-dev.sh
+++ b/scripts/ff-release-from-dev.sh
@@ -36,15 +36,21 @@ if [ "${DEV_SHA}" = "${REL_SHA}" ]; then
     exit 0
 fi
 
-# Verify dev is a strict descendant of release (ff is possible).
-if ! git merge-base --is-ancestor "${REL_SHA}" "${DEV_SHA}"; then
+# git push (without --force) is intrinsically ff-only — the server rejects
+# non-fast-forward updates with "non-fast-forward" / "fetch first". Use that
+# instead of a pre-check via merge-base; only the push contacts the remote.
+PUSH_ERR=$(mktemp)
+trap 'rm -f "$PUSH_ERR"' EXIT
+if git push origin "${DEV_SHA}:refs/heads/${RELEASE_BRANCH}" 2>"$PUSH_ERR"; then
+    echo "::notice::${RELEASE_BRANCH} advanced from ${REL_SHA} to ${DEV_SHA}."
+    exit 0
+fi
+
+cat "$PUSH_ERR" >&2
+if grep -qE 'non-fast-forward|fetch first|rejected' "$PUSH_ERR"; then
     if [ -n "${GITHUB_ENV:-}" ]; then
         echo "NOT_FAST_FORWARD=1" >> "$GITHUB_ENV"
     fi
-    echo "::error::${RELEASE_BRANCH} (${REL_SHA}) is not an ancestor of ${DEV_BRANCH} (${DEV_SHA}); ff not possible."
-    exit 1
+    echo "::error::${RELEASE_BRANCH} (${REL_SHA}) has diverged from ${DEV_BRANCH} (${DEV_SHA}); ff not possible."
 fi
-
-# Fast-forward the remote release branch.
-git push origin "${DEV_SHA}:refs/heads/${RELEASE_BRANCH}"
-echo "::notice::${RELEASE_BRANCH} advanced from ${REL_SHA} to ${DEV_SHA}."
+exit 1

--- a/scripts/ff-release-from-dev.sh
+++ b/scripts/ff-release-from-dev.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fast-forward release-XX to dev-XX, refusing to overwrite if not a ff.
+#
+# Usage: scripts/ff-release-from-dev.sh <version>
+#   <version>  release series (e.g. 58, 59, 510, 60, 61, 62, 63)
+#
+# Behaviour:
+# - If origin/release-XX == origin/dev-XX: nothing to do, exit 0.
+# - If origin/release-XX is an ancestor of origin/dev-XX: fast-forward push.
+# - Otherwise: write NOT_FAST_FORWARD=1 to $GITHUB_ENV (when set), log a clear
+#   error, exit 1. The caller's failure-notification step can read the env var
+#   to phrase a more helpful Slack alert.
+#
+# Designed to run inside .github/workflows/sync-dev-to-release.yaml but does
+# not strictly require GitHub Actions. Outside CI, $GITHUB_ENV is unset and
+# the NOT_FAST_FORWARD signal is just skipped.
+
+set -euxo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "usage: $0 <version>" >&2
+    exit 2
+fi
+
+VERSION="$1"
+DEV_BRANCH="dev-${VERSION}"
+RELEASE_BRANCH="release-${VERSION}"
+
+git fetch origin "${DEV_BRANCH}" "${RELEASE_BRANCH}"
+
+DEV_SHA=$(git rev-parse "origin/${DEV_BRANCH}")
+REL_SHA=$(git rev-parse "origin/${RELEASE_BRANCH}")
+
+if [ "${DEV_SHA}" = "${REL_SHA}" ]; then
+    echo "::notice::${DEV_BRANCH} and ${RELEASE_BRANCH} already at ${DEV_SHA}; nothing to do."
+    exit 0
+fi
+
+# Verify dev is a strict descendant of release (ff is possible).
+if ! git merge-base --is-ancestor "${REL_SHA}" "${DEV_SHA}"; then
+    if [ -n "${GITHUB_ENV:-}" ]; then
+        echo "NOT_FAST_FORWARD=1" >> "$GITHUB_ENV"
+    fi
+    echo "::error::${RELEASE_BRANCH} (${REL_SHA}) is not an ancestor of ${DEV_BRANCH} (${DEV_SHA}); ff not possible."
+    exit 1
+fi
+
+# Fast-forward the remote release branch.
+git push origin "${DEV_SHA}:refs/heads/${RELEASE_BRANCH}"
+echo "::notice::${RELEASE_BRANCH} advanced from ${REL_SHA} to ${DEV_SHA}."


### PR DESCRIPTION
## Summary

Adds a daily cron that fast-forwards each \`release-XX\` branch from the matching \`dev-XX\`. New work lands on \`dev-XX\`; the bot publishes the validated state to \`release-XX\` at 21:00 UTC. No PR, no merge commit, exact SHAs preserved.

Three files:

- \`.github/workflows/sync-dev-to-release.yaml\` — the ff cron. Matrices over versions \`58, 59, 510, 60, 61, 62, 63\`. \`fail-fast: false\` so one diverged branch doesn't block the others. Triggered by schedule and \`workflow_dispatch\`.
- \`scripts/ff-release-from-dev.sh\` — the per-version action. Takes the version (e.g. \`58\`) as its only argument. Reusable outside CI for ad-hoc syncs or recovery.
- \`.github/workflows/green_master.yaml\` (existing file) — extended so that, in addition to auto-retrying failed Push Entrypoint runs (up to 3 attempts), it posts a Slack alert when the third attempt has also failed.

Both workflow Slack steps post to \`#emqx-devs\` via the Slack \`chat.postMessage\` API with an explicit channel id, matching what the local notify scripts target.

## Behaviour — ff cron

For each version \`X\` in the matrix:

1. If \`origin/dev-X\` does not exist → soft skip (the leg stays green).
2. If \`origin/dev-X == origin/release-X\` → nothing to do, green.
3. If \`origin/release-X\` is an ancestor of \`origin/dev-X\` → fast-forward push, green. (The ff invariant is enforced by \`git push\` itself: non-fast-forward updates are rejected by the server when \`--force\` is not used.)
4. Otherwise (divergence) → set \`NOT_FAST_FORWARD=1\`, log a clear error, exit 1. The failure-notification step posts a Slack alert to \`#emqx-devs\`.

## Behaviour — green_master extension

Once an hour, after the auto-retry loop, the workflow looks for failed Push Entrypoint runs where attempt ≥ 3 AND \`updatedAt\` is within the last ~65 minutes (one cron window + buffer, so each exhausted run is announced once rather than every hour for as long as it stays red). For each such run, posts a Slack alert to \`#emqx-devs\` with the run URL.

## Prerequisites

- **\`SLACK_BOT_TOKEN\` repo secret**: required by both new Slack steps. Should be a Slack bot token with \`chat:write\` for \`#emqx-devs\`. If unset, both steps soft-skip with a notice (no breakage).
- **\`release-XX\` branch protection**: the bot identity (GitHub App backed by \`AUTH_APP_ID\` / \`AUTH_APP_PRIVATE_KEY\`) needs to be a bypass principal so its fast-forward push goes through. Suggested:
  - Require linear history.
  - Restrict pushes to the bot only.
  - PR-merge settings: keep only \"Allow merge commits\" (squash and rebase merge create new SHAs and would diverge the branches).

## Recovery (when the cron alerts \`NOT_FAST_FORWARD\`)

If someone bypass-pushes a commit \`B\` to \`release-X\`, the next cron run fails the \`X\` leg. Recover via a PR so CI verifies the merged state before it lands — do not push directly to \`dev-X\`.

1. Branch off \`dev-X\` and merge \`release-X\` in:

   \`\`\`sh
   git fetch origin
   git checkout -b YYMMDD-recover-dev-X-from-release-X origin/dev-X
   git merge --no-ff origin/release-X
   git push <your-fork> HEAD
   \`\`\`

2. Open a PR to \`dev-X\`. **Merge strategy on this PR must be \"Create a merge commit\"** (squash / rebase rewrite \`B\` to a new SHA and the divergence persists). Title example: \`chore: recover dev-X by merging stray commit from release-X\`.

3. Wait for the PR's CI to go green, then merge.

4. The next 21:00 UTC cron run sees \`release-X\` as an ancestor of \`dev-X\` and ff's it forward. To unblock sooner, manually trigger the workflow (\`workflow_dispatch\` from the Actions tab) or run:

   \`\`\`sh
   ./scripts/ff-release-from-dev.sh X
   \`\`\`

   (The script is also usable for ad-hoc syncs outside CI.)

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking