### PR TITLE
fix(plugins): use fresh_install mode in CLI and add --cluster flag

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -80,6 +80,7 @@
 {emqx_plugins,2}.
 {emqx_plugins,3}.
 {emqx_plugins,4}.
+{emqx_plugins,5}.
 {emqx_prometheus,1}.
 {emqx_prometheus,2}.
 {emqx_resource,1}.

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -503,6 +503,8 @@ plugins(["disallow", NameVsn]) ->
     emqx_plugins_cli:disallow_installation(NameVsn, fun emqx_ctl:print/2);
 plugins(["install", NameVsn]) ->
     emqx_plugins_cli:ensure_installed(NameVsn, fun emqx_ctl:print/2);
+plugins(["install", NameVsn, "--cluster"]) ->
+    emqx_plugins_cli:ensure_installed_cluster(NameVsn, fun emqx_ctl:print/2);
 plugins(["uninstall", NameVsn]) ->
     emqx_plugins_cli:ensure_uninstalled(NameVsn, fun emqx_ctl:print/2);
 plugins(["start", NameVsn]) ->
@@ -534,9 +536,10 @@ plugins(_) ->
                 "must hash to that value or the install is rejected."},
             {"plugins disallow  Name-Vsn",
                 "Disallows installation of a plugin in the cluster from Dashboard or API"},
-            {"plugins install   Name-Vsn",
+            {"plugins install   Name-Vsn [--cluster]",
                 "Install a plugin package placed\n"
-                "in plugin's install_dir"},
+                "in plugin's install_dir.\n"
+                "Use --cluster to install on all running nodes"},
             {"plugins uninstall Name-Vsn",
                 "Uninstall a plugin. NOTE: it deletes\n"
                 "all files in install_dir/Name-Vsn"},

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -87,7 +87,8 @@
 %% internal RPC targets
 -export([
     get_tar/1,
-    get_config/3
+    get_config/3,
+    install_package/2
 ]).
 
 %% for test cases
@@ -844,6 +845,19 @@ get_config(NameVsn, ?CONFIG_FORMAT_MAP, Default) ->
 
 get_tar(NameVsn) ->
     emqx_plugins_fs:get_tar(NameVsn).
+
+-spec install_package(name_vsn(), binary()) -> ok | {error, term()}.
+install_package(NameVsn, Bin) ->
+    ok = write_package(NameVsn, Bin),
+    case ensure_installed(NameVsn, ?fresh_install) of
+        {error, #{reason := plugin_not_found}} = NotFound ->
+            NotFound;
+        {error, _} = Error ->
+            _ = delete_package(NameVsn),
+            Error;
+        Result ->
+            Result
+    end.
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_plugins/src/emqx_plugins_cli.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_cli.erl
@@ -8,6 +8,7 @@
     list/1,
     describe/2,
     ensure_installed/2,
+    ensure_installed_cluster/2,
     ensure_uninstalled/2,
     ensure_started/2,
     ensure_stopped/2,
@@ -19,6 +20,7 @@
     disallow_installation/2
 ]).
 
+-include("emqx_plugins.hrl").
 -include_lib("emqx/include/logger.hrl").
 
 -define(BPAPI_NAME, emqx_plugins).
@@ -98,6 +100,22 @@ print_allow_result(Nodes, Results, NameVsn, LogFun) ->
         end,
     print(NameVsn, Result, LogFun, allow_installation).
 
+print_cluster_result(Nodes, Results, NameVsn, LogFun) ->
+    Errors =
+        lists:filter(
+            fun
+                ({_Node, {ok, ok}}) -> false;
+                ({_Node, _}) -> true
+            end,
+            lists:zip(Nodes, Results)
+        ),
+    Result =
+        case Errors of
+            [] -> ok;
+            _ -> {error, maps:from_list(Errors)}
+        end,
+    print(NameVsn, Result, LogFun, ensure_installed_cluster).
+
 disallow_installation(NameVsn, LogFun) ->
     try emqx_plugins_utils:parse_name_vsn(NameVsn) of
         {_AppName, _Vsn} ->
