### PR TITLE
fix(prometheus api): allow namespaced admins to filter only its namespace in `/prometheus/ns_stats`

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -10,6 +10,8 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
+-include_lib("emqx_utils/include/emqx_http_api.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -46,7 +48,7 @@
 -export([lookup_from_local_nodes/3]).
 -export([scopes/0]).
 
--export([namespaced_stats_filter/2]).
+-export([namespaced_filter/2]).
 
 -define(TAGS, [<<"Monitor">>]).
 
@@ -99,7 +101,7 @@ schema("/prometheus") ->
 schema("/prometheus/namespaced_stats") ->
     #{
         'operationId' => ns_stats,
-        filter => fun ?MODULE:namespaced_stats_filter/2,
+        filter => fun ?MODULE:namespaced_filter/2,
         get =>
             #{
                 description => ?DESC("ns_stats"),
@@ -240,13 +242,9 @@ setting(put, #{body := Body}) ->
 stats(get, #{headers := Headers, query_string := Qs}) ->
     collect(emqx_prometheus, collect_opts(Headers, Qs)).
 
-ns_stats(get, #{headers := Headers, query_string := Qs}) ->
-    case response_type(Headers) of
-        <<"json">> ->
-            {400, <<"only prometheus format is supported">>};
-        <<"prometheus">> ->
-            collect_ns_stats(collect_opts_ns(Qs))
-    end.
+ns_stats(get, Req) ->
+    Opts = get_collect_opts(Req),
+    collect_ns_stats(Opts).
 
 auth(get, #{headers := Headers, query_string := Qs}) ->
     collect(emqx_prometheus_auth, collect_opts(Headers, Qs)).
@@ -306,8 +304,14 @@ maybe_ensure_prometheus_registry(_) ->
 collect_opts(Headers, Qs) ->
     #{type => response_type(Headers), mode => mode(Qs)}.
 
-collect_opts_ns(Qs) ->
-    #{namespace => namespace(Qs), mode => mode(Qs)}.
+collect_opts_ns_or_all(Req = #{query_string := Qs}) ->
+    Namespace0 = get_namespace(Req),
+    Namespace =
+        case maps:get(<<"only_global">>, Qs, false) of
+            false when Namespace0 == ?global_ns -> all;
+            _ -> Namespace0
+        end,
+    #{namespace => Namespace, mode => mode(Qs)}.
 
 response_type(#{<<"accept">> := <<"application/json">>}) ->
     <<"json">>;
@@ -329,11 +333,6 @@ mode(#{<<"mode">> := Mode}) ->
     end;
 mode(_) ->
     ?PROM_DATA_MODE__NODE.
-
-namespace(#{<<"ns">> := Namespace}) ->
-    Namespace;
-namespace(_) ->
-    all.
 
 gen_response(<<"json">>, Data) ->
     {200, Data};
@@ -418,9 +417,12 @@ validate_not_json(#{headers := Headers} = Req, _Meta) ->
             {ok, Req}
     end.
 
-parse_collect_opt_ns(#{query_string := Qs} = Req, _Meta) ->
-    Opts = collect_opts_ns(Qs),
+parse_collect_opt_ns(#{} = Req, _Meta) ->
+    Opts = collect_opts_ns_or_all(Req),
     {ok, Req#{collect_opts => Opts}}.
+
+get_collect_opts(Req) ->
+    maps:get(collect_opts, Req).
 
 rate_limit_all_ns_stats(#{collect_opts := #{namespace := all}} = Req, _Meta) ->
     Client = emqx_prometheus_limiter:connect_api(),
@@ -433,9 +435,30 @@ rate_limit_all_ns_stats(#{collect_opts := #{namespace := all}} = Req, _Meta) ->
 rate_limit_all_ns_stats(Req, _Meta) ->
     {ok, Req}.
 
-namespaced_stats_filter(Req0, Meta) ->
+namespaced_filter(Req0, Meta) ->
     maybe
-        {ok, Req1} ?= validate_not_json(Req0, Meta),
-        {ok, Req2} ?= parse_collect_opt_ns(Req1, Meta),
-        rate_limit_all_ns_stats(Req2, Meta)
+        {ok, Req1} ?= resolve_namespace(Req0, Meta),
+        {ok, Req2} ?= validate_not_json(Req1, Meta),
+        {ok, Req3} ?= parse_collect_opt_ns(Req2, Meta),
+        rate_limit_all_ns_stats(Req3, Meta)
+    end.
+
+get_namespace(#{resolved_ns := Namespace}) ->
+    Namespace.
+
+parse_namespace(#{query_string := QueryString} = Req) ->
+    ActorNamespace = emqx_dashboard:get_namespace(Req),
+    case maps:get(<<"ns">>, QueryString, ActorNamespace) of
+        QSNamespace when QSNamespace /= ActorNamespace andalso ActorNamespace /= ?global_ns ->
+            {error, not_authorized};
+        QSNamespace ->
+            {ok, QSNamespace}
+    end.
+
+resolve_namespace(Req, _Meta) ->
+    case parse_namespace(Req) of
+        {ok, Namespace} ->
+            {ok, Req#{resolved_ns => Namespace}};
+        {error, not_authorized} ->
+            ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
@@ -51,13 +51,26 @@ get_data_integration(Mode, Format, Opts) ->
     URL = emqx_mgmt_api_test_util:api_path(["prometheus", "data_integration"]),
     get_prometheus(URL, Mode, Format, Opts).
 
+get_namespaced_stats(Mode, Opts) ->
+    URL = emqx_mgmt_api_test_util:api_path(["prometheus", "namespaced_stats"]),
+    %% format argument is dropped on 6.3
+    get_prometheus(URL, Mode, _Format = prometheus, Opts).
+
 get_prometheus(URL, Mode, Format, Opts) ->
+    Ns = maps:get(ns, Opts, undefined),
+    OnlyGlobal = maps:get(only_global, Opts, undefined),
     Headers =
         case Format of
             json -> [{"accept", "application/json"}];
             prometheus -> []
         end,
-    QueryString = uri_string:compose_query([{"mode", atom_to_binary(Mode)}]),
+    QueryString = uri_string:compose_query(
+        lists:flatten([
+            {"mode", atom_to_binary(Mode)},
+            [{"ns", Ns} || Ns /= undefined],
+            [{"only_global", OnlyGlobal} || OnlyGlobal /= undefined]
+        ])
+    ),
     AuthHeader = maps:get(auth_header, Opts, {"no", "auth"}),
     {Status, Response} = emqx_mgmt_api_test_util:simple_request(#{
         method => get,
@@ -129,7 +142,7 @@ start_local(TestCase, TCConfig, Opts) ->
             emqx_conf,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard(),
-            emqx_prometheus
+            {emqx_prometheus, "prometheus.namespaced_metrics_limiter.rate = infinity"}
         ] ++ ExtraApps,
     Apps = emqx_cth_suite:start(AppSpecs, #{work_dir => emqx_cth_suite:work_dir(TestCase, TCConfig)}),
     on_exit(fun() -> emqx_cth_suite:stop(Apps) end),
@@ -157,6 +170,127 @@ create_action_api(TCConfig, Overrides) ->
 %%------------------------------------------------------------------------------
 %% Test cases
 %%------------------------------------------------------------------------------
+
+-doc """
+Checks that global admins may observe namespaced metrics from all namespaces, and
+namespaced admins only see their own namespace.
+""".
+t_namespaced_stats(TCConfig) ->
+    start_local(?FUNCTION_NAME, TCConfig, #{
+        extra_apps => [
+            emqx_auth_mnesia,
+            emqx_auth,
+            emqx_mt
+        ]
+    }),
+
+    GetLabels = fun(Key, Res) -> lists:sort(maps:keys(maps:get(Key, Res))) end,
+    Ns1 = <<"ns1">>,
+    ok = emqx_mt_config:create_managed_ns(Ns1),
+    Ns2 = <<"ns2">>,
+    ok = emqx_mt_config:create_managed_ns(Ns2),
+
+    %% without authn enabled, there's nothing much we can do...  all namespaces are returned
+    {ok, _} = emqx:update_config([prometheus, enable_basic_auth], false),
+    #{started := Started0} = emqx_dashboard:listeners_status(),
+    ok = emqx_dashboard_dispatch:regenerate_dispatch(Started0),
+
+    {200, NoAuthRes} = get_namespaced_stats(?PROM_DATA_MODE__NODE, #{}),
+    ?assertMatch(
+        [
+            #{<<"namespace">> := Ns1},
+            #{<<"namespace">> := Ns2}
+        ],
+        GetLabels(<<"emqx_bytes_received">>, NoAuthRes)
+    ),
+
+    {ok, _} = emqx:update_config([prometheus, enable_basic_auth], true),
+    #{started := Started1} = emqx_dashboard:listeners_status(),
+    ok = emqx_dashboard_dispatch:regenerate_dispatch(Started1),
+
+    %% sanity check: auth should be enabled
+    ?assertMatch({401, _}, get_namespaced_stats(?PROM_DATA_MODE__NODE, #{})),
+
+    Ns1AuthHeader = create_namespaced_user_auth_header(#{
+        params => #{
+            <<"username">> => Ns1,
+            <<"role">> => <<"ns:", Ns1/binary, "::administrator">>
+        }
+    }),
+    Ns2AuthHeader = create_namespaced_user_auth_header(#{
+        params => #{
+            <<"username">> => Ns2,
+            <<"role">> => <<"ns:", Ns2/binary, "::administrator">>
+        }
+    }),
+    GlobalAuthHeader = global_admin_auth_header(),
+
+    lists:foreach(
+        fun(Mode) ->
+            ct:pal("mode ~s", [Mode]),
+
+            %% global admin sees metrics from all namespaces (except global; there's
+            %% another endpoint for that)
+            {200, GlobalNodeRes1} = get_namespaced_stats(Mode, #{
+                auth_header => GlobalAuthHeader
+            }),
+            ?assertMatch(
+                [
+                    #{<<"namespace">> := Ns1},
+                    #{<<"namespace">> := Ns2}
+                ],
+                GetLabels(<<"emqx_bytes_received">>, GlobalNodeRes1)
+            ),
+            %% possible to filter one specific namespace
+            {200, GlobalNodeRes2} = get_namespaced_stats(Mode, #{
+                auth_header => GlobalAuthHeader,
+                ns => Ns2
+            }),
+            ?assertMatch(
+                [
+                    #{<<"namespace">> := Ns2}
+                ],
+                GetLabels(<<"emqx_bytes_received">>, GlobalNodeRes2)
+            ),
+
+            %% namespaced admin can only filter its own namespace
+            {200, NsNodeRes1} = get_namespaced_stats(Mode, #{
+                auth_header => Ns1AuthHeader
+            }),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns1}],
+                GetLabels(<<"emqx_bytes_received">>, NsNodeRes1)
+            ),
+            {200, NsNodeRes2} = get_namespaced_stats(Mode, #{
+                auth_header => Ns1AuthHeader,
+                ns => Ns1
+            }),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns1}],
+                GetLabels(<<"emqx_bytes_received">>, NsNodeRes2)
+            ),
+            ?assertMatch(
+                {403, _},
+                get_namespaced_stats(Mode, #{
+                    auth_header => Ns1AuthHeader,
+                    ns => Ns2
+                })
+            ),
+
+            {200, NsNodeRes3} = get_namespaced_stats(Mode, #{
+                auth_header => Ns2AuthHeader
+            }),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns2}],
+                GetLabels(<<"emqx_bytes_received">>, NsNodeRes3)
+            ),
+
+            ok
+        end,
+        ?PROM_DATA_MODES
+    ),
+
+    ok.
 
 -doc """
 Regression test for the case where there is an action whose connector does not exist.

--- a/changes/ee/fix-17757.en.md
+++ b/changes/ee/fix-17757.en.md
@@ -1,0 +1,1 @@
+Fixed `/prometheus/namespaced_stats` so that namespaced admins/API keys can only see data from their own namespaced.  Global admins/API keys can still see data from all namespaces.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/71

Release version:
6.1.4, 6.2.3

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
