### PR TITLE
fix(connector/mqtt): Fix unsupported IPv6

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -3618,8 +3618,6 @@ do_parse_server(Str, Opts) ->
         false ->
             ok
     end,
-    %% do not split with space, there should be no space allowed between host and port
-    Tokens = string:tokens(Str, ":"),
     Context = #{
         not_expecting_port => NotExpectingPort,
         not_expecting_scheme => NotExpectingScheme,
@@ -3627,106 +3625,83 @@ do_parse_server(Str, Opts) ->
         default_scheme => DefaultScheme,
         opts => Opts
     },
-    Parsed = check_server_parts(Tokens, Context),
+    Parsed = check_server_parts(parse_server_uri(Str), Context),
     maybe_check_ssrf(Parsed, Opts),
     Parsed.
 
-check_server_parts([Scheme, "//" ++ Hostname, Port], Context) ->
-    #{
-        not_expecting_scheme := NotExpectingScheme,
-        not_expecting_port := NotExpectingPort,
-        opts := Opts
-    } = Context,
+%% @doc Split `[scheme://]host[:port]' via emqx_utils_uri:parse/1 (URI-aware, handles `[ipv6]').
+parse_server_uri(Str) ->
+    Bin = iolist_to_binary(Str),
+    %% parse/1 only sees host/port inside a `//' authority; add one when scheme-less.
+    URIString =
+        case binary:match(Bin, <<"//">>) of
+            nomatch -> <<"//", Bin/binary>>;
+            _ -> Bin
+        end,
+    #{scheme := Scheme, authority := Authority} = emqx_utils_uri:parse(URIString),
+    {uri_scheme(Scheme), Authority}.
+
+uri_scheme(undefined) -> undefined;
+uri_scheme(Scheme) -> binary_to_list(Scheme).
+
+%% parse/1 only splits; connector-specific validation and error reasons live here.
+check_server_parts({_Scheme, undefined}, _Context) ->
+    %% no authority parsed at all (e.g. empty input)
+    throw("bad_host_port");
+check_server_parts({Scheme, #{host_type := HostType, host := HostBin, port := Port}}, Context) ->
+    check_authority(Scheme, HostType, binary_to_list(HostBin), Port, Context).
+
+%% Empty host, e.g. ":1883" — keep the historical numeric-hostname error.
+check_authority(_Scheme, _HostType, "", Port, _Context) when is_integer(Port) ->
+    throw("expecting_hostname_but_got_a_number");
+check_authority(_Scheme, _HostType, "", _Port, _Context) ->
+    throw("bad_host_port");
+%% `loose' = stray colon that isn't a valid `:port' (e.g. "host:33x", "host:name:80").
+check_authority(_Scheme, loose, Host, Port, Context) ->
+    #{not_expecting_port := NotExpectingPort} = Context,
     NotExpectingPort andalso throw("not_expecting_port_number"),
-    NotExpectingScheme andalso throw("not_expecting_scheme"),
-    #{
-        scheme => check_scheme(Scheme, Opts),
-        hostname => check_hostname(Hostname),
-        port => parse_port_(Port)
-    };
-check_server_parts([Scheme, "//" ++ Hostname], Context) ->
+    case {Port, string:tokens(Host, ":")} of
+        {undefined, [_Host, _BadPort]} -> throw("bad_port_number");
+        _ -> throw("bad_host_port")
+    end;
+check_authority(Scheme, _HostType, Host, Port, Context) ->
     #{
         not_expecting_scheme := NotExpectingScheme,
         not_expecting_port := NotExpectingPort,
         default_port := DefaultPort,
+        default_scheme := DefaultScheme,
         opts := Opts
     } = Context,
+    SchemePart = check_server_scheme(Scheme, NotExpectingScheme, DefaultScheme, Opts),
+    PortPart = check_server_port(Port, NotExpectingPort, DefaultPort),
+    maps:merge(#{hostname => check_hostname(Host)}, maps:merge(SchemePart, PortPart)).
+
+check_server_scheme(undefined, _NotExpectingScheme, DefaultScheme, _Opts) when
+    is_list(DefaultScheme)
+->
+    #{scheme => DefaultScheme};
+check_server_scheme(undefined, true, _DefaultScheme, _Opts) ->
+    #{};
+check_server_scheme(undefined, false, _DefaultScheme, _Opts) ->
+    throw("missing_scheme");
+check_server_scheme(Scheme, NotExpectingScheme, _DefaultScheme, Opts) ->
     NotExpectingScheme andalso throw("not_expecting_scheme"),
-    case is_integer(DefaultPort) of
-        true ->
-            #{
-                scheme => check_scheme(Scheme, Opts),
-                hostname => check_hostname(Hostname),
-                port => DefaultPort
-            };
-        false when NotExpectingPort ->
-            #{
-                scheme => check_scheme(Scheme, Opts),
-                hostname => check_hostname(Hostname)
-            };
-        false ->
-            throw("missing_port_number")
-    end;
-check_server_parts([Hostname, Port], Context) ->
-    #{
-        not_expecting_port := NotExpectingPort,
-        default_scheme := DefaultScheme
-    } = Context,
+    #{scheme => check_scheme(Scheme, Opts)}.
+
+check_server_port(undefined, _NotExpectingPort, DefaultPort) when is_integer(DefaultPort) ->
+    #{port => DefaultPort};
+check_server_port(undefined, true, _DefaultPort) ->
+    #{};
+check_server_port(undefined, false, _DefaultPort) ->
+    throw("missing_port_number");
+check_server_port(Port, NotExpectingPort, _DefaultPort) when is_integer(Port) ->
     NotExpectingPort andalso throw("not_expecting_port_number"),
-    case is_list(DefaultScheme) of
-        false ->
-            #{
-                hostname => check_hostname(Hostname),
-                port => parse_port_(Port)
-            };
-        true ->
-            #{
-                scheme => DefaultScheme,
-                hostname => check_hostname(Hostname),
-                port => parse_port_(Port)
-            }
-    end;
-check_server_parts([Hostname], Context) ->
-    #{
-        not_expecting_scheme := NotExpectingScheme,
-        not_expecting_port := NotExpectingPort,
-        default_port := DefaultPort,
-        default_scheme := DefaultScheme
-    } = Context,
-    case is_integer(DefaultPort) orelse NotExpectingPort of
-        true ->
-            ok;
-        false ->
-            throw("missing_port_number")
-    end,
-    case is_list(DefaultScheme) orelse NotExpectingScheme of
-        true ->
-            ok;
-        false ->
-            throw("missing_scheme")
-    end,
-    case {is_integer(DefaultPort), is_list(DefaultScheme)} of
-        {true, true} ->
-            #{
-                scheme => DefaultScheme,
-                hostname => check_hostname(Hostname),
-                port => DefaultPort
-            };
-        {true, false} ->
-            #{
-                hostname => check_hostname(Hostname),
-                port => DefaultPort
-            };
-        {false, true} ->
-            #{
-                scheme => DefaultScheme,
-                hostname => check_hostname(Hostname)
-            };
-        {false, false} ->
-            #{hostname => check_hostname(Hostname)}
-    end;
-check_server_parts(_Tokens, _Context) ->
-    throw("bad_host_port").
+    #{port => check_port_range(Port)}.
+
+check_port_range(Port) when Port > 65535 ->
+    throw("port_number_too_large");
+check_port_range(Port) ->
+    Port.
 
 check_scheme(Str, Opts) ->
     SupportedSchemes = maps:get(supported_schemes, Opts, []),
@@ -3783,12 +3758,6 @@ convert_hocon_map_host_port(Map) ->
 is_port_number(Str) ->
     {Status, _} = parse_port(Str),
     Status == ok.
-
-parse_port_(Str) ->
-    case parse_port(Str) of
-        {ok, Port} -> Port;
-        {error, Reason} -> throw(Reason)
-    end.
 
 parse_port(Port) ->
     case string:to_integer(string:strip(Port)) of

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -697,6 +697,50 @@ parse_server_test_() ->
                     }
                 )
             )
+        ),
+        ?T(
+            "ipv6 in brackets, no port",
+            ?assertEqual(
+                [#{hostname => "::1", port => DefaultPort}],
+                Parse(<<"[::1]">>)
+            )
+        ),
+        ?T(
+            "ipv6 in brackets, with port",
+            ?assertEqual(
+                [#{hostname => "::1", port => 9999}],
+                Parse(<<"[::1]:9999">>)
+            )
+        ),
+        ?T(
+            "full ipv6 in brackets, with port",
+            ?assertEqual(
+                [#{hostname => "2a00:1098:2b::1:2e12:3a1f", port => 1877}],
+                Parse(<<"[2a00:1098:2b::1:2e12:3a1f]:1877">>)
+            )
+        ),
+        ?T(
+            "ipv6 in brackets with scheme and port",
+            ?assertEqual(
+                #{scheme => "pulsar+ssl", hostname => "::1", port => 6651},
+                emqx_schema:parse_server(
+                    "pulsar+ssl://[::1]:6651",
+                    #{
+                        default_port => 6650,
+                        supported_schemes => ["pulsar", "pulsar+ssl"]
+                    }
+                )
+            )
+        ),
+        ?T(
+            "multiple ipv6 servers in brackets, with ports",
+            ?assertEqual(
+                [
+                    #{hostname => "::1", port => 1234},
+                    #{hostname => "fe80::1", port => 2345}
+                ],
+                Parse("[::1]:1234, [fe80::1]:2345")
+            )
         )
     ].
 

--- a/apps/emqx_bridge_mqtt/mix.exs
+++ b/apps/emqx_bridge_mqtt/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeMQTT.MixProject do
   def project do
     [
       app: :emqx_bridge_mqtt,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -621,7 +621,11 @@ mk_ecpool_client_opts(
         namespace := Namespace
     } =
         emqx_connector_resource:parse_connector_id(ConnResId, #{atom_name => false}),
-    TcpOpts = emqx_schema:client_tcp_opts_to_proplist(maps:get(tcp_opts, Config, #{})),
+    %% `ipv6_probe' lets the client reach an IPv6-only broker (e.g. a host that
+    %% only resolves to an AAAA record); without it the connect defaults to IPv4.
+    TcpOpts = emqx_utils:ipv6_probe(
+        emqx_schema:client_tcp_opts_to_proplist(maps:get(tcp_opts, Config, #{}))
+    ),
     Options#{
         hosts => [HostPort],
         clientid => clientid(Namespace, Name, Config),

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
@@ -39,7 +39,14 @@
 %% reject creating an unrelated valid connector whenever any sibling connector's
 %% `server' is denied by the current SSRF policy. The check is enforced per
 %% connector in `emqx_connector_resource:parse_confs/3' instead.
--define(MQTT_HOST_OPTS, #{default_port => 1883}).
+%% The official MQTT URI schemes: `mqtt' for plain TCP and `mqtts' for TLS.
+%% See https://github.com/mqtt/mqtt.org/wiki/URI-Scheme
+%% A scheme-less `host:port' is accepted and defaults to `mqtt'.
+-define(MQTT_HOST_OPTS, #{
+    default_port => 1883,
+    default_scheme => "mqtt",
+    supported_schemes => ["mqtt", "mqtts"]
+}).
 
 namespace() -> "connector_mqtt".
 

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_schema_tests.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_schema_tests.erl
@@ -352,5 +352,54 @@ schema_test_() ->
                 ?assertEqual([], emqx_schema:client_tcp_opts_to_proplist(undefined)),
                 Partial = emqx_schema:client_tcp_opts_to_proplist(#{nodelay => false}),
                 ?assertEqual([{nodelay, false}], Partial)
-            end)}
+            end)},
+        %% The official MQTT URI schemes are `mqtt' (plain TCP) and `mqtts' (TLS).
+        %% See https://github.com/mqtt/mqtt.org/wiki/URI-Scheme
+        {"server : bare host:port (no scheme) is accepted",
+            ?_assertMatch(
+                #{<<"server">> := <<"127.0.0.1:1883">>},
+                parse_and_check_connector(
+                    connector_config(#{<<"server">> => <<"127.0.0.1:1883">>})
+                )
+            )},
+        {"server : mqtt://host:port is accepted",
+            ?_assertMatch(
+                #{<<"server">> := <<"mqtt://broker.example:1883">>},
+                parse_and_check_connector(
+                    connector_config(#{<<"server">> => <<"mqtt://broker.example:1883">>})
+                )
+            )},
+        {"server : mqtt://ip:port is accepted",
+            ?_assertMatch(
+                #{<<"server">> := <<"mqtt://127.0.0.1:1883">>},
+                parse_and_check_connector(
+                    connector_config(#{<<"server">> => <<"mqtt://127.0.0.1:1883">>})
+                )
+            )},
+        {"server : mqtts://host:port is accepted",
+            ?_assertMatch(
+                #{<<"server">> := <<"mqtts://broker.example:8883">>},
+                parse_and_check_connector(
+                    connector_config(#{<<"server">> => <<"mqtts://broker.example:8883">>})
+                )
+            )},
+        {"server : mqtt://[ipv6]:port is accepted",
+            ?_assertMatch(
+                #{<<"server">> := <<"mqtt://[::1]:1883">>},
+                parse_and_check_connector(
+                    connector_config(#{<<"server">> => <<"mqtt://[::1]:1883">>})
+                )
+            )},
+        {"server : unsupported scheme is rejected",
+            ?_assertThrow(
+                {_SchemaMod, [
+                    #{
+                        reason := "unsupported_scheme",
+                        kind := validation_error
+                    }
+                ]},
+                parse_and_check_connector(
+                    connector_config(#{<<"server">> => <<"tcp://broker.example:1883">>})
+                )
+            )}
     ].

--- a/apps/emqx_cluster_link/mix.exs
+++ b/apps/emqx_cluster_link/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXClusterLink.MixProject do
   def project do
     [
       app: :emqx_cluster_link,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
@@ -11,7 +11,14 @@
 -define(LINKS_PATH, [cluster, links]).
 -define(CERTS_PATH(LinkName), filename:join(["cluster", "links", LinkName])).
 
--define(MQTT_HOST_OPTS, #{default_port => 1883}).
+%% The official MQTT URI schemes: `mqtt' for plain TCP and `mqtts' for TLS.
+%% See https://github.com/mqtt/mqtt.org/wiki/URI-Scheme
+%% A scheme-less `host:port' is accepted and defaults to `mqtt'.
+-define(MQTT_HOST_OPTS, #{
+    default_port => 1883,
+    default_scheme => "mqtt",
+    supported_schemes => ["mqtt", "mqtts"]
+}).
 
 -ifndef(TEST).
 -define(DEFAULT_ACTOR_TTL, 30_000).

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
@@ -42,7 +42,14 @@
     atom() => _
 }.
 
--define(MQTT_HOST_OPTS, #{default_port => 1883}).
+%% The official MQTT URI schemes: `mqtt' for plain TCP and `mqtts' for TLS.
+%% See https://github.com/mqtt/mqtt.org/wiki/URI-Scheme
+%% A scheme-less `host:port' is accepted and defaults to `mqtt'.
+-define(MQTT_HOST_OPTS, #{
+    default_port => 1883,
+    default_scheme => "mqtt",
+    supported_schemes => ["mqtt", "mqtts"]
+}).
 
 namespace() -> "cluster".
 

--- a/changes/ee/fix-17859.en.md
+++ b/changes/ee/fix-17859.en.md
@@ -1,0 +1,7 @@
+Fixed the MQTT connector so it can connect to IPv6 brokers.
+
+Previously, configuring an MQTT connector to an IPv6 broker failed in two ways: an IPv6 literal such as `[::1]:1883` was rejected at save time with a `bad_host_port` validation error, and a hostname that only resolves to an IPv6 (`AAAA`) address failed to connect with a "Could not resolve host" error because the connection defaulted to IPv4.
+
+The server address parser now accepts bracketed IPv6 literals (for example `[::1]`, `[::1]:1883`, and `mqtt://[::1]:1883`), and the MQTT connector now enables IPv6 probing when connecting, so IPv6-only brokers can be reached.
+
+The MQTT connector and cluster link `server` address now accept the official MQTT URI schemes `mqtt` (plain TCP) and `mqtts` (TLS), for example `mqtt://broker:1883` and `mqtts://broker:8883`. A scheme-less `host:port` is still accepted. Any other scheme is now rejected with an `unsupported_scheme` validation error.


### PR DESCRIPTION
Release version:
<!-- uncomment for v5:
5.8.12, 5.10.5
-->

6.0.4, 6.1.3, 6.2.2

## Summary

Previously, configuring an MQTT connector to an IPv6 broker failed in two ways: an IPv6 literal such as `[::1]:1883` was rejected at save time with a `bad_host_port` validation error, and a hostname that only resolves to an IPv6 (`AAAA`) address failed to connect with a "Could not resolve host" error because the connection defaulted to IPv4.

The server address parser now accepts bracketed IPv6 literals (for example `[::1]`, `[::1]:1883`, and `mqtt-tcp://[::1]:1883`), and the MQTT connector now enables IPv6 probing when connecting, so IPv6-only brokers can be reached. Fixes #17858 


## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
-->
