### PR TITLE
fix(redact): redact jose_jwk records in logs

### DIFF
--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -275,6 +275,36 @@ t_invalid_signature_trace_keeps_public_jwks(_) ->
     ?assertEqual(ok, emqx_authn_jwt:destroy(State)),
     ok.
 
+%% The HMAC authenticator runtime state carries a `jose_jwk' record holding the
+%% raw key bytes; `emqx_utils:redact/1' (used by config-update / cluster_rpc log
+%% lines that dump such state) must replace it so the secret never reaches a log.
+t_redact_hmac_state(_) ->
+    Secret = <<"s3cr3t-hmac-key-zzz">>,
+    Config = #{
+        mechanism => jwt,
+        from => password,
+        acl_claim_name => <<"acl">>,
+        use_jwks => false,
+        algorithm => 'hmac-based',
+        secret => Secret,
+        secret_base64_encoded => false,
+        verify_claims => [],
+        disconnect_after_expire => false,
+        enable => true
+    },
+    {ok, State} = emqx_authn_jwt:create(?AUTHN_ID, Config),
+    %% Sanity: the un-redacted state really does carry the raw key bytes.
+    ?assertMatch(#{jwk := #jose_jwk{kty = {jose_jwk_kty_oct, Secret}}}, State),
+    ?assertNotEqual(nomatch, binary:match(render(State), Secret)),
+    %% After redaction the bytes must be gone.
+    Redacted = emqx_utils:redact(State),
+    ?assertEqual(nomatch, binary:match(render(Redacted), Secret)),
+    ?assertEqual(ok, emqx_authn_jwt:destroy(State)),
+    ok.
+
+render(Term) ->
+    unicode:characters_to_binary(io_lib:format("~0p", [Term])).
+
 t_bad_public_keys(_) ->
     BaseConfig = #{
         mechanism => jwt,

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -50,6 +50,9 @@ is_sensitive_key(<<"client_jwks">>) -> true;
 is_sensitive_key(id_token) -> true;
 is_sensitive_key("id_token") -> true;
 is_sensitive_key(<<"id_token">>) -> true;
+is_sensitive_key(jwk) -> true;
+is_sensitive_key("jwk") -> true;
+is_sensitive_key(<<"jwk">>) -> true;
 is_sensitive_key(jwt) -> true;
 is_sensitive_key("jwt") -> true;
 is_sensitive_key(<<"jwt">>) -> true;
@@ -127,6 +130,11 @@ do_redact({Key, Value}, Checker) ->
         false ->
             {do_redact(Key, Checker), do_redact(Value, Checker)}
     end;
+do_redact({jose_jwk, _Keys, _Kty, _Fields}, _Checker) ->
+    %% A jose_jwk record carries the raw key material (a kty_oct binary for HMAC,
+    %% kty_rsa fields for RSA, etc.) in its inner tuples. Replace it wholesale so
+    %% the generic tuple walk below never descends into the key bytes.
+    {jose_jwk, '******'};
 do_redact(T, Checker) when is_tuple(T) ->
     Elements = erlang:tuple_to_list(T),
     Redact = do_redact(Elements, Checker),
@@ -347,6 +355,40 @@ redact_improper_list_test_() ->
     [
         ?_assertEqual([alias | foo], redact([alias | foo])),
         ?_assertEqual([1, 2 | foo], redact([1, 2 | foo]))
+    ].
+
+jose_jwk_redact_test_() ->
+    %% The kty_oct binary is the raw HMAC key material; it must never survive redaction.
+    Secret = <<"abcd1234">>,
+    JWK = {jose_jwk, undefined, {jose_jwk_kty_oct, Secret}, #{}},
+    NoLeak = fun(Term) ->
+        Rendered = iolist_to_binary(io_lib:format("~p", [redact(Term)])),
+        nomatch =:= binary:match(Rendered, Secret)
+    end,
+    [
+        %% Record-shape redaction (Layer 1): matched anywhere the record is walked,
+        %% e.g. under a non-sensitive key, the whole record is replaced.
+        ?_assertEqual({jose_jwk, '******'}, redact(JWK)),
+        ?_assertMatch(
+            #{current_jwk := {jose_jwk, '******'}, other := <<"value">>},
+            redact(#{current_jwk => JWK, other => <<"value">>})
+        ),
+        ?_assert(NoLeak(JWK)),
+        %% Deeply nested inside a config-update style state map.
+        ?_assert(
+            NoLeak(#{
+                emqx_authn_config => #{
+                    state => #{
+                        jwk => JWK,
+                        disconnect_after_expire => true
+                    }
+                }
+            })
+        ),
+        %% Map-key redaction (Layer 1b): a `jwk' key has its value replaced wholesale,
+        %% covering non-record values too (e.g. a plain map from a JWKS endpoint).
+        ?_assertEqual(#{jwk => ?REDACT_VAL}, redact(#{jwk => #{<<"k">> => Secret}})),
+        ?_assert(NoLeak(#{jwk => #{<<"k">> => Secret}}))
     ].
 
 deobfuscate_test() ->

--- a/changes/ee/fix-17791.en.md
+++ b/changes/ee/fix-17791.en.md
@@ -1,0 +1,3 @@
+Improved log redaction so that JWT HMAC key bytes no longer appear in `cluster_rpc_apply_result` and `cluster_rpc_apply_ok` debug log lines emitted during configuration updates.
+
+The redactor now recognises the internal JWK record shape and replaces it with a placeholder before logging, and also treats the `jwk` field as sensitive.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.3, 6.2.2

## Summary

`emqx_utils:redact/1` walked `jose_jwk` records element by element. Because the inner `jose_jwk_kty_oct` tuple was treated as a plain `{Key, Value}` pair whose key is not in the sensitive-key list, the raw HMAC key bytes survived redaction and could appear in `cluster_rpc_apply_result` / `cluster_rpc_apply_ok` debug log lines that dump the JWT authenticator runtime state during config updates.

Changes in `apps/emqx_utils/src/emqx_utils_redact.erl`:

* Add a `do_redact/2` head clause matching the `jose_jwk` record shape, placed before the generic tuple walk, so the whole record is replaced with a `{jose_jwk, '******'}` placeholder before recursion can descend into the key material.
* Mark the `jwk` map key as sensitive (atom / string / binary forms), so non-record JWK values (e.g. a plain map fetched from a JWKS endpoint) are also redacted wholesale.

Tests:

* EUnit cases in `emqx_utils_redact` covering the record shape, the map-key shape, and deeply-nested state maps — asserting the raw bytes never appear in the redacted output.
* CT case `t_redact_hmac_state` in `emqx_authn_jwt_SUITE` that builds a real HMAC authenticator state and asserts `emqx_utils:redact/1` removes the secret.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
