### PR TITLE
test(crl): block on last cache event in t_cache_overflow before trace check

### DIFF
--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -770,6 +770,16 @@ t_cache_overflow(Config) ->
             %% URL (1) connects again and needs to be re-cached; this
             %% time, (2) gets evicted
             assert_successful_connection(Config, 1),
+            %% The final emqtt:connect returns before the server-side
+            %% emqx_crl_cache gen_server has emitted the URL1 re-insert /
+            %% URL2 overflow / URL1 timer events.  Block until the second
+            %% overflow (evicting URL2) lands so ?check_trace snapshots the
+            %% full event sequence rather than a 7-event prefix.
+            URL2 = "http://localhost:9878/intermediate2.crl.pem",
+            {ok, _} = ?block_until(
+                #{?snk_kind := crl_cache_overflow, oldest_url := URL2},
+                5_000
+            ),
             %% TODO: force race condition where the same URL is fetched
             %% at the same time and tries to be registered
             ok


### PR DESCRIPTION
Release version:
6.0.4

## Summary

De-flake `emqx_crl_cache_SUITE:t_cache_overflow`.

The test's `?check_trace` post-condition expects 10 cache events in a fixed
global order, but the last `emqtt:connect/1` in the test body returns (CONNACK
delivered to the client) before the server-side `emqx_crl_cache` gen_server has
processed the URL1 re-insert and emitted the trailing
`new_crl_url_inserted` / `crl_cache_overflow` (evicting URL2) /
`crl_cache_ensure_timer` events. On a loaded runner the trace was snapshotted
with only the first 7 of the 10 events, failing the assertion.

This adds a `?block_until` barrier on the second `crl_cache_overflow` event
(the URL2 eviction) at the end of the test body, before `?check_trace` runs its
assertions, so the full event sequence is in the trace when it is collected.
The assertion itself is unchanged.

Two prior partial fixes (`74d62735d4`, `f0ae6777b2`, PR #17706) narrowed the
assertion to only cache events but did not add a synchronization barrier between
the last connect and the trace collection, so the same gen_server async-event
race remained.

Failing run that motivated this:
https://github.com/emqx/emqx/actions/runs/28366863617/job/84059967498

Validated by looping `t_cache_overflow` 50× locally (50/50 passed) plus the
full suite.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
