### PR TITLE
test(mqtt): await c1 disconnected before publishing in offline queueing

### DIFF
--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -217,7 +217,19 @@ t_offline_message_queueing(_) ->
     ]),
     {ok, _} = emqtt:connect(C1),
     {ok, _, [2]} = emqtt:subscribe(C1, <<"+/+">>, 2),
+    [ChanPid] = emqx_cm:lookup_channels(<<"c1">>),
     ok = emqtt:disconnect(C1),
+
+    %% Wait until the broker has fully transitioned c1's channel to the
+    %% 'disconnected' state before publishing. emqtt:disconnect/1 returns as soon
+    %% as the client has sent DISCONNECT and closed its socket, but the broker-side
+    %% channel may still be 'connected' for a brief window. A message delivered in
+    %% that window takes the live-delivery path (emqx_channel:do_handle_deliver):
+    %% QoS 1/2 messages land in the session *inflight* window, which mqueue_len
+    %% does not count, and the QoS 0 message is written to the closing socket and
+    %% dropped. Only once the channel is 'disconnected' do deliveries go straight
+    %% to the offline mqueue, so mqueue_len can reach 3 deterministically.
+    ?WAIT(?assertEqual(disconnected, maps:get(conn_state, emqx_connection:info(ChanPid))), 10),
 
     {ok, C2} = emqtt:start_link([
         {clean_start, true},
@@ -239,7 +251,6 @@ t_offline_message_queueing(_) ->
     %% channel's emit_stats timer (default mqtt.idle_timeout = 15s). Once c1
     %% disconnects the channel hibernates and stops emitting stats, so the cached
     %% mqueue_len can lag reality for the whole retry budget.
-    [ChanPid] = emqx_cm:lookup_channels(<<"c1">>),
     ?WAIT(?assertEqual(3, proplists:get_value(mqueue_len, emqx_connection:stats(ChanPid))), 30),
     emqtt:disconnect(C2),
 


### PR DESCRIPTION
Release version: 6.0.4

## Summary

De-flakes `emqx_client_SUITE:t_offline_message_queueing`. The test published
to `c1`'s wildcard subscription immediately after `emqtt:disconnect/1`
returned, which races the broker-side transition of `c1`'s channel to the
`disconnected` state.

A message delivered while the channel is still `connected` takes the
live-delivery path (`emqx_channel:do_handle_deliver/2`) instead of the
offline-enqueue path:

* QoS 1/2 messages land in the session **inflight** window, which
  `mqueue_len` does not count (it counts only the mqueue).
* The QoS 0 message is written to the closing socket and dropped.

On a loaded runner this left `mqueue_len` below 3 (the CI failure observed
`mqueue_len = 1`), so the live-stats `?WAIT(mqueue_len == 3, 30)` exhausted
its full 30 s budget and failed. This was confirmed by forcing the
deliver-before-disconnect ordering, which reproduces `mqueue_len = 0,
inflight_cnt = 2`; the two inflight messages are not lost — they replay on
reconnect.

Fix: look up `c1`'s channel before disconnecting and wait until it reports
`conn_state = disconnected` before publishing, so all three deliveries go
straight to the offline mqueue and `mqueue_len` reaches 3 deterministically.
Verified with 47 clean executions of the case (30 in a single node boot via
`--repeat`, plus 17 standalone runs) and the full `gen_tcp_listener.mqttv4`
group.

The fix is test-only; broker behavior is unchanged and correct (QoS 1/2 are
retained in inflight and replayed; QoS 0 is best-effort).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
