### PR TITLE
[v6] chore: add a script to list release versions

### DIFF
--- a/scripts/rel-versions
+++ b/scripts/rel-versions
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Print the next-to-be-released EMQX version on the current branch and every
+# downstream branch in the forward-sync chain.
+#
+# Example: if HEAD is on a v6.0 topic branch (last reachable GA tag is 6.0.3),
+# this prints
+#
+#     6.0.4
+#     6.1.3
+#     6.2.2
+#
+# computed by running `git describe <remote>/dev-XX --tags --match 'X.Y.*'
+# --exclude '*-*'` against the matching dev-XX branch (so the answers reflect
+# what is actually in upstream right now, not what is on disk locally).
+#
+# The pre-release tag forms (6.2.2-rc.1, 6.0.0-alpha.1, ...) are excluded
+# from the lookup; the script computes "next patch after the most recent GA".
+#
+# Branches in the forward-sync chain (v6 line):
+#   dev-60 -> dev-61 -> dev-62 -> dev-63
+#
+# The script auto-detects the remote pointing at github.com:emqx/emqx from
+# `git remote -v` -- it doesn't assume the remote is called `origin`.
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $0
+
+Prints, one per line, the next release version on the current branch's release
+line and every downstream branch it would forward-sync to.
+
+No arguments. The starting point is determined by the most recent GA tag
+reachable from HEAD (e.g. 6.0.3 -> start from the v6.0 line).
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Detect the canonical emqx/emqx remote name.
+# Accept both SSH (git@github.com:emqx/emqx.git) and HTTPS
+# (https://github.com/emqx/emqx.git, with or without the .git suffix).
+# ---------------------------------------------------------------------------
+detect_remote() {
+    local name url first=""
+    while read -r name url _; do
+        # filter to fetch entries only
+        case "$url" in
+            *github.com[:/]emqx/emqx*)
+                # Strip optional trailing .git, accept the path matching exactly.
+                if [[ "$url" =~ github\.com[:/]emqx/emqx(\.git)?$ ]]; then
+                    if [[ "$name" == "origin" ]]; then
+                        echo "$name"
+                        return 0
+                    fi
+                    first="${first:-$name}"
+                fi
+                ;;
+        esac
+    done < <(git remote -v | awk '$3 == "(fetch)"')
+    if [[ -n "$first" ]]; then
+        echo "$first"
+        return 0
+    fi
+    return 1
+}
+
+REMOTE=$(detect_remote || true)
+if [[ -z "${REMOTE:-}" ]]; then
+    echo "error: no git remote points at github.com:emqx/emqx" >&2
+    exit 1
+fi
+
+git fetch "$REMOTE" --tags --quiet
+
+# ---------------------------------------------------------------------------
+# Resolve the starting minor from the most recent GA tag reachable from HEAD.
+# ---------------------------------------------------------------------------
+prev_tag=$(git describe --tags --match '[0-9]*.*' --exclude '*-*' --abbrev=0 2>/dev/null || true)
+if [[ -z "$prev_tag" ]]; then
+    echo "error: no GA tag (X.Y.Z) reachable from HEAD" >&2
+    exit 1
+fi
+if [[ ! "$prev_tag" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    echo "error: cannot parse tag '$prev_tag'" >&2
+    exit 1
+fi
+start_major="${BASH_REMATCH[1]}"
+start_minor="${BASH_REMATCH[2]}"
+
+# ---------------------------------------------------------------------------
+# Forward-sync chain per major version.
+# ---------------------------------------------------------------------------
+case "$start_major" in
+    6) chain=(60 61 62 63) ;;
+    *)
+        echo "error: unsupported major version $start_major" >&2
+        exit 1
+        ;;
+esac
+
+# Encode the starting minor the same way the chain entries are encoded:
+# chain entries are e.g. 60, 61, 62, 63 (concatenation of major+minor).
+start_key="${start_major}${start_minor}"
+
+# ---------------------------------------------------------------------------
+# For each step in the chain >= start, look up dev-<N>'s latest GA tag and
+# print the next patch version.
+# ---------------------------------------------------------------------------
+seen_start=0
+for step in "${chain[@]}"; do
+    if [[ "$step" != "$start_key" && "$seen_start" -eq 0 ]]; then
+        continue
+    fi
+    seen_start=1
+
+    # Extract minor from the chain key (e.g. 60 -> major=6 minor=0).
+    if [[ "$step" =~ ^([0-9])([0-9]+)$ ]]; then
+        major="${BASH_REMATCH[1]}"
+        minor="${BASH_REMATCH[2]}"
+    else
+        echo "error: cannot parse chain entry '$step'" >&2
+        exit 1
+    fi
+
+    branch="${REMOTE}/dev-${step}"
+    desc=$(git describe "$branch" --tags --match "${major}.${minor}.*" --exclude '*-*' --abbrev=0 2>/dev/null || true)
+    if [[ -z "$desc" ]]; then
+        echo "warning: no GA tag (${major}.${minor}.*) on ${branch} -- skipping" >&2
+        continue
+    fi
+
+    # desc is the GA tag itself (e.g. 6.0.3) because of --abbrev=0.
+    if [[ ! "$desc" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        echo "warning: cannot parse tag '$desc' on ${branch} -- skipping" >&2
+        continue
+    fi
+    patch="${BASH_REMATCH[3]}"
+    next_patch=$((patch + 1))
+    echo "${major}.${minor}.${next_patch}"
+done


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Companion to #17788 (v5). Adds `scripts/rel-versions` for the v6 line.

Given a checkout, the script prints, one per line, the next release version on the current branch's release line and every downstream branch it would forward-sync to.

Example: on a v6.0 topic branch (last reachable GA tag `6.0.3`):

    6.0.4
    6.1.3
    6.2.2

If HEAD is descended from `6.1.2`, the v6.0 line is dropped from the output (`6.1.3`, `6.2.2`). dev-63 currently has no GA tag yet, so the script emits a warning and skips it; once `6.3.0` lands the entry appears automatically.

- Auto-detects the canonical `emqx/emqx` git remote (parses `git remote -v`; doesn't assume `origin`).
- Runs `git fetch <remote> --tags --quiet` before computing so the answers reflect upstream right now.
- Excludes pre-release tags (`-rc.N`, `-alpha`, `-beta`, `-patch.N`) via `--exclude '*-*'`; the version is "next patch after the most recent GA".
- v6 tags use no `e` prefix (`6.0.3`, `6.1.2`, ...); the v5 sibling script in #17788 keeps the `e` prefix.

`shellcheck -S style` clean.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)