### PR TITLE
fix(agent): validate stream and kv tool formats

### DIFF
--- a/plugins/emqx_agent/priv/config_schema.avsc
+++ b/plugins/emqx_agent/priv/config_schema.avsc
@@ -77,7 +77,7 @@
               {"name": "id", "type": "string", "description": "$tool_id_desc"},
               {"name": "desc", "type": "string", "description": "$tool_desc_desc"},
               {"name": "stream", "type": "string", "description": "$tool_stream_desc"},
-              {"name": "format", "type": "string", "default": "json", "description": "$tool_format_desc"}
+              {"name": "format", "type": {"type": "enum", "name": "StreamWriteFormat", "symbols": ["json", "binary"]}, "description": "$tool_format_desc"}
             ]
           },
           {
@@ -88,7 +88,7 @@
               {"name": "id", "type": "string", "description": "$tool_id_desc"},
               {"name": "desc", "type": "string", "description": "$tool_desc_desc"},
               {"name": "stream", "type": "string", "description": "$tool_stream_desc"},
-              {"name": "format", "type": "string", "default": "json", "description": "$tool_format_desc"}
+              {"name": "format", "type": {"type": "enum", "name": "StreamReadFormat", "symbols": ["json", "binary"]}, "description": "$tool_format_desc"}
             ]
           },
           {
@@ -109,7 +109,7 @@
               {"name": "id", "type": "string", "description": "$tool_id_desc"},
               {"name": "desc", "type": "string", "description": "$tool_desc_desc"},
               {"name": "stream", "type": "string", "description": "$tool_stream_desc"},
-              {"name": "format", "type": "string", "default": "json", "description": "$tool_format_desc"}
+              {"name": "format", "type": {"type": "enum", "name": "KvWriteFormat", "symbols": ["json", "binary"]}, "description": "$tool_format_desc"}
             ]
           },
           {
@@ -120,7 +120,7 @@
               {"name": "id", "type": "string", "description": "$tool_id_desc"},
               {"name": "desc", "type": "string", "description": "$tool_desc_desc"},
               {"name": "stream", "type": "string", "description": "$tool_stream_desc"},
-              {"name": "format", "type": "string", "default": "json", "description": "$tool_format_desc"}
+              {"name": "format", "type": {"type": "enum", "name": "KvReadFormat", "symbols": ["json", "binary"]}, "description": "$tool_format_desc"}
             ]
           },
           {
@@ -131,7 +131,7 @@
               {"name": "id", "type": "string", "description": "$tool_id_desc"},
               {"name": "desc", "type": "string", "description": "$tool_desc_desc"},
               {"name": "stream", "type": "string", "description": "$tool_stream_desc"},
-              {"name": "format", "type": "string", "default": "json", "description": "$tool_format_desc"}
+              {"name": "format", "type": {"type": "enum", "name": "KvReadAllFormat", "symbols": ["json", "binary"]}, "description": "$tool_format_desc"}
             ]
           },
           {

--- a/plugins/emqx_agent/priv/index.html
+++ b/plugins/emqx_agent/priv/index.html
@@ -197,8 +197,8 @@
         <!-- stream / kv read-write format -->
         <div id="f-format" style="display:none">
           <div class="field">
-            <label>Format</label>
-            <select id="tool-format">
+            <label>Format *</label>
+            <select id="tool-format" required>
               <option value="json">json</option>
               <option value="binary">binary</option>
             </select>

--- a/plugins/emqx_agent/priv/ui/tools.js
+++ b/plugins/emqx_agent/priv/ui/tools.js
@@ -88,6 +88,7 @@ export function collectToolBody() {
 export async function saveTool() {
   const body = collectToolBody();
   if (!body.id) return setMsg('tool-msg', 'ID is required', true);
+  if (hasFormat(body.type) && !body.format) return setMsg('tool-msg', 'Format is required', true);
   try {
     if (editingToolKey.type) {
       await api('PUT', `/tools/${encodeURIComponent(editingToolKey.type)}/${encodeURIComponent(editingToolKey.id)}`, body);
@@ -148,7 +149,7 @@ export function editTool(type, id) {
     document.getElementById('tool-query').value = tool.query ?? '';
   } else if (isStreamTool(type)) {
     document.getElementById('tool-stream').value = tool.stream ?? '';
-    if (hasFormat(type)) document.getElementById('tool-format').value = tool.format ?? 'json';
+    if (hasFormat(type)) document.getElementById('tool-format').value = tool.format;
   }
 
   document.querySelector('#tab-tools .card').scrollIntoView({ behavior: 'smooth', block: 'start' });

--- a/plugins/emqx_agent/src/emqx_agent_config.erl
+++ b/plugins/emqx_agent/src/emqx_agent_config.erl
@@ -381,9 +381,38 @@ normalize_config_for_storage(Config) ->
     end.
 
 validate_config(Config) ->
+    case validate_tools(Config) of
+        ok -> validate_config_schemas_and_refs(Config);
+        {error, _} = Error -> Error
+    end.
+
+validate_config_schemas_and_refs(Config) ->
     case validate_oai_schemas(Config) of
         ok -> validate_pipeline_tool_refs(Config);
         {error, _} = Error -> Error
+    end.
+
+validate_tools(Config) ->
+    validate_tool_entries(maps:get(?TOOLS, Config, [])).
+
+validate_tool_entries([]) ->
+    ok;
+validate_tool_entries([Tool0 | Rest]) ->
+    Tool = unwrap_union(Tool0),
+    case validate_tool(Tool) of
+        ok -> validate_tool_entries(Rest);
+        {error, _} = Error -> Error
+    end.
+
+validate_tool(#{?TOOL_TYPE := Type} = Tool) ->
+    try emqx_agent_tool_registry:resolve_type(Type) of
+        Module ->
+            case erlang:function_exported(Module, validate, 1) of
+                true -> Module:validate(Tool);
+                false -> ok
+            end
+    catch
+        throw:Reason -> {error, Reason}
     end.
 
 avro_config_with_defaults(Config) ->

--- a/plugins/emqx_agent/src/emqx_agent_tool.erl
+++ b/plugins/emqx_agent/src/emqx_agent_tool.erl
@@ -10,11 +10,14 @@
 %% Behaviour definition
 -callback init() -> ok.
 -callback deinit() -> ok.
+-callback validate(Context :: map()) -> ok | {error, term()}.
 -callback create(Context :: map()) -> {ok, map()} | {error, term()}.
 -callback destroy(Tool :: map()) -> ok.
 -callback to_map(Tool :: map()) -> map().
 -callback handle_invoke(Context :: map(), Request :: map()) ->
     ok | {ok, map()} | {ok, map(), [map()]} | {error, term()}.
+
+-optional_callbacks([validate/1]).
 
 -export([init/0, deinit/0, on_message_publish/1]).
 -export([discover_tool_modules/0]).

--- a/plugins/emqx_agent/src/tools/emqx_agent_tool_kv.erl
+++ b/plugins/emqx_agent/src/tools/emqx_agent_tool_kv.erl
@@ -159,14 +159,16 @@ tool_format(#{<<"type">> := Type, <<"format">> := Format}) when
         (Format =:= <<"json">> orelse Format =:= <<"binary">>)
 ->
     {ok, Format};
+tool_format(#{<<"type">> := Type, <<"format">> := Format}) when
+    Type =:= ?WRITE_TYPE; Type =:= ?READ_TYPE; Type =:= ?READ_ALL_TYPE
+->
+    {error, {invalid_format, Format}};
 tool_format(#{<<"type">> := Type}) when
     Type =:= ?WRITE_TYPE; Type =:= ?READ_TYPE; Type =:= ?READ_ALL_TYPE
 ->
-    {ok, <<"json">>};
+    {error, {missing_field, <<"format">>}};
 tool_format(#{<<"type">> := Type}) when Type =:= ?DEL_TYPE; Type =:= ?CLEAR_TYPE ->
-    {ok, undefined};
-tool_format(#{<<"format">> := Format}) ->
-    {error, {invalid_format, Format}}.
+    {ok, undefined}.
 
 display_name(Desc, ?WRITE_TYPE) -> <<Desc/binary, " — KV Write">>;
 display_name(Desc, ?READ_TYPE) -> <<Desc/binary, " — KV Read">>;

--- a/plugins/emqx_agent/src/tools/emqx_agent_tool_stream.erl
+++ b/plugins/emqx_agent/src/tools/emqx_agent_tool_stream.erl
@@ -235,10 +235,12 @@ tool_format(#{<<"type">> := Type, <<"format">> := Format}) when
         (Format =:= <<"json">> orelse Format =:= <<"binary">>)
 ->
     {ok, Format};
+tool_format(#{<<"type">> := Type, <<"format">> := Format}) when
+    Type =:= ?WRITE_TYPE orelse Type =:= ?READ_TYPE
+->
+    {error, {invalid_format, Format}};
 tool_format(#{<<"type">> := Type}) when Type =:= ?WRITE_TYPE orelse Type =:= ?READ_TYPE ->
-    {ok, <<"json">>};
-tool_format(#{<<"format">> := Format}) ->
-    {error, {invalid_format, Format}}.
+    {error, {missing_field, <<"format">>}}.
 
 stream_topic(#{topic_filter := TopicFilter}) ->
     concrete_topic(TopicFilter).

--- a/plugins/emqx_agent/test/emqx_agent_api_SUITE.erl
+++ b/plugins/emqx_agent/test/emqx_agent_api_SUITE.erl
@@ -349,6 +349,41 @@ t_tool_statuses(Config) ->
     ),
     ?assertEqual({error, not_found}, emqx_agent_tool_registry:lookup(<<"postgresql__query">>, Id)).
 
+t_tool_rejects_invalid_format(Config) ->
+    Id = ?config(tc_id, Config),
+    MissingId = <<Id/binary, "-missing">>,
+
+    ?assertMatch(
+        {ok, 400, _},
+        api_post([agent, tools], #{
+            <<"type">> => <<"stream__write">>,
+            <<"id">> => Id,
+            <<"desc">> => <<"invalid format">>,
+            <<"stream">> => <<"stream">>,
+            <<"format">> => <<"xml">>
+        })
+    ),
+    ?assertMatch(
+        {ok, 404, _},
+        api_get([agent, tools, <<"stream__write">>, Id])
+    ),
+    ?assertMatch(
+        {ok, 400, _},
+        api_post([agent, tools], #{
+            <<"type">> => <<"stream__write">>,
+            <<"id">> => MissingId,
+            <<"desc">> => <<"missing format">>,
+            <<"stream">> => <<"stream">>
+        })
+    ),
+    ?assertMatch(
+        {ok, 404, _},
+        api_get([agent, tools, <<"stream__write">>, MissingId])
+    ),
+    {ok, 200, Statuses} = api_get([agent, tools, statuses]),
+    ?assertNot(maps:is_key(<<"stream__write@", Id/binary>>, Statuses)),
+    ?assertNot(maps:is_key(<<"stream__write@", MissingId/binary>>, Statuses)).
+
 t_tools_validation(_Config) ->
     %% Missing type field
     ?assertMatch(

--- a/plugins/emqx_agent/test/emqx_agent_avro_config_SUITE.erl
+++ b/plugins/emqx_agent/test/emqx_agent_avro_config_SUITE.erl
@@ -8,8 +8,19 @@
 -compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [emqx_resource, emqx_agent],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(apps, Config)).
 
 t_valid_full_config(_Config) ->
     ?assertMatch({ok, _}, decode(sample_config())).
@@ -42,6 +53,12 @@ t_reject_missing_required_tool_field(_Config) ->
     },
     Config = sample_config_with_tool(Tool),
     ?assertMatch({error, _}, decode(Config)).
+
+t_tool_format_is_required_enum(_Config) ->
+    ?assertMatch({ok, _}, decode(sample_config_with_tool(stream_write_tool(<<"json">>)))),
+    ?assertMatch({ok, _}, decode(sample_config_with_tool(stream_write_tool(<<"binary">>)))),
+    ?assertMatch({error, _}, decode(sample_config_with_tool(stream_write_tool(<<"xml">>)))),
+    ?assertMatch({error, _}, decode(sample_config_with_tool(stream_write_tool(undefined)))).
 
 t_reject_invalid_connection_enable_type(_Config) ->
     [Conn0] = maps:get(<<"connections">>, sample_config()),
@@ -167,6 +184,20 @@ unwrap_union(Value) ->
 
 sample_config_with_tool(Tool) ->
     (sample_config())#{<<"tools">> => [Tool]}.
+
+stream_write_tool(Format) ->
+    Tool0 = #{
+        <<"type">> => <<"stream__write">>,
+        <<"id">> => <<"stream-writer">>,
+        <<"desc">> => <<"Write stream">>,
+        <<"stream">> => <<"stream">>
+    },
+    Tool =
+        case Format of
+            undefined -> Tool0;
+            _ -> Tool0#{<<"format">> => Format}
+        end,
+    #{<<"Stream_Write">> => Tool}.
 
 sample_config() ->
     #{

--- a/plugins/emqx_agent/test/emqx_agent_tool_kv_SUITE.erl
+++ b/plugins/emqx_agent/test/emqx_agent_tool_kv_SUITE.erl
@@ -92,7 +92,7 @@ t_binary_format_roundtrip(_Config) ->
 
 t_write_input_schema_matches_format(_Config) ->
     {ok, #{input_schema := JsonSchema}} = emqx_agent_tool_kv:create(
-        tool(<<"kv__write">>, <<"json-schema-writer">>, <<"Write JSON KV">>, ?STREAM)
+        tool(<<"kv__write">>, <<"json-schema-writer">>, <<"Write JSON KV">>, ?STREAM, <<"json">>)
     ),
     ?assertMatch(
         #{<<"properties">> := #{<<"payload">> := #{<<"type">> := <<"object">>}}},
@@ -111,6 +111,20 @@ t_write_input_schema_matches_format(_Config) ->
     ?assertMatch(
         #{<<"properties">> := #{<<"payload">> := #{<<"type">> := <<"string">>}}},
         BinarySchema
+    ).
+
+t_create_rejects_invalid_format(_Config) ->
+    ?assertEqual(
+        {error, {invalid_format, <<"xml">>}},
+        emqx_agent_tool_kv:create(
+            tool(<<"kv__write">>, <<"invalid-format">>, <<"Invalid format">>, ?STREAM, <<"xml">>)
+        )
+    ),
+    ?assertEqual(
+        {error, {missing_field, <<"format">>}},
+        emqx_agent_tool_kv:create(
+            tool(<<"kv__write">>, <<"missing-format">>, <<"Missing format">>, ?STREAM)
+        )
     ).
 
 t_write_overwrites_key(_Config) ->
@@ -174,7 +188,9 @@ t_create_rejects_regular_stream(_Config) ->
 
     ?assertEqual(
         {error, stream_is_not_lastvalue},
-        emqx_agent_tool_kv:create(tool(<<"kv__read">>, <<"bad-kv">>, <<"Bad KV">>, ?REGULAR_STREAM))
+        emqx_agent_tool_kv:create(
+            tool(<<"kv__read">>, <<"bad-kv">>, <<"Bad KV">>, ?REGULAR_STREAM, <<"json">>)
+        )
     ).
 
 write(Key, Payload) ->
@@ -183,10 +199,14 @@ write(Key, Payload) ->
     ok.
 
 register_tools() ->
-    ok = emqx_agent_config:create_tool(tool(<<"kv__write">>, ?WRITE_ID, <<"Write KV">>, ?STREAM)),
-    ok = emqx_agent_config:create_tool(tool(<<"kv__read">>, ?READ_ID, <<"Read KV">>, ?STREAM)),
     ok = emqx_agent_config:create_tool(
-        tool(<<"kv__read_all">>, ?READ_ALL_ID, <<"Read All KV">>, ?STREAM)
+        tool(<<"kv__write">>, ?WRITE_ID, <<"Write KV">>, ?STREAM, <<"json">>)
+    ),
+    ok = emqx_agent_config:create_tool(
+        tool(<<"kv__read">>, ?READ_ID, <<"Read KV">>, ?STREAM, <<"json">>)
+    ),
+    ok = emqx_agent_config:create_tool(
+        tool(<<"kv__read_all">>, ?READ_ALL_ID, <<"Read All KV">>, ?STREAM, <<"json">>)
     ),
     ok = emqx_agent_config:create_tool(tool(<<"kv__del">>, ?DEL_ID, <<"Delete KV">>, ?STREAM)),
     ok = emqx_agent_config:create_tool(tool(<<"kv__clear">>, ?CLEAR_ID, <<"Clear KV">>, ?STREAM)),

--- a/plugins/emqx_agent/test/emqx_agent_tool_stream_SUITE.erl
+++ b/plugins/emqx_agent/test/emqx_agent_tool_stream_SUITE.erl
@@ -102,7 +102,7 @@ t_binary_format_roundtrip(_Config) ->
 
 t_write_input_schema_matches_format(_Config) ->
     {ok, #{input_schema := JsonSchema}} = emqx_agent_tool_stream:create(
-        tool(<<"stream__write">>, <<"json-schema-writer">>, <<"Write JSON stream">>)
+        tool(<<"stream__write">>, <<"json-schema-writer">>, <<"Write JSON stream">>, <<"json">>)
     ),
     ?assertMatch(
         #{<<"properties">> := #{<<"data">> := #{<<"type">> := <<"object">>}}},
@@ -117,6 +117,20 @@ t_write_input_schema_matches_format(_Config) ->
     ?assertMatch(
         #{<<"properties">> := #{<<"data">> := #{<<"type">> := <<"string">>}}},
         BinarySchema
+    ).
+
+t_create_rejects_invalid_format(_Config) ->
+    ?assertEqual(
+        {error, {invalid_format, <<"xml">>}},
+        emqx_agent_tool_stream:create(
+            tool(<<"stream__write">>, <<"invalid-format">>, <<"Invalid format">>, <<"xml">>)
+        )
+    ),
+    ?assertEqual(
+        {error, {missing_field, <<"format">>}},
+        emqx_agent_tool_stream:create(
+            tool(<<"stream__write">>, <<"missing-format">>, <<"Missing format">>)
+        )
     ).
 
 t_write_returns_error_on_json_encode_failure(_Config) ->
@@ -210,8 +224,12 @@ write(Key, Data) ->
     ok.
 
 register_tools() ->
-    ok = emqx_agent_config:create_tool(tool(<<"stream__write">>, ?WRITE_ID, <<"Write stream">>)),
-    ok = emqx_agent_config:create_tool(tool(<<"stream__read">>, ?READ_ID, <<"Read stream">>)),
+    ok = emqx_agent_config:create_tool(
+        tool(<<"stream__write">>, ?WRITE_ID, <<"Write stream">>, <<"json">>)
+    ),
+    ok = emqx_agent_config:create_tool(
+        tool(<<"stream__read">>, ?READ_ID, <<"Read stream">>, <<"json">>)
+    ),
     ok = emqx_agent_config:create_tool(tool(<<"stream__del">>, ?DEL_ID, <<"Delete stream">>)),
     ok = emqx_agent_config:create_tool(
         tool(<<"stream__write">>, ?BIN_WRITE_ID, <<"Write binary stream">>, <<"binary">>)


### PR DESCRIPTION
Release version: 6.3.0

Fixes #17942

## Summary

- Require stream and KV tool formats to be explicitly configured as `json` or `binary`, rejecting missing and unsupported values.
- Validate tool-specific configuration through optional tool callbacks (`pre_config_update` alternative).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files -- **unreleased feature**
- [x] Schema changes are backward compatible or intentionally breaking (described in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->
