### PR TITLE
fix(listeners): allow switching a listener off a deleted managed-cert bundle

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -46,6 +46,7 @@
 
 -export([pre_config_update/3, post_config_update/5]).
 -export([post_zone_config_update/2, update_listener_for_zone_changes/3]).
+-export([reconcile_cert_source/2]).
 
 -export([format_bind/1]).
 
@@ -591,8 +592,9 @@ pre_config_update([?ROOT_KEY, _Type, _Name], {update, _Request}, undefined) ->
     {error, not_found};
 pre_config_update([?ROOT_KEY, Type, Name], {update, Request}, RawConf) ->
     RawConf1 = emqx_utils_maps:deep_merge(RawConf, Request),
-    ok = assert_zone_exists(RawConf1),
-    {ok, convert_certs(Type, Name, RawConf1)};
+    RawConf2 = reconcile_cert_source(Request, RawConf1),
+    ok = assert_zone_exists(RawConf2),
+    {ok, convert_certs(Type, Name, RawConf2)};
 pre_config_update([?ROOT_KEY, _Type, _Name], {action, _Action, Updated}, RawConf) ->
     {ok, emqx_utils_maps:deep_merge(RawConf, Updated)};
 pre_config_update([?ROOT_KEY, _Type, _Name], ?MARK_DEL, _RawConf) ->
@@ -996,6 +998,41 @@ convert_certs(ListenerConf) ->
         #{},
         ListenerConf
     ).
