### PR TITLE
test(prometheus): fix t_listener_shutdown_count takeover race

### DIFF
--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -387,6 +387,12 @@ t_listener_shutdown_count(_Config) ->
     ClientId2 = fresh_clientid(?FUNCTION_NAME),
     {ok, C3} = emqtt_connect(ClientId2),
     ok = emqtt:stop(C3),
+    %% Wait until C3's channel is fully deregistered before reconnecting with the
+    %% same clientid. emqtt:stop/1 closes the socket, but the broker records
+    %% tcp_closed asynchronously when it detects the peer close. If C4's CONNECT
+    %% (same clientid) races ahead of C3's reaping, C4 takes over C3's lingering
+    %% session and the event is miscounted as "discarded" instead of "tcp_closed".
+    ?retry(100, 20, [] = emqx_cm:lookup_channels(ClientId2)),
     %% Disconnect with reason code
     {ok, C4} = emqtt_connect(ClientId2),
     ok = emqtt:disconnect(C4, ?RC_IMPLEMENTATION_SPECIFIC_ERROR),


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Fixes the flaky `emqx_prometheus_api_SUITE:t_listener_shutdown_count`.

The case connects C3 with `ClientId2`, calls `emqtt:stop(C3)` to trigger a
`tcp_closed` disconnect, then immediately reconnects C4 with the **same**
clientid. `emqtt:stop/1` closes the socket, but the broker records the
`tcp_closed` disconnect-reason counter **asynchronously** when it detects the
peer close. If C4's CONNECT arrives before C3's channel is reaped, C4 takes
over C3's lingering session and the event is counted as `discarded` instead of
`tcp_closed` — producing the intermittent failure where `discarded => 2` and
`tcp_closed` is missing.

Four prior de-flakes only wrapped the assertion **reads** in a `?retry`
barrier. Retrying the read cannot recover a `tcp_closed` that was never
recorded: once the takeover happened the counters are permanently wrong for
that run.

The fix waits until C3's channel is fully deregistered
(`emqx_cm:lookup_channels/1` returns `[]`) before reconnecting C4, closing the
takeover ordering. Looped the case 20× with zero failures.

Relevant file: `apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
