### PR TITLE
Make PostgreSQL application_name configurable

### DIFF
--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -79,6 +79,7 @@ roots() ->
 fields(config) ->
     [
         {server, server()},
+        {application_name, application_name()},
         {disable_prepared_statements, emqx_connector_schema_lib:disable_prepared_statements_field()}
     ] ++
         emqx_connector_schema_lib:relational_db_fields(#{username => #{required => true}}) ++
@@ -88,6 +89,13 @@ fields(config) ->
 server() ->
     Meta = #{desc => ?DESC("server")},
     emqx_schema:servers_sc(Meta, ?PGSQL_HOST_OPTIONS).
+
+application_name() ->
+    hoconsc:mk(binary(), #{
+        default => <<"emqx">>,
+        desc => ?DESC("application_name"),
+        validator => fun emqx_schema:non_empty_string/1
+    }).
 
 %% ===================================================================
 resource_type() -> pgsql.
@@ -132,7 +140,8 @@ on_start(
         {username, User},
         {password, maps:get(password, Config, emqx_secret:wrap(""))},
         {database, DB},
-        {application_name, "emqx"},
+        {application_name,
+            to_epgsql_application_name(maps:get(application_name, Config, <<"emqx">>))},
         {auto_reconnect, ?AUTO_RECONNECT_INTERVAL},
         {pool_size, PoolSize},
         [{codecs, []} || Codecs /= undefined]
@@ -609,6 +618,9 @@ connect(Opts) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+to_epgsql_application_name(ApplicationName) ->
+    unicode:characters_to_list(ApplicationName).
 
 query(Conn, SQL, Params) ->
     case epgsql:equery(Conn, SQL, Params) of

--- a/apps/emqx_postgresql/src/schema/emqx_postgresql_connector_schema.erl
+++ b/apps/emqx_postgresql/src/schema/emqx_postgresql_connector_schema.erl
@@ -37,6 +37,7 @@ roots() ->
 fields("connection_fields") ->
     [
         {server, server()},
+        {application_name, application_name()},
         {disable_prepared_statements, emqx_connector_schema_lib:disable_prepared_statements_field()}
     ] ++
         emqx_connector_schema_lib:relational_db_fields(#{username => #{required => true}}) ++
@@ -87,6 +88,13 @@ server() ->
     Meta = #{desc => ?DESC("server")},
     emqx_schema:servers_sc(Meta, ?PGSQL_HOST_OPTIONS).
 
+application_name() ->
+    hoconsc:mk(binary(), #{
+        default => <<"emqx">>,
+        desc => ?DESC("application_name"),
+        validator => fun emqx_schema:non_empty_string/1
+    }).
+
 %% Examples
 connector_examples(Method) ->
     [
@@ -125,6 +133,7 @@ values({put, _PostgreSQLType}) ->
     values(common);
 values(common) ->
     #{
+        <<"application_name">> => <<"emqx">>,
         <<"database">> => <<"emqx_data">>,
         <<"enable">> => true,
         <<"password">> => <<"public">>,

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -54,11 +54,27 @@ t_lifecycle(_Config) ->
     ).
 
 t_application_name_connect_option(_Config) ->
-    ResourceId = <<"emqx_postgresql_SUITE_application_name">>,
+    assert_application_name_connect_option(
+        <<"emqx_postgresql_SUITE_application_name">>,
+        #{},
+        "emqx"
+    ).
+
+t_custom_application_name_connect_option(_Config) ->
+    assert_application_name_connect_option(
+        <<"emqx_postgresql_SUITE_custom_application_name">>,
+        #{application_name => <<"emqx-test-app">>},
+        "emqx-test-app"
+    ).
+
+assert_application_name_connect_option(ResourceId, Overrides, ExpectedApplicationName) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(
             ?PGSQL_RESOURCE_MOD,
-            pgsql_config(#{server => <<"invalid-postgresql-host:5432">>, pool_size => 1})
+            pgsql_config(Overrides#{
+                server => <<"invalid-postgresql-host:5432">>,
+                pool_size => 1
+            })
         ),
     ?check_trace(
         begin
@@ -77,7 +93,7 @@ t_application_name_connect_option(_Config) ->
                 ?of_kind("postgres_epgsql_connect", Trace)
             ),
             [#{opts := Opts} | _] = ?of_kind("postgres_epgsql_connect", Trace),
-            ?assert(lists:member({application_name, "emqx"}, Opts))
+            ?assert(lists:member({application_name, ExpectedApplicationName}, Opts))
         end
     ).
 
@@ -396,7 +412,7 @@ pgsql_config() ->
 
 pgsql_config(Overrides) ->
     PoolSize = maps:get(pool_size, Overrides, 8),
-    #{
+    Config0 = #{
         <<"config">> => #{
             <<"auto_reconnect">> => true,
             <<"database">> => <<"mqtt">>,
@@ -406,11 +422,23 @@ pgsql_config(Overrides) ->
             <<"username">> => <<"root">>,
             <<"password">> => <<"public">>,
             <<"pool_size">> => PoolSize,
-            <<"server">> => iolist_to_binary([
-                ?PGSQL_HOST, ":", integer_to_list(?PGSQL_DEFAULT_PORT)
-            ])
+            <<"server">> => maps:get(
+                server,
+                Overrides,
+                iolist_to_binary([?PGSQL_HOST, ":", integer_to_list(?PGSQL_DEFAULT_PORT)])
+            )
         }
