### PR TITLE
fix(rel): reject alpha/beta dashboard when cutting a final release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ include env.sh
 # from https://github.com/emqx/emqx-dashboard5
 export EMQX_DASHBOARD_VERSION ?= 2.0.3-1
 
+.PHONY: print-dashboard-version
+print-dashboard-version:
+	@echo $(EMQX_DASHBOARD_VERSION)
+
 export EMQX_REL_FORM ?= tgz
 export QUICER_TLS_VER ?= sys
 

--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -254,14 +254,14 @@ check_bpapi() {
 ## to ship a pre-release dashboard.
 check_dashboard_version() {
     local dashboard_vsn
-    dashboard_vsn="$(sed -nE 's/^export[[:space:]]+EMQX_DASHBOARD_VERSION[[:space:]]*\??=[[:space:]]*([^[:space:]]+).*/\1/p' Makefile | head -n 1)"
+    dashboard_vsn="$(make -s print-dashboard-version)"
     if [ -z "$dashboard_vsn" ]; then
-        logerr "Could not read EMQX_DASHBOARD_VERSION from Makefile"
+        logerr "Could not read EMQX_DASHBOARD_VERSION via 'make print-dashboard-version'"
         exit 1
     fi
     case "$dashboard_vsn" in
         *alpha*|*beta*)
-            logerr "EMQX_DASHBOARD_VERSION in Makefile is a pre-release ($dashboard_vsn)"
+            logerr "EMQX_DASHBOARD_VERSION is a pre-release ($dashboard_vsn)"
             logerr "A final EMQX release must not bundle an alpha or beta dashboard."
             logerr "Bump EMQX_DASHBOARD_VERSION in Makefile to a final release before cutting $TAG."
             exit 1

--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -248,6 +248,30 @@ check_bpapi() {
     esac
 }
 
+## Assert that EMQX_DASHBOARD_VERSION in Makefile is a final release,
+## i.e. does not contain 'alpha' or 'beta'. Called only when cutting
+## a final EMQX release; pre-release cuts (rc/alpha/beta) are allowed
+## to ship a pre-release dashboard.
+check_dashboard_version() {
+    local dashboard_vsn
+    dashboard_vsn="$(sed -nE 's/^export[[:space:]]+EMQX_DASHBOARD_VERSION[[:space:]]*\??=[[:space:]]*([^[:space:]]+).*/\1/p' Makefile | head -n 1)"
+    if [ -z "$dashboard_vsn" ]; then
+        logerr "Could not read EMQX_DASHBOARD_VERSION from Makefile"
+        exit 1
+    fi
+    case "$dashboard_vsn" in
+        *alpha*|*beta*)
+            logerr "EMQX_DASHBOARD_VERSION in Makefile is a pre-release ($dashboard_vsn)"
+            logerr "A final EMQX release must not bundle an alpha or beta dashboard."
+            logerr "Bump EMQX_DASHBOARD_VERSION in Makefile to a final release before cutting $TAG."
+            exit 1
+            ;;
+        *)
+            logmsg "EMQX_DASHBOARD_VERSION is $dashboard_vsn"
+            ;;
+    esac
+}
+
 case "$TAG" in
     *rc*)
         true
@@ -261,6 +285,7 @@ case "$TAG" in
     *)
         check_bpapi
         check_changelog
+        check_dashboard_version
         ;;
 esac
 


### PR DESCRIPTION
## Summary

`scripts/rel/cut.sh` already refuses to tag a final EMQX release without a matching `changes/<tag>.en.md` file and (for `.0` cuts) a BPAPI baseline. This PR adds a matching guard against shipping a pre-release dashboard by accident: for final release cuts, if `EMQX_DASHBOARD_VERSION` in the top-level `Makefile` still ends in `-alpha...` or `-beta...`, `cut.sh` now exits with an error and asks the operator to bump the dashboard version first.

Pre-release EMQX cuts (`rc`, `alpha`, `beta`) continue to allow a pre-release dashboard.

The extraction reads the first `export EMQX_DASHBOARD_VERSION ?= <vsn>` line from the `Makefile` (matching the exact form used today) and only checks for `alpha` / `beta` substrings — the `-1`, `-2`, ... build-number suffixes on final dashboard tags pass through.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)