### PR TITLE
fix(dashboard): redact TOTP secret from login-failed server log

### DIFF
--- a/apps/emqx/test/emqx_cth_log_capture.erl
+++ b/apps/emqx/test/emqx_cth_log_capture.erl
@@ -1,0 +1,61 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_cth_log_capture).
+
+-moduledoc """
+Test helper to capture structured log reports emitted while running a function.
+
+Installs a temporary `logger` handler that forwards report-style log events at or
+above a given level to the calling process, runs the provided function, and
+returns the captured reports in emission order.
+""".
+
+%% API
+-export([capture/1, capture/2]).
+
+%% logger handler callback
+-export([log/2]).
+
+-define(HANDLER_ID, ?MODULE).
+
+-doc "Same as `capture(warning, Fun)`.".
+-spec capture(fun(() -> term())) -> [map()].
+capture(Fun) ->
+    capture(warning, Fun).
+
+-doc """
+Run `Fun' while capturing log reports at or above `Level', returning the captured
+reports (the `Data' maps passed to `?SLOG'/`?TRACE') in emission order.
+""".
+-spec capture(logger:level(), fun(() -> term())) -> [map()].
+capture(Level, Fun) ->
+    ok = logger:add_handler(?HANDLER_ID, ?MODULE, #{
+        level => Level,
+        config => #{test_pid => self()},
+        filter_default => log,
+        filters => []
+    }),
+    PrevLevel = emqx_logger:get_primary_log_level(),
+    ok = emqx_logger:set_primary_log_level(Level),
+    try
+        _ = Fun(),
+        collect([])
+    after
+        ok = emqx_logger:set_primary_log_level(PrevLevel),
+        ok = logger:remove_handler(?HANDLER_ID)
+    end.
+
+%% @private logger handler callback.
+log(#{msg := {report, Report}}, #{config := #{test_pid := Pid}}) when is_map(Report) ->
+    Pid ! {?MODULE, Report},
+    ok;
+log(_Event, _Config) ->
+    ok.
+
+collect(Acc) ->
+    receive
+        {?MODULE, Report} -> collect([Report | Acc])
+    after 200 -> lists:reverse(Acc)
+    end.

--- a/apps/emqx_dashboard/mix.exs
+++ b/apps/emqx_dashboard/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDashboard.MixProject do
   def project do
     [
       app: :emqx_dashboard,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: [{:d, :APPLICATION, :emqx} | UMP.strict_erlc_options()],

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -338,7 +338,15 @@ login(post, #{body := Params}) ->
                 })};
         {error, R} ->
             ok = register_unsuccessful_login(Username, R),
-            ?SLOG(info, #{msg => "dashboard_login_failed", username => Username, reason => R}),
+            %% During first-time MFA setup the reason map carries the TOTP
+            %% `secret', which is intentionally returned in the 401 response
+            %% body so the dashboard can render the authenticator QR code. The
+            %% server log must not keep a copy of it, so redact before logging.
+            ?SLOG(info, #{
+                msg => "dashboard_login_failed",
+                username => Username,
+                reason => emqx_utils:redact(R)
+            }),
             format_login_failed_error(R)
     end.
 

--- a/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
@@ -193,6 +193,38 @@ t_login_with_mfa_setting(_Config) ->
     ok = ExpectBadTotpFn(BadPwd#{<<"mfa_token">> => <<"badtoken2">>}),
     ok.
 
+%% During first-time MFA setup the TOTP secret is returned in the 401 response
+%% body so the dashboard can render the QR code. Assert that the same secret is
+%% NOT written to the `dashboard_login_failed' server log.
+t_login_failed_log_redacts_totp_secret({init, Config}) ->
+    ok = mock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(<<"viewer2">>),
+    Config;
+t_login_failed_log_redacts_totp_secret({'end', _Config}) ->
+    ok = unmock_totp();
+t_login_failed_log_redacts_totp_secret(_Config) ->
+    LoginBody =
+        #{
+            <<"username">> => <<"viewer2">>,
+            <<"password">> => <<"viewer2pass">>
+        },
+    ?assertMatch({ok, 204, _}, enable_mfa(<<"viewer2">>)),
+    {ok, #{secret := Secret}} = emqx_dashboard_admin:get_mfa_state(<<"viewer2">>),
+    Reports = emqx_cth_log_capture:capture(info, fun() ->
+        %% first login without a token: response carries the secret for QR rendering
+        {ok, 401, Rsp} = login(LoginBody),
+        ?assertMatch(
+            #{<<"code">> := <<"BAD_MFA_TOKEN">>, <<"message">> := #{<<"secret">> := Secret}},
+            json_map(Rsp)
+        )
+    end),
+    %% the captured login-failure log must not carry the secret bytes
+    [Report] = [R || #{msg := "dashboard_login_failed"} = R <- Reports],
+    ReportBin = unicode:characters_to_binary(io_lib:format("~0p", [Report])),
+    ?assertEqual(nomatch, binary:match(ReportBin, Secret)),
+    ?assertMatch(#{reason := #{secret := <<"******">>}}, Report),
+    ok.
+
 %% Enable then delete MFA.
 t_disable_mfa({init, Config}) ->
     ok = mock_totp(),

--- a/changes/ee/fix-17790.en.md
+++ b/changes/ee/fix-17790.en.md
@@ -1,0 +1,1 @@
+Stopped writing the TOTP shared secret to the `dashboard_login_failed` server log. The secret was previously included in this log entry during first-time MFA setup.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.3, 6.2.2

## Summary

Fixes emqx/emqx-dev-team-tasks#274.

The `dashboard_login_failed` server-log entry included the TOTP shared secret when an MFA-enabled user logged in without supplying a token during first-time setup. The reason map is now passed through `emqx_utils:redact/1` before it reaches `?SLOG`, which replaces the `secret` value with `******`.

The secret is still returned in the 401 response body, where the dashboard needs it to render the authenticator QR code on first-time MFA setup (documented behavior in `apps/emqx_dashboard/README.md`). Only the server-side log copy is removed; the redaction is log-only.

Key change in `apps/emqx_dashboard/src/emqx_dashboard_api.erl`. A new CT case (`emqx_dashboard_mfa_SUITE:t_login_failed_log_redacts_totp_secret`) captures the log event and asserts the secret bytes are absent from the log while still present in the 401 body.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
