### PR TITLE
fix(mq): restore empty stream buffers as active

### DIFF
--- a/apps/emqx_mq/mix.exs
+++ b/apps/emqx_mq/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMQ.MixProject do
   def project do
     [
       app: :emqx_mq,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       compilers: [:elixir, :asn1, :erlang, :app],
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_mq/src/emqx_mq_consumer/emqx_mq_consumer_stream_buffer.erl
+++ b/apps/emqx_mq/src/emqx_mq_consumer/emqx_mq_consumer_stream_buffer.erl
@@ -103,7 +103,7 @@ new(StartIterator, MQ) ->
 
 -spec restore(progress(), emqx_mq_types:mq()) -> t().
 %% The previous buffer did not see any messages, so we can just start a new buffer
-restore(#{last_message_id := undefined, it_begin := It}, MQ) ->
+restore(#{last_message_id := undefined, it := It}, MQ) ->
     new(It, MQ);
 %% The previous buffer saw some messages, so we need to restore the buffer from the saved state
 restore(#{it := It, last_message_id := LastMessageId, unacked := UnackedMaps}, MQ) ->

--- a/apps/emqx_mq/test/emqx_mq_consumer_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_consumer_SUITE.erl
@@ -43,6 +43,23 @@ end_per_testcase(_CaseName, _Config) ->
 %% Test cases
 %%--------------------------------------------------------------------
 
+t_restore_empty_stream_buffer(_Config) ->
+    MQ = #{stream_max_buffer_size => 100},
+    It = fake_iterator,
+    SB0 = emqx_mq_consumer_stream_buffer:new(It, MQ),
+
+    Progress = emqx_mq_consumer_stream_buffer:progress(SB0),
+    SB = emqx_mq_consumer_stream_buffer:restore(Progress, MQ),
+
+    ?assertMatch(
+        #{
+            status := active,
+            last_message_id := undefined,
+            lower_buffer := #{n := 0, unacked := 0}
+        },
+        emqx_mq_consumer_stream_buffer:inspect(SB)
+    ).
+
 %% Verify that the consumer stops itself after there are no active subscribers for a while
 t_auto_shutdown(_Config) ->
     %% Create a non-lastvalue Queue

--- a/changes/ee/fix-17733.en.md
+++ b/changes/ee/fix-17733.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where MQ consumers could fail to restore an empty stream buffer after durable storage subscription recovery.


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Fix MQ stream buffer restoration after subscription recovery when no messages were previously seen.

Also should fix test flakyness like https://github.com/emqx/emqx/actions/runs/28100131661/job/83202994466

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)