### PR TITLE
fix(a2a): return 404 with a clear message when retainer is disabled

### DIFF
--- a/apps/emqx_a2a_registry/mix.exs
+++ b/apps/emqx_a2a_registry/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXA2ARegistry.MixProject do
   def project do
     [
       app: :emqx_a2a_registry,
-      version: "6.2.1",
+      version: "6.2.2",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry.erl
@@ -72,24 +72,27 @@ list_cards(Opts) ->
         false ->
             {error, retainer_disabled};
         true ->
-            Namespace = maps:get(namespace, Opts, ?global_ns),
-            OrgId = maps:get(org_id, Opts, <<"+">>),
-            UnitId = maps:get(unit_id, Opts, <<"+">>),
-            AgentId = maps:get(agent_id, Opts, <<"+">>),
-            Cursor = undefined,
-            MatchOpts = #{batch_read_number => all_remaining},
-            Filters =
-                case Namespace of
-                    all ->
-                        [
-                            discovery_topic(?global_ns, OrgId, UnitId, AgentId),
-                            discovery_topic(<<"+">>, OrgId, UnitId, AgentId)
-                        ];
-                    _ ->
-                        [discovery_topic(Namespace, OrgId, UnitId, AgentId)]
-                end,
-            {ok, match_cards(Filters, Cursor, MatchOpts, [])}
+            do_list_cards(Opts)
     end.
+
+do_list_cards(Opts) ->
+    Namespace = maps:get(namespace, Opts, ?global_ns),
+    OrgId = maps:get(org_id, Opts, <<"+">>),
+    UnitId = maps:get(unit_id, Opts, <<"+">>),
+    AgentId = maps:get(agent_id, Opts, <<"+">>),
+    Cursor = undefined,
+    MatchOpts = #{batch_read_number => all_remaining},
+    Filters =
+        case Namespace of
+            all ->
+                [
+                    discovery_topic(?global_ns, OrgId, UnitId, AgentId),
+                    discovery_topic(<<"+">>, OrgId, UnitId, AgentId)
+                ];
+            _ ->
+                [discovery_topic(Namespace, OrgId, UnitId, AgentId)]
+        end,
+    {ok, match_cards(Filters, Cursor, MatchOpts, [])}.
 
 match_cards([], _Cursor, _MatchOpts, Acc) ->
     lists:map(
@@ -114,19 +117,22 @@ lookup_agent_status(ClientId) ->
 
 -spec delete_card(map()) -> ok | {error, retainer_disabled}.
 delete_card(Opts) ->
+    case emqx_retainer:is_enabled() of
+        false ->
+            {error, retainer_disabled};
+        true ->
+            do_delete_card(Opts)
+    end.
+
+do_delete_card(Opts) ->
     #{
         namespace := Namespace,
         org_id := OrgId,
         unit_id := UnitId,
         agent_id := AgentId
     } = Opts,
-    case emqx_retainer:is_enabled() of
-        false ->
-            {error, retainer_disabled};
-        true ->
-            Topic = discovery_topic(Namespace, OrgId, UnitId, AgentId),
-            ok = emqx_retainer:delete(Topic)
-    end.
+    Topic = discovery_topic(Namespace, OrgId, UnitId, AgentId),
+    ok = emqx_retainer:delete(Topic).
 
 write_card(Opts) ->
     #{

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry.erl
@@ -62,9 +62,11 @@ discovery_topic(Namespace, OrgId, UnitId, AgentId) when is_binary(Namespace) ->
         AgentId
     ]).
 
+-spec list_cards() -> {ok, [map()]} | {error, retainer_disabled}.
 list_cards() ->
     list_cards(_Opts = #{}).
 
+-spec list_cards(map()) -> {ok, [map()]} | {error, retainer_disabled}.
 list_cards(Opts) ->
     Namespace = maps:get(namespace, Opts, ?global_ns),
     OrgId = maps:get(org_id, Opts, <<"+">>),
@@ -72,29 +74,34 @@ list_cards(Opts) ->
     AgentId = maps:get(agent_id, Opts, <<"+">>),
     Cursor = undefined,
     MatchOpts = #{batch_read_number => all_remaining},
-    Msgs =
+    Filters =
         case Namespace of
             all ->
-                TopicFilterGlobal = discovery_topic(?global_ns, OrgId, UnitId, AgentId),
-                {ok, MsgsGlobal, undefined} =
-                    emqx_retainer:match_messages(TopicFilterGlobal, Cursor, MatchOpts),
-                TopicFilterNs = discovery_topic(<<"+">>, OrgId, UnitId, AgentId),
-                {ok, MsgsNs, undefined} =
-                    emqx_retainer:match_messages(TopicFilterNs, Cursor, MatchOpts),
-                MsgsGlobal ++ MsgsNs;
+                [
+                    discovery_topic(?global_ns, OrgId, UnitId, AgentId),
+                    discovery_topic(<<"+">>, OrgId, UnitId, AgentId)
+                ];
             _ ->
-                TopicFilter = discovery_topic(Namespace, OrgId, UnitId, AgentId),
-                {ok, Msgs0, undefined} =
-                    emqx_retainer:match_messages(TopicFilter, Cursor, MatchOpts),
-                Msgs0
+                [discovery_topic(Namespace, OrgId, UnitId, AgentId)]
         end,
-    lists:map(
+    match_cards(Filters, Cursor, MatchOpts, []).
+
+match_cards([], _Cursor, _MatchOpts, Acc) ->
+    Cards = lists:map(
         fun(#message{from = From, topic = Topic, payload = PayloadRaw}) ->
             Card = emqx_utils_json:decode(PayloadRaw),
             format_card(Card, PayloadRaw, Topic, From)
         end,
-        Msgs
-    ).
+        lists:reverse(Acc)
+    ),
+    {ok, Cards};
+match_cards([TopicFilter | Rest], Cursor, MatchOpts, Acc) ->
+    case emqx_retainer:match_messages(TopicFilter, Cursor, MatchOpts) of
+        {ok, Msgs, undefined} ->
+            match_cards(Rest, Cursor, MatchOpts, lists:reverse(Msgs, Acc));
+        {error, no_backend} ->
+            {error, retainer_disabled}
+    end.
 
 lookup_agent_status(ClientId) ->
     FormatFn = undefined,
@@ -105,6 +112,7 @@ lookup_agent_status(ClientId) ->
             ?A2A_PROP_OFFLINE_VAL
     end.
 
+-spec delete_card(map()) -> ok | {error, retainer_disabled}.
 delete_card(Opts) ->
     #{
         namespace := Namespace,
@@ -112,9 +120,13 @@ delete_card(Opts) ->
         unit_id := UnitId,
         agent_id := AgentId
     } = Opts,
-    Topic = discovery_topic(Namespace, OrgId, UnitId, AgentId),
-    ok = emqx_retainer:delete(Topic),
-    ok.
+    case emqx_retainer:is_enabled() of
+        false ->
+            {error, retainer_disabled};
+        true ->
+            Topic = discovery_topic(Namespace, OrgId, UnitId, AgentId),
+            ok = emqx_retainer:delete(Topic)
+    end.
 
 write_card(Opts) ->
     #{
@@ -136,7 +148,15 @@ write_card(Opts) ->
         Flags = #{retain => true},
         Headers = #{original_topic => OriginalTopic},
         Msg = emqx_message:make(ClientId, QoS, Topic, CardBin, Flags, Headers),
-        ok ?= emqx_retainer:store_retained(Msg)
+        ok ?= store_retained(Msg)
+    end.
+
+store_retained(Msg) ->
+    case emqx_retainer:store_retained(Msg) of
+        {error, no_backend} ->
+            {error, retainer_disabled};
+        Other ->
+            Other
     end.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry.erl
@@ -68,40 +68,40 @@ list_cards() ->
 
 -spec list_cards(map()) -> {ok, [map()]} | {error, retainer_disabled}.
 list_cards(Opts) ->
-    Namespace = maps:get(namespace, Opts, ?global_ns),
-    OrgId = maps:get(org_id, Opts, <<"+">>),
-    UnitId = maps:get(unit_id, Opts, <<"+">>),
-    AgentId = maps:get(agent_id, Opts, <<"+">>),
-    Cursor = undefined,
-    MatchOpts = #{batch_read_number => all_remaining},
-    Filters =
-        case Namespace of
-            all ->
-                [
-                    discovery_topic(?global_ns, OrgId, UnitId, AgentId),
-                    discovery_topic(<<"+">>, OrgId, UnitId, AgentId)
-                ];
-            _ ->
-                [discovery_topic(Namespace, OrgId, UnitId, AgentId)]
-        end,
-    match_cards(Filters, Cursor, MatchOpts, []).
+    case emqx_retainer:is_enabled() of
+        false ->
+            {error, retainer_disabled};
+        true ->
+            Namespace = maps:get(namespace, Opts, ?global_ns),
+            OrgId = maps:get(org_id, Opts, <<"+">>),
+            UnitId = maps:get(unit_id, Opts, <<"+">>),
+            AgentId = maps:get(agent_id, Opts, <<"+">>),
+            Cursor = undefined,
+            MatchOpts = #{batch_read_number => all_remaining},
+            Filters =
+                case Namespace of
+                    all ->
+                        [
+                            discovery_topic(?global_ns, OrgId, UnitId, AgentId),
+                            discovery_topic(<<"+">>, OrgId, UnitId, AgentId)
+                        ];
+                    _ ->
+                        [discovery_topic(Namespace, OrgId, UnitId, AgentId)]
+                end,
+            {ok, match_cards(Filters, Cursor, MatchOpts, [])}
+    end.
 
 match_cards([], _Cursor, _MatchOpts, Acc) ->
-    Cards = lists:map(
+    lists:map(
         fun(#message{from = From, topic = Topic, payload = PayloadRaw}) ->
             Card = emqx_utils_json:decode(PayloadRaw),
             format_card(Card, PayloadRaw, Topic, From)
         end,
         lists:reverse(Acc)
-    ),
-    {ok, Cards};
+    );
 match_cards([TopicFilter | Rest], Cursor, MatchOpts, Acc) ->
-    case emqx_retainer:match_messages(TopicFilter, Cursor, MatchOpts) of
-        {ok, Msgs, undefined} ->
-            match_cards(Rest, Cursor, MatchOpts, lists:reverse(Msgs, Acc));
-        {error, no_backend} ->
-            {error, retainer_disabled}
-    end.
+    {ok, Msgs, undefined} = emqx_retainer:match_messages(TopicFilter, Cursor, MatchOpts),
+    match_cards(Rest, Cursor, MatchOpts, lists:reverse(Msgs, Acc)).
 
 lookup_agent_status(ClientId) ->
     FormatFn = undefined,

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry_api.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry_api.erl
@@ -76,6 +76,7 @@ schema("/a2a/cards/list") ->
                             array(ref(card_out)),
                             example_card_list()
                         ),
+                    404 => error_schema(?NOT_FOUND, ?DESC("not_found")),
                     503 => error_schema(?SERVICE_UNAVAILABLE, ?DESC("service_unavailable"))
                 }
         }
