### PR TITLE
fix(retainer): cap retained message qos for wildcard subscribers

### DIFF
--- a/apps/emqx_retainer/mix.exs
+++ b/apps/emqx_retainer/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXRetainer.MixProject do
   def project do
     [
       app: :emqx_retainer,
-      version: "6.1.1",
+      version: "6.1.2",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.strict_erlc_options(),

--- a/apps/emqx_retainer/src/emqx_retainer_extsub_handler.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_extsub_handler.erl
@@ -38,6 +38,7 @@
 -define(MIN_RATE_LIMIT_DELAY_MS, 300).
 -define(MAX_RATE_LIMIT_DELAY_MS, 10_000).
 -define(DEFAULT_BATCH_SIZE, 1_000).
+-define(HEADER_SUB_TOPIC, sub_topic).
 
 -record(h, {
     send_fn,
@@ -261,7 +262,7 @@ try_consume(#h{} = Handler0, N0) when is_integer(N0) ->
             NumFetchedMessages = length(Messages0),
             Surplus = max(0, N - NumFetchedMessages),
             Limiter = emqx_limiter_client:put_back(Limiter1, Surplus),
-            Messages = filter_delivery(Messages0),
+            Messages = enrich_messages(TopicFilter, filter_delivery(Messages0)),
             Cursor = next_cursor(InnerCursor, NumFetchedMessages, Handler0),
             Handler = Handler0#h{
                 limiter = Limiter,
@@ -286,6 +287,9 @@ try_consume(#h{} = Handler0, N0) when is_integer(N0) ->
             Handler = Handler0#h{limiter = Limiter1, times_throttled = TimesThrottled0 + 1},
             {error, Handler}
     end.
+
+enrich_messages(TopicFilter, Messages) ->
+    [emqx_message:set_header(?HEADER_SUB_TOPIC, TopicFilter, Msg) || Msg <- Messages].
 
 try_consume_at_most(Limiter, N) ->
     MinBatch = min_batch_backoff(N),

--- a/apps/emqx_retainer/test/emqx_retainer_mqtt_v5_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_mqtt_v5_SUITE.erl
@@ -208,3 +208,26 @@ t_subscribe_retain_handing(_) ->
     clean_retained(<<"topic/A">>),
     clean_retained(<<"topic/B">>),
     clean_retained(<<"topic/C">>).
+
+t_subscribe_wildcard_caps_retained_qos(_) ->
+    Topic = <<"retainer/qos/1">>,
+    TopicFilter = <<"retainer/qos/+">>,
+
+    {ok, Client} = emqtt:start_link([{proto_ver, v5}]),
+    {ok, _} = emqtt:connect(Client),
+    {ok, _} = emqtt:publish(
+        Client,
+        Topic,
+        #{},
+        <<"retained message">>,
+        [{qos, 2}, {retain, true}]
+    ),
+
+    {ok, _, [0]} = emqtt:subscribe(Client, #{}, [{TopicFilter, [{rh, 0}, {qos, 0}]}]),
+    [Msg] = receive_messages(1),
+    ?assertEqual(Topic, maps:get(topic, Msg)),
+    ?assertEqual(<<"retained message">>, maps:get(payload, Msg)),
+    ?assertEqual(0, maps:get(qos, Msg)),
+
+    ok = emqtt:disconnect(Client),
+    clean_retained(Topic).

--- a/changes/ee/fix-17798.en.md
+++ b/changes/ee/fix-17798.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where retained messages could be delivered with the original publish QoS instead of the wildcard subscription QoS limit.


### PR DESCRIPTION
Release version: 6.1.3, 6.2.2, 6.3

Fixes #17781

## Summary

Fix qos enrichment for retained messages to wildcard subscriptions.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
