### PR TITLE
feat(api_keys): accept namespace as a top-level request body field

### DIFF
--- a/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
@@ -721,6 +721,106 @@ t_namespace_immutable(_TCConfig) ->
 
     ok.
 
+-doc """
+A bare role plus a top-level `namespace' field is assembled into a namespaced
+API key (issue #17726).
+""".
+t_api_key_namespace_field_assemble(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    ExpiresAt = to_rfc3339(erlang:system_time(second) + 1_000),
+    ?assertMatch(
+        {200, #{
+            <<"role">> := <<"administrator">>,
+            <<"namespace">> := <<"ns1">>
+        }},
+        create_api_key_api(
+            #{
+                <<"name">> => <<"nsfield1">>,
+                <<"expired_at">> => ExpiresAt,
+                <<"desc">> => <<"bare role + namespace field">>,
+                <<"enable">> => true,
+                <<"role">> => <<"administrator">>,
+                <<"namespace">> => <<"ns1">>
+            },
+            GlobalAdminHeader
+        )
+    ),
+    ok.
+
+-doc """
+A role-encoded namespace and a matching top-level `namespace' field are accepted
+(idempotent) (issue #17726).
+""".
+t_api_key_namespace_field_redundant_match(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    ExpiresAt = to_rfc3339(erlang:system_time(second) + 1_000),
+    ?assertMatch(
+        {200, #{
+            <<"role">> := <<"administrator">>,
+            <<"namespace">> := <<"ns1">>
+        }},
+        create_api_key_api(
+            #{
+                <<"name">> => <<"nsfield2">>,
+                <<"expired_at">> => ExpiresAt,
+                <<"desc">> => <<"role-encoded + matching namespace field">>,
+                <<"enable">> => true,
+                <<"role">> => <<"ns:ns1::administrator">>,
+                <<"namespace">> => <<"ns1">>
+            },
+            GlobalAdminHeader
+        )
+    ),
+    ok.
+
+-doc """
+A role-encoded namespace that disagrees with the top-level `namespace' field is
+rejected with a clear 400 message (issue #17726).
+""".
+t_api_key_namespace_field_mismatch(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    ExpiresAt = to_rfc3339(erlang:system_time(second) + 1_000),
+    ?assertMatch(
+        {400, #{<<"message">> := <<"namespace mismatch:", _/binary>>}},
+        create_api_key_api(
+            #{
+                <<"name">> => <<"nsfield3">>,
+                <<"expired_at">> => ExpiresAt,
+                <<"desc">> => <<"mismatching namespace">>,
+                <<"enable">> => true,
+                <<"role">> => <<"ns:ns1::administrator">>,
+                <<"namespace">> => <<"ns2">>
+            },
+            GlobalAdminHeader
+        )
+    ),
+    ok.
+
+-doc """
+Omitting both the role-encoded namespace and the `namespace' field creates a
+global API key, unchanged from previous behaviour (issue #17726).
+""".
+t_api_key_namespace_field_absent(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    ExpiresAt = to_rfc3339(erlang:system_time(second) + 1_000),
+    ?assertMatch(
+        {200, #{
+            <<"role">> := <<"administrator">>,
+            <<"namespace">> := null
+        }},
+        create_api_key_api(
+            #{
+                <<"name">> => <<"nsfield4">>,
+                <<"expired_at">> => ExpiresAt,
+                <<"desc">> => <<"global key">>,
+                <<"enable">> => true,
+                <<"role">> => <<"administrator">>
+            },
+            GlobalAdminHeader
+        )
+    ),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Cookie auth for plugin API
 %%------------------------------------------------------------------------------

--- a/apps/emqx_dashboard_rbac/mix.exs
+++ b/apps/emqx_dashboard_rbac/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDashboardRbac.MixProject do
   def project do
     [
       app: :emqx_dashboard_rbac,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -14,6 +14,7 @@
     check_login_user_scopes/2,
     parse_dashboard_role/1,
     parse_api_role/1,
+    serialize_role/1,
     role_list/1
 ]).
 
