### PR TITLE
fix(mqttsn): preserve sessions across UDP proxy reroutes

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -41,6 +41,7 @@
 {emqx_ft_storage_fs_reader,1}.
 {emqx_gateway_api_listeners,1}.
 {emqx_gateway_cm,1}.
+{emqx_gateway_cm,2}.
 {emqx_gateway_http,1}.
 {emqx_license,2}.
 {emqx_license,3}.

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -494,7 +494,7 @@ handle_msg(
     Ctx = ChannMod:info(ctx, Channel),
     ok = emqx_gateway_ctx:metrics_inc(Ctx, 'bytes.received', Oct),
 
-    NState = State#state{socket = NSock},
+    NState = State#state{socket = NSock, sockstate = running},
     {ok, next_incoming_msgs(Packets), NState};
 handle_msg({Inet, _Sock, Data}, State) when
     Inet == tcp;
@@ -541,6 +541,22 @@ handle_msg({inet_reply, _Sock, {error, Reason}}, State) ->
 handle_msg({close, Reason}, State) ->
     ?tp(debug, force_socket_close, #{reason => Reason}),
     handle_info({sock_closed, Reason}, close_socket(State));
+handle_msg(udp_proxy_closed, State = #state{sockstate = closed}) ->
+    {ok, State};
+handle_msg(
+    udp_proxy_closed,
+    State = #state{
+        chann_mod = ChannMod,
+        channel = Channel
+    }
+) ->
+    case ChannMod:info(conn_state, Channel) of
+        ConnState when ConnState == asleep; ConnState == disconnected ->
+            ?tp(debug, udp_proxy_detached, #{conn_state => ConnState}),
+            {ok, State#state{sockstate = closed}};
+        _ConnState ->
+            handle_udp_proxy_closed(State)
+    end;
 handle_msg(udp_proxy_closed, State) ->
     ?tp(debug, udp_proxy_closed, #{reason => normal}),
     handle_info({sock_closed, normal}, close_socket(State));
@@ -589,6 +605,10 @@ handle_msg(Shutdown = {shutdown, _Reason}, State) ->
     stop(Shutdown, State);
 handle_msg(Msg, State) ->
     handle_info(Msg, State).
+
+handle_udp_proxy_closed(State) ->
+    ?tp(debug, udp_proxy_closed, #{reason => normal}),
+    handle_info({sock_closed, normal}, close_socket(State)).
 
 %%--------------------------------------------------------------------
 %% Terminate

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -494,6 +494,7 @@ handle_msg(
     Ctx = ChannMod:info(ctx, Channel),
     ok = emqx_gateway_ctx:metrics_inc(Ctx, 'bytes.received', Oct),
 
+    maybe_takeover_udp_proxy(NSock, State),
     NState = State#state{socket = NSock, sockstate = running},
     {ok, next_incoming_msgs(Packets), NState};
 handle_msg({Inet, _Sock, Data}, State) when
@@ -541,42 +542,26 @@ handle_msg({inet_reply, _Sock, {error, Reason}}, State) ->
 handle_msg({close, Reason}, State) ->
     ?tp(debug, force_socket_close, #{reason => Reason}),
     handle_info({sock_closed, Reason}, close_socket(State));
-handle_msg(udp_proxy_detached, State = #state{sockstate = closed}) ->
+handle_msg(udp_proxy_detached, State) ->
     {ok, State};
-handle_msg(
-    udp_proxy_detached,
-    State = #state{
-        chann_mod = ChannMod,
-        channel = Channel
-    }
-) ->
-    case ChannMod:info(conn_state, Channel) of
-        ConnState when ConnState == asleep; ConnState == disconnected ->
-            ?tp(debug, udp_proxy_detached, #{conn_state => ConnState}),
-            {ok, State#state{sockstate = closed}};
-        ConnState ->
-            ?tp(debug, udp_proxy_detached, #{conn_state => ConnState}),
-            handle_udp_proxy_detached(State#state{sockstate = closed})
+handle_msg({udp_proxy_detached, ProxyId}, State) ->
+    case is_current_udp_proxy(ProxyId, State) of
+        true ->
+            handle_udp_proxy_detached_msg(State);
+        false ->
+            ?tp(debug, stale_udp_proxy_detached, #{proxy_id => ProxyId}),
+            {ok, State}
     end;
-handle_msg(udp_proxy_closed, State = #state{sockstate = closed}) ->
-    {ok, State};
-handle_msg(
-    udp_proxy_closed,
-    State = #state{
-        chann_mod = ChannMod,
-        channel = Channel
-    }
-) ->
-    case ChannMod:info(conn_state, Channel) of
-        ConnState when ConnState == asleep; ConnState == disconnected ->
-            ?tp(debug, udp_proxy_closed, #{conn_state => ConnState}),
-            {ok, State#state{sockstate = closed}};
-        _ConnState ->
-            handle_udp_proxy_closed(State)
+handle_msg({udp_proxy_closed, ProxyId}, State) ->
+    case is_current_udp_proxy(ProxyId, State) of
+        true ->
+            handle_udp_proxy_closed_msg(State);
+        false ->
+            ?tp(debug, stale_udp_proxy_closed, #{proxy_id => ProxyId}),
+            {ok, State}
     end;
 handle_msg(udp_proxy_closed, State) ->
-    ?tp(debug, udp_proxy_closed, #{reason => normal}),
-    handle_info({sock_closed, normal}, close_socket(State));
+    {ok, State};
 handle_msg(
     {event, connected},
     State = #state{
@@ -622,6 +607,67 @@ handle_msg(Shutdown = {shutdown, _Reason}, State) ->
     stop(Shutdown, State);
 handle_msg(Msg, State) ->
     handle_info(Msg, State).
+
+maybe_takeover_udp_proxy(
+    {esockd_udp_proxy, ProxyId, _Socket},
+    #state{socket = {esockd_udp_proxy, ProxyId, _OldSocket}}
+) ->
+    ok;
+maybe_takeover_udp_proxy(
+    {esockd_udp_proxy, _ProxyId, _Socket},
+    #state{
+        socket = {esockd_udp_proxy, OldProxyId, _OldSocket},
+        chann_mod = ChannMod,
+        channel = Channel
+    }
+) ->
+    try ChannMod:info(clientid, Channel) of
+        ClientId ->
+            esockd_udp_proxy:takeover(OldProxyId, ClientId)
+    catch
+        _:_ ->
+            ok
+    end;
+maybe_takeover_udp_proxy(_Socket, _State) ->
+    ok.
+
+is_current_udp_proxy(ProxyId, #state{socket = {esockd_udp_proxy, ProxyId, _Socket}}) ->
+    true;
+is_current_udp_proxy(_ProxyId, _State) ->
+    false.
+
+handle_udp_proxy_detached_msg(State = #state{sockstate = closed}) ->
+    {ok, State};
+handle_udp_proxy_detached_msg(
+    State = #state{
+        chann_mod = ChannMod,
+        channel = Channel
+    }
+) ->
+    case ChannMod:info(conn_state, Channel) of
+        ConnState when ConnState == asleep; ConnState == disconnected ->
+            ?tp(debug, udp_proxy_detached, #{conn_state => ConnState}),
+            {ok, State#state{sockstate = closed}};
+        ConnState ->
+            ?tp(debug, udp_proxy_detached, #{conn_state => ConnState}),
+            handle_udp_proxy_detached(State#state{sockstate = closed})
+    end.
+
+handle_udp_proxy_closed_msg(State = #state{sockstate = closed}) ->
+    {ok, State};
+handle_udp_proxy_closed_msg(
+    State = #state{
+        chann_mod = ChannMod,
+        channel = Channel
+    }
+) ->
+    case ChannMod:info(conn_state, Channel) of
+        ConnState when ConnState == asleep; ConnState == disconnected ->
+            ?tp(debug, udp_proxy_closed, #{conn_state => ConnState}),
+            {ok, State#state{sockstate = closed}};
+        _ConnState ->
+            handle_udp_proxy_closed(State)
+    end.
 
 handle_udp_proxy_closed(State) ->
     ?tp(debug, udp_proxy_closed, #{reason => normal}),

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -541,6 +541,23 @@ handle_msg({inet_reply, _Sock, {error, Reason}}, State) ->
 handle_msg({close, Reason}, State) ->
     ?tp(debug, force_socket_close, #{reason => Reason}),
     handle_info({sock_closed, Reason}, close_socket(State));
+handle_msg(udp_proxy_detached, State = #state{sockstate = closed}) ->
+    {ok, State};
+handle_msg(
+    udp_proxy_detached,
+    State = #state{
+        chann_mod = ChannMod,
+        channel = Channel
+    }
+) ->
+    case ChannMod:info(conn_state, Channel) of
+        ConnState when ConnState == asleep; ConnState == disconnected ->
+            ?tp(debug, udp_proxy_detached, #{conn_state => ConnState}),
+            {ok, State#state{sockstate = closed}};
+        ConnState ->
+            ?tp(debug, udp_proxy_detached, #{conn_state => ConnState}),
+            handle_info({sock_closed, normal}, State#state{sockstate = closed})
+    end;
 handle_msg(udp_proxy_closed, State = #state{sockstate = closed}) ->
     {ok, State};
 handle_msg(

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -556,7 +556,7 @@ handle_msg(
             {ok, State#state{sockstate = closed}};
         ConnState ->
             ?tp(debug, udp_proxy_detached, #{conn_state => ConnState}),
-            handle_info({sock_closed, normal}, State#state{sockstate = closed})
+            handle_udp_proxy_detached(State#state{sockstate = closed})
     end;
 handle_msg(udp_proxy_closed, State = #state{sockstate = closed}) ->
     {ok, State};
@@ -569,7 +569,7 @@ handle_msg(
 ) ->
     case ChannMod:info(conn_state, Channel) of
         ConnState when ConnState == asleep; ConnState == disconnected ->
-            ?tp(debug, udp_proxy_detached, #{conn_state => ConnState}),
+            ?tp(debug, udp_proxy_closed, #{conn_state => ConnState}),
             {ok, State#state{sockstate = closed}};
         _ConnState ->
             handle_udp_proxy_closed(State)
@@ -626,6 +626,25 @@ handle_msg(Msg, State) ->
 handle_udp_proxy_closed(State) ->
     ?tp(debug, udp_proxy_closed, #{reason => normal}),
     handle_info({sock_closed, normal}, close_socket(State)).
+
+handle_udp_proxy_detached(State) ->
+    case with_channel(handle_info, [{sock_closed, normal}], State) of
+        {ok, {event, disconnected}, NState} ->
+            handle_udp_proxy_detached_disconnected(NState);
+        Other ->
+            Other
+    end.
+
+handle_udp_proxy_detached_disconnected(
+    State = #state{
+        chann_mod = ChannMod,
+        channel = Channel
+    }
+) ->
+    Ctx = ChannMod:info(ctx, Channel),
+    ClientId = ChannMod:info(clientid, Channel),
+    emqx_gateway_ctx:set_chan_info(Ctx, ClientId, info(State)),
+    {ok, State}.
 
 %%--------------------------------------------------------------------
 %% Terminate

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -542,8 +542,14 @@ handle_msg({inet_reply, _Sock, {error, Reason}}, State) ->
 handle_msg({close, Reason}, State) ->
     ?tp(debug, force_socket_close, #{reason => Reason}),
     handle_info({sock_closed, Reason}, close_socket(State));
+%% Legacy detach notifications do not identify their proxy owner, so they cannot
+%% safely detach a channel which may already have moved to a newer proxy.
 handle_msg(udp_proxy_detached, State) ->
     {ok, State};
+%% Keep the legacy close callback behavior for proxy connection modules which do
+%% not implement the owner-aware close/3 callback.
+handle_msg(udp_proxy_closed, State) ->
+    handle_udp_proxy_closed(State);
 handle_msg({udp_proxy_detached, ProxyId}, State) ->
     case is_current_udp_proxy(ProxyId, State) of
         true ->
@@ -560,8 +566,6 @@ handle_msg({udp_proxy_closed, ProxyId}, State) ->
             ?tp(debug, stale_udp_proxy_closed, #{proxy_id => ProxyId}),
             {ok, State}
     end;
-handle_msg(udp_proxy_closed, State) ->
-    {ok, State};
 handle_msg(
     {event, connected},
     State = #state{

--- a/apps/emqx_gateway/src/emqx_gateway_cm.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cm.erl
@@ -303,10 +303,11 @@ set_chan_stats(GwName, ClientId, ChanPid, Stats) ->
     wrap_rpc(emqx_gateway_cm_proto_v1:set_chan_stats(GwName, ClientId, ChanPid, Stats)).
 
 -spec connection_closed(gateway_name(), emqx_types:clientid()) -> true.
-connection_closed(GwName, ClientId) ->
-    %% XXX: Why we need to delete conn_mod tab ???
-    Chan = {ClientId, self()},
-    ets:delete_object(tabname(conn, GwName), Chan).
+connection_closed(_GwName, _ClientId) ->
+    %% The transport may be closed while the channel/session is still retained.
+    %% Keep the connection module until the channel is unregistered so session
+    %% takeover/kick/discard can still call the lingering channel.
+    true.
 
 -spec open_session(
     GwName :: gateway_name(),

--- a/apps/emqx_gateway/src/emqx_gateway_cm.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cm.erl
@@ -33,6 +33,7 @@
     set_chan_info/4,
     get_chan_info/2,
     get_chan_info/3,
+    get_chan_info/4,
     set_chan_stats/3,
     set_chan_stats/4,
     get_chan_stats/2,
@@ -194,8 +195,13 @@ do_get_chan_info(GwName, ClientId, ChanPid) ->
 -spec get_chan_info(gateway_name(), emqx_types:clientid(), pid()) ->
     emqx_types:infos() | undefined.
 get_chan_info(GwName, ClientId, ChanPid) ->
+    wrap_rpc(emqx_gateway_cm_proto_v1:get_chan_info(GwName, ClientId, ChanPid)).
+
+-spec get_chan_info(gateway_name(), emqx_types:clientid(), pid(), timeout()) ->
+    emqx_types:infos() | undefined.
+get_chan_info(GwName, ClientId, ChanPid, Timeout) ->
     wrap_rpc(
-        emqx_gateway_cm_proto_v1:get_chan_info(GwName, ClientId, ChanPid)
+        emqx_gateway_cm_proto_v2:get_chan_info(GwName, ClientId, ChanPid, Timeout)
     ).
 
 -spec lookup_by_clientid(gateway_name(), emqx_types:clientid()) -> [pid()].
@@ -304,9 +310,8 @@ set_chan_stats(GwName, ClientId, ChanPid, Stats) ->
 
 -spec connection_closed(gateway_name(), emqx_types:clientid()) -> true.
 connection_closed(_GwName, _ClientId) ->
-    %% The transport may be closed while the channel/session is still retained.
-    %% Keep the connection module until the channel is unregistered so session
-    %% takeover/kick/discard can still call the lingering channel.
+    %% Transport close may keep the channel/session alive. The registry/chan/conn/info
+    %% cleanup is done by unregister_channel/2 or the DOWN path in do_unregister_channel/3.
     true.
 
 -spec open_session(

--- a/apps/emqx_gateway/src/proto/emqx_gateway_cm_proto_v2.erl
+++ b/apps/emqx_gateway/src/proto/emqx_gateway_cm_proto_v2.erl
@@ -1,0 +1,24 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_gateway_cm_proto_v2).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+    get_chan_info/4
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+introduced_in() ->
+    "6.0.4".
+
+-spec get_chan_info(emqx_gateway_cm:gateway_name(), emqx_types:clientid(), pid(), timeout()) ->
+    emqx_types:infos() | undefined | {badrpc, _}.
+get_chan_info(GwName, ClientId, ChanPid, Timeout) ->
+    rpc:call(
+        node(ChanPid), emqx_gateway_cm, do_get_chan_info, [GwName, ClientId, ChanPid], Timeout
+    ).

--- a/apps/emqx_gateway/test/emqx_gateway_cm_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_cm_SUITE.erl
@@ -190,6 +190,25 @@ t_get_set_chan_info_stats(_) ->
     emqx_gateway_cm:connection_closed(?GWNAME, ?CLIENTID),
     emqx_gateway_cm:unregister_channel(?GWNAME, ?CLIENTID).
 
+t_connection_closed_keeps_channel_callable(_) ->
+    {ok, _} = emqx_gateway_cm:open_session(
+        ?GWNAME,
+        true,
+        clientinfo(),
+        conninfo(),
+        fun(_, _) -> #{no => 1} end
+    ),
+
+    true = emqx_gateway_cm:connection_closed(?GWNAME, ?CLIENTID),
+    ok = emqx_gateway_cm:kick_session(?GWNAME, ?CLIENTID),
+    receive
+        kick -> ok
+    after 100 ->
+        ?assert(false, "waiting kick msg timeout")
+    end,
+
+    emqx_gateway_cm:unregister_channel(?GWNAME, ?CLIENTID).
+
 t_handle_process_down(Conf) ->
     Pid = proplists:get_value(cm, Conf),
 

--- a/apps/emqx_gateway/test/emqx_gateway_cm_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_cm_SUITE.erl
@@ -175,6 +175,14 @@ t_get_set_chan_info_stats(_) ->
         NInfo,
         emqx_gateway_cm:get_chan_info(?GWNAME, ?CLIENTID, self())
     ),
+    ?assertEqual(
+        NInfo,
+        emqx_gateway_cm:get_chan_info(?GWNAME, ?CLIENTID, self(), 1000)
+    ),
+    ?assertEqual(
+        NInfo,
+        emqx_gateway_cm_proto_v2:get_chan_info(?GWNAME, ?CLIENTID, self(), 1000)
+    ),
     %% Stats: get/set
     NStats = [{newstats, true}],
     emqx_gateway_cm:set_chan_stats(?GWNAME, ?CLIENTID, NStats),
@@ -190,13 +198,19 @@ t_get_set_chan_info_stats(_) ->
     emqx_gateway_cm:connection_closed(?GWNAME, ?CLIENTID),
     emqx_gateway_cm:unregister_channel(?GWNAME, ?CLIENTID).
 
-t_connection_closed_keeps_channel_callable(_) ->
+t_connection_closed_defers_cleanup_until_unregister(_) ->
     {ok, _} = emqx_gateway_cm:open_session(
         ?GWNAME,
         true,
         clientinfo(),
         conninfo(),
         fun(_, _) -> #{no => 1} end
+    ),
+    emqx_gateway_cm:insert_channel_info(
+        ?GWNAME,
+        ?CLIENTID,
+        #{clientinfo => clientinfo(), conninfo => conninfo()},
+        []
     ),
 
     true = emqx_gateway_cm:connection_closed(?GWNAME, ?CLIENTID),
@@ -207,7 +221,14 @@ t_connection_closed_keeps_channel_callable(_) ->
         ?assert(false, "waiting kick msg timeout")
     end,
 
-    emqx_gateway_cm:unregister_channel(?GWNAME, ?CLIENTID).
+    ?assertEqual(1, ets:info(emqx_gateway_cm:tabname(chan, ?GWNAME), size)),
+    ?assertEqual(1, ets:info(emqx_gateway_cm:tabname(conn, ?GWNAME), size)),
+    ?assertEqual(1, ets:info(emqx_gateway_cm:tabname(info, ?GWNAME), size)),
+
+    emqx_gateway_cm:unregister_channel(?GWNAME, ?CLIENTID),
+    ?assertEqual(0, ets:info(emqx_gateway_cm:tabname(chan, ?GWNAME), size)),
+    ?assertEqual(0, ets:info(emqx_gateway_cm:tabname(conn, ?GWNAME), size)),
+    ?assertEqual(0, ets:info(emqx_gateway_cm:tabname(info, ?GWNAME), size)).
 
 t_handle_process_down(Conf) ->
     Pid = proplists:get_value(cm, Conf),

--- a/apps/emqx_gateway_coap/mix.exs
+++ b/apps/emqx_gateway_coap/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayCoap.MixProject do
   def project do
     [
       app: :emqx_gateway_coap,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
@@ -8,7 +8,7 @@
 
 -include("emqx_coap.hrl").
 
--export([initialize/1, find_or_create/4, get_connection_id/4, dispatch/3, close/2]).
+-export([initialize/1, find_or_create/4, get_connection_id/4, dispatch/3, close/2, close/3]).
 
 %%--------------------------------------------------------------------
 %% Callbacks
@@ -82,7 +82,12 @@ dispatch(Pid, _State, Packet) ->
     erlang:send(Pid, Packet).
 
 close(Pid, _State) ->
-    erlang:send(Pid, udp_proxy_closed).
+    erlang:send(Pid, udp_proxy_closed),
+    ok.
+
+close(Pid, ProxyId, _State) ->
+    erlang:send(Pid, {udp_proxy_closed, ProxyId}),
+    ok.
 
 parse_incoming(<<>>, Packets, State) ->
     {Packets, State};

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -811,6 +811,16 @@ t_proxy_conn_keep_bound_clientid_on_different_clientid(_) ->
         emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State1, Bin2)
     ).
 
+t_proxy_conn_close_passes_proxy_owner(_) ->
+    ProxyId = self(),
+    ?assertEqual(ok, emqx_coap_proxy_conn:close(self(), ProxyId, #{})),
+    receive
+        {udp_proxy_closed, ProxyId} ->
+            ok
+    after 100 ->
+        error(missing_udp_proxy_closed)
+    end.
+
 %%--------------------------------------------------------------------
 %% helpers
 

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -821,6 +821,31 @@ t_proxy_conn_close_passes_proxy_owner(_) ->
         error(missing_udp_proxy_closed)
     end.
 
+t_legacy_proxy_close_closes_transport(_) ->
+    {ok, Sock, Channel} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    _Token = connection(Channel),
+    [Pid] = emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>),
+    try
+        ?assertEqual(ok, emqx_coap_proxy_conn:close(Pid, #{})),
+        ?retry(
+            100,
+            10,
+            ?assertMatch(
+                #{sockinfo := #{sockstate := closed}},
+                emqx_gateway_conn:info(Pid)
+            )
+        )
+    after
+        _ = catch emqx_gateway_cm:kick_session(coap, <<"client1">>),
+        ?retry(
+            100,
+            10,
+            ?assertEqual([], emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>))
+        ),
+        er_coap_channel:close(Channel),
+        er_coap_udp_socket:close(Sock)
+    end.
+
 %%--------------------------------------------------------------------
 %% helpers
 

--- a/apps/emqx_gateway_mqttsn/src/emqx_gateway_mqttsn.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_gateway_mqttsn.erl
@@ -24,7 +24,7 @@
     on_gateway_unload/2
 ]).
 
--define(MOD_CFG, #{
+-define(DEFAULT_MOD_CFG, #{
     frame_mod => emqx_mqttsn_frame,
     chann_mod => emqx_mqttsn_channel
 }).
@@ -42,9 +42,10 @@ on_gateway_load(
 ) ->
     ensure_broadcast_started(Config),
     ensure_predefined_topics(Config),
+    ModConfig = mod_cfg(),
     NConfig = maps:without([broadcast, predefined], Config),
     ListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-        GwName, NConfig, ?MOD_CFG, Ctx
+        GwName, NConfig, ModConfig, Ctx
     ),
     case emqx_gateway_utils:start_listeners(ListenerConfigs) of
         {ok, ListenerPids} ->
@@ -68,11 +69,12 @@ on_gateway_update(
         ensure_predefined_topics(Config),
         Config1 = maps:without([broadcast, predefined], Config),
         OldConfig1 = maps:without([broadcast, predefined], OldConfig),
+        ModConfig = mod_cfg(),
         OldListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-            GwName, OldConfig1, ?MOD_CFG, Ctx
+            GwName, OldConfig1, ModConfig, Ctx
         ),
         NewListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-            GwName, Config1, ?MOD_CFG, Ctx
+            GwName, Config1, ModConfig, Ctx
         ),
         case
             emqx_gateway_utils:update_gateway_listeners(
@@ -110,6 +112,17 @@ on_gateway_unload(
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
+
+mod_cfg() ->
+    #{
+        udp => maps:merge(?DEFAULT_MOD_CFG, #{
+            connection_mod => esockd_udp_proxy,
+            esockd_proxy_opts => #{
+                connection_mod => emqx_mqttsn_proxy_conn
+            }
+        }),
+        default => ?DEFAULT_MOD_CFG
+    }.
 
 ensure_broadcast_started(Config) ->
     case maps:get(broadcast, Config, false) of

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -444,22 +444,16 @@ handle_in(
 handle_in(?SN_ADVERTISE_MSG(_GwId, _Radius), Channel) ->
     % ignore
     shutdown(normal, Channel);
-%% A `disconnected' channel is kept alive (indexed by the peer UDP
-%% {ip, port}) so its session can be resumed within the expiry interval.
-%% The OS, or a NAT box, may re-assign the same ephemeral port to a
-%% different sender, in which case that sender's packets are routed here.
-%% Treat a CONNECT as a takeover request: retire this stale channel so the
-%% connection layer can spawn a fresh one for the new session.
-handle_in(
-    ?SN_CONNECT_MSG(_Flags, _ProtoId, _Duration, _ClientId),
-    Channel = #channel{conn_state = disconnected}
-) ->
-    shutdown(takeover_by_new_connect, Channel);
-%% Any other packet on a `disconnected' channel is stale traffic (e.g. a
-%% retransmit from the previous peer of a reused port). Retire the channel
-%% rather than crash; no live session should be addressed here.
-handle_in(_Pkt, Channel = #channel{conn_state = disconnected}) ->
-    shutdown(stale_packet_after_disconnect, Channel);
+%% CONNECT/PINGREQ with a reusable ClientId is routed or taken over before it
+%% reaches `disconnected'. Packets still arriving here are stale old-proxy
+%% traffic, so keep the session alive until it expires or is explicitly taken
+%% over.
+handle_in(Pkt, Channel = #channel{conn_state = disconnected}) ->
+    ?SLOG(debug, #{
+        msg => "ignore_packet_in_disconnected_state",
+        packet => Pkt
+    }),
+    {ok, Channel};
 %% Ack DISCONNECT even if it is not connected
 handle_in(
     ?SN_DISCONNECT_MSG(_Duration),

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -1891,11 +1891,12 @@ handle_info(
     %% How to get the flapping detect policy ???
     %emqx_zone:enable_flapping_detect(Zone)
     %    andalso emqx_flapping:detect(ClientInfo),
-    NChannel = ensure_disconnected(Reason, mabye_publish_will_msg(Channel)),
-    case maybe_shutdown(Reason, NChannel) of
-        {ok, NChannel1} -> {ok, {event, disconnected}, NChannel1};
-        Shutdown -> Shutdown
-    end;
+    handle_active_sock_closed(Reason, Channel);
+handle_info(
+    {sock_closed, Reason},
+    Channel = #channel{conn_state = awake}
+) ->
+    handle_active_sock_closed(Reason, Channel);
 handle_info(
     {sock_closed, Reason},
     Channel = #channel{conn_state = disconnected}
@@ -1930,6 +1931,13 @@ handle_info(Info, Channel) ->
         info => Info
     }),
     {ok, Channel}.
+
+handle_active_sock_closed(Reason, Channel) ->
+    NChannel = ensure_disconnected(Reason, mabye_publish_will_msg(Channel)),
+    case maybe_shutdown(Reason, NChannel) of
+        {ok, NChannel1} -> {ok, {event, disconnected}, NChannel1};
+        Shutdown -> Shutdown
+    end.
 
 maybe_shutdown(Reason, Channel = #channel{conninfo = ConnInfo}) ->
     case maps:get(expiry_interval, ConnInfo) of

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
@@ -37,8 +37,6 @@ initialize(Opts) ->
 find_or_create(CId, Transport, Peer, Opts) ->
     find_or_create(CId, Transport, Peer, Opts, #{}).
 
-find_or_create({peer, _Peer}, Transport, Peer, Opts, _State) ->
-    emqx_gateway_conn:start_link(Transport, Peer, Opts);
 find_or_create(ClientId, Transport, Peer, Opts, State) when is_binary(ClientId) ->
     ReusableStates =
         case maps:get(packet_type, State, undefined) of
@@ -91,23 +89,16 @@ close(Pid, ProxyId, _State) ->
 
 find_reusable_channel(ClientId, ReusableStates) ->
     Pids = emqx_gateway_cm_registry:lookup_channels(?GATEWAY, ClientId),
-    pick_reusable_channel(ClientId, ReusableStates, lists:reverse(Pids)).
-
-pick_reusable_channel(_ClientId, _ReusableStates, []) ->
-    false;
-pick_reusable_channel(ClientId, ReusableStates, [Pid | Rest]) ->
-    case channel_conn_state(ClientId, Pid) of
-        ConnState when
-            ConnState == connected; ConnState == asleep; ConnState == awake
-        ->
-            case lists:member(ConnState, ReusableStates) of
-                true ->
-                    {ok, Pid};
-                false ->
-                    pick_reusable_channel(ClientId, ReusableStates, Rest)
-            end;
-        _Other ->
-            pick_reusable_channel(ClientId, ReusableStates, Rest)
+    case
+        lists:search(
+            fun(Pid) ->
+                lists:member(channel_conn_state(ClientId, Pid), ReusableStates)
+            end,
+            lists:reverse(Pids)
+        )
+    of
+        {value, Pid} -> {ok, Pid};
+        false -> false
     end.
 
 channel_conn_state(ClientId, Pid) ->
@@ -178,10 +169,6 @@ select_cid(_PacketType, undefined, BoundCId, _Peer) ->
     {BoundCId, BoundCId};
 select_cid(pingreq, ReqCId, BoundCId, Peer) ->
     select_pingreq_cid(ReqCId, BoundCId, Peer);
-select_cid(_PacketType, ReqCId, undefined, _Peer) ->
-    {ReqCId, ReqCId};
-select_cid(_PacketType, ReqCId, {peer, _Peer}, _Peer0) ->
-    {ReqCId, ReqCId};
 select_cid(_PacketType, ReqCId, _BoundCId, _Peer) ->
     {ReqCId, ReqCId}.
 

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
@@ -1,0 +1,163 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_mqttsn_proxy_conn).
+
+-behaviour(esockd_udp_proxy_connection).
+
+-include("emqx_mqttsn.hrl").
+
+-export([initialize/1, find_or_create/4, find_or_create/5, get_connection_id/4, dispatch/3, close/2]).
+
+-define(GATEWAY, mqttsn).
+
+%%--------------------------------------------------------------------
+%% Callbacks
+%%--------------------------------------------------------------------
+
+initialize(Opts) ->
+    FrameOpts = emqx_gateway_utils:frame_options(Opts),
+    #{
+        parse_state => emqx_mqttsn_frame:initial_parse_state(FrameOpts),
+        cid => undefined,
+        packet_type => undefined
+    }.
+
+find_or_create(CId, Transport, Peer, Opts) ->
+    find_or_create(CId, Transport, Peer, Opts, #{}).
+
+find_or_create({peer, _Peer}, Transport, Peer, Opts, _State) ->
+    emqx_gateway_conn:start_link(Transport, Peer, Opts);
+find_or_create(ClientId, Transport, Peer, Opts, State) when is_binary(ClientId) ->
+    ReusableStates =
+        case maps:get(packet_type, State, undefined) of
+            connect -> [asleep, awake];
+            pingreq -> [connected, asleep, awake];
+            _Other -> [connected, asleep, awake]
+        end,
+    find_or_create_by_clientid(ClientId, ReusableStates, Transport, Peer, Opts);
+find_or_create(_CId, Transport, Peer, Opts, _State) ->
+    emqx_gateway_conn:start_link(Transport, Peer, Opts).
+
+find_or_create_by_clientid(ClientId, ReusableStates, Transport, Peer, Opts) ->
+    case find_reusable_channel(ClientId, ReusableStates) of
+        {ok, Pid} ->
+            {ok, Pid};
+        false ->
+            emqx_gateway_conn:start_link(Transport, Peer, Opts)
+    end.
+
+get_connection_id(_Transport, Peer, State, Data) ->
+    {ParseState, BoundCId} = split_state(State),
+    case parse_incoming(Data, [], ParseState) of
+        {[Packet | _] = Packets, NParseState} ->
+            {CId, NBoundCId, PacketType} = choose_cid(Packet, BoundCId, Peer),
+            {ok, CId, Packets, merge_state(NParseState, NBoundCId, PacketType)};
+        {[], NParseState} ->
+            {ok, peer_id(Peer), [], merge_state(NParseState, BoundCId, undefined)}
+    end.
+
+dispatch(Pid, _State, Packet) ->
+    erlang:send(Pid, Packet).
+
+close(Pid, _State) ->
+    erlang:send(Pid, udp_proxy_closed).
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+find_reusable_channel(ClientId, ReusableStates) ->
+    Pids = emqx_gateway_cm_registry:lookup_channels(?GATEWAY, ClientId),
+    pick_reusable_channel(ClientId, ReusableStates, lists:reverse(Pids)).
+
+pick_reusable_channel(_ClientId, _ReusableStates, []) ->
+    false;
+pick_reusable_channel(ClientId, ReusableStates, [Pid | Rest]) ->
+    case channel_conn_state(ClientId, Pid) of
+        ConnState when
+            ConnState == connected; ConnState == asleep; ConnState == awake
+        ->
+            case lists:member(ConnState, ReusableStates) of
+                true ->
+                    {ok, Pid};
+                false ->
+                    pick_reusable_channel(ClientId, ReusableStates, Rest)
+            end;
+        _Other ->
+            pick_reusable_channel(ClientId, ReusableStates, Rest)
+    end.
+
+channel_conn_state(ClientId, Pid) ->
+    case safe_chan_info(ClientId, Pid) of
+        #{conn_state := ConnState} ->
+            ConnState;
+        _ ->
+            undefined
+    end.
+
+safe_chan_info(ClientId, Pid) ->
+    case catch emqx_gateway_cm:get_chan_info(?GATEWAY, ClientId, Pid) of
+        Info = #{} ->
+            Info;
+        _ ->
+            case catch emqx_gateway_conn:info(Pid) of
+                Info = #{} -> Info;
+                _ -> undefined
+            end
+    end.
+
+split_state(#{parse_state := ParseState, cid := BoundCId}) ->
+    {ParseState, BoundCId};
+split_state(#{parse_state := ParseState}) ->
+    {ParseState, undefined};
+split_state(ParseState) ->
+    {ParseState, undefined}.
+
+merge_state(ParseState, BoundCId, PacketType) ->
+    #{parse_state => ParseState, cid => BoundCId, packet_type => PacketType}.
+
+choose_cid(Packet, BoundCId, Peer) ->
+    {ReqCId, PacketType} = packet_cid(Packet),
+    {CId, NBoundCId} = select_cid(ReqCId, BoundCId, Peer),
+    {CId, NBoundCId, PacketType}.
+
+packet_cid(?SN_CONNECT_MSG(_Flags, _ProtoId, _Duration, ClientId)) ->
+    {normalize_clientid(ClientId), connect};
+packet_cid(?SN_PINGREQ_MSG(ClientId)) ->
+    {normalize_clientid(ClientId), pingreq};
+packet_cid(_Packet) ->
+    {undefined, undefined}.
+
+normalize_clientid(ClientId) when ClientId == undefined; ClientId == <<>> ->
+    undefined;
+normalize_clientid(ClientId) when is_binary(ClientId) ->
+    ClientId;
+normalize_clientid(_ClientId) ->
+    undefined.
+
+select_cid(undefined, undefined, Peer) ->
+    {peer_id(Peer), undefined};
+select_cid(undefined, BoundCId, _Peer) ->
+    {BoundCId, BoundCId};
+select_cid(ReqCId, undefined, _Peer) ->
+    {ReqCId, ReqCId};
+select_cid(ReqCId, {peer, _Peer}, _Peer0) ->
+    {ReqCId, ReqCId};
+select_cid(ReqCId, _BoundCId, _Peer) ->
+    {ReqCId, ReqCId}.
+
+peer_id(Peer) ->
+    {peer, Peer}.
+
+parse_incoming(<<>>, Packets, State) ->
+    {Packets, State};
+parse_incoming(Data, Packets, State) ->
+    try emqx_mqttsn_frame:parse(Data, State) of
+        {ok, Packet, Rest, NParseState} ->
+            parse_incoming(Rest, [Packet | Packets], NParseState)
+    catch
+        error:Reason ->
+            {[{frame_error, Reason} | Packets], State}
+    end.

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
@@ -98,14 +98,28 @@ channel_conn_state(ClientId, Pid) ->
     end.
 
 safe_chan_info(ClientId, Pid) ->
-    case catch emqx_gateway_cm:get_chan_info(?GATEWAY, ClientId, Pid) of
+    case safe_gateway_chan_info(ClientId, Pid) of
         Info = #{} ->
             Info;
         _ ->
-            case catch emqx_gateway_conn:info(Pid) of
+            case safe_gateway_conn_info(Pid) of
                 Info = #{} -> Info;
                 _ -> undefined
             end
+    end.
+
+safe_gateway_chan_info(ClientId, Pid) ->
+    try emqx_gateway_cm:get_chan_info(?GATEWAY, ClientId, Pid) of
+        Info -> Info
+    catch
+        _:_ -> undefined
+    end.
+
+safe_gateway_conn_info(Pid) ->
+    try emqx_gateway_conn:info(Pid) of
+        Info -> Info
+    catch
+        _:_ -> undefined
     end.
 
 split_state(#{parse_state := ParseState, cid := BoundCId}) ->

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
@@ -15,7 +15,9 @@
     get_connection_id/4,
     dispatch/3,
     detach/2,
-    close/2
+    detach/3,
+    close/2,
+    close/3
 ]).
 
 -define(GATEWAY, mqttsn).
@@ -41,7 +43,7 @@ find_or_create(ClientId, Transport, Peer, Opts, State) when is_binary(ClientId) 
     ReusableStates =
         case maps:get(packet_type, State, undefined) of
             connect -> [asleep, awake];
-            pingreq -> [connected, asleep, awake];
+            pingreq -> [asleep, awake];
             _Other -> [connected, asleep, awake]
         end,
     find_or_create_by_clientid(ClientId, ReusableStates, Transport, Peer, Opts);
@@ -74,8 +76,16 @@ detach(Pid, _State) ->
     erlang:send(Pid, udp_proxy_detached),
     ok.
 
+detach(Pid, ProxyId, _State) ->
+    erlang:send(Pid, {udp_proxy_detached, ProxyId}),
+    ok.
+
 close(Pid, _State) ->
     erlang:send(Pid, udp_proxy_closed),
+    ok.
+
+close(Pid, ProxyId, _State) ->
+    erlang:send(Pid, {udp_proxy_closed, ProxyId}),
     ok.
 
 %%--------------------------------------------------------------------
@@ -148,7 +158,7 @@ merge_state(ParseState, BoundCId, PacketType) ->
 
 choose_cid(Packet, BoundCId, Peer) ->
     {ReqCId, PacketType} = packet_cid(Packet),
-    {CId, NBoundCId} = select_cid(ReqCId, BoundCId, Peer),
+    {CId, NBoundCId} = select_cid(PacketType, ReqCId, BoundCId, Peer),
     {CId, NBoundCId, PacketType}.
 
 packet_cid(?SN_CONNECT_MSG(_Flags, _ProtoId, _Duration, ClientId)) ->
@@ -165,16 +175,28 @@ normalize_clientid(ClientId) when is_binary(ClientId) ->
 normalize_clientid(_ClientId) ->
     undefined.
 
-select_cid(undefined, undefined, Peer) ->
+select_cid(_PacketType, undefined, undefined, Peer) ->
     {peer_id(Peer), undefined};
-select_cid(undefined, BoundCId, _Peer) ->
+select_cid(_PacketType, undefined, BoundCId, _Peer) ->
     {BoundCId, BoundCId};
-select_cid(ReqCId, undefined, _Peer) ->
+select_cid(pingreq, ReqCId, BoundCId, Peer) ->
+    select_pingreq_cid(ReqCId, BoundCId, Peer);
+select_cid(_PacketType, ReqCId, undefined, _Peer) ->
     {ReqCId, ReqCId};
-select_cid(ReqCId, {peer, _Peer}, _Peer0) ->
+select_cid(_PacketType, ReqCId, {peer, _Peer}, _Peer0) ->
     {ReqCId, ReqCId};
-select_cid(ReqCId, _BoundCId, _Peer) ->
+select_cid(_PacketType, ReqCId, _BoundCId, _Peer) ->
     {ReqCId, ReqCId}.
+
+select_pingreq_cid(ReqCId, ReqCId, _Peer) ->
+    {ReqCId, ReqCId};
+select_pingreq_cid(ReqCId, _BoundCId, Peer) ->
+    case find_reusable_channel(ReqCId, [asleep, awake]) of
+        {ok, _Pid} ->
+            {ReqCId, ReqCId};
+        false ->
+            {peer_id(Peer), undefined}
+    end.
 
 peer_id(Peer) ->
     {peer, Peer}.

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
@@ -46,17 +46,14 @@ find_or_create(ClientId, Transport, Peer, Opts, State) when is_binary(ClientId) 
             pingreq -> [asleep, awake];
             _Other -> [connected, asleep, awake]
         end,
-    find_or_create_by_clientid(ClientId, ReusableStates, Transport, Peer, Opts);
-find_or_create(_CId, Transport, Peer, Opts, _State) ->
-    emqx_gateway_conn:start_link(Transport, Peer, Opts).
-
-find_or_create_by_clientid(ClientId, ReusableStates, Transport, Peer, Opts) ->
     case find_reusable_channel(ClientId, ReusableStates) of
         {ok, Pid} ->
             {ok, Pid};
         false ->
             emqx_gateway_conn:start_link(Transport, Peer, Opts)
-    end.
+    end;
+find_or_create(_CId, Transport, Peer, Opts, _State) ->
+    emqx_gateway_conn:start_link(Transport, Peer, Opts).
 
 get_connection_id(_Transport, Peer, State, Data) ->
     {ParseState, BoundCId} = split_state(State),

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
@@ -8,7 +8,15 @@
 
 -include("emqx_mqttsn.hrl").
 
--export([initialize/1, find_or_create/4, find_or_create/5, get_connection_id/4, dispatch/3, close/2]).
+-export([
+    initialize/1,
+    find_or_create/4,
+    find_or_create/5,
+    get_connection_id/4,
+    dispatch/3,
+    detach/2,
+    close/2
+]).
 
 -define(GATEWAY, mqttsn).
 
@@ -59,10 +67,16 @@ get_connection_id(_Transport, Peer, State, Data) ->
     end.
 
 dispatch(Pid, _State, Packet) ->
-    erlang:send(Pid, Packet).
+    erlang:send(Pid, Packet),
+    ok.
+
+detach(Pid, _State) ->
+    erlang:send(Pid, udp_proxy_detached),
+    ok.
 
 close(Pid, _State) ->
-    erlang:send(Pid, udp_proxy_closed).
+    erlang:send(Pid, udp_proxy_closed),
+    ok.
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_proxy_conn.erl
@@ -21,6 +21,7 @@
 ]).
 
 -define(GATEWAY, mqttsn).
+-define(CHAN_INFO_TIMEOUT, 5000).
 
 %%--------------------------------------------------------------------
 %% Callbacks
@@ -37,6 +38,10 @@ initialize(Opts) ->
 find_or_create(CId, Transport, Peer, Opts) ->
     find_or_create(CId, Transport, Peer, Opts, #{}).
 
+find_or_create(ClientId, _Transport, _Peer, _Opts, #{reusable_channel := {ClientId, Pid}}) when
+    is_binary(ClientId), is_pid(Pid)
+->
+    {ok, Pid};
 find_or_create(ClientId, Transport, Peer, Opts, State) when is_binary(ClientId) ->
     ReusableStates =
         case maps:get(packet_type, State, undefined) of
@@ -57,26 +62,27 @@ get_connection_id(_Transport, Peer, State, Data) ->
     {ParseState, BoundCId} = split_state(State),
     case parse_incoming(Data, [], ParseState) of
         {[Packet | _] = Packets, NParseState} ->
-            {CId, NBoundCId, PacketType} = choose_cid(Packet, BoundCId, Peer),
-            {ok, CId, Packets, merge_state(NParseState, NBoundCId, PacketType)};
+            {CId, NBoundCId, PacketType, ReusableChannel} = choose_cid(Packet, BoundCId, Peer),
+            {ok, CId, Packets, merge_state(NParseState, NBoundCId, PacketType, ReusableChannel)};
         {[], NParseState} ->
-            {ok, peer_id(Peer), [], merge_state(NParseState, BoundCId, undefined)}
+            {ok, peer_id(Peer), [], merge_state(NParseState, BoundCId, undefined, undefined)}
     end.
 
 dispatch(Pid, _State, Packet) ->
     erlang:send(Pid, Packet),
     ok.
 
-detach(Pid, _State) ->
-    erlang:send(Pid, udp_proxy_detached),
+%% The legacy callback has no proxy owner, so acting on it could detach a
+%% channel which has already moved to a newer proxy.
+detach(_Pid, _State) ->
     ok.
 
 detach(Pid, ProxyId, _State) ->
     erlang:send(Pid, {udp_proxy_detached, ProxyId}),
     ok.
 
-close(Pid, _State) ->
-    erlang:send(Pid, udp_proxy_closed),
+%% See detach/2. esockd 5.17.1 uses the owner-aware close/3 callback.
+close(_Pid, _State) ->
     ok.
 
 close(Pid, ProxyId, _State) ->
@@ -102,33 +108,18 @@ find_reusable_channel(ClientId, ReusableStates) ->
     end.
 
 channel_conn_state(ClientId, Pid) ->
-    case safe_chan_info(ClientId, Pid) of
+    %% Registry and info ETS are updated separately. If the pid is visible before
+    %% its info snapshot, do not call the live process from UDP proxy routing.
+    %% Treat it as not reusable; CONNECT can take over later, and PINGREQ can retry.
+    case safe_gateway_chan_info(ClientId, Pid) of
         #{conn_state := ConnState} ->
             ConnState;
         _ ->
             undefined
     end.
 
-safe_chan_info(ClientId, Pid) ->
-    case safe_gateway_chan_info(ClientId, Pid) of
-        Info = #{} ->
-            Info;
-        _ ->
-            case safe_gateway_conn_info(Pid) of
-                Info = #{} -> Info;
-                _ -> undefined
-            end
-    end.
-
 safe_gateway_chan_info(ClientId, Pid) ->
-    try emqx_gateway_cm:get_chan_info(?GATEWAY, ClientId, Pid) of
-        Info -> Info
-    catch
-        _:_ -> undefined
-    end.
-
-safe_gateway_conn_info(Pid) ->
-    try emqx_gateway_conn:info(Pid) of
+    try emqx_gateway_cm:get_chan_info(?GATEWAY, ClientId, Pid, ?CHAN_INFO_TIMEOUT) of
         Info -> Info
     catch
         _:_ -> undefined
@@ -141,13 +132,18 @@ split_state(#{parse_state := ParseState}) ->
 split_state(ParseState) ->
     {ParseState, undefined}.
 
-merge_state(ParseState, BoundCId, PacketType) ->
-    #{parse_state => ParseState, cid => BoundCId, packet_type => PacketType}.
+merge_state(ParseState, BoundCId, PacketType, undefined) ->
+    %% Rebuild state on each datagram so a reusable_channel hint is single-use.
+    #{parse_state => ParseState, cid => BoundCId, packet_type => PacketType};
+merge_state(ParseState, BoundCId, PacketType, ReusableChannel) ->
+    (merge_state(ParseState, BoundCId, PacketType, undefined))#{
+        reusable_channel => ReusableChannel
+    }.
 
 choose_cid(Packet, BoundCId, Peer) ->
     {ReqCId, PacketType} = packet_cid(Packet),
-    {CId, NBoundCId} = select_cid(PacketType, ReqCId, BoundCId, Peer),
-    {CId, NBoundCId, PacketType}.
+    {CId, NBoundCId, ReusableChannel} = select_cid(PacketType, ReqCId, BoundCId, Peer),
+    {CId, NBoundCId, PacketType, ReusableChannel}.
 
 packet_cid(?SN_CONNECT_MSG(_Flags, _ProtoId, _Duration, ClientId)) ->
     {normalize_clientid(ClientId), connect};
@@ -164,22 +160,22 @@ normalize_clientid(_ClientId) ->
     undefined.
 
 select_cid(_PacketType, undefined, undefined, Peer) ->
-    {peer_id(Peer), undefined};
+    {peer_id(Peer), undefined, undefined};
 select_cid(_PacketType, undefined, BoundCId, _Peer) ->
-    {BoundCId, BoundCId};
+    {BoundCId, BoundCId, undefined};
 select_cid(pingreq, ReqCId, BoundCId, Peer) ->
     select_pingreq_cid(ReqCId, BoundCId, Peer);
 select_cid(_PacketType, ReqCId, _BoundCId, _Peer) ->
-    {ReqCId, ReqCId}.
+    {ReqCId, ReqCId, undefined}.
 
 select_pingreq_cid(ReqCId, ReqCId, _Peer) ->
-    {ReqCId, ReqCId};
+    {ReqCId, ReqCId, undefined};
 select_pingreq_cid(ReqCId, _BoundCId, Peer) ->
     case find_reusable_channel(ReqCId, [asleep, awake]) of
-        {ok, _Pid} ->
-            {ReqCId, ReqCId};
+        {ok, Pid} ->
+            {ReqCId, ReqCId, {ReqCId, Pid}};
         false ->
-            {peer_id(Peer), undefined}
+            {peer_id(Peer), undefined, undefined}
     end.
 
 peer_id(Peer) ->

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -2016,6 +2016,74 @@ t_connected_same_source_tuple_reused_by_other_clientid(_) ->
         gen_udp:close(Socket)
     end.
 
+t_connected_clean_session_false_same_source_tuple_reused_preserves_session(_) ->
+    QoS = 1,
+    ClientId1 = <<"connected-clean-false-source-reuse-1">>,
+    ClientId2 = <<"connected-clean-false-source-reuse-2">>,
+    TopicName = <<"connected/clean/false/source/reuse">>,
+    Payload = <<"queued-for-persistent-connected-client">>,
+    MsgId = 29,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    {ok, Socket2} = gen_udp:open(0, [binary]),
+    TestPid = self(),
+    ok = meck:new(emqx_gateway_ctx, [passthrough, no_history, no_link]),
+    ok = meck:expect(
+        emqx_gateway_ctx,
+        connection_closed,
+        fun(Ctx, ClientId) ->
+            TestPid ! {connection_closed, ClientId},
+            meck:passthrough([Ctx, ClientId])
+        end
+    ),
+    try
+        send_connect_msg(Socket, ClientId1, CleanSession),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        send_subscribe_msg_normal_topic(Socket, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+            TopicId:16, MsgId:16,
+            ?SN_RC_ACCEPTED>> =
+            SubAck,
+
+        send_connect_msg(Socket, ClientId2),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+
+        ?retry(
+            50,
+            20,
+            #{conn_state := disconnected} = emqx_gateway_cm:get_chan_info(mqttsn, ClientId1)
+        ),
+        ?assertNot(received_connection_closed(ClientId1)),
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
+        timer:sleep(100),
+
+        ?assertEqual(udp_receive_timeout, receive_response(Socket, 500)),
+
+        send_connect_msg(Socket2, ClientId1, CleanSession),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket2)),
+        UdpData = receive_response(Socket2),
+        PubMsgId = check_publish_msg_on_udp(
+            {Dup, QoS, Retain, WillBit, CleanSession, ?SN_NORMAL_TOPIC, TopicId, Payload},
+            UdpData
+        ),
+        send_puback_msg(Socket2, TopicId, PubMsgId)
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId1),
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId2),
+        gen_udp:close(Socket),
+        gen_udp:close(Socket2),
+        meck:unload(emqx_gateway_ctx)
+    end.
+
 t_asleep_test04_to_awake_qos1_dl_msg(_) ->
     QoS = 1,
     Duration = 5,
@@ -3366,6 +3434,14 @@ ensure_channel_gone(ClientId) ->
         ?assertEqual([], emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId))
     ),
     ok.
+
+received_connection_closed(ClientId) ->
+    receive
+        {connection_closed, ClientId} ->
+            true
+    after 100 ->
+        false
+    end.
 
 with_gateway_authz_result(Protocol, ActionType, Topic, Result, Fun) ->
     Action = {?MODULE, gateway_authz_result, [Protocol, ActionType, Topic, Result]},

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -2173,16 +2173,7 @@ t_connected_clean_session_false_same_source_tuple_reused_preserves_session(_) ->
     CleanSession = 0,
     {ok, Socket} = gen_udp:open(0, [binary]),
     {ok, Socket2} = gen_udp:open(0, [binary]),
-    TestPid = self(),
-    ok = meck:new(emqx_gateway_ctx, [passthrough, no_history, no_link]),
-    ok = meck:expect(
-        emqx_gateway_ctx,
-        connection_closed,
-        fun(Ctx, ClientId) ->
-            TestPid ! {connection_closed, ClientId},
-            meck:passthrough([Ctx, ClientId])
-        end
-    ),
+    ok = setup_connection_closed_spy(),
     try
         send_connect_msg(Socket, ClientId1, CleanSession),
         ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
@@ -2245,16 +2236,7 @@ t_awake_same_source_tuple_reused_by_other_clientid(_) ->
     CleanSession = 0,
     {ok, Socket} = gen_udp:open(0, [binary]),
     {ok, Socket2} = gen_udp:open(0, [binary]),
-    TestPid = self(),
-    ok = meck:new(emqx_gateway_ctx, [passthrough, no_history, no_link]),
-    ok = meck:expect(
-        emqx_gateway_ctx,
-        connection_closed,
-        fun(Ctx, ClientId) ->
-            TestPid ! {connection_closed, ClientId},
-            meck:passthrough([Ctx, ClientId])
-        end
-    ),
+    ok = setup_connection_closed_spy(),
     try
         send_connect_msg(Socket, ClientId1, CleanSession),
         ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
@@ -3671,6 +3653,18 @@ received_connection_closed(ClientId) ->
     after 100 ->
         false
     end.
+
+setup_connection_closed_spy() ->
+    TestPid = self(),
+    ok = meck:new(emqx_gateway_ctx, [passthrough, no_history, no_link]),
+    ok = meck:expect(
+        emqx_gateway_ctx,
+        connection_closed,
+        fun(Ctx, ClientId) ->
+            TestPid ! {connection_closed, ClientId},
+            meck:passthrough([Ctx, ClientId])
+        end
+    ).
 
 with_gateway_authz_result(Protocol, ActionType, Topic, Result, Fun) ->
     Action = {?MODULE, gateway_authz_result, [Protocol, ActionType, Topic, Result]},

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -1988,6 +1988,39 @@ t_stale_udp_proxy_close_does_not_close_current_socket(_) ->
         gen_udp:close(Socket)
     end.
 
+t_current_udp_proxy_close_closes_current_socket(_) ->
+    QoS = 1,
+    ClientId = <<"current-proxy-close-current-socket">>,
+    TopicName = <<"current/proxy/close/current/socket">>,
+    Payload = <<"not-delivered-after-current-close">>,
+    MsgId = 34,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket, ClientId),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        send_subscribe_msg_normal_topic(Socket, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+
+        [Pid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
+        Pid ! {udp_proxy_closed, current_udp_proxy_id(Pid)},
+        timer:sleep(100),
+
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
+        ?assertEqual(udp_receive_timeout, receive_response(Socket, 500))
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId),
+        gen_udp:close(Socket)
+    end.
+
 t_asleep_pingreq_after_proxy_close(_) ->
     QoS = 1,
     SleepDuration = 5,
@@ -3713,6 +3746,10 @@ assert_publish_received(Socket, TopicId, ExpectedPayload, Attempts) ->
         Other ->
             error({unexpected_publish_response, Other})
     end.
+
+current_udp_proxy_id(Pid) ->
+    {esockd_udp_proxy, ProxyId, _Sock} = element(2, sys:get_state(Pid)),
+    ProxyId.
 
 get_udp_broadcast_address() ->
     "255.255.255.255".

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -1982,6 +1982,40 @@ t_asleep_same_source_tuple_reused_by_other_clientid(_) ->
         gen_udp:close(Socket2)
     end.
 
+t_connected_same_source_tuple_reused_by_other_clientid(_) ->
+    QoS = 1,
+    ClientId1 = <<"connected-source-reuse-1">>,
+    ClientId2 = <<"connected-source-reuse-2">>,
+    TopicName = <<"connected/source/reuse">>,
+    Payload = <<"queued-for-first-connected-client">>,
+    MsgId = 28,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket, ClientId1),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        send_subscribe_msg_normal_topic(Socket, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+
+        send_connect_msg(Socket, ClientId2),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
+        ?assertEqual(udp_receive_timeout, receive_response(Socket, 500))
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId1),
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId2),
+        gen_udp:close(Socket)
+    end.
+
 t_asleep_test04_to_awake_qos1_dl_msg(_) ->
     QoS = 1,
     Duration = 5,

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -1862,19 +1862,130 @@ t_asleep_pingreq_after_source_tuple_change(_) ->
     end.
 
 t_connected_pingreq_after_source_tuple_change(_) ->
+    QoS = 1,
     ClientId = <<"connected-source-change-pingreq">>,
+    TopicName = <<"connected/source/change/pingreq">>,
+    Payload = <<"deliver-to-original-connected-socket">>,
+    MsgId = 31,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
     {ok, Socket1} = gen_udp:open(0, [binary]),
     {ok, Socket2} = gen_udp:open(0, [binary]),
     try
         send_connect_msg(Socket1, ClientId),
         ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket1)),
+        send_subscribe_msg_normal_topic(Socket1, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket1),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+            TopicId:16, MsgId:16,
+            ?SN_RC_ACCEPTED>> =
+            SubAck,
 
         send_pingreq_msg(Socket2, ClientId),
-        ?assertEqual(<<2, ?SN_PINGRESP>>, receive_response(Socket2))
+        ?assertEqual(udp_receive_timeout, receive_response(Socket2, 500)),
+
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
+        UdpData = receive_response(Socket1),
+        _PubMsgId = check_publish_msg_on_udp(
+            {Dup, QoS, Retain, WillBit, CleanSession, ?SN_NORMAL_TOPIC, TopicId, Payload},
+            UdpData
+        ),
+        ?assertEqual(udp_receive_timeout, receive_response(Socket2, 500))
     after
         _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId),
         gen_udp:close(Socket1),
         gen_udp:close(Socket2)
+    end.
+
+t_stale_udp_proxy_detach_does_not_close_current_socket(_) ->
+    QoS = 1,
+    ClientId = <<"stale-proxy-detach-current-socket">>,
+    TopicName = <<"stale/proxy/detach/current/socket">>,
+    Payload = <<"deliver-after-stale-detach">>,
+    MsgId = 32,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket, ClientId),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        send_subscribe_msg_normal_topic(Socket, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+            TopicId:16, MsgId:16,
+            ?SN_RC_ACCEPTED>> =
+            SubAck,
+
+        [Pid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
+        Pid ! {udp_proxy_detached, self()},
+        Pid ! udp_proxy_detached,
+        timer:sleep(100),
+
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
+        UdpData = receive_response(Socket),
+        _PubMsgId = check_publish_msg_on_udp(
+            {Dup, QoS, Retain, WillBit, CleanSession, ?SN_NORMAL_TOPIC, TopicId, Payload},
+            UdpData
+        )
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId),
+        gen_udp:close(Socket)
+    end.
+
+t_stale_udp_proxy_close_does_not_close_current_socket(_) ->
+    QoS = 1,
+    ClientId = <<"stale-proxy-close-current-socket">>,
+    TopicName = <<"stale/proxy/close/current/socket">>,
+    Payload = <<"deliver-after-stale-close">>,
+    MsgId = 33,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket, ClientId),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        send_subscribe_msg_normal_topic(Socket, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+            TopicId:16, MsgId:16,
+            ?SN_RC_ACCEPTED>> =
+            SubAck,
+
+        [Pid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
+        Pid ! {udp_proxy_closed, self()},
+        Pid ! udp_proxy_closed,
+        timer:sleep(100),
+
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
+        UdpData = receive_response(Socket),
+        _PubMsgId = check_publish_msg_on_udp(
+            {Dup, QoS, Retain, WillBit, CleanSession, ?SN_NORMAL_TOPIC, TopicId, Payload},
+            UdpData
+        )
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId),
+        gen_udp:close(Socket)
     end.
 
 t_asleep_pingreq_after_proxy_close(_) ->
@@ -2101,6 +2212,16 @@ t_awake_same_source_tuple_reused_by_other_clientid(_) ->
     CleanSession = 0,
     {ok, Socket} = gen_udp:open(0, [binary]),
     {ok, Socket2} = gen_udp:open(0, [binary]),
+    TestPid = self(),
+    ok = meck:new(emqx_gateway_ctx, [passthrough, no_history, no_link]),
+    ok = meck:expect(
+        emqx_gateway_ctx,
+        connection_closed,
+        fun(Ctx, ClientId) ->
+            TestPid ! {connection_closed, ClientId},
+            meck:passthrough([Ctx, ClientId])
+        end
+    ),
     try
         send_connect_msg(Socket, ClientId1, CleanSession),
         ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
@@ -2137,20 +2258,26 @@ t_awake_same_source_tuple_reused_by_other_clientid(_) ->
         ?retry(
             50,
             20,
-            #{conn_state := disconnected} = emqx_gateway_cm:get_chan_info(mqttsn, ClientId1)
+            #{
+                conn_state := disconnected,
+                session := #{subscriptions := #{TopicName := _}}
+            } = emqx_gateway_cm:get_chan_info(mqttsn, ClientId1)
         ),
+        ?assertNot(received_connection_closed(ClientId1)),
         emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload2)),
         timer:sleep(100),
 
         ?assertEqual(udp_receive_timeout, receive_response(Socket, 500)),
 
         send_connect_msg(Socket2, ClientId1, CleanSession),
-        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket2))
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket2)),
+        assert_publish_received(Socket2, TopicId, Payload2)
     after
         _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId1),
         _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId2),
         gen_udp:close(Socket),
-        gen_udp:close(Socket2)
+        gen_udp:close(Socket2),
+        meck:unload(emqx_gateway_ctx)
     end.
 
 t_asleep_test04_to_awake_qos1_dl_msg(_) ->
@@ -3567,6 +3694,25 @@ check_dispatched_message(Dup, QoS, Retain, TopicIdType, TopicId, Payload, Socket
             ?assertEqual(<<4, ?SN_PUBCOMP, MsgId:16>>, receive_response(Socket))
     end,
     ok.
+
+assert_publish_received(Socket, TopicId, ExpectedPayload) ->
+    assert_publish_received(Socket, TopicId, ExpectedPayload, 3).
+
+assert_publish_received(_Socket, _TopicId, ExpectedPayload, 0) ->
+    error({expected_publish_not_received, ExpectedPayload});
+assert_publish_received(Socket, TopicId, ExpectedPayload, Attempts) ->
+    case receive_response(Socket) of
+        <<_Length, ?SN_PUBLISH, _Dup:1, QoS:2, _Retain:1, ?FNU:2, ?SN_NORMAL_TOPIC:2, TopicId:16,
+            MsgId:16, ExpectedPayload/binary>> ->
+            QoS == 1 andalso send_puback_msg(Socket, TopicId, MsgId),
+            ok;
+        <<_Length, ?SN_PUBLISH, _Dup:1, QoS:2, _Retain:1, ?FNU:2, ?SN_NORMAL_TOPIC:2, TopicId:16,
+            MsgId:16, _OtherPayload/binary>> ->
+            QoS == 1 andalso send_puback_msg(Socket, TopicId, MsgId),
+            assert_publish_received(Socket, TopicId, ExpectedPayload, Attempts - 1);
+        Other ->
+            error({unexpected_publish_response, Other})
+    end.
 
 get_udp_broadcast_address() ->
     "255.255.255.255".

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -2060,7 +2060,10 @@ t_connected_clean_session_false_same_source_tuple_reused_preserves_session(_) ->
         ?retry(
             50,
             20,
-            #{conn_state := disconnected} = emqx_gateway_cm:get_chan_info(mqttsn, ClientId1)
+            #{
+                conn_state := disconnected,
+                session := #{subscriptions := #{TopicName := _}}
+            } = emqx_gateway_cm:get_chan_info(mqttsn, ClientId1)
         ),
         ?assertNot(received_connection_closed(ClientId1)),
         emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
@@ -2082,6 +2085,72 @@ t_connected_clean_session_false_same_source_tuple_reused_preserves_session(_) ->
         gen_udp:close(Socket),
         gen_udp:close(Socket2),
         meck:unload(emqx_gateway_ctx)
+    end.
+
+t_awake_same_source_tuple_reused_by_other_clientid(_) ->
+    QoS = 1,
+    ClientId1 = <<"awake-source-reuse-1">>,
+    ClientId2 = <<"awake-source-reuse-2">>,
+    TopicName = <<"awake/source/reuse">>,
+    Payload1 = <<"inflight-for-first-awake-client">>,
+    Payload2 = <<"queued-for-first-awake-client">>,
+    MsgId = 30,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    {ok, Socket2} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket, ClientId1, CleanSession),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        send_subscribe_msg_normal_topic(Socket, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+            TopicId:16, MsgId:16,
+            ?SN_RC_ACCEPTED>> =
+            SubAck,
+
+        send_disconnect_msg(Socket, 5),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload1)),
+        timer:sleep(100),
+
+        send_pingreq_msg(Socket, ClientId1),
+        UdpData = receive_response(Socket),
+        _PubMsgId = check_publish_msg_on_udp(
+            {Dup, QoS, Retain, WillBit, CleanSession, ?SN_NORMAL_TOPIC, TopicId, Payload1},
+            UdpData
+        ),
+
+        ?retry(50, 20, #{conn_state := awake} = emqx_gateway_cm:get_chan_info(mqttsn, ClientId1)),
+
+        send_connect_msg(Socket, ClientId2),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+
+        ?retry(
+            50,
+            20,
+            #{conn_state := disconnected} = emqx_gateway_cm:get_chan_info(mqttsn, ClientId1)
+        ),
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload2)),
+        timer:sleep(100),
+
+        ?assertEqual(udp_receive_timeout, receive_response(Socket, 500)),
+
+        send_connect_msg(Socket2, ClientId1, CleanSession),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket2))
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId1),
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId2),
+        gen_udp:close(Socket),
+        gen_udp:close(Socket2)
     end.
 
 t_asleep_test04_to_awake_qos1_dl_msg(_) ->

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -1627,14 +1627,13 @@ t_will_case06(_) ->
     %% here so the SUITE does not depend on UDP port-allocation luck.
     ok = ensure_channel_gone(ClientId).
 
-%% Reproduces UDP ephemeral-port reuse deterministically: a stale
-%% `disconnected' channel bound to a peer UDP port must not crash when a new
-%% device connects from the same source port. The stale channel is retired
-%% cleanly and the new device is able to connect.
+%% Reproduces a same-ClientId reconnect after the UDP source port is reused by a
+%% new proxy process. The new connection takes over the old disconnected session
+%% immediately.
 t_takeover_on_udp_port_reuse(_) ->
     {ok, SockA} = gen_udp:open(0, [binary]),
     {ok, PortA} = inet:port(SockA),
-    ClientA = ?CLIENTID,
+    ClientA = <<"disconnected-port-reuse-same-client">>,
     %% device A connects with CleanSession=0 and disconnects, leaving its
     %% channel alive in the `disconnected' state.
     send_connect_msg(SockA, ClientA, 0),
@@ -1650,30 +1649,72 @@ t_takeover_on_udp_port_reuse(_) ->
     %% device B reuses the exact same source UDP port.
     {ok, SockB} = gen_udp:open(PortA, [binary, {reuseaddr, true}]),
     try
-        ClientB = ?CLIENTID,
-        %% the CONNECT is routed to the stale channel, which is retired
-        %% cleanly (before the fix this crashed with a function_clause).
+        ClientB = ClientA,
         send_connect_msg(SockB, ClientB, 0),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(SockB)),
         receive
             {'DOWN', MRef, process, OldPid, Reason} ->
-                ?assertEqual({shutdown, takeover_by_new_connect}, Reason)
+                ?assertEqual({shutdown, takenover}, Reason)
         after 2000 ->
             ct:fail(stale_channel_not_retired)
         end,
-        %% the CONNECT that retired the stale channel gets no reply on the
-        %% wire (the channel is shut down without an ack frame); the device
-        %% must recover on retransmit.
-        ?assertEqual(udp_receive_timeout, receive_response(SockB, 500)),
-        %% the new device connects on retransmit (MQTT-SN clients retransmit
-        %% CONNECT when no reply is received).
+        ok = ensure_channel_gone(ClientB)
+    after
+        gen_udp:close(SockB)
+    end.
+
+%% Reproduces a same-ClientId reconnect on the same UDP source tuple. The new
+%% connection takes over the old disconnected session immediately.
+t_disconnected_same_proxy_same_clientid_reconnect(_) ->
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    ClientId = <<"disconnected-same-proxy-reconnect">>,
+    try
+        send_connect_msg(Socket, ClientId, 0),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        send_disconnect_msg(Socket, undefined),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+        OldPid = wait_for_disconnected_channel(ClientId),
+
+        MRef = erlang:monitor(process, OldPid),
+        send_connect_msg(Socket, ClientId, 0),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        receive
+            {'DOWN', MRef, process, OldPid, Reason} ->
+                ?assertEqual({shutdown, takenover}, Reason)
+        after 2000 ->
+            ct:fail(stale_channel_not_retired)
+        end,
+        ok = ensure_channel_gone(ClientId)
+    after
+        gen_udp:close(Socket)
+    end.
+
+%% Reproduces a different ClientId reusing the same UDP source port. UDP proxy
+%% routing must follow the CONNECT ClientId, not the peer port, so the new client
+%% connects immediately and the old disconnected session stays resumable.
+t_disconnected_same_source_tuple_reused_by_other_clientid(_) ->
+    {ok, SockA} = gen_udp:open(0, [binary]),
+    {ok, PortA} = inet:port(SockA),
+    ClientA = <<"disconnected-source-reuse-1">>,
+    ClientB = <<"disconnected-source-reuse-2">>,
+    send_connect_msg(SockA, ClientA, 0),
+    ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(SockA)),
+    send_disconnect_msg(SockA, undefined),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(SockA)),
+    OldPid = wait_for_disconnected_channel(ClientA),
+    ok = gen_udp:close(SockA),
+
+    {ok, SockB} = gen_udp:open(PortA, [binary, {reuseaddr, true}]),
+    try
+        send_connect_msg(SockB, ClientB, 0),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(SockB)),
+        ?assert(is_process_alive(OldPid)),
         ?retry(
-            200,
-            10,
-            begin
-                send_connect_msg(SockB, ClientB, 0),
-                ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(SockB))
-            end
+            50,
+            20,
+            #{conn_state := disconnected} = emqx_gateway_cm:get_chan_info(mqttsn, ClientA, OldPid)
         ),
+        ok = ensure_channel_gone(ClientA),
         ok = ensure_channel_gone(ClientB)
     after
         gen_udp:close(SockB)
@@ -1932,7 +1973,7 @@ t_stale_udp_proxy_detach_does_not_close_current_socket(_) ->
 
         [Pid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
         Pid ! {udp_proxy_detached, self()},
-        Pid ! udp_proxy_detached,
+        ok = emqx_mqttsn_proxy_conn:detach(Pid, #{}),
         timer:sleep(100),
 
         emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
@@ -1974,7 +2015,7 @@ t_stale_udp_proxy_close_does_not_close_current_socket(_) ->
 
         [Pid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
         Pid ! {udp_proxy_closed, self()},
-        Pid ! udp_proxy_closed,
+        ok = emqx_mqttsn_proxy_conn:close(Pid, #{}),
         timer:sleep(100),
 
         emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
@@ -2054,7 +2095,7 @@ t_asleep_pingreq_after_proxy_close(_) ->
         ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket1)),
 
         [Pid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
-        _ = emqx_mqttsn_proxy_conn:close(Pid, #{}),
+        _ = emqx_mqttsn_proxy_conn:close(Pid, current_udp_proxy_id(Pid), #{}),
         timer:sleep(100),
 
         emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -1811,6 +1811,177 @@ t_asleep_test03_to_awake_qos1_dl_msg(_) ->
 
     gen_udp:close(Socket).
 
+t_asleep_pingreq_after_source_tuple_change(_) ->
+    QoS = 1,
+    SleepDuration = 5,
+    ClientId = <<"asleep-source-change-pingreq">>,
+    TopicName = <<"asleep/source/change/pingreq">>,
+    Payload = <<"queued-after-source-change">>,
+    MsgId = 25,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {ok, Socket1} = gen_udp:open(0, [binary]),
+    {ok, Socket2} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket1, ClientId),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket1)),
+
+        send_subscribe_msg_normal_topic(Socket1, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket1),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+            TopicId:16, MsgId:16,
+            ?SN_RC_ACCEPTED>> =
+            SubAck,
+
+        send_disconnect_msg(Socket1, SleepDuration),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket1)),
+
+        timer:sleep(100),
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
+        timer:sleep(100),
+
+        send_pingreq_msg(Socket2, ClientId),
+        UdpData = receive_response(Socket2),
+        PubMsgId = check_publish_msg_on_udp(
+            {Dup, QoS, Retain, WillBit, CleanSession, ?SN_NORMAL_TOPIC, TopicId, Payload},
+            UdpData
+        ),
+        send_puback_msg(Socket2, TopicId, PubMsgId),
+        ?assertEqual(<<2, ?SN_PINGRESP>>, receive_response(Socket2))
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId),
+        gen_udp:close(Socket1),
+        gen_udp:close(Socket2)
+    end.
+
+t_connected_pingreq_after_source_tuple_change(_) ->
+    ClientId = <<"connected-source-change-pingreq">>,
+    {ok, Socket1} = gen_udp:open(0, [binary]),
+    {ok, Socket2} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket1, ClientId),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket1)),
+
+        send_pingreq_msg(Socket2, ClientId),
+        ?assertEqual(<<2, ?SN_PINGRESP>>, receive_response(Socket2))
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId),
+        gen_udp:close(Socket1),
+        gen_udp:close(Socket2)
+    end.
+
+t_asleep_pingreq_after_proxy_close(_) ->
+    QoS = 1,
+    SleepDuration = 5,
+    ClientId = <<"asleep-proxy-close-pingreq">>,
+    TopicName = <<"asleep/proxy/close/pingreq">>,
+    Payload = <<"queued-after-proxy-close">>,
+    MsgId = 26,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {ok, Socket1} = gen_udp:open(0, [binary]),
+    {ok, Socket2} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket1, ClientId),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket1)),
+
+        send_subscribe_msg_normal_topic(Socket1, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket1),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+            TopicId:16, MsgId:16,
+            ?SN_RC_ACCEPTED>> =
+            SubAck,
+
+        send_disconnect_msg(Socket1, SleepDuration),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket1)),
+
+        [Pid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
+        _ = emqx_mqttsn_proxy_conn:close(Pid, #{}),
+        timer:sleep(100),
+
+        emqx_broker:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
+        timer:sleep(100),
+
+        send_pingreq_msg(Socket2, ClientId),
+        UdpData = receive_response(Socket2),
+        PubMsgId = check_publish_msg_on_udp(
+            {Dup, QoS, Retain, WillBit, CleanSession, ?SN_NORMAL_TOPIC, TopicId, Payload},
+            UdpData
+        ),
+        send_puback_msg(Socket2, TopicId, PubMsgId),
+        ?assertEqual(<<2, ?SN_PINGRESP>>, receive_response(Socket2))
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId),
+        gen_udp:close(Socket1),
+        gen_udp:close(Socket2)
+    end.
+
+t_asleep_same_source_tuple_reused_by_other_clientid(_) ->
+    QoS = 1,
+    ClientId1 = <<"asleep-source-reuse-1">>,
+    ClientId2 = <<"asleep-source-reuse-2">>,
+    TopicName = <<"asleep/source/reuse">>,
+    Payload = <<"queued-for-first-client">>,
+    MsgId = 27,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    {ok, Socket2} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket, ClientId1),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        send_subscribe_msg_normal_topic(Socket, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+            TopicId:16, MsgId:16,
+            ?SN_RC_ACCEPTED>> =
+            SubAck,
+
+        send_disconnect_msg(Socket, 5),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+
+        send_connect_msg(Socket, ClientId2),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+
+        emqx_broker:publish(emqx_message:make(<<"ct">>, 1, TopicName, Payload)),
+        timer:sleep(100),
+
+        send_pingreq_msg(Socket2, ClientId1),
+        UdpData = receive_response(Socket2),
+        PubMsgId = check_publish_msg_on_udp(
+            {Dup, QoS, Retain, WillBit, CleanSession, ?SN_NORMAL_TOPIC, TopicId, Payload},
+            UdpData
+        ),
+        send_puback_msg(Socket2, TopicId, PubMsgId),
+        ?assertEqual(<<2, ?SN_PINGRESP>>, receive_response(Socket2))
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId1),
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId2),
+        gen_udp:close(Socket),
+        gen_udp:close(Socket2)
+    end.
+
 t_asleep_test04_to_awake_qos1_dl_msg(_) ->
     QoS = 1,
     Duration = 5,
@@ -2411,6 +2582,52 @@ t_register_subs_resume_on(_) ->
     ?assertMatch(<<2, ?SN_DISCONNECT>>, receive_response(NSocket1)),
     gen_udp:close(NSocket1),
     update_mqttsn_with_subs_resume_off().
+
+t_register_subs_resume_on_same_source_tuple(_) ->
+    update_mqttsn_with_subs_resume_on(),
+    ClientId = ?CLIENTID,
+    MsgId = 1,
+    TopicName = ?PREDEF_TOPIC_NAME1,
+    Payload = <<"same-source-offline">>,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket, ClientId, 0),
+        ?assertMatch(
+            <<_, ?SN_CONNACK, ?SN_RC_ACCEPTED>>,
+            receive_response(Socket)
+        ),
+
+        send_subscribe_msg_predefined_topic(Socket, ?QOS_1, ?PREDEF_TOPIC_ID1, MsgId),
+        <<_, ?SN_SUBACK, 2#00100000, ?PREDEF_TOPIC_ID1:16, _:16, ?SN_RC_ACCEPTED>> =
+            receive_response(Socket),
+
+        send_disconnect_msg(Socket, undefined),
+        ?assertMatch(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+
+        timer:sleep(100),
+        _ = emqx:publish(
+            emqx_message:make(test, ?QOS_1, TopicName, Payload)
+        ),
+        timer:sleep(100),
+
+        send_connect_msg(Socket, ClientId, 0),
+        ?assertMatch(
+            <<_, ?SN_CONNACK, ?SN_RC_ACCEPTED>>,
+            receive_response(Socket)
+        ),
+
+        <<_, ?SN_REGISTER, ?PREDEF_TOPIC_ID1:16, RegMsgId:16, TopicName/binary>> =
+            receive_response(Socket),
+        send_regack_msg(Socket, ?PREDEF_TOPIC_ID1, RegMsgId),
+
+        <<_, ?SN_PUBLISH, 2#00100001, ?PREDEF_TOPIC_ID1:16, PubMsgId:16, Payload/binary>> =
+            receive_response(Socket),
+        send_puback_msg(Socket, ?PREDEF_TOPIC_ID1, PubMsgId, ?SN_RC_ACCEPTED)
+    after
+        _ = catch emqx_gateway_cm:kick_session(mqttsn, ClientId),
+        gen_udp:close(Socket),
+        update_mqttsn_with_subs_resume_off()
+    end.
 
 t_register_subs_resume_off(_) ->
     MsgId = 1,

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_proxy_cluster_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_proxy_cluster_SUITE.erl
@@ -1,0 +1,225 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_sn_proxy_cluster_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include("emqx_mqttsn.hrl").
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(HOST, {127, 0, 0, 1}).
+-define(FNU, 0).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+t_asleep_pingreq_reroutes_across_nodes_and_retires_old_proxy(Config) ->
+    QoS = 1,
+    SleepDuration = 5,
+    ClientId = <<"cluster-asleep-proxy-reroute">>,
+    TopicName = <<"cluster/asleep/proxy/reroute">>,
+    Payload1 = <<"cluster-queued-before-reroute">>,
+    Payload2 = <<"cluster-queued-after-stale-old-tuple">>,
+    MsgId = 41,
+    Dup = 0,
+    Retain = 0,
+    WillBit = 0,
+    CleanSession = 0,
+    {Nodes, Port1, Port2} = start_mqttsn_cluster(Config),
+    [Node1, _Node2] = Nodes,
+    {ok, Socket1} = gen_udp:open(0, [binary]),
+    {ok, Socket2} = gen_udp:open(0, [binary]),
+    try
+        send_connect_msg(Socket1, Port1, ClientId),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket1)),
+
+        send_subscribe_msg_normal_topic(Socket1, Port1, QoS, TopicName, MsgId),
+        SubAck = receive_response(Socket1),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                _TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            SubAck
+        ),
+        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+            TopicId:16, MsgId:16,
+            ?SN_RC_ACCEPTED>> =
+            SubAck,
+
+        send_disconnect_msg(Socket1, Port1, SleepDuration),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket1)),
+        ?retry(
+            50,
+            20,
+            #{conn_state := asleep} = erpc:call(Node1, emqx_gateway_cm, get_chan_info, [
+                mqttsn, ClientId
+            ])
+        ),
+
+        publish(Node1, QoS, TopicName, Payload1),
+        timer:sleep(100),
+
+        send_pingreq_msg(Socket2, Port2, ClientId),
+        PubMsgId1 = receive_publish(
+            Socket2, Dup, QoS, Retain, WillBit, CleanSession, TopicId, Payload1
+        ),
+        send_puback_msg(Socket2, Port2, TopicId, PubMsgId1),
+        ?assertEqual(<<2, ?SN_PINGRESP>>, receive_response(Socket2)),
+        ?retry(
+            50,
+            20,
+            #{conn_state := asleep} = erpc:call(Node1, emqx_gateway_cm, get_chan_info, [
+                mqttsn, ClientId
+            ])
+        ),
+
+        %% If the old node1 proxy was not retired, this stale datagram
+        %% has no ClientId but is still routed to ClientId's old channel.
+        send_disconnect_msg(Socket1, Port1, undefined),
+        _ = receive_response(Socket1, 500),
+
+        publish(Node1, QoS, TopicName, Payload2),
+        timer:sleep(100),
+
+        send_pingreq_msg(Socket2, Port2, ClientId),
+        PubMsgId2 = receive_publish(
+            Socket2, Dup, QoS, Retain, WillBit, CleanSession, TopicId, Payload2
+        ),
+        send_puback_msg(Socket2, Port2, TopicId, PubMsgId2),
+        ?assertEqual(<<2, ?SN_PINGRESP>>, receive_response(Socket2))
+    after
+        _ = catch erpc:call(Node1, emqx_gateway_cm, kick_session, [mqttsn, ClientId]),
+        gen_udp:close(Socket1),
+        gen_udp:close(Socket2),
+        emqx_cth_cluster:stop(Nodes)
+    end.
+
+start_mqttsn_cluster(Config) ->
+    Port1 = emqx_common_test_helpers:select_free_port(udp),
+    Port2 = emqx_common_test_helpers:select_free_port(udp),
+    Apps1 = mqttsn_apps(Port1),
+    Apps2 = mqttsn_apps(Port2),
+    NodeSpecs = emqx_cth_cluster:mk_nodespecs(
+        [
+            {cluster_node_name(?FUNCTION_NAME, 1), #{apps => Apps1}},
+            {cluster_node_name(?FUNCTION_NAME, 2), #{apps => Apps2}}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+    ),
+    [Node1, Node2] = Nodes = emqx_cth_cluster:start(NodeSpecs),
+    ?retry(
+        50,
+        20,
+        true = is_pid(erpc:call(Node1, erlang, whereis, [emqx_gateway_sup]))
+    ),
+    ?retry(
+        50,
+        20,
+        true = is_pid(erpc:call(Node2, erlang, whereis, [emqx_gateway_sup]))
+    ),
+    {Nodes, Port1, Port2}.
+
+cluster_node_name(TestCase, N) ->
+    binary_to_atom(iolist_to_binary(io_lib:format("~s_~B", [TestCase, N]))).
+
+mqttsn_apps(Port) ->
+    [
+        {emqx_conf, mqttsn_conf(Port)},
+        emqx_gateway,
+        emqx_auth
+    ].
+
+mqttsn_conf(Port) ->
+    iolist_to_binary(
+        io_lib:format(
+            "gateway.mqttsn {\n"
+            "  gateway_id = 1\n"
+            "  broadcast = false\n"
+            "  enable_qos3 = true\n"
+            "  clientinfo_override {\n"
+            "    username = \"user1\"\n"
+            "    password = \"pw123\"\n"
+            "  }\n"
+            "  listeners.udp.default {\n"
+            "    bind = \"127.0.0.1:~B\"\n"
+            "  }\n"
+            "}\n",
+            [Port]
+        )
+    ).
+
+publish(Node, QoS, TopicName, Payload) ->
+    Msg = emqx_message:make(<<"ct">>, QoS, TopicName, Payload),
+    _ = erpc:call(Node, emqx_broker, publish, [Msg]),
+    ok.
+
+receive_publish(Socket, Dup, QoS, Retain, WillBit, CleanSession, TopicId, Payload) ->
+    UdpData = receive_response(Socket),
+    emqx_sn_protocol_SUITE:check_publish_msg_on_udp(
+        {Dup, QoS, Retain, WillBit, CleanSession, ?SN_NORMAL_TOPIC, TopicId, Payload},
+        UdpData
+    ).
+
+send_connect_msg(Socket, Port, ClientId) ->
+    Packet = make_connect_msg(ClientId, 1),
+    ok = gen_udp:send(Socket, ?HOST, Port, Packet).
+
+make_connect_msg(ClientId, CleanSession) ->
+    Length = 6 + byte_size(ClientId),
+    MsgType = ?SN_CONNECT,
+    Will = 0,
+    ProtocolId = 1,
+    Duration = 10,
+    <<Length:8, MsgType:8, ?FNU:4, Will:1, CleanSession:1, ?FNU:2, ProtocolId:8, Duration:16,
+        ClientId/binary>>.
+
+send_subscribe_msg_normal_topic(Socket, Port, QoS, Topic, MsgId) ->
+    MsgType = ?SN_SUBSCRIBE,
+    Dup = 0,
+    Retain = 0,
+    Will = 0,
+    CleanSession = 0,
+    TopicIdType = ?SN_NORMAL_TOPIC,
+    Length = byte_size(Topic) + 5,
+    SubscribePacket =
+        <<Length:8, MsgType:8, Dup:1, QoS:2, Retain:1, Will:1, CleanSession:1, TopicIdType:2,
+            MsgId:16, Topic/binary>>,
+    ok = gen_udp:send(Socket, ?HOST, Port, SubscribePacket).
+
+send_disconnect_msg(Socket, Port, undefined) ->
+    Packet = <<2, ?SN_DISCONNECT>>,
+    ok = gen_udp:send(Socket, ?HOST, Port, Packet);
+send_disconnect_msg(Socket, Port, Duration) ->
+    Length = 4,
+    MsgType = ?SN_DISCONNECT,
+    Packet = <<Length:8, MsgType:8, Duration:16>>,
+    ok = gen_udp:send(Socket, ?HOST, Port, Packet).
+
+send_pingreq_msg(Socket, Port, ClientId) ->
+    Length = 2 + byte_size(ClientId),
+    MsgType = ?SN_PINGREQ,
+    PingReq = <<Length:8, MsgType:8, ClientId/binary>>,
+    ok = gen_udp:send(Socket, ?HOST, Port, PingReq).
+
+send_puback_msg(Socket, Port, TopicId, MsgId) ->
+    Length = 7,
+    MsgType = ?SN_PUBACK,
+    ReturnCode = ?SN_RC_ACCEPTED,
+    PubAckPacket = <<Length:8, MsgType:8, TopicId:16, MsgId:16, ReturnCode:8>>,
+    ok = gen_udp:send(Socket, ?HOST, Port, PubAckPacket).
+
+receive_response(Socket) ->
+    receive_response(Socket, 2000).
+
+receive_response(Socket, Timeout) ->
+    receive
+        {udp, Socket, _, _, Bin} ->
+            Bin
+    after Timeout ->
+        udp_receive_timeout
+    end.

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_proxy_cluster_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_proxy_cluster_SUITE.erl
@@ -166,17 +166,8 @@ receive_publish(Socket, Dup, QoS, Retain, WillBit, CleanSession, TopicId, Payloa
     ).
 
 send_connect_msg(Socket, Port, ClientId) ->
-    Packet = make_connect_msg(ClientId, 1),
+    Packet = emqx_sn_protocol_SUITE:make_connect_msg(ClientId, 1),
     ok = gen_udp:send(Socket, ?HOST, Port, Packet).
-
-make_connect_msg(ClientId, CleanSession) ->
-    Length = 6 + byte_size(ClientId),
-    MsgType = ?SN_CONNECT,
-    Will = 0,
-    ProtocolId = 1,
-    Duration = 10,
-    <<Length:8, MsgType:8, ?FNU:4, Will:1, CleanSession:1, ?FNU:2, ProtocolId:8, Duration:16,
-        ClientId/binary>>.
 
 send_subscribe_msg_normal_topic(Socket, Port, QoS, Topic, MsgId) ->
     MsgType = ?SN_SUBSCRIBE,
@@ -191,13 +182,8 @@ send_subscribe_msg_normal_topic(Socket, Port, QoS, Topic, MsgId) ->
             MsgId:16, Topic/binary>>,
     ok = gen_udp:send(Socket, ?HOST, Port, SubscribePacket).
 
-send_disconnect_msg(Socket, Port, undefined) ->
-    Packet = <<2, ?SN_DISCONNECT>>,
-    ok = gen_udp:send(Socket, ?HOST, Port, Packet);
 send_disconnect_msg(Socket, Port, Duration) ->
-    Length = 4,
-    MsgType = ?SN_DISCONNECT,
-    Packet = <<Length:8, MsgType:8, Duration:16>>,
+    Packet = emqx_sn_protocol_SUITE:make_disconnect_msg(Duration),
     ok = gen_udp:send(Socket, ?HOST, Port, Packet).
 
 send_pingreq_msg(Socket, Port, ClientId) ->

--- a/changes/ee/fix-17815.en.md
+++ b/changes/ee/fix-17815.en.md
@@ -1,0 +1,3 @@
+Fixed MQTT-SN UDP session routing when UDP source tuples change or are reused.
+
+MQTT-SN UDP listeners now route packets by the ClientId parsed from the packet through `esockd_udp_proxy`, allowing asleep sessions to resume from a different UDP source tuple while preventing a reused UDP source tuple from delivering another ClientId's packets to the old session.

--- a/mix.exs
+++ b/mix.exs
@@ -174,7 +174,12 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.0", override: true}
-  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.16.3", override: true}
+
+  def common_dep(:esockd),
+    do:
+      {:esockd,
+       github: "emqx/esockd", ref: "5257195441d2bedcfa32c21908733bab6b1e6b1f", override: true}
+
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.9", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}

--- a/mix.exs
+++ b/mix.exs
@@ -178,7 +178,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:esockd),
     do:
       {:esockd,
-       github: "emqx/esockd", ref: "e356c703afc02049ce29e3f0fd1e9cf338f107a2", override: true}
+       github: "emqx/esockd", ref: "637975beedaa252d47af5736436e2bbade750732", override: true}
 
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.9", override: true}

--- a/mix.exs
+++ b/mix.exs
@@ -178,7 +178,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:esockd),
     do:
       {:esockd,
-       github: "emqx/esockd", ref: "5257195441d2bedcfa32c21908733bab6b1e6b1f", override: true}
+       github: "emqx/esockd", ref: "e356c703afc02049ce29e3f0fd1e9cf338f107a2", override: true}
 
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.9", override: true}

--- a/mix.exs
+++ b/mix.exs
@@ -175,10 +175,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.0", override: true}
 
-  def common_dep(:esockd),
-    do:
-      {:esockd,
-       github: "emqx/esockd", ref: "637975beedaa252d47af5736436e2bbade750732", override: true}
+  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.1", override: true}
 
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.9", override: true}


### PR DESCRIPTION
Release version: 6.0.4

## Summary

This PR changes MQTT-SN UDP listeners to use `esockd_udp_proxy` with ClientId-based routing, backed by the esockd UDP proxy reroute and owner-aware detach/close callback fix in emqx/esockd#221.

The gateway now treats MQTT-SN ClientId as the logical connection identity instead of relying on the UDP source tuple. This allows asleep sessions to be resumed when a client wakes from a different UDP source tuple, and prevents a reused UDP source tuple from delivering another ClientId's packets into the old session.

`PINGREQ(ClientId)` only reuses existing `asleep` or `awake` channels. It does not migrate a `connected` session from another UDP tuple, so an already connected client continues to receive traffic on its current socket.

When an esockd UDP proxy is rebound from one ClientId to another, MQTT-SN receives an owner-tagged transport detach notification for the old logical connection. EMQX only acts on owner-tagged detach/close notifications from the current UDP proxy, so an old proxy cannot close a newer socket. MQTT-SN's legacy ownerless callbacks are no-ops, while the shared gateway connection process preserves CoAP's legacy bare close behavior. The CoAP UDP proxy close callback also opts in to owner-tagged close notifications. When an asleep session is awakened through a new proxy, the channel retires the previous proxy by ClientId, including the cross-node case where the new UDP tuple is routed to another EMQX node.

Asleep or disconnected channels keep the lingering logical session. Active channels detached by a proxy reroute run the normal logical disconnect path without marking the channel connection closed, so a persistent `CleanSession=false` session remains available for later takeover while the newly rebound proxy stays open. Existing non-UDP-proxy listener behavior remains unchanged.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

