### PR TITLE
fix(data_backup): require credential-management scopes for sensitive-table import and export

### DIFF
--- a/apps/emqx_management/mix.exs
+++ b/apps/emqx_management/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXManagement.MixProject do
   def project do
     [
       app: :emqx_management,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
@@ -266,11 +266,7 @@ data_import(post, #{body := #{<<"filename">> := Filename} = Body} = Req) ->
         FileNode ->
             case check_no_sensitive_tables(Filename, auth_meta(Req)) of
                 {forbidden, Sets} ->
-                    SensMsg = iolist_to_binary([
-                        <<"API key import refused: backup contains restricted tables: ">>,
-                        lists:join(<<", ">>, Sets)
-                    ]),
-                    {403, #{code => 'FORBIDDEN', message => SensMsg}};
+                    {403, #{code => 'FORBIDDEN', message => import_refused_msg(Sets)}};
                 {peek_error, Reason} ->
                     {400, #{
                         code => ?BAD_REQUEST,
@@ -405,14 +401,42 @@ handle_file_op_response({badrpc, Reason}) ->
 auth_meta(#{auth_meta := AuthMeta}) -> AuthMeta;
 auth_meta(_) -> #{}.
 
-is_api_key_caller(#{auth_type := api_key}) -> true;
-is_api_key_caller(_) -> false.
+%% The `dashboard_users' and `api_keys' table sets are governed at their
+%% dedicated REST endpoints (`/users', `/api_key') by the
+%% `user_management' and `api_key_management' scopes. A caller may only
+%% back up or restore those tables through the data-backup endpoints when
+%% it holds the same scopes; otherwise the sensitive table sets are
+%% filtered on export and rejected on import. The predicate returns
+%% `true' when this restriction applies to the caller.
+%%
+%%   * API-key callers: always restricted (API keys cannot hold the
+%%     credential-management scopes at all).
+%%   * Dashboard JWT callers: restricted unless they are a global
+%%     administrator whose effective scope set includes both
+%%     `user_management' and `api_key_management'.
+%%   * Anything else: restricted (fail closed).
+requires_sensitive_table_check(#{auth_type := api_key}) ->
+    true;
+requires_sensitive_table_check(#{auth_type := jwt_token} = AuthMeta) ->
+    not has_credential_management_scopes(AuthMeta);
+requires_sensitive_table_check(_) ->
+    true.
 
-%% API key callers must not export tables that hold dashboard accounts or
-%% API keys themselves. Force-filter the requested table sets accordingly.
-%% Dashboard JWT callers are unaffected.
+has_credential_management_scopes(#{
+    source := Source,
+    actor := #{?role := ?ROLE_SUPERUSER, ?namespace := ?global_ns}
+}) ->
+    Scopes = emqx_dashboard_admin:effective_scopes_of(Source),
+    lists:member(?SCOPE_USER_MGMT, Scopes) andalso
+        lists:member(?SCOPE_API_KEY_MGMT, Scopes);
+has_credential_management_scopes(_) ->
+    false.
+
+%% Callers without the credential-management scopes must not export tables
+%% that hold dashboard accounts or API keys themselves. Force-filter the
+%% requested table sets accordingly.
 maybe_filter_export_params(Params, AuthMeta) ->
-    case is_api_key_caller(AuthMeta) of
+    case requires_sensitive_table_check(AuthMeta) of
         true -> filter_sensitive_table_sets(Params);
         false -> Params
     end.
@@ -428,10 +452,10 @@ filter_sensitive_table_sets(Params) ->
 
 %% Peek the local file. If the file lives on a different node (caller passed
 %% `node' in the body), the local peek returns `{error, not_found}' and the
-%% handler reports a 400 -- API-key callers must upload to the same node where
-%% they import.
+%% handler reports a 400 -- restricted callers must upload to the same node
+%% where they import.
 check_no_sensitive_tables(Filename, AuthMeta) ->
-    case is_api_key_caller(AuthMeta) of
+    case requires_sensitive_table_check(AuthMeta) of
         false ->
             ok;
         true ->
@@ -480,6 +504,15 @@ download_forbidden_msg() ->
         "Only the global administrator may download backup files. "
         "Backups may contain dashboard accounts and API key records."
     >>.
+
+import_refused_msg(Sets) ->
+    iolist_to_binary([
+        <<
+            "Import refused: backup contains tables that require the "
+            "user_management and api_key_management scopes: "
+        >>,
+        lists:join(<<", ">>, Sets)
+    ]).
 
 api_key_download_forbidden_msg(Sets) ->
     iolist_to_binary([

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -366,6 +366,78 @@ t_import_dashboard_token_allows_sensitive_tables(Config) ->
     ?assertMatch({ok, _}, import_backup(?NODE1_PORT, DashboardAuth, ?UPLOAD_CE_BACKUP)),
     ok.
 
+%% A Dashboard administrator whose effective scope set does not include both
+%% `user_management' and `api_key_management' must be rejected with 403 when
+%% importing a backup that contains the dashboard_users / api_keys tables,
+%% the same as an API-key caller.
+t_import_restricted_dashboard_token_blocks_sensitive_tables(Config) ->
+    ApiAuth = ?config(auth, Config),
+    [Core1 | _] = ?config(cluster, Config),
+    %% `system' is what lets the caller reach the data-backup endpoint at
+    %% all; it does NOT include the credential-management scopes that govern
+    %% the sensitive tables.
+    RestrictedAuth = scoped_dashboard_token_auth(
+        Core1, <<"restricted_admin_for_test">>, ?DASHBOARD_PASS, [<<"system">>]
+    ),
+    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
+    ?assertEqual(ok, upload_backup(?NODE1_PORT, ApiAuth, UploadFile)),
+    {Status, Body} = import_backup_full(?NODE1_PORT, RestrictedAuth, ?UPLOAD_CE_BACKUP),
+    ?assertEqual(403, Status),
+    ?assertMatch(#{<<"code">> := <<"FORBIDDEN">>}, Body),
+    ok.
+
+%% A Dashboard administrator whose effective scope set includes both
+%% `user_management' and `api_key_management' may import a backup that
+%% contains the dashboard_users / api_keys tables. (`system' is also required,
+%% otherwise the login-user scope check blocks the data-backup endpoint
+%% before the sensitive-table check runs.)
+t_import_dashboard_token_with_credential_scopes_allows_sensitive_tables(Config) ->
+    ApiAuth = ?config(auth, Config),
+    [Core1 | _] = ?config(cluster, Config),
+    PrivilegedAuth = scoped_dashboard_token_auth(
+        Core1,
+        <<"privileged_admin_for_test">>,
+        ?DASHBOARD_PASS,
+        [<<"system">>, <<"user_management">>, <<"api_key_management">>]
+    ),
+    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
+    ?assertEqual(ok, upload_backup(?NODE1_PORT, ApiAuth, UploadFile)),
+    ?assertMatch({ok, _}, import_backup(?NODE1_PORT, PrivilegedAuth, ?UPLOAD_CE_BACKUP)),
+    ok.
+
+%% A restricted Dashboard administrator's export must omit the sensitive table
+%% sets, mirroring the API-key export behaviour.
+t_export_restricted_dashboard_token_omits_sensitive_tables(Config) ->
+    [Core1 | _] = ?config(cluster, Config),
+    RestrictedAuth = scoped_dashboard_token_auth(
+        Core1, <<"restricted_exporter_for_test">>, ?DASHBOARD_PASS, [<<"system">>]
+    ),
+    {200, #{<<"filename">> := Filename, <<"node">> := NodeBin}} =
+        export_backup2(?NODE1_PORT, RestrictedAuth, #{}),
+    Node = binary_to_atom(NodeBin, utf8),
+    {ok, BinContents} = ?ON(
+        Node, emqx_mgmt_data_backup:read_file(unicode:characters_to_binary(Filename))
+    ),
+    {ok, TmpFile} = write_tmp_tar(BinContents),
+    try
+        {ok, Entries} = erl_tar:table(TmpFile, [compressed]),
+        SensitiveTabs = ["mnesia/emqx_admin", "mnesia/emqx_app"],
+        FoundSensitive = [
+            E
+         || E <- Entries,
+            S <- SensitiveTabs,
+            string:find(E, S) =/= nomatch
+        ],
+        ?assertEqual(
+            [],
+            FoundSensitive,
+            "restricted dashboard export must not contain dashboard_users / api_keys mnesia tables"
+        )
+    after
+        file:delete(TmpFile)
+    end,
+    ok.
+
 %% API-key callers may download archives that do not contain dashboard users or
 %% API-key records. This keeps backup-sync working: its API-key export path
 %% already filters those sensitive table sets.
@@ -774,6 +846,16 @@ dashboard_token_auth(Node, User, Pass, Role) ->
     {ok, #{token := Token}} = erpc:call(Node, emqx_dashboard_admin, sign_token, [User, Pass]),
     {"Authorization", "Bearer " ++ binary_to_list(Token)}.
 
+%% Create a global dashboard administrator with an explicit scope set and
+%% return its bearer-token auth header.
+scoped_dashboard_token_auth(Node, User, Pass, Scopes) ->
+    _ = erpc:call(Node, emqx_dashboard_admin, add_user, [
+        User, Pass, <<"administrator">>, <<"data backup test user">>
+    ]),
+    {ok, ok} = erpc:call(Node, emqx_dashboard_admin, set_user_scopes, [User, Scopes]),
+    {ok, #{token := Token}} = erpc:call(Node, emqx_dashboard_admin, sign_token, [User, Pass]),
+    {"Authorization", "Bearer " ++ binary_to_list(Token)}.
+
 fresh_dashboard_auth(Config) ->
     [Core1, _Core2, Repl] = ?config(cluster, Config),
     Auth = dashboard_auth_header(Core1),
@@ -849,7 +931,9 @@ test_case_specific_apps_spec(TC) when
     TC =:= t_upload_ce_backup;
     TC =:= t_import_ce_backup;
     TC =:= t_import_api_key_blocks_sensitive_tables;
-    TC =:= t_import_dashboard_token_allows_sensitive_tables
+    TC =:= t_import_dashboard_token_allows_sensitive_tables;
+    TC =:= t_import_restricted_dashboard_token_blocks_sensitive_tables;
+    TC =:= t_import_dashboard_token_with_credential_scopes_allows_sensitive_tables
 ->
     [
         emqx_auth,

--- a/changes/ee/fix-17806.en.md
+++ b/changes/ee/fix-17806.en.md
@@ -1,0 +1,1 @@
+Aligned the data backup import and export endpoints with the principle of least privilege: Dashboard users whose scope set does not include both `user_management` and `api_key_management` can no longer import or export archives containing the `dashboard_users` or `api_keys` table sets. Global administrators and API-key callers with the necessary scopes are unaffected.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.4, 6.2.3

## Summary

Apply the existing sensitive-table check (introduced in #17173 for API-key callers) to Dashboard JWT callers whose scope set does not include both `user_management` and `api_key_management`. With this change, a scope-restricted Dashboard user can no longer import or export backup archives containing the `dashboard_users` or `api_keys` mnesia tables unless they hold the scopes that govern those tables at their dedicated REST endpoints (`/users`, `/api_key`).

Global administrators (no `scopes` field set, or running with the default admin scope set) are unaffected and continue to be able to import and export full backups including those tables. The behaviour for API-key callers is unchanged.

Most relevant change: `apps/emqx_management/src/emqx_mgmt_api_data_backup.erl` replaces the `is_api_key_caller/1` gate with a `requires_sensitive_table_check/1` predicate covering API-key callers, scope-restricted JWT callers, and an unknown-shape fail-closed case. The predicate resolves a JWT caller's effective scopes via `emqx_dashboard_admin:effective_scopes_of/1`, so the role-default fallback (a global admin with no explicit scopes holds the full scope catalog) is preserved.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
