### PR TITLE
test(mgmt): de-flake t_kickout_clients

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -709,12 +709,27 @@ t_kickout_clients(Config) ->
     ?assertReceive({'DOWN', _MRef, process, C1, _}),
     ?assertReceive({'DOWN', _MRef, process, C2, _}),
     ?assertReceive({'DOWN', _MRef, process, C3, _}),
-    ?retry(_Interval = 100, _Attempts = 20, begin
-        ?assertMatch(
-            {ok, {_200, _, #{<<"meta">> := #{<<"count">> := 0}}}},
-            request(get, ClientsPath, Config)
-        )
-    end).
+    %% The emqtt clients are down, but the broker unregisters the kicked
+    %% channels asynchronously (emqx_cm 'DOWN' monitor -> emqx_pool clean_down
+    %% -> emqx_cm:do_unregister_channel/1). Until that runs, GET /clients still
+    %% counts the lingering channel-info rows (meta.count is
+    %% ets:info(?CHAN_INFO_TAB, size)). Wait for the broker-side cleanup to
+    %% finish first. do_unregister_channel/1 deletes ?CHAN_INFO_TAB before
+    %% ?CHAN_TAB, so once lookup_channels/2 is empty the count is guaranteed 0.
+    lists:foreach(
+        fun(ClientId) ->
+            ?retry(
+                _Interval = 100,
+                _Attempts = 50,
+                ?assertEqual([], emqx_cm:lookup_channels(local, ClientId))
+            )
+        end,
+        [ClientId1, ClientId2, ClientId3]
+    ),
+    ?assertMatch(
+        {ok, {_200, _, #{<<"meta">> := #{<<"count">> := 0}}}},
+        request(get, ClientsPath, Config)
+    ).
 
 t_query_clients_with_time(Config) ->
     Username1 = <<"user1">>,


### PR DESCRIPTION
## Summary

`emqx_mgmt_api_clients_SUITE:t_kickout_clients` flaked with:

```
got: #{<<"data">> => [], <<"meta">> => #{<<"count">> => 1, ...}}
```

i.e. the `?retry(100, 20, ...)` (2s) assertion `meta.count == 0` failed every attempt.

## Root cause

After the bulk kickout, the emqtt client processes are torn down synchronously
(the test observes their `'DOWN'`), but the **broker unregisters the kicked
channels asynchronously**: `emqx_cm` `'DOWN'` monitor → `emqx_pool` `clean_down`
→ `emqx_cm:do_unregister_channel/1`. Until that runs, `GET /clients` still counts
the lingering channel-info rows, because `meta.count` for the unfiltered query is
`ets:info(?CHAN_INFO_TAB, size)`. Under load this cleanup can exceed the 2s retry
window, so all 20 attempts see a non-zero count.

(The captured snapshot showed `data == []` while `count == 1` only because
`emqx_mgmt_api:do_select/2` reads the count via `ets:info` a moment before it
selects the rows; that ordering quirk is incidental, not the cause of the
2-second persistence.)

Verified locally: persistence is disabled in this group, the kick correctly
destroys all sessions (including the v5 `Session-Expiry-Interval = 120` client),
and `count`/`data` drop to 0 together — so the flake is purely the async-cleanup
lag, not a persistent-session leak or a count/data mismatch.

## Fix

Test-only. Before asserting the API, wait for the broker-side cleanup to finish
via `emqx_cm:lookup_channels/2` (the authoritative channel registry).
`do_unregister_channel/1` deletes `?CHAN_INFO_TAB` *before* `?CHAN_TAB`, so once
`lookup_channels/2` is empty for each kicked client, `meta.count` is guaranteed
to be 0.

No user-facing change.