+
+-doc """
+Enforce that a listener uses a single certificate source.
+
+`managed_certs' and file-based certificates (`certfile'/`keyfile') are mutually
+exclusive certificate sources.  Configuration updates are applied via `deep_merge',
+which can only add or override keys, never drop them.  Without this reconciliation an
+update that switches a listener from a managed certificate bundle back to file-based
+certificates would keep the stale `managed_certs' reference and fail to resolve a
+(possibly already deleted) bundle.
+
+When `Request' supplies file-based certificate material and does not itself reference
+`managed_certs', drop any residual `managed_certs' from `MergedConf' so the result
+uses only the requested certificate source.  Both arguments are raw (binary-keyed)
+configs.
+""".
+reconcile_cert_source(Request, MergedConf) ->
+    case get_ssl_options(Request) of
+        RequestSSL when is_map(RequestSSL) ->
+            RequestSetsManaged = maps:is_key(<<"managed_certs">>, RequestSSL),
+            RequestSetsFileCerts =
+                maps:is_key(<<"certfile">>, RequestSSL) orelse
+                    maps:is_key(<<"keyfile">>, RequestSSL),
+            case (not RequestSetsManaged) andalso RequestSetsFileCerts of
+                true -> drop_managed_certs(MergedConf);
+                false -> MergedConf
+            end;
+        _ ->
+            MergedConf
+    end.
+
+drop_managed_certs(#{<<"ssl_options">> := SSL} = Conf) when is_map(SSL) ->
+    Conf#{<<"ssl_options">> => maps:remove(<<"managed_certs">>, SSL)};
+drop_managed_certs(Conf) ->
+    Conf.
 
 convert_certs(Type, Name, Conf) ->
     CertsDir = certs_dir(Type, Name),

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -411,7 +411,11 @@ crud_listeners_by_id(put, #{bindings := #{id := Id}, body := Body0}) ->
                 undefined ->
                     {404, #{code => 'BAD_LISTENER_ID', message => ?LISTENER_NOT_FOUND}};
                 PrevConf ->
-                    MergeConf = emqx_utils_maps:deep_merge(PrevConf, Conf),
+                    MergeConf0 = emqx_utils_maps:deep_merge(PrevConf, Conf),
+                    %% The merge above cannot drop keys, so a switch away from a managed
+                    %% certificate bundle would retain the stale `managed_certs'.  Let the
+                    %% raw request decide the certificate source.
+                    MergeConf = emqx_listeners:reconcile_cert_source(Conf, MergeConf0),
                     case update(Type, Name, MergeConf) of
                         {ok, #{raw_config := _RawConf}} ->
                             crud_listeners_by_id(get, #{bindings => #{id => Id}});

--- a/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
@@ -226,6 +226,14 @@ delete_bundle_global(BundleName) ->
         url => URL
     }).
 
+force_delete_bundle_global(BundleName) ->
+    URL = emqx_mgmt_api_test_util:api_path(["certs", "global", "name", BundleName]),
+    simple_request(#{
+        method => delete,
+        url => URL,
+        query_params => #{<<"force_delete">> => <<"true">>}
+    }).
+
 delete_file_global(BundleName, Kind) ->
     URL = emqx_mgmt_api_test_util:api_path(["certs", "global", "name", BundleName]),
     simple_request(#{
@@ -1005,5 +1013,126 @@ t_managed_certs_prometheus_expiry_date(_TCConfig) ->
         Expiry1
     ),
     ?assertNotEqual(WSSExpiry1, TLSExpiry1),
+
+    ok.
+
+-doc """
+Verifies that a listener using a managed certificate bundle can be switched back to
+file-based (default) certificates even after the bundle has been force-deleted.  The
+stale `managed_certs` reference must not survive the update and block it.
+""".
+t_switch_off_deleted_managed_bundle() ->
+    [{matrix, true}].
+t_switch_off_deleted_managed_bundle(matrix) ->
+    [[?local]];
+t_switch_off_deleted_managed_bundle(_TCConfig) ->
+    #{cert_key := CertKeyRoot} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := CA} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := Cert, key_pem := Key} = gen_cert(#{key => ec, issuer => CertKeyRoot}),
+
+    Bundle = <<"switch_off_bundle">>,
+    Files = [
+        {?FILE_KIND_CA_BIN, <<"ca.pem">>, CA},
+        {?FILE_KIND_CHAIN_BIN, <<"chain.pem">>, Cert},
+        {?FILE_KIND_KEY_BIN, <<"key.pem">>, Key}
+    ],
+    ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
+
+    %% Original config uses file-based (default) certs.
+    {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
+    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+
+    %% Switch the listener to the managed bundle.
+    TLSListenerManaged = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        [#{<<"bundle_name">> => Bundle}]
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerManaged)),
+
+    %% Force-delete the bundle while the listener still references it.
+    ?assertMatch({204, _}, force_delete_bundle_global(Bundle)),
+
+    %% Switching back to the original file-based config must succeed even though the
+    %% bundle is gone, and the resulting config must no longer reference managed certs.
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListener0)),
+    {200, TLSListenerFinal} = get_listener_api(<<"ssl">>, <<"default">>),
+    ?assertNot(
+        is_map_key(<<"managed_certs">>, maps:get(<<"ssl_options">>, TLSListenerFinal)),
+        TLSListenerFinal
+    ),
+
+    ok.
+
+-doc """
+Verifies that a listener using a managed certificate bundle can be switched back to
+file-based (default) certificates while the bundle still exists.  The switch must
+actually take effect (the stale `managed_certs` reference must be dropped), not
+silently keep using the bundle.
+""".
+t_switch_off_existing_managed_bundle() ->
+    [{matrix, true}].
+t_switch_off_existing_managed_bundle(matrix) ->
+    [[?local]];
+t_switch_off_existing_managed_bundle(_TCConfig) ->
+    #{cert_key := CertKeyRoot} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := CA} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := Cert, key_pem := Key} = gen_cert(#{key => ec, issuer => CertKeyRoot}),
+
+    Bundle = <<"switch_off_existing_bundle">>,
+    Files = [
+        {?FILE_KIND_CA_BIN, <<"ca.pem">>, CA},
+        {?FILE_KIND_CHAIN_BIN, <<"chain.pem">>, Cert},
+        {?FILE_KIND_KEY_BIN, <<"key.pem">>, Key}
+    ],
+    ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
+
+    {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
+    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+
+    TLSListenerManaged = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        [#{<<"bundle_name">> => Bundle}]
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerManaged)),
+    {200, TLSListenerManaged1} = get_listener_api(<<"ssl">>, <<"default">>),
+    ?assert(
+        is_map_key(<<"managed_certs">>, maps:get(<<"ssl_options">>, TLSListenerManaged1)),
+        TLSListenerManaged1
+    ),
+
+    %% Switch back to file-based certs while the bundle still exists: the update must
+    %% take effect and drop the managed cert reference.
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListener0)),
+    {200, TLSListenerFinal} = get_listener_api(<<"ssl">>, <<"default">>),
+    ?assertNot(
+        is_map_key(<<"managed_certs">>, maps:get(<<"ssl_options">>, TLSListenerFinal)),
+        TLSListenerFinal
+    ),
+
+    ok.
+
+-doc """
+Verifies that updating a listener to reference a non-existent managed certificate
+bundle still fails, so genuine misconfiguration is not masked.
+""".
+t_switch_to_missing_managed_bundle() ->
+    [{matrix, true}].
+t_switch_to_missing_managed_bundle(matrix) ->
+    [[?local]];
+t_switch_to_missing_managed_bundle(_TCConfig) ->
+    {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
+    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+
+    TLSListenerMissing = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        [#{<<"bundle_name">> => <<"does_not_exist">>}]
+    ),
+    ?assertMatch(
+        {400, #{<<"message">> := _}},
+        update_listener_api(<<"ssl">>, <<"default">>, TLSListenerMissing)
+    ),
 
     ok.

--- a/changes/ee/fix-17895.en.md
+++ b/changes/ee/fix-17895.en.md
@@ -1,0 +1,1 @@
+Switching a TLS listener from a managed certificate bundle back to file-based certificates now succeeds even if the referenced bundle has already been removed.


### PR DESCRIPTION
Fixes [EMQX-15326](https://emqx.atlassian.net/browse/EMQX-15326)
Release version: 6.1.4, 6.2.3

## Summary

Fixes a `400 failed_to_resolve_managed_certs` error when switching a TLS listener
from a managed certificate bundle back to file-based certificates after the bundle
has been removed.

Root cause: listener updates are applied with `deep_merge`, which can add or override
keys but never drop them. When a request switched a listener back to file-based certs
(providing `certfile`/`keyfile` and omitting `managed_certs`), the merge retained the
stale `managed_certs` reference, so the update attempted to resolve the deleted bundle
and failed the whole update.

Fix: reconcile the certificate source on update. When the request supplies file-based
certificate material and does not itself reference `managed_certs`, the residual
`managed_certs` is dropped so the listener uses only the requested source. A new
reference to a genuinely missing bundle still fails, so real misconfiguration is not
masked.

Because the REST API pre-merges the previous config into the request before the config
layer merges again, the reconciliation is applied both at the API layer (using the raw
request to capture user intent) and in `pre_config_update` (to counter the config-layer
merge). Relevant modules: `emqx_listeners`, `emqx_mgmt_api_listeners`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)


[EMQX-15326]: https://emqx.atlassian.net/browse/EMQX-15326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