### PR TITLE
ci: migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -167,7 +167,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -240,7 +240,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -266,7 +266,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/bump-dashboard-version.yaml
+++ b/.github/workflows/bump-dashboard-version.yaml
@@ -39,7 +39,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: Get GitHub App User ID

--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: Generate Changelog

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -73,7 +73,7 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       with:
-        app-id: ${{ vars.AUTH_APP_ID }}
+        client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
         private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
     - name: Download emqx package from the latest 'build_packages_cron.yaml' workflow run

--- a/.github/workflows/sync-dev-to-release.yaml
+++ b/.github/workflows/sync-dev-to-release.yaml
@@ -44,7 +44,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: Configure git user
@@ -77,7 +77,7 @@ jobs:
           if [ "${NOT_FAST_FORWARD:-0}" = "1" ]; then
             REASON="${RELEASE_BRANCH} has diverged from ${DEV_BRANCH}; rebase ${DEV_BRANCH} on top of ${RELEASE_BRANCH} (or reset ${DEV_BRANCH} to a descendant of ${RELEASE_BRANCH}) before the next run."
           elif [ "${BRANCH_PROTECTION_DENIED:-0}" = "1" ]; then
-            REASON="${RELEASE_BRANCH} push rejected by branch protection. Add the bot identity (AUTH_APP_ID) as a bypass principal on the ${RELEASE_BRANCH} branch protection rule, and confirm required status checks (if any) pass on the ${DEV_BRANCH} HEAD."
+            REASON="${RELEASE_BRANCH} push rejected by branch protection. Add the bot identity (the GitHub App backing AUTH_APP_CLIENT_ID) as a bypass principal on the ${RELEASE_BRANCH} branch protection rule, and confirm required status checks (if any) pass on the ${DEV_BRANCH} HEAD."
           else
             REASON="Automatic fast-forward of ${RELEASE_BRANCH} from ${DEV_BRANCH} failed."
           fi

--- a/.github/workflows/sync-release-branch.yaml
+++ b/.github/workflows/sync-release-branch.yaml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: Get GitHub App User ID

--- a/.github/workflows/update-emqx-docs.yaml
+++ b/.github/workflows/update-emqx-docs.yaml
@@ -49,7 +49,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Summary

\`actions/create-github-app-token@v3.x\` is deprecating the \`app-id\` input in favour of \`client-id\`. Every workflow run currently logs:

> Input 'app-id' has been deprecated with message: Use 'client-id' instead.

Switch every call site to \`client-id\` so the warning goes away (and so the workflows keep working once the action drops the old input).

## Operator prerequisite

A new **repo variable \`AUTH_APP_CLIENT_ID\`** must be set to the GitHub App's client ID (string like \`Iv23li...\`, found under the App's general settings). Once set, the existing \`AUTH_APP_ID\` variable can be removed — no workflow references it anymore.

## Affected workflows

- \`_push-entrypoint.yaml\` (3 call sites)
- \`sync-release-branch.yaml\`
- \`sync-dev-to-release.yaml\` (also updates the branch-protection-denied Slack message to reference the new variable name)
- \`generate-changelog.yaml\`
- \`bump-dashboard-version.yaml\`
- \`update-emqx-docs.yaml\`
- \`performance_test.yaml\`

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking