### PR TITLE
test(crl): accept {error, closed} for revoked-cert rejection

### DIFF
--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -473,6 +473,22 @@ update_listener_via_api(ListenerId, NewConfig) ->
     Path = emqx_mgmt_api_test_util:api_path(["listeners", ListenerId]),
     request(put, Path, [], NewConfig).
 
+%% A revoked client certificate must be rejected during the TLS handshake.
+%% The server sends a `certificate_revoked' fatal alert, but under a
+%% long-standing race the client can observe the socket close (`{error, closed}')
+%% before it reads the alert. Both outcomes mean the connection was refused.
+assert_connection_rejected_by_revoked_cert(Client) ->
+    case emqtt:connect(Client) of
+        {error, {ssl_error, _Sock, {tls_alert, {certificate_revoked, _}}}} ->
+            ok;
+        {error, {tls_alert, {certificate_revoked, _}}} ->
+            ok;
+        {error, closed} ->
+            ok;
+        Other ->
+            ct:fail({unexpected_connect_result, Other})
+    end.
+
 assert_successful_connection(Config) ->
     assert_successful_connection(Config, default).
 
@@ -943,15 +959,7 @@ t_revoked(Config) ->
         {port, 8883}
     ]),
     unlink(C),
-    case emqtt:connect(C) of
-        {error, {ssl_error, _Sock, {tls_alert, {certificate_revoked, _}}}} ->
-            ok;
-        {error, {tls_alert, {certificate_revoked, _}}} ->
-            ok;
-        {error, closed} ->
-            %% this happens due to an unidentified race-condition
-            ok
-    end.
+    assert_connection_rejected_by_revoked_cert(C).
 
 t_revoke_then_refresh(Config) ->
     DataDir = ?config(data_dir, Config),
@@ -992,9 +1000,7 @@ t_revoke_then_refresh(Config) ->
         {port, 8883}
     ]),
     unlink(C1),
-    ?assertMatch(
-        {error, {ssl_error, _Sock, {tls_alert, {certificate_revoked, _}}}}, emqtt:connect(C1)
-    ),
+    assert_connection_rejected_by_revoked_cert(C1),
     ok.
 
 %% check that we can start with a non-crl listener and restart it with
@@ -1077,9 +1083,7 @@ do_t_update_listener(Config) ->
         {port, 8883}
     ]),
     unlink(C1),
-    ?assertMatch(
-        {error, {ssl_error, _Sock, {tls_alert, {certificate_revoked, _}}}}, emqtt:connect(C1)
-    ),
+    assert_connection_rejected_by_revoked_cert(C1),
     assert_http_get(<<?DEFAULT_URL>>),
 
     ok.


### PR DESCRIPTION
Fixes a flaky `emqx_crl_cache_SUITE` failure:

```
emqx_crl_cache_SUITE ==> t_revoke_then_refresh: FAILED
  expected: {error,{ssl_error,_Sock,{tls_alert,{certificate_revoked,_}}}}
       got: {error,closed}
```

When a revoked client certificate is presented, the server sends a `certificate_revoked` fatal TLS alert. Under a long-standing race, the client can observe the socket close (`{error, closed}`) before it reads the alert — both outcomes mean the connection was refused, which is what the test verifies.

`t_revoked` already tolerated all three outcomes (including `{error, closed}`, with a comment noting the race). `t_revoke_then_refresh` and `do_t_update_listener` still used a strict `?assertMatch` on the alert and therefore flaked. This extracts the tolerant logic into a shared helper `assert_connection_rejected_by_revoked_cert/1` and uses it at all three sites (the helper `ct:fail`s on any other result, so it is not weaker than before for non-revoked outcomes).

Test-only change; no changelog.

Release version: 6.3.0