### PR TITLE
chore(deps): bump greptimedb_rs to 0.1.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -319,7 +319,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.3-emqx.1"}
 
   def common_dep(:greptimedb_rs),
-    do: {:greptimedb_rs, github: "emqx/greptimedb-ingester-erlnif", tag: "0.1.11"}
+    do: {:greptimedb_rs, github: "emqx/greptimedb-ingester-erlnif", tag: "0.1.12"}
 
   def common_dep(:sbom), do: {:sbom, "~> 0.8", runtime: false}
 


### PR DESCRIPTION
Release version: 6.1.3

## Summary

Bump the `greptimedb_rs` driver (`emqx/greptimedb-ingester-erlnif`) from tag `0.1.11` to `0.1.12` in `mix.exs`.

`0.1.12` is a build-only release: it restores the Ubuntu 20.04 (glibc 2.31) precompiled NIF artifact by installing `protoc` and selecting GCC 10 on the focal builder (GCC 9.4 is rejected by `aws-lc-sys` due to [GCC bug #95189](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189)). No runtime behavior change to the GreptimeDB (EMQX Tables) connector.

Verified locally: `mix deps.get` resolves `greptimedb_rs` at `0.1.12` and the Rust NIF compiles (`libgreptimedb_nif.so` builds).

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
