### PR TITLE
test(license): stabilize session HWM history checks

### DIFF
--- a/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -402,6 +402,9 @@ session_hwm_teardown(Config) ->
 session_hwm_uri(Query) ->
     uri(["license", "session_hwm_history"]) ++ Query.
 
+filter_by_period(Rows, ExpectedPeriods) ->
+    [R || R <- Rows, lists:member(maps:get(<<"period">>, R), ExpectedPeriods)].
+
 t_session_hwm_history_default_monthly({init, Config}) ->
     session_hwm_setup(Config);
 t_session_hwm_history_default_monthly({'end', Config}) ->
@@ -413,7 +416,7 @@ t_session_hwm_history_default_monthly(_Config) ->
     ?assertEqual(<<"monthly">>, Period),
     ?assertMatch(
         [#{<<"period">> := <<"2026-05">>}, #{<<"period">> := <<"2026-04">>}],
-        Rows
+        filter_by_period(Rows, [<<"2026-05">>, <<"2026-04">>])
     ).
 
 t_session_hwm_history_monthly({init, Config}) ->
@@ -429,7 +432,7 @@ t_session_hwm_history_monthly(_Config) ->
             #{<<"period">> := <<"2026-05">>, <<"high_watermark">> := 5},
             #{<<"period">> := <<"2026-04">>, <<"high_watermark">> := 20}
         ],
-        Rows
+        filter_by_period(Rows, [<<"2026-05">>, <<"2026-04">>])
     ).
 
 t_session_hwm_history_daily({init, Config}) ->
@@ -446,7 +449,7 @@ t_session_hwm_history_daily(_Config) ->
             #{<<"period">> := <<"2026-04-19">>, <<"high_watermark">> := 20},
             #{<<"period">> := <<"2026-04-18">>, <<"high_watermark">> := 10}
         ],
-        Rows
+        filter_by_period(Rows, [<<"2026-05-01">>, <<"2026-04-19">>, <<"2026-04-18">>])
     ).
 
 t_session_hwm_history_limit({init, Config}) ->


### PR DESCRIPTION
Release version: 6.0.4, 6.1.3, 6.2.2
Fix https://github.com/emqx/emqx/actions/runs/29067650276/job/86716415411?pr=17921

## Summary

Stabilize session HWM history API checks by asserting the expected historical periods in order. The periodic resource sampler can legitimately add a current-day record while the suite runs.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)