### PR TITLE
test(otel): bind-mount config files instead of overlaying /etc/

### DIFF
--- a/.ci/docker-compose-file/docker-compose-otel.yaml
+++ b/.ci/docker-compose-file/docker-compose-otel.yaml
@@ -20,9 +20,14 @@ services:
     networks:
       - emqx_bridge
     restart: always
-    command: ["--config=/etc/otel-collector-config.yaml", "${OTELCOL_ARGS}"]
+    command: ["--config=/otel-share/otel-collector-config.yaml", "${OTELCOL_ARGS}"]
     volumes:
-      - ./otel:/etc/
+      # Mount the host's ./otel/ directory at a non-/etc/ path so Docker's
+      # per-container /etc/hostname and /etc/resolv.conf bind mounts don't
+      # have to create their mountpoint files inside ./otel/ on the host
+      # -- which would intermittently trip runc's stricter make_mountpoint
+      # helper with "file exists" on subsequent container starts.
+      - ./otel:/otel-share/
 #    ports:
 #      - "1888:1888"   # pprof extension
 #      - "8888:8888"   # Prometheus metrics exposed by the collector
@@ -44,9 +49,9 @@ services:
     networks:
       - emqx_bridge
     restart: always
-    command: ["--config=/etc/otel-collector-config-tls.yaml", "${OTELCOL_ARGS}"]
+    command: ["--config=/otel-share/otel-collector-config-tls.yaml", "${OTELCOL_ARGS}"]
     volumes:
-      - ./otel:/etc/
+      - ./otel:/otel-share/
       - ./certs:/etc/certs
  #   ports:
  #     - "14317:4317"   # OTLP gRPC receiver

--- a/.ci/docker-compose-file/otel/otel-collector-config-tls.yaml
+++ b/.ci/docker-compose-file/otel/otel-collector-config-tls.yaml
@@ -23,9 +23,9 @@ exporters:
   debug:
     verbosity: detailed
   file/log:
-    path: /etc/otel_tls_emqx_log.json
+    path: /otel-share/otel_tls_emqx_log.json
   file/metrics:
-    path: /etc/otel_tls_emqx_metrics.json
+    path: /otel-share/otel_tls_emqx_metrics.json
 
 
 processors:

--- a/.ci/docker-compose-file/otel/otel-collector-config.yaml
+++ b/.ci/docker-compose-file/otel/otel-collector-config.yaml
@@ -23,9 +23,9 @@ exporters:
   debug:
     verbosity: detailed
   file/log:
-    path: /etc/otel_tcp_emqx_log.json
+    path: /otel-share/otel_tcp_emqx_log.json
   file/metrics:
-    path: /etc/otel_tcp_emqx_metrics.json
+    path: /otel-share/otel_tcp_emqx_metrics.json
 
 processors:
   batch:


### PR DESCRIPTION
## Summary

The OTel CT docker-compose mounted the host directory `.ci/docker-compose-file/otel/` onto `/etc/` inside `otel-collector` and `otel-collector-tls` containers. That overlay shadowed the container image's `/etc/` with the host directory. Docker's standard per-container bind mounts for `/etc/hostname`, `/etc/resolv.conf` and `/etc/hosts` then had to create their mountpoint files inside the host `./otel/` directory.

On subsequent CT runs, when Docker's teardown left those stub files behind, the next container start tripped `runc`'s stricter `make_mountpoint` helper with

```
OCI runtime create failed: runc create failed: ...
error mounting "/data/docker/containers/<id>/hostname" to rootfs at "/etc/hostname":
  create mountpoint for /etc/hostname mount: make mountpoint "/etc/hostname": file exists
```

and the test never started. Two recent occurrences on the same runner AMI `ami-024761ae8bd0b667b` (different EC2 instances): https://github.com/emqx/emqx/actions/runs/28435522529/job/84262207448 and https://github.com/emqx/emqx/actions/runs/28356864225/job/84003250328.

Only the OTel test triggers this because it's the only docker-compose in the repo that bind-mounts a host directory at the container's `/etc/`. Other ct-docker tests use single-file or non-`/etc/` mounts.

Mount only the specific config file each collector needs; the container's `/etc/` stays owned by the image so Docker's per-container bind mounts have a clean target. The `./certs:/etc/certs` mount on the TLS variant is unchanged — that lands at `/etc/certs`, not at `/etc/`, and is fine.

Test-only CI change, no user-facing behavior change.