### PR TITLE
fix(emqx_conf): normalize cluster_rpc abort reasons to {error, _}

### DIFF
--- a/apps/emqx_conf/mix.exs
+++ b/apps/emqx_conf/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXConf.MixProject do
   def project do
     [
       app: :emqx_conf,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -505,8 +505,19 @@ do_initiate(MFA, State = #{node := Node}, Count, Failure0) ->
             catch_up(State),
             do_initiate(MFA, State, Count + 1, Failure1);
         {aborted, Error} ->
-            {reply, {init_failure, Error}, State, {continue, ?CATCH_UP}}
+            {reply, {init_failure, wrap_abort(Error)}, State, {continue, ?CATCH_UP}}
     end.
+
+%% A transaction abort reason is either an already-structured `{error, _}'
+%% from a failed MFA (`init_mfa/2' calls `mnesia:abort/1' with the MFA's
+%% `{error, _}' result) or a raw mnesia abort reason such as
+%% `{no_exists, cluster_rpc_mfa}' when the cluster_rpc tables are not yet
+%% available (cold start / recovery window). Normalize the latter so that
+%% `multicall/3' always returns an `{error, _}' shape on failure, keeping
+%% callers' `{ok, _} | {error, _}' contract intact; never double-wrap an
+%% existing `{error, _}'.
+wrap_abort({error, _} = Error) -> Error;
+wrap_abort(Reason) -> {error, Reason}.
 
 stale_view_of_cluster_msg(Meta, Count) ->
     Node = find_leader(),

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,0 +1,9 @@
+{application, emqx_conf, [
+    {description, "EMQX configuration management"},
+    {vsn, "0.4.10"},
+    {registered, []},
+    {mod, {emqx_conf_app, []}},
+    {applications, [kernel, stdlib]},
+    {env, []},
+    {modules, []}
+]}.

--- a/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
@@ -104,7 +104,9 @@ t_base_test(_Config) ->
 t_commit_fail_test(_Config) ->
     {atomic, []} = emqx_cluster_rpc:status(),
     {M, F, A} = {?MODULE, failed_on_node, [erlang:whereis(?NODE2)]},
-    {init_failure, "MFA return not ok"} = multicall(M, F, A),
+    %% A non-ok MFA result is normalized to an `{error, _}' shape so that
+    %% multicall/3 callers always observe `{ok, _} | {error, _}' on failure.
+    {init_failure, {error, "MFA return not ok"}} = multicall(M, F, A),
     ?assertEqual({atomic, []}, emqx_cluster_rpc:status()),
     ok.
 

--- a/apps/emqx_gateway/test/emqx_gateway_metrics_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_metrics_SUITE.erl
@@ -36,13 +36,29 @@ end_per_suite(Conf) ->
     ok.
 
 init_per_testcase(_TestCase, Conf) ->
+    %% A previous gateway suite in the same CT run can leave the mqttsn
+    %% gateway metrics ETS table populated with real broker stats
+    %% (bytes.received, client.connect, etc.). emqx_gateway_metrics:start_link/1
+    %% is idempotent on the table -- it does not clear stale rows. Wipe the
+    %% table here so each test sees a clean slate.
+    clear_metrics_tab(),
     {ok, Pid} = emqx_gateway_metrics:start_link(?GWNAME),
     [{metrics, Pid} | Conf].
 
 end_per_testcase(_TestCase, Conf) ->
     Pid = proplists:get_value(metrics, Conf),
     gen_server:stop(Pid),
+    %% Symmetric cleanup -- don't let our test data leak into a subsequent
+    %% suite the same way the cascade just leaked into us.
+    clear_metrics_tab(),
     Conf.
+
+clear_metrics_tab() ->
+    Tab = emqx_gateway_metrics:tabname(?GWNAME),
+    case ets:info(Tab, name) of
+        undefined -> ok;
+        _ -> true = ets:delete_all_objects(Tab)
+    end.
 
 %%--------------------------------------------------------------------
 %% cases

--- a/changes/ee/fix-17773.en.md
+++ b/changes/ee/fix-17773.en.md
@@ -1,0 +1,1 @@
+Fixed configuration update commands (REST API and CLI) crashing with a `function_clause` crash report when the underlying cluster RPC layer aborted with an unexpected reason, for example `{no_exists, cluster_rpc_mfa}` when the cluster RPC tables were not yet available during node startup or recovery. Such failures are now returned to the caller as a structured error instead.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Port of #17770 (dev-58) to dev-60. The bug and the test-isolation gap both exist on dev-60.

### Fix — `emqx_cluster_rpc` failure contract

`emqx_cluster_rpc:multicall/3` is documented to return `{ok, _}` on success and `{error, _}` on failure, and `emqx_conf:update/3` (plus the `emqx_resource`, `emqx_mgmt_api_plugins` and `emqx_rule_engine` config protos) is typed on that contract. But the `init_failure` path in `do_initiate/4` returned the raw mnesia abort reason unwrapped — e.g. `{no_exists, cluster_rpc_mfa}` when the cluster_rpc tables are not yet available during cold start or recovery. That bare tuple then escaped to callers, crashing the request handler with `function_clause` (observed via `emqx_gateway_conf:res/1` in a gateway config teardown).

`wrap_abort/1` normalizes the transaction-abort path: a bare reason becomes `{error, Reason}`, while an already-structured `{error, _}` (a failed MFA result) is left untouched so it is never double-wrapped. `t_commit_fail_test` is updated to expect the normalized shape.

### Test isolation — `emqx_gateway_metrics_SUITE`

`emqx_gateway_metrics:start_link/1` does not clear the broker-wide named ETS table `emqx_gateway_mqttsn_metrics` (`emqx_utils_ets:new/2` is idempotent), so real broker stats from a prior gateway suite in the same CT run could leak into `t_inc_dec`. `init_per_testcase` / `end_per_testcase` now wipe the table so each case starts and leaves a clean slate.

## Differences from #17770

- `emqx_conf.app.src` `vsn`: dev-60 was already at `0.4.9`, bumped to `0.4.10` (vs `0.4.8` → `0.4.9` on dev-58).
- `apps/emqx_conf/mix.exs` `version`: bumped from `6.0.3` → `6.0.4` by the apps-version-check auto-fix (dev-58 doesn't have a `mix.exs` version bump because it's a separate v5 line).
- Changelog renamed `fix-17770.en.md` → `fix-17773.en.md` to match this PR's number.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)