### PR TITLE
test(ds_shared_sub): stabilize t_disconnect_no_double_replay1 drain

### DIFF
--- a/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
@@ -660,8 +660,6 @@ t_disconnect_no_double_replay1(_Config) ->
         publish_done -> ok
     end,
 
-    Pubs = drain_publishes(),
-
     ClientByBid = fun(Pid) ->
         case Pid of
             ConnShared1 -> <<"client_shared1">>;
@@ -669,6 +667,14 @@ t_disconnect_no_double_replay1(_Config) ->
         end
     end,
 
+    %% After ConnShared2 disconnects mid-replay, its streams are reassigned to
+    %% ConnShared1, which then has to (re)deliver the whole backlog. Under load
+    %% this redelivery can stall for more than a few seconds, so a fixed
+    %% silence-based drain may return before the last messages arrive. Instead
+    %% wait until every expected payload has been received, bounded by a
+    %% deadline: if a message is genuinely never delivered the deadline still
+    %% expires and the missing list is reported.
+    Pubs = drain_until_received(2 * NPubs, 60_000),
     {Missing, _Duplicate} = verify_received_pubs(Pubs, 2 * NPubs, ClientByBid),
 
     ?assertEqual([], Missing),
@@ -837,6 +843,37 @@ drain_publishes(Acc) ->
             drain_publishes([Msg | Acc])
     after 5_000 ->
         lists:reverse(Acc)
+    end.
+
+%% Collect received publishes until `NExpect' distinct payloads have been seen
+%% or `TimeoutMs' elapses, whichever comes first. Unlike `drain_publishes/0',
+%% this does not stop on a silence gap, so it tolerates delivery stalls during
+%% stream reassignment without losing late messages. If some payloads are never
+%% delivered, the deadline expires and they are simply absent from the result,
+%% so a genuine message loss is still surfaced by the caller's assertion.
+drain_until_received(NExpect, TimeoutMs) ->
+    Deadline = erlang:monotonic_time(millisecond) + TimeoutMs,
+    drain_until_received(#{}, [], NExpect, Deadline).
+
+drain_until_received(Seen, Acc, NExpect, Deadline) ->
+    case map_size(Seen) >= NExpect of
+        true ->
+            lists:reverse(Acc);
+        false ->
+            Remaining = Deadline - erlang:monotonic_time(millisecond),
+            case Remaining =< 0 of
+                true ->
+                    lists:reverse(Acc);
+                false ->
+                    receive
+                        {publish, #{payload := Payload} = Msg} ->
+                            drain_until_received(
+                                Seen#{Payload => true}, [Msg | Acc], NExpect, Deadline
+                            )
+                    after Remaining ->
+                        lists:reverse(Acc)
+                    end
+            end
     end.
 
 verify_received_pubs(Pubs, NPubs, ClientByBid) ->


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Fix a flaky assertion in `emqx_ds_shared_sub_SUITE:t_disconnect_no_double_replay1`.

The case disconnects one of two shared subscribers in the middle of replay and
then asserts that no message goes missing. Received PUBLISHes were collected
with a drain that stopped after 5 seconds of silence on the mailbox. When the
surviving subscriber takes over the disconnected one's streams it has to
redeliver the backlog, and under load that redelivery can pause for more than a
few seconds. The silence-based drain could therefore return before the tail of
the backlog arrived, reporting spurious "missing messages".

The reassignment path itself is conservative: on a partially consumed stream
the leader stores the begin-of-batch iterator, so the new owner re-reads the
batch (at worst duplicating, never dropping), and every stream is always
reassigned to a live borrower. So the lost tail is a test artifact, not a
broker bug.

This change replaces the silence-based drain in that case with one that waits
until every expected payload has been received, bounded by a deadline
(`drain_until_received/2` in the suite). It returns immediately once all
messages arrive, and if a message is genuinely never delivered the deadline
still expires and the message is reported as missing — so a real loss would
still fail the test. Other cases in the suite that also assert on duplicates
keep the original drain and are unchanged.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
