### PR TITLE
fix(prometheus): expose publish quota exceeded metric

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -454,6 +454,7 @@ emqx_collect(K = emqx_packets_publish_sent, D) -> counter_metrics(?MG(K, D));
 emqx_collect(K = emqx_packets_publish_inuse, D) -> counter_metrics(?MG(K, D));
 emqx_collect(K = emqx_packets_publish_error, D) -> counter_metrics(?MG(K, D));
 emqx_collect(K = emqx_packets_publish_auth_error, D) -> counter_metrics(?MG(K, D));
+emqx_collect(K = emqx_packets_publish_quota_exceeded, D) -> counter_metrics(?MG(K, D));
 %% puback
 emqx_collect(K = emqx_packets_puback_received, D) -> counter_metrics(?MG(K, D));
 emqx_collect(K = emqx_packets_puback_sent, D) -> counter_metrics(?MG(K, D));
@@ -845,6 +846,7 @@ emqx_packet_metric_meta() ->
         {emqx_packets_publish_inuse, counter, 'packets.publish.inuse'},
         {emqx_packets_publish_error, counter, 'packets.publish.error'},
         {emqx_packets_publish_auth_error, counter, 'packets.publish.auth_error'},
+        {emqx_packets_publish_quota_exceeded, counter, 'packets.publish.quota_exceeded'},
         %% puback
         {emqx_packets_puback_received, counter, 'packets.puback.received'},
         {emqx_packets_puback_sent, counter, 'packets.puback.sent'},

--- a/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
@@ -663,6 +663,7 @@ assert_json_data__packets(M, Mode) when
             emqx_packets_pingresp_sent := _,
             emqx_packets_subscribe_received := _,
             emqx_bytes_received := _,
+            emqx_packets_publish_quota_exceeded := _,
             emqx_packets_publish_received := _,
             emqx_packets_connack_sent := _,
             emqx_packets_connack_auth_error := _,

--- a/changes/ce/fix-17886.en.md
+++ b/changes/ce/fix-17886.en.md
@@ -1,0 +1,1 @@
+Exposed the publish quota-exceeded packet metric in Prometheus as `emqx_packets_publish_quota_exceeded`.


### PR DESCRIPTION
Release version:
6.0.4

Fix: N/A (no public ticket provided)

## Summary

Ports #17886 to `dev-60`.

Exposes the existing `packets.publish.quota_exceeded` broker metric as `emqx_packets_publish_quota_exceeded` in Prometheus output. The counter already exists and is incremented in the publish quota-exceeded path on `dev-60`; this PR only adds the Prometheus mapping and data-suite coverage.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/fix-17886.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
