### PR TITLE
fix(ci): improve sync-dev-to-release failure alert accuracy

### DIFF
--- a/.github/workflows/sync-dev-to-release.yaml
+++ b/.github/workflows/sync-dev-to-release.yaml
@@ -76,6 +76,8 @@ jobs:
         run: |
           if [ "${NOT_FAST_FORWARD:-0}" = "1" ]; then
             REASON="${RELEASE_BRANCH} has diverged from ${DEV_BRANCH}; rebase ${DEV_BRANCH} on top of ${RELEASE_BRANCH} (or reset ${DEV_BRANCH} to a descendant of ${RELEASE_BRANCH}) before the next run."
+          elif [ "${BRANCH_PROTECTION_DENIED:-0}" = "1" ]; then
+            REASON="${RELEASE_BRANCH} push rejected by branch protection. Add the bot identity (AUTH_APP_ID) as a bypass principal on the ${RELEASE_BRANCH} branch protection rule, and confirm required status checks (if any) pass on the ${DEV_BRANCH} HEAD."
           else
             REASON="Automatic fast-forward of ${RELEASE_BRANCH} from ${DEV_BRANCH} failed."
           fi

--- a/scripts/ff-release-from-dev.sh
+++ b/scripts/ff-release-from-dev.sh
@@ -47,10 +47,19 @@ if git push origin "${DEV_SHA}:refs/heads/${RELEASE_BRANCH}" 2>"$PUSH_ERR"; then
 fi
 
 cat "$PUSH_ERR" >&2
-if grep -qE 'non-fast-forward|fetch first|rejected' "$PUSH_ERR"; then
+
+# Be specific: don't match the bare substring "rejected" because git uses
+# "[remote rejected]" for every push failure (e.g. branch-protection denial)
+# and we'd misreport those as a divergence.
+if grep -qE 'non-fast-forward|fetch first' "$PUSH_ERR"; then
     if [ -n "${GITHUB_ENV:-}" ]; then
         echo "NOT_FAST_FORWARD=1" >> "$GITHUB_ENV"
     fi
     echo "::error::${RELEASE_BRANCH} (${REL_SHA}) has diverged from ${DEV_BRANCH} (${DEV_SHA}); ff not possible."
+elif grep -qE 'protected branch hook declined|protected branch' "$PUSH_ERR"; then
+    if [ -n "${GITHUB_ENV:-}" ]; then
+        echo "BRANCH_PROTECTION_DENIED=1" >> "$GITHUB_ENV"
+    fi
+    echo "::error::${RELEASE_BRANCH} push rejected by branch protection. Add the bot identity (AUTH_APP_ID) as a bypass principal on the ${RELEASE_BRANCH} branch protection rule, and confirm required status checks (if any) pass on the dev-XX HEAD."
 fi
 exit 1


### PR DESCRIPTION
## Summary

Follow-up to #17707.

The 2026-06-24 21:00 UTC run of the ff cron reported \"release-58 has diverged from dev-58\" when the actual push log said:

```
! [remote rejected] ca79caae... -> release-58 (protected branch hook declined)
```

That's branch protection blocking the bot, not divergence. The regex in \`scripts/ff-release-from-dev.sh\` was too broad — \`rejected\` matches git's \`[remote rejected]\` prefix on every push failure.

This PR:

1. Tightens the regex to match only true non-fast-forward markers (\`non-fast-forward\`, \`fetch first\`).
2. Adds a separate branch for \`protected branch hook declined\` that sets \`BRANCH_PROTECTION_DENIED=1\` instead of \`NOT_FAST_FORWARD=1\`.
3. \`sync-dev-to-release.yaml\`'s Slack-notification step gains a matching \`elif\` so the alert message tells the operator the right thing to fix.

Slack channel and webhook plumbing is unchanged from #17707 (still posts via \`SLACK_WEBHOOK_URL\`).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking