### PR TITLE
fix(prometheus api): allow namespaced admins to filter only its namespace in `/prometheus/ns_stats`

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -10,6 +10,8 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
+-include_lib("emqx_utils/include/emqx_http_api.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -36,14 +38,18 @@
 -export([
     setting/2,
     stats/2,
+    ns_stats/2,
     auth/2,
     data_integration/2,
     schema_validation/2,
-    message_transformation/2
+    message_transformation/2,
+    topic_metrics/2
 ]).
 
 -export([lookup_from_local_nodes/3]).
 -export([scopes/0]).
+
+-export([namespaced_filter/2, validate_not_json/2]).
 
 -define(TAGS, [<<"Monitor">>]).
 
@@ -53,10 +59,12 @@ scopes() ->
     #{
         "/prometheus" => ?SCOPE_SYSTEM,
         "/prometheus/auth" => ?SCOPE_MONITORING,
+        "/prometheus/namespaced_stats" => ?SCOPE_MONITORING,
         "/prometheus/stats" => ?SCOPE_MONITORING,
         "/prometheus/data_integration" => ?SCOPE_MONITORING,
         "/prometheus/schema_validation" => ?SCOPE_MONITORING,
-        "/prometheus/message_transformation" => ?SCOPE_MONITORING
+        "/prometheus/message_transformation" => ?SCOPE_MONITORING,
+        "/prometheus/topic_metrics" => ?SCOPE_MONITORING
     }.
 
 api_spec() ->
@@ -65,15 +73,13 @@ api_spec() ->
 paths() ->
     [
         "/prometheus",
+        "/prometheus/namespaced_stats",
         "/prometheus/auth",
         "/prometheus/stats",
-        "/prometheus/data_integration"
-    ] ++ paths_ee().
-
-paths_ee() ->
-    [
+        "/prometheus/data_integration",
         "/prometheus/schema_validation",
-        "/prometheus/message_transformation"
+        "/prometheus/message_transformation",
+        "/prometheus/topic_metrics"
     ].
 
 schema("/prometheus") ->
@@ -95,9 +101,24 @@ schema("/prometheus") ->
                     #{200 => prometheus_setting_response()}
             }
     };
+schema("/prometheus/namespaced_stats") ->
+    #{
+        'operationId' => ns_stats,
+        filter => fun ?MODULE:namespaced_filter/2,
+        get =>
+            #{
+                description => ?DESC("ns_stats"),
+                tags => ?TAGS,
+                parameters => [ref(mode), ref(ns)],
+                security => security(),
+                responses =>
+                    #{200 => prometheus_data_schema()}
+            }
+    };
 schema("/prometheus/auth") ->
     #{
         'operationId' => auth,
+        filter => fun ?MODULE:validate_not_json/2,
         get =>
             #{
                 description => ?DESC(get_prom_auth_data),
@@ -111,6 +132,7 @@ schema("/prometheus/auth") ->
 schema("/prometheus/stats") ->
     #{
         'operationId' => stats,
+        filter => fun ?MODULE:validate_not_json/2,
         get =>
             #{
                 description => ?DESC(get_prom_data),
@@ -124,11 +146,12 @@ schema("/prometheus/stats") ->
 schema("/prometheus/data_integration") ->
     #{
         'operationId' => data_integration,
+        filter => fun ?MODULE:namespaced_filter/2,
         get =>
             #{
                 description => ?DESC(get_prom_data_integration_data),
                 tags => ?TAGS,
-                parameters => [ref(mode)],
+                parameters => [ref(mode), ns_qs_param(), only_global_qs_param()],
                 security => security(),
                 responses =>
                     #{200 => prometheus_data_schema()}
@@ -137,6 +160,7 @@ schema("/prometheus/data_integration") ->
 schema("/prometheus/schema_validation") ->
     #{
         'operationId' => schema_validation,
+        filter => fun ?MODULE:validate_not_json/2,
         get =>
             #{
                 description => ?DESC(get_prom_schema_validation),
@@ -150,9 +174,24 @@ schema("/prometheus/schema_validation") ->
 schema("/prometheus/message_transformation") ->
     #{
         'operationId' => message_transformation,
+        filter => fun ?MODULE:validate_not_json/2,
         get =>
             #{
                 description => ?DESC(get_prom_message_transformation),
+                tags => ?TAGS,
+                parameters => [ref(mode)],
+                security => security(),
+                responses =>
+                    #{200 => prometheus_data_schema()}
+            }
+    };
+schema("/prometheus/topic_metrics") ->
+    #{
+        'operationId' => topic_metrics,
+        filter => fun ?MODULE:validate_not_json/2,
+        get =>
+            #{
+                description => ?DESC(get_prom_topic_metrics),
                 tags => ?TAGS,
                 parameters => [ref(mode)],
                 security => security(),
@@ -167,7 +206,12 @@ security() ->
         false -> []
     end.
 
-%% erlfmt-ignore
+ns_qs_param() ->
+    {ns, mk(binary(), #{in => query, required => false})}.
+
+only_global_qs_param() ->
+    {only_global, mk(boolean(), #{in => query, required => false, default => false})}.
+
 fields(mode) ->
     [
         {mode,
@@ -179,6 +223,19 @@ fields(mode) ->
                     in => query,
                     required => false,
                     example => node
+                }
+            )}
+    ];
+fields(ns) ->
+    [
+        {ns,
+            mk(
+                binary(),
+                #{
+                    required => false,
+                    desc => ?DESC("qp_namespace"),
+                    in => query,
+                    example => <<"some_ns">>
                 }
             )}
     ].
@@ -210,37 +267,39 @@ setting(put, #{body := Body}) ->
             {500, 'INTERNAL_ERROR', Message}
     end.
 
-stats(get, #{headers := Headers, query_string := Qs}) ->
-    collect(emqx_prometheus, collect_opts(Headers, Qs)).
+stats(get, #{query_string := Qs}) ->
+    collect(emqx_prometheus, collect_opts(Qs)).
 
-auth(get, #{headers := Headers, query_string := Qs}) ->
-    collect(emqx_prometheus_auth, collect_opts(Headers, Qs)).
+ns_stats(get, Req) ->
+    Opts = get_collect_opts(Req),
+    collect_ns_stats(Opts).
 
-data_integration(get, #{headers := Headers, query_string := Qs}) ->
-    collect(emqx_prometheus_data_integration, collect_opts(Headers, Qs)).
+auth(get, #{query_string := Qs}) ->
+    collect(emqx_prometheus_auth, collect_opts(Qs)).
 
-schema_validation(get, #{headers := Headers, query_string := Qs}) ->
-    collect(emqx_prometheus_schema_validation, collect_opts(Headers, Qs)).
+data_integration(get, Req) ->
+    Opts = collect_opts_ns_or_all(Req),
+    collect_data_integration(Opts).
 
-message_transformation(get, #{headers := Headers, query_string := Qs}) ->
-    collect(emqx_prometheus_message_transformation, collect_opts(Headers, Qs)).
+schema_validation(get, #{query_string := Qs}) ->
+    collect(emqx_prometheus_schema_validation, collect_opts(Qs)).
+
+message_transformation(get, #{query_string := Qs}) ->
+    collect(emqx_prometheus_message_transformation, collect_opts(Qs)).
+
+topic_metrics(get, #{query_string := Qs}) ->
+    collect(emqx_prometheus_topic_metrics, collect_opts(Qs)).
 
 %%--------------------------------------------------------------------
 %% Internal funcs
 %%--------------------------------------------------------------------
 
-collect(Module, #{type := Type, mode := Mode}) ->
-    %% `Mode` is used to control the format of the returned data
-    %% It will used in callback `Module:collect_mf/1` to fetch data from node or cluster
-    %% And use this mode parameter to determine the formatting method of the returned information.
-    %% Since the arity of the callback function has been fixed.
-    %% so it is placed in the process dictionary of the current process.
-    ?PUT_PROM_DATA_MODE(Mode),
-    maybe_ensure_prometheus_registry(Type),
+collect(Module, #{mode := Mode}) ->
+    put_prom_data_mode(Mode),
     Data =
         case erlang:function_exported(Module, collect, 1) of
             true ->
-                erlang:apply(Module, collect, [Type]);
+                erlang:apply(Module, collect, [<<"prometheus">>]);
             false ->
                 ?SLOG(error, #{
                     msg => "prometheus callback module not found, empty data responded",
@@ -248,33 +307,49 @@ collect(Module, #{type := Type, mode := Mode}) ->
                 }),
                 <<>>
         end,
-    gen_response(Type, Data).
+    gen_response(Data).
 
-maybe_ensure_prometheus_registry(<<"prometheus">>) ->
-    case ets:info(prometheus_registry_table) of
-        undefined ->
-            case erlang:whereis(prometheus_sup) of
-                undefined ->
-                    case prometheus_sup:start_link() of
-                        {ok, _Pid} -> ok;
-                        {error, {already_started, _Pid}} -> ok
-                    end;
-                _Pid ->
-                    ok
-            end;
-        _Info ->
-            ok
-    end;
-maybe_ensure_prometheus_registry(_) ->
-    ok.
+collect_data_integration(#{namespace := Namespace, mode := Mode}) ->
+    Data = emqx_prometheus_data_integration:collect_ns(Namespace, Mode),
+    gen_response(Data).
 
-collect_opts(Headers, Qs) ->
-    #{type => response_type(Headers), mode => mode(Qs)}.
+collect_ns_stats(#{mode := Mode, namespace := Namespace}) ->
+    Data = emqx_prometheus:collect_ns(Namespace, Mode),
+    gen_response(Data).
 
-response_type(#{<<"accept">> := <<"application/json">>}) ->
-    <<"json">>;
-response_type(_) ->
-    <<"prometheus">>.
+collect_opts(Qs) ->
+    #{mode => mode(Qs)}.
+
+collect_opts_ns(Qs) ->
+    #{namespace => namespace(Qs), mode => mode(Qs)}.
+
+collect_opts_ns_or_all(Req = #{query_string := Qs}) ->
+    Namespace0 = get_namespace(Req),
+    Namespace =
+        case maps:get(<<"only_global">>, Qs, false) of
+            false when Namespace0 == ?global_ns -> all;
+            _ -> Namespace0
+        end,
+    #{namespace => Namespace, mode => mode(Qs)}.
+
+%% The JSON metrics format is no longer supported; only the Prometheus text
+%% format is produced. Requests asking for JSON are rejected (see the
+%% `validate_not_json/2' filter wired into the relevant `schema/1' declarations).
+is_json_requested(#{<<"accept">> := <<"application/json">>}) ->
+    true;
+is_json_requested(_) ->
+    false.
+
+json_not_supported() ->
+    {400, <<"only prometheus format is supported">>}.
+
+put_prom_data_mode(Mode) ->
+    %% `Mode` is used to control the format of the returned data
+    %% It will used in callback `Module:collect_mf/1` to fetch data from node or cluster
+    %% And use this mode parameter to determine the formatting method of the returned information.
+    %% Since the arity of the callback function has been fixed.
+    %% so it is placed in the process dictionary of the current process.
+    ?PUT_PROM_DATA_MODE(Mode).
 
 mode(#{<<"mode">> := Mode}) ->
     case lists:member(Mode, ?PROM_DATA_MODES) of
@@ -284,9 +359,12 @@ mode(#{<<"mode">> := Mode}) ->
 mode(_) ->
     ?PROM_DATA_MODE__NODE.
 
-gen_response(<<"json">>, Data) ->
-    {200, Data};
-gen_response(<<"prometheus">>, Data) ->
+namespace(#{<<"ns">> := Namespace}) ->
+    Namespace;
+namespace(_) ->
+    all.
+
+gen_response(Data) ->
     {200, #{<<"content-type">> => <<"text/plain">>}, Data}.
 
 prometheus_setting_request() ->
@@ -331,7 +409,7 @@ recommend_setting_example() ->
     {Summary, #{
         summary => Summary,
         value => #{
-            enable_basic_auth => false,
+            enable_basic_auth => true,
             push_gateway => #{
                 interval => <<"15s">>,
                 method => put,
@@ -354,7 +432,60 @@ prometheus_data_schema() ->
     #{
         content =>
             [
-                {'text/plain', #{schema => #{type => string}}},
-                {'application/json', #{schema => #{type => object}}}
+                {'text/plain', #{schema => #{type => string}}}
             ]
     }.
+
+validate_not_json(#{headers := Headers} = Req, _Meta) ->
+    case is_json_requested(Headers) of
+        true ->
+            json_not_supported();
+        false ->
+            {ok, Req}
+    end.
+
+parse_collect_opt_ns(#{} = Req, _Meta) ->
+    Opts = collect_opts_ns_or_all(Req),
+    {ok, Req#{collect_opts => Opts}}.
+
+get_collect_opts(Req) ->
+    maps:get(collect_opts, Req).
+
+rate_limit_all_ns_stats(#{collect_opts := #{namespace := all}} = Req, _Meta) ->
+    Client = emqx_prometheus_limiter:connect_api(),
+    case emqx_limiter_client:try_consume(Client, 1) of
+        {true, _NewClient} ->
+            {ok, Req};
+        {false, _NewClient, _Reason} ->
+            {429, <<"Too many requests">>}
+    end;
+rate_limit_all_ns_stats(Req, _Meta) ->
+    {ok, Req}.
+
+namespaced_filter(Req0, Meta) ->
+    maybe
+        {ok, Req1} ?= resolve_namespace(Req0, Meta),
+        {ok, Req2} ?= validate_not_json(Req1, Meta),
+        {ok, Req3} ?= parse_collect_opt_ns(Req2, Meta),
+        rate_limit_all_ns_stats(Req3, Meta)
+    end.
+
+get_namespace(#{resolved_ns := Namespace}) ->
+    Namespace.
+
+parse_namespace(#{query_string := QueryString} = Req) ->
+    ActorNamespace = emqx_dashboard:get_namespace(Req),
+    case maps:get(<<"ns">>, QueryString, ActorNamespace) of
+        QSNamespace when QSNamespace /= ActorNamespace andalso ActorNamespace /= ?global_ns ->
+            {error, not_authorized};
+        QSNamespace ->
+            {ok, QSNamespace}
+    end.
+
+resolve_namespace(Req, _Meta) ->
+    case parse_namespace(Req) of
+        {ok, Namespace} ->
+            {ok, Req#{resolved_ns => Namespace}};
+        {error, not_authorized} ->
+            ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
+    end.

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
@@ -18,6 +18,8 @@
 -include_lib("emqx/include/asserts.hrl").
 -include("emqx_prometheus.hrl").
 
+-define(with_auth_header(HEADER, BODY), with_auth_header(HEADER, fun() -> BODY end)).
+
 %%------------------------------------------------------------------------------
 %% CT boilerplate
 %%------------------------------------------------------------------------------
@@ -47,31 +49,36 @@ end_per_testcase(_TestCase, _TCConfig) ->
 %% Helper fns
 %%------------------------------------------------------------------------------
 
-get_data_integration(Mode, Format, Opts) ->
+get_data_integration(Mode, Opts) ->
     URL = emqx_mgmt_api_test_util:api_path(["prometheus", "data_integration"]),
-    get_prometheus(URL, Mode, Format, Opts).
+    get_prometheus(URL, Mode, Opts).
 
-get_prometheus(URL, Mode, Format, Opts) ->
-    Headers =
-        case Format of
-            json -> [{"accept", "application/json"}];
-            prometheus -> []
-        end,
-    QueryString = uri_string:compose_query([{"mode", atom_to_binary(Mode)}]),
+get_namespaced_stats(Mode, Opts) ->
+    URL = emqx_mgmt_api_test_util:api_path(["prometheus", "namespaced_stats"]),
+    get_prometheus(URL, Mode, Opts).
+
+get_prometheus(URL, Mode, Opts) ->
+    Ns = maps:get(ns, Opts, undefined),
+    OnlyGlobal = maps:get(only_global, Opts, undefined),
+    QueryString = uri_string:compose_query(
+        lists:flatten([
+            {"mode", atom_to_binary(Mode)},
+            [{"ns", Ns} || Ns /= undefined],
+            [{"only_global", OnlyGlobal} || OnlyGlobal /= undefined]
+        ])
+    ),
     AuthHeader = maps:get(auth_header, Opts, {"no", "auth"}),
     {Status, Response} = emqx_mgmt_api_test_util:simple_request(#{
         method => get,
         url => URL,
-        extra_headers => Headers,
+        extra_headers => [],
         query_params => QueryString,
         auth_header => AuthHeader
     }),
-    case Format of
-        json ->
-            {Status, Response};
-        prometheus when Status == 200 ->
+    case Status of
+        200 ->
             {Status, parse_prometheus(Response)};
-        prometheus ->
+        _ ->
             {Status, Response}
     end.
 
@@ -129,7 +136,7 @@ start_local(TestCase, TCConfig, Opts) ->
             emqx_conf,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard(),
-            emqx_prometheus
+            {emqx_prometheus, "prometheus.namespaced_metrics_limiter.rate = infinity"}
         ] ++ ExtraApps,
     Apps = emqx_cth_suite:start(AppSpecs, #{work_dir => emqx_cth_suite:work_dir(TestCase, TCConfig)}),
     on_exit(fun() -> emqx_cth_suite:stop(Apps) end),
@@ -153,6 +160,19 @@ create_action_api(TCConfig, Overrides) ->
     emqx_bridge_v2_testlib:simplify_result(
         emqx_bridge_v2_testlib:create_action_api(TCConfig, Overrides)
     ).
+
+simple_create_rule_api(Opts0, TCConfig) ->
+    Opts = maps:merge(#{sql => auto}, Opts0),
+    emqx_bridge_v2_testlib:simple_create_rule_api(Opts, TCConfig).
+
+with_auth_header(AuthHeader, Fn) ->
+    try
+        AuthFn = fun() -> AuthHeader end,
+        emqx_bridge_v2_testlib:set_auth_header_getter(AuthFn),
+        Fn()
+    after
+        emqx_bridge_v2_testlib:clear_auth_header_getter()
+    end.
 
 %%------------------------------------------------------------------------------
 %% Test cases
@@ -188,10 +208,387 @@ t_action_without_connector(TCConfig) ->
         fun(Mode) ->
             ?assertMatch(
                 {200, _},
-                get_data_integration(Mode, prometheus, #{auth_header => AuthHeader}),
+                get_data_integration(Mode, #{auth_header => AuthHeader}),
                 #{mode => Mode}
             )
         end,
         ?PROM_DATA_MODES
     ),
+    ok.
+
+t_namespaced_data_integration(TCConfig) ->
+    start_local(?FUNCTION_NAME, TCConfig, #{
+        extra_apps => [
+            emqx_bridge_mqtt,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_mt
+        ]
+    }),
+    %% sanity check: auth should be enabled
+    ?assertMatch({401, _}, get_data_integration(?PROM_DATA_MODE__NODE, #{})),
+
+    MkBridgeConfig = fun(Name) ->
+        [
+            {bridge_kind, action},
+            {connector_type, <<"mqtt">>},
+            {connector_name, Name},
+            {connector_config, emqx_bridge_schema_testlib:mqtt_connector_config(#{})},
+            {action_type, <<"mqtt">>},
+            {action_name, Name},
+            {action_config,
+                emqx_bridge_schema_testlib:mqtt_action_config(#{<<"connector">> => Name})}
+        ]
+    end,
+    Ns = <<"ns1">>,
+    ok = emqx_mt_config:create_managed_ns(Ns),
+    NsAuthHeader = create_namespaced_user_auth_header(#{}),
+    ?with_auth_header(NsAuthHeader, begin
+        Cfg = MkBridgeConfig(Ns),
+        {201, _} = create_connector_api(Cfg, #{}),
+        {201, _} = create_action_api(Cfg, #{}),
+        simple_create_rule_api(#{id => Ns}, Cfg),
+        ok
+    end),
+    GlobalAuthHeader = global_admin_auth_header(),
+    ?with_auth_header(GlobalAuthHeader, begin
+        Cfg = MkBridgeConfig(<<"global">>),
+        {201, _} = create_connector_api(Cfg, #{}),
+        {201, _} = create_action_api(Cfg, #{}),
+        simple_create_rule_api(#{id => <<"global">>}, Cfg),
+        ok
+    end),
+
+    GetLabels = fun(Key, Res) -> lists:sort(maps:keys(maps:get(Key, Res))) end,
+
+    lists:foreach(
+        fun(Mode) ->
+            ct:pal("mode ~s", [Mode]),
+
+            %% namespaced admin cannot see other namespaces
+            ?assertMatch(
+                {403, _},
+                get_data_integration(Mode, #{
+                    auth_header => NsAuthHeader,
+                    ns => <<"other_ns">>
+                })
+            ),
+
+            {200, NsNodeRes1} = get_data_integration(Mode, #{
+                auth_header => NsAuthHeader
+            }),
+            ?assertNotMatch(
+                [#{<<"id">> := <<"mqtt:global">>}],
+                GetLabels(<<"emqx_connector_status">>, NsNodeRes1)
+            ),
+            ?assertNotMatch(
+                [#{<<"id">> := <<"mqtt:global">>}], GetLabels(<<"emqx_action_enable">>, NsNodeRes1)
+            ),
+            ?assertNotMatch(
+                [#{<<"id">> := <<"mqtt:global">>}], GetLabels(<<"emqx_rule_enable">>, NsNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_connector_status">>, NsNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_action_enable">>, NsNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_rule_enable">>, NsNodeRes1)
+            ),
+
+            %% without specifying `only_global`, global admin sees metrics from all namespaces
+            {200, GlobalNodeRes1} = get_data_integration(Mode, #{
+                auth_header => GlobalAuthHeader
+            }),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>},
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>},
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"global">>},
+                    #{
+                        <<"id">> := <<"ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes1)
+            ),
+            %% with `only_global`, global admin sees metrics only from global ns
+            {200, GlobalNodeRes2} = get_data_integration(Mode, #{
+                auth_header => GlobalAuthHeader,
+                only_global => true
+            }),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>}
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes2)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>}
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes2)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"global">>}
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes2)
+            ),
+
+            %% namespaced admin can filter specific namespaces
+            {200, GlobalNodeRes3} = get_data_integration(Mode, #{
+                auth_header => GlobalAuthHeader,
+                ns => Ns
+            }),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes3)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes3)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        <<"id">> := <<"ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes3)
+            ),
+
+            ok
+        end,
+        ?PROM_DATA_MODES
+    ),
+
+    %% if auth is disabled, there's not much we can do.  we treat the request as if coming
+    %% from a global admin.
+    {ok, _} = emqx:update_config([prometheus, enable_basic_auth], false),
+    #{started := Started} = emqx_dashboard:listeners_status(),
+    ok = emqx_dashboard_dispatch:regenerate_dispatch(Started),
+    lists:foreach(
+        fun(Mode) ->
+            ct:pal("mode ~s", [Mode]),
+            %% without specifying `only_global`, global admin sees metrics from all namespaces
+            {200, GlobalNodeRes1} = get_data_integration(Mode, #{}),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>},
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>},
+                    #{
+                        <<"id">> := <<"mqtt:ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes1)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"global">>},
+                    #{
+                        <<"id">> := <<"ns1">>,
+                        <<"namespace">> := Ns
+                    }
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes1)
+            ),
+            %% with `only_global`, global admin sees metrics only from global ns
+            {200, GlobalNodeRes2} = get_data_integration(Mode, #{
+                only_global => true
+            }),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>}
+                ],
+                GetLabels(<<"emqx_connector_status">>, GlobalNodeRes2)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"mqtt:global">>}
+                ],
+                GetLabels(<<"emqx_action_enable">>, GlobalNodeRes2)
+            ),
+            ?assertMatch(
+                [
+                    #{<<"id">> := <<"global">>}
+                ],
+                GetLabels(<<"emqx_rule_enable">>, GlobalNodeRes2)
+            ),
+            ok
+        end,
+        ?PROM_DATA_MODES
+    ),
+
+    ok.
+
+-doc """
+Checks that global admins may observe namespaced metrics from all namespaces, and
+namespaced admins only see their own namespace.
+""".
+t_namespaced_stats(TCConfig) ->
+    start_local(?FUNCTION_NAME, TCConfig, #{
+        extra_apps => [
+            emqx_bridge_mqtt,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_mt
+        ]
+    }),
+    %% sanity check: auth should be enabled
+    ?assertMatch({401, _}, get_data_integration(?PROM_DATA_MODE__NODE, #{})),
+
+    Ns1 = <<"ns1">>,
+    ok = emqx_mt_config:create_managed_ns(Ns1),
+    Ns2 = <<"ns2">>,
+    ok = emqx_mt_config:create_managed_ns(Ns2),
+
+    Ns1AuthHeader = create_namespaced_user_auth_header(#{
+        params => #{
+            <<"username">> => Ns1,
+            <<"role">> => <<"ns:", Ns1/binary, "::administrator">>
+        }
+    }),
+    Ns2AuthHeader = create_namespaced_user_auth_header(#{
+        params => #{
+            <<"username">> => Ns2,
+            <<"role">> => <<"ns:", Ns2/binary, "::administrator">>
+        }
+    }),
+    GlobalAuthHeader = global_admin_auth_header(),
+
+    GetLabels = fun(Key, Res) -> lists:sort(maps:keys(maps:get(Key, Res))) end,
+
+    lists:foreach(
+        fun(Mode) ->
+            ct:pal("mode ~s", [Mode]),
+
+            %% namespaced admin cannot see other namespaces
+            ?assertMatch(
+                {403, _},
+                get_namespaced_stats(Mode, #{
+                    auth_header => Ns1AuthHeader,
+                    ns => <<"other_ns">>
+                })
+            ),
+
+            %% global admin sees metrics from all namespaces (except global; there's
+            %% another endpoint for that)
+            {200, GlobalNodeRes1} = get_namespaced_stats(Mode, #{
+                auth_header => GlobalAuthHeader
+            }),
+            ?assertMatch(
+                [
+                    #{<<"namespace">> := Ns1},
+                    #{<<"namespace">> := Ns2}
+                ],
+                GetLabels(<<"emqx_bytes_received">>, GlobalNodeRes1)
+            ),
+            %% possible to filter one specific namespace
+            {200, GlobalNodeRes2} = get_namespaced_stats(Mode, #{
+                auth_header => GlobalAuthHeader,
+                ns => Ns2
+            }),
+            ?assertMatch(
+                [
+                    #{<<"namespace">> := Ns2}
+                ],
+                GetLabels(<<"emqx_bytes_received">>, GlobalNodeRes2)
+            ),
+
+            %% namespaced admin can only filter its own namespace
+            {200, NsNodeRes1} = get_namespaced_stats(Mode, #{
+                auth_header => Ns1AuthHeader
+            }),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns1}],
+                GetLabels(<<"emqx_bytes_received">>, NsNodeRes1)
+            ),
+            {200, NsNodeRes2} = get_namespaced_stats(Mode, #{
+                auth_header => Ns1AuthHeader,
+                ns => Ns1
+            }),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns1}],
+                GetLabels(<<"emqx_bytes_received">>, NsNodeRes2)
+            ),
+            ?assertMatch(
+                {403, _},
+                get_namespaced_stats(Mode, #{
+                    auth_header => Ns1AuthHeader,
+                    ns => Ns2
+                })
+            ),
+
+            {200, NsNodeRes3} = get_namespaced_stats(Mode, #{
+                auth_header => Ns2AuthHeader
+            }),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns2}],
+                GetLabels(<<"emqx_bytes_received">>, NsNodeRes3)
+            ),
+
+            ok
+        end,
+        ?PROM_DATA_MODES
+    ),
+
     ok.

--- a/changes/ee/fix-17756.en.md
+++ b/changes/ee/fix-17756.en.md
@@ -1,0 +1,1 @@
+Fixed `/prometheus/namespaced_stats` so that namespaced admins/API keys can only see data from their own namespaced.  Global admins/API keys can still see data from all namespaces.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/71

Release version:
6.0.4, 6.1.3, 6.2.2

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
