### PR TITLE
feat(node): support sourcing node.cookie from a file via file://

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -566,7 +566,13 @@ fields("node") ->
             sc(
                 string(),
                 #{
-                    mapping => "vm_args.-setcookie",
+                    %% NOTE: intentionally NOT mapped to "vm_args.-setcookie".
+                    %% The cookie is passed to the Erlang VM via the `-setcookie`
+                    %% command-line flag from `bin/emqx` instead, so the resolved
+                    %% secret is never written to the generated vm.<time>.args file
+                    %% on disk. This also lets `bin/emqx` resolve `file://` sources
+                    %% (which the VM/HOCON layer cannot do, as the cookie is needed
+                    %% before the VM starts).
                     required => true,
                     'readOnly' => true,
                     sensitive => true,

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -53,6 +53,18 @@ array_nodes_test() ->
     ),
     ok.
 
+%% The node cookie must NOT be emitted into the generated vm.args. It is passed
+%% to the Erlang VM via the `-setcookie` command-line flag from `bin/emqx`
+%% instead, so the secret is never persisted to the vm.<time>.args file on disk.
+cookie_not_in_vm_args_test() ->
+    ensure_acl_conf(),
+    ConfFile = to_bin(?BASE_CONF, [["emqx1@127.0.0.1"]]),
+    {ok, Conf} = hocon:binary(ConfFile, #{format => richmap}),
+    ConfList = hocon_tconf:generate(emqx_conf_schema, Conf),
+    VMArgs = proplists:get_value(vm_args, ConfList),
+    ?assertEqual(undefined, proplists:get_value('-setcookie', VMArgs)),
+    ok.
+
 %% erlfmt-ignore
 -define(OUTDATED_LOG_CONF,
     "

--- a/bin/emqx
+++ b/bin/emqx
@@ -871,13 +871,70 @@ export ESCRIPT_NAME="$SHORT_NAME"
 
 PIPE_DIR="${PIPE_DIR:-/$DATA_DIR/${WHOAMI}_erl_pipes/$NAME/}"
 
+# Resolve a 'file://<path>' cookie source to the secret stored in the file.
+# The file may be a regular file or a FIFO (named pipe). A FIFO can be drained
+# only once per writer, so this MUST only be called during boot (see below).
+resolve_cookie_source() {
+    local raw="$1"
+    case "$raw" in
+        "file://"*)
+            local path="${raw#file://}"
+            if [ ! -e "$path" ] && [ ! -p "$path" ]; then
+                die "node.cookie file '$path' does not exist"
+            fi
+            local val
+            # 'cat' reads both regular files and FIFOs; command substitution
+            # strips any trailing newline (e.g. from 'echo secret > file').
+            val="$(cat "$path")"
+            if [ -z "$val" ]; then
+                die "node.cookie file '$path' is empty"
+            fi
+            # Re-validate the resolved value so we fail with a clear message
+            # instead of letting 'erl -setcookie' choke on a weird character.
+            case "$val" in
+                *[\\\'\"\ ]*)
+                    die "resolved node.cookie contains a disallowed character (backslash, single/double quote, or space)"
+                    ;;
+            esac
+            printf '%s' "$val"
+            ;;
+        *)
+            printf '%s' "$raw"
+            ;;
+    esac
+}
+
 COOKIE="${EMQX_NODE__COOKIE:-}"
 COOKIE_IN_USE="$(get_boot_config 'node.cookie')"
+# Tracks whether the cookie was sourced from a 'file://' URL (see below).
+COOKIE_FROM_FILE='no'
+# Resolve 'file://' cookie sources only during boot. The resolution reads the
+# referenced file (possibly a write-once FIFO) and must happen before
+# 'erl -setcookie'. Maintenance commands (ctl/remote_console/stop/...) pick up
+# the already-resolved cookie from the running node's 'ps' output, so they must
+# NOT re-read the file (a FIFO would block forever waiting for a writer).
+if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
+    case "$COOKIE" in "file://"*) COOKIE_FROM_FILE='yes' ;; esac
+    COOKIE="$(resolve_cookie_source "$COOKIE")"
+    if [ -z "$COOKIE" ]; then
+        ## Resolve the configured cookie only when there is no env override, so a
+        ## 'file://' source is read at most once per boot.
+        case "$COOKIE_IN_USE" in "file://"*) COOKIE_FROM_FILE='yes' ;; esac
+        COOKIE_IN_USE="$(resolve_cookie_source "$COOKIE_IN_USE")"
+    fi
+fi
 if [ "$IS_BOOT_COMMAND" != 'yes' ] && [ -n "$COOKIE_IN_USE" ] && [ -n "$COOKIE" ] && [ "$COOKIE" != "$COOKIE_IN_USE" ]; then
     die "EMQX_NODE__COOKIE is different from the cookie used by $NAME"
 fi
 [ -z "$COOKIE" ] && COOKIE="$COOKIE_IN_USE"
 [ -z "$COOKIE" ] && COOKIE="$EMQX_DEFAULT_ERLANG_COOKIE"
