### PR TITLE
fix(data_backup): isolate namespaced backups per namespace

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -61,6 +61,7 @@
 {emqx_mgmt_cluster,3}.
 {emqx_mgmt_data_backup,1}.
 {emqx_mgmt_data_backup,2}.
+{emqx_mgmt_data_backup,3}.
 {emqx_mgmt_trace,2}.
 {emqx_mgmt_trace,3}.
 {emqx_mq_consumer,1}.

--- a/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
@@ -557,8 +557,8 @@ t_namespaced_user_permissions(_TCConfig) ->
     ok.
 
 %% Keep in sync with the namespaced-deny clauses in
-%% `emqx_dashboard_rbac:do_check_rbac/3' for these three modules.  Adding a new
-%% global-only message endpoint there means adding it here too.
+%% `emqx_dashboard_rbac:do_check_rbac/3' for these modules.  Adding a new
+%% global-only endpoint there means adding it here too.
 namespaced_get_denylist() ->
     [
         #{method => get, module => emqx_mgmt_api_clients, function => mqueue_msgs},

--- a/apps/emqx_dashboard_rbac/mix.exs
+++ b/apps/emqx_dashboard_rbac/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDashboardRbac.MixProject do
   def project do
     [
       app: :emqx_dashboard_rbac,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -344,7 +344,10 @@ do_check_rbac(
 ) when
     is_binary(Namespace)
 ->
-    %% Configuration backup export/import.
+    %% Namespaced configuration backup export/import and per-namespace backup
+    %% file management.  The handlers isolate each namespace to its own backup
+    %% directory, so a namespaced administrator only ever sees or acts on its
+    %% own archives, never global (or legacy) ones.
     true;
 do_check_rbac(_, _, _) ->
     {error, <<"You don't have permission to access this resource">>}.

--- a/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
@@ -111,7 +111,8 @@ schema("/data/files") ->
             desc => ?DESC("list_backup_files"),
             parameters => [
                 ?R_REF(emqx_dashboard_swagger, page),
-                ?R_REF(emqx_dashboard_swagger, limit)
+                ?R_REF(emqx_dashboard_swagger, limit),
+                field_namespace(false, #{in => query})
             ],
             responses => #{
                 200 =>
@@ -130,7 +131,8 @@ schema("/data/files/:filename") ->
             description => ?DESC("download_backup_file"),
             parameters => [
                 field_filename(true, #{in => path}),
-                field_node(false, #{in => query})
+                field_node(false, #{in => query}),
+                field_namespace(false, #{in => query})
             ],
             responses => #{
                 200 => ?HOCON(binary),
@@ -147,7 +149,8 @@ schema("/data/files/:filename") ->
             desc => ?DESC("delete_backup_file"),
             parameters => [
                 field_filename(true, #{in => path}),
-                field_node(false, #{in => query})
+                field_node(false, #{in => query}),
+                field_namespace(false, #{in => query})
             ],
             responses => #{
                 204 => <<"No Content">>,
@@ -213,6 +216,9 @@ field_node(IsRequired) ->
 field_node(IsRequired, Meta) ->
     {node, ?HOCON(binary(), Meta#{desc => ?DESC("node_name"), required => IsRequired})}.
 
+field_namespace(IsRequired, Meta) ->
+    {namespace, ?HOCON(binary(), Meta#{desc => ?DESC("namespace"), required => IsRequired})}.
+
 field_filename(IsRequired) ->
     field_filename(IsRequired, #{}).
 
@@ -264,18 +270,27 @@ data_import(post, #{body := #{<<"filename">> := Filename} = Body} = Req) ->
         {error, Msg} ->
             {400, #{code => ?BAD_REQUEST, message => Msg}};
         FileNode ->
-            case check_no_sensitive_tables(Filename, auth_meta(Req)) of
-                {forbidden, Sets} ->
-                    {403, #{code => 'FORBIDDEN', message => import_refused_msg(Sets)}};
-                {peek_error, Reason} ->
-                    {400, #{
-                        code => ?BAD_REQUEST,
-                        message => emqx_mgmt_data_backup:format_error(Reason)
-                    }};
-                ok ->
-                    do_data_import(FileNode, Filename, Namespace)
-            end
+            data_import_checked(Namespace, FileNode, Filename, Req)
     end.
+
+%% Namespaced imports are scoped to the caller's own namespace and never write
+%% mnesia tables (only that namespace's configuration), so the sensitive-table
+%% guard -- which protects the global mnesia tables -- does not apply. Global
+%% imports keep the guard.
+data_import_checked(?global_ns, FileNode, Filename, Req) ->
+    case check_no_sensitive_tables(Filename, auth_meta(Req)) of
+        {forbidden, Sets} ->
+            {403, #{code => 'FORBIDDEN', message => import_refused_msg(Sets)}};
+        {peek_error, Reason} ->
+            {400, #{
+                code => ?BAD_REQUEST,
+                message => emqx_mgmt_data_backup:format_error(Reason)
+            }};
+        ok ->
+            do_data_import(FileNode, Filename, ?global_ns)
+    end;
+data_import_checked(Namespace, FileNode, Filename, _Req) when is_binary(Namespace) ->
+    do_data_import(FileNode, Filename, Namespace).
 
 do_data_import(FileNode, Filename, Namespace) ->
     CoreNode = core_node(FileNode),
@@ -333,9 +348,10 @@ core_node(FileNode) ->
             end
     end.
 
-data_files(post, #{body := #{<<"filename">> := #{type := _} = File}}) ->
+data_files(post, #{body := #{<<"filename">> := #{type := _} = File}} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
     [{Filename, FileContent} | _] = maps:to_list(maps:without([type], File)),
-    case emqx_mgmt_data_backup:upload(Filename, FileContent) of
+    case emqx_mgmt_data_backup:upload(Namespace, Filename, FileContent) of
         ok ->
             {204};
         {error, Reason} ->
@@ -343,17 +359,38 @@ data_files(post, #{body := #{<<"filename">> := #{type := _} = File}}) ->
     end;
 data_files(post, #{body := _}) ->
     {400, #{code => ?BAD_REQUEST, message => ?DESC("missing_filename")}};
-data_files(get, #{query_string := PageParams}) ->
+data_files(get, #{query_string := PageParams} = Req) ->
+    Namespace = op_namespace(Req, PageParams),
     case emqx_mgmt_api:parse_pager_params(PageParams) of
         false ->
             {400, #{code => ?BAD_REQUEST, message => ?DESC("page_limit_invalid")}};
         #{page := Page, limit := Limit} = Pager ->
-            {Count, HasNext, Data} = list_backup_files(Page, Limit),
+            {Count, HasNext, Data} = list_backup_files(Namespace, Page, Limit),
             {200, #{data => Data, meta => Pager#{count => Count, hasnext => HasNext}}}
     end.
 
 data_file_by_name(get, #{bindings := #{filename := Filename}, query_string := QS} = Req) ->
-    AuthMeta = auth_meta(Req),
+    case op_namespace(Req, QS) of
+        ?global_ns ->
+            do_download_file(Filename, QS, auth_meta(Req));
+        Namespace when is_binary(Namespace) ->
+            %% Namespaced backups only ever contain that namespace's
+            %% configuration -- never global mnesia tables -- so the
+            %% sensitive-table download guard does not apply.
+            do_namespaced_file_op(get, Namespace, Filename, QS)
+    end;
+data_file_by_name(delete, #{bindings := #{filename := Filename}, query_string := QS} = Req) ->
+    do_namespaced_file_op(delete, op_namespace(Req, QS), Filename, QS).
+
+do_namespaced_file_op(Method, Namespace, Filename, QS) ->
+    case safe_parse_node(QS) of
+        {error, Msg} ->
+            {400, #{code => ?BAD_REQUEST, message => Msg}};
+        Node ->
+            handle_file_op_response(get_or_delete_file(Method, Namespace, Filename, Node))
+    end.
+
+do_download_file(Filename, QS, AuthMeta) ->
     case can_attempt_download(AuthMeta) of
         false ->
             {403, #{code => 'FORBIDDEN', message => download_forbidden_msg()}};
@@ -362,22 +399,18 @@ data_file_by_name(get, #{bindings := #{filename := Filename}, query_string := QS
                 {error, Msg} ->
                     {400, #{code => ?BAD_REQUEST, message => Msg}};
                 Node ->
-                    case can_download_backup(AuthMeta, Filename, Node) of
-                        ok ->
-                            handle_file_op_response(get_or_delete_file(get, Filename, Node));
-                        {forbidden, Msg} ->
-                            {403, #{code => ?FORBIDDEN, message => Msg}};
-                        {error, Reason} ->
-                            handle_file_op_response(Reason)
-                    end
+                    download_checked_file(AuthMeta, Filename, Node)
             end
-    end;
-data_file_by_name(delete, #{bindings := #{filename := Filename}, query_string := QS}) ->
-    case safe_parse_node(QS) of
-        {error, Msg} ->
-            {400, #{code => ?BAD_REQUEST, message => Msg}};
-        Node ->
-            handle_file_op_response(get_or_delete_file(delete, Filename, Node))
+    end.
+
+download_checked_file(AuthMeta, Filename, Node) ->
+    case can_download_backup(AuthMeta, Filename, Node) of
+        ok ->
+            handle_file_op_response(get_or_delete_file(get, ?global_ns, Filename, Node));
+        {forbidden, Msg} ->
+            {403, #{code => ?FORBIDDEN, message => Msg}};
+        {error, Reason} ->
+            handle_file_op_response(Reason)
     end.
 
 handle_file_op_response({error, not_found}) ->
@@ -400,6 +433,24 @@ handle_file_op_response({badrpc, Reason}) ->
 
 auth_meta(#{auth_meta := AuthMeta}) -> AuthMeta;
 auth_meta(_) -> #{}.
+
+%% The namespace a file operation acts on. Namespaced callers are always
+%% confined to their own namespace -- the `namespace' query parameter is
+%% ignored for them. A global administrator may pass `namespace' to inspect or
+%% clean up a specific namespace's backups; without it, they operate on the
+%% global (non-namespaced) backups.
+op_namespace(Req, QueryString) ->
+    case emqx_dashboard:get_namespace(Req) of
+        ?global_ns -> query_namespace(QueryString);
+        Namespace when is_binary(Namespace) -> Namespace
+    end.
+
+query_namespace(#{<<"namespace">> := Namespace}) when
+    is_binary(Namespace), Namespace =/= <<>>
+->
+    Namespace;
+query_namespace(_) ->
+    ?global_ns.
 
 %% The `dashboard_users' and `api_keys' table sets are governed at their
 %% dedicated REST endpoints (`/users', `/api_key') by the
@@ -520,10 +571,17 @@ api_key_download_forbidden_msg(Sets) ->
         lists:join(<<", ">>, Sets)
     ]).
 
-get_or_delete_file(get, Filename, Node) ->
+%% Global (and legacy) backups live in the root backup directory and are served
+%% by the v1 RPCs; namespaced backups are isolated under a per-namespace
+%% subdirectory and require the v3 RPCs that carry the namespace.
+get_or_delete_file(get, ?global_ns, Filename, Node) ->
     emqx_mgmt_data_backup_proto_v1:read_file(Node, Filename, infinity);
-get_or_delete_file(delete, Filename, Node) ->
-    emqx_mgmt_data_backup_proto_v1:delete_file(Node, Filename, infinity).
+get_or_delete_file(delete, ?global_ns, Filename, Node) ->
+    emqx_mgmt_data_backup_proto_v1:delete_file(Node, Filename, infinity);
+get_or_delete_file(get, Namespace, Filename, Node) when is_binary(Namespace) ->
+    emqx_mgmt_data_backup_proto_v3:read_file(Node, Namespace, Filename, infinity);
+get_or_delete_file(delete, Namespace, Filename, Node) when is_binary(Namespace) ->
+    emqx_mgmt_data_backup_proto_v3:delete_file(Node, Namespace, Filename, infinity).
 
 safe_parse_node(BodyParams) ->
     Nodes = emqx:running_nodes(),
@@ -538,16 +596,26 @@ safe_parse_node(#{<<"node">> := NodeBin}, Nodes) ->
 safe_parse_node(_, _) ->
     node().
 
-list_backup_files(Page, Limit) ->
+list_backup_files(Namespace, Page, Limit) ->
     Start = Page * Limit - Limit + 1,
-    AllFiles = list_backup_files(),
+    AllFiles = list_backup_files(Namespace),
     Count = length(AllFiles),
     HasNext = Start + Limit - 1 < Count,
     {Count, HasNext, lists:sublist(AllFiles, Start, Limit)}.
 
-list_backup_files() ->
+%% Global (and legacy) backups are listed from the root directory via the v1
+%% RPC; a namespaced caller only sees its own backups, listed via the v3 RPC on
+%% the nodes that support it.
+list_backup_files(?global_ns) ->
     Nodes = emqx:running_nodes(),
     Results = emqx_mgmt_data_backup_proto_v1:list_files(Nodes, 30_0000),
+    collect_backup_files(Nodes, Results);
+list_backup_files(Namespace) when is_binary(Namespace) ->
+    Nodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI_NAME, 3),
+    Results = emqx_mgmt_data_backup_proto_v3:list_files(Nodes, Namespace, 30_0000),
+    collect_backup_files(Nodes, Results).
+
+collect_backup_files(Nodes, Results) ->
     NodeResults = lists:zip(Nodes, Results),
     {Successes, Failures} =
         lists:partition(

--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -21,6 +21,7 @@
 %% HTTP API
 -export([
     upload/2,
+    upload/3,
     %% RPC target (v1)
     maybe_copy_and_import/2,
     %% RPC target (v2)
@@ -28,6 +29,10 @@
     read_file/1,
     delete_file/1,
     list_files/0,
+    %% RPC target (v3): namespace-scoped file operations
+    read_file/2,
+    delete_file/2,
+    list_files/1,
     format_conf_errors/1,
     format_db_errors/1,
     sensitive_table_set_names/0,
@@ -62,6 +67,8 @@
 -include_lib("emqx/include/emqx_config.hrl").
 
 -define(ROOT_BACKUP_DIR, "backup").
+%% Namespaced backups are isolated under `<root>/ns/<Namespace>/'.
+-define(NS_BACKUP_SUBDIR, "ns").
 -define(BACKUP_MNESIA_DIR, "mnesia").
 -define(TAR_SUFFIX, ".tar.gz").
 -define(META_FILENAME, "META.hocon").
@@ -369,9 +376,10 @@ import(BackupFilename) ->
 
 -spec import(file:filename_all(), import_opts()) -> import_res().
 import(BackupFilename, Opts) ->
+    Namespace = maps:get(namespace, Opts, ?global_ns),
     maybe
         ok ?= validate_import_allowed(),
-        {ok, BackupFilePath} ?= backup_path(BackupFilename),
+        {ok, BackupFilePath} ?= backup_path(Namespace, BackupFilename),
         ok ?= validate_file_exists(BackupFilePath),
         do_import(BackupFilePath, Opts)
     end.
@@ -394,30 +402,47 @@ It runs on a core node.
 """.
 -spec maybe_copy_and_import(node(), file:filename_all(), import_opts()) -> import_res().
 maybe_copy_and_import(FileNode, BackupFilename, Opts) ->
+    Namespace = maps:get(namespace, Opts, ?global_ns),
     maybe
-        ok ?= maybe_copy(FileNode, BackupFilename),
+        ok ?= maybe_copy(FileNode, BackupFilename, Namespace),
         import(BackupFilename, Opts)
     end.
 
 -spec read_file(file:filename_all()) ->
     {ok, #{filename => file:filename_all(), file => binary()}} | {error, _}.
 read_file(BackupFilename) ->
+    read_file(?global_ns, BackupFilename).
+
+%% RPC target (v3). `Namespace' scopes the lookup to the caller's backup
+%% directory, keeping tenants isolated from each other and from global backups.
+-spec read_file(maybe_namespace(), file:filename_all()) ->
+    {ok, #{filename => file:filename_all(), file => binary()}} | {error, _}.
+read_file(Namespace, BackupFilename) ->
     maybe
-        {ok, FilePath} ?= backup_path(BackupFilename),
+        {ok, FilePath} ?= backup_path(Namespace, BackupFilename),
         maybe_not_found(file:read_file(FilePath))
     end.
 
 -spec delete_file(file:filename_all()) -> ok | {error, _}.
 delete_file(BackupFilename) ->
+    delete_file(?global_ns, BackupFilename).
+
+%% RPC target (v3). See `read_file/2'.
+-spec delete_file(maybe_namespace(), file:filename_all()) -> ok | {error, _}.
+delete_file(Namespace, BackupFilename) ->
     maybe
-        {ok, FilePath} ?= backup_path(BackupFilename),
+        {ok, FilePath} ?= backup_path(Namespace, BackupFilename),
         maybe_not_found(file:delete(FilePath))
     end.
 
 -spec upload(file:filename_all(), binary()) -> ok | {error, _}.
 upload(BackupFilename, BackupFileContent) ->
+    upload(?global_ns, BackupFilename, BackupFileContent).
+
+-spec upload(maybe_namespace(), file:filename_all(), binary()) -> ok | {error, _}.
+upload(Namespace, BackupFilename, BackupFileContent) ->
     maybe
-        {ok, FilePath} ?= backup_path(BackupFilename),
+        {ok, FilePath} ?= backup_path(Namespace, BackupFilename),
         case filelib:is_file(FilePath) of
             true -> {error, {already_exists, BackupFilename}};
             false -> do_upload(FilePath, BackupFileContent)
@@ -426,6 +451,13 @@ upload(BackupFilename, BackupFileContent) ->
 
 -spec list_files() -> [backup_file_info()].
 list_files() ->
+    list_files(?global_ns).
+
+%% RPC target (v3). Lists only the backups owned by `Namespace'; global backups
+%% (including legacy ones created before namespace isolation) live in the root
+%% directory and are only visible to global administrators.
+-spec list_files(maybe_namespace()) -> [backup_file_info()].
+list_files(Namespace) ->
     Filter =
         fun(File) ->
             case file:read_file_info(File, [{time, posix}]) of
@@ -443,11 +475,11 @@ list_files() ->
                     false
             end
         end,
-    lists:filtermap(Filter, backup_files()).
+    lists:filtermap(Filter, backup_files(Namespace)).
 
--spec backup_files() -> [file:filename()].
-backup_files() ->
-    {ok, Pattern} = backup_path("*" ++ ?TAR_SUFFIX),
+-spec backup_files(maybe_namespace()) -> [file:filename()].
+backup_files(Namespace) ->
+    {ok, Pattern} = backup_path(Namespace, "*" ++ ?TAR_SUFFIX),
     filelib:wildcard(Pattern).
 
 -spec format_error(atom()) -> string() | term().
@@ -513,25 +545,33 @@ format_db_errors(Errors) ->
 %% Internal functions
 %%------------------------------------------------------------------------------
 
-maybe_copy(FileNode, _BackupFilename) when FileNode =:= node() ->
+maybe_copy(FileNode, _BackupFilename, _Namespace) when FileNode =:= node() ->
     ok;
-maybe_copy(FileNode, BackupFilename) ->
+maybe_copy(FileNode, BackupFilename, Namespace) ->
     maybe
-        {ok, FilePath} ?= backup_path(BackupFilename),
+        {ok, FilePath} ?= backup_path(Namespace, BackupFilename),
         %% The file can be already present locally.
         case filelib:is_regular(FilePath) of
             true ->
                 ok;
             false ->
-                copy(FileNode, BackupFilename)
+                copy(FileNode, BackupFilename, Namespace)
         end
     end.
 
-copy(FileNode, BackupFilename) ->
+copy(FileNode, BackupFilename, ?global_ns) ->
     maybe
         {ok, BackupFileContent} ?=
             emqx_mgmt_data_backup_proto_v1:read_file(FileNode, BackupFilename, infinity),
-        ok ?= upload(BackupFilename, BackupFileContent)
+        ok ?= upload(?global_ns, BackupFilename, BackupFileContent)
+    end;
+copy(FileNode, BackupFilename, Namespace) when is_binary(Namespace) ->
+    maybe
+        {ok, BackupFileContent} ?=
+            emqx_mgmt_data_backup_proto_v3:read_file(
+                FileNode, Namespace, BackupFilename, infinity
+            ),
+        ok ?= upload(Namespace, BackupFilename, BackupFileContent)
     end.
 
 maybe_not_found({error, enoent}) ->
@@ -595,7 +635,9 @@ prepare_new_backup(Opts) ->
             [Y, M, D, HH, MM, SS, Ts rem 1000]
         )
     ),
-    BackupDir = maps:get(out_dir, Opts, root_backup_dir()),
+    Namespace = maps:get(namespace, Opts, ?global_ns),
+    {ok, DefaultDir} = backup_root_dir(Namespace),
+    BackupDir = maps:get(out_dir, Opts, DefaultDir),
     BackupName = filename:join(BackupDir, BackupBaseName),
     BackupTarName = tar(BackupName),
     maybe_print("Exporting data to ~p...~n", [BackupTarName], Opts),
@@ -1539,15 +1581,43 @@ backup_dir(BackupFilePath) ->
         _ -> {ok, filename:join(RootBackupDir, BaseName)}
     end.
 
-backup_path(Filename) when is_binary(Filename) ->
-    backup_path(str(Filename));
-backup_path(Filename) when is_list(Filename) ->
+backup_path(Filename) ->
+    backup_path(?global_ns, Filename).
+
+backup_path(Namespace, Filename) when is_binary(Filename) ->
+    backup_path(Namespace, str(Filename));
+backup_path(Namespace, Filename) when is_list(Filename) ->
     maybe
         [Filename] ?= filename:split(Filename),
         ok ?= validate_backup_basename(Filename),
-        {ok, filename:join(root_backup_dir(), Filename)}
+        {ok, Dir} ?= backup_root_dir(Namespace),
+        {ok, filename:join(Dir, Filename)}
     else
+        {error, _} = Error -> Error;
         _ -> {error, bad_backup_name}
+    end.
+
+%% Global (and legacy) backups live directly in the root backup directory;
+%% namespaced backups are isolated under `<root>/ns/<Namespace>/'. This is the
+%% single choke point that keeps tenants from reaching each other's or the
+%% global administrator's archives.
+backup_root_dir(?global_ns) ->
+    {ok, root_backup_dir()};
+backup_root_dir(Namespace) when is_binary(Namespace) ->
+    namespaced_backup_dir(Namespace).
+
+%% The namespace comes from the authenticated caller, but we still resolve it as
+%% a safe relative path so a crafted namespace cannot escape the backup root.
+namespaced_backup_dir(Namespace) ->
+    Root = root_backup_dir(),
+    RelPath = filename:join(?NS_BACKUP_SUBDIR, str(Namespace)),
+    case filelib:safe_relative_path(RelPath, Root) of
+        unsafe ->
+            {error, bad_backup_name};
+        SafeRel ->
+            Dir = filename:join(Root, SafeRel),
+            ok = ensure_path(Dir),
+            {ok, Dir}
     end.
 
 cleanup_backup_dir(BackupFilePath) ->

--- a/apps/emqx_management/src/proto/emqx_mgmt_data_backup_proto_v3.erl
+++ b/apps/emqx_management/src/proto/emqx_mgmt_data_backup_proto_v3.erl
@@ -1,0 +1,37 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_mgmt_data_backup_proto_v3).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+    list_files/3,
+    read_file/4,
+    delete_file/4
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+introduced_in() ->
+    "6.0.4".
+
+%% `Namespace' scopes the operation to the caller's backup directory. Global
+%% (and legacy) backups use `?global_ns' and live in the root backup directory;
+%% namespaced backups are isolated under a per-namespace subdirectory.
+-spec list_files([node()], emqx_config:maybe_namespace(), timeout()) ->
+    emqx_rpc:erpc_multicall({non_neg_integer(), map()}).
+list_files(Nodes, Namespace, Timeout) ->
+    erpc:multicall(Nodes, emqx_mgmt_data_backup, list_files, [Namespace], Timeout).
+
+-spec read_file(node(), emqx_config:maybe_namespace(), binary(), timeout()) ->
+    {ok, binary()} | {error, _} | {badrpc, _}.
+read_file(Node, Namespace, FileName, Timeout) ->
+    rpc:call(Node, emqx_mgmt_data_backup, read_file, [Namespace, FileName], Timeout).
+
+-spec delete_file(node(), emqx_config:maybe_namespace(), binary(), timeout()) ->
+    ok | {error, _} | {badrpc, _}.
+delete_file(Node, Namespace, FileName, Timeout) ->
+    rpc:call(Node, emqx_mgmt_data_backup, delete_file, [Namespace, FileName], Timeout).

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -498,17 +498,111 @@ t_download_viewer_forbidden(Config) ->
     ?assertMatch(#{<<"code">> := <<"FORBIDDEN">>}, Body),
     ok.
 
-%% Namespaced administrators must be rejected with 403 when downloading a
-%% backup file. Backups span all namespaces; downloading one would leak
-%% cross-namespace dashboard accounts and API-key records.
-t_download_ns_admin_forbidden(Config) ->
+%% Namespaced administrators get an isolated backup space under
+%% `<backup>/ns/<Namespace>/'. Export, list, download and delete only ever act
+%% on that space: a namespaced administrator cannot see or touch global (or
+%% legacy) backups, nor another namespace's backups.
+t_namespaced_backup_isolation(Config) ->
+    [Core1, _Core2, _Repl] = ?config(cluster, Config),
     ApiAuth = ?config(auth, Config),
-    NsAdminAuth = ?config(ns_admin_auth, Config),
-    {200, #{<<"filename">> := Filename}} =
-        export_backup2(?NODE1_PORT, ApiAuth, #{}),
-    {Status, Body} = download_backup(?NODE1_PORT, NsAdminAuth, Filename),
-    ?assertEqual(403, Status),
-    ?assertMatch(#{<<"code">> := <<"FORBIDDEN">>}, Body),
+    DashboardAuth = ?config(dashboard_auth, Config),
+    Ns1Auth = ?config(ns_admin_auth, Config),
+    Ns2Auth = ns_admin_auth_header(Core1, <<"ns2">>, <<"ns2_admin_for_test">>, ?NS_ADMIN_PASS),
+
+    %% Global export lands in the flat/global space; each namespace exports into
+    %% its own space.
+    {200, #{<<"filename">> := GFile}} = export_backup2(?NODE1_PORT, ApiAuth, #{}),
+    {200, #{<<"filename">> := N1File}} = export_backup2(?NODE1_PORT, Ns1Auth, #{}),
+    {200, #{<<"filename">> := N2File}} = export_backup2(?NODE1_PORT, Ns2Auth, #{}),
+
+    %% Listing is scoped: each namespace sees only its own file.
+    ?assertEqual([N1File], list_filenames(?NODE1_PORT, Ns1Auth)),
+    ?assertEqual([N2File], list_filenames(?NODE1_PORT, Ns2Auth)),
+    %% A namespaced API key resolves to the same isolated space as the
+    %% namespaced dashboard administrator.
+    Ns1ApiKeyAuth = ns_api_key_auth_header(Core1),
+    ?assertEqual([N1File], list_filenames(?NODE1_PORT, Ns1ApiKeyAuth)),
+    %% Global listing sees the global file, never the namespaced ones.
+    GlobalFiles = list_filenames(?NODE1_PORT, DashboardAuth),
+    ?assert(lists:member(GFile, GlobalFiles)),
+    ?assertNot(lists:member(N1File, GlobalFiles)),
+    ?assertNot(lists:member(N2File, GlobalFiles)),
+
+    %% ns1 can download its own file, but not the global one nor ns2's --
+    %% those are invisible in its space and resolve to 404.
+    ?assertMatch({200, _}, download_backup(?NODE1_PORT, Ns1Auth, N1File)),
+    ?assertMatch({404, _}, download_backup(?NODE1_PORT, Ns1Auth, GFile)),
+    ?assertMatch({404, _}, download_backup(?NODE1_PORT, Ns1Auth, N2File)),
+
+    %% ns1 cannot delete another space's file, but can delete its own.
+    ?assertMatch({404, _}, delete_backup(?NODE1_PORT, Ns1Auth, GFile)),
+    ?assertMatch({404, _}, delete_backup(?NODE1_PORT, Ns1Auth, N2File)),
+    ?assertMatch({204, _}, delete_backup(?NODE1_PORT, Ns1Auth, N1File)),
+    ?assertEqual([], list_filenames(?NODE1_PORT, Ns1Auth)),
+
+    %% Global download of the global file still works (regression).
+    ?assertMatch({200, _}, download_backup(?NODE1_PORT, DashboardAuth, GFile)),
+    ok.
+
+%% A namespaced administrator can round-trip its own configuration: export then
+%% re-import, scoped entirely to its namespace.
+t_namespaced_export_import(Config) ->
+    Ns1Auth = ?config(ns_admin_auth, Config),
+    {200, #{<<"filename">> := N1File}} = export_backup2(?NODE1_PORT, Ns1Auth, #{}),
+    ?assertMatch({204, _}, import_backup_full(?NODE1_PORT, Ns1Auth, N1File)),
+    ok.
+
+%% A namespaced administrator uploading a backup lands it in its own space; the
+%% global administrator never sees it.
+t_namespaced_upload_isolation(Config) ->
+    Ns1Auth = ?config(ns_admin_auth, Config),
+    DashboardAuth = ?config(dashboard_auth, Config),
+    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
+    ?assertEqual(ok, upload_backup(?NODE1_PORT, Ns1Auth, UploadFile)),
+    Base = list_to_binary(?UPLOAD_CE_BACKUP),
+    ?assert(lists:member(Base, list_filenames(?NODE1_PORT, Ns1Auth))),
+    ?assertNot(lists:member(Base, list_filenames(?NODE1_PORT, DashboardAuth))),
+    ok.
+
+%% A global administrator may opt in to a specific namespace's backup space with
+%% the `namespace' query parameter -- to inspect or clean up after a tenant --
+%% while the default (no parameter) stays on the global backups.
+t_global_admin_scoped_namespace(Config) ->
+    DashboardAuth = ?config(dashboard_auth, Config),
+    Ns1Auth = ?config(ns_admin_auth, Config),
+    Ns1 = #{<<"namespace">> => <<"ns1">>},
+
+    {200, #{<<"filename">> := N1File}} = export_backup2(?NODE1_PORT, Ns1Auth, #{}),
+
+    %% Default global listing does not see the namespaced backup...
+    ?assertNot(lists:member(N1File, list_filenames(?NODE1_PORT, DashboardAuth))),
+    %% ...but opting into ns1 does.
+    ?assertEqual([N1File], list_filenames(?NODE1_PORT, DashboardAuth, Ns1)),
+
+    %% Global admin can download and delete within the opted-in namespace.
+    ?assertMatch({200, _}, download_backup(?NODE1_PORT, DashboardAuth, N1File, Ns1)),
+    ?assertMatch({204, _}, delete_backup(?NODE1_PORT, DashboardAuth, N1File, Ns1)),
+    ?assertEqual([], list_filenames(?NODE1_PORT, DashboardAuth, Ns1)),
+    ok.
+
+%% A namespaced administrator cannot escape its namespace by supplying the
+%% `namespace' query parameter -- it is ignored for namespaced callers.
+t_namespaced_admin_cannot_override_namespace(Config) ->
+    [Core1, _Core2, _Repl] = ?config(cluster, Config),
+    Ns1Auth = ?config(ns_admin_auth, Config),
+    Ns2Auth = ns_admin_auth_header(Core1, <<"ns2">>, <<"ns2_admin_for_test">>, ?NS_ADMIN_PASS),
+
+    {200, #{<<"filename">> := N1File}} = export_backup2(?NODE1_PORT, Ns1Auth, #{}),
+    {200, #{<<"filename">> := N2File}} = export_backup2(?NODE1_PORT, Ns2Auth, #{}),
+
+    %% ns1 asking for ns2 still only sees (and can only act on) its own space.
+    ?assertEqual([N1File], list_filenames(?NODE1_PORT, Ns1Auth, #{<<"namespace">> => <<"ns2">>})),
+    ?assertMatch(
+        {404, _}, download_backup(?NODE1_PORT, Ns1Auth, N2File, #{<<"namespace">> => <<"ns2">>})
+    ),
+    ?assertMatch(
+        {404, _}, delete_backup(?NODE1_PORT, Ns1Auth, N2File, #{<<"namespace">> => <<"ns2">>})
+    ),
     ok.
 
 %% Global dashboard administrators must still be able to download a backup
@@ -522,28 +616,24 @@ t_download_global_admin_allowed(Config) ->
     ?assertEqual(200, Status),
     ok.
 
-%% Listing the backup directory remains open to dashboard viewers and
-%% namespaced administrators: the listing only exposes filenames / sizes /
-%% timestamps, not the archive contents. The download is the dangerous
-%% operation and is gated separately above.
+%% Listing the backup directory remains open to global dashboard viewers: the
+%% listing only exposes filenames / sizes / timestamps, not the archive
+%% contents, and the download is gated separately above. Namespaced callers see
+%% only their own namespace's backups (see t_namespaced_backup_isolation).
 t_list_files_viewer_allowed(Config) ->
     ApiAuth = ?config(auth, Config),
     ViewerAuth = ?config(viewer_auth, Config),
-    NsAdminAuth = ?config(ns_admin_auth, Config),
     {ok, _} = export_backup(?NODE1_PORT, ApiAuth),
-    lists:foreach(
-        fun(Auth) ->
-            {ok, _} = list_backups(?NODE1_PORT, Auth, <<"1">>, <<"100">>)
-        end,
-        [ViewerAuth, NsAdminAuth]
-    ),
+    {ok, _} = list_backups(?NODE1_PORT, ViewerAuth, <<"1">>, <<"100">>),
     ok.
 
 download_backup(NodeApiPort, Auth, BackupName) ->
-    Path = emqx_mgmt_api_test_util:api_path(
-        ?api_base_url(NodeApiPort), ["data", "files", to_list(BackupName)]
-    ),
-    emqx_mgmt_api_test_util:simple_request(get, Path, [], Auth).
+    download_backup(NodeApiPort, Auth, BackupName, #{}).
+
+download_backup(NodeApiPort, Auth, BackupName, QueryParams) ->
+    data_backup_simple_request(
+        get, NodeApiPort, ["data", "files", to_list(BackupName)], [], Auth, QueryParams
+    ).
 
 to_list(B) when is_binary(B) -> unicode:characters_to_list(B);
 to_list(L) when is_list(L) -> L.
@@ -835,9 +925,11 @@ viewer_auth_header(Node) ->
     dashboard_token_auth(Node, ?VIEWER_USER, ?VIEWER_PASS, <<"viewer">>).
 
 ns_admin_auth_header(Node) ->
-    dashboard_token_auth(
-        Node, ?NS_ADMIN_USER, ?NS_ADMIN_PASS, <<"ns:ns1::administrator">>
-    ).
+    ns_admin_auth_header(Node, <<"ns1">>, ?NS_ADMIN_USER, ?NS_ADMIN_PASS).
+
+ns_admin_auth_header(Node, Namespace, User, Pass) ->
+    Role = <<"ns:", Namespace/binary, "::administrator">>,
+    dashboard_token_auth(Node, User, Pass, Role).
 
 dashboard_token_auth(Node, User, Pass, Role) ->
     _ = erpc:call(Node, emqx_dashboard_admin, add_user, [
@@ -855,6 +947,47 @@ scoped_dashboard_token_auth(Node, User, Pass, Scopes) ->
     {ok, ok} = erpc:call(Node, emqx_dashboard_admin, set_user_scopes, [User, Scopes]),
     {ok, #{token := Token}} = erpc:call(Node, emqx_dashboard_admin, sign_token, [User, Pass]),
     {"Authorization", "Bearer " ++ binary_to_list(Token)}.
+
+ns_api_key_auth_header(Node) ->
+    Name = <<"ns_api_key_for_test">>,
+    {ok, #{api_key := Key, api_secret := Secret}} = erpc:call(Node, emqx_mgmt_auth, create, [
+        Name,
+        true,
+        _NeverExpire = undefined,
+        <<"data backup test ns api key">>,
+        <<"ns:ns1::administrator">>
+    ]),
+    emqx_common_test_http:auth_header(binary_to_list(Key), binary_to_list(Secret)).
+
+%% Return the basenames of the backups visible to `Auth'.
+list_filenames(Port, Auth) ->
+    list_filenames(Port, Auth, #{}).
+
+list_filenames(Port, Auth, QueryParams) ->
+    {200, #{<<"data">> := Data}} =
+        data_backup_simple_request(get, Port, ["data", "files"], [], Auth, QueryParams),
+    [maps:get(<<"filename">>, D) || D <- Data].
+
+delete_backup(Port, Auth, BackupName) ->
+    delete_backup(Port, Auth, BackupName, #{}).
+
+delete_backup(Port, Auth, BackupName, QueryParams) ->
+    data_backup_simple_request(
+        delete, Port, ["data", "files", to_list(BackupName)], [], Auth, QueryParams
+    ).
+
+data_backup_simple_request(Method, Port, PathParts, Body, Auth) ->
+    data_backup_simple_request(Method, Port, PathParts, Body, Auth, #{}).
+
+data_backup_simple_request(Method, Port, PathParts, Body, Auth, QueryParams) ->
+    Path = emqx_mgmt_api_test_util:api_path(?api_base_url(Port), PathParts),
+    emqx_mgmt_api_test_util:simple_request(#{
+        method => Method,
+        url => Path,
+        body => Body,
+        auth_header => Auth,
+        query_params => QueryParams
+    }).
 
 fresh_dashboard_auth(Config) ->
     [Core1, _Core2, Repl] = ?config(cluster, Config),
@@ -933,7 +1066,8 @@ test_case_specific_apps_spec(TC) when
     TC =:= t_import_api_key_blocks_sensitive_tables;
     TC =:= t_import_dashboard_token_allows_sensitive_tables;
     TC =:= t_import_restricted_dashboard_token_blocks_sensitive_tables;
-    TC =:= t_import_dashboard_token_with_credential_scopes_allows_sensitive_tables
+    TC =:= t_import_dashboard_token_with_credential_scopes_allows_sensitive_tables;
+    TC =:= t_namespaced_upload_isolation
 ->
     [
         emqx_auth,

--- a/changes/ee/fix-17807.en.md
+++ b/changes/ee/fix-17807.en.md
@@ -1,0 +1,3 @@
+Namespaced administrators now have an isolated data backup space. Their exports, uploads, listings, downloads, imports and deletes through the data backup endpoints (`/data/export`, `/data/import`, `/data/files`, `/data/files/:filename`) only ever act on their own namespace's backups. A namespaced administrator can no longer see, download, or delete global backups or another namespace's backups.
+
+Global administrators continue to manage global backups by default (including any created before this change), and may additionally pass a `namespace` query parameter to `GET`/`DELETE /data/files` and `GET /data/files/:filename` to inspect or clean up a specific namespace's backups.

--- a/rel/i18n/emqx_mgmt_api_data_backup.hocon
+++ b/rel/i18n/emqx_mgmt_api_data_backup.hocon
@@ -35,6 +35,11 @@ node_name.desc:
 node_name.label:
 """Node Name"""
 
+namespace.desc:
+"""Namespace whose backups to operate on. Only honored for global administrators; namespaced administrators are always confined to their own namespace. When omitted, a global administrator operates on the global (non-namespaced) backups."""
+namespace.label:
+"""Namespace"""
+
 filename.desc:
 """Data backup file name."""
 filename.label:


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Data backup archives are stored per node in a single flat directory shared across all callers. Namespaced administrators therefore shared the same backup space as the global administrator and other namespaces, so they could list, download, or delete each other's (and the global) archives.

This change isolates namespaced backups under a per-namespace subdirectory (`<backup>/ns/<Namespace>/`). Every data-backup operation for a namespaced caller — export, import, upload, list, download, delete — now resolves within that namespace's own directory:

- RBAC continues to allow namespaced administrators (and namespaced API keys) on the data-backup endpoints.
- The handler and backend derive the caller's namespace and scope all file resolution to its subdirectory. A new `_proto_v3` carries the namespace on the cross-node list/read/delete RPCs.
- A namespaced caller can no longer see, download, or delete global backups or another namespace's backups.

Global backups (including any created before this change) stay in the root directory and remain visible only to global administrators; global behaviour is unchanged by default. A global administrator may additionally pass a `namespace` query parameter to `GET`/`DELETE /data/files` and `GET /data/files/:filename` to inspect or clean up a specific namespace's backups. The parameter is ignored for namespaced callers, who stay confined to their own namespace.

This is one of a series of multi-tenancy scope-tightening changes.

Relevant modules:
- `apps/emqx_management/src/emqx_mgmt_data_backup.erl` — per-namespace path resolution; namespace-scoped `list_files`/`read_file`/`delete_file`/`upload`/`import`/export output.
- `apps/emqx_management/src/proto/emqx_mgmt_data_backup_proto_v3.erl` — namespace-scoped RPC targets.
- `apps/emqx_management/src/emqx_mgmt_api_data_backup.erl` — handlers resolve the effective namespace (caller identity, or `namespace` query param for global admins).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
