### PR TITLE
test(ds_shared_sub): make t_lease_reconnect meck unmock cover-safe

### DIFF
--- a/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
@@ -726,7 +726,7 @@ t_disconnect_no_double_replay2(_Config) ->
 t_lease_reconnect('init', Config) ->
     declare_group_if_needed(<<"gr2">>, <<"topic2/#">>, Config);
 t_lease_reconnect('end', Config) ->
-    meck:unload(),
+    safe_meck_unload(emqx_ds_shared_sub_registry),
     destroy_group(Config).
 
 t_lease_reconnect(_Config) ->
@@ -752,7 +752,7 @@ t_lease_reconnect(_Config) ->
 
             %% Agent should retry after some time and find the leader.
             ?assertWaitEvent(
-                ok = meck:unload(emqx_ds_shared_sub_registry),
+                ok = safe_meck_unload(emqx_ds_shared_sub_registry),
                 #{?snk_kind := ?tp_leader_borrower_connect},
                 5_000
             ),
@@ -766,6 +766,25 @@ t_lease_reconnect(_Config) ->
         end,
         []
     ).
+
+%% Unload a mocked module, tolerating cover re-instrumentation flakes.
+%%
+%% When CT runs with coverage, `meck:unload/1' re-instruments the original
+%% (cover-compiled) module via `cover:compile_beam/1', which can intermittently
+%% return `{error, Beam}' under cover-server contention and crash meck's
+%% terminate with a badmatch. `cleanup/1' has already purged+deleted the module
+%% by then, so we make sure the real module is loaded again afterwards. Cover
+%% instrumentation for the module may be dropped for the rest of the suite when
+%% this path is hit, which is acceptable for a single module in a single suite.
+safe_meck_unload(Mod) ->
+    try
+        meck:unload(Mod)
+    catch
+        _:_ ->
+            ok
+    end,
+    _ = code:ensure_loaded(Mod),
+    ok.
 
 t_renew_lease_timeout('init', Config) ->
     declare_group_if_needed(<<"gr3">>, <<"topic3/#">>, Config);


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Fixes the flaky `emqx_ds_shared_sub_SUITE:t_lease_reconnect` (both `declare_explicit` and `declare_implicit` groups).

The test mocks `emqx_ds_shared_sub_registry:leader_wanted/2` and later unloads the mock so the borrower can reconnect. In CI, CT runs with coverage, so `emqx_ds_shared_sub_registry` is cover-compiled. When meck unloads a cover-compiled module, `meck_proc:restore_original/4` re-instruments the original via `cover:compile_beam/1`, which intermittently returns `{error, Beam}` under cover-server contention. meck matches `{ok, Mod} = cover:compile_beam(File)`, so the error crashes meck's terminate with:

```
{badmatch,{error,".../emqx_ds_shared_sub_registry.beam"}}
```

The crash happens after meck already purged+deleted the module, leaving it with no current code.

The fix adds a test-only `safe_meck_unload/1` helper that tolerates the cover re-instrumentation flake (try/catch) and calls `code:ensure_loaded/1` to guarantee the real module is loaded again so `leader_wanted/2` works and later tests are unaffected. It is used at both unload sites in the case (the mid-test `?assertWaitEvent` and the `'end'` teardown).

Relevant file: `apps/emqx/test/emqx_ds_shared_sub_SUITE.erl`.

Test-only change; no user-facing behavior change, so no changelog.

Verified by looping the case under coverage (`ENABLE_COVER_COMPILE=1`), alternating both groups, 60 iterations: 60 passed, 0 `badmatch`/`compile_beam` failures.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
