### PR TITLE
fix(lwm2m): drop secrets from registration reports

### DIFF
--- a/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.app.src
+++ b/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway_lwm2m, [
     {description, "LwM2M Gateway"},
-    {vsn, "0.1.10"},
+    {vsn, "0.1.11"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway, emqx_gateway_coap, xmerl]},
     {env, []},

--- a/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.app.src
+++ b/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.app.src
@@ -3,7 +3,7 @@
     {description, "LwM2M Gateway"},
     {vsn, "0.1.11"},
     {registered, []},
-    {applications, [kernel, stdlib, emqx, emqx_gateway, emqx_gateway_coap, xmerl]},
+    {applications, [kernel, stdlib, emqx, emqx_utils, emqx_gateway, emqx_gateway_coap, xmerl]},
     {env, []},
     {modules, []},
     {links, []}

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
@@ -99,30 +99,6 @@
 %% uplink and downlink topic configuration
 -define(lwm2m_up_dm_topic, {<<"/v1/up/dm">>, 0}).
 
--define(SENSITIVE_REG_INFO_KEYS, [
-    <<"account_key">>,
-    <<"access_key_id">>,
-    <<"access_key_secret">>,
-    <<"access_token">>,
-    <<"api_key">>,
-    <<"api_secret">>,
-    <<"aws_secret_access_key">>,
-    <<"bind_password">>,
-    <<"jwt">>,
-    <<"passcode">>,
-    <<"passwd">>,
-    <<"password">>,
-    <<"private_key">>,
-    <<"private_key_password">>,
-    <<"secret">>,
-    <<"secret_access_key">>,
-    <<"secret_key">>,
-    <<"security_token">>,
-    <<"sentinel_password">>,
-    <<"sp_private_key">>,
-    <<"token">>
-]).
-
 %% steal from emqx_session
 -define(INFO_KEYS, [
     id,
@@ -345,7 +321,12 @@ fix_reg_info(_, RegInfo) ->
     RegInfo.
 
 drop_sensitive_reg_info(RegInfo) ->
-    maps:without(?SENSITIVE_REG_INFO_KEYS, RegInfo).
+    maps:filter(
+        fun(Key, _Value) ->
+            not emqx_utils:is_sensitive_key(Key)
+        end,
+        RegInfo
+    ).
 
 parse_object_list(<<>>) ->
     {<<"/">>, <<>>};

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
@@ -99,6 +99,30 @@
 %% uplink and downlink topic configuration
 -define(lwm2m_up_dm_topic, {<<"/v1/up/dm">>, 0}).
 
+-define(SENSITIVE_REG_INFO_KEYS, [
+    <<"account_key">>,
+    <<"access_key_id">>,
+    <<"access_key_secret">>,
+    <<"access_token">>,
+    <<"api_key">>,
+    <<"api_secret">>,
+    <<"aws_secret_access_key">>,
+    <<"bind_password">>,
+    <<"jwt">>,
+    <<"passcode">>,
+    <<"passwd">>,
+    <<"password">>,
+    <<"private_key">>,
+    <<"private_key_password">>,
+    <<"secret">>,
+    <<"secret_access_key">>,
+    <<"secret_key">>,
+    <<"security_token">>,
+    <<"sentinel_password">>,
+    <<"sp_private_key">>,
+    <<"token">>
+]).
+
 %% steal from emqx_session
 -define(INFO_KEYS, [
     id,
@@ -297,7 +321,7 @@ handle_protocol_in({reset, CtxMsg}, WithContext, Session) ->
 %% Register
 %%--------------------------------------------------------------------
 append_object_list(Query, Payload) ->
-    RegInfo = append_object_list2(Query, Payload),
+    RegInfo = drop_sensitive_reg_info(append_object_list2(Query, Payload)),
     lists:foldl(
         fun(Key, Acc) ->
             fix_reg_info(Key, Acc)
@@ -319,6 +343,9 @@ fix_reg_info(<<"lt">>, #{<<"lt">> := LT} = RegInfo) ->
     RegInfo#{<<"lt">> := erlang:binary_to_integer(LT)};
 fix_reg_info(_, RegInfo) ->
     RegInfo.
+
+drop_sensitive_reg_info(RegInfo) ->
+    maps:without(?SENSITIVE_REG_INFO_KEYS, RegInfo).
 
 parse_object_list(<<>>) ->
     {<<"/">>, <<>>};
@@ -402,7 +429,7 @@ update(
 ) ->
     Query = maps:get(uri_query, Opts, #{}),
     RegInfo = append_object_list(Query, Payload),
-    UpdateRegInfo = maps:merge(OldRegInfo, RegInfo),
+    UpdateRegInfo = drop_sensitive_reg_info(maps:merge(OldRegInfo, RegInfo)),
     LifeTime = get_lifetime(UpdateRegInfo, OldRegInfo),
 
     NewSession = Session#session{

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
@@ -323,7 +323,7 @@ fix_reg_info(_, RegInfo) ->
 drop_sensitive_reg_info(RegInfo) ->
     maps:filter(
         fun(Key, _Value) ->
-            not emqx_utils:is_sensitive_key(Key)
+            not emqx_utils_redact:is_sensitive_key(Key)
         end,
         RegInfo
     ).

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
@@ -833,8 +833,8 @@ maybe_do_deliver_to_coap(
         queue = Queue
     } = Session
 ) ->
-    MHeaders = maps:get(mheaders, Ctx, #{}),
-    TTL = maps:get(<<"ttl">>, MHeaders, 7200),
+    Mheaders = maps:get(mheaders, Ctx, #{}),
+    TTL = maps:get(<<"ttl">>, Mheaders, 7200),
     case TTL of
         0 ->
             send_msg_not_waiting_ack(Ctx, Req, Session);
@@ -898,10 +898,10 @@ get_outs() ->
         Any -> Any
     end.
 
-return(#session{coap = CoAP} = Session) ->
+return(#session{coap = Coap} = Session) ->
     Outs = get_outs(),
     erlang:put(?OUT_LIST_KEY, []),
-    {ok, Coap2, Msgs} = do_out(Outs, CoAP, []),
+    {ok, Coap2, Msgs} = do_out(Outs, Coap, []),
     #{return => {Msgs, Session#session{coap = Coap2}}}.
 
 do_out([{Ctx, Out} | T], TM, Msgs) ->

--- a/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
+++ b/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
@@ -563,7 +563,10 @@ case02_update_deregister(Config) ->
     test_send_coap_request(
         UdpSock,
         post,
-        sprintf("coap://127.0.0.1:~b/rd?ep=~ts&lt=345&lwm2m=1", [?PORT, Epn]),
+        sprintf(
+            "coap://127.0.0.1:~b/rd?ep=~ts&lt=345&lwm2m=1&password=public&secret=top&private_key=priv&access_token=token",
+            [?PORT, Epn]
+        ),
         #coap_content{
             content_format = <<"text/plain">>,
             payload = <<"</1>, </2>, </3>, </4>, </5>">>
@@ -581,15 +584,16 @@ case02_update_deregister(Config) ->
 
     ?LOGT("Options got: ~p", [Opts]),
     Location = maps:get(location_path, Opts),
-    Register = emqx_utils_json:encode(
+    Register = emqx_utils_json:decode(test_recv_mqtt_response(ReportTopic)),
+    ?assertMatch(
         #{
-            <<"msgType">> => <<"register">>,
-            <<"data">> => #{
-                <<"alternatePath">> => <<"/">>,
-                <<"ep">> => list_to_binary(Epn),
-                <<"lt">> => 345,
-                <<"lwm2m">> => <<"1">>,
-                <<"objectList">> => [
+            <<"msgType">> := <<"register">>,
+            <<"data">> := #{
+                <<"alternatePath">> := <<"/">>,
+                <<"ep">> := <<"urn:oma:lwm2m:oma:3">>,
+                <<"lt">> := 345,
+                <<"lwm2m">> := <<"1">>,
+                <<"objectList">> := [
                     <<"/1">>,
                     <<"/2">>,
                     <<"/3">>,
@@ -597,9 +601,10 @@ case02_update_deregister(Config) ->
                     <<"/5">>
                 ]
             }
-        }
+        },
+        Register
     ),
-    ?assertEqual(Register, test_recv_mqtt_response(ReportTopic)),
+    assert_no_secret_register_fields(Register),
 
     %%----------------------------------------
     %% UPDATE command
@@ -609,11 +614,8 @@ case02_update_deregister(Config) ->
     test_send_coap_request(
         UdpSock,
         post,
-        sprintf("coap://127.0.0.1:~b~ts?lt=789", [?PORT, join_path(Location, <<>>)]),
-        #coap_content{
-            content_format = <<"text/plain">>,
-            payload = <<"</1>, </2>, </3>, </4>, </5>, </6>">>
-        },
+        sprintf("coap://127.0.0.1:~b~ts", [?PORT, join_path(Location, <<>>)]),
+        #coap_content{payload = <<>>},
         [],
         MsgId2
     ),
@@ -624,26 +626,27 @@ case02_update_deregister(Config) ->
     } = test_recv_coap_response(UdpSock),
     {ok, changed} = Method2,
     MsgId2 = RspId2,
-    Update = emqx_utils_json:encode(
+    Update = emqx_utils_json:decode(test_recv_mqtt_response(ReportTopic)),
+    ?assertMatch(
         #{
-            <<"msgType">> => <<"update">>,
-            <<"data">> => #{
-                <<"alternatePath">> => <<"/">>,
-                <<"ep">> => list_to_binary(Epn),
-                <<"lt">> => 789,
-                <<"lwm2m">> => <<"1">>,
-                <<"objectList">> => [
+            <<"msgType">> := <<"update">>,
+            <<"data">> := #{
+                <<"alternatePath">> := <<"/">>,
+                <<"ep">> := <<"urn:oma:lwm2m:oma:3">>,
+                <<"lt">> := 345,
+                <<"lwm2m">> := <<"1">>,
+                <<"objectList">> := [
                     <<"/1">>,
                     <<"/2">>,
                     <<"/3">>,
                     <<"/4">>,
-                    <<"/5">>,
-                    <<"/6">>
+                    <<"/5">>
                 ]
             }
-        }
+        },
+        Update
     ),
-    ?assertEqual(Update, test_recv_mqtt_response(ReportTopic)),
+    assert_no_secret_register_fields(Update),
 
     %%----------------------------------------
     %% DE-REGISTER command
@@ -2688,6 +2691,19 @@ test_recv_mqtt_response(RespTopic) ->
             RM
     after 1000 -> timeout_test_recv_mqtt_response
     end.
+
+assert_no_secret_register_fields(#{<<"data">> := Data}) ->
+    lists:foreach(
+        fun(Key) ->
+            ?assertNot(maps:is_key(Key, Data))
+        end,
+        [
+            <<"password">>,
+            <<"secret">>,
+            <<"private_key">>,
+            <<"access_token">>
+        ]
+    ).
 
 test_send_coap_request(UdpSock, Method, Uri, Content, Options, MsgId) ->
     is_record(Content, coap_content) orelse

--- a/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
+++ b/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
@@ -564,7 +564,8 @@ case02_update_deregister(Config) ->
         UdpSock,
         post,
         sprintf(
-            "coap://127.0.0.1:~b/rd?ep=~ts&lt=345&lwm2m=1&password=public&secret=top&private_key=priv&access_token=token",
+            "coap://127.0.0.1:~b/rd?ep=~ts&lt=345&lwm2m=1" ++
+                "&password=public&secret=top&private_key=priv&access_token=token",
             [?PORT, Epn]
         ),
         #coap_content{

--- a/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
+++ b/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
@@ -2694,16 +2694,17 @@ test_recv_mqtt_response(RespTopic) ->
     end.
 
 assert_no_secret_register_fields(#{<<"data">> := Data}) ->
-    lists:foreach(
-        fun(Key) ->
-            ?assertNot(maps:is_key(Key, Data))
-        end,
-        [
-            <<"password">>,
-            <<"secret">>,
-            <<"private_key">>,
-            <<"access_token">>
-        ]
+    ?assertEqual(
+        #{},
+        maps:with(
+            [
+                <<"password">>,
+                <<"secret">>,
+                <<"private_key">>,
+                <<"access_token">>
+            ],
+            Data
+        )
     ).
 
 test_send_coap_request(UdpSock, Method, Uri, Content, Options, MsgId) ->

--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.6.2"},
+    {vsn, "5.6.3"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -86,7 +86,7 @@
     nolink_apply/2
 ]).
 
--export([clamp/3, redact/1, redact/2, is_redacted/2, is_redacted/3]).
+-export([clamp/3, redact/1, redact/2, is_sensitive_key/1, is_redacted/2, is_redacted/3]).
 -export([deobfuscate/2]).
 
 -export_type([
@@ -684,6 +684,9 @@ redact(Term) ->
 
 redact(Term, Checker) ->
     emqx_utils_redact:redact(Term, Checker).
+
+is_sensitive_key(Key) ->
+    emqx_utils_redact:is_sensitive_key(Key).
 
 deobfuscate(NewConf, OldConf) ->
     emqx_utils_redact:deobfuscate(NewConf, OldConf).

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -86,7 +86,7 @@
     nolink_apply/2
 ]).
 
--export([clamp/3, redact/1, redact/2, is_sensitive_key/1, is_redacted/2, is_redacted/3]).
+-export([clamp/3, redact/1, redact/2, is_redacted/2, is_redacted/3]).
 -export([deobfuscate/2]).
 
 -export_type([
@@ -684,9 +684,6 @@ redact(Term) ->
 
 redact(Term, Checker) ->
     emqx_utils_redact:redact(Term, Checker).
-
-is_sensitive_key(Key) ->
-    emqx_utils_redact:is_sensitive_key(Key).
 
 deobfuscate(NewConf, OldConf) ->
     emqx_utils_redact:deobfuscate(NewConf, OldConf).

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -16,7 +16,7 @@
 
 -module(emqx_utils_redact).
 
--export([redact/1, redact/2, redact_headers/1, is_redacted/2, is_redacted/3]).
+-export([redact/1, redact/2, redact_headers/1, is_sensitive_key/1, is_redacted/2, is_redacted/3]).
 -export([deobfuscate/2]).
 
 -define(REDACT_VAL, "******").
@@ -26,12 +26,24 @@
 is_sensitive_key(account_key) -> true;
 is_sensitive_key("account_key") -> true;
 is_sensitive_key(<<"account_key">>) -> true;
+is_sensitive_key(access_token) -> true;
+is_sensitive_key("access_token") -> true;
+is_sensitive_key(<<"access_token">>) -> true;
 is_sensitive_key(api_key) -> true;
 is_sensitive_key("api_key") -> true;
 is_sensitive_key(<<"api_key">>) -> true;
+is_sensitive_key(api_secret) -> true;
+is_sensitive_key("api_secret") -> true;
+is_sensitive_key(<<"api_secret">>) -> true;
 is_sensitive_key(aws_secret_access_key) -> true;
 is_sensitive_key("aws_secret_access_key") -> true;
 is_sensitive_key(<<"aws_secret_access_key">>) -> true;
+is_sensitive_key(passcode) -> true;
+is_sensitive_key("passcode") -> true;
+is_sensitive_key(<<"passcode">>) -> true;
+is_sensitive_key(passwd) -> true;
+is_sensitive_key("passwd") -> true;
+is_sensitive_key(<<"passwd">>) -> true;
 is_sensitive_key(password) -> true;
 is_sensitive_key("password") -> true;
 is_sensitive_key(<<"password">>) -> true;
@@ -286,7 +298,11 @@ redact_test_() ->
     Types = [atom, string, binary],
     Keys = [
         account_key,
+        access_token,
+        api_secret,
         aws_secret_access_key,
+        passcode,
+        passwd,
         password,
         private_key,
         secret,

--- a/changes/ce/fix-17885.en.md
+++ b/changes/ce/fix-17885.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the LwM2M gateway could include sensitive REGISTER query fields such as `password`, `secret`, `private_key`, and `access_token` in registration/update MQTT reports.

--- a/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
+++ b/plugins/emqx_relup/priv/relup/5.10.4-to-5.10.5.relup
@@ -14,6 +14,8 @@
         {load_module, emqx_oracle},
         {load_module, emqx_relup_oracle_upgrade},
         {apply, emqx_relup_oracle_upgrade, restart_oracle_connectors, []},
+        {load_module, emqx_utils_redact},
+        {load_module, emqx_lwm2m_session},
         {apply, emqx_relup_eredis_upgrade, stop_redis_resources, []},
         {restart_application, eredis},
         {load_module, emqx_redis},

--- a/plugins/emqx_relup/priv/relup/README.md
+++ b/plugins/emqx_relup/priv/relup/README.md
@@ -20,6 +20,7 @@ are arbitrary; `<from>-to-<to>.relup` is the convention.
 - Load dashboard/data-backup modules and re-announce `emqx` BPAPI so backup-file download authorization changes take effect for API-key callers.
 - Load the PostgreSQL connector module so disabled-prepared-statement batch execution and table-existence checks use the serialized worker path.
 - Restart `jamdb_oracle`, load Oracle connector modules, then restart running Oracle connector resources so prepare/status checks and large text binds use the updated driver and callback code.
+- Load central redaction helpers and the LwM2M session module so registration/update reports drop sensitive fields and do not replay secrets.
 - Stop Redis resources, restart `eredis`, reload `emqx_redis`, then start Redis resources so Sentinel managers are recreated with isolated manager names.
 
 ## Schema

--- a/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_handler_SUITE.erl
@@ -109,8 +109,8 @@ t_5105_catalog_uses_plugin_eredis_upgrade_module(_Config) ->
     ).
 
 -doc "The 5.10.4 -> 5.10.5 hop also applies SAML XXE, backup download, "
-"PostgreSQL, and Oracle fixes without extending the Redis stop/start window.".
-t_5105_catalog_covers_saml_xxe_backup_download_postgresql_and_oracle_fixes(_Config) ->
+"PostgreSQL, Oracle, and LwM2M fixes without extending the Redis stop/start window.".
+t_5105_catalog_covers_saml_xxe_backup_download_postgresql_oracle_and_lwm2m_fixes(_Config) ->
     {Valid, _Errors} = emqx_relup_handler:validate_priv_catalog(),
     #{code_changes := CodeChanges} = find_relup_entry("5.10.4", "5.10.5", Valid),
     LoadRelease = {load_module, emqx_release},
@@ -144,7 +144,9 @@ t_5105_catalog_covers_saml_xxe_backup_download_postgresql_and_oracle_fixes(_Conf
             {restart_application, jamdb_oracle},
             {load_module, emqx_oracle},
             {load_module, emqx_relup_oracle_upgrade},
-            {apply, emqx_relup_oracle_upgrade, restart_oracle_connectors, []}
+            {apply, emqx_relup_oracle_upgrade, restart_oracle_connectors, []},
+            {load_module, emqx_utils_redact},
+            {load_module, emqx_lwm2m_session}
         ]
     ),
     ?assert(
@@ -167,6 +169,9 @@ t_5105_catalog_covers_saml_xxe_backup_download_postgresql_and_oracle_fixes(_Conf
             {apply, emqx_relup_oracle_upgrade, restart_oracle_connectors, []},
             CodeChanges
         )
+    ),
+    ?assert(
+        is_before({load_module, emqx_utils_redact}, {load_module, emqx_lwm2m_session}, CodeChanges)
     ),
     ?assert(is_before({load_module, emqx_mgmt_data_backup_proto_v2}, AnnounceBPAPI, CodeChanges)).
 


### PR DESCRIPTION
Release version:
5.10.5

Fix: N/A (no public ticket provided)

## Summary

LwM2M REGISTER and UPDATE reports now drop sensitive query fields such as `password`, `secret`, `private_key`, and `access_token` before storing registration info or publishing it to MQTT.

The filtering reuses EMQX's central redaction sensitive-key predicate instead of keeping an LwM2M-local key list. The central predicate now also treats `access_token`, `api_secret`, `passcode`, and `passwd` as sensitive keys.

Empty UPDATE requests keep existing non-sensitive registration data but no longer replay secrets captured during REGISTER. The LwM2M gateway and `emqx_utils` app versions were bumped for the source changes, and the 5.10.4 to 5.10.5 relup catalog reloads the updated redaction helper and LwM2M session modules.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/fix-17885.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
