### PR TITLE
fix(http_connector): drop request headers from worker-down error reason

### DIFF
--- a/apps/emqx_bridge_http/mix.exs
+++ b/apps/emqx_bridge_http/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeHTTP.MixProject do
   def project do
     [
       app: :emqx_bridge_http,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
@@ -688,6 +688,17 @@ redact_request({Path, Headers}) ->
 redact_request({Path, Headers, _Body}) ->
     {Path, emqx_utils_redact:redact_headers(Headers), <<"******">>}.
 
+%% An `ehttpc_worker_down' exit reason carries the original `gen_server:call'
+%% arguments of the in-flight request, including the raw request headers. Drop
+%% the call args entirely, keeping the worker-down classification and stop
+%% reason for diagnostics; for any other sub-shape fall back to a bare atom.
+drop_ehttpc_worker_down_call_args(
+    {ehttpc_worker_down, {Stop, {gen_server, call, _Args}}}
+) ->
+    {ehttpc_worker_down, {Stop, {gen_server, call, '...'}}};
+drop_ehttpc_worker_down_call_args({ehttpc_worker_down, _}) ->
+    ehttpc_worker_down.
+
 render_headers(HeadersTemplate) ->
     RenderTemplateFn = fun render_template/2,
     render_headers(HeadersTemplate, RenderTemplateFn, _Msg = #{}).
@@ -906,6 +917,11 @@ transform_result(Result) ->
         %% the request has been fully processed
         {error, {shutdown, Reason}} ->
             transform_result({error, Reason});
+        {error, {ehttpc_worker_down, _} = Reason} ->
+            %% The reason carries the `gen_server:call' arguments of the request
+            %% that was in flight when the worker died, which include the raw
+            %% request headers. Drop the call args before the reason is logged.
+            {error, drop_ehttpc_worker_down_call_args(Reason)};
         {error, Reason} when
             Reason =:= econnrefused;
             Reason =:= timeout;

--- a/apps/emqx_bridge_http/test/emqx_bridge_http_connector_tests.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_connector_tests.erl
@@ -81,6 +81,43 @@ is_unwrapped_header({_, V}) when is_function(V) -> false;
 is_unwrapped_header({_, [{str, _V}]}) -> throw(unexpected_tmpl_token);
 is_unwrapped_header(_) -> true.
 
+transform_result_drops_ehttpc_worker_down_call_args_test() ->
+    LeakyHeaders = [
+        {<<"authorization">>, <<"Bearer secret-authz-token">>},
+        {<<"x-api-key">>, <<"secret-authz-key">>}
+    ],
+    Reason =
+        {ehttpc_worker_down,
+            {killed,
+                {gen_server, call, [
+                    self(), {get, {[[], 47, <<"authz">>], LeakyHeaders}, 1782800788278}, 5500
+                ]}}},
+    {error, Sanitized} = emqx_bridge_http_connector:transform_result({error, Reason}),
+    Flat = lists:flatten(io_lib:format("~0p", [Sanitized])),
+    ?assertEqual(0, string:str(Flat, "secret-authz-token"), Flat),
+    ?assertEqual(0, string:str(Flat, "secret-authz-key"), Flat),
+    %% Worker-down classification and stop reason are kept; the call args are
+    %% dropped entirely.
+    ?assertEqual({ehttpc_worker_down, {killed, {gen_server, call, '...'}}}, Sanitized),
+    ok.
+
+transform_result_drops_wrapped_ehttpc_worker_down_call_args_test() ->
+    LeakyHeaders = [{<<"authorization">>, <<"Bearer secret-authz-token">>}],
+    Reason =
+        {ehttpc_worker_down,
+            {killed,
+                {gen_server, call, [
+                    self(), {get, {[<<"authz">>], LeakyHeaders}, 1}, 5500
+                ]}}},
+    %% Arrives wrapped in `{shutdown, ...}`; the recursion must still sanitize it.
+    {error, Sanitized} = emqx_bridge_http_connector:transform_result(
+        {error, {shutdown, Reason}}
+    ),
+    Flat = lists:flatten(io_lib:format("~0p", [Sanitized])),
+    ?assertEqual(0, string:str(Flat, "secret-authz-token"), Flat),
+    ?assertEqual({ehttpc_worker_down, {killed, {gen_server, call, '...'}}}, Sanitized),
+    ok.
+
 method_validator_test() ->
     lists:foreach(
         fun(Method) ->

--- a/changes/ee/fix-17787.en.md
+++ b/changes/ee/fix-17787.en.md
@@ -1,0 +1,3 @@
+Stopped HTTP connector error logs from including request headers when an `ehttpc` worker is killed mid-request.
+
+When the HTTP connector's `ehttpc` worker was killed while a request was in flight (for example, by deleting the source while the request had not yet returned), the resulting EXIT reason carried the original `gen_server:call` arguments, which include the request headers. These headers were then written verbatim to the error log. The call arguments are now dropped from the reason before it is logged.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Fixes emqx/emqx-dev-team-tasks#273.

When the HTTP connector's `ehttpc` worker is killed while a request is in flight — for example, by deleting the source while the request has not yet returned — the `gen_server:call` to the dead worker returns an EXIT whose reason carries the original call arguments. Those arguments include the request headers (`Authorization`, `x-api-key`, etc.). The reason then flowed verbatim into several error logs: `http_connector_do_request_failed`, `unrecoverable_resource_error`, and `http_server_query_failed`.

The fix drops the call arguments at the source, in `emqx_bridge_http_connector:transform_result/1`: a new clause matches the `{ehttpc_worker_down, _}` reason and replaces the captured `gen_server:call` args with `'...'`, keeping the worker-down classification and stop reason for diagnostics. Any unrecognized sub-shape falls back to a bare `ehttpc_worker_down` atom. Sanitizing the reason once at this boundary keeps every downstream log consumer safe without logging any header bytes and without relying on per-field redaction.

Relevant files:
- `apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl` — new `transform_result/1` clause and `drop_ehttpc_worker_down_call_args/1` helper.
- `apps/emqx_bridge_http/test/emqx_bridge_http_connector_tests.erl` — unit tests asserting no header bytes survive, including the `{shutdown, ...}`-wrapped variant.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)