### PR TITLE
fix(authn): consistent namespace handling for built-in users HTTP API

### DIFF
--- a/apps/emqx_auth/mix.exs
+++ b/apps/emqx_auth/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuth.MixProject do
   def project do
     [
       app: :emqx_auth,
-      version: "6.1.1",
+      version: "6.1.2",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
@@ -1785,35 +1785,27 @@ user_out(User) ->
 get_namespace(#{resolved_ns := Namespace}) ->
     Namespace.
 
-parse_namespace(Req, Method) ->
+parse_namespace(Req) ->
     ActorNamespace = emqx_dashboard:get_namespace(Req),
-    case requested_namespace(Method, Req) of
+    case requested_namespace(Req) of
         undefined ->
             {ok, ActorNamespace};
         ActorNamespace ->
             {ok, ActorNamespace};
-        _Other when ActorNamespace =:= ?global_ns ->
+        Other when ActorNamespace =:= ?global_ns ->
             %% Only a global admin may operate on an arbitrary namespace.
-            {ok, _Other};
+            {ok, Other};
         _Other ->
             {error, not_authorized}
     end.
 
-%% Decide where the requested namespace comes from, per HTTP method:
-%%   * POST / PUT carry a body, so the `namespace' body field takes precedence,
-%%     falling back to the `ns' query parameter.
-%%   * DELETE may carry a body too, but the `ns' query parameter wins; the body
-%%     `namespace' is only a fallback.
-%%   * GET (and anything else) only reads the `ns' query parameter, as a GET body
-%%     has no defined semantics.
-%% Returns `undefined' when no namespace was requested, so the caller can default
-%% to the actor's namespace.
-requested_namespace(Method, Req) when Method =:= post; Method =:= put ->
-    first_defined([body_namespace(Req), qs_namespace(Req)]);
-requested_namespace(delete, Req) ->
-    first_defined([qs_namespace(Req), body_namespace(Req)]);
-requested_namespace(_Method, Req) ->
-    qs_namespace(Req).
+%% The requested namespace may be carried in the `ns' query parameter or in the
+%% `namespace' request body field. The query parameter always takes precedence;
+%% the body field is only a fallback (and is the only option for GET, which has
+%% no body). Returns `undefined' when no namespace was requested, so the caller
+%% can default to the actor's namespace.
+requested_namespace(Req) ->
+    first_defined([qs_namespace(Req), body_namespace(Req)]).
 
 qs_namespace(#{query_string := QueryString}) ->
     maps:get(<<"ns">>, QueryString, undefined);
@@ -1829,8 +1821,8 @@ first_defined([undefined | Rest]) -> first_defined(Rest);
 first_defined([Value | _Rest]) -> Value;
 first_defined([]) -> undefined.
 
-resolve_namespace(Req, #{method := Method}) ->
-    case parse_namespace(Req, Method) of
+resolve_namespace(Req, _Meta) ->
+    case parse_namespace(Req) of
         {ok, Namespace} ->
             {ok, Req#{resolved_ns => Namespace}};
         {error, not_authorized} ->

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
@@ -125,6 +125,7 @@ roots() ->
     [
         request_user_create,
         request_user_update,
+        request_user_delete,
         response_user,
         response_users,
         request_authn_order
@@ -132,12 +133,16 @@ roots() ->
 
 fields(request_user_create) ->
     [
-        {namespace, mk(binary(), #{required => false})},
         {user_id, mk(binary(), #{required => true})}
         | fields(request_user_update)
     ];
+fields(request_user_delete) ->
+    [
+        {namespace, mk(binary(), #{required => false})}
+    ];
 fields(request_user_update) ->
     [
+        {namespace, mk(binary(), #{required => false})},
         {password, mk(binary(), #{required => true})},
         {is_superuser, mk(boolean(), #{default => false, required => false})}
     ];
@@ -380,7 +385,7 @@ schema("/authentication/:id/users") ->
         post => #{
             tags => ?API_TAGS_GLOBAL,
             description => ?DESC(authentication_id_users_post),
-            parameters => [param_auth_id()],
+            parameters => [param_auth_id(), ns_qs_param()],
             'requestBody' => emqx_dashboard_swagger:schema_with_examples(
                 ref(request_user_create),
                 request_user_create_examples()
@@ -507,6 +512,10 @@ schema("/authentication/:id/users/:user_id") ->
             tags => ?API_TAGS_GLOBAL,
             description => ?DESC(authentication_id_users_user_id_delete),
             parameters => [param_auth_id(), param_user_id(), ns_qs_param()],
+            'requestBody' => emqx_dashboard_swagger:schema_with_example(
+                ref(request_user_delete),
+                #{<<"namespace">> => <<"ns1">>}
+            ),
             responses => #{
                 204 => ?DESC("user_deleted"),
                 404 => error_codes([?NOT_FOUND], ?DESC(?NOT_FOUND))
@@ -851,17 +860,17 @@ listener_authenticator_position(
         end
     ).
 
-authenticator_users(post, #{
-    bindings := #{id := AuthenticatorID},
-    body := UserInfo,
-    resolved_ns := ResolvedNs
-}) ->
-    case effective_user_namespace(UserInfo, ResolvedNs) of
-        {ok, Namespace} ->
-            add_user(?GLOBAL, AuthenticatorID, UserInfo#{<<"namespace">> => Namespace});
-        {error, forbidden} ->
-            ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
-    end;
+authenticator_users(
+    post,
+    #{
+        bindings := #{id := AuthenticatorID},
+        body := UserInfo
+    } = Req
+) ->
+    %% Namespace is resolved (and authorized against the actor) in `filter/2',
+    %% honoring the `namespace' body field and the `ns' query param.
+    Namespace = get_namespace(Req),
+    add_user(?GLOBAL, AuthenticatorID, UserInfo#{<<"namespace">> => Namespace});
 authenticator_users(get, #{
     bindings := #{id := AuthenticatorID},
     query_string := QueryString,
@@ -1306,17 +1315,6 @@ update_user(ChainName, Namespace, AuthenticatorID, UserID, UserInfo0) ->
                 {error, Reason} ->
                     serialize_error(Reason)
             end
-    end.
-
-%% A global admin (resolved_ns = ?global_ns) may write to any namespace by
-%% specifying it in the body; a namespaced admin may only write to their own
-%% namespace and any mismatch in the body is rejected.
-effective_user_namespace(UserInfo, ?global_ns) ->
-    {ok, maps:get(<<"namespace">>, UserInfo, ?global_ns)};
-effective_user_namespace(UserInfo, ResolvedNs) ->
-    case maps:get(<<"namespace">>, UserInfo, ResolvedNs) of
-        ResolvedNs -> {ok, ResolvedNs};
-        _Other -> {error, forbidden}
     end.
 
 %% MQTT users in a non-global namespace must never be superusers: explicit ACL
@@ -1787,17 +1785,52 @@ user_out(User) ->
 get_namespace(#{resolved_ns := Namespace}) ->
     Namespace.
 
-parse_namespace(#{query_string := QueryString} = Req) ->
+parse_namespace(Req, Method) ->
     ActorNamespace = emqx_dashboard:get_namespace(Req),
-    case maps:get(<<"ns">>, QueryString, ActorNamespace) of
-        QSNamespace when QSNamespace /= ActorNamespace andalso ActorNamespace /= ?global_ns ->
-            {error, not_authorized};
-        QSNamespace ->
-            {ok, QSNamespace}
+    case requested_namespace(Method, Req) of
+        undefined ->
+            {ok, ActorNamespace};
+        ActorNamespace ->
+            {ok, ActorNamespace};
+        _Other when ActorNamespace =:= ?global_ns ->
+            %% Only a global admin may operate on an arbitrary namespace.
+            {ok, _Other};
+        _Other ->
+            {error, not_authorized}
     end.
 
-resolve_namespace(Req, _Meta) ->
-    case parse_namespace(Req) of
+%% Decide where the requested namespace comes from, per HTTP method:
+%%   * POST / PUT carry a body, so the `namespace' body field takes precedence,
+%%     falling back to the `ns' query parameter.
+%%   * DELETE may carry a body too, but the `ns' query parameter wins; the body
+%%     `namespace' is only a fallback.
+%%   * GET (and anything else) only reads the `ns' query parameter, as a GET body
+%%     has no defined semantics.
+%% Returns `undefined' when no namespace was requested, so the caller can default
+%% to the actor's namespace.
+requested_namespace(Method, Req) when Method =:= post; Method =:= put ->
+    first_defined([body_namespace(Req), qs_namespace(Req)]);
+requested_namespace(delete, Req) ->
+    first_defined([qs_namespace(Req), body_namespace(Req)]);
+requested_namespace(_Method, Req) ->
+    qs_namespace(Req).
+
+qs_namespace(#{query_string := QueryString}) ->
+    maps:get(<<"ns">>, QueryString, undefined);
+qs_namespace(_Req) ->
+    undefined.
+
+body_namespace(#{body := Body}) when is_map(Body) ->
+    maps:get(<<"namespace">>, Body, undefined);
+body_namespace(_Req) ->
+    undefined.
+
+first_defined([undefined | Rest]) -> first_defined(Rest);
+first_defined([Value | _Rest]) -> Value;
+first_defined([]) -> undefined.
+
+resolve_namespace(Req, #{method := Method}) ->
+    case parse_namespace(Req, Method) of
         {ok, Namespace} ->
             {ok, Req#{resolved_ns => Namespace}};
         {error, not_authorized} ->
@@ -1806,15 +1839,23 @@ resolve_namespace(Req, _Meta) ->
 
 validate_managed_namespace(#{resolved_ns := ?global_ns} = Req, _Meta) ->
     {ok, Req};
-validate_managed_namespace(#{resolved_ns := Namespace} = Req, _Meta) ->
-    Res = emqx_hooks:run_fold('namespace.resource_pre_create', [#{namespace => Namespace}], #{
-        exists => false
-    }),
-    case Res of
-        #{exists := false} ->
-            ?BAD_REQUEST(<<"Managed namespace not found">>);
-        #{exists := true} ->
-            {ok, Req}
+validate_managed_namespace(#{resolved_ns := Namespace} = Req, #{method := Method}) ->
+    %% A global admin must be able to delete built-in auth records even when the
+    %% owning namespace has already been deleted (cleanup of orphaned data), so
+    %% the existence check is skipped for global-admin deletes.
+    case Method =:= delete andalso emqx_dashboard:get_namespace(Req) =:= ?global_ns of
+        true ->
+            {ok, Req};
+        false ->
+            Res = emqx_hooks:run_fold(
+                'namespace.resource_pre_create', [#{namespace => Namespace}], #{exists => false}
+            ),
+            case Res of
+                #{exists := false} ->
+                    ?BAD_REQUEST(<<"Managed namespace not found">>);
+                #{exists := true} ->
+                    {ok, Req}
+            end
     end.
 
 filter(Req0, Meta) ->

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
@@ -1788,24 +1788,31 @@ get_namespace(#{resolved_ns := Namespace}) ->
 parse_namespace(Req) ->
     ActorNamespace = emqx_dashboard:get_namespace(Req),
     case requested_namespace(Req) of
-        undefined ->
+        {error, conflicting_namespaces} = Err ->
+            Err;
+        {ok, undefined} ->
             {ok, ActorNamespace};
-        ActorNamespace ->
+        {ok, ActorNamespace} ->
             {ok, ActorNamespace};
-        Other when ActorNamespace =:= ?global_ns ->
+        {ok, Other} when ActorNamespace =:= ?global_ns ->
             %% Only a global admin may operate on an arbitrary namespace.
             {ok, Other};
-        _Other ->
+        {ok, _Other} ->
             {error, not_authorized}
     end.
 
 %% The requested namespace may be carried in the `ns' query parameter or in the
-%% `namespace' request body field. The query parameter always takes precedence;
-%% the body field is only a fallback (and is the only option for GET, which has
-%% no body). Returns `undefined' when no namespace was requested, so the caller
-%% can default to the actor's namespace.
+%% `namespace' request body field. If both are present they must agree, otherwise
+%% the request is rejected. Returns `{ok, undefined}' when no namespace was
+%% requested, so the caller can default to the actor's namespace.
 requested_namespace(Req) ->
-    first_defined([qs_namespace(Req), body_namespace(Req)]).
+    case {qs_namespace(Req), body_namespace(Req)} of
+        {undefined, undefined} -> {ok, undefined};
+        {Ns, undefined} -> {ok, Ns};
+        {undefined, Ns} -> {ok, Ns};
+        {Ns, Ns} -> {ok, Ns};
+        {_QsNs, _BodyNs} -> {error, conflicting_namespaces}
+    end.
 
 qs_namespace(#{query_string := QueryString}) ->
     maps:get(<<"ns">>, QueryString, undefined);
@@ -1817,14 +1824,14 @@ body_namespace(#{body := Body}) when is_map(Body) ->
 body_namespace(_Req) ->
     undefined.
 
-first_defined([undefined | Rest]) -> first_defined(Rest);
-first_defined([Value | _Rest]) -> Value;
-first_defined([]) -> undefined.
-
 resolve_namespace(Req, _Meta) ->
     case parse_namespace(Req) of
         {ok, Namespace} ->
             {ok, Req#{resolved_ns => Namespace}};
+        {error, conflicting_namespaces} ->
+            ?BAD_REQUEST(
+                <<"Conflicting namespace in the `ns` query parameter and request body">>
+            );
         {error, not_authorized} ->
             ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -686,6 +686,23 @@ t_update_user_namespace_in_body(_TCConfig) ->
         {200, _},
         update_user(<<"u1">>, #{<<"password">> => <<"p2">>, <<"namespace">> => Ns}, #{})
     ),
+    %% A body namespace pointing at a different namespace (where the user does
+    %% not exist) is honored and yields 404 rather than touching another record.
+    ?assertMatch(
+        {404, _},
+        update_user(
+            <<"u1">>, #{<<"password">> => <<"p2">>, <<"namespace">> => <<"another_ns">>}, #{}
+        )
+    ),
+    %% The `ns' query parameter takes precedence over the `namespace' body field.
+    ?assertMatch(
+        {200, _},
+        update_user(
+            <<"u1">>,
+            #{<<"password">> => <<"p3">>, <<"namespace">> => <<"another_ns">>},
+            #{<<"ns">> => Ns}
+        )
+    ),
     ?assertMatch({204, _}, delete_user(<<"u1">>, #{<<"ns">> => Ns})),
     ok.
 

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -665,6 +665,13 @@ t_delete_user_namespace_resolution(_TCConfig) ->
         delete_user(<<"u1">>, #{<<"ns">> => Ns}, #{<<"namespace">> => <<"wrong_ns">>})
     ),
     ?assertMatch({200, #{<<"data">> := []}}, list_users(#{<<"ns">> => Ns})),
+    %% A `namespace' body field pointing at another namespace (where the user
+    %% does not exist) is honored as the fallback and yields 404 rather than
+    %% touching the record in `Ns'.
+    ?assertMatch({201, _}, add_user(User)),
+    ?assertMatch({404, _}, delete_user(<<"u1">>, #{}, #{<<"namespace">> => <<"another_ns">>})),
+    ?assertMatch({200, #{<<"data">> := [_]}}, list_users(#{<<"ns">> => Ns})),
+    ?assertMatch({204, _}, delete_user(<<"u1">>, #{<<"ns">> => Ns})),
     ok.
 
 %% A built-in user that belongs to a namespace which has since been deleted must

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -646,8 +646,8 @@ t_authenticator_user(TCConfig) ->
     ok.
 
 %% A global admin may select the target namespace of a built-in user delete via
-%% either the `namespace' body field or the `ns' query parameter; the query
-%% parameter wins when both are given.
+%% either the `namespace' body field or the `ns' query parameter; if both are
+%% given they must agree.
 t_delete_user_namespace_resolution(_TCConfig) ->
     put_auth_header(create_superuser()),
     {200, _} = create_authenticator(emqx_authn_test_lib:built_in_database_example()),
@@ -658,17 +658,20 @@ t_delete_user_namespace_resolution(_TCConfig) ->
     ?assertMatch({200, #{<<"data">> := [_]}}, list_users(#{<<"ns">> => Ns})),
     ?assertMatch({204, _}, delete_user(<<"u1">>, #{}, #{<<"namespace">> => Ns})),
     ?assertMatch({200, #{<<"data">> := []}}, list_users(#{<<"ns">> => Ns})),
-    %% The `ns' query parameter wins over a conflicting `namespace' body field.
+    %% The `ns' query parameter alone selects the namespace.
+    ?assertMatch({201, _}, add_user(User)),
+    ?assertMatch({204, _}, delete_user(<<"u1">>, #{<<"ns">> => Ns}, #{})),
+    ?assertMatch({200, #{<<"data">> := []}}, list_users(#{<<"ns">> => Ns})),
+    %% A conflicting `ns' query parameter and `namespace' body field is rejected,
+    %% leaving the record untouched.
     ?assertMatch({201, _}, add_user(User)),
     ?assertMatch(
-        {204, _},
+        {400, _},
         delete_user(<<"u1">>, #{<<"ns">> => Ns}, #{<<"namespace">> => <<"wrong_ns">>})
     ),
-    ?assertMatch({200, #{<<"data">> := []}}, list_users(#{<<"ns">> => Ns})),
+    ?assertMatch({200, #{<<"data">> := [_]}}, list_users(#{<<"ns">> => Ns})),
     %% A `namespace' body field pointing at another namespace (where the user
-    %% does not exist) is honored as the fallback and yields 404 rather than
-    %% touching the record in `Ns'.
-    ?assertMatch({201, _}, add_user(User)),
+    %% does not exist) yields 404 rather than touching the record in `Ns'.
     ?assertMatch({404, _}, delete_user(<<"u1">>, #{}, #{<<"namespace">> => <<"another_ns">>})),
     ?assertMatch({200, #{<<"data">> := [_]}}, list_users(#{<<"ns">> => Ns})),
     ?assertMatch({204, _}, delete_user(<<"u1">>, #{<<"ns">> => Ns})),
@@ -711,9 +714,9 @@ t_update_user_namespace_in_body(_TCConfig) ->
             <<"u1">>, #{<<"password">> => <<"p2">>, <<"namespace">> => <<"another_ns">>}, #{}
         )
     ),
-    %% The `ns' query parameter takes precedence over the `namespace' body field.
+    %% A conflicting `ns' query parameter and `namespace' body field is rejected.
     ?assertMatch(
-        {200, _},
+        {400, _},
         update_user(
             <<"u1">>,
             #{<<"password">> => <<"p3">>, <<"namespace">> => <<"another_ns">>},

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -220,6 +220,16 @@ add_user(Params) ->
         body => Params
     }).
 
+add_user(Params, QueryParams) ->
+    URL = uri([?CONF_NS, "password_based:built_in_database", "users"]),
+    emqx_mgmt_api_test_util:simple_request(#{
+        auth_header => get_auth_header(),
+        method => post,
+        url => URL,
+        body => Params,
+        query_params => QueryParams
+    }).
+
 get_user(UserId, QueryParams) ->
     URL = uri([?CONF_NS, "password_based:built_in_database", "users", UserId]),
     emqx_mgmt_api_test_util:simple_request(#{
@@ -704,6 +714,25 @@ t_update_user_namespace_in_body(_TCConfig) ->
         )
     ),
     ?assertMatch({204, _}, delete_user(<<"u1">>, #{<<"ns">> => Ns})),
+    ok.
+
+%% Creating a built-in user that targets a namespace which is not a known
+%% managed namespace must be rejected, whether the namespace is given in the
+%% request body or in the `ns' query parameter.
+t_create_user_unknown_namespace_rejected(_TCConfig) ->
+    put_auth_header(create_superuser()),
+    {200, _} = create_authenticator(emqx_authn_test_lib:built_in_database_example()),
+    Ns = ?OTHER_NS,
+    %% Mark the namespace as not managed (never created / already deleted).
+    mark_namespace_deleted(Ns),
+    ?assertMatch(
+        {400, #{<<"message">> := <<"Managed namespace not found">>}},
+        add_user(#{<<"user_id">> => <<"u1">>, <<"password">> => <<"p1">>, <<"namespace">> => Ns})
+    ),
+    ?assertMatch(
+        {400, #{<<"message">> := <<"Managed namespace not found">>}},
+        add_user(#{<<"user_id">> => <<"u2">>, <<"password">> => <<"p2">>}, #{<<"ns">> => Ns})
+    ),
     ok.
 
 t_authenticator_import_users_global() ->

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -116,14 +116,23 @@ init_per_testcase(_Case, Config) ->
     Config.
 
 end_per_testcase(_, Config) ->
+    _ = persistent_term:erase({?MODULE, deleted_namespaces}),
     Config.
 
 %%------------------------------------------------------------------------------
 %% Helper fns
 %%------------------------------------------------------------------------------
 
-on_namespace_resource_pre_create(#{namespace := _Namespace}, ResCtx) ->
-    {stop, ResCtx#{exists := true}}.
+on_namespace_resource_pre_create(#{namespace := Namespace}, ResCtx) ->
+    Deleted = persistent_term:get({?MODULE, deleted_namespaces}, []),
+    Exists = not lists:member(Namespace, Deleted),
+    {stop, ResCtx#{exists := Exists}}.
+
+%% Simulate a managed namespace that has been deleted: its resources no longer
+%% "exist" as far as `namespace.resource_pre_create' is concerned.
+mark_namespace_deleted(Namespace) ->
+    Deleted = persistent_term:get({?MODULE, deleted_namespaces}, []),
+    persistent_term:put({?MODULE, deleted_namespaces}, lists:usort([Namespace | Deleted])).
 
 put_auth_header(Header) ->
     _ = put({?MODULE, authn}, Header),
@@ -237,6 +246,16 @@ delete_user(UserId, QueryParams) ->
         method => delete,
         url => URL,
         query_params => QueryParams
+    }).
+
+delete_user(UserId, QueryParams, Body) ->
+    URL = uri([?CONF_NS, "password_based:built_in_database", "users", UserId]),
+    emqx_mgmt_api_test_util:simple_request(#{
+        auth_header => get_auth_header(),
+        method => delete,
+        url => URL,
+        query_params => QueryParams,
+        body => Body
     }).
 
 list_users(QueryParams) ->
@@ -575,9 +594,11 @@ t_authenticator_user(TCConfig) ->
         ok
     end,
 
+    %% `namespace' is now an accepted body field (it selects the target
+    %% namespace), so it is no longer rejected here; `user_id' remains invalid in
+    %% an update body.
     InvalidUserUpdates = [
-        #{user_id => <<"u1">>, password => <<"p1">>},
-        #{namespace => ?OTHER_NS, password => <<"p1">>}
+        #{user_id => <<"u1">>, password => <<"p1">>}
     ],
 
     lists:foreach(
@@ -612,6 +633,60 @@ t_authenticator_user(TCConfig) ->
         ok
     end,
 
+    ok.
+
+%% A global admin may select the target namespace of a built-in user delete via
+%% either the `namespace' body field or the `ns' query parameter; the query
+%% parameter wins when both are given.
+t_delete_user_namespace_resolution(_TCConfig) ->
+    put_auth_header(create_superuser()),
+    {200, _} = create_authenticator(emqx_authn_test_lib:built_in_database_example()),
+    Ns = ?OTHER_NS,
+    User = #{<<"user_id">> => <<"u1">>, <<"password">> => <<"p1">>, <<"namespace">> => Ns},
+    %% `namespace' in the body (no query param) selects the namespace to delete from.
+    ?assertMatch({201, #{<<"namespace">> := Ns}}, add_user(User)),
+    ?assertMatch({200, #{<<"data">> := [_]}}, list_users(#{<<"ns">> => Ns})),
+    ?assertMatch({204, _}, delete_user(<<"u1">>, #{}, #{<<"namespace">> => Ns})),
+    ?assertMatch({200, #{<<"data">> := []}}, list_users(#{<<"ns">> => Ns})),
+    %% The `ns' query parameter wins over a conflicting `namespace' body field.
+    ?assertMatch({201, _}, add_user(User)),
+    ?assertMatch(
+        {204, _},
+        delete_user(<<"u1">>, #{<<"ns">> => Ns}, #{<<"namespace">> => <<"wrong_ns">>})
+    ),
+    ?assertMatch({200, #{<<"data">> := []}}, list_users(#{<<"ns">> => Ns})),
+    ok.
+
+%% A built-in user that belongs to a namespace which has since been deleted must
+%% still be deletable by a global admin (no "Managed namespace not found").
+t_delete_user_orphaned_namespace(_TCConfig) ->
+    put_auth_header(create_superuser()),
+    {200, _} = create_authenticator(emqx_authn_test_lib:built_in_database_example()),
+    Ns = ?OTHER_NS,
+    User = #{<<"user_id">> => <<"u1">>, <<"password">> => <<"p1">>, <<"namespace">> => Ns},
+    ?assertMatch({201, _}, add_user(User)),
+    %% The namespace is deleted out from under the record.
+    mark_namespace_deleted(Ns),
+    %% Creating in a now-missing namespace is still rejected ...
+    NewUser = #{<<"user_id">> => <<"u2">>, <<"password">> => <<"p2">>, <<"namespace">> => Ns},
+    ?assertMatch({400, #{<<"message">> := <<"Managed namespace not found">>}}, add_user(NewUser)),
+    %% ... but a global admin can still delete the orphaned record.
+    ?assertMatch({204, _}, delete_user(<<"u1">>, #{<<"ns">> => Ns})),
+    ok.
+
+%% A global admin may select the target namespace of a built-in user update via
+%% the `namespace' body field.
+t_update_user_namespace_in_body(_TCConfig) ->
+    put_auth_header(create_superuser()),
+    {200, _} = create_authenticator(emqx_authn_test_lib:built_in_database_example()),
+    Ns = ?OTHER_NS,
+    User = #{<<"user_id">> => <<"u1">>, <<"password">> => <<"p1">>, <<"namespace">> => Ns},
+    ?assertMatch({201, _}, add_user(User)),
+    ?assertMatch(
+        {200, _},
+        update_user(<<"u1">>, #{<<"password">> => <<"p2">>, <<"namespace">> => Ns}, #{})
+    ),
+    ?assertMatch({204, _}, delete_user(<<"u1">>, #{<<"ns">> => Ns})),
     ok.
 
 t_authenticator_import_users_global() ->

--- a/changes/ee/feat-17711.en.md
+++ b/changes/ee/feat-17711.en.md
@@ -1,0 +1,3 @@
+Made namespace selection consistent across the built-in database authentication user HTTP APIs, and allowed cleanup of records left over from a deleted namespace.
+
+Previously only user creation accepted a `namespace` field in the request body; updating and deleting a user accepted the target namespace only through the `ns` query parameter. The update and delete endpoints now also accept a `namespace` field in the request body. When both are provided, the `ns` query parameter takes precedence. Listing users continues to use the `ns` query parameter.

--- a/changes/ee/fix-17711.en.md
+++ b/changes/ee/fix-17711.en.md
@@ -1,0 +1,11 @@
+Made namespace handling consistent across the built-in database authentication user HTTP APIs, and allowed cleanup of orphaned records.
+
+Previously, creating a user accepted the target namespace from the request body, while updating, deleting and listing users only honored the `ns` query parameter. As a result, a user created in a namespace via the request body could not be found or deleted with the same body field, appearing as if it still authenticated after deletion.
+
+Now:
+
+- Creating and updating a user accept the namespace from either the request body (`namespace` field) or the `ns` query parameter, with the body taking precedence.
+- Deleting a user accepts the namespace from either the request body or the `ns` query parameter, with the query parameter taking precedence.
+- Listing users continues to use the `ns` query parameter.
+
+In addition, a global administrator can now delete a built-in database user that belongs to a namespace which has already been deleted, instead of receiving a "Managed namespace not found" error.

--- a/changes/ee/fix-17711.en.md
+++ b/changes/ee/fix-17711.en.md
@@ -1,7 +1,5 @@
-Made namespace selection consistent across the built-in database authentication user HTTP APIs, and allowed cleanup of records left over from a deleted namespace.
+Creating or updating a built-in database user that targets a namespace which is not a known managed namespace is now rejected with "Managed namespace not found".
+Previously a user supplied with a namespace in the request body could be created even when that namespace did not exist.
 
-Previously only user creation accepted a `namespace` field in the request body; updating and deleting a user accepted the target namespace only through the `ns` query parameter. The update and delete endpoints now also accept a `namespace` field in the request body. When both are provided, the `ns` query parameter takes precedence. Listing users continues to use the `ns` query parameter.
-
-Creating or updating a built-in database user that targets a namespace which is not a known managed namespace is now rejected with "Managed namespace not found". Previously a user supplied with a namespace in the request body could be created even when that namespace did not exist.
-
-In addition, a global administrator can now delete a built-in database user that belongs to a namespace which has already been deleted, instead of receiving a "Managed namespace not found" error.
+In addition, a global administrator can now delete a built-in database user that belongs to a namespace which has already been deleted,
+instead of receiving a "Managed namespace not found" error.

--- a/changes/ee/fix-17711.en.md
+++ b/changes/ee/fix-17711.en.md
@@ -1,11 +1,5 @@
-Made namespace handling consistent across the built-in database authentication user HTTP APIs, and allowed cleanup of orphaned records.
+Made namespace selection consistent across the built-in database authentication user HTTP APIs, and allowed cleanup of records left over from a deleted namespace.
 
-Previously, creating a user accepted the target namespace from the request body, while updating, deleting and listing users only honored the `ns` query parameter. As a result, a user created in a namespace via the request body could not be found or deleted with the same body field, appearing as if it still authenticated after deletion.
-
-Now:
-
-- Creating and updating a user accept the namespace from either the request body (`namespace` field) or the `ns` query parameter, with the body taking precedence.
-- Deleting a user accepts the namespace from either the request body or the `ns` query parameter, with the query parameter taking precedence.
-- Listing users continues to use the `ns` query parameter.
+Previously only user creation accepted a `namespace` field in the request body; updating and deleting a user accepted the target namespace only through the `ns` query parameter. The update and delete endpoints now also accept a `namespace` field in the request body. When both are provided, the `ns` query parameter takes precedence. Listing users continues to use the `ns` query parameter.
 
 In addition, a global administrator can now delete a built-in database user that belongs to a namespace which has already been deleted, instead of receiving a "Managed namespace not found" error.

--- a/changes/ee/fix-17711.en.md
+++ b/changes/ee/fix-17711.en.md
@@ -2,4 +2,6 @@ Made namespace selection consistent across the built-in database authentication 
 
 Previously only user creation accepted a `namespace` field in the request body; updating and deleting a user accepted the target namespace only through the `ns` query parameter. The update and delete endpoints now also accept a `namespace` field in the request body. When both are provided, the `ns` query parameter takes precedence. Listing users continues to use the `ns` query parameter.
 
+Creating or updating a built-in database user that targets a namespace which is not a known managed namespace is now rejected with "Managed namespace not found". Previously a user supplied with a namespace in the request body could be created even when that namespace did not exist.
+
 In addition, a global administrator can now delete a built-in database user that belongs to a namespace which has already been deleted, instead of receiving a "Managed namespace not found" error.


### PR DESCRIPTION
Release version: 6.1.2

## Summary

The built-in database authentication user endpoints resolved the target namespace from **different sources per HTTP verb**: `POST` read it from the request body (`namespace`), while `PUT`/`DELETE`/`GET` only honored the `ns` query parameter. A user created in a namespace via the body therefore could not be found or deleted with the same body field — it appeared to still authenticate after a "successful" delete, and the dashboard listing (which also uses `ns`) showed nothing. This is the root cause of a customer report where a deleted built-in user kept authenticating.

Namespace resolution is now unified in the operation `filter/2`, keyed off the HTTP method:

- `POST` / `PUT` accept the namespace from the request body (`namespace`) **or** the `ns` query parameter — **body wins**.
- `DELETE` accepts the namespace from the `ns` query parameter **or** the request body — **query parameter wins**.
- `GET` / list keep the `ns` query parameter (a GET body has no defined semantics).

Actor authorization is preserved: a namespace-scoped admin may still only operate on its own namespace; only a global admin may target an arbitrary namespace.

Separately, a global admin can now delete a built-in user whose namespace has already been deleted, instead of getting `Managed namespace not found` — so orphaned records can be cleaned up.

### Most relevant changes

- `apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl`: per-method namespace resolution (`requested_namespace/2`), `namespace` added to the update body schema and a small `request_user_delete` body schema (optional `namespace`) so the DELETE body survives validation, and the managed-namespace existence check is skipped for global-admin deletes.
- `apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl`: regression tests for body/query precedence on delete, body namespace on update, and deleting an orphaned-namespace record; one obsolete assertion (rejecting `namespace` in an update body) was updated to reflect the new behavior.

> Note: the full CT suite could not be executed in my local environment (the fresh worktree cannot build unrelated enterprise native deps — `aws-lc-sys`/`grpc_plugin` — with the available toolchain). The changed module compiles cleanly and `make fmt`/elvis pass; CI will run the suite.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
