### PR TITLE
test(mqtt): t_offline_message_queueing query live channel stats

### DIFF
--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -233,7 +233,14 @@ t_offline_message_queueing(_) ->
     %% return before dispatch reaches the subscriber: QoS 0 has no broker ack at
     %% all, and the QoS 1/2 acks are sent before the broker drives the dispatch
     %% to subscribers. A fixed sleep here races the disconnect on slow runners.
-    ?WAIT(?assertEqual(3, proplists:get_value(mqueue_len, emqx_cm:get_chan_stats(<<"c1">>))), 30),
+    %%
+    %% Read live stats straight from the channel process. emqx_cm:get_chan_stats/1
+    %% returns a cached snapshot from ?CHAN_INFO_TAB that is only refreshed by the
+    %% channel's emit_stats timer (default mqtt.idle_timeout = 15s). Once c1
+    %% disconnects the channel hibernates and stops emitting stats, so the cached
+    %% mqueue_len can lag reality for the whole retry budget.
+    [ChanPid] = emqx_cm:lookup_channels(<<"c1">>),
+    ?WAIT(?assertEqual(3, proplists:get_value(mqueue_len, emqx_connection:stats(ChanPid))), 30),
     emqtt:disconnect(C2),
 
     {ok, C3} = emqtt:start_link([{clean_start, false}, {clientid, <<"c1">>}]),


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Re-fix the flaky `emqx_client_SUITE:t_offline_message_queueing`.

The prior de-flake (#17686, commit `0641fbd86e`) introduced the right rendezvous
— wait until c1's offline mqueue holds all three messages before disconnecting
the publisher — but read the wrong stat source. It polled
`emqx_cm:get_chan_stats/1`, which returns a **cached** snapshot from
`?CHAN_INFO_TAB`. That cache is only refreshed when the channel process fires its
`emit_stats` timer (default `mqtt.idle_timeout = 15s`). After c1 disconnects the
channel hibernates and stops emitting stats, so the cached `mqueue_len` can lag
the real value for the entire 30s retry budget. The test then failed with
`expected: 3, got: 1` after waiting the full budget:

https://github.com/emqx/emqx/actions/runs/28230162739/job/83633896141

This change reads **live** stats directly from the channel process via
`emqx_connection:stats/1` (a synchronous `gen_server:call` that recomputes from
current channel state, including `emqx_mqueue:len/1`), looking the pid up with
`emqx_cm:lookup_channels/1`. The case only runs under the
`gen_tcp_listener.mqttv4` group (plain `emqx_connection`), so no protocol
dispatch is needed.

Validation: 50× local loop pinned to a single core (`taskset -c 0`) — 50/50 pass;
full `emqx_client_SUITE` — 49/49 pass.

Test-only change, no user-facing behavior change.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
