### PR TITLE
test(sessds): stabilize flaky t_session_replay_retry

### DIFF
--- a/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
@@ -1298,8 +1298,13 @@ t_session_replay_retry(_Config) ->
                 ClientsPub
             ),
             %% 3. The subscriber receives them, but doesn't ack. This
-            %% sets the stage for message replay:
-            Pubs0 = emqx_common_test_helpers:wait_publishes(NClients, 5_000),
+            %% sets the stage for message replay. Delivery through the
+            %% persistent-session DS stream-polling path can lag under CI load;
+            %% since every message was acked it is durably stored, so nothing is
+            %% lost. `wait_publishes' returns as soon as all NClients arrive, so
+            %% a generous per-message-gap timeout only stretches the rare slow
+            %% tail and costs nothing in the happy path:
+            Pubs0 = emqx_common_test_helpers:wait_publishes(NClients, 30_000),
             NPubs = length(Pubs0),
             ?assertEqual(NClients, NPubs, ?drainMailbox(2_500)),
 
@@ -1323,6 +1328,10 @@ t_session_replay_retry(_Config) ->
             %% 5. Reconnect the client and let it receive *some* messages:
             _ClientSub = start_connect_client(ClientSubOpts#{clean_start => false}),
 
+            %% The mocked shards stay unavailable, so only *some* messages are
+            %% delivered here; this wait is expected to end on the per-message
+            %% gap timeout, hence it is kept short on purpose (bumping it would
+            %% add dead wait time to every run):
             Pubs1 = emqx_common_test_helpers:wait_publishes(NPubs, 5_000),
             ?assert(length(Pubs1) < length(Pubs0), #{
                 num_pubs1 => length(Pubs1),
@@ -1331,10 +1340,13 @@ t_session_replay_retry(_Config) ->
                 pubs0 => Pubs0
             }),
 
-            %% 6. Recover the shards and receive the rest of the messages:
+            %% 6. Recover the shards and receive the rest of the messages.
+            %% Same delivery-latency exposure as step 3: this wait also returns
+            %% as soon as the remaining durable messages arrive, so a generous
+            %% timeout only guards the slow tail.
             meck:unload(emqx_ds),
 
-            Pubs2 = emqx_common_test_helpers:wait_publishes(NPubs - length(Pubs1), 5_000),
+            Pubs2 = emqx_common_test_helpers:wait_publishes(NPubs - length(Pubs1), 30_000),
             snabbkaffe_diff:assert_lists_eq(
                 [maps:with([topic, payload, qos], P) || P <- Pubs0],
                 [maps:with([topic, payload, qos], P) || P <- Pubs1 ++ Pubs2],


### PR DESCRIPTION
Release version: 6.1.3

## Summary

Test-only stabilization of the flaky CT case
`emqx_persistent_session_ds_SUITE:t_session_replay_retry`, which intermittently
failed with `NPubs=9` (expected 10).

The setup-phase wait gave the subscriber only a 5 s per-message gap to receive
all 10 durable publishes. Delivery runs through the persistent-session DS
stream-polling path, whose per-message shard poll can occasionally lag past 5 s
under CI load, so the 10th message arrived late. Every publish was acked before
the wait, so the message is durably stored — this is a delivery-latency race,
not message loss.

`wait_publishes/2` returns as soon as all expected messages arrive, so raising
its per-message-gap timeout costs nothing in the happy path and only stretches
the rare slow tail. This bumps the two waits that return early on success (steps
3 and 6) from 5 s to 30 s, and deliberately leaves the step-5 wait at 5 s: with
the mocked shards still unavailable it is expected to end on the gap timeout, so
a larger value there would only add dead wait time to every run.

Ran the case 10× locally with no failures; happy-path runtime is unchanged.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
