### PR TITLE
Revert "fix(plugins): purge stale plugins after cluster rejoin"

### DIFF
--- a/apps/emqx_plugins/mix.exs
+++ b/apps/emqx_plugins/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXPlugins.MixProject do
   def project do
     [
       app: :emqx_plugins,
-      version: "6.2.2",
+      version: "6.2.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -32,7 +32,6 @@
     allow_ttl_ms/0,
 
     ensure_installed/0,
-    purge_unconfigured/0,
     ensure_installed/1,
     ensure_installed/2,
 
@@ -293,23 +292,6 @@ ensure_installed() ->
     end,
     ok = for_plugins(Fun).
 
-%% @doc Purge local packages that do not belong to the current cluster config.
-%%
-%% A node may miss the cluster-wide uninstall while it is outside the cluster.
-%% When it comes back, the existing cluster config is authoritative. Keep local
-%% packages for other versions of a configured plugin app so force-sync can still
-%% switch versions after a join.
--spec purge_unconfigured() -> ok.
-purge_unconfigured() ->
-    ConfiguredNameVsns = configured_name_vsns(),
-    ConfiguredAppNames = configured_app_names(ConfiguredNameVsns),
-    lists:foreach(
-        fun(NameVsn) ->
-            maybe_purge_unconfigured(NameVsn, ConfiguredNameVsns, ConfiguredAppNames)
-        end,
-        emqx_plugins_fs:list_name_vsn()
-    ).
-
 %% @doc
 %% * Install a .tar.gz package placed in install_dir
 %% * Configure the plugin
@@ -380,7 +362,7 @@ ensure_disabled(NameVsn) ->
 %% will cause deletion of loaded beams.
 %% It should not be a problem, because shared lib should
 %% reside in all the plugin install dirs.
--spec purge(name_vsn()) -> ok | {error, term()}.
+-spec purge(name_vsn()) -> ok.
 purge(NameVsn) ->
     ?SLOG(debug, #{msg => "purge_plugin", name_vsn => NameVsn}),
     ok = delete_cached_config(NameVsn),
@@ -1025,70 +1007,6 @@ put_configured(Configured, ConfLocation) ->
 
 configured() ->
     lists:map(fun emqx_plugins_utils:normalize_state_item/1, get_config_internal(states, [])).
-
-configured_name_vsns() ->
-    lists:map(fun(#{name_vsn := NameVsn}) -> bin(NameVsn) end, configured()).
-
-configured_app_names(ConfiguredNameVsns) ->
-    lists:filtermap(
-        fun(NameVsn) ->
-            case parse_plugin_app_name(NameVsn) of
-                {ok, AppName} -> {true, AppName};
-                {error, _} -> false
-            end
-        end,
-        ConfiguredNameVsns
-    ).
-
-maybe_purge_unconfigured(NameVsn0, ConfiguredNameVsns, ConfiguredAppNames) ->
-    NameVsn = bin(NameVsn0),
-    case lists:member(NameVsn, ConfiguredNameVsns) of
-        true ->
-            ok;
-        false ->
-            case parse_plugin_app_name(NameVsn) of
-                {ok, AppName} ->
-                    case lists:member(AppName, ConfiguredAppNames) of
-                        true -> ok;
-                        false -> do_purge_unconfigured(NameVsn0)
-                    end;
-                {error, Reason} ->
-                    do_purge_unconfigured(NameVsn0, Reason)
-            end
-    end.
-
-parse_plugin_app_name(NameVsn) ->
-    try emqx_plugins_utils:parse_name_vsn(NameVsn) of
-        {AppName, _Vsn} ->
-            {ok, AppName}
-    catch
-        error:Reason ->
-            {error, Reason}
-    end.
-
-do_purge_unconfigured(NameVsn) ->
-    do_purge_unconfigured(NameVsn, not_configured).
-
-do_purge_unconfigured(NameVsn, Reason) ->
-    ?SLOG(info, #{
-        msg => "purge_unconfigured_plugin",
-        name_vsn => NameVsn,
-        reason => Reason
-    }),
-    _ = ensure_stopped(NameVsn),
-    ok = maybe_log_purge_error(NameVsn, purge(NameVsn)),
-    _ = delete_package(NameVsn),
-    ok.
-
-maybe_log_purge_error(_NameVsn, ok) ->
-    ok;
-maybe_log_purge_error(NameVsn, {error, Reason}) ->
-    ?SLOG(error, #{
-        msg => "failed_to_purge_unconfigured_plugin",
-        name_vsn => NameVsn,
-        reason => Reason
-    }),
-    ok.
 
 for_plugins(ActionFun) ->
     for_plugins(configured(), ActionFun).

--- a/apps/emqx_plugins/src/emqx_plugins_app.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_app.erl
@@ -18,7 +18,6 @@ start(_Type, _Args) ->
     %% load all pre-configured
     {ok, Sup} = emqx_plugins_sup:start_link(),
     ok = emqx_plugins:ensure_installed(),
-    ok = emqx_plugins:purge_unconfigured(),
     ok = emqx_plugins:ensure_started(),
     ok = emqx_config_handler:add_handler([?CONF_ROOT], emqx_plugins),
     ?tp("emqx_plugins_app_started", #{}),

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -52,7 +52,6 @@ groups() ->
             group_t_copy_plugin_to_a_new_node,
             group_t_copy_plugin_to_a_new_node_single_node,
             group_t_cluster_leave,
-            group_t_cluster_rejoin_after_uninstall,
             group_t_cluster_force_sync_vsn
         ]},
         {create_tar_copy_plugin, [sequence], [group_t_copy_plugin_to_a_new_node]}
@@ -71,7 +70,7 @@ init_per_suite(Config) ->
     InstallDir = filename:join([WorkDir, "plugins"]),
     Apps = emqx_cth_suite:start(
         [
-            {emqx_conf, #{config => isolated_listener_config()}},
+            emqx_conf,
             emqx_ctl,
             {emqx_plugins, #{config => #{plugins => #{install_dir => InstallDir}}}}
         ],
@@ -82,19 +81,6 @@ init_per_suite(Config) ->
 
 end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
-
-isolated_listener_config() ->
-    #{
-        listeners =>
-            maps:from_list([
-                {Type, #{default => #{bind => listener_bind()}}}
-             || Type <- [tcp, ssl, ws, wss]
-            ])
-    }.
-
-listener_bind() ->
-    Port = emqx_common_test_helpers:select_free_port(tcp),
-    iolist_to_binary(io_lib:format("127.0.0.1:~B", [Port])).
 
 init_per_testcase(TestCase, Config) ->
     emqx_plugins_test_helpers:purge_plugins(),
@@ -939,143 +925,6 @@ group_t_cluster_leave(Config) ->
         erpc:call(N2, emqx_mgmt_api_plugins, list_plugins, [get, Params])
     ),
     ok.
-
-group_t_cluster_rejoin_after_uninstall({init, Config}) ->
-    Specs = emqx_cth_cluster:mk_nodespecs(
-        [
-            {plugin_rejoin_clean1, #{
-                role => core, apps => [emqx, emqx_conf, emqx_ctl]
-            }},
-            {plugin_rejoin_clean2, #{
-                role => core, apps => [emqx, emqx_conf, emqx_ctl]
-            }}
-        ],
-        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
-    ),
-    Nodes = emqx_cth_cluster:start(Specs),
-    InstallRelDir = "plugins_rejoin_after_uninstall",
-    InstallDirs = [filename:join(WD, InstallRelDir) || #{work_dir := WD} <- Specs],
-    ok = lists:foreach(fun filelib:ensure_path/1, InstallDirs),
-    [#{package := Package} | _] = [make_minimal_plugin_package(Dir) || Dir <- InstallDirs],
-    NameVsn = filename:basename(Package, ?PACKAGE_SUFFIX),
-    [{ok, _}, {ok, _}] = erpc:multicall(Nodes, emqx_cth_suite, start_app, [
-        emqx_plugins,
-        #{
-            config => #{
-                plugins => #{
-                    install_dir => InstallRelDir,
-                    states => [#{name_vsn => NameVsn, enable => false}]
-                }
-            }
-        }
-    ]),
-    [
-        {nodes, Nodes},
-        {name_vsn, NameVsn}
-        | Config
-    ];
-group_t_cluster_rejoin_after_uninstall({'end', Config}) ->
-    Nodes = ?config(nodes, Config),
-    ok = emqx_cth_cluster:stop(Nodes);
-group_t_cluster_rejoin_after_uninstall(Config) ->
-    [N1, N2] = ?config(nodes, Config),
-    NameVsn = ?config(name_vsn, Config),
-    Params = unused,
-
-    %% Both nodes start with the plugin installed and configured.
-    ?assertMatch(
-        {ok, #{config_status := disabled}},
-        erpc:call(N1, emqx_plugins, describe, [NameVsn])
-    ),
-    ?assertMatch(
-        {ok, #{config_status := disabled}},
-        erpc:call(N2, emqx_plugins, describe, [NameVsn])
-    ),
-
-    %% N2 leaves and misses the later cluster-wide uninstall.
-    ok = erpc:call(N2, ekka, leave, []),
-    timer:sleep(1000),
-    ?assertEqual([N2], erpc:call(N2, emqx, running_nodes, [])),
-    ?assertEqual([N1], erpc:call(N1, emqx, running_nodes, [])),
-
-    {204} = erpc:call(N1, emqx_mgmt_api_plugins, plugin, [
-        delete, #{bindings => #{name => NameVsn}}
-    ]),
-    ?assertEqual([], erpc:call(N1, emqx_plugins, list, [])),
-
-    %% The isolated node still has the old local package.
-    ?assertMatch(
-        {ok, #{config_status := disabled}},
-        erpc:call(N2, emqx_plugins, describe, [NameVsn])
-    ),
-
-    ?check_trace(
-        #{timetrap => 30_000},
-        begin
-            ok = ?ON(N2, emqx_machine_boot:start_autocluster()),
-            ?ON(N2, begin
-                StartCallback0 =
-                    case ekka:env({callback, start}) of
-                        {ok, SC0} -> SC0;
-                        _ -> fun() -> ok end
-                    end,
-                StartCallback = fun() ->
-                    ok = emqx_app:set_config_loader(emqx_cth_suite),
-                    StartCallback0()
-                end,
-                ekka:callback(start, StartCallback)
-            end),
-            {ok, {ok, _}} =
-                ?wait_async_action(
-                    ?ON(N2, emqx_cluster:join(N1)),
-                    #{?snk_kind := "emqx_plugins_app_started"}
-                ),
-            ?assertMatch({error, _}, erpc:call(N2, emqx_plugins, describe, [NameVsn])),
-            ?assertEqual([], erpc:call(N2, emqx_plugins, list, [])),
-            ok
-        end,
-        []
-    ),
-    ?assertMatch(
-        {200, []},
-        erpc:call(N1, emqx_mgmt_api_plugins, list_plugins, [get, Params])
-    ),
-    ok.
-
-make_minimal_plugin_package(InstallDir) ->
-    PluginName = "emqx_plugin_rejoin_test",
-    PluginVsn = "1.0.0",
-    NameVsn = PluginName ++ "-" ++ PluginVsn,
-    PluginDir = filename:join(InstallDir, NameVsn),
-    EbinDir = filename:join([PluginDir, NameVsn, "ebin"]),
-    ok = filelib:ensure_path(filename:join(EbinDir, "dummy")),
-    ok = file:write_file(
-        filename:join(PluginDir, "release.json"),
-        io_lib:format(
-            "name=\"~s\", rel_vsn=\"~s\", rel_apps=[\"~s\"], description=\"test plugin\"",
-            [PluginName, PluginVsn, NameVsn]
-        )
-    ),
-    ok = file:write_file(
-        filename:join(EbinDir, PluginName ++ ".app"),
-        io_lib:format(
-            "{application, ~s, [{description, \"test plugin\"}, {vsn, \"~s\"}, "
-            "{registered, []}, {applications, [kernel, stdlib]}, {env, []}]}.\n",
-            [PluginName, PluginVsn]
-        )
-    ),
-    Package = filename:join(InstallDir, NameVsn ++ ?PACKAGE_SUFFIX),
-    ok = create_tar_from_dir(InstallDir, Package, NameVsn),
-    #{package => Package, name_vsn => NameVsn, release_name => PluginName}.
-
-create_tar_from_dir(Dir, Package, NameVsn) ->
-    {ok, Cwd} = file:get_cwd(),
-    ok = file:set_cwd(Dir),
-    try
-        erl_tar:create(filename:basename(Package), [NameVsn], [compressed])
-    after
-        ok = file:set_cwd(Cwd)
-    end.
 
 group_t_cluster_force_sync_vsn({init, Config}) ->
     OldInstallDir = filename:join(emqx_cth_suite:work_dir(?FUNCTION_NAME, Config), old),

--- a/apps/emqx_plugins/test/emqx_plugins_tests.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_tests.erl
@@ -185,67 +185,6 @@ purge_test() ->
     ),
     unmeck_emqx().
 
-purge_unconfigured_removes_package_absent_from_cluster_config_test() ->
-    meck_emqx(),
-    meck_plugins_apps(),
-    try
-        with_rand_install_dir(
-            fun(_Dir) ->
-                NameVsn = "stale-1",
-                ok = emqx_plugins:put_configured([]),
-                ok = write_fake_plugin_release(NameVsn),
-                ok = write_file(emqx_plugins_fs:tar_file_path(NameVsn), "tar"),
-
-                ?assertMatch({ok, _}, file:read_file_info(emqx_plugins_fs:plugin_dir(NameVsn))),
-                ?assertMatch({ok, _}, file:read_file_info(emqx_plugins_fs:tar_file_path(NameVsn))),
-
-                ok = emqx_plugins:purge_unconfigured(),
-
-                ?assertMatch(
-                    {error, enoent}, file:read_file_info(emqx_plugins_fs:plugin_dir(NameVsn))
-                ),
-                ?assertMatch(
-                    {error, enoent}, file:read_file_info(emqx_plugins_fs:tar_file_path(NameVsn))
-                )
-            end
-        )
-    after
-        ok = emqx_plugins:put_configured([]),
-        unmeck_plugins_apps(),
-        unmeck_emqx()
-    end.
-
-purge_unconfigured_keeps_other_versions_of_configured_plugin_test() ->
-    meck_emqx(),
-    meck_plugins_apps(),
-    try
-        with_rand_install_dir(
-            fun(_Dir) ->
-                ok = emqx_plugins:put_configured([#{name_vsn => "demo-1", enable => false}]),
-                ok = write_fake_plugin_release("demo-2"),
-
-                ok = emqx_plugins:purge_unconfigured(),
-
-                ?assertMatch({ok, _}, file:read_file_info(emqx_plugins_fs:plugin_dir("demo-2")))
-            end
-        )
-    after
-        ok = emqx_plugins:put_configured([]),
-        unmeck_plugins_apps(),
-        unmeck_emqx()
-    end.
-
-write_fake_plugin_release(NameVsn) ->
-    {AppName, Vsn} = emqx_plugins_utils:parse_name_vsn(NameVsn),
-    AppNameStr = atom_to_list(AppName),
-    write_file(
-        emqx_plugins_fs:info_file_path(NameVsn),
-        io_lib:format(
-            "name=\"~s\", rel_vsn=\"~s\", rel_apps=[\"~s-~s\"], description=\"desc ~s\"",
-            [AppNameStr, Vsn, AppNameStr, Vsn, AppNameStr]
-        )
-    ).
-
 meck_emqx() ->
     meck:new(emqx, [passthrough]),
     meck:new(emqx_plugins_serde),
@@ -253,7 +192,7 @@ meck_emqx() ->
         emqx,
         update_config,
         fun(Path, Values, _Opts) ->
-            emqx_config:put(Path, mock_schema_key_transform(Values))
+            emqx_config:put(Path, Values)
         end
     ),
     meck:expect(
@@ -263,34 +202,7 @@ meck_emqx() ->
     ),
     ok.
 
-mock_schema_key_transform(List = [#{} | _]) ->
-    [mock_schema_key_transform(Item) || Item <- List];
-mock_schema_key_transform(Map) when is_map(Map) ->
-    maps:fold(
-        fun(K, V, Acc) ->
-            Acc#{mock_schema_key_transform(K) => mock_schema_key_transform(V)}
-        end,
-        #{},
-        Map
-    );
-mock_schema_key_transform(<<"name_vsn">>) ->
-    name_vsn;
-mock_schema_key_transform(<<"enable">>) ->
-    enable;
-mock_schema_key_transform(Term) ->
-    Term.
-
 unmeck_emqx() ->
     meck:unload(emqx),
     meck:unload(emqx_plugins_serde),
-    ok.
-
-meck_plugins_apps() ->
-    meck:new(emqx_plugins_apps, [passthrough]),
-    meck:expect(emqx_plugins_apps, running_status, fun(_NameVsn) -> stopped end),
-    meck:expect(emqx_plugins_apps, stop, fun(_Plugin) -> ok end),
-    ok.
-
-unmeck_plugins_apps() ->
-    meck:unload(emqx_plugins_apps),
     ok.

--- a/changes/6.2.2.en.md
+++ b/changes/6.2.2.en.md
@@ -144,8 +144,6 @@
 
 - [#17773](https://github.com/emqx/emqx/pull/17773) Fixed configuration update commands (REST API and CLI) crashing with a `function_clause` crash report when the underlying cluster RPC layer aborted with an unexpected reason, for example `{no_exists, cluster_rpc_mfa}` when the cluster RPC tables were not yet available during node startup or recovery. Such failures are now returned to the caller as a structured error instead.
 
-- [#17764](https://github.com/emqx/emqx/pull/17764) Fixed stale plugin entries after a node rejoins a cluster where the plugin was uninstalled while the node was offline. EMQX now removes local plugin packages that are no longer present in the cluster plugin configuration during plugin startup.
-
 ### Access Control
 
 - [#17575](https://github.com/emqx/emqx/pull/17575) Fixed a race condition in the emqx_username_quota plugin that could cause the per-username session counter to become inconsistent with the actual number of tracked client records. The counter could be decremented past zero and then be deleted while a concurrent session registration incremented it, losing the increment permanently.

--- a/changes/ce/fix-17764.en.md
+++ b/changes/ce/fix-17764.en.md
@@ -1,1 +1,0 @@
-Fixed stale plugin entries after a node rejoins a cluster where the plugin was uninstalled while the node was offline. EMQX now removes local plugin packages that are no longer present in the cluster plugin configuration during plugin startup.


### PR DESCRIPTION
Release version:
6.2.2

Fix: N/A (revert of #17764 / #17780)

## Summary

Reverts #17764 / #17780 on `rel-6.2.2` so plugin startup no longer purges local plugin packages that are absent from the cluster plugin configuration.

Also removes the corresponding 6.2.2 changelog entry and pending change file because the fix is no longer included in this release.

No schema changes.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