@@ -128,7 +146,37 @@ do_disallow_installation(NameVsn, LogFun) ->
     ?PRINT(Result, LogFun).
 
 ensure_installed(NameVsn, LogFun) ->
-    ?PRINT(emqx_plugins:ensure_installed(NameVsn), LogFun).
+    case emqx_plugins:describe(NameVsn, #{}) of
+        {ok, _} ->
+            ?PRINT(
+                {error, #{
+                    msg => "plugin_already_installed", name_vsn => NameVsn
+                }},
+                LogFun
+            );
+        {error, _} ->
+            ?PRINT(emqx_plugins:ensure_installed(NameVsn, ?fresh_install), LogFun)
+    end.
+
+ensure_installed_cluster(NameVsn, LogFun) ->
+    case emqx_plugins_fs:get_tar(NameVsn) of
+        {ok, TarBin} ->
+            Running = emqx:running_nodes(),
+            V5Nodes = nodes_supporting_bpapi_version(5),
+            case Running -- V5Nodes of
+                [] ->
+                    Results = emqx_plugins_proto_v5:install_package(V5Nodes, NameVsn, TarBin),
+                    print_cluster_result(V5Nodes, Results, NameVsn, LogFun);
+                Missing ->
+                    Reason = #{
+                        hint => <<"cluster install requires all nodes to support proto v5">>,
+                        nodes_missing_v5 => Missing
+                    },
+                    ?PRINT({error, Reason}, LogFun)
+            end;
+        {error, Reason} ->
+            ?PRINT({error, Reason}, LogFun)
+    end.
 
 ensure_uninstalled(NameVsn, LogFun) ->
     ?PRINT(emqx_plugins:ensure_uninstalled(NameVsn), LogFun).

--- a/apps/emqx_plugins/src/proto/emqx_plugins_proto_v5.erl
+++ b/apps/emqx_plugins/src/proto/emqx_plugins_proto_v5.erl
@@ -1,0 +1,36 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_plugins_proto_v5).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+
+    install_package/3
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+-define(TIMEOUT, 25_000).
+
+introduced_in() ->
+    "5.10.5".
+
+-spec install_package([node()], binary() | string(), binary()) ->
+    emqx_rpc:erpc_multicall(ok | {error, term()}).
+install_package(Nodes, NameVsn, TarBin) ->
+    erpc:multicall(Nodes, emqx_plugins, install_package, [NameVsn, TarBin], ?TIMEOUT).

--- a/apps/emqx_plugins/src/proto/emqx_plugins_proto_v5.erl
+++ b/apps/emqx_plugins/src/proto/emqx_plugins_proto_v5.erl
@@ -28,7 +28,7 @@
 -define(TIMEOUT, 25_000).
 
 introduced_in() ->
-    "5.10.5".
+    "6.0.4".
 
 -spec install_package([node()], binary() | string(), binary()) ->
     emqx_rpc:erpc_multicall(ok | {error, term()}).

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_plugins/include/emqx_plugins.hrl").
 
 -define(EMQX_PLUGIN_APP_NAME, my_emqx_plugin).
 -define(EMQX_PLUGIN_APP_NAME_BIN, <<"my_emqx_plugin">>).
@@ -52,7 +53,8 @@ groups() ->
             group_t_copy_plugin_to_a_new_node,
             group_t_copy_plugin_to_a_new_node_single_node,
             group_t_cluster_leave,
-            group_t_cluster_force_sync_vsn
+            group_t_cluster_force_sync_vsn,
+            group_t_cluster_install
         ]},
         {create_tar_copy_plugin, [sequence], [group_t_copy_plugin_to_a_new_node]}
     ].
