### PR TITLE
fix(lwm2m): drop secrets from registration reports

### DIFF
--- a/apps/emqx_gateway_lwm2m/mix.exs
+++ b/apps/emqx_gateway_lwm2m/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayLwm2m.MixProject do
   def project do
     [
       app: :emqx_gateway_lwm2m,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),
@@ -24,6 +24,7 @@ defmodule EMQXGatewayLwm2m.MixProject do
   def deps() do
     UMP.deps([
       {:emqx, in_umbrella: true},
+      {:emqx_utils, in_umbrella: true},
       {:emqx_gateway, in_umbrella: true},
       {:emqx_gateway_coap, in_umbrella: true}
     ])

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
@@ -297,7 +297,7 @@ handle_protocol_in({reset, CtxMsg}, WithContext, Session) ->
 %% Register
 %%--------------------------------------------------------------------
 append_object_list(Query, Payload) ->
-    RegInfo = append_object_list2(Query, Payload),
+    RegInfo = drop_sensitive_reg_info(append_object_list2(Query, Payload)),
     lists:foldl(
         fun(Key, Acc) ->
             fix_reg_info(Key, Acc)
@@ -319,6 +319,14 @@ fix_reg_info(<<"lt">>, #{<<"lt">> := LT} = RegInfo) ->
     RegInfo#{<<"lt">> := erlang:binary_to_integer(LT)};
 fix_reg_info(_, RegInfo) ->
     RegInfo.
+
+drop_sensitive_reg_info(RegInfo) ->
+    maps:filter(
+        fun(Key, _Value) ->
+            not emqx_utils_redact:is_sensitive_key(Key)
+        end,
+        RegInfo
+    ).
 
 parse_object_list(<<>>) ->
     {<<"/">>, <<>>};
@@ -402,7 +410,7 @@ update(
 ) ->
     Query = maps:get(uri_query, Opts, #{}),
     RegInfo = append_object_list(Query, Payload),
-    UpdateRegInfo = maps:merge(OldRegInfo, RegInfo),
+    UpdateRegInfo = drop_sensitive_reg_info(maps:merge(OldRegInfo, RegInfo)),
     LifeTime = get_lifetime(UpdateRegInfo, OldRegInfo),
 
     NewSession = Session#session{
@@ -806,8 +814,8 @@ maybe_do_deliver_to_coap(
         queue = Queue
     } = Session
 ) ->
-    MHeaders = maps:get(mheaders, Ctx, #{}),
-    TTL = maps:get(<<"ttl">>, MHeaders, 7200),
+    Mheaders = maps:get(mheaders, Ctx, #{}),
+    TTL = maps:get(<<"ttl">>, Mheaders, 7200),
     case TTL of
         0 ->
             send_msg_not_waiting_ack(Ctx, Req, Session);
@@ -871,10 +879,10 @@ get_outs() ->
         Any -> Any
     end.
 
-return(#session{coap = CoAP} = Session) ->
+return(#session{coap = Coap} = Session) ->
     Outs = get_outs(),
     erlang:put(?OUT_LIST_KEY, []),
-    {ok, Coap2, Msgs} = do_out(Outs, CoAP, []),
+    {ok, Coap2, Msgs} = do_out(Outs, Coap, []),
     #{return => {Msgs, Session#session{coap = Coap2}}}.
 
 do_out([{Ctx, Out} | T], TM, Msgs) ->

--- a/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
+++ b/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_SUITE.erl
@@ -564,7 +564,11 @@ case02_update_deregister(Config) ->
     test_send_coap_request(
         UdpSock,
         post,
-        sprintf("coap://127.0.0.1:~b/rd?ep=~ts&lt=345&lwm2m=1", [?PORT, Epn]),
+        sprintf(
+            "coap://127.0.0.1:~b/rd?ep=~ts&lt=345&lwm2m=1" ++
+                "&password=public&secret=top&private_key=priv&access_token=token",
+            [?PORT, Epn]
+        ),
         #coap_content{
             content_format = <<"text/plain">>,
             payload = <<"</1>, </2>, </3>, </4>, </5>">>
@@ -582,15 +586,16 @@ case02_update_deregister(Config) ->
 
     ?LOGT("Options got: ~p", [Opts]),
     Location = maps:get(location_path, Opts),
-    Register = emqx_utils_json:encode(
+    Register = emqx_utils_json:decode(test_recv_mqtt_response(ReportTopic)),
+    ?assertMatch(
         #{
-            <<"msgType">> => <<"register">>,
-            <<"data">> => #{
-                <<"alternatePath">> => <<"/">>,
-                <<"ep">> => list_to_binary(Epn),
-                <<"lt">> => 345,
-                <<"lwm2m">> => <<"1">>,
-                <<"objectList">> => [
+            <<"msgType">> := <<"register">>,
+            <<"data">> := #{
+                <<"alternatePath">> := <<"/">>,
+                <<"ep">> := <<"urn:oma:lwm2m:oma:3">>,
+                <<"lt">> := 345,
+                <<"lwm2m">> := <<"1">>,
+                <<"objectList">> := [
                     <<"/1">>,
                     <<"/2">>,
                     <<"/3">>,
@@ -598,9 +603,10 @@ case02_update_deregister(Config) ->
                     <<"/5">>
                 ]
             }
-        }
+        },
+        Register
     ),
-    ?assertEqual(Register, test_recv_mqtt_response(ReportTopic)),
+    assert_no_secret_register_fields(Register),
 
     %%----------------------------------------
     %% UPDATE command
@@ -610,11 +616,8 @@ case02_update_deregister(Config) ->
     test_send_coap_request(
         UdpSock,
         post,
-        sprintf("coap://127.0.0.1:~b~ts?lt=789", [?PORT, join_path(Location, <<>>)]),
-        #coap_content{
-            content_format = <<"text/plain">>,
-            payload = <<"</1>, </2>, </3>, </4>, </5>, </6>">>
-        },
+        sprintf("coap://127.0.0.1:~b~ts", [?PORT, join_path(Location, <<>>)]),
+        #coap_content{payload = <<>>},
         [],
         MsgId2
     ),
@@ -625,26 +628,27 @@ case02_update_deregister(Config) ->
     } = test_recv_coap_response(UdpSock),
     {ok, changed} = Method2,
     MsgId2 = RspId2,
-    Update = emqx_utils_json:encode(
+    Update = emqx_utils_json:decode(test_recv_mqtt_response(ReportTopic)),
+    ?assertMatch(
         #{
-            <<"msgType">> => <<"update">>,
-            <<"data">> => #{
-                <<"alternatePath">> => <<"/">>,
-                <<"ep">> => list_to_binary(Epn),
-                <<"lt">> => 789,
-                <<"lwm2m">> => <<"1">>,
-                <<"objectList">> => [
+            <<"msgType">> := <<"update">>,
+            <<"data">> := #{
+                <<"alternatePath">> := <<"/">>,
+                <<"ep">> := <<"urn:oma:lwm2m:oma:3">>,
+                <<"lt">> := 345,
+                <<"lwm2m">> := <<"1">>,
+                <<"objectList">> := [
                     <<"/1">>,
                     <<"/2">>,
                     <<"/3">>,
                     <<"/4">>,
-                    <<"/5">>,
-                    <<"/6">>
+                    <<"/5">>
                 ]
             }
-        }
+        },
+        Update
     ),
-    ?assertEqual(Update, test_recv_mqtt_response(ReportTopic)),
+    assert_no_secret_register_fields(Update),
 
     %%----------------------------------------
     %% DE-REGISTER command
@@ -2689,6 +2693,20 @@ test_recv_mqtt_response(RespTopic) ->
             RM
     after 1000 -> timeout_test_recv_mqtt_response
     end.
+
+assert_no_secret_register_fields(#{<<"data">> := Data}) ->
+    ?assertEqual(
+        #{},
+        maps:with(
+            [
+                <<"password">>,
+                <<"secret">>,
+                <<"private_key">>,
+                <<"access_token">>
+            ],
+            Data
+        )
+    ).
 
 test_send_coap_request(UdpSock, Method, Uri, Content, Options, MsgId) ->
     is_record(Content, coap_content) orelse

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -16,7 +16,7 @@
 
 -module(emqx_utils_redact).
 
--export([redact/1, redact/2, redact_headers/1, is_redacted/2, is_redacted/3]).
+-export([redact/1, redact/2, redact_headers/1, is_sensitive_key/1, is_redacted/2, is_redacted/3]).
 -export([deobfuscate/2]).
 
 -define(REDACT_VAL, "******").
@@ -38,6 +38,9 @@ is_sensitive_key(<<"account_key">>) -> true;
 is_sensitive_key(api_key) -> true;
 is_sensitive_key("api_key") -> true;
 is_sensitive_key(<<"api_key">>) -> true;
+is_sensitive_key(api_secret) -> true;
+is_sensitive_key("api_secret") -> true;
+is_sensitive_key(<<"api_secret">>) -> true;
 is_sensitive_key(aws_secret_access_key) -> true;
 is_sensitive_key("aws_secret_access_key") -> true;
 is_sensitive_key(<<"aws_secret_access_key">>) -> true;
@@ -65,6 +68,12 @@ is_sensitive_key(<<"new_pwd">>) -> true;
 is_sensitive_key(old_pwd) -> true;
 is_sensitive_key("old_pwd") -> true;
 is_sensitive_key(<<"old_pwd">>) -> true;
+is_sensitive_key(passcode) -> true;
+is_sensitive_key("passcode") -> true;
+is_sensitive_key(<<"passcode">>) -> true;
+is_sensitive_key(passwd) -> true;
+is_sensitive_key("passwd") -> true;
+is_sensitive_key(<<"passwd">>) -> true;
 is_sensitive_key(password) -> true;
 is_sensitive_key("password") -> true;
 is_sensitive_key(<<"password">>) -> true;
@@ -332,7 +341,11 @@ redact_test_() ->
     Types = [atom, string, binary],
     Keys = [
         account_key,
+        access_token,
+        api_secret,
         aws_secret_access_key,
+        passcode,
+        passwd,
         password,
         private_key,
         secret,

--- a/changes/ce/fix-17888.en.md
+++ b/changes/ce/fix-17888.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the LwM2M gateway could include sensitive REGISTER query fields such as `password`, `secret`, `private_key`, and `access_token` in registration/update MQTT reports.


### PR DESCRIPTION
Release version:
6.0.4

Fix: N/A (no public ticket provided)

## Summary

Port #17885 to dev-60 without the relup changes.

LwM2M REGISTER and UPDATE reports now drop sensitive query fields such as `password`, `secret`, `private_key`, and `access_token` before storing registration info or publishing it to MQTT.

The filtering reuses EMQX's central redaction sensitive-key predicate. This port exports that predicate for the LwM2M gateway and adds `api_secret`, `passcode`, and `passwd` to the central sensitive-key list.

Empty UPDATE requests keep existing non-sensitive registration data but no longer replay secrets captured during REGISTER.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/fix-17888.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