@@ -118,6 +119,13 @@ check_login_user_scopes_for_path(Username, Path) ->
 
 parse_api_role(Role) ->
     parse_role(api, Role).
+
+-doc "Render a parsed role map back to its wire string (inverse of `parse_api_role/1`).".
+-spec serialize_role(#{?role := role(), ?namespace := ?global_ns | namespace()}) -> role().
+serialize_role(#{?role := Role, ?namespace := ?global_ns}) ->
+    Role;
+serialize_role(#{?role := Role, ?namespace := Namespace}) when is_binary(Namespace) ->
+    <<"ns:", Namespace/binary, "::", Role/binary>>.
 
 check_login_user_scopes_strict(Username, Path) ->
     %% Always work on the effective scope list (role-default expanded)

--- a/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
@@ -9,6 +9,7 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx_dashboard/include/emqx_dashboard_rbac.hrl").
 -include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -export([api_spec/0, fields/1, paths/0, schema/1, namespace/0]).
 -export([api_key/2, api_key_by_name/2, api_key_scopes/2]).
@@ -316,7 +317,16 @@ api_key(post, #{body := App}) ->
     } = App,
     ExpiredAt = ensure_expired_at(App),
     Desc = unicode:characters_to_binary(Desc0, unicode),
-    Role = maps:get(<<"role">>, App, ?ROLE_API_DEFAULT),
+    Role0 = maps:get(<<"role">>, App, ?ROLE_API_DEFAULT),
+    Namespace = maps:get(<<"namespace">>, App, undefined),
+    case resolve_effective_role(Role0, Namespace) of
+        {ok, Role} ->
+            create_api_key(App, Name, Enable, ExpiredAt, Desc, Role);
+        {error, Msg} ->
+            {400, #{code => 'BAD_REQUEST', message => Msg}}
+    end.
+
+create_api_key(App, Name, Enable, ExpiredAt, Desc, Role) ->
     %% Materialize role defaults when the client omitted `scopes' entirely.
     %% Explicit `[]' (deny-all) and explicit lists pass through unchanged.
     %% After this PR `<<"unset">>' in a GET response is reserved for legacy
@@ -356,10 +366,19 @@ api_key_by_name(delete, #{bindings := #{name := Name}}) ->
         {error, not_found} -> {404, ?NOT_FOUND_RESPONSE}
     end;
 api_key_by_name(put, #{bindings := #{name := Name}, body := Body}) ->
+    Role0 = maps:get(<<"role">>, Body, ?ROLE_API_DEFAULT),
+    Namespace = maps:get(<<"namespace">>, Body, undefined),
+    case resolve_effective_role(Role0, Namespace) of
+        {ok, Role} ->
+            update_api_key(Name, Role, Body);
+        {error, Msg} ->
+            {400, #{code => 'BAD_REQUEST', message => Msg}}
+    end.
+
+update_api_key(Name, Role, Body) ->
     Enable = maps:get(<<"enable">>, Body, undefined),
     ExpiredAt = ensure_expired_at(Body),
     Desc = maps:get(<<"desc">>, Body, undefined),
-    Role = maps:get(<<"role">>, Body, ?ROLE_API_DEFAULT),
     Scopes = maps:get(<<"scopes">>, Body, undefined),
     %% Validation runs against the effective scope list (request body
     %% when supplied, otherwise the persisted scopes) so a role change
@@ -403,6 +422,44 @@ effective_request_scopes(Name, undefined) ->
 
 ensure_expired_at(#{<<"expired_at">> := ExpiredAt}) when is_integer(ExpiredAt) -> ExpiredAt;
 ensure_expired_at(_) -> infinity.
+
+%% Resolve the effective role string from the request `role' field and the
+%% optional top-level `namespace' field.
+%%
+%% A namespace can be specified in two ways: encoded into the role string
+%% (`ns:<namespace>::<role>') or via the standalone `namespace' field. When
+%% both are present they must agree.
+%%
+%%   * neither present                       -> role unchanged (global key)
+%%   * only role-encoded `ns:X::r'           -> role unchanged
+%%   * only `namespace = X' + bare role `r'  -> assemble `ns:X::r'
+%%   * both, encoded X == field X            -> role unchanged (idempotent)
+%%   * both, encoded X /= field Y            -> {error, mismatch}
+resolve_effective_role(Role, undefined) ->
+    {ok, Role};
+resolve_effective_role(_Role, <<>>) ->
+    {error, <<"namespace must not be empty">>};
+resolve_effective_role(Role, Namespace) when is_binary(Namespace) ->
+    case emqx_dashboard_rbac:parse_api_role(Role) of
+        {ok, #{?role := BareRole, ?namespace := ?global_ns}} ->
+            {ok, emqx_dashboard_rbac:serialize_role(#{?role => BareRole, ?namespace => Namespace})};
+        {ok, #{?namespace := Namespace}} ->
+            %% Role-encoded namespace equals the namespace field; idempotent.
+            {ok, Role};
+        {ok, #{?namespace := Other}} ->
+            {error, namespace_mismatch_msg(Other, Namespace)};
+        {error, _} = Error ->
+            Error
+    end.
+
+namespace_mismatch_msg(RoleNs, FieldNs) ->
+    iolist_to_binary([
+        <<"namespace mismatch: role is scoped to namespace '">>,
+        RoleNs,
+        <<"' but the namespace field is '">>,
+        FieldNs,
+        <<"'">>
+    ]).
 
 api_key_scopes(get, _) ->
     Scopes = [resolve_scope_desc(S) || S <- emqx_scope_catalog:scope_catalog()],
@@ -493,5 +550,11 @@ app_extend_fields() ->
                         ok
                     end
                 end
+            })},
+        {namespace,
+            hoconsc:mk(binary(), #{
+                desc => ?DESC(namespace_field),
+                required => false,
+                example => <<"ns1">>
             })}
     ].

--- a/changes/ee/feat-17732.en.md
+++ b/changes/ee/feat-17732.en.md
@@ -1,0 +1,1 @@
+Added a `namespace` field to the API key creation and update endpoints, so operators no longer need to encode the namespace inside the `role` string (the existing `ns:<namespace>::<role>` form keeps working). When both forms are supplied they must agree.

--- a/rel/i18n/emqx_mgmt_api_api_keys.hocon
+++ b/rel/i18n/emqx_mgmt_api_api_keys.hocon
@@ -30,6 +30,11 @@ role.desc:
 role.label:
 """Role"""
 
+namespace_field.desc:
+"""Namespace to scope this API key to. This is an alternative to encoding the namespace inside the `role` string (`ns:<namespace>::<role>`). When both forms are supplied they must agree, otherwise the request is rejected. Omit for a global (non-namespaced) API key."""
+namespace_field.label:
+"""Namespace"""
+
 name_format.desc:
 """API key name. Must start with a letter, may contain letters, digits, hyphen and underscore. Length 1-256 characters. Pattern: ^[A-Za-z]+[A-Za-z0-9-_]*$"""
 name_format.label:


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Accept a standalone `namespace` field in the `POST /api_key` and `PUT /api_key/:name` request bodies, as an alternative to encoding the namespace inside the `role` string (`ns:<namespace>::<role>`).

When both forms are supplied they must agree: a bare role plus a namespace field is assembled internally; a matching role-encoded namespace is accepted idempotently; a mismatch is rejected with 400.

Main change: `apps/emqx_management/src/emqx_mgmt_api_api_keys.erl` (`resolve_effective_role/2` and the new `namespace` request-body field).

Closes #17726

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
