### PR TITLE
feat(authz): expose backend failure setting in API

### DIFF
--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_api_settings.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_api_settings.erl
@@ -57,7 +57,7 @@ schema("/authorization/settings") ->
     }.
 
 ref_authz_schema() ->
-    emqx_schema:authz_fields().
+    emqx_schema:authz_fields() ++ [emqx_authz_schema:ignore_backend_failures_field()].
 
 settings(get, _Params) ->
     {200, authorization_settings()};
@@ -66,7 +66,8 @@ settings(put, #{body := Body}) ->
         <<"no_match">> := NoMatch,
         <<"deny_action">> := DenyAction,
         <<"cache">> := Cache,
-        <<"include_mountpoint">> := IncludeMountpoint
+        <<"include_mountpoint">> := IncludeMountpoint,
+        <<"ignore_backend_failures">> := IgnoreBackendFailures
         %% We do not pass the body to emqx_conf:update_config/3 which
         %% fills the defaults. So we need to fill the defaults here
     } = emqx_schema:fill_defaults(ref_authz_schema(), Body),
@@ -81,6 +82,9 @@ settings(put, #{body := Body}) ->
     {ok, _} = emqx_authz_utils:update_config([authorization, cache], Cache),
     {ok, _} = emqx_authz_utils:update_config(
         [authorization, include_mountpoint], IncludeMountpoint
+    ),
+    {ok, _} = emqx_authz_utils:update_config(
+        [authorization, ignore_backend_failures], IgnoreBackendFailures
     ),
 
     {200, authorization_settings()}.

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
@@ -16,6 +16,7 @@
 
 -export([
     authz_fields/0,
+    ignore_backend_failures_field/0,
     api_source_type/0,
     source_types/0
 ]).
@@ -125,12 +126,7 @@ injected_fields(AuthzSchemaMods) ->
 
 authz_fields() ->
     [
-        {ignore_backend_failures,
-            hoconsc:mk(boolean(), #{
-                default => false,
-                desc => ?DESC(ignore_backend_failures),
-                importance => ?IMPORTANCE_LOW
-            })},
+        ignore_backend_failures_field(),
         {builtin_record_count_refresh_interval,
             hoconsc:mk(emqx_schema:timeout_duration_ms(), #{
                 default => <<"1h">>,
@@ -138,6 +134,14 @@ authz_fields() ->
             })}
         | sources_fields() ++ node_cache_fields()
     ].
+
+ignore_backend_failures_field() ->
+    {ignore_backend_failures,
+        hoconsc:mk(boolean(), #{
+            default => false,
+            desc => ?DESC(ignore_backend_failures),
+            importance => ?IMPORTANCE_LOW
+        })}.
 
 sources_fields() ->
     AuthzSchemaMods = source_schema_mods(),

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
@@ -724,7 +724,10 @@ t_cache(_Config) ->
         uri(["authentication", "settings"])
     ),
     ?assertMatch(
-        #{<<"node_cache">> := #{<<"enable">> := true}},
+        #{
+            <<"node_cache">> := #{<<"enable">> := true},
+            <<"ignore_backend_failures">> := false
+        },
         emqx_utils_json:decode(CacheData0)
     ),
     {ok, 200, MetricsData0} = request(
@@ -739,7 +742,8 @@ t_cache(_Config) ->
         put,
         uri(["authentication", "settings"]),
         #{
-            <<"node_cache">> => #{<<"enable">> => true}
+            <<"node_cache">> => #{<<"enable">> => true},
+            <<"ignore_backend_failures">> => true
         }
     ),
     {ok, 200, CacheData1} = request(
@@ -747,7 +751,10 @@ t_cache(_Config) ->
         uri(["authentication", "settings"])
     ),
     ?assertMatch(
-        #{<<"node_cache">> := #{<<"enable">> := true}},
+        #{
+            <<"node_cache">> := #{<<"enable">> := true},
+            <<"ignore_backend_failures">> := true
+        },
         emqx_utils_json:decode(CacheData1)
     ),
 

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_settings_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_settings_SUITE.erl
@@ -59,7 +59,8 @@ t_api(_) ->
             <<"ttl">> => <<"60s">>,
             <<"excludes">> => [<<"nocache/#">>]
         },
-        <<"include_mountpoint">> => true
+        <<"include_mountpoint">> => true,
+        <<"ignore_backend_failures">> => true
     },
     Settings1Get = Settings1Put,
 
@@ -80,7 +81,8 @@ t_api(_) ->
 
     Settings2Get = Settings2Put#{
         <<"cache">> := Cache#{<<"excludes">> => []},
-        <<"include_mountpoint">> => false
+        <<"include_mountpoint">> => false,
+        <<"ignore_backend_failures">> => false
     },
 
     {ok, 200, Result2} = request(put, uri(["authorization", "settings"]), Settings2Put),


### PR DESCRIPTION
Release version: e6.2.2

## Summary

Expose `authorization.ignore_backend_failures` through the dedicated authorization settings API

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