@@ -116,6 +117,7 @@ schema("/a2a/cards/card/:org_id/:unit_id/:agent_id") ->
             responses =>
                 #{
                     204 => <<"">>,
+                    404 => error_schema(?NOT_FOUND, ?DESC("not_found")),
                     503 => error_schema(?SERVICE_UNAVAILABLE, ?DESC("service_unavailable"))
                 }
         },
@@ -136,6 +138,7 @@ schema("/a2a/cards/card/:org_id/:unit_id/:agent_id") ->
                 #{
                     204 => <<"">>,
                     400 => error_schema(?BAD_REQUEST, ?DESC("bad_request")),
+                    404 => error_schema(?NOT_FOUND, ?DESC("not_found")),
                     500 => error_schema(?INTERNAL_ERROR, ?DESC("internal_error")),
                     503 => error_schema(?SERVICE_UNAVAILABLE, ?DESC("service_unavailable"))
                 }
@@ -266,24 +269,34 @@ agent_id_path() ->
 handle_list_cards(Namespace, QueryParams) ->
     Opts0 = parse_query_params(QueryParams),
     Opts = Opts0#{namespace => Namespace},
-    Cards = emqx_a2a_registry:list_cards(Opts),
-    ?OK(lists:map(fun card_out/1, Cards)).
+    case emqx_a2a_registry:list_cards(Opts) of
+        {ok, Cards} ->
+            ?OK(lists:map(fun card_out/1, Cards));
+        {error, retainer_disabled} ->
+            ?NOT_FOUND(retainer_disabled_message())
+    end.
 
 handle_get_card(Namespace, Bindings) ->
     Opts0 = maps:with([org_id, unit_id, agent_id], Bindings),
     Opts = Opts0#{namespace => Namespace},
     case emqx_a2a_registry:list_cards(Opts) of
