### PR TITLE
fix(gateway): reclaim orphan locker on gateway re-load

### DIFF
--- a/apps/emqx_gateway/mix.exs
+++ b/apps/emqx_gateway/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGateway.MixProject do
   def project do
     [
       app: :emqx_gateway,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_gateway/src/emqx_gateway_cm.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cm.erl
@@ -756,22 +756,75 @@ init(Options) ->
     ok = emqx_utils_ets:new(ConnTab, [bag | TabOpts]),
     ok = emqx_utils_ets:new(InfoTab, [ordered_set, compressed | TabOpts]),
 
-    %% Start link cm-registry process
-    %% XXX: Should I hang it under a higher level supervisor?
-    {ok, Registry} = emqx_gateway_cm_registry:start_link(GwName),
-
-    %% Start locker process
-    {ok, _LockerPid} = ekka_locker:start_link(lockername(GwName)),
-
     %% Interval update stats
     %% TODO: v0.2
     %ok = emqx_stats:update_interval(chan_stats, fun ?MODULE:stats_fun/0),
 
-    {ok, #state{
-        gwname = GwName,
-        registry = Registry,
-        chan_pmon = emqx_pmon:new()
-    }}.
+    case start_cm_children(GwName) of
+        {ok, Registry} ->
+            {ok, #state{
+                gwname = GwName,
+                registry = Registry,
+                chan_pmon = emqx_pmon:new()
+            }};
+        {error, Reason} ->
+            {stop, Reason}
+    end.
+
+%% Start the per-gateway registry and locker processes.
+%%
+%% XXX: These are linked to this gen_server rather than supervised as proper
+%% children (tracked as a follow-up). Because they are not supervised, a
+%% gateway load that aborts partway through can leave the named locker behind;
+%% the next load would then crash with `{already_started, _}'. To keep
+%% (re)loads robust we reclaim any leftover locker, and we tear down whatever
+%% we already started should a later step fail.
+start_cm_children(GwName) ->
+    case emqx_gateway_cm_registry:start_link(GwName) of
+        {ok, Registry} ->
+            case ensure_locker_started(GwName) of
+                ok ->
+                    {ok, Registry};
+                {error, _} = Err ->
+                    _ = gen_server:stop(Registry),
+                    Err
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+ensure_locker_started(GwName) ->
+    LockerName = lockername(GwName),
+    case ekka_locker:start_link(LockerName) of
+        {ok, _Pid} ->
+            ok;
+        ignore ->
+            ok;
+        {error, {already_started, OldPid}} ->
+            %% A locker left behind by a previously aborted load of this
+            %% gateway. There is only one cm per gateway, so this registered
+            %% name can only belong to an orphan; reclaim it and retry once.
+            ok = reclaim_orphan(OldPid),
+            case ekka_locker:start_link(LockerName) of
+                {ok, _Pid} -> ok;
+                ignore -> ok;
+                {error, Reason} -> {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% Synchronously take down an orphan process and wait until it is gone so its
+%% registered name is freed before we retry.
+reclaim_orphan(Pid) ->
+    MRef = erlang:monitor(process, Pid),
+    exit(Pid, kill),
+    receive
+        {'DOWN', MRef, process, Pid, _Reason} -> ok
+    after 5000 ->
+        erlang:demonitor(MRef, [flush]),
+        ok
+    end.
 
 handle_call(_Request, _From, State) ->
     Reply = ok,

--- a/apps/emqx_gateway/test/emqx_gateway_cm_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_cm_SUITE.erl
@@ -281,6 +281,27 @@ t_unexpected_handle(Conf) ->
     ok = gen_server:call(Pid, unexpected_call),
     ok = gen_server:cast(Pid, unexpected_cast).
 
+-doc """
+A gateway load that aborts partway through can leave its locker process
+registered. cm:init/1 must reclaim such an orphan so the gateway can still be
+(re)started instead of crashing with `{already_started, _}'.
+""".
+t_init_reclaims_orphan_locker(_) ->
+    GwName = orphan_gw,
+    LockerName = list_to_atom(lists:concat(['emqx_gateway_', GwName, '_locker'])),
+    %% Simulate a locker left behind by a previously aborted load.
+    {ok, Orphan} = ekka_locker:start_link(LockerName),
+    ?assertEqual(Orphan, whereis(LockerName)),
+    %% A fresh cm for the same gateway must still start cleanly.
+    {ok, CMPid} = emqx_gateway_cm:start_link([{gwname, GwName}]),
+    ?assert(is_process_alive(CMPid)),
+    %% The orphan was reclaimed and a live locker is registered under the name.
+    ?assertNot(is_process_alive(Orphan)),
+    NewLocker = whereis(LockerName),
+    ?assert(is_pid(NewLocker) andalso is_process_alive(NewLocker)),
+    ?assertNotEqual(Orphan, NewLocker),
+    ok = gen_server:stop(CMPid).
+
 %%--------------------------------------------------------------------
 %% helpers
 

--- a/changes/ee/fix-17805.en.md
+++ b/changes/ee/fix-17805.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where re-loading a gateway could fail with an `already_started` error after a previous load attempt aborted partway through (for example due to an invalid configuration or a busy listener port). The leftover locker process from the failed attempt is now reclaimed automatically, so the next `load` (or operator retry) starts from a clean state.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

A gateway load that aborts partway through — for example with an invalid
config (`xml_dir` pointing at a missing directory) or a busy listener port —
could leave the per-gateway `ekka_locker` process registered. The locker is
started and linked inside `emqx_gateway_cm:init/1` rather than supervised, so
on a partial-start failure its registered name lingers. The next
`emqx_gateway:load/2` (or an operator retry) then crashed:

```
{badmatch, {error, {already_started, <pid>}}}
  at emqx_gateway_cm:init/1
```

This surfaced as a flaky failure of
`emqx_lwm2m_SUITE:case111_gateway_error_paths` in CI:
https://github.com/emqx/emqx/actions/runs/28470327099/job/84383995021?pr=17802

### Change

`emqx_gateway_cm:init/1` now:
- reclaims a leftover locker before retrying (there is only one `cm` per
  gateway, so the registered locker name can only belong to an orphan), and
- tears down anything it already started and returns `{stop, Reason}` instead
  of crashing should a later step fail.

Most relevant module: `apps/emqx_gateway/src/emqx_gateway_cm.erl`.

### Tests

Added `emqx_gateway_cm_SUITE:t_init_reclaims_orphan_locker`, which simulates an
orphan locker and asserts a fresh `cm` still starts cleanly. It reproduces the
exact `{already_started, _}` crash against the unpatched code and passes with
the fix (looped 30×). The bug exists on dev-60+; this targets dev-60 so the fix
forward-syncs to dev-61/62/63, where `case111_gateway_error_paths` also
exercises it.

Follow-up (separate issue): make `cm_registry` and `ekka_locker` proper
supervisor children instead of linking them inside the gen_server's `init/1`
(the long-standing `XXX` in the source).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
