### PR TITLE
fix(plugins): hide stale packages in HTTP API

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -539,12 +539,7 @@ get_plugins() ->
     {node(), lists:filter(fun api_visible_plugin/1, Plugins)}.
 
 upload_install(post, #{name := NameVsn, bin := Bin}) ->
-    case api_visible_on_any_node(NameVsn) of
-        true ->
-            already_installed(NameVsn);
-        false ->
-            do_upload_install(NameVsn, Bin)
-    end;
+    do_upload_install(NameVsn, Bin);
 upload_install(post, #{}) ->
     {400, #{
         code => 'BAD_FORM_DATA',

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -298,7 +298,8 @@ schema("/plugins/:name/move") ->
             'requestBody' => move_request_body(),
             responses => #{
                 204 => <<"Boot order changed successfully">>,
-                400 => emqx_dashboard_swagger:error_codes(['MOVE_FAILED'], <<"Move failed">>)
+                400 => emqx_dashboard_swagger:error_codes(['MOVE_FAILED'], <<"Move failed">>),
+                404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'], <<"Plugin Not Found">>)
             }
         }
     };
@@ -534,10 +535,25 @@ list_plugins(get, _) ->
     {200, format_plugins(Plugins)}.
 
 get_plugins() ->
-    {node(), emqx_plugins:list(?normal, #{health_check => true})}.
+    Plugins = emqx_plugins:list(?normal, #{health_check => true}),
+    {node(), lists:filter(fun api_visible_plugin/1, Plugins)}.
 
 upload_install(post, #{name := NameVsn, bin := Bin}) ->
-    case emqx_plugins:describe(NameVsn, #{}) of
+    case api_visible_on_any_node(NameVsn) of
+        true ->
+            already_installed(NameVsn);
+        false ->
+            do_upload_install(NameVsn, Bin)
+    end;
+upload_install(post, #{}) ->
+    {400, #{
+        code => 'BAD_FORM_DATA',
+        message =>
+            <<"form-data should be `plugin=@packagename-vsn.tar.gz;type=application/x-gzip`">>
+    }}.
+
+do_upload_install(NameVsn, Bin) ->
+    case describe_api_plugin(NameVsn, #{}) of
         {error, #{msg := "bad_info_file", reason := {enoent, _Path}}} ->
             case emqx_plugins:is_package_present(NameVsn) of
                 false ->
@@ -551,17 +567,16 @@ upload_install(post, #{name := NameVsn, bin := Bin}) ->
                         message => iolist_to_binary(io_lib:format("~p already installed", [TarGzs]))
                     }}
             end;
+        {error, stale_plugin} ->
+            install_package_on_nodes(NameVsn, Bin);
         {ok, _} ->
-            {400, #{
-                code => 'ALREADY_INSTALLED',
-                message => iolist_to_binary(io_lib:format("~p is already installed", [NameVsn]))
-            }}
-    end;
-upload_install(post, #{}) ->
+            already_installed(NameVsn)
+    end.
+
+already_installed(NameVsn) ->
     {400, #{
-        code => 'BAD_FORM_DATA',
-        message =>
-            <<"form-data should be `plugin=@packagename-vsn.tar.gz;type=application/x-gzip`">>
+        code => 'ALREADY_INSTALLED',
+        message => iolist_to_binary(io_lib:format("~p is already installed", [NameVsn]))
     }}.
 
 install_package_on_nodes(NameVsn, Bin) ->
@@ -634,12 +649,22 @@ plugin(get, #{bindings := #{name := NameVsn}}) ->
         [] -> {404, #{code => 'NOT_FOUND', message => NameVsn}}
     end;
 plugin(delete, #{bindings := #{name := NameVsn}}) ->
-    Res = emqx_mgmt_api_plugins_proto_v4:delete_package(NameVsn),
-    return(204, Res).
+    case api_visible_on_any_node(NameVsn) of
+        true ->
+            Res = emqx_mgmt_api_plugins_proto_v4:delete_package(NameVsn),
+            return(204, Res);
+        false ->
+            {404, plugin_not_found_msg()}
+    end.
 
 update_plugin(put, #{bindings := #{name := NameVsn, action := Action}}) ->
-    Res = emqx_mgmt_api_plugins_proto_v4:ensure_action(NameVsn, Action),
-    return(204, Res).
+    case api_visible_on_any_node(NameVsn) of
+        true ->
+            Res = emqx_mgmt_api_plugins_proto_v4:ensure_action(NameVsn, Action),
+            return(204, Res);
+        false ->
+            {404, plugin_not_found_msg()}
+    end.
 
 plugin_config(get, #{bindings := #{name := NameVsn}}) ->
     get_plugin_config(NameVsn);
@@ -665,7 +690,7 @@ download_plugin_config(get, #{bindings := #{name := NameVsn}}) ->
     end.
 
 get_plugin_config(NameVsn) ->
-    case emqx_plugins:describe(NameVsn, #{}) of
+    case describe_api_plugin(NameVsn, #{}) of
         {ok, _} ->
             case emqx_plugins:get_config(NameVsn, ?plugin_conf_not_found) of
                 Config when is_map(Config) ->
@@ -682,7 +707,7 @@ get_plugin_config(NameVsn) ->
 
 put_plugin_config(NameVsn, Config) ->
     Nodes = emqx:running_nodes(),
-    case emqx_plugins:describe(NameVsn, #{}) of
+    case describe_api_plugin(NameVsn, #{}) of
         {ok, _} ->
             case emqx_plugins:decode_plugin_config_map(NameVsn, Config) of
                 {ok, ?plugin_without_config_schema} ->
@@ -708,7 +733,7 @@ put_plugin_config(NameVsn, Config) ->
     end.
 
 plugin_schema(get, #{bindings := #{name := NameVsn}}) ->
-    case emqx_plugins:describe(NameVsn, #{}) of
+    case describe_api_plugin(NameVsn, #{}) of
         {ok, _Plugin} ->
             {200, format_plugin_avsc_and_i18n(NameVsn)};
         _ ->
@@ -716,19 +741,24 @@ plugin_schema(get, #{bindings := #{name := NameVsn}}) ->
     end.
 
 update_boot_order(post, #{bindings := #{name := Name}, body := Body}) ->
-    case parse_position(Body, Name) of
-        {error, Reason} ->
-            {400, #{code => 'BAD_POSITION', message => Reason}};
-        Position ->
-            case emqx_plugins:ensure_enabled(Name, Position, global) of
-                ok ->
-                    {204};
+    case describe_api_plugin(Name, #{}) of
+        {ok, _Plugin} ->
+            case parse_position(Body, Name) of
                 {error, Reason} ->
-                    {400, #{
-                        code => 'MOVE_FAILED',
-                        message => readable_error_msg(Reason)
-                    }}
-            end
+                    {400, #{code => 'BAD_POSITION', message => Reason}};
+                Position ->
+                    case emqx_plugins:ensure_enabled(Name, Position, global) of
+                        ok ->
+                            {204};
+                        {error, Reason} ->
+                            {400, #{
+                                code => 'MOVE_FAILED',
+                                message => readable_error_msg(Reason)
+                            }}
+                    end
+            end;
+        _ ->
+            {404, plugin_not_found_msg()}
     end.
 
 sync_plugin(post, #{body := Body}) ->
@@ -738,24 +768,34 @@ sync_plugin(post, #{body := Body}) ->
                 msg => "sync_plugin_to_cluster",
                 keep_namevsn => NameVsn
             }),
-            case ensure_existed(NameVsn) of
-                ok ->
-                    case
-                        emqx_mgmt_api_plugins_proto_v4:sync_plugin_cluster(
-                            emqx:running_nodes(), node(), NameVsn
-                        )
-                    of
-                        {_Res, []} -> {204};
-                        {_Res, BadNodes} -> {400, plugin_sync_failed_msg(BadNodes)}
-                    end;
-                {error, {plugin_error, _Reason}} ->
-                    {404, plugin_not_found_msg()}
+            case describe_api_plugin(NameVsn, #{}) of
+                {ok, _Plugin} ->
+                    do_sync_plugin(NameVsn);
+                {error, stale_plugin} ->
+                    {404, plugin_not_found_msg()};
+                _ ->
+                    do_sync_plugin(NameVsn)
             end;
         {error, {plugin_error, Reason}} ->
             {400, #{
                 code => 'BAD_PLUGIN_INFO',
                 message => Reason
             }}
+    end.
+
+do_sync_plugin(NameVsn) ->
+    case ensure_existed(NameVsn) of
+        ok ->
+            case
+                emqx_mgmt_api_plugins_proto_v4:sync_plugin_cluster(
+                    emqx:running_nodes(), node(), NameVsn
+                )
+            of
+                {_Res, []} -> {204};
+                {_Res, BadNodes} -> {400, plugin_sync_failed_msg(BadNodes)}
+            end;
+        {error, {plugin_error, _Reason}} ->
+            {404, plugin_not_found_msg()}
     end.
 
 %% API CallBack End
@@ -781,7 +821,7 @@ install_package_v4(NameVsn, Bin) ->
 %% For RPC plugin get
 describe_package(NameVsn) ->
     Node = node(),
-    case emqx_plugins:describe(NameVsn) of
+    case describe_api_plugin(NameVsn) of
         {ok, Plugin} -> {Node, [Plugin]};
         _ -> {Node, []}
     end.
@@ -899,6 +939,30 @@ plugin_sync_failed_msg(Nodes) ->
             )
         )
     }.
+
+describe_api_plugin(NameVsn) ->
+    describe_api_plugin(NameVsn, #{fill_readme => true, health_check => true}).
+
+describe_api_plugin(NameVsn, Options) ->
+    case emqx_plugins:describe(NameVsn, Options) of
+        {ok, Plugin} ->
+            case api_visible_plugin(Plugin) of
+                true -> {ok, Plugin};
+                false -> {error, stale_plugin}
+            end;
+        Error ->
+            Error
+    end.
+
+api_visible_plugin(#{config_status := not_configured, running_status := RunningStatus}) ->
+    RunningStatus =:= running;
+api_visible_plugin(_) ->
+    true.
+
+api_visible_on_any_node(NameVsn) ->
+    Nodes = emqx:running_nodes(),
+    {Plugins, _} = emqx_mgmt_api_plugins_proto_v4:describe_package(Nodes, NameVsn),
+    format_plugins(Plugins) =/= [].
 
 parse_position(#{<<"position">> := <<"front">>}, _) ->
     front;

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -954,8 +954,14 @@ describe_api_plugin(NameVsn, Options) ->
             Error
     end.
 
-api_visible_plugin(#{config_status := not_configured, running_status := RunningStatus}) ->
-    RunningStatus =:= running;
+api_visible_plugin(#{config_status := not_configured, running_status := RunningStatus} = Plugin) ->
+    case RunningStatus of
+        running ->
+            true;
+        _ ->
+            emqx_plugins:log_unconfigured_plugin(Plugin),
+            false
+    end;
 api_visible_plugin(_) ->
     true.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -333,6 +333,58 @@ t_bad_plugin(_Config) ->
         )
     ).
 
+t_stale_plugin_is_ignored_by_http_api(_Config) ->
+    PackagePath = get_demo_plugin_package(),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    StalePluginPath = emqx_mgmt_api_test_util:api_path(["plugins", NameVsn]),
+    StaleConfigPath = emqx_mgmt_api_test_util:api_path(["plugins", NameVsn, "config"]),
+    StaleSchemaPath = emqx_mgmt_api_test_util:api_path(["plugins", NameVsn, "schema"]),
+    StaleMovePath = emqx_mgmt_api_test_util:api_path(["plugins", NameVsn, "move"]),
+    ClusterSyncPath = emqx_mgmt_api_test_util:api_path(["plugins", "cluster_sync"]),
+    NameVsnBin = list_to_binary(NameVsn),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ok = emqx_plugins:delete_package(NameVsn),
+    ok = make_stale_plugin(PackagePath),
+    on_exit(fun() ->
+        emqx_plugins:put_configured([]),
+        _ = emqx_plugins:ensure_stopped(NameVsn),
+        _ = emqx_plugins:purge(NameVsn),
+        _ = emqx_plugins:delete_package(NameVsn)
+    end),
+    ?assertMatch(
+        {ok, #{config_status := not_configured, running_status := stopped}},
+        emqx_plugins:describe(NameVsn, #{})
+    ),
+
+    ?assertNot(
+        lists:any(fun(Plugin) -> plugin_json_name_vsn(Plugin) =:= NameVsnBin end, list_plugins())
+    ),
+    ?assertMatch({error, {_, 404, _}}, emqx_mgmt_api_test_util:request_api(get, StalePluginPath)),
+    ?assertMatch({error, {_, 404, _}}, emqx_mgmt_api_test_util:request_api(get, StaleConfigPath)),
+    ?assertMatch({error, {_, 404, _}}, emqx_mgmt_api_test_util:request_api(get, StaleSchemaPath)),
+    ?assertMatch({error, {_, 404, _}}, update_plugin(NameVsn, "start")),
+    ?assertMatch({error, {_, 404, _}}, uninstall_plugin(NameVsn)),
+    ?assertMatch(
+        {error, {_, 404, _}},
+        emqx_mgmt_api_test_util:request_api(
+            post, StaleMovePath, "", [], #{<<"position">> => <<"front">>}
+        )
+    ),
+    ?assertMatch(
+        {error, {_, 404, _}},
+        emqx_mgmt_api_test_util:request_api(
+            post, ClusterSyncPath, "", [], #{<<"name">> => NameVsnBin}
+        )
+    ),
+
+    ok = allow_installation(NameVsn),
+    ok = install_plugin(PackagePath),
+    ?assert(
+        lists:any(fun(Plugin) -> plugin_json_name_vsn(Plugin) =:= NameVsnBin end, list_plugins())
+    ),
+    {ok, []} = uninstall_plugin(NameVsn),
+    ok.
+
 t_delete_non_existing(_Config) ->
     Path = emqx_mgmt_api_test_util:api_path(["plugins", "non_exists-1.0.0"]),
     ?assertMatch(
@@ -512,11 +564,30 @@ uninstall_plugin(Name) ->
     emqx_mgmt_api_test_util:request_api(delete, DeletePath).
 
 get_demo_plugin_package() ->
-    #{package := Pkg} = emqx_plugins_test_helpers:get_demo_plugin_package(
-        maps:merge(?EMQX_PLUGIN, #{shdir => "./"})
-    ),
-    true = filelib:is_regular(Pkg),
-    Pkg.
+    PkgName = lists:flatten([
+        ?EMQX_PLUGIN_TEMPLATE_NAME, "-", ?EMQX_PLUGIN_TEMPLATE_VSN, ?PACKAGE_SUFFIX
+    ]),
+    Pkg = filename:join(emqx_common_test_helpers:proj_root(), PkgName),
+    case filelib:is_regular(Pkg) of
+        true ->
+            Pkg;
+        false ->
+            #{package := Pkg} = emqx_plugins_test_helpers:get_demo_plugin_package(
+                maps:merge(?EMQX_PLUGIN, #{shdir => emqx_common_test_helpers:proj_root()})
+            ),
+            true = filelib:is_regular(Pkg),
+            Pkg
+    end.
+
+make_stale_plugin(PackagePath) ->
+    InstallDir = emqx_plugins_fs:install_dir(),
+    ok = filelib:ensure_dir(filename:join(InstallDir, "dummy")),
+    {ok, _} = file:copy(PackagePath, filename:join(InstallDir, filename:basename(PackagePath))),
+    ok = erl_tar:extract(PackagePath, [compressed, {cwd, InstallDir}]),
+    emqx_plugins:put_configured([]).
+
+plugin_json_name_vsn(#{<<"name">> := Name, <<"rel_vsn">> := Vsn}) ->
+    <<Name/binary, "-", Vsn/binary>>.
 
 create_renamed_package(PackagePath, NewNameVsn) ->
     {ok, Content} = erl_tar:extract(PackagePath, [compressed, memory]),

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -333,7 +333,7 @@ t_bad_plugin(_Config) ->
         )
     ).
 
-t_stale_plugin_is_ignored_by_http_api(_Config) ->
+t_preinstall_step1_without_plugins_states_is_ignored_by_http_api(_Config) ->
     PackagePath = get_demo_plugin_package(),
     NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
     StalePluginPath = emqx_mgmt_api_test_util:api_path(["plugins", NameVsn]),
@@ -383,6 +383,35 @@ t_stale_plugin_is_ignored_by_http_api(_Config) ->
         lists:any(fun(Plugin) -> plugin_json_name_vsn(Plugin) =:= NameVsnBin end, list_plugins())
     ),
     {ok, []} = uninstall_plugin(NameVsn),
+    ok.
+
+t_preinstall_with_plugins_states_is_visible_to_http_api(_Config) ->
+    PackagePath = get_demo_plugin_package(),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    NameVsnBin = list_to_binary(NameVsn),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ok = emqx_plugins:delete_package(NameVsn),
+    ok = preinstall_step1_extract_package(PackagePath),
+    ok = emqx_plugins:put_configured([#{name_vsn => NameVsn, enable => false}]),
+    ok = emqx_plugins:ensure_installed(),
+    on_exit(fun() ->
+        emqx_plugins:put_configured([]),
+        _ = emqx_plugins:ensure_stopped(NameVsn),
+        _ = emqx_plugins:purge(NameVsn),
+        _ = emqx_plugins:delete_package(NameVsn)
+    end),
+    ?assertMatch(
+        {ok, #{config_status := disabled, running_status := stopped}},
+        emqx_plugins:describe(NameVsn, #{})
+    ),
+
+    ?assert(
+        lists:any(fun(Plugin) -> plugin_json_name_vsn(Plugin) =:= NameVsnBin end, list_plugins())
+    ),
+    ?assertMatch(
+        #{<<"running_status">> := [#{<<"status">> := <<"stopped">>}]},
+        describe_plugin(NameVsn)
+    ),
     ok.
 
 t_delete_non_existing(_Config) ->
@@ -580,11 +609,14 @@ get_demo_plugin_package() ->
     end.
 
 make_stale_plugin(PackagePath) ->
+    ok = preinstall_step1_extract_package(PackagePath),
+    emqx_plugins:put_configured([]).
+
+preinstall_step1_extract_package(PackagePath) ->
     InstallDir = emqx_plugins_fs:install_dir(),
     ok = filelib:ensure_dir(filename:join(InstallDir, "dummy")),
     {ok, _} = file:copy(PackagePath, filename:join(InstallDir, filename:basename(PackagePath))),
-    ok = erl_tar:extract(PackagePath, [compressed, {cwd, InstallDir}]),
-    emqx_plugins:put_configured([]).
+    ok = erl_tar:extract(PackagePath, [compressed, {cwd, InstallDir}]).
 
 plugin_json_name_vsn(#{<<"name">> := Name, <<"rel_vsn">> := Vsn}) ->
     <<Name/binary, "-", Vsn/binary>>.

--- a/apps/emqx_plugins/src/emqx_plugins.app.src
+++ b/apps/emqx_plugins/src/emqx_plugins.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_plugins, [
     {description, "EMQX Plugin Management"},
-    {vsn, "0.3.5"},
+    {vsn, "0.3.6"},
     {modules, []},
     {mod, {emqx_plugins_app, []}},
     {applications, [kernel, stdlib, emqx, erlavro]},

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -59,7 +59,9 @@
     list/0,
     list/1,
     list/2,
-    list_active/0
+    list_active/0,
+    log_unconfigured_plugins/0,
+    log_unconfigured_plugin/1
 ]).
 
 %% Plugin config APIs
@@ -469,6 +471,35 @@ list_active() ->
             list()
         )
     ).
+
+log_unconfigured_plugins() ->
+    lists:foreach(
+        fun log_unconfigured_plugin/1,
+        list(?normal, #{})
+    ).
+
+log_unconfigured_plugin(#{
+    config_status := not_configured,
+    name := Name,
+    rel_vsn := RelVsn,
+    running_status := RunningStatus
+}) ->
+    NameVsn = name_vsn(Name, RelVsn),
+    ?SLOG(error, #{
+        msg => plugin_package_not_configured,
+        name_vsn => NameVsn,
+        running_status => RunningStatus,
+        hint => iolist_to_binary([
+            "Plugin package is unpacked but is neither enabled nor disabled in plugins.states. ",
+            "Run `emqx ctl plugins enable ",
+            NameVsn,
+            "` or `emqx ctl plugins disable ",
+            NameVsn,
+            "`, or delete the plugin package."
+        ])
+    });
+log_unconfigured_plugin(_Plugin) ->
+    ok.
 
 %% @doc List all installed plugins.
 %% Including the ones that are installed, but not enabled in config.

--- a/apps/emqx_plugins/src/emqx_plugins_app.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_app.erl
@@ -19,6 +19,7 @@ start(_Type, _Args) ->
     {ok, Sup} = emqx_plugins_sup:start_link(),
     ok = emqx_plugins:ensure_installed(),
     ok = emqx_plugins:ensure_started(),
+    emqx_plugins:log_unconfigured_plugins(),
     ok = emqx_config_handler:add_handler([?CONF_ROOT], emqx_plugins),
     ?tp("emqx_plugins_app_started", #{}),
     {ok, Sup}.

--- a/changes/ce/fix-17875.en.md
+++ b/changes/ce/fix-17875.en.md
@@ -1,3 +1,5 @@
 Fixed plugin management HTTP APIs to ignore stale unpacked plugin directories that are not present in the cluster plugin config and are not running locally.
 
 Such stale packages no longer appear in plugin list/detail/config/schema responses, cannot be acted on by plugin operation APIs, and no longer block reinstalling the same package through the HTTP install API. Configured pre-installed plugins are still visible and continue to follow the documented pre-install workflow.
+
+EMQX now logs an error on startup and HTTP API access when a plugin package is unpacked but is neither enabled nor disabled in `plugins.states`.

--- a/changes/ce/fix-17875.en.md
+++ b/changes/ce/fix-17875.en.md
@@ -1,0 +1,3 @@
+Fixed plugin management HTTP APIs to ignore stale unpacked plugin directories that are not present in the cluster plugin config and are not running locally.
+
+Such stale packages no longer appear in plugin list/detail/config/schema responses, cannot be acted on by plugin operation APIs, and no longer block reinstalling the same package through the HTTP install API. Configured pre-installed plugins are still visible and continue to follow the documented pre-install workflow.

--- a/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
+++ b/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
@@ -8,6 +8,8 @@
         {load_module, emqx_mgmt_data_backup},
         {load_module, emqx_mgmt_data_backup_proto_v2},
         {load_module, emqx_mgmt_api_data_backup},
+        {load_module, emqx_plugins},
+        {load_module, emqx_plugins_app},
         {load_module, emqx_mgmt_api_plugins},
         {apply, emqx_bpapi, announce, [node(), emqx]},
         {load_module, emqx_postgresql},

--- a/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
+++ b/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
@@ -8,6 +8,7 @@
         {load_module, emqx_mgmt_data_backup},
         {load_module, emqx_mgmt_data_backup_proto_v2},
         {load_module, emqx_mgmt_api_data_backup},
+        {load_module, emqx_mgmt_api_plugins},
         {apply, emqx_bpapi, announce, [node(), emqx]},
         {load_module, emqx_postgresql},
         {restart_application, jamdb_oracle},

--- a/plugins/emqx_relup/priv/relup/README.md
+++ b/plugins/emqx_relup/priv/relup/README.md
@@ -18,7 +18,7 @@ are arbitrary; `<from>-to-<to>.relup` is the convention.
 
 - Restart `esaml` so hot-upgraded nodes pick up SAML XXE protection.
 - Load dashboard/data-backup modules and re-announce `emqx` BPAPI so backup-file download authorization changes take effect for API-key callers.
-- Load the plugin management API module so stale plugin packages are hidden from HTTP API responses and operations.
+- Load plugin management modules so stale plugin packages are logged on startup/request and hidden from HTTP API responses and operations.
 - Load the PostgreSQL connector module so disabled-prepared-statement batch execution and table-existence checks use the serialized worker path.
 - Restart `jamdb_oracle`, load Oracle connector modules, then restart running Oracle connector resources so prepare/status checks and large text binds use the updated driver and callback code.
 - Load central redaction helpers and the LwM2M session module so registration/update reports drop sensitive fields and do not replay secrets.

--- a/plugins/emqx_relup/priv/relup/README.md
+++ b/plugins/emqx_relup/priv/relup/README.md
@@ -18,6 +18,7 @@ are arbitrary; `<from>-to-<to>.relup` is the convention.
 
 - Restart `esaml` so hot-upgraded nodes pick up SAML XXE protection.
 - Load dashboard/data-backup modules and re-announce `emqx` BPAPI so backup-file download authorization changes take effect for API-key callers.
+- Load the plugin management API module so stale plugin packages are hidden from HTTP API responses and operations.
 - Load the PostgreSQL connector module so disabled-prepared-statement batch execution and table-existence checks use the serialized worker path.
 - Restart `jamdb_oracle`, load Oracle connector modules, then restart running Oracle connector resources so prepare/status checks and large text binds use the updated driver and callback code.
 - Load central redaction helpers and the LwM2M session module so registration/update reports drop sensitive fields and do not replay secrets.

--- a/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
@@ -108,9 +108,9 @@ t_5105_catalog_uses_plugin_eredis_upgrade_module(_Config) ->
         )
     ).
 
--doc "The 5.10.4 -> 5.10.5 hop also applies SAML XXE, backup download, "
+-doc "The 5.10.4 -> 5.10.5 hop also applies SAML XXE, backup/plugin API, "
 "PostgreSQL, Oracle, and LwM2M fixes without extending the Redis stop/start window.".
-t_5105_catalog_covers_saml_xxe_backup_download_postgresql_oracle_and_lwm2m_fixes(_Config) ->
+t_5105_catalog_covers_saml_xxe_backup_plugin_api_postgresql_oracle_and_lwm2m_fixes(_Config) ->
     {Valid, _Errors} = emqx_relup_handler:validate_priv_catalog(),
     #{code_changes := CodeChanges} = find_relup_entry("5.10.4", "5.10.5", Valid),
     LoadRelease = {load_module, emqx_release},
@@ -139,6 +139,7 @@ t_5105_catalog_covers_saml_xxe_backup_download_postgresql_oracle_and_lwm2m_fixes
             {load_module, emqx_mgmt_data_backup},
             {load_module, emqx_mgmt_data_backup_proto_v2},
             {load_module, emqx_mgmt_api_data_backup},
+            {load_module, emqx_mgmt_api_plugins},
             AnnounceBPAPI,
             {load_module, emqx_postgresql},
             {restart_application, jamdb_oracle},

--- a/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
@@ -139,6 +139,8 @@ t_5105_catalog_covers_saml_xxe_backup_plugin_api_postgresql_oracle_and_lwm2m_fix
             {load_module, emqx_mgmt_data_backup},
             {load_module, emqx_mgmt_data_backup_proto_v2},
             {load_module, emqx_mgmt_api_data_backup},
+            {load_module, emqx_plugins},
+            {load_module, emqx_plugins_app},
             {load_module, emqx_mgmt_api_plugins},
             AnnounceBPAPI,
             {load_module, emqx_postgresql},


### PR DESCRIPTION
Release version:
5.10.5

Fix: https://emqx.atlassian.net/browse/EMQX-14124

## Summary

Fixed plugin management HTTP APIs to ignore stale unpacked plugin directories that are not present in the cluster plugin config and are not running locally. Such stale packages no longer appear in list/detail/config/schema responses, cannot be acted on by delete/start/move/cluster-sync APIs, and no longer block reinstalling the same package through the HTTP install API.

Configured pre-installed plugins and running local-only plugins remain visible, so the documented pre-install path and temporary local runtime state are preserved.

EMQX now logs an error on startup and HTTP API access when a plugin package is unpacked but is neither enabled nor disabled in `plugins.states`, with a CLI enable/disable or delete hint.

The 5.10.4 -> 5.10.5 relup catalog now reloads `emqx_plugins`, `emqx_plugins_app`, and `emqx_mgmt_api_plugins`, with catalog README and CT coverage.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/fix-17875.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
