### PR TITLE
fix(hooks): make emqx_hooks:del/2 synchronous

### DIFF
--- a/apps/emqx/src/emqx_hooks.erl
+++ b/apps/emqx/src/emqx_hooks.erl
@@ -146,7 +146,7 @@ do_put(HookPoint, Callback) ->
 %% @doc Unregister a callback.
 -spec del(hookpoint(), action() | {module(), atom()}) -> ok.
 del(HookPoint, Action) ->
-    gen_server:cast(?SERVER, {del, HookPoint, Action}).
+    gen_server:call(?SERVER, {del, HookPoint, Action}, infinity).
 
 %% @doc Run hooks.
 -spec run(hookpoint(), list(Arg :: term())) -> ok.
@@ -265,18 +265,13 @@ handle_call({put, HookPoint, Callback = #callback{action = {M, F, _}}}, _From, S
     Callbacks = del_callback({M, F}, lookup(HookPoint)),
     Reply = insert_hook(HookPoint, add_callback(Callback, Callbacks)),
     {reply, Reply, State};
+handle_call({del, HookPoint, Action}, _From, State) ->
+    ok = do_del(HookPoint, Action),
+    {reply, ok, State};
 handle_call(Req, _From, State) ->
     ?SLOG(error, #{msg => "unexpected_call", req => Req}),
     {reply, ignored, State}.
 
-handle_cast({del, HookPoint, Action}, State) ->
-    case del_callback(Action, lookup(HookPoint)) of
-        [] ->
-            delete_hook(HookPoint);
-        Callbacks ->
-            insert_hook(HookPoint, Callbacks)
-    end,
-    {noreply, State};
 handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", req => Msg}),
     {noreply, State}.
@@ -294,6 +289,15 @@ code_change(_OldVsn, State, _Extra) ->
 %%------------------------------------------------------------------------------
 %% Internal functions
 %%------------------------------------------------------------------------------
+
+do_del(HookPoint, Action) ->
+    case del_callback(Action, lookup(HookPoint)) of
+        [] ->
+            delete_hook(HookPoint);
+        Callbacks ->
+            insert_hook(HookPoint, Callbacks)
+    end,
+    ok.
 
 insert_hook(HookPoint, Callbacks) ->
     persistent_term:put({?PTERM, HookPoint}, Callbacks).

--- a/changes/ce/fix-17821.en.md
+++ b/changes/ce/fix-17821.en.md
@@ -1,0 +1,3 @@
+Fixed a race condition where a hook callback could still be invoked briefly after the feature that owns it was disabled.
+
+Unregistering a hook now takes effect before the call returns, instead of being processed asynchronously. This ensures that once a module (such as delayed publish) is turned off, its hook is guaranteed to be removed.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.4, 6.2.3

## Summary

`emqx_hooks:del/2` used `gen_server:cast`, so it returned as soon as the
removal was queued rather than after it took effect. A caller that
disabled a feature and then immediately looked up its hook could still
observe the stale callback until the hooks server drained its mailbox.

This changes `del/2` to use `gen_server:call`, mirroring the synchronous
confirmation path already present in `put/3`. The removal is now applied
before the call returns. The hooks server does not call out to any other
process while handling `{del, ...}` (it only touches ETS/persistent_term),
and all callers of `del/2` are module-unload handlers that already await
the `ok` return, so there is no deadlock risk.

Crucial change: `apps/emqx/src/emqx_hooks.erl` — `del/2` now issues a
`gen_server:call`, with a new matching `handle_call({del, ...}, ...)`
clause (the old `handle_cast` clause is removed; shared logic extracted
into `do_del/2`).

This fixes the flake in
`emqx_delayed_SUITE:t_delayed_load_unload`, where disabling delayed
publishing and immediately asserting the hook's absence would
intermittently still see the hook.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
