### PR TITLE
fix(listeners): retry ws/wss listener rebind on transient eaddrinuse

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -490,7 +490,7 @@ do_update_listener(Type, Name, OldConf, NewConf) when
     end,
     ok = ranch:set_protocol_options(Id, WsOpts),
     %% No-op if the listener was not suspended.
-    ranch:resume_listener(Id);
+    resume_cowboy_listener(Id);
 do_update_listener(quic = Type, Name, OldConf, NewConf) ->
     case quicer:listener(listener_id(Type, Name)) of
         {ok, ListenerPid} ->
@@ -522,6 +522,24 @@ do_update_listener(quic = Type, Name, OldConf, NewConf) ->
     end;
 do_update_listener(_Type, _Name, _OldConf, _NewConf) ->
     {error, not_supported}.
+
+%% Resuming a ws/wss listener after a transport-options change rebinds the same
+%% port (`ranch:suspend_listener' closes the old listen socket, `resume' reopens
+%% it). The OS may not have released the port yet when we rebind, which surfaces
+%% as a transient `eaddrinuse'. Retry a few times with a short backoff before
+%% giving up. The proper fix (avoid rebinding when the bind address is unchanged)
+%% is tracked separately.
+resume_cowboy_listener(Id) ->
+    resume_cowboy_listener(Id, 10).
+
+resume_cowboy_listener(Id, Retries) ->
+    case ranch:resume_listener(Id) of
+        {error, eaddrinuse} when Retries > 0 ->
+            timer:sleep(100),
+            resume_cowboy_listener(Id, Retries - 1);
+        Res ->
+            Res
+    end.
 
 %% Update the listeners at runtime
 pre_config_update([?ROOT_KEY, Type, Name], {create, NewConf}, V) when

--- a/changes/ce/fix-17729.en.md
+++ b/changes/ce/fix-17729.en.md
@@ -1,0 +1,1 @@
+Fixed a transient "address already in use" error that could occur when updating the options of a WS or WSS listener (for example when rotating TLS certificates). Updating such a listener rebinds its port, and the operating system may not have released the old socket yet; EMQX now retries the rebind briefly instead of failing the update.


### PR DESCRIPTION
Release version: 5.10.5

## Summary

Updating a WS/WSS listener's transport options (e.g. rotating TLS certificates, changing `verify`) goes through `ranch:suspend_listener` → `ranch:set_transport_options` → `ranch:resume_listener`, where `resume_listener` **rebinds the same port**. If the OS has not released the old listen socket yet, the rebind fails with a transient `eaddrinuse`, which fails the config update and leaves the listener down.

`resume_listener` is now retried a few times with a short backoff on `eaddrinuse`. TCP/SSL listeners are unaffected — they update options in place (`esockd:reset_options`) without rebinding.

This also fixes a CI flake in `emqx_listeners_SUITE:t_wss_update_opts`, which exercises exactly this path (e.g. https://github.com/emqx/emqx/actions/runs/28154468551/job/83381256857). Note this is a different race than the `select_free_port` hand-off addressed by #17694 — here the port is one the listener already owns and is rebinding during a hot reload.

The proper fix — avoid rebinding entirely when the bind address\/port is unchanged — is tracked in #17730.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
