### PR TITLE
fix(agent): materialize record-valued avro defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ plugin-%:
 		echo "Error: $(PLUGIN_APP_DIR) is not an EMQX plugin app (missing :emqx_plugin)."; \
 		exit 1; \
 	}
-	cd "$(PLUGIN_APP_DIR)" && MIX_ENV="$(PROFILE)" PROFILE="$(PROFILE)" $(MIX) do deps.get, emqx.plugin
+	cd "$(PLUGIN_APP_DIR)" && MIX_ENV="$(PROFILE)" PROFILE="$(PROFILE)" $(MIX) do deps.get + emqx.plugin
 
 .PHONY: plugins
 plugins: $(REBAR)

--- a/apps/emqx_bridge_s3tables/src/emqx_bridge_s3tables_aggreg_partitioned.erl
+++ b/apps/emqx_bridge_s3tables/src/emqx_bridge_s3tables_aggreg_partitioned.erl
@@ -48,7 +48,7 @@ Tracks one or more Avro files for different partition keys.
 -type partition_out() :: #{[partition_key()] => iodata()}.
 -type write_metadata() :: #{[partition_key()] => #{?num_records := pos_integer()}}.
 
--type inner_container_opts() :: emqx_bridge_s3tables_aggreg_avro:options().
+-type inner_container_opts() :: emqx_bridge_s3tables_aggreg_unpartitioned:options().
 
 %%------------------------------------------------------------------------------
 %% `emqx_connector_aggreg_container' API

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule EMQXUmbrella.MixProject do
 
   Here, transitive dependencies from our app dependencies should be placed when there's a
   need to override them.  For example, since `jsone` is a dependency to `rocketmq` and to
-  `erlavro`, which are both dependencies and not umbrella apps, we need to add the
+  `ekka`, which are both dependencies and not umbrella apps, we need to add the
   override here.  Also, there are cases where adding `override: true` to the umbrella
   application dependency simply won't satisfy mix.  In such cases, it's fine to add it
   here.
@@ -287,7 +287,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.8.1.1"}
 
   def common_dep(:erlavro),
-    do: {:erlavro, github: "emqx/erlavro", tag: "2.10.2-emqx-3", override: true}
+    do: {:erlavro, github: "emqx/erlavro", tag: "2.11.2-emqx-1", override: true}
 
   def common_dep(:erlcloud), do: {:erlcloud, github: "emqx/erlcloud", tag: "3.8.3.2"}
 

--- a/plugins/emqx_agent/src/emqx_agent_config.erl
+++ b/plugins/emqx_agent/src/emqx_agent_config.erl
@@ -423,10 +423,12 @@ avro_config_with_defaults(Config, Name) ->
         {ok, AvscBin} = read_config_schema_bin(),
         Store0 = avro_schema_store:new([map]),
         Store = avro_schema_store:import_schema_json(Name, AvscBin, Store0),
+        Hook = avro_decoder_hooks:materialize_defaults(Store),
         DecodeOpts = avro:make_decoder_options([
             {map_type, map},
             {record_type, map},
-            {encoding, avro_json}
+            {encoding, avro_json},
+            {hook, Hook}
         ]),
         AvroValue = avro_json_decoder:decode_value(
             emqx_utils_json:encode(Config), Name, Store, DecodeOpts

--- a/plugins/emqx_agent/test/emqx_agent_avro_config_SUITE.erl
+++ b/plugins/emqx_agent/test/emqx_agent_avro_config_SUITE.erl
@@ -57,6 +57,30 @@ t_publish_payload_schema_default_materialized(_Config) ->
         PayloadSchema
     ).
 
+t_postgresql_ssl_record_default_materialized(_Config) ->
+    #{<<"ConnectionPostgresql">> := Connection0} = postgresql_connection(),
+    Config0 = maps:get(<<"config">>, Connection0),
+    Connection = #{
+        <<"ConnectionPostgresql">> => Connection0#{
+            <<"config">> => maps:remove(<<"ssl">>, Config0)
+        }
+    },
+    {ok, Config} = encode_with_defaults((sample_config())#{<<"connections">> => [Connection]}),
+    [#{<<"ConnectionPostgresql">> := MaterializedConnection}] = maps:get(
+        <<"connections">>, Config
+    ),
+    ?assertEqual(
+        #{
+            <<"enable">> => false,
+            <<"server_name_indication">> => <<"disable">>,
+            <<"verify">> => <<"verify_none">>,
+            <<"cacertfile">> => <<>>,
+            <<"certfile">> => <<>>,
+            <<"keyfile">> => <<>>
+        },
+        emqx_utils_maps:deep_get([<<"config">>, <<"ssl">>], MaterializedConnection)
+    ).
+
 t_all_config_oai_schemas_valid(_Config) ->
     {ok, Config} = encode_with_defaults(sample_config()),
     ?assertEqual([], oai_schema_errors(Config)).


### PR DESCRIPTION
Release version: 6.3.0

## Summary

- Materialize omitted Avro defaults while decoding agent plugin configuration before encoding it for storage.
- Support record-valued defaults, including the PostgreSQL SSL configuration, in addition to scalar defaults.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files -- **unreleased feature**
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->