-        [] ->
+        {ok, []} ->
             ?NOT_FOUND(<<"Card not found">>);
-        [Card | _] ->
-            ?OK(card_out(Card))
+        {ok, [Card | _]} ->
+            ?OK(card_out(Card));
+        {error, retainer_disabled} ->
+            ?NOT_FOUND(retainer_disabled_message())
     end.
 
 handle_delete_card(Namespace, Bindings) ->
     Opts0 = maps:with([org_id, unit_id, agent_id], Bindings),
     Opts = Opts0#{namespace => Namespace},
-    ok = emqx_a2a_registry:delete_card(Opts),
-    ?NO_CONTENT.
+    case emqx_a2a_registry:delete_card(Opts) of
+        ok ->
+            ?NO_CONTENT;
+        {error, retainer_disabled} ->
+            ?NOT_FOUND(retainer_disabled_message())
+    end.
 
 handle_register_card(Namespace, Bindings, Body) ->
     #{<<"card">> := CardBin} = Body,
@@ -292,6 +305,8 @@ handle_register_card(Namespace, Bindings, Body) ->
     case emqx_a2a_registry:write_card(Opts) of
         ok ->
             ?NO_CONTENT;
+        {error, retainer_disabled} ->
+            ?NOT_FOUND(retainer_disabled_message());
         {error, Reason} ->
             case emqx_a2a_registry_adapter:format_register_error(Reason) of
                 {ok, Msg} ->
@@ -301,6 +316,14 @@ handle_register_card(Namespace, Bindings, Body) ->
                     ?INTERNAL_ERROR(Msg)
             end
     end.
+
+retainer_disabled_message() ->
+    <<
+        "A2A registry requires the retainer feature. "
+        "Enable retainer under 'Retained Messages' in the Dashboard, "
+        "or set `retainer.enable = true` in the configuration, "
+        "and try again."
+    >>.
 
 %%-------------------------------------------------------------------------------------------------
 %% Internal exports

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry_cli.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry_cli.erl
@@ -78,10 +78,14 @@ if_enabled(Fn) ->
 handle_list(Args) ->
     case list_args(Args) of
         {ok, Opts} ->
-            Cards0 = emqx_a2a_registry:list_cards(Opts),
-            Cards1 = filter_by_status(Cards0, Opts),
-            Cards = lists:map(fun emqx_a2a_registry_adapter:card_out/1, Cards1),
-            print_json(Cards);
+            case emqx_a2a_registry:list_cards(Opts) of
+                {ok, Cards0} ->
+                    Cards1 = filter_by_status(Cards0, Opts),
+                    Cards = lists:map(fun emqx_a2a_registry_adapter:card_out/1, Cards1),
+                    print_json(Cards);
+                {error, retainer_disabled} ->
+                    print_retainer_disabled()
+            end;
         {error, Reason} ->
             Error = mk_error(fmt("Invalid list args: ~ts\n", [Reason])),
             print_json(Error),
@@ -91,13 +95,17 @@ handle_list(Args) ->
 handle_get(Args) ->
     case get_args(Args) of
         {ok, Opts} ->
-            Cards0 = emqx_a2a_registry:list_cards(Opts),
-            case filter_by_status(Cards0, Opts) of
-                [] ->
-                    print_json(null);
-                [Card0 | _] ->
-                    Card = emqx_a2a_registry_adapter:card_out(Card0),
-                    print_json(Card)
+            case emqx_a2a_registry:list_cards(Opts) of
+                {ok, Cards0} ->
+                    case filter_by_status(Cards0, Opts) of
+                        [] ->
+                            print_json(null);
+                        [Card0 | _] ->
+                            Card = emqx_a2a_registry_adapter:card_out(Card0),
+                            print_json(Card)
+                    end;
+                {error, retainer_disabled} ->
+                    print_retainer_disabled()
             end;
         {error, Reason} ->
             Error = mk_error(fmt("Invalid get args: ~ts\n", [Reason])),
@@ -108,8 +116,12 @@ handle_get(Args) ->
 handle_delete(Args) ->
     case delete_args(Args) of
         {ok, Opts} ->
