### PR TITLE
feat(api_keys): allow namespace admins to manage keys in their own namespace

### DIFF
--- a/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
@@ -43,7 +43,9 @@ end_per_suite(Config) ->
 
 end_per_testcase(_, _Config) ->
     All = emqx_dashboard_admin:all_users(),
-    [emqx_dashboard_admin:remove_user(Name) || #{username := Name} <- All].
+    [emqx_dashboard_admin:remove_user(Name) || #{username := Name} <- All],
+    [emqx_mgmt_auth:delete(Name) || #{name := Name} <- emqx_mgmt_auth:list()],
+    ok.
 
 %%------------------------------------------------------------------------------
 %% Helper fns
@@ -104,6 +106,70 @@ update_api_key_api(Name, Params, AuthHeader) ->
         url => URL,
         body => Params
     }).
+
+list_api_keys_api(AuthHeader) ->
+    URL = emqx_mgmt_api_test_util:api_path(["api_key"]),
+    emqx_mgmt_api_test_util:simple_request(#{
+        auth_header => AuthHeader,
+        method => get,
+        url => URL
+    }).
+
+get_api_key_api(Name, AuthHeader) ->
+    URL = emqx_mgmt_api_test_util:api_path(["api_key", Name]),
+    emqx_mgmt_api_test_util:simple_request(#{
+        auth_header => AuthHeader,
+        method => get,
+        url => URL
+    }).
+
+delete_api_key_api(Name, AuthHeader) ->
+    URL = emqx_mgmt_api_test_util:api_path(["api_key", Name]),
+    emqx_mgmt_api_test_util:simple_request(#{
+        auth_header => AuthHeader,
+        method => delete,
+        url => URL
+    }).
+
+%% Create a namespaced dashboard administrator and return their bearer auth
+%% header. Used to exercise namespace-scoped API-key management (issue #17728).
+create_namespaced_admin(Namespace, GlobalAdminHeader) ->
+    Username = <<"nsadmin_", Namespace/binary>>,
+    Password = <<"superSecureP@ss1">>,
+    Role = <<"ns:", Namespace/binary, "::", ?ROLE_SUPERUSER/binary>>,
+    {200, _} = create_user_api(
+        #{
+            <<"username">> => Username,
+            <<"password">> => Password,
+            <<"role">> => Role,
+            <<"description">> => <<"namespaced admin">>
+        },
+        GlobalAdminHeader
+    ),
+    {200, #{<<"token">> := Token}} =
+        login(#{<<"username">> => Username, <<"password">> => Password}),
+    bearer_auth_header(Token).
+
+%% Create an API key scoped to `Namespace' (or global when `?global_ns') as the
+%% global administrator, returning the key name.
+create_key_in_namespace(Name, Namespace, GlobalAdminHeader) ->
+    ExpiresAt = to_rfc3339(erlang:system_time(second) + 1_000),
+    Role =
+        case Namespace of
+            global -> ?ROLE_SUPERUSER;
+            _ -> <<"ns:", Namespace/binary, "::", ?ROLE_SUPERUSER/binary>>
+        end,
+    {200, _} = create_api_key_api(
+        #{
+            <<"name">> => Name,
+            <<"expired_at">> => ExpiresAt,
+            <<"desc">> => <<"seed key">>,
+            <<"enable">> => true,
+            <<"role">> => Role
+        },
+        GlobalAdminHeader
+    ),
+    Name.
 
 to_rfc3339(Sec) ->
     list_to_binary(calendar:system_time_to_rfc3339(Sec)).
@@ -819,6 +885,183 @@ t_api_key_namespace_field_absent(_TCConfig) ->
             GlobalAdminHeader
         )
     ),
