### PR TITLE
fix(rel): reject alpha/beta dashboard when cutting a final release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@ include env.sh
 export EMQX_DASHBOARD_VERSION ?= v1.10.9
 export EMQX_EE_DASHBOARD_VERSION ?= e1.8.11
 
+.PHONY: print-dashboard-version
+print-dashboard-version:
+	@echo $(EMQX_DASHBOARD_VERSION)
+
+.PHONY: print-ee-dashboard-version
+print-ee-dashboard-version:
+	@echo $(EMQX_EE_DASHBOARD_VERSION)
+
 export EMQX_RELUP ?= true
 export EMQX_REL_FORM ?= tgz
 export QUICER_TLS_VER ?= sys

--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -265,6 +265,44 @@ check_bpapi() {
     esac
 }
 
+## Assert that the dashboard version pinned in Makefile is a final
+## release, i.e. does not contain 'alpha' or 'beta'. `e*` cuts check
+## the enterprise dashboard; `v*` cuts check the open-source dashboard.
+## Called only when cutting a final EMQX release; pre-release cuts
+## (rc/alpha/beta) are allowed to ship a pre-release dashboard.
+check_dashboard_version() {
+    local var recipe dashboard_vsn
+    case "$TAG" in
+        e*)
+            var='EMQX_EE_DASHBOARD_VERSION'
+            recipe='print-ee-dashboard-version'
+            ;;
+        v*)
+            var='EMQX_DASHBOARD_VERSION'
+            recipe='print-dashboard-version'
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+    dashboard_vsn="$(make -s "$recipe")"
+    if [ -z "$dashboard_vsn" ]; then
+        logerr "Could not read $var via 'make $recipe'"
+        exit 1
+    fi
+    case "$dashboard_vsn" in
+        *alpha*|*beta*)
+            logerr "$var is a pre-release ($dashboard_vsn)"
+            logerr "A final EMQX release must not bundle an alpha or beta dashboard."
+            logerr "Bump $var in Makefile to a final release before cutting $TAG."
+            exit 1
+            ;;
+        *)
+            logmsg "$var is $dashboard_vsn"
+            ;;
+    esac
+}
+
 case "$TAG" in
     *rc*)
         true
@@ -278,9 +316,11 @@ case "$TAG" in
     e*)
         check_bpapi
         check_changelog
+        check_dashboard_version
         ;;
     v*)
         check_changelog
+        check_dashboard_version
         ;;
 esac
 


### PR DESCRIPTION
Release version: 5.8.11, 5.10.4

Port of #17819 to dev-58.

## Summary

`scripts/rel/cut.sh` already refuses to tag a final EMQX release without a matching `changes/<tag>.en.md` file and (for `.0` cuts) a BPAPI baseline. This PR adds a matching guard against shipping a pre-release dashboard by accident: for final release cuts, if the dashboard version pinned in the top-level `Makefile` still ends in `-alpha...` or `-beta...`, `cut.sh` now exits with an error and asks the operator to bump the dashboard version first.

Two dashboard variables exist on this line — `EMQX_DASHBOARD_VERSION` (community) and `EMQX_EE_DASHBOARD_VERSION` (enterprise). The check picks the relevant one based on the tag prefix (`v*` → community, `e*` → enterprise). Pre-release EMQX cuts (`rc`, `alpha`, `beta`) continue to allow a pre-release dashboard.

The extraction goes through a Makefile recipe (`make -s print-dashboard-version` / `make -s print-ee-dashboard-version`) rather than sed-parsing the Makefile source, so it works against the resolved make variable and respects any environment override.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)