### PR TITLE
ci: migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -167,7 +167,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -240,7 +240,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
@@ -266,7 +266,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/bump-dashboard-version.yaml
+++ b/.github/workflows/bump-dashboard-version.yaml
@@ -36,7 +36,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: Get GitHub App User ID

--- a/.github/workflows/generate-changelog.yaml
+++ b/.github/workflows/generate-changelog.yaml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: Generate Changelog

--- a/.github/workflows/sync-release-branch.yaml
+++ b/.github/workflows/sync-release-branch.yaml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
 
       - name: Get GitHub App User ID

--- a/.github/workflows/update-emqx-docs.yaml
+++ b/.github/workflows/update-emqx-docs.yaml
@@ -49,7 +49,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.AUTH_APP_ID }}
+          client-id: ${{ vars.AUTH_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
Release version: 6.0.x

## Summary

\`actions/create-github-app-token@v3.x\` is deprecating the \`app-id\` input in favour of \`client-id\`. Every workflow run currently logs:

> Input 'app-id' has been deprecated with message: Use 'client-id' instead.

Switch every call site on this branch to \`client-id\`.

## Operator prerequisite

A new repo variable \`AUTH_APP_CLIENT_ID\` must be set to the GitHub App's client ID (string like \`Iv23li...\`, found under the App's general settings). Once set, the existing \`AUTH_APP_ID\` variable is no longer referenced by any workflow on this branch and can be removed (do this after all branches are migrated).

## Affected workflows on dev-60

- \`_push-entrypoint.yaml\` (3 call sites)
- \`sync-release-branch.yaml\`
- \`generate-changelog.yaml\`
- \`bump-dashboard-version.yaml\`
- \`update-emqx-docs.yaml\`

A sibling PR for dev-58 covers the v5 workflow set. The master-only \`sync-dev-to-release.yaml\` and \`performance_test.yaml\` will pick up the change via the normal forward-sync cycle (dev-60 → dev-61 → ... → master).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking