### PR TITLE
fix(prometheus): expose publish quota exceeded metric

### DIFF
--- a/apps/emqx/include/emqx_metrics.hrl
+++ b/apps/emqx/include/emqx_metrics.hrl
@@ -48,6 +48,8 @@
     %% PUBLISH(QoS2) packets dropped
     {counter, 'packets.publish.dropped',
         <<"Number of messages discarded due to the receiving limit">>},
+    {counter, 'packets.publish.quota_exceeded',
+        <<"Number of PUBLISH packets rejected due to quota exceeded">>},
     %% PUBACK packets received
     {counter, 'packets.puback.received', <<"Number of received PUBACK packet">>},
     %% PUBACK packets sent

--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.5.8"},
+    {vsn, "5.5.9"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -718,6 +718,7 @@ process_publish(Packet = ?PUBLISH_PACKET(QoS, Topic, PacketId), Channel) ->
                 },
                 #{topic => Topic, tag => "AUTHZ"}
             ),
+            ok = emqx_metrics:inc('packets.publish.quota_exceeded'),
             case QoS of
                 ?QOS_0 ->
                     ok = emqx_metrics:inc('packets.publish.dropped'),

--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -472,6 +472,7 @@ reserved_idx('packets.disconnect.sent') -> 46;
 reserved_idx('packets.auth.received') -> 47;
 reserved_idx('packets.auth.sent') -> 48;
 reserved_idx('packets.publish.dropped') -> 49;
+reserved_idx('packets.publish.quota_exceeded') -> 50;
 %% Reserved indices of message's metrics
 reserved_idx('messages.received') -> 100;
 reserved_idx('messages.sent') -> 101;

--- a/apps/emqx_prometheus/src/emqx_prometheus.app.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.app.src
@@ -2,7 +2,7 @@
 {application, emqx_prometheus, [
     {description, "Prometheus for EMQX"},
     % strict semver, bump manually!
-    {vsn, "5.2.10"},
+    {vsn, "5.2.11"},
     {modules, []},
     {registered, [emqx_prometheus_sup]},
     {applications, [kernel, stdlib, prometheus, emqx, emqx_auth, emqx_resource, emqx_management]},

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -418,6 +418,7 @@ emqx_collect(K = emqx_packets_publish_inuse, D) -> counter_metrics(?MG(K, D));
 emqx_collect(K = emqx_packets_publish_error, D) -> counter_metrics(?MG(K, D));
 emqx_collect(K = emqx_packets_publish_auth_error, D) -> counter_metrics(?MG(K, D));
 emqx_collect(K = emqx_packets_publish_dropped, D) -> counter_metrics(?MG(K, D));
+emqx_collect(K = emqx_packets_publish_quota_exceeded, D) -> counter_metrics(?MG(K, D));
 %% puback
 emqx_collect(K = emqx_packets_puback_received, D) -> counter_metrics(?MG(K, D));
 emqx_collect(K = emqx_packets_puback_sent, D) -> counter_metrics(?MG(K, D));
@@ -785,6 +786,7 @@ emqx_packet_metric_meta() ->
         {emqx_packets_publish_error, counter, 'packets.publish.error'},
         {emqx_packets_publish_auth_error, counter, 'packets.publish.auth_error'},
         {emqx_packets_publish_dropped, counter, 'packets.publish.dropped'},
+        {emqx_packets_publish_quota_exceeded, counter, 'packets.publish.quota_exceeded'},
         %% puback
         {emqx_packets_puback_received, counter, 'packets.puback.received'},
         {emqx_packets_puback_sent, counter, 'packets.puback.sent'},

--- a/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
@@ -606,6 +606,7 @@ assert_json_data__packets(M, Mode) when
             emqx_packets_subscribe_received := _,
             emqx_bytes_received := _,
             emqx_packets_publish_dropped := _,
+            emqx_packets_publish_quota_exceeded := _,
             emqx_packets_publish_received := _,
             emqx_packets_connack_sent := _,
             emqx_packets_connack_auth_error := _,

--- a/changes/ce/fix-17886.en.md
+++ b/changes/ce/fix-17886.en.md
@@ -1,0 +1,1 @@
+Exposed the publish quota-exceeded packet metric in Prometheus as `emqx_packets_publish_quota_exceeded`.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.3, 5.10.5

## Summary

Expose `packets.publish.quota_exceeded` as `emqx_packets_publish_quota_exceeded` in Prometheus metrics so publish-side TPS limiter rejections can be observed directly.

On `dev-58`, add the broker metric at the quota-exceeded publish path and keep the existing QoS 0 `packets.publish.dropped` metric unchanged.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/fix-17886.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)