### PR TITLE
fix(pgsql): reject row-returning batch SQL

### DIFF
--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -856,14 +856,25 @@ on_format_query_result({ok, Cnt}) when is_integer(Cnt) ->
 on_format_query_result(Res) ->
     Res.
 
-handle_batch_result([{ok, Count} | Rest], Acc) ->
+handle_batch_result([{ok, Count} | Rest], Acc) when is_integer(Count) ->
     handle_batch_result(Rest, Acc + Count);
+handle_batch_result([{ok, _Rows} | _Rest], _Acc) ->
+    unsupported_row_returning_batch_result();
+handle_batch_result([{ok, _Count, _Rows} | _Rest], _Acc) ->
+    unsupported_row_returning_batch_result();
 handle_batch_result([{error, Error} | _Rest], _Acc) ->
     TranslatedError = translate_to_log_context(Error),
     {error, {unrecoverable_error, export_error(TranslatedError)}};
 handle_batch_result([], Acc) ->
     ?tp("postgres_success_batch_result", #{row_count => Acc}),
     {ok, Acc}.
+
+unsupported_row_returning_batch_result() ->
+    {error,
+        {unrecoverable_error, #{
+            reason => row_returning_batch_sql_unsupported,
+            msg => <<"PostgreSQL action batch SQL must not return rows">>
+        }}}.
 
 translate_to_log_context({error, Reason}) ->
     translate_to_log_context(Reason);

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -334,6 +334,42 @@ t_raw_batch_not_confused_by_table_check(_Config) ->
         emqx_resource:remove_local(ResourceId)
     end.
 
+t_batch_query_rejects_row_returning_sql(_Config) ->
+    ResourceId = <<"emqx_postgresql_SUITE_row_returning_batch">>,
+    Sql = <<"SELECT ${a}">>,
+    {ok, #{config := CheckedConfig}} =
+        emqx_resource:check_config(?PGSQL_RESOURCE_MOD, pgsql_config()),
+    {ok, #{state := State0}} = emqx_resource:create_local(
+        ResourceId,
+        ?CONNECTOR_RESOURCE_GROUP,
+        ?PGSQL_RESOURCE_MOD,
+        CheckedConfig,
+        #{spawn_buffer_workers => false}
+    ),
+    try
+        {ok, State} = emqx_postgresql:on_add_channel(
+            ResourceId, State0, <<"row_returning">>, #{parameters => #{sql => Sql}}
+        ),
+        Result = batch_query_with_timeout(
+            ResourceId,
+            [
+                {<<"row_returning">>, #{a => 1}},
+                {<<"row_returning">>, #{a => 2}}
+            ],
+            State
+        ),
+        ?assertMatch(
+            {error,
+                {unrecoverable_error, #{
+                    reason := row_returning_batch_sql_unsupported,
+                    msg := <<"PostgreSQL action batch SQL must not return rows">>
+                }}},
+            Result
+        )
+    after
+        emqx_resource:remove_local(ResourceId)
+    end.
+
 perform_lifecycle_check(ResourceId, InitialConfig) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(?PGSQL_RESOURCE_MOD, InitialConfig),

--- a/changes/ce/fix-17701.en.md
+++ b/changes/ce/fix-17701.en.md
@@ -1,0 +1,3 @@
+Fixed a confusing `badarith` error from PostgreSQL actions when a batched SQL template returned rows, for example `SELECT ...`.
+
+PostgreSQL action batching does not support row-returning SQL. EMQX now returns a clear unsupported SQL error instead of crashing the batch result handler.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.3, 6.2.2

## Summary

Fix: https://github.com/emqx/emqx/issues/17701

Port of https://github.com/emqx/emqx/pull/17742 to `dev-60`.

PostgreSQL action batch result handling now treats only integer row counts as countable successes. If a batched SQL template returns rows, for example `SELECT ...`, EMQX returns a clear `row_returning_batch_sql_unsupported` error instead of crashing with `badarith`.

Added a regression test for row-returning batch SQL and kept the existing raw batch success path covered.

No schema changes.

Local note: `make static_checks` is currently blocked by unrelated Dialyzer warnings in `emqx_bridge_snowflake_aggregated_impl` and `emqx_bridge_sqlserver_connector` around `odbc:connect/2`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/fix-17701.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
