### PR TITLE
fix(authn): harden JWT authn with explicit JWS algorithm allowlists

### DIFF
--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
@@ -22,6 +22,25 @@
     ?VAR_USERNAME
 ]).
 
+-define(JWT_HMAC_ALGORITHMS, [
+    <<"HS256">>,
+    <<"HS384">>,
+    <<"HS512">>
+]).
+
+-define(JWT_PUBLIC_KEY_ALGORITHMS, [
+    <<"RS256">>,
+    <<"RS384">>,
+    <<"RS512">>,
+    <<"PS256">>,
+    <<"PS384">>,
+    <<"PS512">>,
+    <<"ES256">>,
+    <<"ES384">>,
+    <<"ES512">>,
+    <<"EdDSA">>
+]).
+
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
@@ -83,6 +102,7 @@ authenticate(
         verify_claims := VerifyClaims0,
         disconnect_after_expire := DisconnectAfterExpire,
         jwk := JWK,
+        allowed_algs := AllowedAlgs,
         acl_claim_name := AclClaimName,
         from := From
     }
@@ -91,13 +111,14 @@ authenticate(
     %% XXX: Only supports single public key
     JWKs = [JWK],
     VerifyClaims = render_expected(VerifyClaims0, Credential),
-    verify(JWT, JWKs, VerifyClaims, AclClaimName, DisconnectAfterExpire);
+    verify(JWT, JWKs, AllowedAlgs, VerifyClaims, AclClaimName, DisconnectAfterExpire);
 authenticate(
     Credential,
     #{
         verify_claims := VerifyClaims0,
         disconnect_after_expire := DisconnectAfterExpire,
         resource_id := ResourceId,
+        allowed_algs := AllowedAlgs,
         acl_claim_name := AclClaimName,
         from := From
     }
@@ -112,7 +133,7 @@ authenticate(
         {ok, JWKs} ->
             JWT = maps:get(From, Credential),
             VerifyClaims = render_expected(VerifyClaims0, Credential),
-            verify(JWT, JWKs, VerifyClaims, AclClaimName, DisconnectAfterExpire)
+            verify(JWT, JWKs, AllowedAlgs, VerifyClaims, AclClaimName, DisconnectAfterExpire)
     end.
 
 destroy(#{resource_id := ResourceId}) ->
@@ -141,6 +162,7 @@ create_authn_hmac_based(#{
             JWK = jose_jwk:from_oct(Secret),
             {ok, #{
                 jwk => JWK,
+                allowed_algs => ?JWT_HMAC_ALGORITHMS,
                 verify_claims => handle_verify_claims(VerifyClaims),
                 disconnect_after_expire => DisconnectAfterExpire,
                 acl_claim_name => AclClaimName,
@@ -167,6 +189,7 @@ create_authn_public_key(
             ),
         {ok, #{
             jwk => JWK,
+            allowed_algs => ?JWT_PUBLIC_KEY_ALGORITHMS,
             verify_claims => handle_verify_claims(VerifyClaims),
             disconnect_after_expire => DisconnectAfterExpire,
             acl_claim_name => AclClaimName,
@@ -191,6 +214,7 @@ create_authn_public_key_with_jwks(
         Config,
         #{
             resource_id => ResourceId,
+            allowed_algs => ?JWT_PUBLIC_KEY_ALGORITHMS,
             verify_claims => handle_verify_claims(VerifyClaims),
             disconnect_after_expire => DisconnectAfterExpire,
             acl_claim_name => AclClaimName,
@@ -239,10 +263,10 @@ render_expected([{Name, ExpectedTemplate} | More], Variables) ->
     Expected = emqx_auth_template:render_str(ExpectedTemplate, Variables),
     [{Name, Expected} | render_expected(More, Variables)].
 
-verify(undefined, _, _, _, _) ->
+verify(undefined, _, _, _, _, _) ->
     ignore;
-verify(JWT, JWKs, VerifyClaims, AclClaimName, DisconnectAfterExpire) ->
-    case do_verify(JWT, JWKs, VerifyClaims) of
+verify(JWT, JWKs, AllowedAlgs, VerifyClaims, AclClaimName, DisconnectAfterExpire) ->
+    case do_verify(JWT, JWKs, AllowedAlgs, VerifyClaims) of
         {ok, Extra} ->
             extra_to_auth_data(Extra, JWT, AclClaimName, DisconnectAfterExpire);
         {error, {missing_claim, Claim}} ->
@@ -296,10 +320,10 @@ acl(Claims, AclClaimName) ->
             #{}
     end.
 
-do_verify(_JWT, [], _VerifyClaims) ->
+do_verify(_JWT, [], _AllowedAlgs, _VerifyClaims) ->
     {error, invalid_signature};
-do_verify(JWT, [JWK | More], VerifyClaims) ->
-    try jose_jws:verify(JWK, JWT) of
+do_verify(JWT, [JWK | More], AllowedAlgs, VerifyClaims) ->
+    try jose_jws:verify_strict(JWK, AllowedAlgs, JWT) of
         {true, Payload, _JWT} ->
             Claims0 = emqx_utils_json:decode(Payload),
             Claims = try_convert_to_num(Claims0, [<<"exp">>, <<"nbf">>]),
@@ -310,11 +334,11 @@ do_verify(JWT, [JWK | More], VerifyClaims) ->
                     {error, Reason}
             end;
         {false, _, _} ->
-            do_verify(JWT, More, VerifyClaims)
+            do_verify(JWT, More, AllowedAlgs, VerifyClaims)
     catch
         _:Reason ->
             ?TRACE_AUTHN_PROVIDER("jwt_verify_error", #{jwt => JWT, reason => Reason}),
-            do_verify(JWT, More, VerifyClaims)
+            do_verify(JWT, More, AllowedAlgs, VerifyClaims)
     end.
 
 verify_claims(Claims, VerifyClaims0) ->

--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -81,6 +81,12 @@ t_hmac_based(_) ->
     Credential2 = Credential#{password => BadJWS},
     ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential2, State)),
 
+    NoneJWS = generate_none_jws(Payload),
+    ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential#{password => NoneJWS}, State)),
+
+    RSAJWS = generate_jws('public-key', Payload, test_rsa_key(private)),
+    ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential#{password => RSAJWS}, State)),
+
     %% secret_base64_encoded
     Config2 = Config#{
         secret => base64:encode(Secret),
@@ -191,6 +197,10 @@ t_public_key(_) ->
     ?assertEqual(
         ignore, emqx_authn_jwt:authenticate(Credential#{password => <<"badpassword">>}, State)
     ),
+
+    {ok, PublicKeyPEM} = file:read_file(PublicKey),
+    HMACJWS = generate_jws('hmac-based', Payload, PublicKeyPEM),
+    ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential#{password => HMACJWS}, State)),
 
     ?assertEqual(ok, emqx_authn_jwt:destroy(State)),
     ok.
@@ -404,6 +414,10 @@ t_jwks_renewal(_Config) ->
         {error, bad_username_or_password},
         emqx_authn_jwt:authenticate(Credential1#{password => JWS2}, State2)
     ),
+
+    {ok, PublicKeyPEM} = file:read_file(test_rsa_key(public)),
+    HMACJWS = generate_jws('hmac-based', Payload1, PublicKeyPEM),
+    ?assertEqual(ignore, emqx_authn_jwt:authenticate(Credential1#{password => HMACJWS}, State2)),
 
     ?assertEqual(ok, emqx_authn_jwt:destroy(State2)),
     ok = emqx_utils_http_test_server:stop().
@@ -1225,6 +1239,18 @@ generate_jws('public-key', Payload, PrivateKey) ->
     Signed = jose_jwt:sign(JWK, Header, Payload),
     {_, JWS} = jose_jws:compact(Signed),
     JWS.
+
+generate_none_jws(Payload) ->
+    Header = emqx_utils_json:encode(#{
+        <<"alg">> => <<"none">>,
+        <<"typ">> => <<"JWT">>
+    }),
+    iolist_to_binary([
+        jose_jwa_base64url:encode(Header),
+        <<".">>,
+        jose_jwa_base64url:encode(emqx_utils_json:encode(Payload)),
+        <<".">>
+    ]).
 
 client_ssl_opts() ->
     #{


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Use explicit algorithm lists for JWT authentication. This is not a security fix, but making restrictions explicit.

Fixes emqx/emqx-dev-team-tasks#268

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (not needed: internal hardening not visible to users)
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
