### PR TITLE
fix(conf/plugins cli): move load/unload from `emqx_modules`/`emqx_management` to own applications

### DIFF
--- a/apps/emqx_conf/mix.exs
+++ b/apps/emqx_conf/mix.exs
@@ -25,6 +25,7 @@ defmodule EMQXConf.MixProject do
 
   def deps() do
     UMP.deps([
+      {:emqx_ctl, in_umbrella: true},
       {:emqx, in_umbrella: true, runtime: false},
       {:emqx_auth, in_umbrella: true, runtime: false}
     ])

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -34,10 +34,13 @@ start(_StartType, _StartArgs) ->
             exit_loop(1)
     end,
     ok = emqx_config_logger:refresh_config(),
-    emqx_conf_sup:start_link().
+    {ok, Sup} = emqx_conf_sup:start_link(),
+    emqx_conf_cli:load(),
+    {ok, Sup}.
 
 stop(_State) ->
     emqx_config:clear_all_invalid_namespaced_configs(),
+    emqx_conf_cli:unload(),
     ok.
 
 exit_loop(ExitCode) ->

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -26,7 +26,6 @@
     clients/1,
     topics/1,
     subscriptions/1,
-    plugins/1,
     listeners/1,
     vm/1,
     mnesia/1,
@@ -45,13 +44,30 @@
     cluster_info/0
 ]).
 
+-define(COMMANDS, [
+    authz,
+    broker,
+    clients,
+    cluster,
+    data,
+    ds,
+    exclusive,
+    listeners,
+    log,
+    mnesia,
+    olp,
+    pem_cache,
+    status,
+    subscriptions,
+    topics,
+    trace,
+    traces,
+    vm
+]).
+
 -spec load() -> ok.
 load() ->
-    Cmds = [Fun || {Fun, 1} <- ?MODULE:module_info(exports), is_cmd(Fun)],
-    lists:foreach(fun(Cmd) -> emqx_ctl:register_command(Cmd, {?MODULE, Cmd}, []) end, Cmds).
-
-is_cmd(Fun) ->
-    not lists:member(Fun, [init, load, module_info]).
+    lists:foreach(fun(Cmd) -> emqx_ctl:register_command(Cmd, {?MODULE, Cmd}, []) end, ?COMMANDS).
 
 %%--------------------------------------------------------------------
 %% @doc Node status
@@ -484,85 +500,6 @@ if_valid_qos(QoS, Fun) ->
         _:_ ->
             emqx_ctl:print("QoS should be 0, 1, 2~n")
     end.
