### PR TITLE
refactor(features): make auth part of the core, not a gateable feature

### DIFF
--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -14,7 +14,7 @@
 -export([read_apps/0]).
 
 %% internal export only for companion module `emqx_machine_features`
--export([reboot_apps_with_deps/0, full_sorted_reboot_apps/0]).
+-export([reboot_apps_with_deps/0, full_sorted_reboot_apps/0, is_umbrella_app/1]).
 
 -dialyzer({no_match, [basic_reboot_apps/0]}).
 

--- a/apps/emqx_machine/src/emqx_machine_features.erl
+++ b/apps/emqx_machine/src/emqx_machine_features.erl
@@ -17,6 +17,7 @@
 %%------------------------------------------------------------------------------
 
 -define(PT_KEY, {?MODULE, features}).
+-define(CORE_APPS_PT_KEY, {?MODULE, core_apps}).
 -define(ENV_VAR, "EMQX_FEATURES").
 
 %%------------------------------------------------------------------------------
@@ -37,7 +38,9 @@ is_umbrella_application_enabled(Application) when is_atom(Application) ->
 
 %% only for tests
 clear_features() ->
-    persistent_term:erase(?PT_KEY).
+    _ = persistent_term:erase(?PT_KEY),
+    _ = persistent_term:erase(?CORE_APPS_PT_KEY),
+    ok.
 
 %%------------------------------------------------------------------------------
 %% Internal fns
@@ -52,6 +55,16 @@ features() ->
     end.
 
 core_apps() ->
+    case persistent_term:get(?CORE_APPS_PT_KEY, undefined) of
+        undefined ->
+            Apps = base_core_apps() ++ auth_apps(),
+            _ = persistent_term:put(?CORE_APPS_PT_KEY, Apps),
+            Apps;
+        Apps ->
+            Apps
+    end.
+
+base_core_apps() ->
     [
         emqx,
         emqx_machine,
@@ -92,16 +105,6 @@ known_features() ->
             ],
             deps => []
         },
-        auth => #{
-            apps => [
-                emqx_auth,
-                emqx_ldap,
-                emqx_mongodb,
-                emqx_redis,
-                emqx_bridge_http
-            ] ++ auth_dynamic_apps(),
-            deps => []
-        },
         data_integration => #{
             apps => [
                 emqx_connector,
@@ -136,7 +139,7 @@ known_features() ->
         },
         gateways => #{
             apps => [emqx_gateway] ++ gateway_dynamic_apps(),
-            deps => [auth]
+            deps => []
         },
         cluster_link => #{
             apps => [emqx_cluster_link],
@@ -156,7 +159,7 @@ known_features() ->
         },
         metrics => #{
             apps => [emqx_prometheus, emqx_topic_metrics],
-            deps => [dashboard, auth]
+            deps => [dashboard]
         },
         mqtt_extensions => #{
             apps => [
@@ -175,7 +178,7 @@ known_features() ->
         },
         gcp_device => #{
             apps => [emqx_gcp_device],
-            deps => [auth]
+            deps => []
         },
         exhook => #{
             apps => [emqx_exhook],
@@ -203,18 +206,31 @@ data_integration_dynamic_apps() ->
         end
     ].
 
