### PR TITLE
fix(build): restore default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ BUILD = $(CURDIR)/build
 SCRIPTS = $(CURDIR)/scripts
 include env.sh
 
+.DEFAULT_GOAL := default
+
 # Dashboard version
 # from https://github.com/emqx/emqx-dashboard5
 export EMQX_DASHBOARD_VERSION ?= 2.0.3-1


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Restore the top-level Makefile default goal to `default` explicitly.

PR #17819 added `print-dashboard-version` before the `default` target. Since GNU Make picks the first target as the default when `.DEFAULT_GOAL` is not set, bare `make` started printing `EMQX_DASHBOARD_VERSION` instead of building the default profile.

`print-dashboard-version` stays available for release scripts; only the implicit default target is restored.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)