### PR TITLE
feat(rel): emit emqx.com download links for a release

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -73,6 +73,27 @@ permissions:
   contents: read
 
 jobs:
+  # scripts/rel/build_matrix.py is the single source of truth for the platforms
+  # offered as emqx.com downloads (it also drives the download-links script).
+  # The linux and mac jobs below read their os/arch dimensions from these
+  # outputs via fromJSON, so the build matrix cannot drift from the
+  # download-links matrix. (Snap is not an emqx.com download; its matrix stays
+  # inline in the snap job.)
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      linux_os: ${{ steps.matrix.outputs.linux_os }}
+      linux_arch: ${{ steps.matrix.outputs.linux_arch }}
+      linux_exclude: ${{ steps.matrix.outputs.linux_exclude }}
+      mac_os: ${{ steps.matrix.outputs.mac_os }}
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ github.event.inputs.ref }}
+    - name: compute package matrix
+      id: matrix
+      run: ./scripts/rel/build_matrix.py --github >> "$GITHUB_OUTPUT"
+
   plugins-linux-debian13-amd64:
     runs-on: ${{ github.repository_owner == 'emqx' && 'aws-ubuntu22.04-amd64' || 'ubuntu-22.04' }}
     defaults:
@@ -101,14 +122,13 @@ jobs:
         retention-days: 7
 
   mac:
+    needs: prepare-matrix
     strategy:
       fail-fast: false
       matrix:
         profile:
           - ${{ inputs.profile }}
-        os:
-          - macos-14
-          - macos-15
+        os: ${{ fromJSON(needs.prepare-matrix.outputs.mac_os) }}
         otp:
           - ${{ inputs.otp_vsn }}
         elixir:
@@ -137,15 +157,15 @@ jobs:
         retention-days: 7
 
   test-mac:
-    needs: mac
+    needs:
+      - mac
+      - prepare-matrix
     strategy:
       fail-fast: false
       matrix:
         profile:
           - ${{ inputs.profile }}
-        os:
-          - macos-14
-          - macos-15
+        os: ${{ fromJSON(needs.prepare-matrix.outputs.mac_os) }}
         otp:
           - ${{ inputs.otp_vsn }}
 
@@ -171,38 +191,22 @@ jobs:
         ./emqx/bin/emqx stop || cat emqx/log/erlang.log.1
 
   linux:
