### PR TITLE
test: ESSENTIAL-mode paho interop, authn/authz and cluster smoke tests

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -217,6 +217,12 @@ jobs:
       - build_docker
     uses: ./.github/workflows/run_docker_tests.yaml
 
+  run_cluster_tests:
+    needs:
+      - sanity-checks
+      - build_docker
+    uses: ./.github/workflows/run_cluster_tests.yaml
+
   run_helm_tests:
     needs:
       - sanity-checks

--- a/.github/workflows/run_cluster_tests.yaml
+++ b/.github/workflows/run_cluster_tests.yaml
@@ -1,0 +1,64 @@
+name: Cluster tests
+
+concurrency:
+  group: cluster-tests-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  cluster-smoke-test:
+    runs-on: ${{ github.repository_owner == 'emqx' && 'aws-ubuntu22.04-amd64' || 'ubuntu-22.04' }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      EMQX_NAME: emqx-enterprise
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Presets the two-node cluster boots with. Both must form a cluster and
+        # route MQTT messages across nodes; ESSENTIAL is the minimal feature set.
+        features:
+          - FULL
+          - ESSENTIAL
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.EMQX_NAME }}-docker-amd64
+      - name: load docker image
+        run: |
+          EMQX_TAG=$(docker load < ${EMQX_NAME}-docker-*.tar.gz 2>/dev/null | sed 's/Loaded image: //g')
+          echo "CI_EMQX_DOCKER_IMAGE_TAG=$EMQX_TAG" | tee -a $GITHUB_ENV
+
+      - name: start two-node cluster (features=${{ matrix.features }})
+        timeout-minutes: 5
+        env:
+          # The smoke test is about clustering, not authorization: make authz
+          # permissive so an anonymous client can publish/subscribe freely.
+          EMQX_FEATURES: ${{ matrix.features }}
+          EMQX_AUTHORIZATION__NO_MATCH: allow
+          EMQX_AUTHORIZATION__SOURCES: "[]"
+        run: ./scripts/test/start-two-nodes-in-docker.sh "$CI_EMQX_DOCKER_IMAGE_TAG"
+
+      - name: cluster mqtt smoke test
+        timeout-minutes: 5
+        run: ./scripts/test/cluster-smoke/run.sh
+
+      - name: dump logs on failure
+        if: failure()
+        run: |
+          echo "==============  node1  =============="; docker logs node1.emqx.io || true
+          echo "==============  node2  =============="; docker logs node2.emqx.io || true
+          echo "============== haproxy =============="; docker logs haproxy || true
+
+      - name: cleanup
+        if: always()
+        run: ./scripts/test/start-two-nodes-in-docker.sh -c

--- a/.github/workflows/run_docker_tests.yaml
+++ b/.github/workflows/run_docker_tests.yaml
@@ -70,9 +70,18 @@ jobs:
       matrix:
         profile:
           - emqx-enterprise
+        # EMQX_FEATURES preset the node boots with. FULL is the default; the
+        # ESSENTIAL entry (added via `include` below) checks that the minimal
+        # feature set still passes the full MQTT interoperability suite.
+        features:
+          - FULL
         overrides:
           - "--tcp-backend gen_tcp"
           - "--tcp-backend socket"
+        include:
+          - profile: emqx-enterprise
+            features: ESSENTIAL
+            overrides: "--tcp-backend gen_tcp"
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -89,6 +98,7 @@ jobs:
         run: |
           .ci/docker-compose-file/scripts/run-emqx.sh $CI_EMQX_DOCKER_IMAGE_TAG \
             --db-backend $CI_EMQX_DB_BACKEND \
+            --override EMQX_FEATURES=${{ matrix.features }} \
             ${{ matrix.overrides }}
 
       - name: make paho tests
@@ -104,6 +114,28 @@ jobs:
             echo "DUMP_CONTAINER_LOGS_END"
             exit 1
           fi
+
+  # ESSENTIAL-mode smoke test: built-in-database authn + acl.conf authz.
+  essential-auth-smoke-test:
+    runs-on: ${{ github.repository_owner == 'emqx' && 'aws-ubuntu22.04-amd64' || 'ubuntu-22.04' }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      EMQX_NAME: emqx-enterprise
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.EMQX_NAME }}-docker-amd64
+      - name: load docker image
+        run: |
+          EMQX_TAG=$(docker load < ${EMQX_NAME}-docker-*.tar.gz 2>/dev/null | sed 's/Loaded image: //g')
+          echo "CI_EMQX_DOCKER_IMAGE_TAG=$EMQX_TAG" | tee -a $GITHUB_ENV
+      - name: essential auth smoke test
+        timeout-minutes: 5
+        run: ./scripts/test/essential-auth-smoke/run.sh "$CI_EMQX_DOCKER_IMAGE_TAG"
 
   # simple smoke test for node_dump
   node-dump-test:

