### PR TITLE
test(doris): wait for BE disk readiness before DDL in bridge SUITE

### DIFF
--- a/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
@@ -97,6 +97,7 @@ init_per_testcase(TestCase, TCConfig) ->
     ActionConfig = action_config(#{
         <<"connector">> => ConnectorName
     }),
+    wait_for_be_ready(TCConfig),
     create_database(TCConfig),
     create_table(TCConfig),
     snabbkaffe:start_trace(),
@@ -223,7 +224,61 @@ create_database(TCConfig) ->
     ok = eval_query(["create database if not exists mqtt"], TCConfig).
 
 create_table(TCConfig) ->
-    ok = eval_query(["use mqtt; ", create_table_ddl()], TCConfig).
+    %% Even after `wait_for_be_ready/1`, the FE may briefly still reject the
+    %% `CREATE TABLE` with "Failed to find enough backend" while it finishes
+    %% accounting the freshly-reported BE disks.  This retry is the safety net
+    %% that complements the readiness poll.
+    ?retry(
+        _Interval = 500,
+        _Tries = 60,
+        ok = eval_query(["use mqtt; ", create_table_ddl()], TCConfig)
+    ).
+
+%% Doris reports the BE as "healthy" (docker healthcheck / FE registration) as
+%% soon as the BE process is up, but the BE only publishes its storage disks to
+%% the FE asynchronously afterwards.  Issuing DDL before disks are published
+%% fails with "Failed to find enough backend ... hdd disks count={}".  Wait
+%% until at least one BE row reports both `Alive=true` and non-zero total
+%% capacity before proceeding.
+wait_for_be_ready(TCConfig) ->
+    ?retry(
+        _Interval = 500,
+        _Tries = 60,
+        ok = assert_be_ready(TCConfig)
+    ).
+
+assert_be_ready(TCConfig) ->
+    case eval_query(<<"SHOW BACKENDS">>, TCConfig) of
+        {ok, Cols, Rows} when Rows =/= [] ->
+            case lists:any(fun(Row) -> is_be_ready(Cols, Row) end, Rows) of
+                true -> ok;
+                false -> error({be_not_ready, Rows})
+            end;
+        Other ->
+            error({show_backends_failed, Other})
+    end.
+
+%% `SHOW BACKENDS` returns ~20 columns whose order varies across Doris
+%% versions, so look the fields up by name rather than by index.
+is_be_ready(Cols, Row) ->
+    Fields = maps:from_list(lists:zip(Cols, Row)),
+    is_true(maps:get(<<"Alive">>, Fields, undefined)) andalso
+        has_capacity(maps:get(<<"TotalCapacity">>, Fields, undefined)).
+
+is_true(<<"true">>) -> true;
+is_true("true") -> true;
+is_true(true) -> true;
+is_true(_) -> false.
+
+%% Capacity columns come back as human-readable strings such as
+%% `<<"930.635 GB">>`; a BE that hasn't reported disks yet shows `<<"0.000 ">>`.
+has_capacity(undefined) ->
+    false;
+has_capacity(Bin) ->
+    case string:to_float(string:trim(iolist_to_binary([Bin]))) of
+        {F, _} when F > 0.0 -> true;
+        _ -> false
+    end.
 
 drop_table(TCConfig) ->
     ok = eval_query(["use mqtt; drop table t_mqtt_msg"], TCConfig).


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Fixes a flake in `emqx_bridge_doris_SUITE`'s TLS sub-group. The Doris BE
registers with the FE (and Docker reports the container "Healthy") before it
asynchronously publishes its storage disks. A `CREATE TABLE` issued in that
window fails in `init_per_testcase` with:

> errCode = 2 ... Failed to find enough backend ... `hdd disks count={}, ssd disk count={}`

The three `plain.*` cases pass because they warm up the plain BE first; the
first `tls.*` case then races the initial DDL against the tls BE's disk
registration.

Failing CI run: https://github.com/emqx/emqx/actions/runs/28508550978/job/84517553416

Changes (test-only, `apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl`):
- **Readiness poll (primary fix):** `wait_for_be_ready/1` polls `SHOW BACKENDS`
  in `init_per_testcase` and proceeds only once at least one BE row reports
  `Alive=true` **and** non-zero `TotalCapacity`. Columns are looked up by name
  (zipped with the row) since their order varies across Doris versions.
  `TotalCapacity` is used deliberately: a not-yet-ready BE reports
  `AvailCapacity=1.000 B` but `TotalCapacity=0.000`, so checking availability
  would false-positive.
- **`create_table` retry (safety net):** wraps the DDL in `?retry` to absorb the
  brief FE accounting lag right after disks are reported.

No sleep-based waits; no suite-level retries; `replication_num=1` unchanged.

Note: local `30×` loop validation could not be run on the dev host — its CPU
lacks AVX2, which the `apache/doris:be-2.1.9` image requires, so the BE exits at
its instruction check and never becomes Alive (no no-AVX2 image is published).
The readiness logic was validated against real `SHOW BACKENDS` output from the
running FE; the suite compiles and passes elvis. CI runners have AVX2 (the
original failure required a live BE) and exercise the real path.

Follow-up (out of scope): add a BE-side `healthcheck` to
`docker-compose-doris.yaml` / `docker-compose-doris-tls.yaml` so
`docker compose --wait` blocks until BE storage is registered — the proper fix
this test-side guard stands in for.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
