### PR TITLE
fix(ocpp): respect listener authn option

### DIFF
--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
@@ -225,7 +225,7 @@ init(
             username => undefined,
             is_bridge => false,
             is_superuser => false,
-            enalbe_authn => EnableAuthn,
+            enable_authn => EnableAuthn,
             mountpoint => Mountpoint
         }
     ),

--- a/changes/ee/fix-17556.en.md
+++ b/changes/ee/fix-17556.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the OCPP gateway did not pass the listener `enable_authn` option to the shared authentication flow because the option was stored under a misspelled client-info key.

--- a/elvis.config
+++ b/elvis.config
@@ -36,6 +36,9 @@
                             ]
                         }},
                         {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+                        {elvis_style, consistent_variable_casing, #{
+                            ignore => [emqx_ocpp_channel]
+                        }},
                         {elvis_style, god_modules, #{limit => 100}},
                         % trust erlfmt
                         {elvis_text_style, line_length, #{


### PR DESCRIPTION
Release version:
6.0.4

## Summary

Fixes emqx/emqx-dev-team-tasks#134.

This ports #17556 to `dev-60`.

The OCPP channel already read the listener `enable_authn` option during initialization, but stored it in `clientinfo` under the misspelled `enalbe_authn` key. The shared authentication flow checks `enable_authn`, so the listener option was not visible to that path.

The port keeps the production change deliberately narrow: the OCPP fix plus the same `changes/ee/fix-17556.en.md` entry from the already merged `release-62` PR. I did not replay the `release-62` CT file change here because it already exists in `release-62`; keeping it out of this `dev-60` port avoids a conflict when `dev-60` is synced upward to `dev-61`/`dev-62`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
