### PR TITLE
fix(greptimedb): avoid health checks cancelling async batch state timeout

### DIFF
--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -26,7 +26,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
-      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.0.1"}
+      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1"}
     ]
   end
 end

--- a/apps/emqx_bridge_greptimedb/rebar.config
+++ b/apps/emqx_bridge_greptimedb/rebar.config
@@ -6,7 +6,7 @@
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}},
-    {greptimedb, {git, "https://github.com/emqx/greptimedb-ingester-erl", {tag, "v0.2.0.1"}}}
+    {greptimedb, {git, "https://github.com/emqx/greptimedb-ingester-erl", {tag, "v0.2.5-emqx.1"}}}
 ]}.
 {plugins, [rebar3_path_deps]}.
 {project_plugins, [erlfmt]}.

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.app.src
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_greptimedb, [
     {description, "EMQX GreptimeDB Bridge"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
@@ -726,7 +726,7 @@ value_type(Val0) ->
             _Error ->
                 throw({unrecoverable_error, {non_utf8_string_value, Val0}})
         end,
-    #{values => #{string_values => Val}, datatype => 'STRING'}.
+    greptimedb_values:string_value(Val).
 
 key_filter(undefined) -> undefined;
 key_filter(Value) -> emqx_utils_conv:bin(Value).

--- a/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_connector_SUITE.erl
+++ b/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_connector_SUITE.erl
@@ -72,6 +72,68 @@ t_lifecycle(Config) ->
         greptimedb_connector_config(Host, Port)
     ).
 
+%% Regression test for https://github.com/emqx/emqx/issues/17952.
+%% A health check must not prevent an underfilled async batch from flushing.
+t_async_write_after_health_check(Config) ->
+    Host = ?config(greptimedb_tcp_host, Config),
+    Port = ?config(greptimedb_tcp_port, Config),
+    Pool = iolist_to_binary([
+        "greptimedb_health_check_", integer_to_binary(erlang:unique_integer([positive]))
+    ]),
+    Options = [
+        {endpoints, [{http, Host, Port}]},
+        {pool, Pool},
+        {pool_size, 1},
+        {pool_type, random},
+        {auth, {basic, #{username => <<"greptime_user">>, password => <<"greptime_pwd">>}}}
+    ],
+    {ok, Client} = greptimedb:start_client(Options),
+    try
+        Ref = make_ref(),
+        TestPid = self(),
+        [{_, PoolWorker}] = ecpool:workers(Pool),
+        {ok, Worker} = ecpool_worker:client(PoolWorker),
+        ResultCallback = {fun(Reply) -> TestPid ! {Ref, Reply} end, []},
+        Points = [
+            #{
+                fields => #{<<"value">> => 1.0},
+                tags => #{<<"source">> => <<"health_check">>},
+                timestamp => erlang:system_time(millisecond)
+            }
+        ],
+        ok = greptimedb:async_write(Client, <<"async_health_check">>, Points, ResultCallback),
+        true = greptimedb:is_alive(Client),
+        Deadline = erlang:monotonic_time(millisecond) + 2000,
+        Flood = fun F() ->
+            case erlang:monotonic_time(millisecond) < Deadline of
+                true ->
+                    _ = sys:get_state(Worker),
+                    F();
+                false ->
+                    TestPid ! {Ref, flood_done}
+            end
+        end,
+        spawn(Flood),
+        receive
+            {Ref, {ok, _}} ->
+                ok;
+            {Ref, flood_done} ->
+                ct:fail(async_write_delayed_by_worker_messages);
+            {Ref, Error} ->
+                ct:fail({async_write_failed, Error})
+        after 5000 ->
+            ct:fail(async_write_not_flushed)
+        end,
+        receive
+            {Ref, flood_done} ->
+                ok
+        after 3000 ->
+            ct:fail(worker_message_flood_not_finished)
+        end
+    after
+        greptimedb:stop_client(Client)
+    end.
+
 perform_lifecycle_check(PoolName, InitialConfig) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(?GREPTIMEDB_RESOURCE_MOD, InitialConfig),

--- a/changes/ce/fix-17954.en.md
+++ b/changes/ce/fix-17954.en.md
@@ -1,0 +1,1 @@
+Fix GreptimeDB async batches that could remain unflushed after health checks at low write rates.

--- a/mix.exs
+++ b/mix.exs
@@ -439,7 +439,7 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:snappyer),
       common_dep(:crc32cer),
       {:opentsdb, github: "emqx/opentsdb-client-erl", tag: "v0.5.1", override: true},
-      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.0.1", override: true},
+      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1", override: true},
       # The following two are dependencies of rabbit_common. They are needed here to
       # make mix not complain about conflicting versions
       {:thoas, github: "emqx/thoas", tag: "v1.0.0", override: true},


### PR DESCRIPTION
Release version: 5.8.12

Fix: #17952

## Summary

Update the GreptimeDB ingester driver to `v0.2.5-emqx.1`. Previously, a health check handled by the same worker cancelled the driver's async batch `gen_server` state timeout. If no later write rearmed it, the pending batch was never flushed, causing action callbacks to expire and messages to fail.

Adapt the v5 GreptimeDB connector's string value encoding to the upgraded driver's `value_data` format, and add a regression test that queues an underfilled async batch, runs a health check on the same worker, and verifies that the write callback still completes.

## PR Checklist

- [x] Added tests
- [x] Changes are backward compatible
- [x] Change log file has been added
- [x] Code has been formatted