--- a/scripts/test/cluster-smoke/publisher.py
+++ b/scripts/test/cluster-smoke/publisher.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""One-shot MQTT publisher for the cluster smoke test.
+
+Connects through HAProxy (a separate connection from the subscriber, so with
+HAProxy's static round-robin balancing it typically lands on the other node)
+and publishes a payload to the smoke topic.
+"""
+import sys
+import time
+import paho.mqtt.client as mqtt
+
+HOST = sys.argv[1] if len(sys.argv) > 1 else "haproxy"
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 1883
+TOPIC = sys.argv[3] if len(sys.argv) > 3 else "cluster/smoke/1"
+PAYLOAD = sys.argv[4] if len(sys.argv) > 4 else "cluster-smoke-payload"
+
+
+def new_client(cid):
+    try:  # paho-mqtt 2.x
+        return mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION1, client_id=cid, protocol=mqtt.MQTTv5
+        )
+    except AttributeError:  # paho-mqtt 1.x
+        return mqtt.Client(client_id=cid, protocol=mqtt.MQTTv5)
+
+
+c = new_client("cluster-smoke-pub")
+connected = {}
+c.on_connect = lambda cl, u, flags, rc, props=None: connected.update(
+    rc=getattr(rc, "value", rc)
+)
+c.connect(HOST, PORT, 30)
+c.loop_start()
+for _ in range(50):
+    if "rc" in connected:
+        break
+    time.sleep(0.1)
+if connected.get("rc") != 0:
+    print(f"PUBLISHER CONNECT FAILED rc={connected.get('rc')}", flush=True)
+    sys.exit(1)
+info = c.publish(TOPIC, PAYLOAD.encode(), qos=1)
+info.wait_for_publish(10)
+print(f"PUBLISHED {TOPIC} {PAYLOAD}", flush=True)
+c.loop_stop()
+c.disconnect()

--- a/scripts/test/cluster-smoke/publisher.py
+++ b/scripts/test/cluster-smoke/publisher.py
@@ -16,12 +16,9 @@ PAYLOAD = sys.argv[4] if len(sys.argv) > 4 else "cluster-smoke-payload"
 
 
 def new_client(cid):
-    try:  # paho-mqtt 2.x
-        return mqtt.Client(
-            mqtt.CallbackAPIVersion.VERSION1, client_id=cid, protocol=mqtt.MQTTv5
-        )
-    except AttributeError:  # paho-mqtt 1.x
-        return mqtt.Client(client_id=cid, protocol=mqtt.MQTTv5)
+    return mqtt.Client(
+        mqtt.CallbackAPIVersion.VERSION1, client_id=cid, protocol=mqtt.MQTTv5
+    )
 
 
 c = new_client("cluster-smoke-pub")

--- a/scripts/test/cluster-smoke/run.sh
+++ b/scripts/test/cluster-smoke/run.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+## Cluster smoke test. Assumes a two-node cluster started by
+## scripts/test/start-two-nodes-in-docker.sh is already running (containers
+## node1.emqx.io, node2.emqx.io and haproxy on the emqx.io docker network).
+##
+## Verifies clustering at the MQTT level:
+##   1. a subscription made on one node is replicated into the cluster-wide
+##      routing table and is visible from BOTH nodes (cross-node routing);
+##   2. a message published on a separate connection (typically the other node,
+##      via HAProxy round-robin) is delivered to that subscriber end to end.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+NET="${NET:-emqx.io}"
+NODE1="${NODE1:-node1.emqx.io}"
+NODE2="${NODE2:-node2.emqx.io}"
+PYTHON_IMAGE="${PYTHON_IMAGE:-python:3-slim}"
+TOPIC="cluster/smoke/1"
+PAYLOAD="cluster-smoke-payload"
+SUB="cluster-smoke-sub"
+
+cleanup() {
+  docker rm -f "${SUB}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+cleanup
+
+## Start the long-lived subscriber (installs paho-mqtt, then subscribes).
+docker run -d --name "${SUB}" --net "${NET}" -v "${HERE}:/smoke:ro" "${PYTHON_IMAGE}" \
+  sh -c "pip install --quiet --disable-pip-version-check --root-user-action=ignore paho-mqtt \
+         && python /smoke/subscriber.py haproxy 1883 ${TOPIC}" >/dev/null
+
+echo "Waiting for the subscriber to connect ..."
+connected=false
+for _ in $(seq 1 60); do
+  if docker logs "${SUB}" 2>&1 | grep -q "SUBSCRIBER CONNECTED rc=0"; then
+    connected=true
+    break
+  fi
+  sleep 2
+done
+if [ "${connected}" != true ]; then
+  echo "subscriber failed to connect; logs:"; docker logs "${SUB}" || true; exit 1
+fi
+
+## Assert the route is replicated cluster-wide: it must be visible from BOTH
+## nodes, including the node the subscriber is NOT connected to.
+route_count_on() {
+  docker exec "$1" emqx eval \
+    "length(emqx_router:lookup_routes(<<\"${TOPIC}\">>))." 2>/dev/null | tr -d '[:space:]'
+}
+
+for node in "${NODE1}" "${NODE2}"; do
+  ok=false
+  for _ in $(seq 1 30); do
+    n="$(route_count_on "${node}")"
+    if [ -n "${n}" ] && [ "${n}" -ge 1 ] 2>/dev/null; then ok=true; break; fi
+    sleep 1
+  done
+  if [ "${ok}" != true ]; then
+    echo "FAIL: route for ${TOPIC} not visible on ${node} (cross-node routing broken)"
+    exit 1
+  fi
+  echo "PASS: route for ${TOPIC} visible on ${node}"
+done
+
+## Publish on a separate connection and confirm end-to-end delivery.
+docker run --rm --net "${NET}" -v "${HERE}:/smoke:ro" "${PYTHON_IMAGE}" \
+  sh -c "pip install --quiet --disable-pip-version-check --root-user-action=ignore paho-mqtt \
+         && python /smoke/publisher.py haproxy 1883 ${TOPIC} ${PAYLOAD}"
+
+echo "Waiting for delivery to the subscriber ..."
+delivered=false
+for _ in $(seq 1 30); do
+  if docker logs "${SUB}" 2>&1 | grep -q "RECEIVED ${TOPIC} ${PAYLOAD}"; then
+    delivered=true
+    break
+  fi
+  sleep 1
+done
+if [ "${delivered}" != true ]; then
+  echo "FAIL: published message was not delivered to the subscriber"
+  echo "--- subscriber logs ---"; docker logs "${SUB}" || true
+  exit 1
+fi
+echo "PASS: message delivered across the cluster"
+echo "ALL PASSED"

--- a/scripts/test/cluster-smoke/run.sh
+++ b/scripts/test/cluster-smoke/run.sh
@@ -29,7 +29,7 @@ cleanup
 
 ## Start the long-lived subscriber (installs paho-mqtt, then subscribes).
 docker run -d --name "${SUB}" --net "${NET}" -v "${HERE}:/smoke:ro" "${PYTHON_IMAGE}" \
-  sh -c "pip install --quiet --disable-pip-version-check --root-user-action=ignore paho-mqtt \
+  sh -c "pip install --quiet --disable-pip-version-check --root-user-action=ignore 'paho-mqtt==2.1.0' \
          && python /smoke/subscriber.py haproxy 1883 ${TOPIC}" >/dev/null
 
 echo "Waiting for the subscriber to connect ..."
@@ -68,7 +68,7 @@ done
 
 ## Publish on a separate connection and confirm end-to-end delivery.
 docker run --rm --net "${NET}" -v "${HERE}:/smoke:ro" "${PYTHON_IMAGE}" \
-  sh -c "pip install --quiet --disable-pip-version-check --root-user-action=ignore paho-mqtt \
+  sh -c "pip install --quiet --disable-pip-version-check --root-user-action=ignore 'paho-mqtt==2.1.0' \
          && python /smoke/publisher.py haproxy 1883 ${TOPIC} ${PAYLOAD}"
 
 echo "Waiting for delivery to the subscriber ..."

--- a/scripts/test/cluster-smoke/subscriber.py
+++ b/scripts/test/cluster-smoke/subscriber.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Long-lived MQTT subscriber for the cluster smoke test.
+
+Connects through HAProxy, subscribes to the smoke topic and prints a line for
+every message received. Runs until killed. Used together with publisher.py and
+run.sh to verify cross-node message routing in a two-node cluster.
+"""
+import sys
+import time
+import paho.mqtt.client as mqtt
+
+HOST = sys.argv[1] if len(sys.argv) > 1 else "haproxy"
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 1883
+TOPIC = sys.argv[3] if len(sys.argv) > 3 else "cluster/smoke/1"
+
+
+def new_client(cid):
+    try:  # paho-mqtt 2.x
+        return mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION1, client_id=cid, protocol=mqtt.MQTTv5
+        )
+    except AttributeError:  # paho-mqtt 1.x
+        return mqtt.Client(client_id=cid, protocol=mqtt.MQTTv5)
+
+
+def on_connect(cl, u, flags, rc, props=None):
+    print(f"SUBSCRIBER CONNECTED rc={getattr(rc, 'value', rc)}", flush=True)
+    cl.subscribe(TOPIC, 1)
+
+
+def on_message(cl, u, msg):
+    print(f"RECEIVED {msg.topic} {msg.payload.decode(errors='replace')}", flush=True)
+
+
+c = new_client("cluster-smoke-sub")
+c.on_connect = on_connect
+c.on_message = on_message
+c.connect(HOST, PORT, 30)
+c.loop_start()
+while True:
+    time.sleep(1)

--- a/scripts/test/cluster-smoke/subscriber.py
+++ b/scripts/test/cluster-smoke/subscriber.py
@@ -15,12 +15,9 @@ TOPIC = sys.argv[3] if len(sys.argv) > 3 else "cluster/smoke/1"
 
 
 def new_client(cid):
-    try:  # paho-mqtt 2.x
-        return mqtt.Client(
-            mqtt.CallbackAPIVersion.VERSION1, client_id=cid, protocol=mqtt.MQTTv5
-        )
-    except AttributeError:  # paho-mqtt 1.x
-        return mqtt.Client(client_id=cid, protocol=mqtt.MQTTv5)
+    return mqtt.Client(
+        mqtt.CallbackAPIVersion.VERSION1, client_id=cid, protocol=mqtt.MQTTv5
+    )
 
 
 def on_connect(cl, u, flags, rc, props=None):

--- a/scripts/test/essential-auth-smoke/acl.conf
+++ b/scripts/test/essential-auth-smoke/acl.conf
@@ -1,0 +1,6 @@
+%% ACL rules for the ESSENTIAL-mode auth smoke test.
+%% smoke_user may publish/subscribe only under its own subtree; the
+%% ${username} placeholder is interpolated from the connecting client.
+{allow, {username, "smoke_user"}, all, ["smoke/${username}/#"]}.
+%% Everything else is denied (authorization.no_match = deny also covers this).
+{deny, all, all, ["#"]}.

--- a/scripts/test/essential-auth-smoke/bootstrap.csv
+++ b/scripts/test/essential-auth-smoke/bootstrap.csv
@@ -1,0 +1,2 @@
+user_id,password,is_superuser
+smoke_user,smoke_pass,false

--- a/scripts/test/essential-auth-smoke/run.sh
+++ b/scripts/test/essential-auth-smoke/run.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+## Smoke test: boot a single EMQX node in ESSENTIAL mode with the built-in
+## database authenticator (seeded from bootstrap.csv) and the file authorizer
+## (acl.conf), then verify authentication and authorization behaviour with a
+## real MQTT client.
+##
+## This proves that ESSENTIAL mode ships a usable authn/authz stack: auth is
+## core infrastructure and is never gated off.
+##
+## Usage: run.sh IMAGE_TAG   (e.g. run.sh emqx/emqx-enterprise:latest)
+
+set -euo pipefail
+
+IMAGE_TAG="${1:-${_EMQX_DOCKER_IMAGE_TAG:-}}"
+[ -z "${IMAGE_TAG}" ] && { echo "Usage: $0 IMAGE_TAG"; exit 1; }
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CONTAINER="emqx-essential-auth-smoke"
+PYTHON_IMAGE="${PYTHON_IMAGE:-python:3-slim}"
+
+cleanup() {
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+cleanup
+
+ACL_IN_CONTAINER="/opt/emqx/etc/acl-smoke.conf"
+CSV_IN_CONTAINER="/opt/emqx/data/auth-bootstrap.csv"
+
+authentication="[{
+  mechanism = password_based,
+  backend = built_in_database,
+  user_id_type = username,
+  password_hash_algorithm = {name = plain, salt_position = disable},
+  bootstrap_file = \"${CSV_IN_CONTAINER}\",
+  bootstrap_type = plain
+}]"
+
+echo "Starting ${CONTAINER} from ${IMAGE_TAG} ..."
+docker run -d --name "${CONTAINER}" \
+  -v "${HERE}/acl.conf:${ACL_IN_CONTAINER}:ro" \
+  -v "${HERE}/bootstrap.csv:${CSV_IN_CONTAINER}:ro" \
+  -e EMQX_FEATURES=ESSENTIAL \
+  -e EMQX_NODE__NAME="emqx@127.0.0.1" \
+  -e EMQX_AUTHENTICATION="${authentication}" \
+  -e EMQX_AUTHORIZATION__NO_MATCH=deny \
+  -e EMQX_AUTHORIZATION__SOURCES="[{type = file, enable = true, path = \"${ACL_IN_CONTAINER}\"}]" \
+  "${IMAGE_TAG}" >/dev/null
+
+echo "Waiting for the TCP listener ..."
+ready=false
+for _ in $(seq 1 60); do
+  if docker exec "${CONTAINER}" emqx ctl listeners 2>/dev/null \
+       | grep -A6 'tcp:default' | grep -qE 'running *: true'; then
+    ready=true
+    break
+  fi
+  sleep 2
+done
+if [ "${ready}" != true ]; then
+  echo "EMQX did not become ready; dumping logs:"
+  docker logs "${CONTAINER}" || true
+  exit 1
+fi
+
+## Sanity: exactly one user was bootstrapped from the CSV.
+user_count="$(docker exec "${CONTAINER}" emqx eval \
+  'mnesia:table_info(emqx_authn_mnesia, size).' 2>/dev/null | tr -d '[:space:]')"
+echo "bootstrapped authn users: ${user_count}"
+if [ "${user_count}" != "1" ]; then
+  echo "expected exactly 1 bootstrapped user, got '${user_count}'"
+  docker logs "${CONTAINER}" || true
+  exit 1
+fi
+
+## Run the MQTT client checks from a throwaway python container that shares the
+## broker's network namespace (so 127.0.0.1:1883 reaches the broker), avoiding
+## any dependency on the host's python environment.
+echo "Running MQTT authn/authz checks ..."
+docker run --rm \
+  --network "container:${CONTAINER}" \
+  -v "${HERE}:/smoke:ro" \
+  "${PYTHON_IMAGE}" \
+  sh -c "pip install --quiet --disable-pip-version-check --root-user-action=ignore paho-mqtt && python /smoke/verify.py 127.0.0.1 1883"

