### PR TITLE
fix(tls): accept IANA-format cipher names in ssl_opts.ciphers

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -3369,7 +3369,7 @@ validate_ciphers(Ciphers) ->
     Set = emqx_tls_lib:all_ciphers_set_cached(),
     case lists:filter(fun(Cipher) -> not sets:is_element(Cipher, Set) end, Ciphers) of
         [] -> ok;
-        Bad -> {error, {bad_ciphers, Bad}}
+        Bad -> {error, #{cause => bad_ciphers, ciphers => [iolist_to_binary(C) || C <- Bad]}}
     end.
 
 validate_tls_versions(Collection, Versions) ->

--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -152,7 +152,20 @@ integral_versions(Type, DesiredIn) ->
 all_ciphers_set_cached() ->
     case persistent_term:get(?FUNCTION_NAME, false) of
         false ->
-            S = sets:from_list(all_ciphers()),
+            OpenSslNames = all_ciphers(),
+            %% Also include the RFC/IANA name for every supported cipher so
+            %% configs written in either convention validate. ssl:str_to_suite
+            %% accepts both, so we keep both forms in the set for the
+            %% schema-side validator.
+            RfcNames = [
+                try
+                    cipher_to_rfc(C)
+                catch
+                    _:_ -> C
+                end
+             || C <- OpenSslNames
+            ],
+            S = sets:from_list(OpenSslNames ++ RfcNames),
             persistent_term:put(?FUNCTION_NAME, S),
             S;
         Set ->

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -104,7 +104,7 @@ ssl_opts_cert_depth_test() ->
 
 bad_cipher_test() ->
     Sc = emqx_schema:server_ssl_opts_schema(#{}, false),
-    Reason = {bad_ciphers, ["foo"]},
+    Reason = #{cause => bad_ciphers, ciphers => [<<"foo">>]},
     ?assertThrow(
         {_Sc, [#{kind := validation_error, reason := Reason}]},
         validate(Sc, #{
@@ -113,6 +113,32 @@ bad_cipher_test() ->
         })
     ),
     ok.
+
+validate_ciphers_accepts_both_formats_test_() ->
+    Sc = emqx_schema:server_ssl_opts_schema(#{}, false),
+    Check = fun(Ciphers) ->
+        validate(Sc, #{
+            <<"versions">> => [<<"tlsv1.3">>, <<"tlsv1.2">>],
+            <<"ciphers">> => Ciphers
+        })
+    end,
+    [
+        %% OpenSSL-format TLS 1.2 cipher
+        ?_assertMatch(
+            #{ciphers := ["ECDHE-ECDSA-AES256-GCM-SHA384"]},
+            Check([<<"ECDHE-ECDSA-AES256-GCM-SHA384">>])
+        ),
+        %% IANA/RFC-format TLS 1.2 cipher
+        ?_assertMatch(
+            #{ciphers := ["TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"]},
+            Check([<<"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384">>])
+        ),
+        %% TLS 1.3 cipher (same name in both formats)
+        ?_assertMatch(
+            #{ciphers := ["TLS_AES_256_GCM_SHA384"]},
+            Check([<<"TLS_AES_256_GCM_SHA384">>])
+        )
+    ].
 
 fail_if_no_peer_cert_test_() ->
     Sc = #{

--- a/apps/emqx/test/emqx_tls_lib_tests.erl
+++ b/apps/emqx/test/emqx_tls_lib_tests.erl
@@ -11,6 +11,7 @@
 
 %% one of the cipher suite from tlsv1.2 and tlsv1.3 each
 -define(TLS_12_CIPHER, "ECDHE-ECDSA-AES256-GCM-SHA384").
+-define(TLS_12_CIPHER_RFC, "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384").
 -define(TLS_13_CIPHER, "TLS_AES_256_GCM_SHA384").
 
 -define(ns, <<"some_ns">>).
@@ -79,6 +80,37 @@ tls_version_unknown_test_() ->
 cipher_suites_no_duplication_test() ->
     AllCiphers = emqx_tls_lib:default_ciphers(),
     ?assertEqual(length(AllCiphers), length(lists:usort(AllCiphers))).
+
+%% The cached set used by the schema validator must hold both the OpenSSL and
+%% the RFC/IANA name for a TLS 1.2 cipher (TLS 1.3 names are identical).
+all_ciphers_set_contains_both_formats_test() ->
+    Set = emqx_tls_lib:all_ciphers_set_cached(),
+    ?assert(sets:is_element(?TLS_12_CIPHER, Set)),
+    ?assert(sets:is_element(?TLS_12_CIPHER_RFC, Set)),
+    ?assert(sets:is_element(?TLS_13_CIPHER, Set)).
+
+%% cipher_to_rfc/1 must be idempotent: feeding it an RFC name returns the same
+%% RFC name (ssl:str_to_suite/1 accepts both conventions).
+cipher_to_rfc_idempotent_test() ->
+    ?assertEqual(?TLS_12_CIPHER_RFC, emqx_tls_lib:cipher_to_rfc(?TLS_12_CIPHER)),
+    ?assertEqual(?TLS_12_CIPHER_RFC, emqx_tls_lib:cipher_to_rfc(?TLS_12_CIPHER_RFC)).
+
+%% The greptimedb NIF path (convert_ciphers_to_rfc/2) must accept ciphers given
+%% in either convention and resolve both to the supported RFC name.
+convert_ciphers_to_rfc_accepts_both_formats_test() ->
+    Supported = [?TLS_12_CIPHER_RFC],
+    ?assertEqual(
+        {[?TLS_12_CIPHER_RFC], []},
+        emqx_tls_lib:convert_ciphers_to_rfc([?TLS_12_CIPHER], Supported)
+    ),
+    ?assertEqual(
+        {[?TLS_12_CIPHER_RFC], []},
+        emqx_tls_lib:convert_ciphers_to_rfc([?TLS_12_CIPHER_RFC], Supported)
+    ),
+    ?assertMatch(
+        {[], [_]},
+        emqx_tls_lib:convert_ciphers_to_rfc(["NOT_A_CIPHER"], Supported)
+    ).
 
 ssl_files_failure_test_() ->
     lists:flatten([

--- a/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
+++ b/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
@@ -754,3 +754,22 @@ t_authentication_error_on_send_message(TCConfig) ->
         end
     ),
     ok.
+
+t_create_with_invalid_cipher(TCConfig) ->
+    %% An unknown TLS cipher must be rejected with a clean 400 carrying a
+    %% JSON error body, not crash the API with a 500 while encoding the reason.
+    Res = create_connector_api(TCConfig, #{
+        <<"ssl">> => #{
+            <<"enable">> => true,
+            <<"verify">> => <<"verify_none">>,
+            <<"ciphers">> => [<<"NOT_A_CIPHER">>]
+        }
+    }),
+    ?assertMatch({400, _}, Res),
+    {400, Body} = Res,
+    ?assertMatch(
+        {match, _},
+        re:run(emqx_utils_json:encode(Body), <<"bad_ciphers">>),
+        #{body => Body}
+    ),
+    ok.


### PR DESCRIPTION
Release version: 6.1.3, 6.2.2

## Summary

The `ssl_opts.ciphers` validator only recognized OpenSSL-format cipher
names, so a valid TLS 1.2 cipher supplied in its IANA/RFC name (e.g.
`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`) was rejected as `bad_ciphers`.
Erlang's `ssl` module accepts both naming conventions, so the
pre-validation was stricter than the runtime it guards.

- `emqx_tls_lib:all_ciphers_set_cached/0` now stores both the OpenSSL and
  the RFC/IANA name for every supported cipher, using the existing
  `cipher_to_rfc/1` utility. Configs written in either convention now
  validate. TLS 1.3 ciphers were already accepted because their IANA and
  OpenSSL names are identical; the divergence only affected TLS 1.2.
- `emqx_schema:validate_ciphers/1` now returns a JSON-friendly map
  (`#{cause => bad_ciphers, ciphers => [...]}`) on failure, so the REST
  API responds with a clean 400 instead of crashing while encoding the
  reason term for a genuinely unknown cipher.

Fixes #17793

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
