### PR TITLE
fix(logger): avoid formatter crash on tuple log fields without chars_limit

### DIFF
--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -131,7 +131,7 @@ format_msg({Fmt, Args}, _Meta, Config) ->
     emqx_utils_log:format(Fmt, Args, Config).
 
 add_default_config(Config0) ->
-    Default = #{single_line => true},
+    Default = #{single_line => true, chars_limit => unlimited},
     Depth = get_depth(maps:get(depth, Config0, undefined)),
     maps:merge(Default, Config0#{depth => Depth}).
 

--- a/apps/emqx/test/emqx_logger_fmt_SUITE.erl
+++ b/apps/emqx/test/emqx_logger_fmt_SUITE.erl
@@ -69,6 +69,47 @@ t_nested_report_with_utf8_strings(_TCConfig) ->
 t_json_fmt_gen_rpc_packet(_) ->
     check_fmt_gen_rpc_packet(emqx_logger_jsonfmt).
 
+t_text_fmt_tuple_field_without_chars_limit(_) ->
+    check_fmt_tuple_field_without_chars_limit(emqx_logger_textfmt).
+
+t_json_fmt_tuple_field_without_chars_limit(_) ->
+    check_fmt_tuple_field_without_chars_limit(emqx_logger_jsonfmt).
+
+%% A formatter config may legitimately omit the `chars_limit' rendering hint
+%% (e.g. handlers added programmatically). Such a config must not crash the
+%% formatter when a log field holds a tuple. This reproduces the "FORMATTER
+%% CRASH" seen on authn trace events, whose `result' field is a tuple such as
+%% `{ok, #{...}}' / `{error, _}' / `{stop, _}'.
+check_fmt_tuple_field_without_chars_limit(FormatModule) ->
+    %% Note: no `chars_limit' key in the config on purpose.
+    Conf = #{
+        time_offset => [],
+        depth => 100,
+        single_line => true,
+        template => ["[", level, "] ", msg, "\n"],
+        timestamp_format => auto,
+        payload_encode => text
+    },
+    Event = #{
+        level => debug,
+        msg =>
+            {report, #{
+                msg => authenticator_result,
+                tag => "AUTHN",
+                authenticator => <<"password_based:built_in_database">>,
+                result => {ok, #{is_superuser => false}}
+            }},
+        meta => #{
+            time => 0,
+            report_cb => fun logger:format_otp_report/1
+        }
+    },
+    LogEntryIOData = FormatModule:format(Event, Conf),
+    LogEntryBin = unicode:characters_to_binary(LogEntryIOData),
+    ?assertNotEqual(nomatch, binary:match(LogEntryBin, [<<"authenticator_result">>])),
+    ?assertNotEqual(nomatch, binary:match(LogEntryBin, [<<"is_superuser">>])),
+    ok.
+
 check_fmt_lazy_values(FormatModule) ->
     LogEntryIOData = FormatModule:format(event_with_lazy_value(), conf()),
     LogEntryBin = unicode:characters_to_binary(LogEntryIOData),

--- a/apps/emqx_utils/mix.exs
+++ b/apps/emqx_utils/mix.exs
@@ -6,7 +6,7 @@ defmodule EMQXUtils.MixProject do
   def project do
     [
       app: :emqx_utils,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       compilers: [:yecc, :leex] ++ Mix.compilers(),
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_utils/src/emqx_utils_log.erl
+++ b/apps/emqx_utils/src/emqx_utils_log.erl
@@ -18,11 +18,15 @@
 
 -export([format/3]).
 
-format(Format0, Args, #{
-    depth := Depth,
-    single_line := SingleLine,
-    chars_limit := Limit
-}) ->
+%% `depth', `single_line' and `chars_limit' are rendering hints that may be
+%% absent from a formatter config (e.g. a handler added programmatically, or a
+%% trace formatter that only carries `payload_fmt_opts'). Treat them as optional
+%% and fall back to the same defaults `logger_formatter' uses, so that formatting
+%% never crashes with `function_clause' on an otherwise valid config.
+format(Format0, Args, Config) when is_map(Config) ->
+    Depth = maps:get(depth, Config, unlimited),
+    SingleLine = maps:get(single_line, Config, true),
+    Limit = maps:get(chars_limit, Config, unlimited),
     Opts = chars_limit_to_opts(Limit),
     Format1 = io_lib:scan_format(Format0, Args),
     Format = reformat(Format1, Depth, SingleLine),

--- a/changes/ee/fix-17708.en.md
+++ b/changes/ee/fix-17708.en.md
@@ -1,0 +1,3 @@
+Fixed a logger formatter crash that could replace some debug-level trace events with a `FORMATTER CRASH` line.
+
+The crash happened when a log field held a tuple value (for example the `result` field of the `authenticator_result` and `authentication_result` authentication trace events) and the active formatter configuration did not carry a `chars_limit` setting. As a result, the events that show which authenticator accepted or rejected a connection were missing from the trace output. These events are now formatted correctly.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.3, 6.2.2

## Summary

Some debug-level trace events were being replaced by an OTP `FORMATTER CRASH: <msg>` line, hiding the event content. This was reported on the `authenticator_result` and `authentication_result` authentication trace events — exactly the events that show which authenticator accepted or rejected a connection.

Root cause: `emqx_utils_log:format/3` pattern-matched `chars_limit` (and `depth`, `single_line`) as required config keys, so it died with `function_clause` when the formatter config did not carry `chars_limit`. In the JSON encoder, atoms/numbers/binaries/maps/lists are encoded inline; only **tuple** values fall through to `emqx_utils_log:format("~0p", [Term], Config)`. The authentication trace events carry a tuple-valued `result` field (`{ok, _}` / `{error, _}` / `{stop, _}`), so they were uniquely exposed. OTP's `logger_h_common:try_format/3` then re-emitted the event through the default formatter as `FORMATTER CRASH`.

Changes:
- `apps/emqx_utils/src/emqx_utils_log.erl`: treat `depth` / `single_line` / `chars_limit` as optional, defaulting to the same values `logger_formatter` uses (`unlimited` / `true` / `unlimited`). This is the actual crash site and a shared utility, so the fix covers all caller paths.
- `apps/emqx/src/emqx_logger_jsonfmt.erl`: `add_default_config/1` now also fills `chars_limit => unlimited` (it is the defaults helper, and was the only key it missed).
- Regression tests in `emqx_logger_fmt_SUITE` for both the text and JSON formatters.

The same defect exists on v5 (`emqx_logger_jsonfmt:do_format_msg/3`, inline) and forward; this PR targets `dev-60` and forward-syncs.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