--- a/scripts/test/essential-auth-smoke/run.sh
+++ b/scripts/test/essential-auth-smoke/run.sh
@@ -82,4 +82,4 @@ docker run --rm \
   --network "container:${CONTAINER}" \
   -v "${HERE}:/smoke:ro" \
   "${PYTHON_IMAGE}" \
-  sh -c "pip install --quiet --disable-pip-version-check --root-user-action=ignore paho-mqtt && python /smoke/verify.py 127.0.0.1 1883"
+  sh -c "pip install --quiet --disable-pip-version-check --root-user-action=ignore 'paho-mqtt==2.1.0' && python /smoke/verify.py 127.0.0.1 1883"

--- a/scripts/test/essential-auth-smoke/verify.py
+++ b/scripts/test/essential-auth-smoke/verify.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Verify built-in-database authentication and acl.conf authorization.
+
+Connects to a running EMQX broker (expected to be configured with a
+`built_in_database` authenticator seeded from `bootstrap.csv` and a `file`
+authorizer using `acl.conf`) and asserts that:
+
+  * valid credentials connect, wrong password and anonymous are rejected;
+  * a subscribe/publish under the user's own subtree is allowed;
+  * a subscribe/publish outside it is denied.
+
+Usage: verify.py [host] [port]   (defaults: 127.0.0.1 1883)
+
+Requires the `paho-mqtt` package; works with both 1.x and 2.x.
+"""
+import sys
+import time
+import paho.mqtt.client as mqtt
+
+HOST = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+PORT = int(sys.argv[2]) if len(sys.argv) > 2 else 1883
+USER, PASSWD = "smoke_user", "smoke_pass"
+ALLOWED = f"smoke/{USER}/data"
+DENIED = "forbidden/data"
+
+failures = []
+
+
+def rc_val(rc):
+    return getattr(rc, "value", rc)
+
+
+def check(name, cond):
+    print(("PASS" if cond else "FAIL") + f": {name}")
+    if not cond:
+        failures.append(name)
+
+
+def new_client(cid):
+    try:  # paho-mqtt 2.x
+        return mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION1, client_id=cid, protocol=mqtt.MQTTv5
+        )
+    except AttributeError:  # paho-mqtt 1.x
+        return mqtt.Client(client_id=cid, protocol=mqtt.MQTTv5)
+
+
+def connect(user, pw, cid):
+    c = new_client(cid)
+    state = {}
+    c.on_connect = lambda cl, u, flags, rc, props=None: state.update(rc=rc)
+    if user is not None:
+        c.username_pw_set(user, pw)
+    c.connect(HOST, PORT, 30)
+    c.loop_start()
+    for _ in range(50):
+        if "rc" in state:
+            break
+        time.sleep(0.1)
+    return c, state.get("rc")
+
+
+def main():
+    # 1. valid credentials -> success
+    c, rc = connect(USER, PASSWD, "smoke-ok")
+    check("valid credentials connect succeeds", rc is not None and rc_val(rc) == 0)
+    c.loop_stop()
+    c.disconnect()
+
+    # 2. wrong password -> rejected
+    c, rc = connect(USER, "wrong", "smoke-badpw")
+    check("wrong password rejected", rc is None or rc_val(rc) != 0)
+    c.loop_stop()
+    c.disconnect()
+
+    # 3. anonymous -> rejected
+    c, rc = connect(None, None, "smoke-anon")
+    check("anonymous rejected", rc is None or rc_val(rc) != 0)
+    c.loop_stop()
+    c.disconnect()
+
+    # 4. ACL: subscribe allowed vs denied
+    c, rc = connect(USER, PASSWD, "smoke-acl")
+    if rc is None or rc_val(rc) != 0:
+        check("setup connect for ACL checks", False)
+        return
+    suback = {}
+    c.on_subscribe = lambda cl, u, mid, codes, props=None: suback.__setitem__(mid, codes)
+
+    def sub(topic):
+        _, mid = c.subscribe(topic, 1)
+        for _ in range(50):
+            if mid in suback:
+                return rc_val(suback[mid][0])
+            time.sleep(0.1)
+        return None
+
+    check("subscribe to allowed topic granted", (sub(ALLOWED) or 128) < 128)
+    check("subscribe to denied topic refused", (sub(DENIED) or 0) >= 128)
+
+    # 5. ACL: publish allowed delivered, denied dropped
+    got = []
+    c.on_message = lambda cl, u, msg: got.append(msg.topic)
+    c.subscribe(ALLOWED, 1)
+    time.sleep(0.3)
+    c.publish(ALLOWED, b"hello", 1)
+    time.sleep(0.5)
+    check("publish to allowed topic delivered", ALLOWED in got)
+    c.publish(DENIED, b"nope", 1)
+    time.sleep(0.5)
+    check("publish to denied topic not delivered", DENIED not in got)
+    c.loop_stop()
+    c.disconnect()
+
+
+main()
+print(f"\n{'ALL PASSED' if not failures else 'FAILURES: ' + ', '.join(failures)}")
+sys.exit(1 if failures else 0)

--- a/scripts/test/essential-auth-smoke/verify.py
+++ b/scripts/test/essential-auth-smoke/verify.py
@@ -11,7 +11,7 @@ authorizer using `acl.conf`) and asserts that:
 
 Usage: verify.py [host] [port]   (defaults: 127.0.0.1 1883)
 
-Requires the `paho-mqtt` package; works with both 1.x and 2.x.
+Requires the `paho-mqtt` 2.x package (pinned by the caller).
 """
 import sys
 import time