@@ -1324,4 +1326,130 @@ t_tar_path_traversal(Config) ->
     ?assertEqual({error, enoent}, file:read_file_info(EvilTarget)),
     %% And no plugin dir should have been created either.
     ?assertEqual({error, enoent}, file:read_file_info(emqx_plugins_fs:plugin_dir(NameVsn))),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Phase 1: CLI install uses ?fresh_install — no cluster config lookup
+%%--------------------------------------------------------------------
+
+t_cli_install_no_warning({init, Config}) ->
+    Config;
+t_cli_install_no_warning({'end', _Config}) ->
+    ok;
+t_cli_install_no_warning(_Config) ->
+    #{name_vsn := NameVsn} = get_demo_plugin_package(),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    ?assertMatch(
+        {ok, #{config_status := disabled}},
+        emqx_plugins:describe(NameVsn)
+    ),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ok.
+
+t_install_package_rpc({init, Config}) ->
+    Config;
+t_install_package_rpc({'end', _Config}) ->
+    ok;
+t_install_package_rpc(_Config) ->
+    #{name_vsn := NameVsn} = get_demo_plugin_package(),
+    TarPath = emqx_plugins_fs:tar_file_path(NameVsn),
+    {ok, TarBin} = file:read_file(TarPath),
+    ok = emqx_plugins:delete_package(NameVsn),
+    ok = emqx_plugins:purge(NameVsn),
+    ok = emqx_plugins:install_package(NameVsn, TarBin),
+    ?assertMatch(
+        {ok, #{config_status := disabled}},
+        emqx_plugins:describe(NameVsn)
+    ),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ok.
+
+t_fresh_install_skips_peer_config({init, Config}) ->
+    Config;
+t_fresh_install_skips_peer_config({'end', _Config}) ->
+    ok;
+t_fresh_install_skips_peer_config(_Config) ->
+    #{name_vsn := NameVsn} = get_demo_plugin_package(),
+    ?check_trace(
+        emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+        fun(Trace) ->
+            ?assertMatch(
+                [],
+                ?of_kind(failed_to_get_plugin_config_from_cluster, Trace)
+            ),
+            ok
+        end
+    ),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Phase 2: cluster install via --cluster flag
+%%--------------------------------------------------------------------
+
+group_t_cluster_install({init, Config}) ->
+    Specs = emqx_cth_cluster:mk_nodespecs(
+        [
+            {group_t_cluster_install1, #{
+                role => core, apps => [emqx, emqx_conf, emqx_ctl]
+            }},
+            {group_t_cluster_install2, #{
+                role => core, apps => [emqx, emqx_conf, emqx_ctl]
+            }}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+    ),
+    Nodes = emqx_cth_cluster:start(Specs),
+    InstallRelDir = "plugins_cluster_install",
+    InstallDirs = [filename:join(WD, InstallRelDir) || #{work_dir := WD} <- Specs],
+    ok = lists:foreach(fun filelib:ensure_path/1, InstallDirs),
+    #{package := Package, name_vsn := NameVsn0} =
+        emqx_plugins_test_helpers:get_demo_plugin_package(#{
+            release_name => ?EMQX_PLUGIN_TEMPLATE_RELEASE_NAME,
+            git_url => ?EMQX_PLUGIN_TEMPLATE_URL,
+            vsn => ?EMQX_PLUGIN_TEMPLATE_VSN,
+            tag => ?EMQX_PLUGIN_TEMPLATE_TAG,
+            shdir => hd(InstallDirs)
+        }),
+    NameVsn = bin(NameVsn0),
+    {ok, TarBin} = file:read_file(Package),
+    [{ok, _}, {ok, _}] = erpc:multicall(Nodes, emqx_cth_suite, start_app, [
+        emqx_plugins,
+        #{config => #{plugins => #{install_dir => InstallRelDir}}}
+    ]),
+    [
+        {nodes, Nodes},
+        {name_vsn, NameVsn},
+        {tar_bin, TarBin}
+        | Config
+    ];
+group_t_cluster_install({'end', Config}) ->
+    Nodes = ?config(nodes, Config),
+    ok = emqx_cth_cluster:stop(Nodes);
+group_t_cluster_install(Config) ->
+    [N1, N2] = ?config(nodes, Config),
+    NameVsn = ?config(name_vsn, Config),
+    TarBin = ?config(tar_bin, Config),
+
+    %% Verify both nodes start with no plugins
+    ?assertEqual([], erpc:call(N1, emqx_plugins, list, [])),
+    ?assertEqual([], erpc:call(N2, emqx_plugins, list, [])),
+
+    %% Install on both nodes via RPC (simulates --cluster)
+    Results = emqx_plugins_proto_v5:install_package([N1, N2], NameVsn, TarBin),
+    ?assertMatch([{ok, ok}, {ok, ok}], lists:sort(Results)),
+
+    %% Both nodes should have the plugin
+    ?assertMatch(
+        [#{config_status := disabled}],
+        erpc:call(N1, emqx_plugins, list, [])
+    ),
+    ?assertMatch(
+        [#{config_status := disabled}],
+        erpc:call(N2, emqx_plugins, list, [])
+    ),
+
+    %% Cleanup
+    ok = erpc:call(N1, emqx_plugins, ensure_uninstalled, [NameVsn]),
+    ok = erpc:call(N2, emqx_plugins, ensure_uninstalled, [NameVsn]),
     ok.

--- a/changes/ee/fix-17932.en.md
+++ b/changes/ee/fix-17932.en.md
@@ -1,0 +1,5 @@
+Fixed noisy `failed_to_get_plugin_config_from_cluster` warning when installing plugins via CLI.
+
+The `emqx ctl plugins install` command now installs plugins in `fresh_install` mode (matching the HTTP API behavior), which skips the cluster config lookup for newly installed plugins, avoiding repeated `config_not_found_on_node` warnings on every node in the cluster.
+
+Added `--cluster` flag to `emqx ctl plugins install` for cluster-wide installation. When specified, the plugin package is distributed to and installed on all running nodes in a single command.


### PR DESCRIPTION
Phase 1: Change emqx_plugins_cli:ensure_installed/2 to use ?fresh_install
mode instead of ?normal, matching the API path behavior. This prevents
the 'failed_to_get_plugin_config_from_cluster' warning when installing
a plugin via CLI on a single node, since peer nodes don't have the
plugin config yet.

Phase 2: Add --cluster flag to 'emqx ctl plugins install' command.
When specified, reads the local tarball and distributes it to all
running nodes via erpc:multicall using the new proto v5.

- emqx_plugins_cli.erl: add ensure_installed_cluster/2, use ?fresh_install
- emqx_plugins.erl: add install_package/2 RPC target
- emqx_plugins_proto_v5.erl: new proto module for cluster install
- emqx_mgmt_cli.erl: parse --cluster flag, update help textRelease version:
<!-- uncomment for v5:
5.8.12, 5.10.5
-->

6.0.4, 6.1.3, 6.2.2

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->

Phase 1: Change emqx_plugins_cli:ensure_installed/2 to use ?fresh_install
mode instead of ?normal, matching the API path behavior. This prevents
the 'failed_to_get_plugin_config_from_cluster' warning when installing
a plugin via CLI on a single node, since peer nodes don't have the
plugin config yet.

Phase 2: Add --cluster flag to 'emqx ctl plugins install' command.
When specified, reads the local tarball and distributes it to all
running nodes via erpc:multicall using the new proto v5.

- emqx_plugins_cli.erl: add ensure_installed_cluster/2, use ?fresh_install
- emqx_plugins.erl: add install_package/2 RPC target
- emqx_plugins_proto_v5.erl: new proto module for cluster install
- emqx_mgmt_cli.erl: parse --cluster flag, update help text