### PR TITLE
fix(emqx_conf): normalize cluster_rpc abort reasons to {error, _}

### DIFF
--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -517,8 +517,19 @@ do_initiate(MFA, State = #{node := Node}, Count, Failure0) ->
             catch_up(State),
             do_initiate(MFA, State, Count + 1, Failure1);
         {aborted, Error} ->
-            {reply, {init_failure, Error}, State, {continue, ?CATCH_UP}}
+            {reply, {init_failure, wrap_abort(Error)}, State, {continue, ?CATCH_UP}}
     end.
+
+%% A transaction abort reason is either an already-structured `{error, _}'
+%% from a failed MFA (`init_mfa/2' calls `mnesia:abort/1' with the MFA's
+%% `{error, _}' result) or a raw mnesia abort reason such as
+%% `{no_exists, cluster_rpc_mfa}' when the cluster_rpc tables are not yet
+%% available (cold start / recovery window). Normalize the latter so that
+%% `multicall/3' always returns an `{error, _}' shape on failure, keeping
+%% callers' `{ok, _} | {error, _}' contract intact; never double-wrap an
+%% existing `{error, _}'.
+wrap_abort({error, _} = Error) -> Error;
+wrap_abort(Reason) -> {error, Reason}.
 
 stale_view_of_cluster_msg(Meta, Count) ->
     Node = find_leader(),

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.4.8"},
+    {vsn, "0.4.9"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
@@ -116,7 +116,9 @@ t_base_test(_Config) ->
 t_commit_fail_test(_Config) ->
     {atomic, []} = emqx_cluster_rpc:status(),
     {M, F, A} = {?MODULE, failed_on_node, [erlang:whereis(?NODE2)]},
-    {init_failure, "MFA return not ok"} = multicall(M, F, A),
+    %% A non-ok MFA result is normalized to an `{error, _}' shape so that
+    %% multicall/3 callers always observe `{ok, _} | {error, _}' on failure.
+    {init_failure, {error, "MFA return not ok"}} = multicall(M, F, A),
     ?assertEqual({atomic, []}, emqx_cluster_rpc:status()),
     ok.
 

--- a/apps/emqx_gateway/test/emqx_gateway_metrics_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_metrics_SUITE.erl
@@ -42,13 +42,29 @@ end_per_suite(_Conf) ->
     emqx_common_test_helpers:stop_apps([]).
 
 init_per_testcase(_TestCase, Conf) ->
+    %% A previous gateway suite in the same CT run can leave the mqttsn
+    %% gateway metrics ETS table populated with real broker stats
+    %% (bytes.received, client.connect, etc.). emqx_gateway_metrics:start_link/1
+    %% is idempotent on the table -- it does not clear stale rows. Wipe the
+    %% table here so each test sees a clean slate.
+    clear_metrics_tab(),
     {ok, Pid} = emqx_gateway_metrics:start_link(?GWNAME),
     [{metrics, Pid} | Conf].
 
 end_per_testcase(_TestCase, Conf) ->
     Pid = proplists:get_value(metrics, Conf),
     gen_server:stop(Pid),
+    %% Symmetric cleanup -- don't let our test data leak into a subsequent
+    %% suite the same way the cascade just leaked into us.
+    clear_metrics_tab(),
     Conf.
+
+clear_metrics_tab() ->
+    Tab = emqx_gateway_metrics:tabname(?GWNAME),
+    case ets:info(Tab, name) of
+        undefined -> ok;
+        _ -> true = ets:delete_all_objects(Tab)
+    end.
 
 %%--------------------------------------------------------------------
 %% cases

--- a/changes/ee/fix-17770.en.md
+++ b/changes/ee/fix-17770.en.md
@@ -1,0 +1,1 @@
+Fixed configuration update commands (REST API and CLI) crashing with a `function_clause` crash report when the underlying cluster RPC layer aborted with an unexpected reason, for example `{no_exists, cluster_rpc_mfa}` when the cluster RPC tables were not yet available during node startup or recovery. Such failures are now returned to the caller as a structured error instead.


### PR DESCRIPTION
Release version: 5.8.11

## Summary

Two changes.

### Fix — `emqx_cluster_rpc` failure contract (`emqx_conf`)

`emqx_cluster_rpc:multicall/3` is documented to return `{ok, _}` on
success and `{error, _}` on failure, and `emqx_conf:update/3` (plus the
`emqx_resource`, `emqx_mgmt_api_plugins` and `emqx_rule_engine` config
protos) is typed `{ok, _} | {error, _}` on that basis. But the
`init_failure` path in `do_initiate/4` returned the raw mnesia abort
reason unwrapped — e.g. `{no_exists, cluster_rpc_mfa}` when the
cluster_rpc tables are not yet available during cold start or recovery.

That bare tuple then escaped all the way to callers, where it crashed
the request handler with a `function_clause` instead of a structured
error (observed via `emqx_gateway_conf:res/1` in a gateway config
teardown).

The fix normalizes the transaction-abort path through `wrap_abort/1`:
a bare reason becomes `{error, Reason}`, while an already-structured
`{error, _}` (a failed MFA result) is left untouched so it is never
double-wrapped. This restores the documented `{ok, _} | {error, _}`
contract for every `multicall/3` caller. `t_commit_fail_test` is updated
to expect the normalized shape.

This is preferred over catching the bad shape in `emqx_gateway_conf:res/1`:
that callee already declares `{ok, _} | {error, _}`, so a downstream
catch-all would be dialyzer-unreachable. Fixing it at the source keeps
the type contract honest for all callers.

### Test isolation — `emqx_gateway_metrics_SUITE`

The suite shares the broker-wide named ETS table
`emqx_gateway_mqttsn_metrics` with the running mqttsn gateway.
`emqx_gateway_metrics:start_link/1` does not clear it
(`emqx_utils_ets:new/2` is idempotent), so real broker stats leaked from
a prior gateway suite in the same CT run made `t_inc_dec` fail with
`got: [{bytes.received,63},...]`. `init_per_testcase`/`end_per_testcase`
now wipe the table so each case starts and leaves a clean slate.

## Validation

- `make dialyzer`: no new warnings from the changed modules (the 7
  warnings reported are pre-existing baseline noise about missing
  `ehttpc`/`ecpool`/`rocketmq_client` functions, unrelated to this PR).
- `emqx_cluster_rpc_SUITE`: 9/9 pass.
- `emqx_conf_cluster_sync_SUITE`: pass.
- `emqx_gateway_metrics_SUITE`: passes in the cascade ordering;
  reproduced the original failure by injecting simulated leftover stats
  and confirmed the clear fixes it.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)