@@ -37,12 +37,9 @@ def check(name, cond):
 
 
 def new_client(cid):
-    try:  # paho-mqtt 2.x
-        return mqtt.Client(
-            mqtt.CallbackAPIVersion.VERSION1, client_id=cid, protocol=mqtt.MQTTv5
-        )
-    except AttributeError:  # paho-mqtt 1.x
-        return mqtt.Client(client_id=cid, protocol=mqtt.MQTTv5)
+    return mqtt.Client(
+        mqtt.CallbackAPIVersion.VERSION1, client_id=cid, protocol=mqtt.MQTTv5
+    )
 
 
 def connect(user, pw, cid):

--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -87,6 +87,21 @@ fi
 
 cleanup
 
+# Forward EMQX_* environment variables set by the caller (e.g. EMQX_FEATURES,
+# EMQX_AUTHORIZATION__*) to both node containers. Node identity, cookie and
+# clustering/RPC variables are managed by this script and are never forwarded.
+# EMQX_NAME is a CI artifact-naming variable, not a broker config, so it is
+# excluded too.
+EXTRA_EMQX_ENV=()
+while IFS= read -r _emqx_var; do
+    case "${_emqx_var}" in
+        EMQX_NAME) ;;
+        EMQX_NODE_NAME|EMQX_NODE_COOKIE|EMQX_NODE__NAME|EMQX_NODE__COOKIE) ;;
+        EMQX_CLUSTER__*|EMQX_RPC__*) ;;
+        EMQX_*) EXTRA_EMQX_ENV+=(-e "${_emqx_var}") ;;
+    esac
+done < <(compgen -e)
+
 if [ -z "${USE_NET}" ]; then
     if [ ${IPV6} = 1 ]; then
         docker network create --ipv6 --subnet 2001:0DB8::/112 "$NET"
