### PR TITLE
ci(dependabot): target all active dev branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # master (default branch)
   - package-ecosystem: github-actions
     directory: "/"
     reviewers:
@@ -12,6 +13,174 @@ updates:
           - "*"
   - package-ecosystem: github-actions
     directory: "/.github/actions/package-macos/" # All subdirectories outside of "/.github/workflows" must be explicitly included.
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions-package-macos:
+        patterns:
+          - "*"
+
+  # dev-63
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: dev-63
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/package-macos/"
+    target-branch: dev-63
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions-package-macos:
+        patterns:
+          - "*"
+
+  # dev-62
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: dev-62
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/package-macos/"
+    target-branch: dev-62
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions-package-macos:
+        patterns:
+          - "*"
+
+  # dev-61
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: dev-61
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/package-macos/"
+    target-branch: dev-61
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions-package-macos:
+        patterns:
+          - "*"
+
+  # dev-60
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: dev-60
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/package-macos/"
+    target-branch: dev-60
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions-package-macos:
+        patterns:
+          - "*"
+
+  # dev-510
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: dev-510
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/package-macos/"
+    target-branch: dev-510
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions-package-macos:
+        patterns:
+          - "*"
+
+  # dev-59
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: dev-59
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/package-macos/"
+    target-branch: dev-59
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions-package-macos:
+        patterns:
+          - "*"
+
+  # dev-58
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: dev-58
+    reviewers:
+      - "emqx/emqx-review-board"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/package-macos/"
+    target-branch: dev-58
     reviewers:
       - "emqx/emqx-review-board"
     schedule:


### PR DESCRIPTION
## Summary

`.github/dependabot.yml` (read only from the default branch, `master`) currently opens GitHub Actions bump PRs against `master` only. Fixes on `master` do not sync back into the `dev-*` branches (sync PRs flow older→newer→master, never the other direction), so those branches drift on GitHub Action SHAs.

This extends the config to open weekly bump PRs against every active dev branch independently, via additional `updates:` entries with `target-branch:` set.

## Details

- Keeps the two existing `master`-targeted entries (root workflows + `.github/actions/package-macos/` composite) unchanged.
- Adds a symmetric pair for each active dev branch: `dev-63`, `dev-62`, `dev-61`, `dev-60`, `dev-510`, `dev-59`, `dev-58`. All eight branches share the same `.github/actions/package-macos/` layout.
- No `release-*` branches are targeted — those are bot-managed fast-forward mirrors and Dependabot PRs against them would be blocked by branch protection.
- Fully-expanded form (no YAML anchors) since Dependabot's config parser does not support anchor/alias merging.
- Validated with `python yaml.safe_load` (16 entries, correct target-branch distribution).