### PR TITLE
test(mqttsn): fix flaky t_takeover_on_udp_port_reuse

### DIFF
--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -1642,12 +1642,15 @@ t_takeover_on_udp_port_reuse(_) ->
     send_disconnect_msg(SockA, undefined),
     ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(SockA)),
     OldPid = wait_for_disconnected_channel(ClientA),
+    %% monitor the stale channel while it is provably alive, before the socket
+    %% churn below. If it is monitored only after `gen_udp:close/open', it may
+    %% already be dead and the DOWN reason collapses to an opaque `noproc'.
+    MRef = erlang:monitor(process, OldPid),
     ok = gen_udp:close(SockA),
     %% device B reuses the exact same source UDP port.
     {ok, SockB} = gen_udp:open(PortA, [binary, {reuseaddr, true}]),
     try
         ClientB = ?CLIENTID,
-        MRef = erlang:monitor(process, OldPid),
         %% the CONNECT is routed to the stale channel, which is retired
         %% cleanly (before the fix this crashed with a function_clause).
         send_connect_msg(SockB, ClientB, 0),


### PR DESCRIPTION
Release version: 6.0.3

## Summary

`emqx_sn_protocol_SUITE:t_takeover_on_udp_port_reuse` intermittently failed
the DOWN-reason assertion with `got: noproc` instead of
`{shutdown, takeover_by_new_connect}`.

Root cause is monitor placement: the test monitored the disconnected channel
only *after* `gen_udp:close(SockA)` + `gen_udp:open(SockB)`. Those syscalls
are scheduler yield points, so if the channel process died in that window,
`erlang:monitor/2` observed an already-dead process and the DOWN reason
collapsed to an opaque `noproc`.

Fix: monitor `OldPid` the instant it is confirmed alive (right after
`wait_for_disconnected_channel`), before the socket churn. This shrinks the
death window to adjacent statements and, for any residual rare death, surfaces
the real shutdown reason instead of an unactionable `noproc`.

This is test-timing only: 260 stress iterations with a deliberately widened
window showed the `disconnected` channel is stable and never reaped
prematurely, so no product-side change is warranted.

Relevant file: `apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)