### PR TITLE
resume action buffer workers

### DIFF
--- a/apps/emqx_resource/src/emqx_resource.app.src
+++ b/apps/emqx_resource/src/emqx_resource.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_resource, [
     {description, "Manager for all external resources"},
-    {vsn, "0.1.41"},
+    {vsn, "0.1.42"},
     {registered, []},
     {mod, {emqx_resource_app, []}},
     {applications, [

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -1293,8 +1293,14 @@ handle_async_worker_down(Data0, Pid) ->
     #{async_workers := AsyncWorkers0} = Data0,
     {AsyncWorkerMRef, AsyncWorkers} = maps:take(Pid, AsyncWorkers0),
     Data = Data0#{async_workers := AsyncWorkers},
-    mark_inflight_items_as_retriable(Data, AsyncWorkerMRef),
-    {next_state, blocked, Data}.
+    case mark_inflight_items_as_retriable(Data, AsyncWorkerMRef) of
+        0 ->
+            %% The async worker may have completed all of its requests before it
+            %% terminated.  Do not leave an otherwise idle buffer worker blocked.
+            {keep_state, Data};
+        _NumAffected ->
+            {next_state, blocked, Data}
+    end.
 
 -spec call_query(force_sync | async_if_possible, _, _, _, _, _) -> _.
 call_query(QM, Id, Index, Ref, Query, QueryOpts) ->
@@ -2165,7 +2171,7 @@ mark_inflight_items_as_retriable(Data, AsyncWorkerMRef) ->
         ),
     _NumAffected = ets:select_replace(InflightTID, MatchSpec),
     ?tp(buffer_worker_async_agent_down, #{num_affected => _NumAffected, buffer_worker => self()}),
-    ok.
+    _NumAffected.
 
 %% used to update a batch after dropping expired individual queries.
 update_inflight_item(InflightTID, Ref, NewBatch, NumExpired) ->
@@ -2524,4 +2530,20 @@ adjust_batch_time_test_() ->
                 adjust_batch_time(Id, infinity, 100)
             )}
     ].
+
+async_worker_down_without_inflight_test() ->
+    InflightTID = inflight_new(1),
+    try
+        MRef = make_ref(),
+        Data = #{
+            inflight_tid => InflightTID,
+            async_workers => #{self() => MRef}
+        },
+        ?assertMatch(
+            {keep_state, #{async_workers := #{}}},
+            handle_async_worker_down(Data, self())
+        )
+    after
+        ets:delete(InflightTID)
+    end.
 -endif.

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -1338,11 +1338,11 @@ continue_with_health_check(#data{} = Data0, CurrentState, HCRes) ->
     {NewStatus, Err} = parse_health_check_result(HCRes, Data0),
     IsDryRun = emqx_resource:is_dry_run(ResId),
     _ = maybe_alarm(NewStatus, IsDryRun, ResId, Err, PrevError),
-    ok = maybe_resume_resource_workers(ResId, NewStatus),
     Data1 = Data0#data{
         status = NewStatus, error = Err
     },
     Data = update_state(Data1),
+    ok = maybe_resume_resource_workers(ResId, NewStatus),
     case CurrentState of
         ?state_connected ->
             continue_resource_health_check_connected(NewStatus, Data);
@@ -1775,7 +1775,9 @@ handle_channel_health_check_worker_down(Data0, Pid, ExitResult) ->
     ),
     CHCActions = start_channel_health_check_action(ChannelId, NewStatus, PreviousChanStatus, Data),
     Actions = Replies ++ CHCActions,
-    {keep_state, update_state(Data), Actions}.
+    CachedData = update_state(Data),
+    ok = maybe_resume_channel_workers(ChannelId, CachedData),
+    {keep_state, CachedData, Actions}.
 
 handle_channel_health_check_worker_down_new_channels_and_status(
     ChannelId,
@@ -1920,6 +1922,24 @@ maybe_resume_resource_workers(ResId, ?status_connected) ->
     );
 maybe_resume_resource_workers(_, _) ->
     ok.
+
+-spec maybe_resume_channel_workers(channel_id(), data()) -> ok.
+maybe_resume_channel_workers(ChannelId, #data{added_channels = AddedChannels}) ->
+    ChannelStatus = maps:get(ChannelId, AddedChannels, undefined),
+    case should_resume_channel_workers(ChannelStatus) of
+        true ->
+            lists:foreach(
+                fun emqx_resource_buffer_worker:resume/1,
+                emqx_resource_buffer_worker_sup:worker_pids(ChannelId)
+            );
+        false ->
+            ok
+    end.
+
+should_resume_channel_workers(#{status := ?status_connected}) ->
+    true;
+should_resume_channel_workers(_) ->
+    false.
 
 -spec maybe_clear_alarm(boolean(), resource_id()) -> ok | {error, not_found}.
 maybe_clear_alarm(true, _ResId) ->
@@ -2231,3 +2251,13 @@ abort_health_checks_for_channel(Data0, ChannelId) ->
         hc_workers = HCWorkers,
         hc_pending_callers = Pending
     }.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+should_resume_channel_workers_test() ->
+    ?assert(should_resume_channel_workers(#{status => ?status_connected})),
+    ?assertNot(should_resume_channel_workers(#{status => ?status_connecting})),
+    ?assertNot(should_resume_channel_workers(undefined)).
+
+-endif.

--- a/changes/ee/fix-17947.en.md
+++ b/changes/ee/fix-17947.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where updating an HTTP connector could leave its action buffer workers blocked after the connector was recreated, causing messages to remain queued until the next retry interval.


### PR DESCRIPTION
Release version: 5.8.x

If an HTTP Connector is updated (recreated) and had previously sent messages before the update, the Channel status will be set to "blocked" during the update. In this state, all subsequent messages will be buffered until the status is reset to "running" after 15 seconds.

This issue can be reproduced simply by updating the description field of the Connector.

<!-- uncomment for v5:
5.8.12, 5.10.5
-->

<!-- uncomment for v6:
6.0.4, 6.1.3, 6.2.2
-->

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
