### PR TITLE
fix(gateway): authorize implicit publish and subscribe paths

### DIFF
--- a/apps/emqx_gateway_gbt32960/mix.exs
+++ b/apps/emqx_gateway_gbt32960/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayGbt32960.MixProject do
   def project do
     [
       app: :emqx_gateway_gbt32960,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
+++ b/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
@@ -9,6 +9,7 @@
 -include_lib("emqx/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 
 -export([
@@ -744,11 +745,29 @@ retry_delivery([{Key, {Frame, RetxCount, Ts}} | Frames], Now, Interval, Inflight
     end.
 
 upstreaming(
-    Frame, Channel = #channel{clientinfo = #{mountpoint := Mountpoint, clientid := ClientId}}
+    Frame,
+    Channel = #channel{
+        ctx = Ctx,
+        clientinfo =
+            ClientInfo =
+                #{
+                    mountpoint := Mountpoint,
+                    clientid := ClientId
+                }
+    }
 ) ->
     {Topic, Payload} = transform(Frame, Mountpoint),
-    log(debug, #{msg => "upstreaming_to_topic", topic => Topic, payload => Payload}, Channel),
-    emqx:publish(emqx_message:make(ClientId, ?QOS_1, Topic, Payload)).
+    Action = ?AUTHZ_PUBLISH(?QOS_1, false),
+    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic) of
+        allow ->
+            log(
+                debug, #{msg => "upstreaming_to_topic", topic => Topic, payload => Payload}, Channel
+            ),
+            emqx:publish(emqx_message:make(ClientId, ?QOS_1, Topic, Payload));
+        deny ->
+            log(info, #{msg => "upstream_publish_denied", topic => Topic}, Channel),
+            ok
+    end.
 
 transform(Frame = ?CMD(Cmd), Mountpoint) ->
     Suffix =
@@ -930,6 +949,13 @@ subscribe_downlink(
     {ParsedTopic, SubOpts0} = emqx_topic:parse(Topic),
     SubOpts = maps:merge(emqx_gateway_utils:default_subopts(), SubOpts0),
     MountedTopic = emqx_mountpoint:mount(Mountpoint, ParsedTopic),
-    _ = emqx_broker:subscribe(MountedTopic, ClientId, SubOpts),
-    run_hooks(Ctx, 'session.subscribed', [ClientInfo, MountedTopic, SubOpts]),
-    Channel#channel{subscriptions = Subscriptions#{MountedTopic => SubOpts}}.
+    Action = ?AUTHZ_SUBSCRIBE(maps:get(qos, SubOpts, 0)),
+    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, MountedTopic) of
+        allow ->
+            _ = emqx_broker:subscribe(MountedTopic, ClientId, SubOpts),
+            run_hooks(Ctx, 'session.subscribed', [ClientInfo, MountedTopic, SubOpts]),
+            Channel#channel{subscriptions = Subscriptions#{MountedTopic => SubOpts}};
+        deny ->
+            log(info, #{msg => "subscribe_denied", topic => MountedTopic}, Channel),
+            Channel
+    end.

--- a/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
+++ b/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include("emqx_gbt32960.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_hooks.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/asserts.hrl").
@@ -101,15 +102,88 @@ to_json(#frame{cmd = Cmd, vin = Vin, encrypt = Encrypt, data = Data}) ->
     emqx_utils_json:encode(#{'Cmd' => Cmd, 'Vin' => Vin, 'Encrypt' => Encrypt, 'Data' => Data}).
 
 get_published_msg() ->
+    case receive_published_msg(5000) of
+        {error, timeout} -> error(timeout);
+        Msg -> Msg
+    end.
+
+receive_published_msg(Timeout) ->
     receive
         {deliver, _Topic, #message{topic = Topic, payload = Payload}} ->
             {Topic, Payload}
-    after 5000 ->
-        error(timeout)
+    after Timeout ->
+        {error, timeout}
     end.
 
 get_subscriptions() ->
     lists:map(fun({_, Topic}) -> Topic end, ets:tab2list(emqx_subscription)).
+
+login_first_without_broker_asserts() ->
+    Time = <<12, 12, 29, 12, 19, 20>>,
+    Data = <<Time/binary, 1:?WORD, "12345678901234567890", 1, 1, "C">>,
+    Packet = encode(?CMD_VIHECLE_LOGIN, <<"1G1BL52P7TR115520">>, Data),
+
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+    ok = gen_tcp:send(Socket, Packet),
+    timer:sleep(200),
+    {ok, AckPacket} = gen_tcp:recv(Socket, 0, 500),
+    ?LOGT("ack packet: ~p", [binary_to_hex_string(AckPacket)]),
+
+    BodyLen = byte_size(AckPacket) - 3,
+    <<"##", Body:BodyLen/binary, Crc:8>> = AckPacket,
+    <<?CMD_VIHECLE_LOGIN, ?ACK_SUCCESS, "1G1BL52P7TR115520", ?ENCRYPT_NONE, 31:?WORD, _/binary>> =
+        Body,
+    ?assertEqual(Crc, make_crc(Body, undefined)),
+    {ok, Socket}.
+
+publish_param_query_downlink() ->
+    Req = #{
+        <<"Action">> => <<"Query">>,
+        <<"Total">> => 2,
+        <<"Ids">> => [<<"0x01">>, <<"0x02">>]
+    },
+    Topic = <<"gbt32960/1G1BL52P7TR115520/dnstream">>,
+    _ = emqx:publish(emqx_message:make(Topic, emqx_utils_json:encode(Req))),
+    ok.
+
+assert_param_query_downlink(Packet) ->
+    BodyLen = byte_size(Packet) - 3,
+    <<"##", Body:BodyLen/binary, Crc>> = Packet,
+    <<?CMD_PARAM_QUERY, ?ACK_IS_CMD, "1G1BL52P7TR115520", ?ENCRYPT_NONE, 9:?WORD, _Time:6/binary, 2,
+        1, 2>> = Body,
+    ?assertEqual(Crc, make_crc(Body, undefined)).
+
+with_gateway_authz_result(Protocol, ActionType, Topic, Result, Fun) ->
+    Action = {?MODULE, gateway_authz_result, [Protocol, ActionType, Topic, Result]},
+    ok = emqx_hooks:put('client.authorize', Action, ?HP_HIGHEST),
+    try
+        Fun()
+    after
+        ok = emqx_hooks:del('client.authorize', Action)
+    end.
+
+gateway_authz_result(
+    #{protocol := Protocol},
+    #{action_type := ActionType},
+    Topic,
+    _DefaultResult,
+    Protocol,
+    ActionType,
+    Topic,
+    Result
+) ->
+    {stop, #{result => Result, from => test, is_cacheable => false}};
+gateway_authz_result(
+    _ClientInfo,
+    _Action,
+    _Topic,
+    DefaultResult,
+    _Protocol,
+    _ActionType,
+    _ExpectedTopic,
+    _Result
+) ->
+    {ok, DefaultResult}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%% test cases %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 login_first() ->
@@ -178,6 +252,67 @@ t_case01_login(_Config) ->
     ),
 
     ok = gen_tcp:close(Socket).
+
+t_authz_denies_login_upstream_publish(_Config) ->
+    Topic = <<"gbt32960/1G1BL52P7TR115520/upstream/vlogin">>,
+    ok = emqx:subscribe("gbt32960/+/upstream/#"),
+    try
+        with_gateway_authz_result(gbt32960, publish, Topic, deny, fun() ->
+            {ok, Socket} = login_first_without_broker_asserts(),
+            try
+                ?assertEqual({error, timeout}, receive_published_msg(500))
+            after
+                ok = gen_tcp:close(Socket)
+            end
+        end)
+    after
+        emqx:unsubscribe("gbt32960/+/upstream/#")
+    end.
+
+t_authz_allows_login_upstream_publish(_Config) ->
+    Topic = <<"gbt32960/1G1BL52P7TR115520/upstream/vlogin">>,
+    ok = emqx:subscribe("gbt32960/+/upstream/#"),
+    try
+        with_gateway_authz_result(gbt32960, publish, Topic, allow, fun() ->
+            {ok, Socket} = login_first_without_broker_asserts(),
+            try
+                {Topic, _PubedMsg} = get_published_msg()
+            after
+                ok = gen_tcp:close(Socket)
+            end
+        end)
+    after
+        emqx:unsubscribe("gbt32960/+/upstream/#")
+    end.
+
+t_authz_denies_auto_subscribe(_Config) ->
+    Topic = <<"gbt32960/1G1BL52P7TR115520/dnstream">>,
+    with_gateway_authz_result(gbt32960, subscribe, Topic, deny, fun() ->
+        {ok, Socket} = login_first_without_broker_asserts(),
+        try
+            ?assertEqual(false, lists:member(Topic, get_subscriptions())),
+            ok = publish_param_query_downlink(),
+            timer:sleep(200),
+            ?assertEqual({error, timeout}, gen_tcp:recv(Socket, 0, 500))
+        after
+            ok = gen_tcp:close(Socket)
+        end
+    end).
+
+t_authz_allows_auto_subscribe(_Config) ->
+    Topic = <<"gbt32960/1G1BL52P7TR115520/dnstream">>,
+    with_gateway_authz_result(gbt32960, subscribe, Topic, allow, fun() ->
+        {ok, Socket} = login_first_without_broker_asserts(),
+        try
+            ?assertEqual(true, lists:member(Topic, get_subscriptions())),
+            ok = publish_param_query_downlink(),
+            timer:sleep(200),
+            {ok, Packet} = gen_tcp:recv(Socket, 0, 500),
+            assert_param_query_downlink(Packet)
+        after
+            ok = gen_tcp:close(Socket)
+        end
+    end).
 
 t_case01_login_channel_info(_Config) ->
     % send VEHICLE LOGIN

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -9,6 +9,7 @@
 -include_lib("emqx/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
@@ -369,7 +370,7 @@ do_handle_in(
     }
 ) ->
     {MsgId, MsgSn} = msgidsn(Frame),
-    _ = do_publish(Topic, Frame),
+    _ = do_publish(Topic, Frame, Channel),
     case is_driver_id_req_exist(Channel) of
         % this is an device passive command
         false ->
@@ -389,7 +390,7 @@ do_handle_in(
     case IsUnknownMessage of
         %% Normal message, handle it
         false ->
-            _ = do_publish(Topic, Frame),
+            _ = do_publish(Topic, Frame, Channel),
             {MsgId, MsgSn} = msgidsn(Frame),
             case is_general_response_needed(MsgId) of
                 % these frames device passive request
@@ -401,16 +402,30 @@ do_handle_in(
                     dispatch_and_reply(Channel#channel{inflight = NewInflight})
             end;
         true ->
-            _ = do_publish(Topic, Frame),
+            _ = do_publish(Topic, Frame, Channel),
             {ok, Channel}
     end;
 do_handle_in(Frame, Channel) ->
     ?SLOG(error, #{msg => "ignore_unknown_frame", frame => Frame}),
     {ok, Channel}.
 
-do_publish(Topic, Frame) ->
-    ?SLOG(debug, #{msg => "publish_msg", to_topic => Topic, farme => Frame}),
-    emqx:publish(emqx_message:make(jt808, ?QOS_1, Topic, emqx_utils_json:encode(Frame))).
+do_publish(
+    Topic,
+    Frame,
+    #channel{
+        ctx = Ctx,
+        clientinfo = ClientInfo
+    }
+) ->
+    Action = ?AUTHZ_PUBLISH(?QOS_1, false),
+    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic) of
+        allow ->
+            ?SLOG(debug, #{msg => "publish_msg", to_topic => Topic, farme => Frame}),
+            emqx:publish(emqx_message:make(jt808, ?QOS_1, Topic, emqx_utils_json:encode(Frame)));
+        deny ->
+            ?SLOG(info, #{msg => "publish_msg_denied", to_topic => Topic}),
+            ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Handle Delivers from broker to client
@@ -1338,15 +1353,23 @@ autosubcribe(#channel{dn_topic = Topic}) when
 ->
     ok;
 autosubcribe(#channel{
+    ctx = Ctx,
     clientinfo =
         ClientInfo =
             #{clientid := ClientId},
     dn_topic = Topic
 }) ->
-    _ = emqx_broker:subscribe(Topic, ClientId, ?DN_TOPIC_SUBOPTS),
-    ok = emqx_hooks:run('session.subscribed', [
-        ClientInfo, Topic, ?DN_TOPIC_SUBOPTS#{is_new => true}
-    ]).
+    Action = ?AUTHZ_SUBSCRIBE(maps:get(qos, ?DN_TOPIC_SUBOPTS, 0)),
+    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic) of
+        allow ->
+            _ = emqx_broker:subscribe(Topic, ClientId, ?DN_TOPIC_SUBOPTS),
+            ok = emqx_hooks:run('session.subscribed', [
+                ClientInfo, Topic, ?DN_TOPIC_SUBOPTS#{is_new => true}
+            ]);
+        deny ->
+            ?SLOG(info, #{msg => "subscribe_denied", topic => Topic}),
+            ok
+    end.
 
 start_keepalive(Secs, _Channel) when Secs > 0 ->
     self() ! {keepalive, start, round(Secs) * 1000}.

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include("emqx_jt808.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_hooks.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
@@ -199,6 +200,13 @@ update_jt808_with_idle_timeout(IdleTimeout) ->
         Conf#{<<"idle_timeout">> => IdleTimeout}
     ).
 
+update_jt808_with_mountpoint(Mountpoint) ->
+    Conf = emqx:get_raw_config([gateway, jt808]),
+    emqx_gateway_conf:update_gateway(
+        jt808,
+        Conf#{<<"mountpoint">> => Mountpoint}
+    ).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% helper functions %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 gen_packet(Header, Body) ->
@@ -303,6 +311,9 @@ assert_register_result(Packet, ExpectedPhoneBCD, ExpectedResult) ->
     ok.
 
 client_auth_procedure(Socket, AuthCode) ->
+    client_auth_procedure(Socket, AuthCode, true).
+
+client_auth_procedure(Socket, AuthCode, AssertSubscribed) ->
     ?LOGT("start auth procedure", []),
     %
     % send AUTH
@@ -331,7 +342,12 @@ client_auth_procedure(Socket, AuthCode) ->
             PhoneBCD/binary, MsgSn2:?WORD>>,
     S2 = gen_packet(Header2, GenAckPacket),
     ?assertEqual(S2, Packet),
-    ?assert(lists:member(?JT808_DN_TOPIC, emqx:topics())),
+    case AssertSubscribed of
+        true ->
+            ?assert(lists:member(?JT808_DN_TOPIC, emqx:topics()));
+        false ->
+            ok
+    end,
 
     ?LOGT("============= auth procedure success ===============", []).
 
@@ -494,6 +510,90 @@ receive_msg() ->
     after 100 ->
         {error, timeout}
     end.
+
+get_subscriptions() ->
+    lists:map(fun({_, Topic}) -> Topic end, ets:tab2list(emqx_subscription)).
+
+connect_jt808() ->
+    connect_jt808(true).
+
+connect_jt808(AssertSubscribed) ->
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [
+        binary, {active, false}, {nodelay, true}
+    ]),
+    {ok, AuthCode} = client_regi_procedure(Socket),
+    ok = client_auth_procedure(Socket, AuthCode, AssertSubscribed),
+    {ok, Socket}.
+
+send_event_report(Socket, EventReportId, MsgSn) ->
+    PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
+    MsgBody = <<EventReportId>>,
+    MsgId = ?MC_EVENT_REPORT,
+    Size = size(MsgBody),
+    Header =
+        <<MsgId:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size), PhoneBCD/binary,
+            MsgSn:?WORD>>,
+    Packet = gen_packet(Header, MsgBody),
+    ok = gen_tcp:send(Socket, Packet),
+    {ok, AckPacket} = gen_tcp:recv(Socket, 0, 500),
+    GenAckPacket = <<MsgSn:?WORD, MsgId:?WORD, 0>>,
+    AckSize = size(GenAckPacket),
+    AckMsgId = ?MS_GENERAL_RESPONSE,
+    AckMsgSn = 2,
+    AckHeader =
+        <<AckMsgId:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(AckSize),
+            PhoneBCD/binary, AckMsgSn:?WORD>>,
+    ?assertEqual(gen_packet(AckHeader, GenAckPacket), AckPacket).
+
+publish_downlink_text() ->
+    PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
+    Flag = 15,
+    Text = <<"who are you">>,
+    DlCommand = #{
+        <<"header">> => #{<<"msg_id">> => ?MS_SEND_TEXT},
+        <<"body">> => #{<<"flag">> => Flag, <<"text">> => Text}
+    },
+    emqx:publish(emqx_message:make(?JT808_DN_TOPIC, emqx_utils_json:encode(DlCommand))),
+    MsgBody = <<Flag:8, Text/binary>>,
+    MsgId = ?MS_SEND_TEXT,
+    MsgSn = 2,
+    Size = size(MsgBody),
+    Header =
+        <<MsgId:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size), PhoneBCD/binary,
+            MsgSn:?WORD>>,
+    gen_packet(Header, MsgBody).
+
+with_gateway_authz_result(Protocol, ActionType, Topic, Result, Fun) ->
+    Action = {?MODULE, gateway_authz_result, [Protocol, ActionType, Topic, Result]},
+    ok = emqx_hooks:put('client.authorize', Action, ?HP_HIGHEST),
+    try
+        Fun()
+    after
+        ok = emqx_hooks:del('client.authorize', Action)
+    end.
+
+gateway_authz_result(
+    #{protocol := Protocol},
+    #{action_type := ActionType},
+    Topic,
+    _DefaultResult,
+    Protocol,
+    ActionType,
+    Topic,
+    Result
+) ->
+    {stop, #{result => Result, from => test, is_cacheable => false}};
+gateway_authz_result(
+    _ClientInfo,
+    _Action,
+    _Topic,
+    DefaultResult,
+    _Protocol,
+    _ActionType,
+    _ExpectedTopic,
+    _Result
+) ->
+    {ok, DefaultResult}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%% test cases %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -690,6 +790,114 @@ t_case04(_) ->
     ),
 
     ok = gen_tcp:close(Socket).
+
+t_authz_denies_upstream_publish(_) ->
+    ok = emqx:subscribe(?JT808_UP_TOPIC),
+    try
+        with_gateway_authz_result(jt808, publish, ?JT808_UP_TOPIC, deny, fun() ->
+            {ok, Socket} = connect_jt808(),
+            try
+                send_event_report(Socket, 98, 79),
+                timer:sleep(100),
+                ?assertEqual({error, timeout}, receive_msg())
+            after
+                ok = gen_tcp:close(Socket)
+            end
+        end)
+    after
+        emqx:unsubscribe(?JT808_UP_TOPIC)
+    end.
+
+t_authz_allows_upstream_publish(_) ->
+    ok = emqx:subscribe(?JT808_UP_TOPIC),
+    try
+        with_gateway_authz_result(jt808, publish, ?JT808_UP_TOPIC, allow, fun() ->
+            {ok, Socket} = connect_jt808(),
+            try
+                send_event_report(Socket, 98, 79),
+                timer:sleep(100),
+                {?JT808_UP_TOPIC, Payload} = receive_msg(),
+                ?assertEqual(
+                    98,
+                    emqx_utils_maps:deep_get(
+                        [<<"body">>, <<"id">>],
+                        emqx_utils_json:decode(Payload)
+                    )
+                )
+            after
+                ok = gen_tcp:close(Socket)
+            end
+        end)
+    after
+        emqx:unsubscribe(?JT808_UP_TOPIC)
+    end.
+
+t_authz_denies_auto_subscribe(_) ->
+    with_gateway_authz_result(jt808, subscribe, ?JT808_DN_TOPIC, deny, fun() ->
+        {ok, Socket} = connect_jt808(false),
+        try
+            timer:sleep(100),
+            ?assertEqual(false, lists:member(?JT808_DN_TOPIC, get_subscriptions())),
+            _Expected = publish_downlink_text(),
+            timer:sleep(100),
+            ?assertEqual({error, timeout}, gen_tcp:recv(Socket, 0, 500))
+        after
+            ok = gen_tcp:close(Socket)
+        end
+    end).
+
+t_authz_allows_auto_subscribe(_) ->
+    with_gateway_authz_result(jt808, subscribe, ?JT808_DN_TOPIC, allow, fun() ->
+        {ok, Socket} = connect_jt808(),
+        try
+            timer:sleep(100),
+            ?assertEqual(true, lists:member(?JT808_DN_TOPIC, get_subscriptions())),
+            Expected = publish_downlink_text(),
+            timer:sleep(100),
+            {ok, Packet} = gen_tcp:recv(Socket, 0, 500),
+            ?assertEqual(Expected, Packet)
+        after
+            ok = gen_tcp:close(Socket)
+        end
+    end).
+
+t_case04_mountpoint_from_register_clientinfo(_) ->
+    ClientId = <<"000123456789">>,
+    Mountpoint = <<"jt808/custom/000123456789/">>,
+    update_jt808_with_mountpoint(<<"jt808/custom/${clientid}/">>),
+    ok = emqx:subscribe(?JT808_UP_TOPIC),
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+    try
+        {ok, AuthCode} = client_regi_procedure(Socket),
+        ok = client_auth_procedure(Socket, AuthCode),
+        ?assertMatch(
+            #{clientinfo := #{mountpoint := Mountpoint}},
+            emqx_gateway_cm:get_chan_info(jt808, ClientId)
+        ),
+
+        PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
+        EventReportId = 98,
+        MsgBody3 = <<EventReportId>>,
+        MsgId3 = ?MC_EVENT_REPORT,
+        MsgSn3 = 79,
+        Size3 = size(MsgBody3),
+        Header3 =
+            <<MsgId3:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size3),
+                PhoneBCD/binary, MsgSn3:?WORD>>,
+        S3 = gen_packet(Header3, MsgBody3),
+
+        ok = gen_tcp:send(Socket, S3),
+        {ok, _Packet4} = gen_tcp:recv(Socket, 0, 500),
+        timer:sleep(100),
+        {?JT808_UP_TOPIC, Payload} = receive_msg(),
+        ?assertEqual(
+            EventReportId,
+            emqx_utils_maps:deep_get([<<"body">>, <<"id">>], emqx_utils_json:decode(Payload))
+        )
+    after
+        update_jt808_with_mountpoint(<<"jt808/${clientid}/">>),
+        gen_tcp:close(Socket)
+    end.
 
 t_case05(_Config) ->
     {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -1947,12 +1947,22 @@ ensure_disconnected(
 mabye_publish_will_msg(Channel = #channel{will_msg = undefined}) ->
     Channel;
 mabye_publish_will_msg(Channel = #channel{will_msg = WillMsg}) ->
-    ok = publish_will_msg(put_message_headers(WillMsg, Channel)),
+    ok = publish_will_msg(put_message_headers(WillMsg, Channel), Channel),
     Channel#channel{will_msg = undefined}.
 
-publish_will_msg(Msg) ->
-    _ = emqx_broker:publish(Msg),
-    ok.
+publish_will_msg(
+    Msg = #message{topic = Topic, qos = QoS, flags = Flags},
+    #channel{ctx = Ctx, clientinfo = ClientInfo}
+) ->
+    Action = ?AUTHZ_PUBLISH(QoS, maps:get(retain, Flags, false)),
+    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic) of
+        allow ->
+            _ = emqx_broker:publish(Msg),
+            ok;
+        deny ->
+            ?tp(info, mqttsn_will_publish_rejected, #{topic => Topic}),
+            ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Handle Delivers from broker to client

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -22,6 +22,7 @@
 
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx/include/emqx_hooks.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
@@ -1393,6 +1394,74 @@ t_will_case01(_) ->
     ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
 
     gen_udp:close(Socket).
+
+t_will_publish_denied_by_authz(_) ->
+    QoS = 1,
+    Duration = 1,
+    WillMsg = <<"will-authz-denied">>,
+    WillTopic = <<"will/authz/denied">>,
+    ClientId = ?CLIENTID,
+    ok = emqx_broker:subscribe(WillTopic),
+    try
+        with_gateway_authz_result('mqtt-sn', publish, WillTopic, deny, fun() ->
+            {ok, Socket} = gen_udp:open(0, [binary]),
+            try
+                send_connect_msg_with_will(Socket, Duration, ClientId),
+                ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+
+                send_willtopic_msg(Socket, WillTopic, QoS),
+                ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
+
+                send_willmsg_msg(Socket, WillMsg),
+                ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+
+                send_pingreq_msg(Socket, undefined),
+                ?assertEqual(<<2, ?SN_PINGRESP>>, receive_response(Socket)),
+
+                timer:sleep(3000),
+                ?assertNotReceive({deliver, WillTopic, #message{payload = WillMsg}}, 1000),
+                ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket))
+            after
+                gen_udp:close(Socket)
+            end
+        end)
+    after
+        ok = emqx_broker:unsubscribe(WillTopic)
+    end.
+
+t_will_publish_allowed_by_authz(_) ->
+    QoS = 1,
+    Duration = 1,
+    WillMsg = <<"will-authz-allowed">>,
+    WillTopic = <<"will/authz/allowed">>,
+    ClientId = ?CLIENTID,
+    ok = emqx_broker:subscribe(WillTopic),
+    try
+        with_gateway_authz_result('mqtt-sn', publish, WillTopic, allow, fun() ->
+            {ok, Socket} = gen_udp:open(0, [binary]),
+            try
+                send_connect_msg_with_will(Socket, Duration, ClientId),
+                ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+
+                send_willtopic_msg(Socket, WillTopic, QoS),
+                ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
+
+                send_willmsg_msg(Socket, WillMsg),
+                ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+
+                send_pingreq_msg(Socket, undefined),
+                ?assertEqual(<<2, ?SN_PINGRESP>>, receive_response(Socket)),
+
+                timer:sleep(3000),
+                ?assertReceive({deliver, WillTopic, #message{payload = WillMsg}}, 1000),
+                ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket))
+            after
+                gen_udp:close(Socket)
+            end
+        end)
+    after
+        ok = emqx_broker:unsubscribe(WillTopic)
+    end.
 
 t_will_test2(_) ->
     QoS = 2,
@@ -2957,6 +3026,38 @@ receive_response(Socket, Timeout) ->
     after Timeout ->
         udp_receive_timeout
     end.
+
+with_gateway_authz_result(Protocol, ActionType, Topic, Result, Fun) ->
+    Action = {?MODULE, gateway_authz_result, [Protocol, ActionType, Topic, Result]},
+    ok = emqx_hooks:put('client.authorize', Action, ?HP_HIGHEST),
+    try
+        Fun()
+    after
+        ok = emqx_hooks:del('client.authorize', Action)
+    end.
+
+gateway_authz_result(
+    #{protocol := Protocol},
+    #{action_type := ActionType},
+    Topic,
+    _DefaultResult,
+    Protocol,
+    ActionType,
+    Topic,
+    Result
+) ->
+    {stop, #{result => Result, from => test, is_cacheable => false}};
+gateway_authz_result(
+    _ClientInfo,
+    _Action,
+    _Topic,
+    DefaultResult,
+    _Protocol,
+    _ActionType,
+    _ExpectedTopic,
+    _Result
+) ->
+    {ok, DefaultResult}.
 
 check_dispatched_message(Dup, QoS, Retain, TopicIdType, TopicId, Payload, Socket) ->
     PubMsg = receive_response(Socket),

--- a/apps/emqx_gateway_ocpp/mix.exs
+++ b/apps/emqx_gateway_ocpp/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayOcpp.MixProject do
   def project do
     [
       app: :emqx_gateway_ocpp,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
@@ -9,6 +9,7 @@
 -include("emqx_ocpp.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 -include_lib("emqx/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
 
@@ -356,14 +357,16 @@ auth_connect(
 publish(
     Frame,
     Channel = #channel{
+        ctx = Ctx,
         clientinfo =
-            #{
-                clientid := ClientId,
-                username := Username,
-                protocol := Protocol,
-                peerhost := PeerHost,
-                mountpoint := Mountpoint
-            },
+            ClientInfo =
+                #{
+                    clientid := ClientId,
+                    username := Username,
+                    protocol := Protocol,
+                    peerhost := PeerHost,
+                    mountpoint := Mountpoint
+                },
         conninfo = #{proto_ver := ProtoVer}
     }
 ) when
@@ -372,21 +375,28 @@ publish(
     Topic0 = upstream_topic(Frame, Channel),
     Topic = emqx_mountpoint:mount(Mountpoint, Topic0),
     Payload = frame2payload(Frame),
-    emqx_broker:publish(
-        emqx_message:make(
-            ClientId,
-            ?QOS_2,
-            Topic,
-            Payload,
-            #{},
-            #{
-                protocol => Protocol,
-                proto_ver => ProtoVer,
-                username => Username,
-                peerhost => PeerHost
-            }
-        )
-    ).
+    Action = ?AUTHZ_PUBLISH(?QOS_2, false),
+    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic0) of
+        allow ->
+            emqx_broker:publish(
+                emqx_message:make(
+                    ClientId,
+                    ?QOS_2,
+                    Topic,
+                    Payload,
+                    #{},
+                    #{
+                        protocol => Protocol,
+                        proto_ver => ProtoVer,
+                        username => Username,
+                        peerhost => PeerHost
+                    }
+                )
+            );
+        deny ->
+            ?SLOG(info, #{msg => "publish_denied", topic => Topic0}),
+            ok
+    end.
 
 upstream_topic(
     Frame = #{id := Id, type := Type},
@@ -681,8 +691,8 @@ reset_timer(Name, Channel) ->
 clean_timer(Name, Channel = #channel{timers = Timers}) ->
     Channel#channel{timers = maps:remove(Name, Timers)}.
 
-interval(alive_timer, #channel{keepalive = KeepAlive}) ->
-    emqx_ocpp_keepalive:info(interval, KeepAlive).
+interval(alive_timer, #channel{keepalive = Keepalive}) ->
+    emqx_ocpp_keepalive:info(interval, Keepalive).
 
 %%--------------------------------------------------------------------
 %% Terminate
@@ -848,15 +858,29 @@ heartbeat_checking_times_backoff() ->
 %% Ensure Subscriptions
 
 ensure_subscribe_dn_topics(
-    Channel = #channel{clientinfo = #{clientid := ClientId, mountpoint := Mountpoint} = ClientInfo}
+    Channel = #channel{
+        ctx = Ctx,
+        clientinfo = #{clientid := ClientId, mountpoint := Mountpoint} = ClientInfo
+    }
 ) ->
     SubOpts = ?DEFAULT_OCPP_DN_SUBOPTS,
-    Topic = dntopic(ClientId, Mountpoint),
-    ok = emqx_broker:subscribe(Topic, ClientId, SubOpts),
-    ok = emqx_hooks:run('session.subscribed', [ClientInfo, Topic, SubOpts]),
-    Channel.
+    Topic0 = dntopic(ClientId),
+    Topic = emqx_mountpoint:mount(Mountpoint, Topic0),
+    Action = ?AUTHZ_SUBSCRIBE(maps:get(qos, SubOpts, 0)),
+    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic0) of
+        allow ->
+            ok = emqx_broker:subscribe(Topic, ClientId, SubOpts),
+            ok = emqx_hooks:run('session.subscribed', [ClientInfo, Topic, SubOpts]),
+            Channel;
+        deny ->
+            ?SLOG(info, #{msg => "subscribe_denied", topic => Topic0}),
+            Channel
+    end.
 
 dntopic(ClientId, Mountpoint) ->
+    emqx_mountpoint:mount(Mountpoint, dntopic(ClientId)).
+
+dntopic(ClientId) ->
     Topic0 = proc_tmpl(
         emqx_ocpp_conf:dntopic(),
         #{
@@ -864,7 +888,7 @@ dntopic(ClientId, Mountpoint) ->
             cid => ClientId
         }
     ),
-    emqx_mountpoint:mount(Mountpoint, Topic0).
+    Topic0.
 
 %%--------------------------------------------------------------------
 %% Helper functions

--- a/apps/emqx_gateway_ocpp/test/emqx_ocpp_SUITE.erl
+++ b/apps/emqx_gateway_ocpp/test/emqx_ocpp_SUITE.erl
@@ -5,6 +5,8 @@
 -module(emqx_ocpp_SUITE).
 
 -include("emqx_ocpp.hrl").
+-include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_hooks.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/asserts.hrl").
@@ -86,6 +88,104 @@ update_ocpp_with_idle_timeout(IdleTimeout) ->
         ocpp,
         Conf#{<<"idle_timeout">> => IdleTimeout}
     ).
+
+boot_notification(UniqueId) ->
+    #{
+        id => UniqueId,
+        type => ?OCPP_MSG_TYPE_ID_CALL,
+        action => <<"BootNotification">>,
+        payload => #{
+            <<"chargePointVendor">> => <<"vendor1">>,
+            <<"chargePointModel">> => <<"model1">>
+        }
+    }.
+
+ack_payload(UniqueId) ->
+    emqx_utils_json:encode(#{
+        <<"MessageTypeId">> => ?OCPP_MSG_TYPE_ID_CALLRESULT,
+        <<"UniqueId">> => UniqueId,
+        <<"Payload">> => #{
+            <<"currentTime">> => "2026-06-11T00:00:00+00:00",
+            <<"interval">> => 300,
+            <<"status">> => <<"Accepted">>
+        }
+    }).
+
+receive_broker_message(Topic, Timeout) ->
+    receive
+        {deliver, Topic, #message{payload = Payload}} ->
+            {ok, emqx_utils_json:decode(Payload)}
+    after Timeout ->
+        {error, timeout}
+    end.
+
+get_subscriptions() ->
+    lists:map(fun({_, Topic}) -> Topic end, ets:tab2list(emqx_subscription)).
+
+with_gateway_authz_result(Protocol, ActionType, Topic, Result, Fun) ->
+    Action = {?MODULE, gateway_authz_result, [Protocol, ActionType, Topic, Result]},
+    ok = emqx_hooks:put('client.authorize', Action, ?HP_HIGHEST),
+    try
+        Fun()
+    after
+        ok = emqx_hooks:del('client.authorize', Action)
+    end.
+
+gateway_authz_result(
+    #{protocol := Protocol},
+    #{action_type := ActionType},
+    Topic,
+    _DefaultResult,
+    Protocol,
+    ActionType,
+    Topic,
+    Result
+) ->
+    {stop, #{result => Result, from => test, is_cacheable => false}};
+gateway_authz_result(
+    _ClientInfo,
+    _Action,
+    _Topic,
+    DefaultResult,
+    _Protocol,
+    _ActionType,
+    _ExpectedTopic,
+    _Result
+) ->
+    {ok, DefaultResult}.
+
+create_authenticator() ->
+    AuthnConfig = #{
+        <<"mechanism">> => <<"password_based">>,
+        <<"backend">> => <<"built_in_database">>,
+        <<"user_id_type">> => <<"username">>,
+        <<"password_hash_algorithm">> => #{
+            <<"name">> => <<"plain">>,
+            <<"salt_position">> => <<"suffix">>
+        }
+    },
+    {ok, _} = emqx_gateway_conf:add_authn(<<"ocpp">>, AuthnConfig),
+    ok.
+
+delete_authenticators() ->
+    _ = emqx_gateway_conf:remove_authn(<<"ocpp">>),
+    emqx_authn_test_lib:delete_authenticators([gateway, ocpp, authentication], 'ocpp:global').
+
+add_authenticator_user(UserId, Password) ->
+    {ok, _} = emqx_authn_chains:add_user(
+        'ocpp:global',
+        <<"password_based:built_in_database">>,
+        #{user_id => UserId, password => Password}
+    ),
+    ok.
+
+set_ocpp_listener_enable_authn(EnableAuthn) ->
+    RawCfg = emqx_conf:get_raw([gateway, ocpp], #{}),
+    ListenerCfg = emqx_utils_maps:deep_get([<<"listeners">>, <<"ws">>, <<"default">>], RawCfg),
+    {ok, _} = emqx_gateway_conf:update_listener(ocpp, {ws, default}, ListenerCfg#{
+        <<"enable_authn">> => EnableAuthn
+    }),
+    ok.
 
 %%--------------------------------------------------------------------
 %% cases
@@ -223,6 +323,92 @@ t_auth_expire(_Config) ->
     ),
 
     meck:unload(emqx_access_control).
+
+t_authz_denies_upstream_publish(_Config) ->
+    ClientId = <<"authz-up-denied">>,
+    AuthzTopic = <<"cp/", ClientId/binary>>,
+    BrokerTopic = <<"ocpp/", AuthzTopic/binary>>,
+    ok = emqx:subscribe(BrokerTopic),
+    try
+        with_gateway_authz_result(ocpp, publish, AuthzTopic, deny, fun() ->
+            {ok, Client} = connect("127.0.0.1", 33033, ClientId),
+            try
+                ok = send_msg(Client, boot_notification(<<"authz-up-denied-id">>)),
+                ?assertEqual({error, timeout}, receive_broker_message(BrokerTopic, 500))
+            after
+                close(Client)
+            end
+        end)
+    after
+        emqx:unsubscribe(BrokerTopic)
+    end.
+
+t_authz_allows_upstream_publish(_Config) ->
+    ClientId = <<"authz-up-allowed">>,
+    UniqueId = <<"authz-up-allowed-id">>,
+    AuthzTopic = <<"cp/", ClientId/binary>>,
+    BrokerTopic = <<"ocpp/", AuthzTopic/binary>>,
+    ok = emqx:subscribe(BrokerTopic),
+    try
+        with_gateway_authz_result(ocpp, publish, AuthzTopic, allow, fun() ->
+            {ok, Client} = connect("127.0.0.1", 33033, ClientId),
+            try
+                ok = send_msg(Client, boot_notification(UniqueId)),
+                ?assertMatch(
+                    {ok, #{
+                        <<"MessageTypeId">> := ?OCPP_MSG_TYPE_ID_CALL,
+                        <<"UniqueId">> := UniqueId,
+                        <<"Action">> := <<"BootNotification">>
+                    }},
+                    receive_broker_message(BrokerTopic, 1000)
+                )
+            after
+                close(Client)
+            end
+        end)
+    after
+        emqx:unsubscribe(BrokerTopic)
+    end.
+
+t_authz_denies_auto_subscribe(_Config) ->
+    ClientId = <<"authz-dn-denied">>,
+    UniqueId = <<"authz-dn-denied-id">>,
+    AuthzTopic = <<"cs/", ClientId/binary>>,
+    BrokerTopic = <<"ocpp/", AuthzTopic/binary>>,
+    with_gateway_authz_result(ocpp, subscribe, AuthzTopic, deny, fun() ->
+        {ok, Client} = connect("127.0.0.1", 33033, ClientId),
+        try
+            timer:sleep(100),
+            ?assertEqual(false, lists:member(BrokerTopic, get_subscriptions())),
+            _ = emqx:publish(emqx_message:make(BrokerTopic, ack_payload(UniqueId))),
+            ?assertMatch({error, {timeout, _}}, receive_msg(Client))
+        after
+            close(Client)
+        end
+    end).
+
+t_authz_allows_auto_subscribe(_Config) ->
+    ClientId = <<"authz-dn-allowed">>,
+    UniqueId = <<"authz-dn-allowed-id">>,
+    AuthzTopic = <<"cs/", ClientId/binary>>,
+    BrokerTopic = <<"ocpp/", AuthzTopic/binary>>,
+    with_gateway_authz_result(ocpp, subscribe, AuthzTopic, allow, fun() ->
+        {ok, Client} = connect("127.0.0.1", 33033, ClientId),
+        try
+            timer:sleep(100),
+            ?assertEqual(true, lists:member(BrokerTopic, get_subscriptions())),
+            _ = emqx:publish(emqx_message:make(BrokerTopic, ack_payload(UniqueId))),
+            ?assertMatch(
+                {ok, #{
+                    type := ?OCPP_MSG_TYPE_ID_CALLRESULT,
+                    id := UniqueId
+                }},
+                receive_msg(Client)
+            )
+        after
+            close(Client)
+        end
+    end).
 
 t_update_not_restart_listener(_Config) ->
     {ok, Client} = connect("127.0.0.1", 33033, <<"client1">>),

--- a/changes/ee/fix-17765.en.md
+++ b/changes/ee/fix-17765.en.md
@@ -1,0 +1,3 @@
+Fixed missing authorization checks in several gateway broker paths.
+
+MQTT-SN will message publishing, JT808 upstream publishing and automatic downlink subscription, GBT32960 upstream publishing and automatic downlink subscription, and OCPP upstream publishing and automatic downlink subscription now check authorization before publishing or subscribing.


### PR DESCRIPTION
Release version:
6.0.4

## Summary

Fixes:
- https://github.com/emqx/emqx-dev-team-tasks/issues/110
- https://github.com/emqx/emqx-dev-team-tasks/issues/114
- https://github.com/emqx/emqx-dev-team-tasks/issues/115
- https://github.com/emqx/emqx-dev-team-tasks/issues/123

Port of https://github.com/emqx/emqx/pull/17528 to dev-60.

This PR closes gateway paths that could publish or subscribe through the broker after authentication without checking authorization:

- MQTT-SN will messages now call gateway authorization before publishing on unexpected disconnect.
- JT808 upstream publish and automatic downlink subscription now call gateway authorization before touching the broker.
- GBT32960 upstream publish and automatic downlink subscription now call gateway authorization before touching the broker or updating subscription state.
- OCPP upstream publish and automatic downlink subscription now call gateway authorization before touching the broker.

The JT808 and OCPP authz regression tests keep the same case/helper names and surrounding layout as the higher-version branches, so later sync into dev-62/dev-63 should merge the tests instead of creating duplicate definitions. Only branch-specific app version lines are expected to need sync resolution.

Changelog: `changes/ee/fix-17765.en.md`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)