### PR TITLE
test(prometheus): de-flake t_listener_shutdown_count

### DIFF
--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx_prometheus/include/emqx_prometheus.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 %%--------------------------------------------------------------------
 %% Setups
@@ -401,30 +402,36 @@ t_listener_shutdown_count(_Config) ->
         ),
         lists:sort(Stats)
     end,
-    #{<<"client">> := JSONClientStatsNode} = get_stats(json, ?PROM_DATA_MODE__NODE),
-    ?assertEqual(
-        [
-            #{
-                <<"emqx_client_disconnected_reason">> => 1,
-                <<"listener_type">> => <<"tcp">>,
-                <<"listener_name">> => <<"default">>,
-                <<"reason">> => <<"discarded">>
-            },
-            #{
-                <<"emqx_client_disconnected_reason">> => 1,
-                <<"listener_type">> => <<"tcp">>,
-                <<"listener_name">> => <<"default">>,
-                <<"reason">> => <<"kicked">>
-            },
-            #{
-                <<"emqx_client_disconnected_reason">> => 1,
-                <<"listener_type">> => <<"tcp">>,
-                <<"listener_name">> => <<"default">>,
-                <<"reason">> => <<"tcp_closed">>
-            }
-        ],
-        OnlyDisconnectStats(JSONClientStatsNode)
-    ),
+    %% The disconnect-reason counters (notably "tcp_closed") are bumped
+    %% asynchronously when the broker detects the peer socket close, which lags
+    %% the client-side emqtt:stop/1 above. Retry until they are all recorded so
+    %% the assertions below (which read the same settled counters) are stable.
+    ?retry(200, 20, begin
+        #{<<"client">> := JSONClientStatsNode} = get_stats(json, ?PROM_DATA_MODE__NODE),
+        ?assertEqual(
+            [
+                #{
+                    <<"emqx_client_disconnected_reason">> => 1,
+                    <<"listener_type">> => <<"tcp">>,
+                    <<"listener_name">> => <<"default">>,
+                    <<"reason">> => <<"discarded">>
+                },
+                #{
+                    <<"emqx_client_disconnected_reason">> => 1,
+                    <<"listener_type">> => <<"tcp">>,
+                    <<"listener_name">> => <<"default">>,
+                    <<"reason">> => <<"kicked">>
+                },
+                #{
+                    <<"emqx_client_disconnected_reason">> => 1,
+                    <<"listener_type">> => <<"tcp">>,
+                    <<"listener_name">> => <<"default">>,
+                    <<"reason">> => <<"tcp_closed">>
+                }
+            ],
+            OnlyDisconnectStats(JSONClientStatsNode)
+        )
+    end),
     #{<<"client">> := JSONClientStatsAgg} = get_stats(json, ?PROM_DATA_MODE__ALL_NODES_AGGREGATED),
     ?assertEqual(
         [


### PR DESCRIPTION
## Problem

`emqx_prometheus_api_SUITE:t_listener_shutdown_count` is flaky. It disconnects clients (takeover, kick, normal `emqtt:stop/1`, disconnect-with-reason) and then immediately reads the `emqx_client_disconnected_reason` metrics and asserts exact counts.

The `tcp_closed` counter (from the normal `emqtt:stop/1`) is bumped **asynchronously** when the broker detects the peer socket close, which lags the client-side stop returning. So the first metric read can miss `tcp_closed`, and the assertion fails with it absent.

Observed in CI: `expected: match, got: nomatch` for the `reason="tcp_closed"} 1` line (`discarded` and `kicked` were present).

## Fix

Wrap the first (node-mode) read+assert in a `?retry` barrier. All six read points in the test read the same underlying counters, so once those are settled the aggregated/unaggregated and prometheus-text reads observe stable values.

## Verification

Ran locally on a fresh build: full suite passes, and `t_listener_shutdown_count` ran **9× with 0 failures**.

Fixing on `dev-60` (earliest branch carrying the test) so the daily sync propagates it forward to dev-61/62/63. No user impact; test-only.