### PR TITLE
test(a2a): attempt to stabilize flaky test

### DIFF
--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_SUITE.erl
@@ -250,9 +250,13 @@ t_smoke_01(TCConfig) ->
     Agent2 = start_client(#{clientid => AgentClientId}, TCConfig),
     {ok, _} = publish_card(Agent2, ?ORG_ID, ?UNIT_ID, ?AGENT_ID, sample_card_bin()),
     {publish, #{properties := #{'User-Property' := Props2}}} = ?assertReceive({publish, _}),
-    ?assertMatch(
-        #{?A2A_PROP_STATUS_KEY := [?A2A_PROP_ONLINE_VAL]},
-        get_a2a_props(Props2)
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            #{?A2A_PROP_STATUS_KEY := [?A2A_PROP_ONLINE_VAL]},
+            get_a2a_props(Props2)
+        )
     ),
 
     %% Unpublish card by publishing empty retained message


### PR DESCRIPTION
```
%%% emqx_a2a_registry_SUITE ==> durable_sessions.namespaced.t_smoke_01: FAILED
%%% emqx_a2a_registry_SUITE ==>
Failure/Error: ?assertMatch(# { ? A2A_PROP_STATUS_KEY := [ ? A2A_PROP_ONLINE_VAL ] }, get_a2a_props ( Props2 ))
  expected: = # { ? A2A_PROP_STATUS_KEY := [ ? A2A_PROP_ONLINE_VAL ] }
       got: #{<<"a2a-status">> => [<<"offline">>],
              <<"a2a-status-source">> => [<<"emqx">>]}
      line: 254
```

https://github.com/emqx/emqx/actions/runs/29255629510/job/86837925557?pr=17937#step:5:292