-auth_dynamic_apps() ->
-    RebootApps = full_sorted_reboot_apps(),
-    [
+%% Authentication/authorization is always available; it is core infrastructure,
+%% not an optional feature. A broker with authn/authz gated off would keep
+%% `enable_authn = true` and `authorization.no_match = deny` with no provider
+%% registered, and would therefore reject every MQTT connection. The
+%% `emqx_auth_*' backend apps are discovered by name so a newly added backend
+%% does not need to be listed here.
+auth_apps() ->
+    Base = [
+        emqx_auth,
+        emqx_ldap,
+        emqx_mongodb,
+        emqx_redis,
+        emqx_bridge_http
+    ],
+    Backends = [
         App
-     || App <- RebootApps,
+     || App <- full_sorted_reboot_apps(),
         case atom_to_list(App) of
             "emqx_auth_" ++ _ ->
                 true;
             _ ->
                 false
         end
-    ].
+    ],
+    Base ++ Backends.
 
 gateway_dynamic_apps() ->
     RebootApps = full_sorted_reboot_apps(),

--- a/apps/emqx_machine/src/emqx_machine_features.erl
+++ b/apps/emqx_machine/src/emqx_machine_features.erl
@@ -225,7 +225,7 @@ auth_apps() ->
      || App <- full_sorted_reboot_apps(),
         case atom_to_list(App) of
             "emqx_auth_" ++ _ ->
-                true;
+                emqx_machine_boot:is_umbrella_app(App);
             _ ->
                 false
         end

--- a/apps/emqx_machine/test/emqx_machine_features_bpapi_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_features_bpapi_SUITE.erl
@@ -113,7 +113,11 @@ sample_apis() ->
                     emqx_ds_builtin_raft,
                     emqx_ds_beamsplitter,
                     emqx_eviction_agent,
-                    emqx_node_rebalance
+                    emqx_node_rebalance,
+                    %% authn/authz is core infrastructure, always available
+                    emqx_authn,
+                    emqx_authz,
+                    emqx_auth_cache
                 ],
                 true
             ),
@@ -141,15 +145,6 @@ sample_apis() ->
             ),
         gateways =>
             maps:from_keys([emqx_gateway_cm], true),
-        auth =>
-            maps:from_keys(
-                [
-                    emqx_authn,
-                    emqx_authz,
-                    emqx_auth_cache
-                ],
-                true
-            ),
         cluster_link =>
             maps:from_keys([emqx_cluster_link], true),
         exhook =>

--- a/apps/emqx_machine/test/emqx_machine_features_tests.erl
+++ b/apps/emqx_machine/test/emqx_machine_features_tests.erl
@@ -164,22 +164,22 @@ essential_test_() ->
 
 custom_test_() ->
     [
-        ?with_features("two features (separated by comma)", "ai,auth", begin
+        ?with_features("two features (separated by comma)", "ai,dashboard", begin
             #{
                 preset := custom,
                 enabled := Enabled
             } = info(),
             ?assert(lists:member(ai, Enabled), #{enabled => Enabled}),
-            ?assert(lists:member(auth, Enabled), #{enabled => Enabled}),
+            ?assert(lists:member(dashboard, Enabled), #{enabled => Enabled}),
             ok
         end),
-        ?with_features("two features (separated by space)", "ai auth", begin
+        ?with_features("two features (separated by space)", "ai dashboard", begin
             #{
                 preset := custom,
                 enabled := Enabled
             } = info(),
             ?assert(lists:member(ai, Enabled), #{enabled => Enabled}),
-            ?assert(lists:member(auth, Enabled), #{enabled => Enabled}),
+            ?assert(lists:member(dashboard, Enabled), #{enabled => Enabled}),
             ok
         end)
     ].
@@ -216,9 +216,11 @@ test_individual_feature(Feature, Info) ->
     ),
     Apps = lists:usort(Apps0 ++ Apps1),
     ?with_features(F, F, begin
-        Enabled = enabled_apps(),
+        Enabled = lists:usort(enabled_apps()),
         CoreApps = emqx_machine_features:core_apps(),
-        Expected = CoreApps ++ Apps,
+        %% usort: some core apps (e.g. auth drivers) are also listed in a
+        %% feature's app list, so the concatenation can contain duplicates.
+        Expected = lists:usort(CoreApps ++ Apps),
         Missing = Expected -- Enabled,
         Extra = Enabled -- Expected,
         ?assertEqual([], Extra),
@@ -245,18 +247,6 @@ test_individual_feature_specific_assertions(data_integration) ->
         #{
             emqx_bridge_http := _,
             emqx_bridge_mqtt := _
-        },
-        maps:from_keys(Enabled, true)
-    ),
-    ok;
-test_individual_feature_specific_assertions(auth) ->
-    Enabled = enabled_apps(),
-    %% not an exhaustive list, since it's dynamically injected by name convention.
-    ?assertMatch(
-        #{
-            emqx_auth_cinfo := _,
-            emqx_auth_mnesia := _,
-            emqx_auth_mongodb := _
         },
         maps:from_keys(Enabled, true)
     ),

--- a/apps/emqx_machine/test/emqx_machine_features_tests.erl
+++ b/apps/emqx_machine/test/emqx_machine_features_tests.erl
@@ -216,7 +216,7 @@ test_individual_feature(Feature, Info) ->
     ),
     Apps = lists:usort(Apps0 ++ Apps1),
     ?with_features(F, F, begin
-        Enabled = lists:usort(enabled_apps()),
+        Enabled = enabled_apps(),
         CoreApps = emqx_machine_features:core_apps(),
         %% usort: some core apps (e.g. auth drivers) are also listed in a
         %% feature's app list, so the concatenation can contain duplicates.

--- a/apps/emqx_management/src/emqx_mgmt_api_features.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_features.erl
@@ -73,8 +73,7 @@ fields(features_out) ->
     [
         {preset, mk(binary(), #{})},
         {enabled, mk(array(binary()), #{})},
-        {disabled, mk(array(binary()), #{})},
-        {bundled, mk(array(binary()), #{})}
+        {disabled, mk(array(binary()), #{})}
     ].
 
 %%-------------------------------------------------------------------------------------------------
@@ -97,8 +96,7 @@ example_features_list() ->
                     preset => <<"custom">>,
                     enabled => [
                         <<"data_integration">>,
-                        <<"dashboard">>,
-                        <<"auth">>
+                        <<"dashboard">>
                     ],
                     disabled => [
                         <<"message_transformation">>,
@@ -111,8 +109,7 @@ example_features_list() ->
                         <<"metrics">>,
                         <<"mqtt_extensions">>,
                         <<"plugins">>
-                    ],
-                    bundled => []
+                    ]
                 }
             }
     }.

--- a/apps/emqx_management/test/emqx_mgmt_api_features_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_features_SUITE.erl
@@ -152,7 +152,7 @@ t_list_full(TCConfig) when is_list(TCConfig) ->
 Smoke tests for listing features via the HTTP API.  Custom preset.
 """.
 t_list_custom(TCConfig) when is_list(TCConfig) ->
-    start_apps("data_integration,auth", ?FUNCTION_NAME, TCConfig),
+    start_apps("data_integration,dashboard", ?FUNCTION_NAME, TCConfig),
     ?assertMatch(
         {200, #{
             <<"preset">> := <<"custom">>,

--- a/changes/ee/feat-17407.en.md
+++ b/changes/ee/feat-17407.en.md
@@ -1,14 +1,15 @@
-Added Feature Gates.  Now, it's possible to start EMQX with a limited set of features by specifying them in an environment variable `EMQX_FEATURES`.  Invalid presets or invalid features prevent the node from booting.  If a feature depends on other features, those are enabled automatically.
+[#17808](https://github.com/emqx/emqx/pull/17808) Added Feature Gates.
+
+Now, it's possible to start EMQX with a limited set of features by specifying them in an environment variable `EMQX_FEATURES`.  Invalid presets or invalid features prevent the node from booting.  If a feature depends on other features, those are enabled automatically.
 
 There are 2 presets available:
 
 - `FULL`: the default.  Starts EMQX with all available features.
-- `ESSENTIAL`: starts EMQX with the minimal amount of features.
+- `ESSENTIAL`: starts EMQX with the minimal amount of features: Core MQTT broker with authentication and authorization.
 
 The available features are:
 
 - `dashboard`: Dashboard UI (including SSO and RBAC), REST API.
-- `auth`: Authentication and authorization.
 - `data_integration`: Connectors, Actions, Sources and Rule Engine.
 - `message_transformation`: Message transformation.
 - `schema_validation`: Schema validation.

--- a/changes/ee/feat-17808.en.md
+++ b/changes/ee/feat-17808.en.md
@@ -1,0 +1,3 @@
+Made authentication and authorization always available, regardless of the `EMQX_FEATURES` setting.
+
+Previously `auth` was an optional feature that could be gated off (e.g. `EMQX_FEATURES=ESSENTIAL`). But with `auth` disabled, listeners still defaulted to `enable_authn = true` with no authentication provider, and `authorization.no_match = deny` with no authorization provider, so the broker rejected every MQTT connection and denied all publish/subscribe. Since a broker is not usable without authn/authz, `auth` is now part of the core and is no longer listed as a gateable feature. The feature listing (CLI and `GET /features`) no longer reports `auth` among the enabled/disabled features, and its `bundled` field has been removed.

--- a/changes/ee/feat-17808.en.md
+++ b/changes/ee/feat-17808.en.md
@@ -1,3 +1,0 @@
-Made authentication and authorization always available, regardless of the `EMQX_FEATURES` setting.
-
-Previously `auth` was an optional feature that could be gated off (e.g. `EMQX_FEATURES=ESSENTIAL`). But with `auth` disabled, listeners still defaulted to `enable_authn = true` with no authentication provider, and `authorization.no_match = deny` with no authorization provider, so the broker rejected every MQTT connection and denied all publish/subscribe. Since a broker is not usable without authn/authz, `auth` is now part of the core and is no longer listed as a gateable feature. The feature listing (CLI and `GET /features`) no longer reports `auth` among the enabled/disabled features, and its `bundled` field has been removed.

--- a/rel/i18n/emqx_mgmt_api_features.hocon
+++ b/rel/i18n/emqx_mgmt_api_features.hocon
@@ -1,7 +1,7 @@
 emqx_mgmt_api_features {
     features_list {
         desc: """~
-            List current preset, enabled, disabled and bundled features.~"""
+            List current preset, enabled and disabled features.~"""
         label: "List Features"
     }
 

--- a/scripts/test/test_emqx_boot.py
+++ b/scripts/test/test_emqx_boot.py
@@ -568,12 +568,6 @@ def test_feature_gate_full(emqx_bin_path):
                     pass;
                 case _:
                     raise AssertionError(f"bad enabled: {enabled}")
-            bundled = log["bundled"]
-            match bundled:
-                case [_, _, _, *_]:
-                    pass;
-                case _:
-                    raise AssertionError(f"bad bundled: {bundled}")
         finally:
             emqx.kill()
 
@@ -603,12 +597,6 @@ def test_feature_gate_essential(emqx_bin_path):
                     pass;
                 case _:
                     raise AssertionError(f"bad disabled: {disabled}")
-            bundled = log["bundled"]
-            match bundled:
-                case []:
-                    pass;
-                case _:
-                    raise AssertionError(f"bad bundled: {bundled}")
         finally:
             emqx.kill()
 
@@ -617,7 +605,6 @@ def test_feature_gate_essential(emqx_bin_path):
 # Remember to update known feature list when `emqx_machine_features:known_features` change.
 KNOWN_FEATURES = {
     "dashboard": {},
-    "auth": {},
     "data_integration": {},
     "message_transformation": {},
     "schema_validation": {},
@@ -656,8 +643,6 @@ def test_feature_gate_custom(emqx_bin_path, feature):
             assert "custom" == log["preset"]
             enabled = log["enabled"]
             assert feature in enabled
-            bundled = log["bundled"]
-            assert [] == bundled
         finally:
             emqx.kill()
 
@@ -685,8 +670,6 @@ def test_feature_gate_custom_multiple(emqx_bin_path):
             enabled = log["enabled"]
             for f in all_features:
                 assert f in enabled
-            bundled = log["bundled"]
-            assert [] == bundled
         finally:
             emqx.kill()
 


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Make authentication/authorization **part of the core** rather than a gateable feature.

### Problem

`auth` was an optional feature that could be gated off (e.g. `EMQX_FEATURES=ESSENTIAL`). But the default config keeps `listeners.tcp.default.enable_authn = true` and `authorization.no_match = deny`. With `auth` gated off, no authn/authz provider is registered, so the core access control rejects every MQTT `CONNECT` (`no_authn_hooks`) and denies all publish/subscribe (`authorization.no_match`). In other words, a default essential node rejected every client — surfaced by running the Paho interoperability suite against an essential node.

Since a broker is not usable without authn/authz, and the feature gates are not released yet (6.3 GA), there is no reason to keep `auth` gateable.

### Change

- `auth` is removed from `known_features/0`; its apps (`emqx_auth`, the auth drivers, and the `emqx_auth_*` backends, discovered by name) are now returned by `core_apps/0`, so they always start. `core_apps/0` result is cached in `persistent_term` since it is now computed.
- `deps => [auth]` is dropped from `gateways`, `metrics`, and `gcp_device` (auth is always available now).
- The `bundled` feature concept is now unused and is removed entirely: from the `/features` response schema, its i18n description, and the boot test.

After the change, an essential node accepts connections and pub/sub with the default config — verified with Paho `test_connect::test_basic` against essential and no auth overrides.

### Memory (unchanged from a usable essential node)

| Metric | full | essential-interactive |
|---|--:|--:|
| OS RSS | 489 MiB | 177 MiB |
| `erlang:memory(total)` | 248 MB | 109 MB |
| `code` (loaded beams) | 103.7 MB | 20.7 MB |
| loaded modules | 3674 | 907 |
| running apps | 259 | 110 |

Auth is ~11 always-on apps / +65 loaded modules over a hypothetical auth-less essential node (~3 MiB RSS, within jitter). Interactive code loading means the unconfigured auth backends (mongodb/redis/ldap/http) never load their beams, so essential stays far below full (RSS 177 vs 489 MiB, −64%).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