-            ok = emqx_a2a_registry:delete_card(Opts),
-            ok;
+            case emqx_a2a_registry:delete_card(Opts) of
+                ok ->
+                    ok;
+                {error, retainer_disabled} ->
+                    print_retainer_disabled()
+            end;
         {error, Reason} ->
             Error = mk_error(fmt("Invalid delete args: ~ts\n", [Reason])),
             print_json(Error),
@@ -126,6 +138,8 @@ handle_register(Args) ->
                 Opts = Opts1#{card_bin => CardBin},
                 ok ?= emqx_a2a_registry:write_card(Opts)
             else
+                {error, retainer_disabled} ->
+                    print_retainer_disabled();
                 {error, Reason0} ->
                     case emqx_a2a_registry_adapter:format_register_error(Reason0) of
                         {ok, Msg} ->
@@ -153,10 +167,14 @@ handle_register(Args) ->
 handle_stats(Args) ->
     case stats_args(Args) of
         {ok, #{namespace := Namespace}} ->
-            AllCards = emqx_a2a_registry:list_cards(#{namespace => Namespace}),
-            NumAllCards = length(AllCards),
-            Stats = #{<<"total">> => NumAllCards},
-            print_json(Stats);
+            case emqx_a2a_registry:list_cards(#{namespace => Namespace}) of
+                {ok, AllCards} ->
+                    NumAllCards = length(AllCards),
+                    Stats = #{<<"total">> => NumAllCards},
+                    print_json(Stats);
+                {error, retainer_disabled} ->
+                    print_retainer_disabled()
+            end;
         {error, Reason} when is_binary(Reason) ->
             Error = mk_error(Reason),
             print_json(Error),
@@ -409,6 +427,16 @@ fmt(Fmt, Args) -> unicode:characters_to_binary(lists:flatten(io_lib:format(Fmt, 
 
 mk_error(Msg) ->
     #{<<"message">> => Msg, <<"error">> => true}.
+
+print_retainer_disabled() ->
+    Msg = <<
+        "A2A registry requires the retainer feature. "
+        "Enable retainer under 'Retained Messages' in the Dashboard, "
+        "or set `retainer.enable = true` in the configuration, "
+        "and try again."
+    >>,
+    print_json(mk_error(Msg)),
+    false.
 
 print_json(X) ->
     ?PRINT("~ts\n", [emqx_utils_json:encode(X)]).

--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
@@ -252,6 +252,44 @@ t_disabled(TCConfig) ->
     ok.
 
 -doc """
+Verifies that the A2A registry API returns a friendly 404 (rather than crashing with a
+500 and an Erlang stacktrace) on every handler when the retainer feature is disabled,
+and that it recovers once the retainer is re-enabled.
+""".
+t_retainer_disabled(TCConfig) ->
+    Card = sample_card_bin(#{<<"name">> => <<"1">>}),
+    ?assertMatch({204, _}, register_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, Card, TCConfig)),
+
+    %% Disable the retainer feature that backs the A2A registry.
+    on_exit(fun() -> {ok, _} = emqx_retainer:update_config(#{<<"enable">> => true}) end),
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => false}),
+
+    AssertRetainerDisabled = fun({Code, Body}) ->
+        ?assertEqual(404, Code),
+        ?assertMatch(#{<<"code">> := <<"NOT_FOUND">>, <<"message">> := _}, Body),
+        #{<<"message">> := Msg} = Body,
+        ?assertNotEqual(
+            nomatch,
+            binary:match(Msg, <<"retainer">>),
+            #{message => Msg}
+        )
+    end,
+
+    AssertRetainerDisabled(list_cards(#{}, TCConfig)),
+    AssertRetainerDisabled(get_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, TCConfig)),
+    AssertRetainerDisabled(delete_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, TCConfig)),
+    AssertRetainerDisabled(register_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, Card, TCConfig)),
+
+    %% Re-enable the retainer; the API recovers with no lingering cached error.
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => true}),
+    ?assertMatch({200, _}, list_cards(#{}, TCConfig)),
+    ?assertMatch({204, _}, register_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, Card, TCConfig)),
+    ?assertMatch({200, _}, get_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, TCConfig)),
+    ?assertMatch({204, _}, delete_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, TCConfig)),
+
+    ok.
+
+-doc """
 Simple smoke test to verify updating configurations via the default, generic config
 management api.
 """.

--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_cli_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_cli_SUITE.erl
@@ -417,6 +417,40 @@ t_card_stats(TCConfig) ->
     ok.
 
 -doc """
+Verifies that the CLI prints a friendly "retainer disabled" error (rather than crashing)
+on every command when the retainer feature that backs the A2A registry is disabled.
+""".
+t_retainer_disabled(TCConfig) ->
+    simple_write_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, TCConfig),
+
+    PrivDir = get_config(priv_dir, TCConfig),
+    Card = sample_card_bin(#{<<"name">> => <<"1">>}),
+    Filepath = filename:join([PrivDir, ?FUNCTION_NAME, "agent-card.json"]),
+    ok = filelib:ensure_dir(Filepath),
+    ok = file:write_file(Filepath, Card),
+
+    on_exit(fun() -> {ok, _} = emqx_retainer:update_config(#{<<"enable">> => true}) end),
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => false}),
+
+    AssertDisabled = fun(Captured) ->
+        ?assertMatch({false, [#{<<"error">> := true, <<"message">> := _}]}, Captured),
+        {false, [#{<<"message">> := Msg}]} = Captured,
+        ?assertNotEqual(nomatch, binary:match(Msg, <<"retainer">>), #{message => Msg})
+    end,
+
+    AssertDisabled(?CAPTURE(list_cards([], TCConfig))),
+    AssertDisabled(?CAPTURE(get_card([?ORG_ID, ?UNIT_ID, ?AGENT_ID], TCConfig))),
+    AssertDisabled(?CAPTURE(delete_card([?ORG_ID, ?UNIT_ID, ?AGENT_ID], TCConfig))),
+    AssertDisabled(?CAPTURE(register_card([?ORG_ID, ?UNIT_ID, ?AGENT_ID, Filepath], TCConfig))),
+    AssertDisabled(?CAPTURE(card_stats(TCConfig))),
+
+    %% Re-enable; the CLI recovers.
+    {ok, _} = emqx_retainer:update_config(#{<<"enable">> => true}),
+    ?assertMatch({ok, [_]}, ?CAPTURE(list_cards([], TCConfig))),
+
+    ok.
+
+-doc """
 Verifies that operations on cards in a namespace do not affect those in a different one.
 """.
 t_namespace_isolation() ->

--- a/changes/ee/fix-17831.en.md
+++ b/changes/ee/fix-17831.en.md
@@ -1,0 +1,1 @@
+The A2A registry HTTP API and `a2a_registry` CLI now return a clear "retainer disabled" message with HTTP 404 when the retainer feature is off, instead of crashing with HTTP 500 and an Erlang stacktrace. Enable the retainer under 'Retained Messages' in the Dashboard (or set `retainer.enable = true`) to use the A2A features.


### PR DESCRIPTION
Release version: 6.2.3

## Summary

Fixes #17829.

When the retainer feature is disabled, the A2A registry API returned HTTP 500 with a raw Erlang stacktrace (`{badmatch,{error,no_backend}}`). The registry strict-matched `emqx_retainer:match_messages/3`, which returns `{error, no_backend}` while the retainer backend is down.

This change:

* `emqx_a2a_registry` now surfaces a typed `{error, retainer_disabled}` from `list_cards/0,1`, `delete_card/1` and `write_card/1` instead of crashing on the strict match. `delete_card/1` is gated on `emqx_retainer:is_enabled/0` since `emqx_retainer:delete/1` silently returns `ok` when disabled.
* `emqx_a2a_registry_api` translates `retainer_disabled` into HTTP 404 with a clear message pointing the operator to enable the retainer, across all four handlers (list, get, delete, register). `404` is added to the affected OpenAPI response schemas.
* `emqx_a2a_registry_cli` prints the same friendly error line (instead of an Erlang crash) for `list`, `get`, `delete`, `register` and `stats`.

Message body:

> A2A registry requires the retainer feature. Enable retainer under 'Retained Messages' in the Dashboard, or set `retainer.enable = true` in the configuration, and try again.

Coverage: new `t_retainer_disabled` cases in both `emqx_a2a_registry_api_SUITE` and `emqx_a2a_registry_cli_SUITE`, exercising every handler with the retainer disabled and confirming the API/CLI recover once it is re-enabled.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
