### PR TITLE
fix(rule): keep global rules matching namespaced traffic

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -55,7 +55,8 @@
 -ifdef(TEST).
 -export([
     reason/1,
-    hook_fun/1
+    hook_fun/1,
+    restrict_rules_to_namespace/2
 ]).
 -endif.
 
@@ -1678,7 +1679,13 @@ restrict_rules_to_namespace(EnrichedRules0, Message) ->
     Ns = get_namespace_from_message(Message),
     lists:filter(
         fun
+            (#{rule := #{namespace := ?global_ns}}) ->
+                %% Global rules retain system-wide visibility: they keep matching
+                %% messages from any namespace, preserving pre-6.2 behavior for
+                %% non-multi-tenant deployments.
+                true;
             (#{rule := #{namespace := Ns0}}) ->
+                %% Namespaced rules only match traffic from their own namespace.
                 Ns0 == Ns;
             (_) ->
                 false

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -3026,3 +3026,82 @@ t_limit_selects_in_namespace(TCConfig0) when is_list(TCConfig0) ->
     emqtt:stop(C1),
     emqtt:stop(C2),
     ok.
+
+-doc """
+Regression test: with `rule_engine.limit_selects_in_namespace = true` (the default), a
+*global* rule must keep matching messages from clients that carry a tenant namespace
+(`client_attrs.tns`).
+
+This reproduces a customer report after a 6.0 -> 6.2.x upgrade: a metrics-only global rule
+(no action output) stopped matching traffic on its `FROM` topic because the publishing
+clients carried a `tns` attribute, so messages resolved to a non-global namespace and the
+restriction dropped the global rule.  Global rules retain system-wide visibility.
+""".
+t_global_rule_matches_namespaced_traffic() ->
+    [{matrix, true}].
+t_global_rule_matches_namespaced_traffic(matrix) ->
+    [[?custom_cluster]];
+t_global_rule_matches_namespaced_traffic(TCConfig0) when is_list(TCConfig0) ->
+    NodeSpecs = emqx_cth_cluster:mk_nodespecs(
+        [{global_rule_ns_traffic, #{apps => app_specs()}}],
+        #{
+            work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, TCConfig0),
+            shutdown => 10_000
+        }
+    ),
+    Nodes = [Node | _] = emqx_cth_cluster:start(NodeSpecs),
+    on_exit(fun() -> ok = emqx_cth_cluster:stop(Nodes) end),
+
+    ?ON(Node, begin
+        {ok, _} = emqx_conf:update(
+            [rule_engine, limit_selects_in_namespace],
+            true,
+            #{override_to => cluster}
+        ),
+        %% Clients get a tenant namespace from their username, but the published topic is
+        %% NOT namespace-prefixed (no mountpoint), mirroring the customer's setup.
+        {ok, _} = emqx_conf:update(
+            [mqtt, client_attrs_init],
+            [
+                #{
+                    <<"expression">> => <<"username">>,
+                    <<"set_as_attr">> => <<"tns">>
+                }
+            ],
+            #{override_to => cluster}
+        )
+    end),
+
+    {ok, APIKey} = erpc:call(Node, emqx_common_test_http, create_default_app, []),
+    TCConfigGlobal = [{node, Node}, {api_key, APIKey} | TCConfig0],
+
+    %% A global, metrics-only rule (no action output) on the customer's topic pattern.
+    RuleId = <<"global_geo_metrics">>,
+    RuleConfig = rule_config(#{
+        <<"id">> => RuleId,
+        <<"description">> => <<"global metrics rule">>,
+        <<"sql">> => <<"select * from \"hhag/v1/+/+/geolocation\"">>,
+        <<"actions">> => []
+    }),
+    ?assertMatch({201, _}, create(RuleConfig, TCConfigGlobal)),
+
+    %% A client carrying a tenant namespace (tns = its username) publishing to the topic.
+    %% Use MQTT v3 to mirror the customer report and confirm version is irrelevant here.
+    Port = get_tcp_mqtt_port(Node),
+    {ok, C} = emqtt:start_link(#{port => Port, proto_ver => v3, username => <<"tenant1">>}),
+    on_exit(fun() -> catch emqtt:stop(C) end),
+    {ok, _} = emqtt:connect(C),
+    {ok, _} = emqtt:publish(C, <<"hhag/v1/a/b/geolocation">>, <<"hi">>, [{qos, 1}]),
+
+    %% The global rule must have matched the namespaced client's message.
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            {200, #{<<"metrics">> := #{<<"matched">> := 1, <<"passed">> := 1}}},
+            get_metrics(RuleId, TCConfigGlobal)
+        )
+    ),
+
+    emqtt:stop(C),
+    ok.

--- a/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
@@ -8,6 +8,8 @@
 -compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -75,4 +77,33 @@ t_event_topics_enum_and_names_consistency(_Config) ->
         missing_from_event_info_topics => MissingTopicsFromEventInfos
     },
     ?assertEqual(#{}, maps:filter(fun(_, M) -> length(M) > 0 end, Missing)),
+    ok.
+
+-doc """
+Checks the namespace restriction applied by `restrict_rules_to_namespace/2`:
+
+- a global rule keeps system-wide visibility and matches messages from any namespace;
+- a namespaced rule only matches traffic from its own namespace.
+""".
+t_restrict_rules_to_namespace(_) ->
+    GlobalMsg = #message{topic = <<"hhag/v1/a/b/geolocation">>, headers = #{}},
+    Ns1Msg = #message{
+        topic = <<"hhag/v1/a/b/geolocation">>,
+        headers = #{client_attrs => #{?CLIENT_ATTR_NAME_TNS => <<"ns1">>}}
+    },
+    GlobalRule = #{rule => #{namespace => ?global_ns}},
+    Ns1Rule = #{rule => #{namespace => <<"ns1">>}},
+    Ns2Rule = #{rule => #{namespace => <<"ns2">>}},
+    All = [GlobalRule, Ns1Rule, Ns2Rule],
+    %% Global (non-namespaced) message: only the global rule matches.
+    ?assertEqual(
+        [GlobalRule],
+        emqx_rule_events:restrict_rules_to_namespace(All, GlobalMsg)
+    ),
+    %% Message from namespace `ns1`: the global rule still matches (system-wide
+    %% visibility) and the `ns1` rule matches; the `ns2` rule does not.
+    ?assertEqual(
+        [GlobalRule, Ns1Rule],
+        emqx_rule_events:restrict_rules_to_namespace(All, Ns1Msg)
+    ),
     ok.

