### PR TITLE
docs: add missing 6.1.3 changelog entry for #17497

### DIFF
--- a/changes/6.1.3.en.md
+++ b/changes/6.1.3.en.md
@@ -141,6 +141,12 @@
 
 ### Observability
 
+- [#17497](https://github.com/emqx/emqx/pull/17497) Fixed the `actions.executed` metric undercounting `actions.messages` for actions configured in non-batch mode (`batch_size = 1`).
+
+  The previous implementation incremented `actions.executed` once per buffer-worker telemetry flush, which could aggregate many individual completions into one event, so `actions.executed` fell behind `actions.messages` even when no batching was configured.
+
+  The two metrics are now incremented at independent call sites: `actions.executed` once per action callback invocation (one per batch in batch mode, one per message in single mode), `actions.messages` per message handled.
+
 - [#17513](https://github.com/emqx/emqx/pull/17513) Fixed Prometheus matched authorization allow/deny metrics so they reflect real matched authorization decisions.
 
 - [#17536](https://github.com/emqx/emqx/pull/17536) Documented the `file://` option in dashboard tooltips for the SSL listener `password` and other secret-typed configuration fields (MQTT bridge password, cluster link password, Dashboard OIDC client secret, S3 secret access key, AI completion API key, Pulsar/RocketMQ credentials, etc.). The generic secret type description already mentioned this convention, but field-specific descriptions shadowed it in the dashboard, causing users to assume the field accepted only literal values.


### PR DESCRIPTION
PR #17497 (fix `actions.executed` undercounting in non-batch mode) was backported to release-61 in code, but its changelog entry was consolidated into the 6.2-only `feat-17558` entry and therefore dropped from the 6.1.3 release notes. This adds the entry back under 6.1.3 → Observability so the 6.1 line documents the fix it actually ships.