### PR TITLE
test(gateway_nats): stabilize flaky t_gateway_client_management

### DIFF
--- a/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
@@ -7,6 +7,7 @@
 -include("emqx_nats.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -124,7 +125,12 @@ t_gateway_client_management(Config) ->
     {ok, [_]} = emqx_nats_client:receive_message(Client),
 
     %% Test list clients
-    [ClientInfo0] = emqx_gateway_test_utils:list_gateway_clients(<<"nats">>),
+    %% the channel is registered into the gateway connection-manager
+    %% asynchronously after the connect ack is sent, so retry until the
+    %% client appears in the list
+    [ClientInfo0] = ?retry(
+        100, 30, [_] = emqx_gateway_test_utils:list_gateway_clients(<<"nats">>)
+    ),
     ?assertEqual(<<"test_user">>, maps:get(username, ClientInfo0)),
     %% ClientId assigned by emqx_gateway_nats, it's a random string.
     %% We can get it from the client info.
@@ -166,7 +172,12 @@ t_gateway_client_subscription_management(Config) ->
     ok = emqx_nats_client:connect(Client),
     {ok, [_]} = emqx_nats_client:receive_message(Client),
 
-    [ClientInfo0] = emqx_gateway_test_utils:list_gateway_clients(<<"nats">>),
+    %% the channel is registered into the gateway connection-manager
+    %% asynchronously after the connect ack is sent, so retry until the
+    %% client appears in the list
+    [ClientInfo0] = ?retry(
+        100, 30, [_] = emqx_gateway_test_utils:list_gateway_clients(<<"nats">>)
+    ),
     ?assertEqual(<<"test_user">>, maps:get(username, ClientInfo0)),
     ClientId = maps:get(clientid, ClientInfo0),
 


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Stabilizes the flaky CT case `emqx_gateway_nats_SUITE:t_gateway_client_management`
(and the same pattern in `t_gateway_client_subscription_management`).

The NATS gateway returns the connect acknowledgement to the socket **before**
the channel is registered into the gateway connection-manager registry. The
test's REST `GET /gateways/nats/clients` call could therefore race ahead of
that async registration and return `[]`, failing with `{badmatch,[]}`.

The fix wraps the `list_gateway_clients` match in `?retry(100, 30, ...)` so the
list is polled until exactly one client appears, mirroring the existing
precedent in `emqx_stomp_SUITE`. Test-only change; no user-facing behavior.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
