### PR TITLE
docs(i18n): capitalize Dashboard, rephrase scope_info_name

### DIFF
--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -1,24 +1,24 @@
 emqx_dashboard_api {
 
 change_pwd_api.desc:
-"""Change dashboard user password"""
+"""Change Dashboard user password"""
 change_pwd_api.label:
-"""Change dashboard user password"""
+"""Change Dashboard user password"""
 
 create_user_api.desc:
-"""Create dashboard user"""
+"""Create Dashboard user"""
 create_user_api.label:
-"""Create dashboard user"""
+"""Create Dashboard user"""
 
 create_user_api_success.desc:
-"""Create dashboard user success"""
+"""Create Dashboard user success"""
 create_user_api_success.label:
-"""Create dashboard user success"""
+"""Create Dashboard user success"""
 
 delete_user_api.desc:
-"""Delete dashboard user"""
+"""Delete Dashboard user"""
 delete_user_api.label:
-"""Delete dashboard user"""
+"""Delete Dashboard user"""
 
 license.desc:
 """EMQX License. opensource or enterprise"""
@@ -62,12 +62,12 @@ token.desc:
 """Dashboard Auth Token"""
 
 update_user_api.desc:
-"""Update dashboard user description"""
+"""Update Dashboard user description"""
 update_user_api.label:
-"""Update dashboard user description"""
+"""Update Dashboard user description"""
 
 update_user_api200.desc:
-"""Update dashboard user success"""
+"""Update Dashboard user success"""
 
 user_description.desc:
 """Dashboard User Description"""
@@ -89,7 +89,7 @@ list_user_scopes_api.desc:
 Returned to any authenticated login user — the endpoint exists to populate the dashboard UI's scope selector and does not itself require a specific scope."""
 
 list_user_scopes_api.label:
-"""List dashboard user scopes"""
+"""List Dashboard user scopes"""
 
 user_scopes_request.desc:
 """Dashboard user scopes: a fine-grained access list applied in addition to the user's role.
@@ -101,7 +101,7 @@ Login users may be assigned any API key catalog scope plus the four login-only s
 user_scopes_response.desc:
 """Dashboard user scopes: a fine-grained access list applied in addition to the user's role.
 
-The literal string `unset` is a legacy-only sentinel for records upgraded from a release that did not support dashboard user scopes. At runtime, such records fall back to the default scopes for the role. Clients should treat `unset` as \"no explicit scope policy has been set yet\". An empty list `[]` means deny-all; only anonymous endpoints such as `/status` remain reachable.
+The literal string `unset` is a legacy-only sentinel for records upgraded from a release that did not support Dashboard user scopes. At runtime, such records fall back to the default scopes for the role. Clients should treat `unset` as \"no explicit scope policy has been set yet\". An empty list `[]` means deny-all; only anonymous endpoints such as `/status` remain reachable.
 
 Login users may be assigned any API key catalog scope plus the four login-only scopes: `user_management`, `mfa_management`, `sso_management`, and `api_key_management`. Among these four scopes, `user_management`, `sso_management`, and `api_key_management` are administrator-only. `mfa_management` may also be assigned to non-administrator users. For non-administrator users, it acts only as a self-exemption key that allows the user to bypass `force_mfa` and `admin_required` locks for their own MFA."""
 
@@ -112,10 +112,10 @@ password_expire_in_seconds.desc:
 """Time in seconds until the password expires."""
 
 change_mfa.desc:
-"""Set up or reset MFA for a dashboard user. Calling this endpoint generates a fresh TOTP secret."""
+"""Set up or reset MFA for a Dashboard user. Calling this endpoint generates a fresh TOTP secret."""
 
 delete_mfa.desc:
-"""Disable MFA for a dashboard user. To reset or re-key TOTP, call the `POST` method."""
+"""Disable MFA for a Dashboard user. To reset or re-key TOTP, call the `POST` method."""
 
 mfa_token.desc:
 """Multifactor authentication token."""

--- a/rel/i18n/emqx_dashboard_sso_schema.hocon
+++ b/rel/i18n/emqx_dashboard_sso_schema.hocon
@@ -10,7 +10,7 @@ backend.label:
 """Backend Type"""
 
 force_mfa.desc:
-"""Whether to force MFA (TOTP) for SSO users. When enabled, SSO users must complete MFA setup or verification before receiving a dashboard token."""
+"""Whether to force MFA (TOTP) for SSO users. When enabled, SSO users must complete MFA setup or verification before receiving a Dashboard token."""
 
 force_mfa.label:
 """Force MFA"""

--- a/rel/i18n/emqx_mgmt_api_api_keys.hocon
+++ b/rel/i18n/emqx_mgmt_api_api_keys.hocon
@@ -91,7 +91,7 @@ api_key_scopes_response.label:
 """API key scopes (response)"""
 
 scope_info_name.desc:
-"""Scope name: a stable identifier for a functional category of API endpoints."""
+"""Scope name, used as a stable identifier for a functional category of API endpoints."""
 scope_info_name.label:
 """Scope name"""
 


### PR DESCRIPTION
Release version:
6.0.3, 6.1.2, 6.2.0

## Summary

Ports the dev-60-applicable subset of #17225:

- Capitalize `Dashboard` in user-facing i18n strings of `emqx_dashboard_api.hocon` and `emqx_dashboard_sso_schema.hocon` (`force_mfa.desc`).
- Rephrase `scope_info_name.desc` in `emqx_mgmt_api_api_keys.hocon` from colon-form to comma-form (the dev-60 baseline uses `:`; the source PR uses `, used as`).

Also picks up two dev-60-only strings under the same convention:

- `list_user_scopes.label`: `List dashboard user scopes` → `List Dashboard user scopes`.
- `user_scopes_response.desc` body: `did not support dashboard user scopes` → `did not support Dashboard user scopes`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)