@@ -116,6 +131,7 @@ docker run -d -t --restart=always --name "$NODE1" \
   -e EMQX_listeners__tcp__default__proxy_protocol=true \
   -e EMQX_listeners__ws__default__proxy_protocol=true \
   -e EMQX_LICENSE__KEY="${LICENSE_KEY1:-evaluation}" \
+  ${EXTRA_EMQX_ENV[@]+"${EXTRA_EMQX_ENV[@]}"} \
   "$IMAGE1"
 
 docker run -d -t --restart=always --name "$NODE2" \
@@ -131,6 +147,7 @@ docker run -d -t --restart=always --name "$NODE2" \
   -e EMQX_listeners__tcp__default__proxy_protocol=true \
   -e EMQX_listeners__ws__default__proxy_protocol=true \
   -e EMQX_LICENSE__KEY="${LICENSE_KEY2:-evaluation}" \
+  ${EXTRA_EMQX_ENV[@]+"${EXTRA_EMQX_ENV[@]}"} \
   "$IMAGE2"
 
 mkdir -p tmp

--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -88,16 +88,18 @@ fi
 cleanup
 
 # Forward EMQX_* environment variables set by the caller (e.g. EMQX_FEATURES,
-# EMQX_AUTHORIZATION__*) to both node containers. Node identity, cookie and
-# clustering/RPC variables are managed by this script and are never forwarded.
-# EMQX_NAME is a CI artifact-naming variable, not a broker config, so it is
-# excluded too.
+# EMQX_AUTHORIZATION__*) to both node containers. Variables managed by this
+# script are never forwarded: node identity/cookie, clustering/RPC, the license
+# key (this script pins it via LICENSE_KEY1/2, and the CI runner may export a
+# single-node community key that would otherwise break clustering), and the
+# EMQX_NAME CI artifact-naming variable. The forwarded vars are also placed
+# before the script's own `-e` flags below, so the pinned values always win.
 EXTRA_EMQX_ENV=()
 while IFS= read -r _emqx_var; do
     case "${_emqx_var}" in
         EMQX_NAME) ;;
         EMQX_NODE_NAME|EMQX_NODE_COOKIE|EMQX_NODE__NAME|EMQX_NODE__COOKIE) ;;
-        EMQX_CLUSTER__*|EMQX_RPC__*) ;;
+        EMQX_CLUSTER__*|EMQX_RPC__*|EMQX_LICENSE__*) ;;
         EMQX_*) EXTRA_EMQX_ENV+=(-e "${_emqx_var}") ;;
     esac
 done < <(compgen -e)
@@ -120,6 +122,7 @@ fi
 
 docker run -d -t --restart=always --name "$NODE1" \
   --net "$NET" \
+  ${EXTRA_EMQX_ENV[@]+"${EXTRA_EMQX_ENV[@]}"} \
   -e EMQX_LOG__CONSOLE_HANDLER__LEVEL=debug \
   -e EMQX_NODE_NAME="emqx@$NODE1" \
   -e EMQX_NODE_COOKIE="$COOKIE" \
@@ -131,11 +134,11 @@ docker run -d -t --restart=always --name "$NODE1" \
   -e EMQX_listeners__tcp__default__proxy_protocol=true \
   -e EMQX_listeners__ws__default__proxy_protocol=true \
   -e EMQX_LICENSE__KEY="${LICENSE_KEY1:-evaluation}" \
-  ${EXTRA_EMQX_ENV[@]+"${EXTRA_EMQX_ENV[@]}"} \
   "$IMAGE1"
 
 docker run -d -t --restart=always --name "$NODE2" \
   --net "$NET" \
+  ${EXTRA_EMQX_ENV[@]+"${EXTRA_EMQX_ENV[@]}"} \
   -e EMQX_LOG__CONSOLE_HANDLER__LEVEL=debug \
   -e EMQX_NODE_NAME="emqx@$NODE2" \
   -e EMQX_NODE_COOKIE="$COOKIE" \
@@ -147,7 +150,6 @@ docker run -d -t --restart=always --name "$NODE2" \
   -e EMQX_listeners__tcp__default__proxy_protocol=true \
   -e EMQX_listeners__ws__default__proxy_protocol=true \
   -e EMQX_LICENSE__KEY="${LICENSE_KEY2:-evaluation}" \
