### PR TITLE
feat(rabbitmq): multi-node servers with connect failover

### DIFF
--- a/apps/emqx_bridge_rabbitmq/mix.exs
+++ b/apps/emqx_bridge_rabbitmq/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeRabbitmq.MixProject do
   def project do
     [
       app: :emqx_bridge_rabbitmq,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_client.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_client.erl
@@ -16,23 +16,14 @@
 -include_lib("amqp_client/include/amqp_client.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--define(HOST_OPTIONS, #{
-    default_port => 5672,
-    ssrf_check => true
-}).
-
 -type host_port() :: {string(), inet:port_number()}.
 -type amqp_params() :: #amqp_params_network{}.
 
-host_options() -> ?HOST_OPTIONS.
+host_options() -> host_options(5672).
 
-%% `servers` wins when set; otherwise legacy `server`+`port`.
-servers_from_config(#{servers := Servers}) when
-    Servers =/= undefined, Servers =/= <<>>, Servers =/= ""
-->
-    parse_servers(Servers);
-servers_from_config(#{server := Host, port := Port}) ->
-    [{emqx_utils_conv:str(Host), Port}].
+%% `server` is normalized to the canonical `servers` field by the schema.
+servers_from_config(#{servers := Servers, port := DefaultPort}) ->
+    parse_servers(Servers, DefaultPort).
 
 rotate_servers([], _WorkerId) ->
     [];
@@ -48,11 +39,14 @@ rotate_servers(Servers, _WorkerId) ->
 start_connection(Servers, AmqpParamsBase) ->
     do_start_connection(Servers, AmqpParamsBase, []).
 
-parse_servers(BinServers) ->
+parse_servers(BinServers, DefaultPort) ->
     [
         {emqx_utils_conv:str(Host), Port}
-     || #{hostname := Host, port := Port} <- emqx_schema:parse_servers(BinServers, ?HOST_OPTIONS)
+     || #{hostname := Host, port := Port} <-
+            emqx_schema:parse_servers(BinServers, host_options(DefaultPort))
     ].
+
+host_options(DefaultPort) -> #{default_port => DefaultPort, ssrf_check => true}.
 
 do_start_connection([], _AmqpParamsBase, Tried) ->
     {error, #{reason => all_nodes_failed, tried => lists:reverse(Tried)}};

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_client.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_client.erl
@@ -1,0 +1,73 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_rabbitmq_client).
+
+%% Single-host amqp_client wrapper with multi-node connect failover.
+
+-export([
+    host_options/0,
+    servers_from_config/1,
+    rotate_servers/2,
+    start_connection/2
+]).
+
+-include_lib("amqp_client/include/amqp_client.hrl").
+-include_lib("emqx/include/logger.hrl").
+
+-define(HOST_OPTIONS, #{
+    default_port => 5672,
+    ssrf_check => true
+}).
+
+-type host_port() :: {string(), inet:port_number()}.
+
+host_options() -> ?HOST_OPTIONS.
+
+%% `servers` wins when set; otherwise legacy `server`+`port`.
+servers_from_config(#{servers := Servers}) when
+    Servers =/= undefined, Servers =/= <<>>, Servers =/= ""
+->
+    parse_servers(Servers);
+servers_from_config(#{server := Host, port := Port}) ->
+    [{str(Host), Port}].
+
+rotate_servers([], _WorkerId) ->
+    [];
+rotate_servers(Servers, WorkerId) when is_integer(WorkerId), WorkerId > 0 ->
+    Offset = (WorkerId - 1) rem length(Servers),
+    {Left, Right} = lists:split(Offset, Servers),
+    Right ++ Left;
+rotate_servers(Servers, _WorkerId) ->
+    Servers.
+
+-spec start_connection([host_port()], #amqp_params_network{}) ->
+    {ok, pid()} | {error, term()}.
+start_connection(Servers, AmqpParamsBase) ->
+    do_start_connection(Servers, AmqpParamsBase, []).
+
+parse_servers(BinServers) ->
+    [
+        {str(Host), Port}
+     || #{hostname := Host, port := Port} <- emqx_schema:parse_servers(BinServers, ?HOST_OPTIONS)
+    ].
+
+do_start_connection([], _AmqpParamsBase, Tried) ->
+    {error, #{reason => all_nodes_failed, tried => lists:reverse(Tried)}};
+do_start_connection([{Host, Port} | Rest], AmqpParamsBase, Tried) ->
+    Params = AmqpParamsBase#amqp_params_network{host = Host, port = Port},
+    case amqp_connection:start(Params) of
+        {ok, Conn} ->
+            {ok, Conn};
+        {error, Reason} ->
+            ?SLOG(warning, #{
+                msg => "rabbitmq_connection_node_failed",
+                host => Host,
+                port => Port,
+                reason => Reason
+            }),
+            do_start_connection(Rest, AmqpParamsBase, [{Host, Port, Reason} | Tried])
+    end.
+
+str(X) -> emqx_utils_conv:str(X).

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_client.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_client.erl
@@ -32,7 +32,7 @@ servers_from_config(#{servers := Servers}) when
 ->
     parse_servers(Servers);
 servers_from_config(#{server := Host, port := Port}) ->
-    [{str(Host), Port}].
+    [{emqx_utils_conv:str(Host), Port}].
 
 rotate_servers([], _WorkerId) ->
     [];
@@ -50,7 +50,7 @@ start_connection(Servers, AmqpParamsBase) ->
 
 parse_servers(BinServers) ->
     [
-        {str(Host), Port}
+        {emqx_utils_conv:str(Host), Port}
      || #{hostname := Host, port := Port} <- emqx_schema:parse_servers(BinServers, ?HOST_OPTIONS)
     ].
 
@@ -70,5 +70,3 @@ do_start_connection([{Host, Port} | Rest], AmqpParamsBase, Tried) ->
             }),
             do_start_connection(Rest, AmqpParamsBase, [{Host, Port, Reason} | Tried])
     end.
-
-str(X) -> emqx_utils_conv:str(X).

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_client.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_client.erl
@@ -22,6 +22,7 @@
 }).
 
 -type host_port() :: {string(), inet:port_number()}.
+-type amqp_params() :: #amqp_params_network{}.
 
 host_options() -> ?HOST_OPTIONS.
 
@@ -42,7 +43,7 @@ rotate_servers(Servers, WorkerId) when is_integer(WorkerId), WorkerId > 0 ->
 rotate_servers(Servers, _WorkerId) ->
     Servers.
 
--spec start_connection([host_port()], #amqp_params_network{}) ->
+-spec start_connection([host_port()], amqp_params()) ->
     {ok, pid()} | {error, term()}.
 start_connection(Servers, AmqpParamsBase) ->
     do_start_connection(Servers, AmqpParamsBase, []).

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector.erl
@@ -152,9 +152,8 @@ on_stop(ResourceID, _State) ->
 -spec connect(term()) -> {ok, {pid(), pid()}, map()} | {error, term()}.
 connect(Options) ->
     Config = proplists:get_value(config, Options),
+    WorkerId = proplists:get_value(ecpool_worker_id, Options, 1),
     #{
-        server := Host,
-        port := Port,
         username := Username,
         password := WrappedPassword,
         timeout := Timeout,
@@ -163,18 +162,17 @@ connect(Options) ->
     } = Config,
     %% TODO: teach `amqp` to accept 0-arity closures as passwords.
     Password = emqx_secret:unwrap(WrappedPassword),
-    RabbitMQConnOptions =
-        #amqp_params_network{
-            host = Host,
-            port = Port,
-            ssl_options = to_ssl_options(Config),
-            username = Username,
-            password = Password,
-            connection_timeout = Timeout,
-            virtual_host = VirtualHost,
-            heartbeat = Heartbeat
-        },
-    case amqp_connection:start(RabbitMQConnOptions) of
+    Servers0 = emqx_bridge_rabbitmq_client:servers_from_config(Config),
+    Servers = emqx_bridge_rabbitmq_client:rotate_servers(Servers0, WorkerId),
+    AmqpParamsBase = #amqp_params_network{
+        ssl_options = to_ssl_options(Config),
+        username = Username,
+        password = Password,
+        connection_timeout = Timeout,
+        virtual_host = VirtualHost,
+        heartbeat = Heartbeat
+    },
+    case emqx_bridge_rabbitmq_client:start_connection(Servers, AmqpParamsBase) of
         {ok, RabbitMQConn} ->
             {ok, RabbitMQConn};
         {error, Reason} ->

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector_schema.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector_schema.erl
@@ -29,18 +29,11 @@ fields(connector) ->
         {servers,
             emqx_schema:servers_sc(
                 #{
-                    required => false,
+                    aliases => [server],
+                    default => <<"localhost">>,
                     desc => ?DESC("servers")
                 },
                 emqx_bridge_rabbitmq_client:host_options()
-            )},
-        {server,
-            ?HOCON(
-                string(),
-                #{
-                    default => <<"localhost">>,
-                    desc => ?DESC("server")
-                }
             )},
         {port,
             ?HOCON(

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector_schema.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector_schema.erl
@@ -26,6 +26,14 @@ fields("config_connector") ->
         emqx_connector_schema:resource_opts_ref(?MODULE, connector_resource_opts);
 fields(connector) ->
     [
+        {servers,
+            emqx_schema:servers_sc(
+                #{
+                    required => false,
+                    desc => ?DESC("servers")
+                },
+                emqx_bridge_rabbitmq_client:host_options()
+            )},
         {server,
             ?HOCON(
                 string(),
@@ -39,7 +47,7 @@ fields(connector) ->
                 emqx_schema:port_number(),
                 #{
                     default => 5672,
-                    desc => ?DESC("server")
+                    desc => ?DESC("port")
                 }
             )},
         {username,
@@ -119,8 +127,7 @@ connector_example_values() ->
         name => <<"rabbitmq_connector">>,
         type => rabbitmq,
         enable => true,
-        server => <<"127.0.0.1">>,
-        port => 5672,
+        servers => <<"127.0.0.1:5672">>,
         username => <<"guest">>,
         password => <<"******">>,
         pool_size => 8,

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_action_SUITE.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_action_SUITE.erl
@@ -244,6 +244,18 @@ t_start_stop(TCConfig) when is_list(TCConfig) ->
 t_on_get_status(TCConfig) when is_list(TCConfig) ->
     emqx_bridge_v2_testlib:t_on_get_status(TCConfig).
 
+t_multi_node_connect_failover(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{
+        <<"servers">> => <<"rabbitmq:1,rabbitmq:5672">>
+    }),
+    {201, _} = create_action_api(TCConfig, #{}),
+    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    Payload = <<"multi-node-failover">>,
+    emqtt:publish(C, Topic, Payload, [{qos, 1}]),
+    ?assertMatch(#{payload := Payload}, receive_message(TCConfig)),
+    ok.
+
 t_rule_action() ->
     [{matrix, true}].
 t_rule_action(matrix) ->

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_client_tests.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_client_tests.erl
@@ -9,30 +9,28 @@
 
 servers_from_config_test_() ->
     [
-        {"prefers servers over legacy fields",
+        {"uses inline ports",
             ?_assertEqual(
                 [{"rmq1", 5672}, {"rmq2", 5673}],
                 emqx_bridge_rabbitmq_client:servers_from_config(#{
                     servers => <<"rmq1:5672,rmq2:5673">>,
-                    server => <<"ignored">>,
                     port => 1111
                 })
             )},
-        {"legacy server+port",
+        {"uses configured default port",
             ?_assertEqual(
-                [{"rmq-legacy", 5672}],
+                [{"rmq-legacy", 5671}],
                 emqx_bridge_rabbitmq_client:servers_from_config(#{
-                    server => <<"rmq-legacy">>,
-                    port => 5672
+                    servers => <<"rmq-legacy">>,
+                    port => 5671
                 })
             )},
         {"default port in servers list",
             ?_assertEqual(
-                [{"rmq1", 5672}, {"rmq2", 5673}],
+                [{"rmq1", 5671}, {"rmq2", 5673}],
                 emqx_bridge_rabbitmq_client:servers_from_config(#{
                     servers => <<"rmq1,rmq2:5673">>,
-                    server => <<"localhost">>,
-                    port => 5672
+                    port => 5671
                 })
             )}
     ].
@@ -108,10 +106,10 @@ schema_test_() ->
             )},
         {"accepts legacy server+port",
             ?_assertMatch(
-                #{<<"server">> := <<"rmq-legacy">>, <<"port">> := 5672},
+                #{<<"servers">> := <<"rmq-legacy">>, <<"port">> := 5671},
                 emqx_bridge_rabbitmq_testlib:connector_config(#{
                     <<"server">> => <<"rmq-legacy">>,
-                    <<"port">> => 5672
+                    <<"port">> => 5671
                 })
             )}
     ].

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_client_tests.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_client_tests.erl
@@ -1,0 +1,117 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_rabbitmq_client_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+
+servers_from_config_test_() ->
+    [
+        {"prefers servers over legacy fields",
+            ?_assertEqual(
+                [{"rmq1", 5672}, {"rmq2", 5673}],
+                emqx_bridge_rabbitmq_client:servers_from_config(#{
+                    servers => <<"rmq1:5672,rmq2:5673">>,
+                    server => <<"ignored">>,
+                    port => 1111
+                })
+            )},
+        {"legacy server+port",
+            ?_assertEqual(
+                [{"rmq-legacy", 5672}],
+                emqx_bridge_rabbitmq_client:servers_from_config(#{
+                    server => <<"rmq-legacy">>,
+                    port => 5672
+                })
+            )},
+        {"default port in servers list",
+            ?_assertEqual(
+                [{"rmq1", 5672}, {"rmq2", 5673}],
+                emqx_bridge_rabbitmq_client:servers_from_config(#{
+                    servers => <<"rmq1,rmq2:5673">>,
+                    server => <<"localhost">>,
+                    port => 5672
+                })
+            )}
+    ].
+
+rotate_servers_test() ->
+    Servers = [{"a", 1}, {"b", 2}, {"c", 3}],
+    ?assertEqual(Servers, emqx_bridge_rabbitmq_client:rotate_servers(Servers, 1)),
+    ?assertEqual(
+        [{"b", 2}, {"c", 3}, {"a", 1}], emqx_bridge_rabbitmq_client:rotate_servers(Servers, 2)
+    ),
+    ?assertEqual(
+        [{"c", 3}, {"a", 1}, {"b", 2}], emqx_bridge_rabbitmq_client:rotate_servers(Servers, 3)
+    ),
+    ?assertEqual(
+        [{"b", 2}, {"c", 3}, {"a", 1}], emqx_bridge_rabbitmq_client:rotate_servers(Servers, 5)
+    ).
+
+start_connection_failover_test() ->
+    meck:new(amqp_connection, [passthrough, no_link]),
+    try
+        meck:expect(
+            amqp_connection,
+            start,
+            fun(#amqp_params_network{host = Host, port = Port}) ->
+                case {Host, Port} of
+                    {"bad", 1} -> {error, econnrefused};
+                    {"good", 5672} -> {ok, rabbitmq_conn_stub}
+                end
+            end
+        ),
+        ?assertEqual(
+            {ok, rabbitmq_conn_stub},
+            emqx_bridge_rabbitmq_client:start_connection(
+                [{"bad", 1}, {"good", 5672}],
+                #amqp_params_network{}
+            )
+        ),
+        History = [
+            {Host, Port}
+         || {_Pid, {amqp_connection, start, [#amqp_params_network{host = Host, port = Port}]}, _Res} <-
+                meck:history(amqp_connection)
+        ],
+        ?assertEqual([{"bad", 1}, {"good", 5672}], History)
+    after
+        meck:unload(amqp_connection)
+    end.
+
+start_connection_all_failed_test() ->
+    meck:new(amqp_connection, [passthrough, no_link]),
+    try
+        meck:expect(amqp_connection, start, fun(#amqp_params_network{}) -> {error, econnrefused} end),
+        ?assertMatch(
+            {error, #{
+                reason := all_nodes_failed,
+                tried := [{"a", 1, econnrefused}, {"b", 2, econnrefused}]
+            }},
+            emqx_bridge_rabbitmq_client:start_connection(
+                [{"a", 1}, {"b", 2}], #amqp_params_network{}
+            )
+        )
+    after
+        meck:unload(amqp_connection)
+    end.
+
+schema_test_() ->
+    [
+        {"accepts servers",
+            ?_assertMatch(
+                #{<<"servers">> := <<"rmq1:5672,rmq2:5672">>},
+                emqx_bridge_rabbitmq_testlib:connector_config(#{
+                    <<"servers">> => <<"rmq1:5672,rmq2:5672">>
+                })
+            )},
+        {"accepts legacy server+port",
+            ?_assertMatch(
+                #{<<"server">> := <<"rmq-legacy">>, <<"port">> := 5672},
+                emqx_bridge_rabbitmq_testlib:connector_config(#{
+                    <<"server">> => <<"rmq-legacy">>,
+                    <<"port">> => 5672
+                })
+            )}
+    ].

--- a/changes/ee/feat-17933.en.md
+++ b/changes/ee/feat-17933.en.md
@@ -1,0 +1,1 @@
+RabbitMQ connector supports a multi-node `servers` list (e.g. `rmq1:5672,rmq2:5672`) with connect-time failover and rotated pool start offsets. Legacy `server`/`port` remain when `servers` is unset.

--- a/rel/i18n/emqx_bridge_rabbitmq_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_rabbitmq_connector_schema.hocon
@@ -3,20 +3,14 @@ emqx_bridge_rabbitmq_connector_schema {
 
 servers.desc:
 """Comma-separated RabbitMQ nodes for connect failover, form `Host[:Port][,Host2:Port]`.<br/>
-Default port 5672 is used when `[:Port]` is omitted.<br/>
-Takes precedence over legacy `server` and `port` when set."""
+The `server` field is accepted as an alias.<br/>
+The `port` value (default 5672) is used when `[:Port]` is omitted."""
 
 servers.label:
 """Servers"""
 
-server.desc:
-"""Legacy single hostname/IP. Used only when `servers` is not set."""
-
-server.label:
-"""Server"""
-
 port.desc:
-"""Legacy port (default 5672). Used only when `servers` is not set."""
+"""The default port for servers without an explicit `:Port` (default 5672)."""
 
 port.label:
 """Port"""

--- a/rel/i18n/emqx_bridge_rabbitmq_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_rabbitmq_connector_schema.hocon
@@ -1,14 +1,22 @@
 
 emqx_bridge_rabbitmq_connector_schema {
 
+servers.desc:
+"""Comma-separated RabbitMQ nodes for connect failover, form `Host[:Port][,Host2:Port]`.<br/>
+Default port 5672 is used when `[:Port]` is omitted.<br/>
+Takes precedence over legacy `server` and `port` when set."""
+
+servers.label:
+"""Servers"""
+
 server.desc:
-"""The RabbitMQ server address that you want to connect to (for example, localhost)."""
+"""Legacy single hostname/IP. Used only when `servers` is not set."""
 
 server.label:
 """Server"""
 
 port.desc:
-"""The port number on which the RabbitMQ server is listening (default is 5672)."""
+"""Legacy port (default 5672). Used only when `servers` is not set."""
 
 port.label:
 """Port"""


### PR DESCRIPTION
Release version: 6.0.4
Fix: https://github.com/emqx/emqx-customer-support/issues/24

## Summary

Allow RabbitMQ connectors to use a comma-separated servers list. Connection establishment fails over through the list and pool workers rotate their starting node. Existing server/port configurations remain supported.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for user-visible changes has been added
- [x] Schema changes are backward compatible