### PR TITLE
Validate PostgreSQL application_name config

### DIFF
--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -34,6 +34,8 @@
 
 -export([connect/1]).
 
+-export([validate_application_name/1]).
+
 -export([
     query/3,
     prepared_query/3,
@@ -54,6 +56,8 @@
 -define(PGSQL_HOST_OPTIONS, #{
     default_port => ?PGSQL_DEFAULT_PORT
 }).
+
+-define(MAX_APPLICATION_NAME_BYTES, 63).
 
 -type template() :: {unicode:chardata(), emqx_template_sql:row_template()}.
 -type state() ::
@@ -94,8 +98,28 @@ application_name() ->
     hoconsc:mk(binary(), #{
         default => <<"emqx">>,
         desc => ?DESC("application_name"),
-        validator => fun emqx_schema:non_empty_string/1
+        validator => fun ?MODULE:validate_application_name/1
     }).
+
+validate_application_name(ApplicationName) ->
+    case emqx_schema:non_empty_string(ApplicationName) of
+        ok ->
+            validate_application_name_binary(unicode:characters_to_binary(ApplicationName));
+        Error ->
+            Error
+    end.
+
+validate_application_name_binary(ApplicationName) when is_binary(ApplicationName) ->
+    case binary:match(ApplicationName, <<0>>) of
+        {_, _} ->
+            {error, application_name_cannot_contain_null_byte};
+        nomatch when byte_size(ApplicationName) =< ?MAX_APPLICATION_NAME_BYTES ->
+            ok;
+        nomatch ->
+            {error, application_name_too_long}
+    end;
+validate_application_name_binary(_) ->
+    {error, invalid_string}.
 
 %% ===================================================================
 resource_type() -> pgsql.

--- a/apps/emqx_postgresql/src/schema/emqx_postgresql_connector_schema.erl
+++ b/apps/emqx_postgresql/src/schema/emqx_postgresql_connector_schema.erl
@@ -92,7 +92,7 @@ application_name() ->
     hoconsc:mk(binary(), #{
         default => <<"emqx">>,
         desc => ?DESC("application_name"),
-        validator => fun emqx_schema:non_empty_string/1
+        validator => fun emqx_postgresql:validate_application_name/1
     }).
 
 %% Examples

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -67,6 +67,22 @@ t_custom_application_name_connect_option(_Config) ->
         "emqx-test-app"
     ).
 
+t_bad_application_name_config(_Config) ->
+    [
+        ?assertMatch(
+            {error, _},
+            emqx_resource:check_config(
+                ?PGSQL_RESOURCE_MOD, pgsql_config(#{application_name => Name})
+            )
+        )
+     || Name <- [
+            <<>>,
+            <<"bad", 0, "name">>,
+            binary:copy(<<"a">>, 64)
+        ]
+    ],
+    ok.
+
 assert_application_name_connect_option(ResourceId, Overrides, ExpectedApplicationName) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(

--- a/changes/ee/feat-17783.en.md
+++ b/changes/ee/feat-17783.en.md
@@ -1,1 +1,1 @@
-Added an `application_name` option to PostgreSQL-family connectors. It defaults to `emqx` and is sent as the PostgreSQL startup parameter so connector sessions can be identified in PostgreSQL activity views and logs.
+Added an `application_name` option to PostgreSQL-family connectors. It defaults to `emqx` and is sent as the PostgreSQL startup parameter so connector sessions can be identified in PostgreSQL activity views and logs. The value must be 1 to 63 bytes long and cannot contain zero bytes.

--- a/rel/i18n/emqx_postgresql.hocon
+++ b/rel/i18n/emqx_postgresql.hocon
@@ -9,7 +9,7 @@ server.label:
 """Server Host"""
 
 application_name.desc:
-"""The application name to use for PostgreSQL connections. This value appears in PostgreSQL activity views and logs."""
+"""The application name to use for PostgreSQL connections. This value appears in PostgreSQL activity views and logs. It must be 1 to 63 bytes long and cannot contain zero bytes."""
 
 application_name.label:
 """Application Name"""

--- a/rel/i18n/emqx_postgresql_connector_schema.hocon
+++ b/rel/i18n/emqx_postgresql_connector_schema.hocon
@@ -10,7 +10,7 @@ server.label:
 """Server Host"""
 
 application_name.desc:
-"""The application name to use for PostgreSQL connections. This value appears in PostgreSQL activity views and logs."""
+"""The application name to use for PostgreSQL connections. This value appears in PostgreSQL activity views and logs. It must be 1 to 63 bytes long and cannot contain zero bytes."""
 
 application_name.label:
 """Application Name"""


### PR DESCRIPTION
Fixes #17384

Release version:
6.3.0

## Summary

Follow-up to #17783. Tighten the PostgreSQL-family connector `application_name` config before it is sent in the PostgreSQL startup packet.

The field now rejects empty values, zero bytes, and values longer than 63 bytes. The existing unreleased changelog entry for #17783 was updated with the same constraint.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