-  ${EXTRA_EMQX_ENV[@]+"${EXTRA_EMQX_ENV[@]}"} \
   "$IMAGE2"
 
 mkdir -p tmp

--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -291,6 +291,15 @@ wait_for_haproxy() {
     done
 }
 
+## Dump logs from both nodes, so a cluster-formation failure shows the state of
+## every node (the node that failed to join is usually not the one being polled).
+dump_all_node_logs() {
+    for node in "$NODE1" "$NODE2"; do
+        echo "==============  ${node}  =============="
+        docker logs "$node" 2>&1 || true
+    done
+}
+
 wait_for_running_nodes() {
     local container="$1"
     local expected_running_nodes="$2"
@@ -308,7 +317,7 @@ wait_for_running_nodes() {
         sleep 1
     done
     echo "Expected running nodes is ${expected_running_nodes}, but got ${running_nodes} after ${wait_limit} seconds"
-    docker logs "$container"
+    dump_all_node_logs
     exit 1
 }
 

--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -296,21 +296,20 @@ wait_for_running_nodes() {
     local expected_running_nodes="$2"
     local wait_limit="$3"
     local wait_sec=0
+    local running_nodes=0
     while [ "${wait_sec}" -lt "${wait_limit}" ]; do
         running_nodes="$(docker exec -t "$container" emqx ctl cluster status --json | jq '.running_nodes | length')"
         if [ "${running_nodes}" -eq "${expected_running_nodes}" ]; then
             echo "Successfully confirmed ${running_nodes} running nodes"
-            exit 0
-        fi
-        if [ "$wait_sec" -gt "$wait_limit" ]; then
-            echo "Expected running nodes is ${expected_running_nodes}, but got ${running_nodes} after ${wait_limit} seconds"
-            docker logs "$container"
-            exit 1
+            return 0
         fi
         wait_sec=$(( wait_sec + 1 ))
         echo -n '.'
         sleep 1
     done
+    echo "Expected running nodes is ${expected_running_nodes}, but got ${running_nodes} after ${wait_limit} seconds"
+    docker logs "$container"
+    exit 1
 }
 
 wait_for_emqx "$NODE1" 60
@@ -321,4 +320,4 @@ echo
 
 docker exec "${NODE2}" emqx ctl cluster join "emqx@$NODE1"
 
-wait_for_running_nodes "$NODE1" "${EXPECTED_RUNNING_NODES:-2}" 30
+wait_for_running_nodes "$NODE1" "${EXPECTED_RUNNING_NODES:-2}" 60


### PR DESCRIPTION
Follow-up test coverage for the feature-gates work (auth is now core, #17808), focused on making sure the minimal **ESSENTIAL** preset is fully usable.

## What

- **Paho against ESSENTIAL** (`run_docker_tests.yaml`): the `paho-mqtt-testing` job now also runs the full MQTT interoperability suite once against an `EMQX_FEATURES=ESSENTIAL` node, in addition to the existing FULL runs.

- **Auth/authz smoke test** (`run_docker_tests.yaml` → `essential-auth-smoke-test`): boots a single ESSENTIAL node with built-in-database authentication (users seeded from `bootstrap.csv`) and `acl.conf` file authorization, then uses a real MQTT client to assert valid credentials connect; wrong-password and anonymous are rejected; and per-topic ACL allow/deny works (`no_match = deny`).

- **Cluster smoke test** (new `run_cluster_tests.yaml`, wired into the PR entrypoint): starts a two-node cluster via `start-two-nodes-in-docker.sh` in **both FULL and ESSENTIAL** mode and asserts, at the MQTT level:
  - a subscription on one node is replicated into the cluster-wide routing table and is visible from **both** nodes (cross-node routing);
  - a message published on a separate connection is delivered end to end.

  `start-two-nodes-in-docker.sh` now forwards caller-set `EMQX_*` env vars (e.g. `EMQX_FEATURES`) to both node containers, excluding the node-identity/clustering vars it manages.

All MQTT client checks run in throwaway `python:3-slim` containers sharing the broker network, so there is no dependency on the runner's Python environment.

## Verification

Both `scripts/test/essential-auth-smoke/run.sh` and `scripts/test/cluster-smoke/run.sh` were validated end-to-end locally against a real EMQX docker image (cluster forms, cross-node route replication and delivery confirmed; all authn/authz checks pass). `shellcheck`, `py_compile` and YAML linting are clean.

No user-facing changes; CI/test only.