### PR TITLE
feat(metrics): increment messages.retained counter

### DIFF
--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -515,6 +515,7 @@ reserved_idx('messages.transformation_succeeded') -> 408;
 reserved_idx('messages.transformation_failed') -> 409;
 reserved_idx('rules.matched') -> 410;
 reserved_idx('actions.executed') -> 411;
+reserved_idx('messages.retained') -> 412;
 reserved_idx(_) -> undefined.
 
 all_metrics() ->
@@ -609,7 +610,8 @@ message_metrics() ->
         {counter, 'messages.validation_succeeded', ?DESC("messages_validation_succeeded")},
         {counter, 'messages.transformation_failed', ?DESC("messages_transformation_failed")},
         {counter, 'messages.transformation_succeeded', ?DESC("messages_transformation_succeeded")},
-        {counter, 'messages.persisted', ?DESC("messages_persisted")}
+        {counter, 'messages.persisted', ?DESC("messages_persisted")},
+        {counter, 'messages.retained', ?DESC("messages_retained")}
     ].
 
 %% Rule and Action related metrics

--- a/apps/emqx_retainer/src/emqx_retainer_publisher.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_publisher.erl
@@ -56,7 +56,8 @@ store_retained(#message{topic = Topic, payload = Payload} = Msg) ->
             end),
             case WithinLimits of
                 true ->
-                    ?tp(retain_within_limit, #{topic => Topic});
+                    ?tp(retain_within_limit, #{topic => Topic}),
+                    emqx_metrics:inc('messages.retained');
                 {false, Reason} ->
                     ?tp(retain_failed_for_rate_exceeded_limit, #{topic => Topic}),
                     ?SLOG_THROTTLE(warning, #{

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -144,6 +144,7 @@ t_store_and_clean(_) ->
     {ok, C1} = emqtt:start_link([{clean_start, true}, {proto_ver, v5}]),
     {ok, _} = emqtt:connect(C1),
 
+    Retained0 = emqx_metrics:val('messages.retained'),
     emqtt:publish(
         C1,
         <<"retained">>,
@@ -151,6 +152,7 @@ t_store_and_clean(_) ->
         [{qos, 0}, {retain, true}]
     ),
     timer:sleep(100),
+    ?assertEqual(Retained0 + 1, emqx_metrics:val('messages.retained')),
 
     {ok, _, List} = emqx_retainer:page_read(<<"retained">>, 1, 10),
     ?assertEqual(1, length(List)),
@@ -171,6 +173,7 @@ t_store_and_clean(_) ->
 
     emqtt:publish(C1, <<"retained">>, <<"">>, [{qos, 0}, {retain, true}]),
     timer:sleep(100),
+    ?assertEqual(Retained0 + 1, emqx_metrics:val('messages.retained')),
 
     {ok, #{}, [0]} = emqtt:subscribe(C1, <<"retained">>, [{qos, 0}, {rh, 0}]),
     ?assertEqual(0, length(receive_messages(1))),

--- a/changes/ee/feat-17755.en.md
+++ b/changes/ee/feat-17755.en.md
@@ -1,0 +1,1 @@
+The Prometheus `emqx_messages_retained` counter now reports actual retained-message writes. Previously the metric was exposed but never incremented, so it always read 0. Each successful retained-message store now bumps the counter.

--- a/rel/i18n/emqx_metrics.hocon
+++ b/rel/i18n/emqx_metrics.hocon
@@ -194,6 +194,9 @@ emqx_metrics {
     messages_persisted {
         desc: "Number of message persisted"
     }
+    messages_retained {
+        desc: "Number of retained message writes"
+    }
     delivery_dropped {
         desc: "Total number of discarded messages when sending"
     }


### PR DESCRIPTION
Fixes #17385.

Release version: 6.3.0

## Summary

Port of #17675 (targets master) to dev-60. Original author: Sahil Patel.

EMQX already exposed `emqx_messages_retained` in Prometheus but the metric was never registered as a counter and never incremented — it always showed 0. This patch:

1. Registers `messages.retained` as a counter in `emqx_metrics.erl` (using reserved index 412 on dev-60; master's port uses 105 because the index space is different).
2. Increments the counter via `emqx_metrics:inc/1` after a successful retained-message store (master uses `inc_global/1`; that API doesn't exist on the v6.0 line, so renamed to `inc/1`, which is the equivalent).
3. Adds test assertions in `t_store_and_clean` to verify the counter increments on publish and stays unchanged on delete.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)