-
-plugins(["list"]) ->
-    emqx_plugins_cli:list(fun emqx_ctl:print/2);
-plugins(["describe", NameVsn]) ->
-    emqx_plugins_cli:describe(NameVsn, fun emqx_ctl:print/2);
-plugins(["allow", NameVsn]) ->
-    emqx_plugins_cli:allow_installation(NameVsn, fun emqx_ctl:print/2);
-plugins(["allow", NameVsn, "sha256:" ++ Hex]) ->
-    case parse_sha256_hex(Hex) of
-        {ok, Sha256} ->
-            emqx_plugins_cli:allow_installation(NameVsn, Sha256, fun emqx_ctl:print/2);
-        error ->
-            emqx_ctl:print(
-                "sha256 must be 64 lowercase hex characters, e.g. sha256:abc...~n"
-            )
-    end;
-plugins(["disallow", NameVsn]) ->
-    emqx_plugins_cli:disallow_installation(NameVsn, fun emqx_ctl:print/2);
-plugins(["install", NameVsn]) ->
-    emqx_plugins_cli:ensure_installed(NameVsn, fun emqx_ctl:print/2);
-plugins(["uninstall", NameVsn]) ->
-    emqx_plugins_cli:ensure_uninstalled(NameVsn, fun emqx_ctl:print/2);
-plugins(["start", NameVsn]) ->
-    emqx_plugins_cli:ensure_started(NameVsn, fun emqx_ctl:print/2);
-plugins(["stop", NameVsn]) ->
-    emqx_plugins_cli:ensure_stopped(NameVsn, fun emqx_ctl:print/2);
-plugins(["restart", NameVsn]) ->
-    emqx_plugins_cli:restart(NameVsn, fun emqx_ctl:print/2);
-plugins(["disable", NameVsn]) ->
-    emqx_plugins_cli:ensure_disabled(NameVsn, fun emqx_ctl:print/2);
-plugins(["enable", NameVsn]) ->
-    emqx_plugins_cli:ensure_enabled(NameVsn, no_move, fun emqx_ctl:print/2);
-plugins(["enable", NameVsn, "front"]) ->
-    emqx_plugins_cli:ensure_enabled(NameVsn, front, fun emqx_ctl:print/2);
-plugins(["enable", NameVsn, "rear"]) ->
-    emqx_plugins_cli:ensure_enabled(NameVsn, rear, fun emqx_ctl:print/2);
-plugins(["enable", NameVsn, "before", Other]) ->
-    emqx_plugins_cli:ensure_enabled(NameVsn, {before, Other}, fun emqx_ctl:print/2);
-plugins(_) ->
-    emqx_ctl:usage(
-        [
-            {"plugins <command> [Name-Vsn]", "e.g. 'start emqx_plugin_template-5.0-rc.1'"},
-            {"plugins list", "List all installed plugins"},
-            {"plugins describe  Name-Vsn", "Describe an installed plugins"},
-            {"plugins allow     Name-Vsn [sha256:HEX]",
-                "Allows installation of a plugin in the cluster from Dashboard or API.\n"
-                "The grant expires 5 minutes after issue.\n"
-                "If sha256:HEX (64 lowercase hex chars) is given, the upload bytes\n"
-                "must hash to that value or the install is rejected."},
-            {"plugins disallow  Name-Vsn",
-                "Disallows installation of a plugin in the cluster from Dashboard or API"},
-            {"plugins install   Name-Vsn",
-                "Install a plugin package placed\n"
-                "in plugin's install_dir"},
-            {"plugins uninstall Name-Vsn",
-                "Uninstall a plugin. NOTE: it deletes\n"
-                "all files in install_dir/Name-Vsn"},
-            {"plugins start     Name-Vsn", "Start a plugin"},
-            {"plugins stop      Name-Vsn", "Stop a plugin"},
-            {"plugins restart   Name-Vsn", "Stop then start a plugin"},
-            {"plugins disable   Name-Vsn", "Disable auto-boot"},
-            {"plugins enable    Name-Vsn [Position]",
-                "Enable auto-boot at Position in the boot list, where Position could be\n"
-                "'front', 'rear', or 'before Other-Vsn' to specify a relative position.\n"
-                "The Position parameter can be used to adjust the boot order.\n"
-                "If no Position is given, an already configured plugin\n"
-                "will stay at is old position; a newly plugin is appended to the rear\n"
-                "e.g. plugins disable foo-0.1.0 front\n"
-                "     plugins enable bar-0.2.0 before foo-0.1.0"}
-        ]
-    ).
-
-parse_sha256_hex(Hex) when length(Hex) =:= 64 ->
-    case re:run(Hex, "^[0-9a-f]{64}$", [{capture, none}]) of
-        match -> {ok, list_to_binary(Hex)};
-        nomatch -> error
-    end;
-parse_sha256_hex(_) ->
-    error.
 
 %%--------------------------------------------------------------------
 %% @doc vm command

--- a/apps/emqx_modules/src/emqx_modules_app.erl
+++ b/apps/emqx_modules/src/emqx_modules_app.erl
@@ -24,7 +24,6 @@ stop(_State) ->
 maybe_enable_modules() ->
     emqx_conf:get([delayed, enable], true) andalso emqx_delayed:load(),
     emqx_observer_cli:enable(),
-    emqx_conf_cli:load(),
     ok = emqx_rewrite:enable(),
     emqx_topic_metrics:enable(),
     emqx_modules_conf:load().
@@ -33,6 +32,5 @@ maybe_disable_modules() ->
     emqx_conf:get([delayed, enable], true) andalso emqx_delayed:unload(),
     emqx_conf:get([observer_cli, enable], true) andalso emqx_observer_cli:disable(),
     emqx_rewrite:disable(),
-    emqx_conf_cli:unload(),
     emqx_topic_metrics:disable(),
     emqx_modules_conf:unload().

--- a/apps/emqx_plugins/src/emqx_plugins_app.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_app.erl
@@ -20,9 +20,11 @@ start(_Type, _Args) ->
     ok = emqx_plugins:ensure_installed(),
     ok = emqx_plugins:ensure_started(),
     ok = emqx_config_handler:add_handler([?CONF_ROOT], emqx_plugins),