+# When the cookie came from a 'file://' URL, re-export the resolved value. The
+# 'start' command re-execs 'bin/emqx console' via run_erl; the child inherits
+# this and skips file resolution, so a write-once FIFO is read exactly once per
+# boot instead of blocking the child forever.
+if [ "$COOKIE_FROM_FILE" = 'yes' ]; then
+    export EMQX_NODE__COOKIE="$COOKIE"
+fi
 
 # Frequently used sample cookie value for testing, not recommended for production use
 EMQX_SAMPLE_ERLANG_COOKIE="emqxsecretcookie"
@@ -1148,6 +1205,7 @@ case "${COMMAND}" in
                 -mode "$CODE_LOADING_MODE" \
                 -config "$CONF_FILE" \
                 -args_file "$ARGS_FILE" \
+                -setcookie "$COOKIE" \
                 $INIT_DEBUG_ARG \
                 $EPMD_ARGS
         else
@@ -1162,6 +1220,7 @@ case "${COMMAND}" in
                 --boot-var RELEASE_LIB "${ERTS_LIB_DIR}" \
                 --erl-config "${CONF_FILE}" \
                 --vm-args "${ARGS_FILE}" \
+                --cookie "$COOKIE" \
                 --erl "$FOREGROUNDOPTIONS" \
                 --erl "-mode $CODE_LOADING_MODE" \
                 --erl "$EPMD_ARGS" \

--- a/changes/ee/feat-17768.en.md
+++ b/changes/ee/feat-17768.en.md
@@ -1,0 +1,14 @@
+Added support for sourcing `node.cookie` from a file using the `file://` URL form.
+
+Operators can now set `node.cookie = "file:///path/to/cookie"` (or point the
+`EMQX_NODE__COOKIE` environment variable at a `file://` URL) so the cluster
+secret is not stored as plain text in the configuration. The referenced path may
+be a regular file or a FIFO (named pipe); it is read once when the node boots.
+When a FIFO is used, the orchestrator must write the cookie to it on each boot,
+before any other `emqx` command is invoked (such as `emqx ctl`), because later
+commands obtain the cookie from the already-running node rather than re-reading
+the file.
+
+The resolved cookie is now passed to the Erlang VM directly and is no longer
+written to the generated `data/configs/vm.*.args` file, so the secret is not
+persisted to disk during boot.

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -358,7 +358,14 @@ log_rotation_count.label:
 node_cookie.desc:
 """Secret cookie is a random string that should be the same on all nodes in
 the given EMQX cluster, but unique per EMQX cluster. It is used to prevent EMQX nodes that
-belong to different clusters from accidentally connecting to each other."""
+belong to different clusters from accidentally connecting to each other.<br/>
+The cookie can also be sourced from a file using the <code>file://path/to/file</code>
+form (e.g. <code>file:///run/emqx/cookie</code>), so the secret does not have to be
+stored as plain text in the config file. The referenced path may be a regular file or a
+FIFO (named pipe); it is read only once, when the node boots. When a FIFO is used, the
+orchestrator must write the cookie to it on each boot, before any other
+<code>emqx</code> command (such as <code>emqx ctl</code>) is invoked, because later
+commands obtain the cookie from the running node instead of re-reading the file."""
 
 node_cookie.label:
 """Node Cookie"""

--- a/scripts/test/test_emqx_boot.py
+++ b/scripts/test/test_emqx_boot.py
@@ -137,6 +137,114 @@ def test_hardened_rejects_insecure_cookie(emqx_bin_path):
         assert "EMQX_SECURITY_PROFILE" in output
 
 
+def test_node_cookie_from_file(emqx_bin_path, tmp_path):
+    """Test that node.cookie can be sourced from a file via the file:// form."""
+    cookie_file = tmp_path / "cookie"
+    # trailing newline is expected from `echo secret > file` and must be stripped
+    cookie_file.write_text("mysecretcookie123\n")
+    with open_emqx_console(
+            emqx_bin_path,
+            {
+                "EMQX_LOG__CONSOLE__FORMATTER": "json",
+                "EMQX_NODE__COOKIE": f"file://{cookie_file}",
+            },
+            stdout=subprocess.PIPE,
+            text=True,
+    ) as emqx:
+        try:
+            # the node boots, which means erl -setcookie got the resolved value
+            outputs = wait_until_stdout(emqx, "feature_gates_resolved", 15)
+            assert outputs
+        finally:
+            emqx.kill()
+
+
+def test_node_cookie_from_missing_file_fails_fast(emqx_bin_path, tmp_path):
+    """Test that a missing node.cookie file fails before boot with a clear error."""
+    result = run_emqx_console(
+        emqx_bin_path,
+        {"EMQX_NODE__COOKIE": f"file://{tmp_path}/does-not-exist"},
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "does not exist" in output
+
+
+def test_node_cookie_from_empty_file_fails_fast(emqx_bin_path, tmp_path):
+    """Test that an empty node.cookie file fails before boot with a clear error."""
+    cookie_file = tmp_path / "empty-cookie"
+    cookie_file.write_text("")
+    result = run_emqx_console(
+        emqx_bin_path,
+        {"EMQX_NODE__COOKIE": f"file://{cookie_file}"},
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "is empty" in output
+
+
+def test_node_cookie_from_fifo_read_once(emqx_bin_path, tmp_path):
+    """Test that node.cookie can be sourced from a write-once FIFO.
+
+    The `start` command re-execs `console` via run_erl; the cookie FIFO must be
+    drained exactly once across that re-exec, otherwise the second read would
+    block forever (no writer) and the node would never come up.
+    """
+    fifo = tmp_path / "cookie.fifo"
+    os.mkfifo(fifo)
+    cookie = "fifocookie12345"
+
+    # A single writer-open: the orchestrator writes the cookie to the FIFO once.
+    # If bin/emqx tried to read it twice, this writer would already be gone and
+    # boot would hang.
+    writer = subprocess.Popen(
+        ["sh", "-c", 'printf "%s\\n" "$0" > "$1"', cookie, str(fifo)]
+    )
+
+    boot_env = os.environ.copy()
+    boot_env["EMQX_NODE__COOKIE"] = f"file://{fifo}"
+    boot_env["EMQX_WAIT_FOR_START"] = "60"
+
+    # Maintenance commands run without the file:// override; they obtain the
+    # cookie from the running node's `ps` output.
+    plain_env = os.environ.copy()
+    plain_env.pop("EMQX_NODE__COOKIE", None)
+
+    try:
+        start = subprocess.run(
+            [str(emqx_bin_path), "start"],
+            env=boot_env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert start.returncode == 0, (
+            f"start failed: {start.stdout + start.stderr}"
+        )
+        got = subprocess.run(
+            [str(emqx_bin_path), "eval", "erlang:get_cookie()."],
+            env=plain_env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert cookie in got.stdout, (
+            f"node cookie mismatch: {got.stdout + got.stderr}"
+        )
+    finally:
+        subprocess.run(
+            [str(emqx_bin_path), "stop"],
+            env=plain_env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        try:
+            writer.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            writer.kill()
+
+
 @pytest.mark.parametrize("security_profile", ["not-a-profile", "HARDENED"])
 def test_invalid_security_profile_fails_fast(emqx_bin_path, security_profile):
     """Test that malformed EMQX_SECURITY_PROFILE fails before boot."""


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Resolves #17723. Adds support for sourcing `node.cookie` from a file using the `file://` URL form, mirroring the existing `ssl_options.password = "file://..."` support (#17523).

### `file://` resolution (`bin/emqx`)

`node.cookie` and the `EMQX_NODE__COOKIE` environment override now accept `file:///path/to/cookie`. The path may be a regular file or a FIFO (named pipe). Resolution happens in `bin/emqx` (new `resolve_cookie_source`), because the cookie is consumed before the Erlang VM starts (passed as `-setcookie`), so the existing in-process `emqx_schema_secret` machinery cannot apply.

Resolution runs only during boot. To keep a write-once FIFO read exactly once per boot — even across the `start` → `console` re-exec via `run_erl` — the configured cookie is resolved only when no env override is present, and the resolved value is re-exported so the re-exec'd child does not read the file again.

### Cookie no longer written to `vm.<time>.args`

The `node.cookie` schema field is no longer mapped to `vm_args.-setcookie`. The resolved cookie is instead passed to the VM via the `-setcookie` (Erlang) / `--cookie` (Elixir) command-line flag from `bin/emqx`. This removes an on-disk plain-text copy of the secret from the generated `data/configs/vm.*.args` file.

This is also required for correctness: `emqx_schema:password_converter` does not resolve `file://`, so keeping the mapping would have written the literal `file://...` string into `vm.args` and booted the node with the wrong cookie. There is no new process-table exposure — the args-file contents were already expanded into the `beam` argv (which is what the existing `ps`-based cookie discovery relies on).

### Most relevant changes

- `bin/emqx` — `resolve_cookie_source`, boot-only resolution with single-read guarantee, `-setcookie`/`--cookie` on the VM start command.
- `apps/emqx_conf/src/emqx_conf_schema.erl` — drop `vm_args.-setcookie` mapping from `node.cookie`.
- `rel/i18n/emqx_conf_schema.hocon` — document the `file://` form and the FIFO once-per-boot caveat.
- Tests: `apps/emqx_conf/test/emqx_conf_schema_tests.erl` (cookie absent from generated vm_args), `scripts/test/test_emqx_boot.py` (regular file, missing/empty file, write-once FIFO daemon boot).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)