### PR TITLE
feat(metrics): increment messages.retained counter

### DIFF
--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -617,6 +617,7 @@ reserved_idx('actions.executed') -> 101;
 reserved_idx('delivery.dropped.filter') -> 102;
 reserved_idx('actions.messages') -> 103;
 reserved_idx('client.post_authn') -> 104;
+reserved_idx('messages.retained') -> 105;
 reserved_idx(_) -> undefined.
 
 all_metrics() ->
@@ -711,7 +712,8 @@ message_metrics() ->
         {counter, 'messages.validation_succeeded', ?DESC("messages_validation_succeeded")},
         {counter, 'messages.transformation_failed', ?DESC("messages_transformation_failed")},
         {counter, 'messages.transformation_succeeded', ?DESC("messages_transformation_succeeded")},
-        {counter, 'messages.persisted', ?DESC("messages_persisted")}
+        {counter, 'messages.persisted', ?DESC("messages_persisted")},
+        {counter, 'messages.retained', ?DESC("messages_retained")}
     ].
 
 %% Rule and Action related metrics

--- a/apps/emqx_retainer/src/emqx_retainer_publisher.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_publisher.erl
@@ -56,7 +56,8 @@ store_retained(#message{topic = Topic, payload = Payload} = Msg) ->
             end),
             case WithinLimits of
                 true ->
-                    ?tp(retain_within_limit, #{topic => Topic});
+                    ?tp(retain_within_limit, #{topic => Topic}),
+                    emqx_metrics:inc_global('messages.retained');
                 {false, Reason} ->
                     ?tp(retain_failed_for_rate_exceeded_limit, #{topic => Topic}),
                     ?SLOG_THROTTLE(warning, #{

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -178,6 +178,7 @@ t_store_and_clean(_) ->
     {ok, C1} = emqtt:start_link([{clean_start, true}, {proto_ver, v5}]),
     {ok, _} = emqtt:connect(C1),
 
+    Retained0 = emqx_metrics:val_global('messages.retained'),
     emqtt:publish(
         C1,
         <<"retained">>,
@@ -185,6 +186,7 @@ t_store_and_clean(_) ->
         [{qos, 0}, {retain, true}]
     ),
     timer:sleep(100),
+    ?assertEqual(Retained0 + 1, emqx_metrics:val_global('messages.retained')),
 
     {ok, _, List} = emqx_retainer:page_read(<<"retained">>, 1, 10),
     ?assertEqual(1, length(List)),
@@ -205,6 +207,7 @@ t_store_and_clean(_) ->
 
     emqtt:publish(C1, <<"retained">>, <<"">>, [{qos, 0}, {retain, true}]),
     timer:sleep(100),
+    ?assertEqual(Retained0 + 1, emqx_metrics:val_global('messages.retained')),
 
     {ok, #{}, [0]} = emqtt:subscribe(C1, <<"retained">>, [{qos, 0}, {rh, 0}]),
     ?assertEqual(0, length(receive_messages(1))),

--- a/changes/ee/feat-17758.en.md
+++ b/changes/ee/feat-17758.en.md
@@ -1,0 +1,1 @@
+The Prometheus `emqx_messages_retained` counter now reports actual retained-message writes. Previously the metric was exposed but never incremented, so it always read 0. Each successful retained-message store now bumps the counter.

--- a/rel/i18n/emqx_metrics.hocon
+++ b/rel/i18n/emqx_metrics.hocon
@@ -194,6 +194,9 @@ emqx_metrics {
     messages_persisted {
         desc: "Number of message persisted"
     }
+    messages_retained {
+        desc: "Number of retained message writes"
+    }
     delivery_dropped {
         desc: "Total number of discarded messages when sending"
     }


### PR DESCRIPTION
Fixes #17385.

Release version: 6.2.2

## Summary

Port of #17675 (which targets master) to dev-62. Original author: Sahil Patel.

EMQX already exposed `emqx_messages_retained` in Prometheus but the metric was never registered as a counter and never incremented — it always showed 0. This patch:

1. Registers `messages.retained` as a counter in `emqx_metrics.erl`.
2. Increments it via `emqx_metrics:inc_global/1` after a successful retained-message store.
3. Adds test assertions in `t_store_and_clean` to verify the counter increments on publish and stays unchanged on delete.

Clean cherry-pick from master — dev-62 already has the same `inc_global` / `val_global` API and the same `reserved_idx` numbering, so no porting tweaks were needed.

Supersedes #17755 (which targeted dev-60).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)