### PR TITLE
fix(a2a api): format global namespace as `null`

### DIFF
--- a/apps/emqx_a2a_registry/mix.exs
+++ b/apps/emqx_a2a_registry/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXA2ARegistry.MixProject do
   def project do
     [
       app: :emqx_a2a_registry,
-      version: "6.2.2",
+      version: "6.2.3",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry_adapter.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry_adapter.erl
@@ -14,12 +14,21 @@
 %% Type declarations
 %%------------------------------------------------------------------------------
 
+-include_lib("emqx/include/emqx_config.hrl").
+
 %%------------------------------------------------------------------------------
 %% API
 %%------------------------------------------------------------------------------
 
 card_out(Card) ->
-    Card.
+    emqx_utils_maps:update_if_present(
+        <<"namespace">>,
+        fun
+            (?global_ns) -> null;
+            (Ns) -> Ns
+        end,
+        Card
+    ).
 
 format_register_error({bad_id, Field, Id}) ->
     {ok, iolist_to_binary(io_lib:format("Bad ~s id: ~s", [Field, Id]))};

--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
@@ -178,6 +178,13 @@ t_crud(TCConfig) when is_list(TCConfig) ->
         list_cards(#{}, TCConfig)
     ),
     ?assertMatch({200, #{<<"namespace">> := _}}, get_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, TCConfig)),
+    maybe
+        false ?= get_config(namespaced, TCConfig, false),
+        ?assertMatch({200, [#{<<"namespace">> := null}]}, list_cards(#{}, TCConfig)),
+        ?assertMatch(
+            {200, #{<<"namespace">> := null}}, get_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, TCConfig)
+        )
+    end,
 
     %% List filters
     Name2 = <<"2">>,

--- a/changes/ee/fix-17936.en.md
+++ b/changes/ee/fix-17936.en.md
@@ -1,0 +1,1 @@
+Fixed the formatting of A2A cards belonging to the global namespace in the HTTP API.  Previously, they would show as the string `"global"`.  Now, they are formatted as `null` to distinguish them from specific namespaces.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/17935

Release version:
6.2.2, 6.3.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
