### PR TITLE
fix(logger): avoid JSON formatter crash on tuple log fields without chars_limit

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.5.7"},
+    {vsn, "5.5.8"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -160,11 +160,15 @@ format_msg({report, Report}, #{report_cb := Fun}, Config) when is_function(Fun, 
 format_msg({Fmt, Args}, _Meta, Config) ->
     do_format_msg(Fmt, Args, Config).
 
-do_format_msg(Format0, Args, #{
-    depth := Depth,
-    single_line := SingleLine,
-    chars_limit := Limit
-}) ->
+do_format_msg(Format0, Args, Config) when is_map(Config) ->
+    %% `depth', `single_line' and `chars_limit' are rendering hints that may be
+    %% absent from a formatter config (e.g. a handler added programmatically).
+    %% Treat them as optional and fall back to the same defaults
+    %% `logger_formatter' uses, so that formatting never crashes with
+    %% `function_clause' on an otherwise valid config.
+    Depth = maps:get(depth, Config, unlimited),
+    SingleLine = maps:get(single_line, Config, true),
+    Limit = maps:get(chars_limit, Config, unlimited),
     Opts = chars_limit_to_opts(Limit),
     Format1 = io_lib:scan_format(Format0, Args),
     Format = reformat(Format1, Depth, SingleLine),
@@ -205,7 +209,7 @@ limit_depth(#{control_char := C0, args := Args} = M0, Depth) ->
     M0#{control_char := C, args := Args ++ [Depth]}.
 
 add_default_config(Config0) ->
-    Default = #{single_line => true},
+    Default = #{single_line => true, chars_limit => unlimited},
     Depth = get_depth(maps:get(depth, Config0, undefined)),
     maps:merge(Default, Config0#{depth => Depth}).
 

--- a/apps/emqx/test/emqx_logger_fmt_SUITE.erl
+++ b/apps/emqx/test/emqx_logger_fmt_SUITE.erl
@@ -48,6 +48,43 @@ t_json_fmt_lazy_values_only_in_debug_level_events(_) ->
 t_json_payload(_) ->
     check_fmt_payload(emqx_logger_jsonfmt).
 
+t_json_fmt_tuple_field_without_chars_limit(_) ->
+    check_fmt_tuple_field_without_chars_limit(emqx_logger_jsonfmt).
+
+%% A formatter config may legitimately omit the `chars_limit' rendering hint
+%% (e.g. handlers added programmatically). Such a config must not crash the
+%% formatter when a log field holds a tuple. This reproduces the "FORMATTER
+%% CRASH" seen on authn trace events, whose `result' field is a tuple such as
+%% `{ok, #{...}}' / `{error, _}' / `{stop, _}'.
+check_fmt_tuple_field_without_chars_limit(FormatModule) ->
+    %% Note: no `chars_limit' key in the config on purpose.
+    Conf = #{
+        time_offset => [],
+        depth => 100,
+        single_line => true,
+        template => ["[", level, "] ", msg, "\n"],
+        timestamp_format => auto
+    },
+    Event = #{
+        level => debug,
+        msg =>
+            {report, #{
+                msg => authenticator_result,
+                tag => "AUTHN",
+                authenticator => <<"password_based:built_in_database">>,
+                result => {ok, #{is_superuser => false}}
+            }},
+        meta => #{
+            time => 0,
+            report_cb => fun logger:format_otp_report/1
+        }
+    },
+    LogEntryIOData = FormatModule:format(Event, Conf),
+    LogEntryBin = unicode:characters_to_binary(LogEntryIOData),
+    ?assertNotEqual(nomatch, binary:match(LogEntryBin, [<<"authenticator_result">>])),
+    ?assertNotEqual(nomatch, binary:match(LogEntryBin, [<<"is_superuser">>])),
+    ok.
+
 check_fmt_lazy_values(FormatModule) ->
     LogEntryIOData = FormatModule:format(event_with_lazy_value(), conf()),
     LogEntryBin = unicode:characters_to_binary(LogEntryIOData),

--- a/changes/ce/fix-17709.en.md
+++ b/changes/ce/fix-17709.en.md
@@ -1,0 +1,3 @@
+Fixed a JSON log formatter crash that could replace some debug-level log and trace events with a `FORMATTER CRASH` line.
+
+The crash happened when a log field held a tuple value (for example the `result` field of the `authenticator_result` and `authentication_result` authentication trace events) and the active formatter configuration did not carry a `chars_limit` setting. As a result, the events that show which authenticator accepted or rejected a connection were missing from the output. These events are now formatted correctly.


### PR DESCRIPTION
Release version: 5.8.11

## Summary

Backport of the JSON log formatter crash fix to the v5 line (see #17708 for the v6 fix).

Some debug-level log and trace events were being replaced by an OTP `FORMATTER CRASH: <msg>` line, hiding the event content. This was reported on the `authenticator_result` and `authentication_result` authentication trace events — exactly the events that show which authenticator accepted or rejected a connection.

Root cause: `emqx_logger_jsonfmt:do_format_msg/3` pattern-matched `chars_limit` (and `depth`, `single_line`) as required config keys, so it died with `function_clause` when the formatter config did not carry `chars_limit`. In the JSON encoder, atoms/numbers/binaries/maps/lists are encoded inline; only **tuple** values fall through to `do_format_msg("~p", [Term], Config)`. The authentication trace events carry a tuple-valued `result` field (`{ok, _}` / `{error, _}` / `{stop, _}`), so they were uniquely exposed. OTP's `logger_h_common:try_format/3` then re-emitted the event through the default formatter as `FORMATTER CRASH`.

Changes:
- `apps/emqx/src/emqx_logger_jsonfmt.erl`: treat `depth` / `single_line` / `chars_limit` as optional in `do_format_msg/3`, defaulting to the same values `logger_formatter` uses (`unlimited` / `true` / `unlimited`); `add_default_config/1` now also fills `chars_limit => unlimited`.
- Regression test in `emqx_logger_fmt_SUITE`.

On v6 this code was refactored into `emqx_utils_log:format/3`; the equivalent fix lands there in #17708.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