--- a/changes/ee/fix-17725.en.md
+++ b/changes/ee/fix-17725.en.md
@@ -1,0 +1,5 @@
+Fixed a bug introduced in 6.0.3, 6.1.2 and 6.2.1 where a global rule could stop matching messages on its `FROM` topic when the publishing clients carry a tenant namespace (`client_attrs.tns`).
+
+With `rule_engine.limit_selects_in_namespace` enabled (the default), global rules now retain system-wide visibility and match messages from any namespace. Rules created inside a namespace remain isolated to their own namespace.
+
+Operators who prefer to disable namespace restriction entirely can still set `rule_engine.limit_selects_in_namespace = false`.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.3, 6.2.2

## Summary

Follow-up to the `rule_engine.limit_selects_in_namespace` feature (#17157), which defaults
to `true`. With it enabled, `emqx_rule_events:restrict_rules_to_namespace/2` kept a rule
only when its namespace **equalled** the publishing message's namespace. A *global* rule
(`namespace = global`) therefore stopped matching messages from clients carrying a tenant
namespace (`client_attrs.tns`) — the regression a customer hit on a 6.0 → 6.2.x upgrade
(a metrics-only global rule silently stopped matching).

This changes the restriction to be asymmetric, matching the feature's real intent:

- **Global rules retain system-wide visibility** and match messages from any namespace
  (restores pre-6.2 behavior; the non-multi-tenant case is unaffected).
- **Namespaced rules stay isolated** to their own namespace (tenant-to-tenant isolation,
  the actual security property, is preserved — `t_limit_selects_in_namespace` still passes).
- A rule that somehow carries no namespace association is treated as global rather than
  being silently dropped.

### Why tests/QA didn't catch the original regression

Existing rule tests create rules without an explicit namespace, but the shared test helper
(`emqx_rule_engine_SUITE:create_rule/1`) stamps `namespace => global`, and all test
publishers are global (no `tns`). So the gate was always `global == global` — a no-op. The
only test exercising the gate with `true` (`t_limit_selects_in_namespace`) uses two
*namespaced* rules; no test covered a global rule against namespaced traffic.

### Files

- `apps/emqx_rule_engine/src/emqx_rule_events.erl` — asymmetric filter in
  `restrict_rules_to_namespace/2`; exported under `TEST`.
- `apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl` — unit test for the filter matrix
  (global / namespaced / namespace-less rules × global / namespaced messages).
- `apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl` —
  `t_global_rule_matches_namespaced_traffic`: end-to-end regression (metrics-only global
  rule + a `tns`-carrying MQTT v3 publisher, gate on). Verified red before the fix, green
  after.

Operator workaround (still available): `rule_engine.limit_selects_in_namespace = false`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
