### PR TITLE
fix(socket): expect socket may be unready after select notify

### DIFF
--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -803,14 +803,20 @@ request_more_data(Socket, More, Acc, State) ->
 %% closes with data available. We keep this clause for backward compatibility.
 %%
 %% Call async receive after '$socket' receive notification is received
-%% no handling of {select, Info} because data is ready,
-%% no handling of {select, {Info, Partial}} because receive length is 0
+%% Getting `{select, Info}` is _expected_ under some circumstances: readiness
+%% notification is not a guarantee that a subsequent nonblocking recv will succeed.
+%% Getting `{select, {Info, Partial}}` is not expected because length is 0,
+%% but keep the clause for consistency with other async receive paths.
 -dialyzer({nowarn_function, handle_data_ready/2}).
 -compile({inline, [handle_data_ready/2]}).
 handle_data_ready(Socket, State) ->
     case sock_async_recv(Socket, 0) of
         {ok, Data} ->
             handle_data(Data, true, State);
+        {select, {_Info, Data}} ->
+            handle_data(Data, true, State);
+        {select, _Info} ->
+            {ok, State};
         {error, {closed, Data}} ->
             %% This is dead code starting from OTP 28
             {ok, [{recv, Data}, {sock_closed, tcp_closed}], socket_closed(State)};

--- a/apps/emqx/test/emqx_socket_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_socket_connection_SUITE.erl
@@ -119,6 +119,28 @@ t_repeated_send_congestion_preserves_send_order(_) ->
         ok = meck:unload(esockd_socket)
     end.
 
+t_data_ready_handles_rearmed_select(_) ->
+    ok = meck_esockd_socket([no_history]),
+    ok = meck:new(socket, [unstick, passthrough, no_history]),
+    SelectInfo = {select_info, recv, make_ref()},
+    ok = meck:expect(socket, recv, fun(sock, 0, [], nowait) ->
+        {select, SelectInfo}
+    end),
+    try
+        State0 = emqx_socket_connection:init_state(sock, #{
+            zone => default,
+            limiter => undefined,
+            listener => {tcp, default}
+        }),
+        ?assertMatch(
+            {ok, _},
+            emqx_socket_connection:handle_msg({'$socket', sock, select, make_ref()}, State0)
+        )
+    after
+        ok = meck:unload(socket),
+        ok = meck:unload(esockd_socket)
+    end.
+
 meck_esockd_socket(Opts) ->
     ok = meck:new(esockd_socket, [passthrough | Opts]),
     ok = meck:expect(esockd_socket, type, fun(_) -> tcp end),

--- a/changes/ee/fix-17918.en.md
+++ b/changes/ee/fix-17918.en.md
@@ -1,0 +1,5 @@
+Fixed an issue where clients using socket-backed TCP listeners could be unexpectedly disconnected under high load, due to occasional readiness signals arriving for not-yet-ready sockets.
+
+```
+[error] crasher: initial call: emqx_socket_connection:init/4, ..., error: {{case_clause,{select,{select_info,recv,#Ref<...>}}},[{emqx_socket_connection,handle_msg,2,[{file,"emqx_socket_connection.erl"},{line,827}]}, ...
+```


### PR DESCRIPTION
Release version: 6.3.0

## Summary

This PR adds missing flow control path for socket-backed connections that manifests in occasional connection crashes under high load.
```
2026-07-09T13:35:40.761 [error] crasher: initial call: emqx_socket_connection:init/4, pid: <0.6914.0>, registered_name: [], process_label: {clientid,<<"bpub858">>}, error: {{case_clause,{select,{select_info,recv,#Ref<0.823449273.2556952590.180400>}}},[{emqx_socket_connection,handle_msg,2,[{file,"emqx_socket_connection.erl"},{line,827}]},{emqx_socket_connection,process_msg,2,[{file,"emqx_socket_connection.erl"},{line,514}]},{emqx_socket_connection,handle_recv,3,[{file,"emqx_socket_connection.erl"},{line,423}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,333}]}]}, ancestors: [<0.4827.0>,<0.4826.0>,esockd_sup,<0.4400.0>], ...
```

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible