### PR TITLE
test(broker_mon): retry initial assertions in t_mnesia_tm_overload

### DIFF
--- a/apps/emqx/test/emqx_broker_mon_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_mon_SUITE.erl
@@ -73,8 +73,13 @@ send_messages(Pid, N) ->
 %%------------------------------------------------------------------------------
 
 t_mnesia_tm_overload(_Config) ->
-    ?assertEqual(0, emqx_broker_mon:get_mnesia_tm_mailbox_size()),
-    ?assertEqual([], emqx_alarm:get_alarms()),
+    %% Wait for mnesia_tm to drain whatever the previous test case or
+    %% init_per_testcase (which runs the `emqx_alarm:delete_all_deactivated_alarms/0'
+    %% mnesia transaction) left behind. The cached mailbox-size atomic is updated
+    %% by a 100ms-interval sampler, so the most recent snapshot can still
+    %% reflect that activity at the moment we enter the test body.
+    ?retry(100, 10, ?assertEqual(0, emqx_broker_mon:get_mnesia_tm_mailbox_size())),
+    ?retry(100, 10, ?assertEqual([], emqx_alarm:get_alarms())),
     on_exit(fun() -> sys:resume(mnesia_tm) end),
     ct:pal("suspending mnesia_tm"),
     ok = sys:suspend(mnesia_tm),


### PR DESCRIPTION
Release version: 6.0.4

## Summary

`emqx_broker_mon_SUITE:t_mnesia_tm_overload` intermittently fails on the first assertion in the test body:

```
emqx_broker_mon_SUITE:t_mnesia_tm_overload failed on line 76
Failure/Error: ?assertEqual(0, emqx_broker_mon:get_mnesia_tm_mailbox_size())
  expected: 0
       got: 1
```

The mailbox-size value comes from a cached atomic that the `emqx_broker_mon` gen_server updates on a 100 ms-interval sampler (override set in `init_per_suite`). `init_per_testcase` runs `emqx_alarm:delete_all_deactivated_alarms/0`, which is itself a mnesia transaction routed through `mnesia_tm`. The most recent sampler snapshot can therefore reflect that activity at the moment the test body starts, so the cached value is 1 instead of 0.

Wrap the two pre-condition assertions in `?retry(100, 10, ...)` so the sampler can tick again and observe an idle `mnesia_tm`. The pattern already used later in the same test for the post-suspend assertions.

Test-only change, no user-facing behaviour change.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)