### PR TITLE
fix(greptimedb): avoid health checks cancelling async batch state timeout

### DIFF
--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -32,7 +32,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
-      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.3-emqx.1"}
+      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1"}
     ])
   end
 end

--- a/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
+++ b/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
@@ -366,6 +366,71 @@ t_start_stop(TCConfig) when is_list(TCConfig) ->
 t_on_get_status(TCConfig) when is_list(TCConfig) ->
     emqx_bridge_v2_testlib:t_on_get_status(TCConfig).
 
+%% Regression test for https://github.com/emqx/emqx/issues/17952.
+%% A health check must not prevent an underfilled async batch from flushing.
+t_async_write_after_health_check() ->
+    [{matrix, true}].
+
+t_async_write_after_health_check(matrix) ->
+    [[?tcp]];
+t_async_write_after_health_check(_TCConfig) ->
+    Pool = iolist_to_binary([
+        "greptimedb_health_check_", integer_to_binary(erlang:unique_integer([positive]))
+    ]),
+    Options = [
+        {endpoints, [{http, ?PROXY_HOST, 4001}]},
+        {pool, Pool},
+        {pool_size, 1},
+        {pool_type, random},
+        {auth, {basic, #{username => <<"greptime_user">>, password => <<"greptime_pwd">>}}}
+    ],
+    {ok, Client} = greptimedb:start_client(Options),
+    try
+        Ref = make_ref(),
+        TestPid = self(),
+        [{_, PoolWorker}] = ecpool:workers(Pool),
+        {ok, Worker} = ecpool_worker:client(PoolWorker),
+        ResultCallback = {fun(Reply) -> TestPid ! {Ref, Reply} end, []},
+        Points = [
+            #{
+                fields => #{<<"value">> => 1.0},
+                tags => #{<<"source">> => <<"health_check">>},
+                timestamp => erlang:system_time(millisecond)
+            }
+        ],
+        ok = greptimedb:async_write(Client, <<"async_health_check">>, Points, ResultCallback),
+        true = greptimedb:is_alive(Client),
+        Deadline = erlang:monotonic_time(millisecond) + 2000,
+        Flood = fun F() ->
+            case erlang:monotonic_time(millisecond) < Deadline of
+                true ->
+                    _ = sys:get_state(Worker),
+                    F();
+                false ->
+                    TestPid ! {Ref, flood_done}
+            end
+        end,
+        spawn(Flood),
+        receive
+            {Ref, {ok, _}} ->
+                ok;
+            {Ref, flood_done} ->
+                ct:fail(async_write_delayed_by_worker_messages);
+            {Ref, Error} ->
+                ct:fail({async_write_failed, Error})
+        after 5000 ->
+            ct:fail(async_write_not_flushed)
+        end,
+        receive
+            {Ref, flood_done} ->
+                ok
+        after 3000 ->
+            ct:fail(worker_message_flood_not_finished)
+        end
+    after
+        greptimedb:stop_client(Client)
+    end.
+
 t_rule_action() ->
     [{matrix, true}].
 t_rule_action(matrix) ->

--- a/changes/ee/fix-17955.en.md
+++ b/changes/ee/fix-17955.en.md
@@ -1,0 +1,1 @@
+Fix GreptimeDB async batches that could remain unflushed after health checks at low write rates.


### PR DESCRIPTION
Release version: 6.0.4

Fix: #17952

## Summary

Update the GreptimeDB ingester driver to `v0.2.5-emqx.1`. Previously, a health check handled by the same worker cancelled the driver's async batch `gen_server` state timeout. If no later write rearmed it, the pending batch was never flushed, causing action callbacks to expire and messages to fail.

The updated driver uses an independent batch-flush timer. Add a connector regression test that queues an underfilled async batch, runs a health check on the same worker, and verifies that the write callback still completes.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-17955.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)