+    ok.
+
+-doc """
+A namespaced administrator may create an API key within their own namespace
+(issue #17728).
+""".
+t_ns_admin_create_own_namespace(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    NsAdminHeader = create_namespaced_admin(<<"ns1">>, GlobalAdminHeader),
+    ExpiresAt = to_rfc3339(erlang:system_time(second) + 1_000),
+    ?assertMatch(
+        {200, #{
+            <<"role">> := <<"administrator">>,
+            <<"namespace">> := <<"ns1">>
+        }},
+        create_api_key_api(
+            #{
+                <<"name">> => <<"ownkey">>,
+                <<"expired_at">> => ExpiresAt,
+                <<"desc">> => <<"own namespace key">>,
+                <<"enable">> => true,
+                <<"role">> => <<"administrator">>,
+                <<"namespace">> => <<"ns1">>
+            },
+            NsAdminHeader
+        )
+    ),
+    ok.
+
+-doc """
+A namespaced administrator may not create a global API key (issue #17728).
+""".
+t_ns_admin_create_global_forbidden(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    NsAdminHeader = create_namespaced_admin(<<"ns1">>, GlobalAdminHeader),
+    ExpiresAt = to_rfc3339(erlang:system_time(second) + 1_000),
+    ?assertMatch(
+        {403, _},
+        create_api_key_api(
+            #{
+                <<"name">> => <<"globalkey">>,
+                <<"expired_at">> => ExpiresAt,
+                <<"desc">> => <<"global key attempt">>,
+                <<"enable">> => true,
+                <<"role">> => <<"administrator">>
+            },
+            NsAdminHeader
+        )
+    ),
+    ok.
+
+-doc """
+A namespaced administrator may not create an API key in another namespace
+(issue #17728).
+""".
+t_ns_admin_create_other_namespace_forbidden(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    NsAdminHeader = create_namespaced_admin(<<"ns1">>, GlobalAdminHeader),
+    ExpiresAt = to_rfc3339(erlang:system_time(second) + 1_000),
+    ?assertMatch(
+        {403, _},
+        create_api_key_api(
+            #{
+                <<"name">> => <<"otherkey">>,
+                <<"expired_at">> => ExpiresAt,
+                <<"desc">> => <<"other namespace attempt">>,
+                <<"enable">> => true,
+                <<"role">> => <<"administrator">>,
+                <<"namespace">> => <<"ns2">>
+            },
+            NsAdminHeader
+        )
+    ),
+    ok.
+
+-doc """
+A namespaced administrator listing API keys sees only the keys in their own
+namespace -- not global keys nor keys in other namespaces (issue #17728).
+""".
+t_ns_admin_list_scoped(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    NsAdminHeader = create_namespaced_admin(<<"ns1">>, GlobalAdminHeader),
+    _ = create_key_in_namespace(<<"globalkey">>, global, GlobalAdminHeader),
+    _ = create_key_in_namespace(<<"ns1key">>, <<"ns1">>, GlobalAdminHeader),
+    _ = create_key_in_namespace(<<"ns2key">>, <<"ns2">>, GlobalAdminHeader),
+    %% Global admin sees all three.
+    {200, AllKeys} = list_api_keys_api(GlobalAdminHeader),
+    AllNames = [N || #{<<"name">> := N} <- AllKeys],
+    ?assert(lists:member(<<"globalkey">>, AllNames)),
+    ?assert(lists:member(<<"ns1key">>, AllNames)),
+    ?assert(lists:member(<<"ns2key">>, AllNames)),
+    %% Namespaced admin sees only its own namespace's key.
+    {200, NsKeys} = list_api_keys_api(NsAdminHeader),
+    ?assertEqual(
+        [<<"ns1key">>],
+        [N || #{<<"name">> := N} <- NsKeys]
+    ),
+    ?assertMatch(
+        [#{<<"namespace">> := <<"ns1">>}],
+        NsKeys
+    ),
+    ok.
+
+-doc """
+A namespaced administrator gets 404 (not 403) when reading an API key in another
+namespace, so the key's existence is not leaked (issue #17728).
+""".
+t_ns_admin_get_other_namespace_404(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    NsAdminHeader = create_namespaced_admin(<<"ns1">>, GlobalAdminHeader),
+    _ = create_key_in_namespace(<<"ns2key">>, <<"ns2">>, GlobalAdminHeader),
+    ?assertMatch({404, _}, get_api_key_api(<<"ns2key">>, NsAdminHeader)),
+    ok.
+
+-doc """
+A namespaced administrator may update an API key in their own namespace, but a
+request that would move it to another namespace is rejected; updating a key in
+another namespace returns 404 (issue #17728).
+""".
+t_ns_admin_put_own_and_change_namespace(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    NsAdminHeader = create_namespaced_admin(<<"ns1">>, GlobalAdminHeader),
+    _ = create_key_in_namespace(<<"ns1key">>, <<"ns1">>, GlobalAdminHeader),
+    _ = create_key_in_namespace(<<"ns2key">>, <<"ns2">>, GlobalAdminHeader),
+    %% Update own key (keeping the same namespace) is allowed.
+    ?assertMatch(
+        {200, #{<<"namespace">> := <<"ns1">>, <<"desc">> := <<"updated">>}},
+        update_api_key_api(
+            <<"ns1key">>,
+            #{
+                <<"role">> => <<"administrator">>,
+                <<"namespace">> => <<"ns1">>,
+                <<"desc">> => <<"updated">>
+            },
+            NsAdminHeader
+        )
+    ),
+    %% Attempting to move the key to another namespace is rejected with 400 by
+    %% the storage layer (changing a key's namespace is forbidden).
+    ?assertMatch(
+        {400, #{<<"message">> := <<"changing_namespace_is_forbidden">>}},
+        update_api_key_api(
+            <<"ns1key">>,
+            #{
+                <<"role">> => <<"administrator">>,
+                <<"namespace">> => <<"ns2">>,
+                <<"desc">> => <<"shouldn't work">>
+            },
+            NsAdminHeader
+        )
+    ),
+    %% Updating a key in another namespace is hidden as 404.
+    ?assertMatch(
+        {404, _},
+        update_api_key_api(
+            <<"ns2key">>,
+            #{
+                <<"role">> => <<"administrator">>,
+                <<"namespace">> => <<"ns2">>,
+                <<"desc">> => <<"shouldn't work">>
+            },
+            NsAdminHeader
+        )
+    ),
+    ok.
+
+-doc """
+A namespaced administrator gets 404 when deleting an API key in another
+namespace, and the key remains (issue #17728).
+""".
+t_ns_admin_delete_other_namespace_404(_TCConfig) ->
+    GlobalAdminHeader = create_superuser(),
+    NsAdminHeader = create_namespaced_admin(<<"ns1">>, GlobalAdminHeader),
+    _ = create_key_in_namespace(<<"ns2key">>, <<"ns2">>, GlobalAdminHeader),
+    ?assertMatch({404, _}, delete_api_key_api(<<"ns2key">>, NsAdminHeader)),
+    %% The key still exists for the global admin.
+    ?assertMatch({200, _}, get_api_key_api(<<"ns2key">>, GlobalAdminHeader)),
     ok.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -47,6 +47,7 @@
 -define(CLIENTS_API(METHOD, FN), ?API(emqx_mgmt_api_clients, METHOD, FN)).
 -define(RETAINER_API(METHOD, FN), ?API(emqx_retainer_api, METHOD, FN)).
 -define(DELAYED_API(METHOD, FN), ?API(emqx_delayed_api, METHOD, FN)).
+-define(API_KEY_API(METHOD, FN), ?API(emqx_mgmt_api_api_keys, METHOD, FN)).
 
 %%=====================================================================
 %% API
@@ -356,6 +357,14 @@ do_check_rbac(
     %% file management.  The handlers isolate each namespace to its own backup
     %% directory, so a namespaced administrator only ever sees or acts on its
     %% own archives, never global (or legacy) ones.
+    true;
+do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := Namespace}, _Req, ?API_KEY_API(_, _)) when
+    is_binary(Namespace)
+->
+    %% Namespaced administrators may manage API keys within their own namespace.
+    %% The handler enforces that the request's effective namespace (create) or the
+    %% target key's namespace (read/update/delete) matches the caller's; global and
+    %% cross-namespace keys are rejected or hidden there.
     true;
 do_check_rbac(_, _, _) ->
     {error, <<"You don't have permission to access this resource">>}.

--- a/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
@@ -61,7 +61,8 @@ schema("/api_key") ->
             'requestBody' => delete([created_at, api_key, api_secret], fields(app)),
             responses => #{
                 200 => hoconsc:ref(app_response),
-                400 => emqx_dashboard_swagger:error_codes(['BAD_REQUEST'])
+                400 => emqx_dashboard_swagger:error_codes(['BAD_REQUEST']),
+                403 => emqx_dashboard_swagger:error_codes(['FORBIDDEN'])
             }
         }
     };
@@ -84,6 +85,7 @@ schema("/api_key/:name") ->
             'requestBody' => delete([created_at, api_key, api_secret, name], fields(app)),
             responses => #{
                 200 => delete([api_secret], fields(app_response)),
+                400 => emqx_dashboard_swagger:error_codes(['BAD_REQUEST']),
                 404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'])
             }
         },