+    needs: prepare-matrix
     runs-on: ${{ github.repository_owner == 'emqx' && format('aws-ubuntu22.04-{0}', matrix.arch) || (matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04') }}
     strategy:
       fail-fast: false
       matrix:
         profile:
           - ${{ inputs.profile }}
-        os:
-          - ubuntu24.04
-          - ubuntu22.04
-          - debian13
-          - debian12
-          - debian11
-          - el10
-          - el9
-          - el8
-          - amzn2023
-        arch:
-          - amd64
-          - arm64
+        os: ${{ fromJSON(needs.prepare-matrix.outputs.linux_os) }}
+        arch: ${{ fromJSON(needs.prepare-matrix.outputs.linux_arch) }}
         otp:
           - ${{ inputs.otp_vsn }}
         builder:
           - ${{ inputs.builder_vsn }}
         elixir:
           - ${{ inputs.elixir_vsn }}
-        include:
-          - profile: ${{ inputs.profile }}
-            os: el7
-            arch: amd64
-            otp: ${{ inputs.otp_vsn }}
-            builder: ${{ inputs.builder_vsn }}
-            elixir: ${{ inputs.elixir_vsn }}
+        exclude: ${{ fromJSON(needs.prepare-matrix.outputs.linux_exclude) }}
 
     defaults:
       run:
@@ -252,6 +256,9 @@ jobs:
       matrix:
         profile:
           - ${{ inputs.profile }}
+        # Snap is published to the Snap Store, not emqx.com, so it is not part
+        # of the download-links matrix in scripts/rel/build_matrix.py; its arch
+        # list is kept inline here.
         arch:
           - amd64
           - arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,13 +62,6 @@ jobs:
           OUTPUT_DIR=${{ steps.profile.outputs.s3dir }}
           aws s3 cp --recursive s3://$BUCKET/$OUTPUT_DIR/${{ env.ref_name }} packages
           aws s3 cp --recursive s3://$BUCKET/emqx-plugins/${{ env.ref_name }} packages/plugins
-      - uses: emqx/upload-assets@974befcf0e72a1811360a81c798855efb66b0551 # 0.5.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          asset_paths: '["packages/*","packages/plugins/*"]'
-          tag_name: "${{ env.ref_name }}"
-          skip_existing: true
       - name: update to emqx.io
         if: (github.event_name == 'release' &&  !github.event.release.prerelease && env.internal_release == 'false') || inputs.publish_release_artifacts
         run: |

--- a/scripts/rel/build_matrix.py
+++ b/scripts/rel/build_matrix.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Canonical package build matrix (platform dimension only: os + arch).
+
+This is the single source of truth for the platforms EMQX offers as emqx.com
+downloads. It feeds two consumers:
+  - .github/workflows/build_packages.yaml, whose linux and mac strategy
+    matrices are generated from the ``--github`` output (a prepare-matrix job
+    writes these arrays to $GITHUB_OUTPUT; the build jobs read them back via
+    ``fromJSON(needs.prepare-matrix.outputs.*)``).
+  - scripts/rel/print-download-links.py (emqx.com download URLs), which imports
+    this module and calls matrix().
+
+Snap is built by build_packages.yaml too, but it is published to the Snap Store
+rather than emqx.com, so its (arch-only) matrix stays inline in that workflow.
+
+Because the workflow generates its matrix from here, the two cannot drift.
+
+Run directly with no arguments, it prints the expanded matrix as JSON (handy for
+debugging). Run with ``--github`` it prints ``key=<json-array>`` lines for
+$GITHUB_OUTPUT.
+
+NOTE: the macOS os tokens differ between the two worlds. GitHub runner labels
+(and therefore the workflow matrix) use ``macos-14``; package *filenames*
+produced by scripts/get-distro.sh drop the dash (``macos14``). MAC_OS below
+holds the runner labels; the download-links view strips the dash.
+"""
+
+import json
+import sys
+
+# Linux: full os x arch product. el7 ships amd64 only (see LINUX_EXCLUDE), so it
+# lives in the os list rather than as a separate include row -- that keeps every
+# generated matrix key pure os/arch data with no build-tool dimensions.
+LINUX_OS = [
+    "ubuntu24.04",
+    "ubuntu22.04",
+    "debian13",
+    "debian12",
+    "debian11",
+    "el10",
+    "el9",
+    "el8",
+    "amzn2023",
+    "el7",
+]
+LINUX_ARCH = ["amd64", "arm64"]
+# os/arch combinations that are NOT built.
+LINUX_EXCLUDE = [{"os": "el7", "arch": "arm64"}]
+
+# macOS: runner labels (workflow matrix). Both hosted runners are arm64 today.
+MAC_OS = ["macos-14", "macos-15"]
+MAC_ARCH = "arm64"
+
+
+def linux_rows():
+    """Expanded linux os/arch combinations, excludes applied."""
+    return [
+        {"os": os, "arch": arch}
+        for os in LINUX_OS
+        for arch in LINUX_ARCH
+        if {"os": os, "arch": arch} not in LINUX_EXCLUDE
+    ]
+
+
+def mac_rows():
+    """macOS rows in package-filename form (macos14, dash stripped)."""
+    return [{"os": os.replace("-", ""), "arch": MAC_ARCH} for os in MAC_OS]
+
+
+def matrix():
+    """Expanded platform matrix as a plain dict (package-filename view).
+
+    Snap is intentionally absent: it is not offered as an emqx.com download
+    (published to the Snap Store instead), so its arch list stays inline in
+    build_packages.yaml rather than being owned here.
+    """
+    return {
+        "linux": linux_rows(),
+        "mac": mac_rows(),
+    }
+
+
+def github_outputs():
+    """Arrays consumed by build_packages.yaml matrices via fromJSON."""
+    return {
+        "linux_os": LINUX_OS,
+        "linux_arch": LINUX_ARCH,
+        "linux_exclude": LINUX_EXCLUDE,
+        "mac_os": MAC_OS,
+    }
+
+
+def main(argv):
+    if "--github" in argv:
+        outputs = github_outputs()
+        # A generated-but-empty array silently produces zero build jobs, so fail
+        # loud here instead -- the prepare-matrix job goes red rather than the
+        # build quietly shipping nothing.
+        empty = [key for key, val in outputs.items() if not val]
+        if empty:
+            print(f"ERROR: empty matrix arrays: {empty}", file=sys.stderr)
+            return 1
+        for key, val in outputs.items():
+            sys.stdout.write(f"{key}={json.dumps(val, separators=(',', ':'))}\n")
+    else:
+        json.dump(matrix(), sys.stdout, separators=(", ", ": "))
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/rel/print-download-links.py
+++ b/scripts/rel/print-download-links.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Print the emqx.com download URLs for every package produced for a release.
+
+Steering users to https://www.emqx.com/en/downloads/... (rather than the GitHub
+release assets) keeps download statistics visible.
+
+This script is pure enumeration: it never touches the network. It expands the
+canonical build matrix (scripts/rel/build_matrix.py) into URLs, so it can run at
+any point in the release cycle without secrets. It uses only the Python standard
+library so CI does not need jq or yq installed.
+
+Note: snap packages are published to the Snap Store, not to emqx.com, so they
+are intentionally omitted here.
+
+Usage:
+  print-download-links.py <version>
+  print-download-links.py --version <version> [--format text|markdown]
+                          [--profile emqx-enterprise]
+
+Examples:
+  print-download-links.py 6.0.3
+  print-download-links.py --version 6.0.3 --format markdown
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import build_matrix  # noqa: E402 (sibling module, path set above)
+
+EDITIONS = {"emqx-enterprise": "enterprise"}
+
+
+def linux_pkg_ext(os_token):
+    """Native package extension for a linux os token.
+
+    Mirrors the PKGERDIR logic in scripts/buildx.sh / build.
+    """
+    if os_token.startswith(("ubuntu", "debian", "raspbian")):
+        return "deb"
+    return "rpm"
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        add_help=True,
+        usage="%(prog)s <version> [--format text|markdown] [--profile <profile>]",
+    )
+    parser.add_argument("version_pos", nargs="?", metavar="version")
+    parser.add_argument("--version", dest="version_opt")
+    parser.add_argument("--format", default="text", choices=["text", "markdown"])
+    parser.add_argument(
+        "--profile", default="emqx-enterprise", choices=list(EDITIONS)
+    )
+    args = parser.parse_args(argv)
+
+    version = args.version_opt or args.version_pos
+    if not version:
+        parser.error("version is required")
+    args.version = version
+    return args
+
+
+class UrlBuilder:
+    def __init__(self, base_url, profile, version):
+        self.base_url = base_url
+        self.profile = profile
+        self.version = version
+
+    def pkg_url(self, os_token, arch, ext):
+        # <os>-<arch>.<ext> style (linux/mac)
+        return (
+            f"{self.base_url}/{self.profile}-{self.version}-"
+            f"{os_token}-{arch}.{ext}"
+        )
+
+
+def emit_text(matrix, urls):
+    lines = []
+    for row in matrix["linux"]:
+        ext = linux_pkg_ext(row["os"])
+        lines.append(urls.pkg_url(row["os"], row["arch"], ext))
+        lines.append(urls.pkg_url(row["os"], row["arch"], "tar.gz"))
+    for row in matrix["mac"]:
+        lines.append(urls.pkg_url(row["os"], row["arch"], "zip"))
+    return "\n".join(lines)
+
+
+def md_link(label, url):
+    return f"[{label}]({url})"
+
+
+def emit_markdown(matrix, urls):
+    lines = ["## Download", ""]
+
+    def linux_bullet(row):
+        ext = linux_pkg_ext(row["os"])
+        pkg = md_link(f".{ext}", urls.pkg_url(row["os"], row["arch"], ext))
+        tar = md_link(".tar.gz", urls.pkg_url(row["os"], row["arch"], "tar.gz"))
+        return f"- `{row['os']}` ({row['arch']}): {pkg} — {tar}"
+
+    lines.append("### Ubuntu / Debian")
+    for row in matrix["linux"]:
+        if row["os"].startswith(("ubuntu", "debian")):
+            lines.append(linux_bullet(row))
+    lines.append("")
+
+    lines.append("### RHEL / Rocky / Amazon Linux")
+    for row in matrix["linux"]:
+        if row["os"].startswith(("el", "amzn")):
+            lines.append(linux_bullet(row))
+    lines.append("")
+
+    lines.append("### macOS")
+    for row in matrix["mac"]:
+        link = md_link(".zip", urls.pkg_url(row["os"], row["arch"], "zip"))
+        lines.append(f"- `{row['os']}` ({row['arch']}): {link}")
+
+    return "\n".join(lines)
+
+
+def main(argv):
+    args = parse_args(argv)
+    edition = EDITIONS[args.profile]
+    base_url = f"https://www.emqx.com/en/downloads/{edition}/{args.version}"
+    urls = UrlBuilder(base_url, args.profile, args.version)
+    matrix = build_matrix.matrix()
+
+    if args.format == "text":
+        print(emit_text(matrix, urls))
+    else:
+        print(emit_markdown(matrix, urls))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/rel/print-download-links.py
+++ b/scripts/rel/print-download-links.py
@@ -1,35 +1,50 @@
 #!/usr/bin/env python3
-"""Print the emqx.com download URLs for every package produced for a release.
+"""Print the download URLs for every package produced for a release.
 
-Steering users to https://www.emqx.com/en/downloads/... (rather than the GitHub
+Steering users to https://www.emqx.com/downloads/... (rather than the GitHub
 release assets) keeps download statistics visible.
 
-This script is pure enumeration: it never touches the network. It expands the
-canonical build matrix (scripts/rel/build_matrix.py) into URLs, so it can run at
-any point in the release cycle without secrets. It uses only the Python standard
-library so CI does not need jq or yq installed.
+This script is pure enumeration: it never touches the network. It reads the
+checked-out tree -- the release version (./pkg-vsn.sh --release), the platform
+matrix (scripts/rel/build_matrix.py), and the plugin versions -- and expands
+them into URLs, so it can run at any point in the release cycle without secrets.
+It uses only the Python standard library so CI does not need jq or yq installed.
+
+Two families of URLs are printed:
+  - EMQX packages, served from the emqx.com download CDN.
+  - Plugin packages, which are NOT on the CDN -- they are fetched straight from
+    S3 (https://packages.emqx.io/emqx-plugins/...). Each plugin under plugins/
+    ships a VERSION file that gives its package version.
 
 Note: snap packages are published to the Snap Store, not to emqx.com, so they
 are intentionally omitted here.
 
 Usage:
-  print-download-links.py <version>
-  print-download-links.py --version <version> [--format text|markdown]
+  print-download-links.py [version]
+  print-download-links.py [--version <version>] [--format text|markdown]
                           [--profile emqx-enterprise]
 
+The version defaults to ./pkg-vsn.sh --release when omitted.
+
 Examples:
+  print-download-links.py
   print-download-links.py 6.0.3
-  print-download-links.py --version 6.0.3 --format markdown
+  print-download-links.py --format markdown
 """
 
 import argparse
+import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import build_matrix  # noqa: E402 (sibling module, path set above)
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 EDITIONS = {"emqx-enterprise": "enterprise"}
+
+# Plugin packages are downloaded straight from S3, not the emqx.com CDN.
+PLUGINS_BASE_URL = "https://packages.emqx.io/emqx-plugins"
 
 
 def linux_pkg_ext(os_token):
@@ -42,12 +57,27 @@ def linux_pkg_ext(os_token):
     return "rpm"
 
 
+def release_version():
+    """The release version of the checked-out tree, via ./pkg-vsn.sh --release."""
+    return subprocess.run(
+        [str(REPO_ROOT / "pkg-vsn.sh"), "--release"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
 def parse_args(argv):
     parser = argparse.ArgumentParser(
         add_help=True,
-        usage="%(prog)s <version> [--format text|markdown] [--profile <profile>]",
+        usage="%(prog)s [version] [--format text|markdown] [--profile <profile>]",
     )
-    parser.add_argument("version_pos", nargs="?", metavar="version")
+    parser.add_argument(
+        "version_pos",
+        nargs="?",
+        metavar="version",
+        help="release version; defaults to ./pkg-vsn.sh --release",
+    )
     parser.add_argument("--version", dest="version_opt")
     parser.add_argument("--format", default="text", choices=["text", "markdown"])
     parser.add_argument(
@@ -55,11 +85,22 @@ def parse_args(argv):
     )
     args = parser.parse_args(argv)
 
-    version = args.version_opt or args.version_pos
-    if not version:
-        parser.error("version is required")
-    args.version = version
+    args.version = args.version_opt or args.version_pos or release_version()
     return args
+
+
+def plugin_rows(repo_root):
+    """(name, version) for every plugin under plugins/ that ships a VERSION file.
+
+    Sorted by plugin name for stable output.
+    """
+    plugins_dir = repo_root / "plugins"
+    rows = []
+    for version_file in sorted(plugins_dir.glob("*/VERSION")):
+        name = version_file.parent.name
+        version = version_file.read_text().strip()
+        rows.append((name, version))
+    return rows
 
 
 class UrlBuilder:
@@ -75,8 +116,14 @@ class UrlBuilder:
             f"{os_token}-{arch}.{ext}"
         )
 
+    def plugin_url(self, name, plugin_version):
+        # <name>-<plugin_version>.tar.gz under the release-version directory.
+        return (
+            f"{PLUGINS_BASE_URL}/{self.version}/{name}-{plugin_version}.tar.gz"
+        )
 
-def emit_text(matrix, urls):
+
+def emit_text(matrix, plugins, urls):
     lines = []
     for row in matrix["linux"]:
         ext = linux_pkg_ext(row["os"])
@@ -84,6 +131,8 @@ def emit_text(matrix, urls):
         lines.append(urls.pkg_url(row["os"], row["arch"], "tar.gz"))
     for row in matrix["mac"]:
         lines.append(urls.pkg_url(row["os"], row["arch"], "zip"))
+    for name, version in plugins:
+        lines.append(urls.plugin_url(name, version))
     return "\n".join(lines)
 
 
@@ -91,7 +140,7 @@ def md_link(label, url):
     return f"[{label}]({url})"
 
 
-def emit_markdown(matrix, urls):
+def emit_markdown(matrix, plugins, urls):
     lines = ["## Download", ""]
 
     def linux_bullet(row):
@@ -117,20 +166,29 @@ def emit_markdown(matrix, urls):
         link = md_link(".zip", urls.pkg_url(row["os"], row["arch"], "zip"))
         lines.append(f"- `{row['os']}` ({row['arch']}): {link}")
 
+    if plugins:
+        lines.append("")
+        lines.append("### Plugins")
+        # Plugin packages are always .tar.gz, so label the link by name-version.
+        for name, version in plugins:
+            link = md_link(f"{name}-{version}", urls.plugin_url(name, version))
+            lines.append(f"- {link}")
+
     return "\n".join(lines)
 
 
 def main(argv):
     args = parse_args(argv)
     edition = EDITIONS[args.profile]
-    base_url = f"https://www.emqx.com/en/downloads/{edition}/{args.version}"
+    base_url = f"https://www.emqx.com/downloads/{edition}/{args.version}"
     urls = UrlBuilder(base_url, args.profile, args.version)
     matrix = build_matrix.matrix()
+    plugins = plugin_rows(REPO_ROOT)
 
     if args.format == "text":
-        print(emit_text(matrix, urls))
+        print(emit_text(matrix, plugins, urls))
     else:
-        print(emit_markdown(matrix, urls))
+        print(emit_markdown(matrix, plugins, urls))
     return 0
 
 


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Adds a script the release manager runs to produce the download links for a release, to paste into the GitHub release notes. Steering users to the emqx.com download page (instead of GitHub release assets) keeps download statistics visible.

### `scripts/rel/print-download-links.py`
Pure, network-free enumeration of a release's download URLs from the checked-out tree. Version defaults to `./pkg-vsn.sh --release`; `--format text` (default) or `--format markdown` (grouped, for the release notes). It prints two families:
- **EMQX packages** — from the emqx.com CDN, e.g. `https://www.emqx.com/downloads/enterprise/<version>/emqx-enterprise-<version>-<os>-<arch>.<ext>`.
- **Plugins** — served straight from S3 (not the CDN), e.g. `https://packages.emqx.io/emqx-plugins/<version>/<name>-<plugin_version>.tar.gz`. Each plugin under `plugins/` is discovered via its `VERSION` file.

### `scripts/rel/build_matrix.py`
Single source of truth for the platforms offered as emqx.com downloads (os + arch). `build_packages.yaml` generates its `linux` and `mac` strategy matrices from this module: a `prepare-matrix` job emits the arrays to `$GITHUB_OUTPUT` and the build jobs read them back via `fromJSON(needs.prepare-matrix.outputs.*)`. The build matrix therefore cannot drift from the download-links matrix — no separate drift-check job is needed.

### `.github/workflows/release.yaml`
No longer attaches the built packages/plugins as GitHub release assets (the `emqx/upload-assets` step is removed); packages are still published to S3, packagecloud, and the Snap Store. The download links are added to the release notes manually via the script above.

### Notes
- The scripts use only the Python standard library, so CI does not depend on `jq` or `yq`.
- Snap packages are published to the Snap Store rather than emqx.com, so they are absent from the download links and their arch matrix stays inline in the snap job.
- The macOS os token in filenames (`macos14`) differs from the runner label (`macos-14`); `build_matrix.py` holds the runner label and the download-links view strips the dash.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)