+    emqx_plugins_cli:load(),
     ?tp("emqx_plugins_app_started", #{}),
     {ok, Sup}.
 
 stop(_State) ->
+    emqx_plugins_cli:unload(),
     ok = emqx_config_handler:remove_handler([?CONF_ROOT]),
     ok.

--- a/apps/emqx_plugins/src/emqx_plugins_cli.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_cli.erl
@@ -4,6 +4,9 @@
 
 -module(emqx_plugins_cli).
 
+-export([load/0, unload/0]).
+-export([plugins/1]).
+
 -export([
     list/1,
     describe/2,
@@ -26,6 +29,93 @@
 -define(PRINT(EXPR, LOG_FUN),
     print(NameVsn, fun() -> EXPR end(), LOG_FUN, ?FUNCTION_NAME)
 ).
+
+load() ->
+    emqx_ctl:register_command(plugins, {?MODULE, plugins}, []),
+    ok.
+
+unload() ->
+    emqx_ctl:unregister_command(plugins),
+    ok.
+
+plugins(["list"]) ->
+    list(fun emqx_ctl:print/2);
+plugins(["describe", NameVsn]) ->
+    describe(NameVsn, fun emqx_ctl:print/2);
+plugins(["allow", NameVsn]) ->
+    allow_installation(NameVsn, fun emqx_ctl:print/2);
+plugins(["allow", NameVsn, "sha256:" ++ Hex]) ->
+    case parse_sha256_hex(Hex) of
+        {ok, Sha256} ->
+            allow_installation(NameVsn, Sha256, fun emqx_ctl:print/2);
+        error ->
+            emqx_ctl:print(
+                "sha256 must be 64 lowercase hex characters, e.g. sha256:abc...~n"
+            )
+    end;
+plugins(["disallow", NameVsn]) ->
+    disallow_installation(NameVsn, fun emqx_ctl:print/2);
+plugins(["install", NameVsn]) ->
+    ensure_installed(NameVsn, fun emqx_ctl:print/2);
+plugins(["uninstall", NameVsn]) ->
+    ensure_uninstalled(NameVsn, fun emqx_ctl:print/2);
+plugins(["start", NameVsn]) ->
+    ensure_started(NameVsn, fun emqx_ctl:print/2);
+plugins(["stop", NameVsn]) ->
+    ensure_stopped(NameVsn, fun emqx_ctl:print/2);
+plugins(["restart", NameVsn]) ->
+    restart(NameVsn, fun emqx_ctl:print/2);
+plugins(["disable", NameVsn]) ->
+    ensure_disabled(NameVsn, fun emqx_ctl:print/2);
+plugins(["enable", NameVsn]) ->
+    ensure_enabled(NameVsn, no_move, fun emqx_ctl:print/2);
+plugins(["enable", NameVsn, "front"]) ->
+    ensure_enabled(NameVsn, front, fun emqx_ctl:print/2);
+plugins(["enable", NameVsn, "rear"]) ->
+    ensure_enabled(NameVsn, rear, fun emqx_ctl:print/2);
+plugins(["enable", NameVsn, "before", Other]) ->
+    ensure_enabled(NameVsn, {before, Other}, fun emqx_ctl:print/2);
+plugins(_) ->
+    emqx_ctl:usage(
+        [
+            {"plugins <command> [Name-Vsn]", "e.g. 'start emqx_plugin_template-5.0-rc.1'"},
+            {"plugins list", "List all installed plugins"},
+            {"plugins describe  Name-Vsn", "Describe an installed plugins"},
+            {"plugins allow     Name-Vsn [sha256:HEX]",
+                "Allows installation of a plugin in the cluster from Dashboard or API.\n"
+                "The grant expires 5 minutes after issue.\n"
+                "If sha256:HEX (64 lowercase hex chars) is given, the upload bytes\n"
+                "must hash to that value or the install is rejected."},
+            {"plugins disallow  Name-Vsn",
+                "Disallows installation of a plugin in the cluster from Dashboard or API"},
+            {"plugins install   Name-Vsn",
+                "Install a plugin package placed\n"
+                "in plugin's install_dir"},
+            {"plugins uninstall Name-Vsn",
+                "Uninstall a plugin. NOTE: it deletes\n"
+                "all files in install_dir/Name-Vsn"},
+            {"plugins start     Name-Vsn", "Start a plugin"},
+            {"plugins stop      Name-Vsn", "Stop a plugin"},
+            {"plugins restart   Name-Vsn", "Stop then start a plugin"},
+            {"plugins disable   Name-Vsn", "Disable auto-boot"},
+            {"plugins enable    Name-Vsn [Position]",
+                "Enable auto-boot at Position in the boot list, where Position could be\n"
+                "'front', 'rear', or 'before Other-Vsn' to specify a relative position.\n"
+                "The Position parameter can be used to adjust the boot order.\n"
+                "If no Position is given, an already configured plugin\n"
+                "will stay at is old position; a newly plugin is appended to the rear\n"
+                "e.g. plugins disable foo-0.1.0 front\n"
+                "     plugins enable bar-0.2.0 before foo-0.1.0"}
+        ]
+    ).
+
+parse_sha256_hex(Hex) when length(Hex) =:= 64 ->
+    case re:run(Hex, "^[0-9a-f]{64}$", [{capture, none}]) of
+        match -> {ok, list_to_binary(Hex)};
+        nomatch -> error
+    end;
+parse_sha256_hex(_) ->
+    error.
 
 list(LogFun) ->
     LogFun("~ts~n", [to_json(emqx_plugins:list())]).


### PR DESCRIPTION
Otherwise, using `ESSENTIAL` feature gate won't have `emqx ctl conf ...` working.  Or would show plugin options when said feature is disabled.

Fixes https://github.com/emqx/emqx/issues/17907

Release version:
6.3.0
