### PR TITLE
fix(gateway): allow ECDHE-PSK ChaCha DTLS cipher

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -1,7 +1,7 @@
 services:
   kdc:
     hostname: kdc.emqx.net
-    image:  ghcr.io/emqx/emqx-builder/6.1-4:1.19.1-28.4.1-3-ubuntu24.04
+    image:  ghcr.io/emqx/emqx-builder/6.1-7:1.19.1-28.4.1-4-ubuntu24.04
     container_name: kdc.emqx.net
     expose:
       - 88 # kdc

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   erlang:
     hostname: erlang.emqx.net
     container_name: erlang
-    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/6.1-4:1.19.1-28.4.1-3-ubuntu24.04}
+    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/6.1-7:1.19.1-28.4.1-4-ubuntu24.04}
     env_file:
       - credentials.env
       - conf.env

--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -232,6 +232,7 @@ all_ciphers(Versions) ->
     %% openssl ciphers -v|grep ^PSK| awk '{print $1}'| sed  "s/^/\"/;s/$/\"/" | tr "\n" ","
     %% Then remove the ciphers that aren't supported by Erlang
     PSK = [
+        "ECDHE-PSK-CHACHA20-POLY1305",
         "PSK-AES256-GCM-SHA384",
         "PSK-AES128-GCM-SHA256",
         "PSK-AES256-CBC-SHA384",

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -22,6 +22,25 @@ ssl_opts_dtls_test() ->
         Checked
     ).
 
+ssl_opts_dtls_ecdhe_psk_chacha20_cipher_test() ->
+    Sc = emqx_schema:server_ssl_opts_schema(
+        #{
+            versions => dtls_all_available
+        },
+        false
+    ),
+    Checked = validate(Sc, #{
+        <<"versions">> => [<<"dtlsv1.2">>],
+        <<"ciphers">> => [<<"ECDHE-PSK-CHACHA20-POLY1305">>]
+    }),
+    ?assertMatch(
+        #{
+            versions := ['dtlsv1.2'],
+            ciphers := ["ECDHE-PSK-CHACHA20-POLY1305"]
+        },
+        Checked
+    ).
+
 ssl_opts_tls_1_3_test() ->
     Sc = emqx_schema:server_ssl_opts_schema(#{}, false),
     Checked = validate(Sc, #{<<"versions">> => [<<"tlsv1.3">>]}),

--- a/changes/ee/fix-17911.en.md
+++ b/changes/ee/fix-17911.en.md
@@ -1,0 +1,1 @@
+Allow DTLS listeners to validate the `ECDHE-PSK-CHACHA20-POLY1305` cipher suite when the runtime OTP ssl application supports it.

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/6.1-4:1.19.1-28.4.1-3-debian13
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/6.1-7:1.19.1-28.4.1-4-debian13
 ARG RUN_FROM=debian:13-slim
 ARG SOURCE_TYPE=src # tgz
 

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 # https://github.com/emqx/emqx-builder
-export EMQX_BUILDER_VSN=6.1-4
-export OTP_VSN=28.4.1-3
+export EMQX_BUILDER_VSN=6.1-7
+export OTP_VSN=28.4.1-4
 export ELIXIR_VSN=1.19.1
 export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-ubuntu24.04
 export EMQX_DOCKER_BUILD_FROM=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-debian13

--- a/rel/i18n/emqx_psk_schema.hocon
+++ b/rel/i18n/emqx_psk_schema.hocon
@@ -16,7 +16,8 @@ psk_authentication.desc:
 This config to enable TLS-PSK authentication.
 
 Important! Make sure the SSL listener with only <code>tlsv1.2</code> enabled, and also PSK cipher suites
-configured, such as <code>RSA-PSK-AES256-GCM-SHA384</code>.
+ configured, such as <code>RSA-PSK-AES256-GCM-SHA384</code> or
+ <code>ECDHE-PSK-CHACHA20-POLY1305</code>.
 
 See listener SSL options config for more details.
 


### PR DESCRIPTION
Release version: 6.1.4

Fix: N/A

## Summary

Allow DTLS listener cipher validation to accept `ECDHE-PSK-CHACHA20-POLY1305`.

Add the cipher to EMQX's manual PSK cipher list and cover the DTLS schema validation path with an eunit test.

Use `emqx-builder` 6.1-7 with OTP 28.4.1-4, which includes the merged OTP ssl support from https://github.com/emqx/otp/pull/107.

A customer running 6.2.0 has already received a hot patch. `dev-61` is the earliest maintained EMQX branch using OTP 28, so this is the starting point for the product fix.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-17911.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)