### PR TITLE
fix(mqttsn): retire stale disconnected channel on UDP port reuse

### DIFF
--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -444,6 +444,22 @@ handle_in(
 handle_in(?SN_ADVERTISE_MSG(_GwId, _Radius), Channel) ->
     % ignore
     shutdown(normal, Channel);
+%% A `disconnected' channel is kept alive (indexed by the peer UDP
+%% {ip, port}) so its session can be resumed within the expiry interval.
+%% The OS, or a NAT box, may re-assign the same ephemeral port to a
+%% different sender, in which case that sender's packets are routed here.
+%% Treat a CONNECT as a takeover request: retire this stale channel so the
+%% connection layer can spawn a fresh one for the new session.
+handle_in(
+    ?SN_CONNECT_MSG(_Flags, _ProtoId, _Duration, _ClientId),
+    Channel = #channel{conn_state = disconnected}
+) ->
+    shutdown(takeover_by_new_connect, Channel);
+%% Any other packet on a `disconnected' channel is stale traffic (e.g. a
+%% retransmit from the previous peer of a reused port). Retire the channel
+%% rather than crash; no live session should be addressed here.
+handle_in(_Pkt, Channel = #channel{conn_state = disconnected}) ->
+    shutdown(stale_packet_after_disconnect, Channel);
 %% Ack DISCONNECT even if it is not connected
 handle_in(
     ?SN_DISCONNECT_MSG(_Duration),

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -1612,7 +1612,63 @@ t_will_case06(_) ->
     end,
     send_disconnect_msg(Socket, undefined),
 
-    gen_udp:close(Socket).
+    gen_udp:close(Socket),
+
+    %% This case connects with CleanSession=0, so its channel lingers in the
+    %% `disconnected' state (indexed by the peer UDP port) until the session
+    %% expires. If the OS re-assigns the same ephemeral port to a later case,
+    %% that case's CONNECT would be routed to this stale channel. Retire it
+    %% here so the SUITE does not depend on UDP port-allocation luck.
+    ok = ensure_channel_gone(ClientId).
+
+%% Reproduces UDP ephemeral-port reuse deterministically: a stale
+%% `disconnected' channel bound to a peer UDP port must not crash when a new
+%% device connects from the same source port. The stale channel is retired
+%% cleanly and the new device is able to connect.
+t_takeover_on_udp_port_reuse(_) ->
+    {ok, SockA} = gen_udp:open(0, [binary]),
+    {ok, PortA} = inet:port(SockA),
+    ClientA = ?CLIENTID,
+    %% device A connects with CleanSession=0 and disconnects, leaving its
+    %% channel alive in the `disconnected' state.
+    send_connect_msg(SockA, ClientA, 0),
+    ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(SockA)),
+    send_disconnect_msg(SockA, undefined),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(SockA)),
+    OldPid = wait_for_disconnected_channel(ClientA),
+    ok = gen_udp:close(SockA),
+    %% device B reuses the exact same source UDP port.
+    {ok, SockB} = gen_udp:open(PortA, [binary, {reuseaddr, true}]),
+    try
+        ClientB = ?CLIENTID,
+        MRef = erlang:monitor(process, OldPid),
+        %% the CONNECT is routed to the stale channel, which is retired
+        %% cleanly (before the fix this crashed with a function_clause).
+        send_connect_msg(SockB, ClientB, 0),
+        receive
+            {'DOWN', MRef, process, OldPid, Reason} ->
+                ?assertEqual({shutdown, takeover_by_new_connect}, Reason)
+        after 2000 ->
+            ct:fail(stale_channel_not_retired)
+        end,
+        %% the CONNECT that retired the stale channel gets no reply on the
+        %% wire (the channel is shut down without an ack frame); the device
+        %% must recover on retransmit.
+        ?assertEqual(udp_receive_timeout, receive_response(SockB, 500)),
+        %% the new device connects on retransmit (MQTT-SN clients retransmit
+        %% CONNECT when no reply is received).
+        ?retry(
+            200,
+            10,
+            begin
+                send_connect_msg(SockB, ClientB, 0),
+                ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(SockB))
+            end
+        ),
+        ok = ensure_channel_gone(ClientB)
+    after
+        gen_udp:close(SockB)
+    end.
 
 t_asleep_test01_timeout(_) ->
     QoS = 1,
@@ -3026,6 +3082,30 @@ receive_response(Socket, Timeout) ->
     after Timeout ->
         udp_receive_timeout
     end.
+
+%% Wait until the channel of ClientId has reached the `disconnected' state
+%% (kept alive for session resumption) and return its pid.
+wait_for_disconnected_channel(ClientId) ->
+    ?retry(
+        100,
+        20,
+        begin
+            [Pid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
+            #{conn_state := disconnected} =
+                emqx_gateway_cm:get_chan_info(mqttsn, ClientId, Pid),
+            Pid
+        end
+    ).
+
+%% Retire any lingering channel of ClientId and wait until it is gone.
+ensure_channel_gone(ClientId) ->
+    _ = emqx_gateway_cm:discard_session(mqttsn, ClientId),
+    ?retry(
+        100,
+        20,
+        ?assertEqual([], emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId))
+    ),
+    ok.
 
 with_gateway_authz_result(Protocol, ActionType, Topic, Result, Fun) ->
     Action = {?MODULE, gateway_authz_result, [Protocol, ActionType, Topic, Result]},

--- a/changes/ee/fix-17796.en.md
+++ b/changes/ee/fix-17796.en.md
@@ -1,0 +1,5 @@
+Fixed a crash in the MQTT-SN gateway when a new device connects from a UDP
+source port that was recently used by a disconnected device (common on
+loopback and behind NAT, where the OS or NAT box re-assigns the same port).
+The stale channel is now retired cleanly and the new connection is processed
+as a fresh session.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

The MQTT-SN gateway indexes channels by the peer UDP `{ip, port}` — the only
addressing UDP offers. When a device disconnects but keeps a non-zero session
expiry (`CleanSession=0`), its channel stays alive in the `disconnected` state
so the session can be resumed. If the OS (on loopback) or a NAT box re-assigns
the same ephemeral source port to a different sender, that sender's `CONNECT`
was routed to the stale `disconnected` channel.

`emqx_mqttsn_channel:handle_in/2` had no clause for a packet arriving in the
`disconnected` state, so the channel crashed with a `function_clause` and the
new device could not connect until the stale session expired.

Crucial changes:

- `apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl`: add `handle_in/2`
  clauses for the `disconnected` state. A `CONNECT` is treated as a takeover —
  the stale channel shuts down with `takeover_by_new_connect` so the connection
  layer can spawn a fresh channel for the new session. Any other packet is
  dropped (`stale_packet_after_disconnect`) and the channel retired.
- `apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl`: `t_will_case06`
  (which connects with `CleanSession=0`) now retires its lingering session in
  teardown, so the SUITE no longer depends on UDP port-allocation luck. Adds
  `t_takeover_on_udp_port_reuse`, a deterministic regression test that binds a
  second client socket to the first client's source port; it reproduces the
  `function_clause` crash without the fix and passes with it.

The whole `emqx_sn_protocol_SUITE` (70 cases) passes, repeated across runs.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