@@ -307,9 +309,11 @@ validate_name(Name) ->
 delete(Keys, Fields) ->
     lists:foldl(fun(Key, Acc) -> lists:keydelete(Key, 1, Acc) end, Fields, Keys).
 
-api_key(get, _) ->
-    {200, [emqx_mgmt_auth:format(App) || App <- emqx_mgmt_auth:list()]};
-api_key(post, #{body := App}) ->
+api_key(get, Req) ->
+    CallerNs = emqx_dashboard:get_namespace(Req),
+    Apps = [App || App <- emqx_mgmt_auth:list(), namespace_accessible(CallerNs, App)],
+    {200, [emqx_mgmt_auth:format(App) || App <- Apps]};
+api_key(post, #{body := App} = Req) ->
     #{
         <<"name">> := Name,
         <<"desc">> := Desc0,
@@ -319,9 +323,14 @@ api_key(post, #{body := App}) ->
     Desc = unicode:characters_to_binary(Desc0, unicode),
     Role0 = maps:get(<<"role">>, App, ?ROLE_API_DEFAULT),
     Namespace = maps:get(<<"namespace">>, App, undefined),
-    case resolve_effective_role(Role0, Namespace) of
-        {ok, Role} ->
-            create_api_key(App, Name, Enable, ExpiredAt, Desc, Role);
+    CallerNs = emqx_dashboard:get_namespace(Req),
+    maybe
+        {ok, Role} ?= resolve_effective_role(Role0, Namespace),
+        ok ?= authorize_target_namespace(CallerNs, role_namespace(Role)),
+        create_api_key(App, Name, Enable, ExpiredAt, Desc, Role)
+    else
+        {error, forbidden, Msg} ->
+            {403, #{code => 'FORBIDDEN', message => Msg}};
         {error, Msg} ->
             {400, #{code => 'BAD_REQUEST', message => Msg}}
     end.
@@ -355,24 +364,41 @@ create_api_key(App, Name, Enable, ExpiredAt, Desc, Role) ->
 
 -define(NOT_FOUND_RESPONSE, #{code => 'NOT_FOUND', message => ?DESC("name_not_found")}).
 
-api_key_by_name(get, #{bindings := #{name := Name}}) ->
-    case emqx_mgmt_auth:read(Name) of
+api_key_by_name(get, #{bindings := #{name := Name}} = Req) ->
+    CallerNs = emqx_dashboard:get_namespace(Req),
+    case read_in_namespace(CallerNs, Name) of
         {ok, App} -> {200, emqx_mgmt_auth:format(App)};
         {error, not_found} -> {404, ?NOT_FOUND_RESPONSE}
     end;
-api_key_by_name(delete, #{bindings := #{name := Name}}) ->
-    case emqx_mgmt_auth:delete(Name) of
-        {ok, _} -> {204};
-        {error, not_found} -> {404, ?NOT_FOUND_RESPONSE}
+api_key_by_name(delete, #{bindings := #{name := Name}} = Req) ->
+    CallerNs = emqx_dashboard:get_namespace(Req),
+    case read_in_namespace(CallerNs, Name) of
+        {ok, _App} ->
+            case emqx_mgmt_auth:delete(Name) of
+                {ok, _} -> {204};
+                {error, not_found} -> {404, ?NOT_FOUND_RESPONSE}
+            end;
+        {error, not_found} ->
+            {404, ?NOT_FOUND_RESPONSE}
     end;
-api_key_by_name(put, #{bindings := #{name := Name}, body := Body}) ->
+api_key_by_name(put, #{bindings := #{name := Name}, body := Body} = Req) ->
+    CallerNs = emqx_dashboard:get_namespace(Req),
     Role0 = maps:get(<<"role">>, Body, ?ROLE_API_DEFAULT),
     Namespace = maps:get(<<"namespace">>, Body, undefined),
-    case resolve_effective_role(Role0, Namespace) of
-        {ok, Role} ->
-            update_api_key(Name, Role, Body);
-        {error, Msg} ->
-            {400, #{code => 'BAD_REQUEST', message => Msg}}
+    case read_in_namespace(CallerNs, Name) of
+        {ok, _App} ->
+            case resolve_effective_role(Role0, Namespace) of
+                {ok, Role} ->
+                    %% A move into another namespace is rejected with 400 by
+                    %% `emqx_mgmt_auth:update/6' (changing_namespace_is_forbidden).
+                    update_api_key(Name, Role, Body);
+                {error, Msg} ->
+                    {400, #{code => 'BAD_REQUEST', message => Msg}}
+            end;
+        {error, not_found} ->
+            %% A key in another namespace is reported as not found so its
+            %% existence is not leaked to a namespaced administrator.
+            {404, ?NOT_FOUND_RESPONSE}
     end.
 
 update_api_key(Name, Role, Body) ->
@@ -460,6 +486,45 @@ namespace_mismatch_msg(RoleNs, FieldNs) ->
         FieldNs,
         <<"'">>
     ]).
+
+%% The namespace an effective role string resolves to (`?global_ns' or a binary).
+role_namespace(Role) ->
+    case emqx_dashboard_rbac:parse_api_role(Role) of
+        {ok, #{?namespace := Ns}} -> Ns;
+        _ -> ?global_ns
+    end.
+
+%% A global caller may create keys in any namespace (including global); a
+%% namespaced caller may only create keys in its own namespace.
+authorize_target_namespace(?global_ns, _TargetNs) ->
+    ok;
+authorize_target_namespace(CallerNs, CallerNs) ->
+    ok;
+authorize_target_namespace(_CallerNs, _TargetNs) ->
+    {error, forbidden, <<"You may only manage API keys within your own namespace">>}.
+
+%% A global caller sees every key; a namespaced caller sees only keys in its
+%% own namespace. `KeyApp' is a formatted-or-raw map carrying a `namespace' key.
+namespace_accessible(?global_ns, _KeyApp) ->
+    true;
+namespace_accessible(CallerNs, #{namespace := CallerNs}) ->
+    true;
+namespace_accessible(_CallerNs, _KeyApp) ->
+    false.
+
+%% Read a key only if it is visible to the caller's namespace. A key in a
+%% different namespace is reported as `not_found' so its existence is not
+%% leaked to a namespaced administrator.
+read_in_namespace(CallerNs, Name) ->
+    case emqx_mgmt_auth:read(Name) of
+        {ok, App} ->
+            case namespace_accessible(CallerNs, App) of
+                true -> {ok, App};
+                false -> {error, not_found}
+            end;
+        {error, not_found} ->
+            {error, not_found}
+    end.
 
 api_key_scopes(get, _) ->
     Scopes = [resolve_scope_desc(S) || S <- emqx_scope_catalog:scope_catalog()],

--- a/changes/ee/feat-17855.en.md
+++ b/changes/ee/feat-17855.en.md
@@ -1,0 +1,1 @@
+Namespace-scoped dashboard administrators can now create, list, read, update, and delete API keys within their own namespace. They cannot create global API keys or keys in another namespace, and API keys outside their namespace are hidden from them.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Allow namespace-scoped dashboard administrators to manage API keys within their own namespace. Adds an RBAC clause permitting a namespaced admin to reach the API-key management endpoints, and enforces in the handler that they may only operate within their own namespace:

- create: the request's effective namespace must equal the caller's; global and cross-namespace creates are rejected with 403.
- list/read: only keys in the caller's namespace are visible; keys in other namespaces are hidden (list filtered, read returns 404).
- update/delete: keys outside the caller's namespace return 404; moving a key to another namespace stays rejected with 400.

A global administrator keeps full cross-namespace access.

Main changes: `apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl` (RBAC clause) and `apps/emqx_management/src/emqx_mgmt_api_api_keys.erl` (per-namespace enforcement).

Depends on #17732 (both target `dev-60`). Closes #17728

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
