### PR TITLE
docs(i18n): capitalize Dashboard in user-management strings

### DIFF
--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -1,24 +1,24 @@
 emqx_dashboard_api {
 
 change_pwd_api.desc:
-"""Change dashboard user password"""
+"""Change Dashboard user password"""
 change_pwd_api.label:
-"""Change dashboard user password"""
+"""Change Dashboard user password"""
 
 create_user_api.desc:
-"""Create dashboard user"""
+"""Create Dashboard user"""
 create_user_api.label:
-"""Create dashboard user"""
+"""Create Dashboard user"""
 
 create_user_api_success.desc:
-"""Create dashboard user success"""
+"""Create Dashboard user success"""
 create_user_api_success.label:
-"""Create dashboard user success"""
+"""Create Dashboard user success"""
 
 delete_user_api.desc:
-"""Delete dashboard user"""
+"""Delete Dashboard user"""
 delete_user_api.label:
-"""Delete dashboard user"""
+"""Delete Dashboard user"""
 
 license.desc:
 """EMQX License. opensource or enterprise"""
@@ -62,12 +62,12 @@ token.desc:
 """Dashboard Auth Token"""
 
 update_user_api.desc:
-"""Update dashboard user description"""
+"""Update Dashboard user description"""
 update_user_api.label:
-"""Update dashboard user description"""
+"""Update Dashboard user description"""
 
 update_user_api200.desc:
-"""Update dashboard user success"""
+"""Update Dashboard user success"""
 
 user_description.desc:
 """Dashboard User Description"""


### PR DESCRIPTION
Release version:
5.8.10

## Summary

Ports the dev-58-applicable subset of #17225 — capitalize `Dashboard` in user-facing i18n strings of `rel/i18n/emqx_dashboard_api.hocon`.

The MFA / SSO `force_mfa` / `scope_info_name` strings touched by #17225 do not exist on this branch, so this PR is limited to the six existing `Change|Create|Delete|Update dashboard user…` strings.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)