-    }.
+    },
+    case maps:find(application_name, Overrides) of
+        {ok, ApplicationName} ->
+            emqx_utils_maps:deep_put(
+                [<<"config">>, <<"application_name">>],
+                Config0,
+                ApplicationName
+            );
+        error ->
+            Config0
+    end.
 
 test_query_no_params() ->
     {query, <<"SELECT 1">>}.

--- a/changes/ee/feat-17783.en.md
+++ b/changes/ee/feat-17783.en.md
@@ -1,0 +1,1 @@
+Added an `application_name` option to PostgreSQL-family connectors. It defaults to `emqx` and is sent as the PostgreSQL startup parameter so connector sessions can be identified in PostgreSQL activity views and logs.

--- a/rel/i18n/emqx_postgresql.hocon
+++ b/rel/i18n/emqx_postgresql.hocon
@@ -8,6 +8,12 @@ The PostgreSQL default port 5432 is used if `[:Port]` is not specified."""
 server.label:
 """Server Host"""
 
+application_name.desc:
+"""The application name to use for PostgreSQL connections. This value appears in PostgreSQL activity views and logs."""
+
+application_name.label:
+"""Application Name"""
+
 config_connector.desc:
 """The configuration for the PostgreSQL connector."""
 

--- a/rel/i18n/emqx_postgresql_connector_schema.hocon
+++ b/rel/i18n/emqx_postgresql_connector_schema.hocon
@@ -9,6 +9,12 @@ The PostgreSQL default port 5432 is used if `[:Port]` is not specified."""
 server.label:
 """Server Host"""
 
+application_name.desc:
+"""The application name to use for PostgreSQL connections. This value appears in PostgreSQL activity views and logs."""
+
+application_name.label:
+"""Application Name"""
+
 config_connector.desc:
 """The configuration for the PostgreSQL connector."""
 


### PR DESCRIPTION
Fixes #17384

Release version:
6.3.0

## Summary

PostgreSQL-family connectors can now configure the PostgreSQL startup parameter `application_name`. The default remains `emqx`, preserving the behavior introduced by #17508 while allowing operators to distinguish connector sessions in PostgreSQL activity views and logs.

The runtime PostgreSQL resource schema and connector API schema both expose the new field, the connector converts the configured value for epgsql connection options, and the i18n/example schema entries were updated. The field rejects empty values, NUL bytes, and values longer than 63 bytes before they reach the PostgreSQL startup packet.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
