### PR TITLE
fix(rule engine): trigger global rules on all events

### DIFF
--- a/apps/emqx_rule_engine/mix.exs
+++ b/apps/emqx_rule_engine/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXRuleEngine.MixProject do
   def project do
     [
       app: :emqx_rule_engine,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -32,6 +32,7 @@
     get_rules_from_all_namespaces/0,
     get_rules_for_topic/1,
     get_enriched_rules_with_matching_event/2,
+    get_enriched_rules_with_matching_event_including_global/2,
     get_enriched_rules_with_matching_event_all_namespaces/1,
     get_rule_ids_by_action/1,
     get_rule_ids_by_bridge_action/2,
@@ -233,6 +234,15 @@ get_rules_from_all_namespaces() ->
 get_rules(Namespace) ->
     get_all_records(Namespace, ?RULE_TAB).
 
+get_rules_including_global(?global_ns) ->
+    get_rules(?global_ns);
+get_rules_including_global(Namespace) when is_binary(Namespace) ->
+    MS = [
+        {{?KEY(Namespace, '$1'), '$2'}, [], [['$1', '$2']]},
+        {{?KEY(?global_ns, '$1'), '$2'}, [], [['$1', '$2']]}
+    ],
+    [Rule#{id => Id} || [Id, Rule] <- ets:select(?RULE_TAB, MS)].
+
 get_rules_ordered_by_ts(Namespace) ->
     lists:sort(
         fun(#{created_at := CreatedA}, #{created_at := CreatedB}) ->
@@ -295,6 +305,19 @@ get_enriched_rules_with_matching_event(Namespace, EventName) ->
             matched => Topic
         }
      || Rule = #{from := Topics} <- get_rules(Namespace),
+        Topic <- Topics,
+        EventNameOther <- emqx_rule_events:match_event_names(Topic),
+        EventNameOther == EventName
+    ]).
+
+get_enriched_rules_with_matching_event_including_global(Namespace, EventName) ->
+    lists:usort([
+        #{
+            rule => Rule,
+            trigger => emqx_rule_events:event_topic(EventName),
+            matched => Topic
+        }
+     || Rule = #{from := Topics} <- get_rules_including_global(Namespace),
         Topic <- Topics,
         EventNameOther <- emqx_rule_events:match_event_names(Topic),
         EventNameOther == EventName

--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -904,7 +904,11 @@ apply_event(NsContext, EventName, GenEventMsg, Conf) ->
     end.
 
 apply_event_namespaced(Namespace, EventName, GenEventMsg, _Conf) ->
-    case emqx_rule_engine:get_enriched_rules_with_matching_event(Namespace, EventName) of
+    case
+        emqx_rule_engine:get_enriched_rules_with_matching_event_including_global(
+            Namespace, EventName
+        )
+    of
         [] ->
             ok;
         EnrichedRules ->
@@ -1643,7 +1647,7 @@ get_limit_selects_in_namespace() ->
 
 resolve_ns({hook_context, EventName}) ->
     case emqx_hooks:context(EventName) of
-        #{namespace := Ns0} -> Ns0;
+        #{namespace := Ns0} when is_binary(Ns0) -> Ns0;
         _ -> ?global_ns
     end;
 resolve_ns(#message{} = Message) ->

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -110,6 +110,7 @@ groups() ->
             t_events,
             t_events_legacy,
             t_events_limit_selects_in_namespace,
+            t_events_limit_selects_in_namespace_global,
             t_event_client_disconnected_normal,
             t_event_client_disconnected_kicked,
             t_event_client_disconnected_discarded,
@@ -338,6 +339,40 @@ init_per_testcase(t_events_limit_selects_in_namespace, Config) ->
     ?assertMatch(#{id := <<"rule:t_events">>}, Rule),
     on_exit(fun() -> ok = delete_rule(Rule) end),
     [{ns, Ns}, {hook_points_rules, Rule} | Config];
+init_per_testcase(t_events_limit_selects_in_namespace_global, Config) ->
+    init_events_counters(),
+    SQL =
+        "SELECT * FROM \"$events/client/connected\", "
+        "\"$events/client/disconnected\", "
+        "\"$events/client/connack\", "
+        "\"$events/auth/check_authz_complete\", "
+        "\"$events/auth/check_authn_complete\", "
+        "\"$events/session/subscribed\", "
+        "\"$events/session/unsubscribed\", "
+        "\"$events/message/acked\", "
+        "\"$events/message/delivered\", "
+        "\"$events/message/dropped\", "
+        "\"$events/message/delivery_dropped\", "
+        "\"$events/schema_validation/failed\", "
+        "\"$events/message_transformation/failed\", "
+        "\"t1\"",
+    {ok, Rule} = create_rule(
+        #{
+            namespace => ?global_ns,
+            id => <<"rule:t_events">>,
+            sql => SQL,
+            actions => [
+                #{
+                    function => <<"emqx_rule_engine_SUITE:action_record_triggered_events">>,
+                    args => #{}
+                }
+            ],
+            description => <<"to print and record triggered events">>
+        }
+    ),
+    ?assertMatch(#{id := <<"rule:t_events">>}, Rule),
+    on_exit(fun() -> ok = delete_rule(Rule) end),
+    [{ns, ?global_ns}, {hook_points_rules, Rule} | Config];
 init_per_testcase(t_events_legacy, Config) ->
     init_events_counters(),
     SQL =
@@ -373,17 +408,12 @@ init_per_testcase(t_events_legacy, Config) ->
 init_per_testcase(_TestCase, Config) ->
     Config.
 
-end_per_testcase(t_events, _Config) ->
-    ets:delete(events_record_tab),
-    emqx_bridge_v2_testlib:delete_all_rules(),
-    emqx_common_test_helpers:call_janitor(),
-    ok;
-end_per_testcase(t_events_limit_selects_in_namespace, _Config) ->
-    ets:delete(events_record_tab),
-    emqx_bridge_v2_testlib:delete_all_rules(),
-    emqx_common_test_helpers:call_janitor(),
-    ok;
-end_per_testcase(t_events_legacy, _Config) ->
+end_per_testcase(TestCase, _Config) when
+    TestCase == t_events;
+    TestCase == t_events_limit_selects_in_namespace;
+    TestCase == t_events_limit_selects_in_namespace_global;
+    TestCase == t_events_legacy
+->
     ets:delete(events_record_tab),
     emqx_bridge_v2_testlib:delete_all_rules(),
     emqx_common_test_helpers:call_janitor(),
@@ -1123,6 +1153,203 @@ t_events_limit_selects_in_namespace(TCConfig) ->
         end,
         Events
     ),
+    ok.
+
+-doc """
+Just like `t_events_limit_selects_in_namespace`, but the rule lives in the global namespace.
+""".
+t_events_limit_selects_in_namespace_global(_TCConfig) ->
+    Ns = ?global_ns,
+    on_exit(fun() ->
+        {ok, _} = emqx_conf:update(
+            [mqtt, client_attrs_init],
+            [],
+            #{override_to => cluster}
+        ),
+        {ok, _} = emqx_conf:update(
+            [rule_engine, limit_selects_in_namespace],
+            false,
+            #{override_to => cluster}
+        )
+    end),
+    {ok, _} = emqx_conf:update(
+        [mqtt, client_attrs_init],
+        [
+            #{
+                <<"expression">> => <<"username">>,
+                <<"set_as_attr">> => <<"tns">>
+            }
+        ],
+        #{override_to => cluster}
+    ),
+    {ok, _} = emqx_conf:update(
+        [rule_engine, limit_selects_in_namespace],
+        true,
+        #{override_to => cluster}
+    ),
+    PublishMsg = fun(C) ->
+        emqtt:publish(
+            C,
+            <<"t1">>,
+            #{'Message-Expiry-Interval' => 60},
+            <<"{\"id\": 1, \"name\": \"ha\"}">>,
+            [{qos, 1}]
+        )
+    end,
+    TriggerEvents = fun(Namespace, C) ->
+        ct:pal("====== $events/client/connected, $events/client/connack"),
+        {ok, _} = emqtt:connect(C),
+        ct:pal("====== $events/message/dropped"),
+        PublishMsg(C),
+        ct:pal("====== $events/session/subscribed, $events/client/authz_complete"),
+        {ok, _, _} = emqtt:subscribe(
+            C,
+            #{'User-Property' => {<<"topic_name">>, <<"t1">>}},
+            <<"t1">>,
+            1
+        ),
+        ct:pal("====== t1"),
+        PublishMsg(C),
+        ct:pal("====== $events/schema_validation/failed"),
+        {ok, _} = emqtt:publish(C, <<"sv/fail">>, <<"">>, [{qos, 1}]),
+        ct:pal("====== $events/message_transformation/failed"),
+        {ok, _} = emqtt:publish(C, <<"mt/fail">>, <<"will fail to { parse">>, [{qos, 1}]),
+        ct:pal("====== $events/message/delivery_dropped"),
+        %% subscribe "t1" and then publish to "t1", the message will not be received by itself
+        %% because we have set the subscribe flag 'nl' = true
+        {ok, _, _} = emqtt:subscribe(C, #{}, <<"t1">>, [{nl, true}, {qos, 1}]),
+        ct:sleep(50),
+        PublishMsg(C),
+        %% ct:pal("====== $events/message/delivered"),
+        %% ct:pal("====== $events/message/acked"),
+        ct:pal("====== $events/session/unsubscribed"),
+        {ok, _, _} = emqtt:unsubscribe(
+            C,
+            #{'User-Property' => {<<"topic_name">>, <<"t1">>}},
+            <<"t1">>
+        ),
+        ct:pal("====== $events/client/disconnected"),
+        ok = emqtt:disconnect(C, 0, #{'User-Property' => {<<"reason">>, <<"normal">>}}),
+        ct:pal("====== $events/client/connack"),
+        {ok, Client} = emqtt:start_link(
+            lists:flatten([
+                [{username, Namespace} || is_binary(Namespace)],
+                {clientid, <<"c_event3">>},
+                {proto_ver, v5},
+                {properties, #{'Session-Expiry-Interval' => 60}}
+            ])
+        ),
+        try
+            meck:new(emqx_access_control, [non_strict, passthrough]),
+            meck:expect(
+                emqx_access_control,
+                authenticate,
+                fun(_) -> {error, bad_username_or_password} end
+            ),
+            process_flag(trap_exit, true),
+            ?assertMatch({error, _}, emqtt:connect(Client)),
+            ok
+        after
+            meck:unload(emqx_access_control)
+        end
+    end,
+
+    %% First, a client from a different namespace from our rule.  Should trigger all,
+    %% nevertheless, because the rule is global.
+    ct:pal("****** Triggering events on different namespace"),
+    OtherNs = <<"some_different_ns">>,
+    %% Sanity check
+    false = OtherNs == Ns,
+    {ok, ClientOtherNs} = emqtt:start_link(
+        [
+            {username, OtherNs},
+            {clientid, <<"c_other_ns">>},
+            {proto_ver, v5},
+            {properties, #{'Session-Expiry-Interval' => 60}}
+        ]
+    ),
+    TriggerEvents(OtherNs, ClientOtherNs),
+    ct:sleep(300),
+    Events = [
+        'client.connack',
+        'message.publish',
+        'client.connected',
+        'client.check_authn_complete',
+        'client.disconnected',
+        'session.subscribed',
+        'client.check_authz_complete',
+        'session.unsubscribed',
+        'message.delivered',
+        'delivery.dropped',
+        'message.acked',
+        'schema.validation_failed',
+        'message.transformation_failed'
+    ],
+    VerifyOpts0 = maps:from_keys(Events, #{
+        clientids => [<<"c_event">>, <<"c_ns">>, <<"c_other_ns">>],
+        usernames => [<<"u_event">>, undefined, OtherNs]
+    }),
+    VerifyOpts = VerifyOpts0#{
+        'client.connack' := #{
+            clientids => [
+                <<"c_event">>,
+                <<"c_event2">>,
+                <<"c_event3">>,
+                <<"c_ns">>,
+                <<"c_other_ns">>
+            ],
+            usernames => [
+                <<"u_event">>,
+                <<"u_event2">>,
+                <<"u_event3">>,
+                undefined,
+                OtherNs
+            ]
+        },
+        'message.delivered' := #{
+            clientids => [<<"c_event2">>, <<"c_ns">>, <<"c_other_ns">>],
+            from_clientids => [<<"c_event2">>, <<"c_ns">>, <<"c_other_ns">>],
+            usernames => [<<"u_event2">>, undefined, OtherNs],
+            from_usernames => [<<"u_event2">>, undefined, OtherNs]
+        },
+        'message.acked' := #{
+            clientids => [<<"c_event">>, <<"c_ns">>, <<"c_other_ns">>],
+            from_clientids => [<<"c_event">>, <<"c_ns">>, <<"c_other_ns">>],
+            usernames => [<<"u_event">>, undefined, OtherNs],
+            from_usernames => [<<"u_event">>, undefined, OtherNs]
+        },
+        'schema.validation_failed' := #{
+            clientids => [<<"c_event2">>, <<"c_ns">>, <<"c_other_ns">>],
+            usernames => [<<"u_event2">>, undefined, OtherNs]
+        }
+    },
+    lists:foreach(
+        fun(EventName) ->
+            ct:pal("checking ~s", [EventName]),
+            verify_event(EventName, VerifyOpts)
+        end,
+        Events
+    ),
+    ets:delete_all_objects(events_record_tab),
+
+    %% Now, a client on the same namespace.  Should trigger on all the events.
+    ct:pal("****** Triggering events on same namespace"),
+    {ok, ClientNs} = emqtt:start_link(
+        [
+            {clientid, <<"c_ns">>},
+            {proto_ver, v5},
+            {properties, #{'Session-Expiry-Interval' => 60}}
+        ]
+    ),
+    TriggerEvents(Ns, ClientNs),
+    lists:foreach(
+        fun(EventName) ->
+            ct:pal("checking ~s", [EventName]),
+            verify_event(EventName, VerifyOpts)
+        end,
+        Events
+    ),
+    ct:sleep(300),
     ok.
 
 %% Tests old event topics (non-namespaced events).
@@ -4411,6 +4638,9 @@ action_record_triggered_events(Data = #{event := EventName}, _Envs, _Args) ->
     ets:insert(events_record_tab, {EventName, Data}).
 
 verify_event(EventName) ->
+    verify_event(EventName, _Opts = #{}).
+
+verify_event(EventName, Opts) ->
     ct:sleep(50),
     case ets:lookup(events_record_tab, EventName) of
         [] ->
@@ -4423,7 +4653,7 @@ verify_event(EventName) ->
                     %% verify metadata fields
                     verify_metadata_fields(EventName, Fields),
                     %% verify available fields for each event name
-                    verify_event_fields(EventName, Fields)
+                    verify_event_fields(EventName, Fields, Opts)
                 end
              || {_Name, Fields} <- Records
             ]
@@ -4435,7 +4665,7 @@ verify_metadata_fields(_EventName, #{metadata := Metadata}) ->
         Metadata
     ).
 
-verify_event_fields('message.publish', Fields) ->
+verify_event_fields('message.publish' = Event, Fields, Opts) ->
     #{
         id := ID,
         clientid := ClientId,
@@ -4454,9 +4684,17 @@ verify_event_fields('message.publish', Fields) ->
     Now = erlang:system_time(millisecond),
     TimestampElapse = Now - Timestamp,
     RcvdAtElapse = Now - EventAt,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"my_ns">>
+    ]),
     ?assert(is_binary(ID)),
-    ?assert(lists:member(ClientId, [<<"c_event">>, <<"c_ns">>]), #{clientid => ClientId}),
-    ?assert(lists:member(Username, [<<"u_event">>, <<"my_ns">>]), #{username => Username}),
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{clientid => ClientId}),
+    ?assert(lists:member(Username, ExpectedUsernames), #{username => Username}),
     ?assertEqual(<<"{\"id\": 1, \"name\": \"ha\"}">>, Payload),
     verify_peername(PeerName),
     verify_ipaddr(PeerHost),
@@ -4468,7 +4706,7 @@ verify_event_fields('message.publish', Fields) ->
     ?assert(0 =< RcvdAtElapse andalso RcvdAtElapse =< 60 * 1000),
     ?assert(EventAt =< Timestamp),
     ?assert(is_map(ClientAttrs));
-verify_event_fields('client.connected', Fields) ->
+verify_event_fields('client.connected' = Event, Fields, Opts) ->
     #{
         clientid := ClientId,
         username := Username,
@@ -4490,10 +4728,20 @@ verify_event_fields('client.connected', Fields) ->
     TimestampElapse = Now - Timestamp,
     RcvdAtElapse = Now - EventAt,
     ?assert(is_binary(MountPoint) orelse MountPoint == undefined),
-    ?assert(lists:member(ClientId, [<<"c_event">>, <<"c_event2">>, <<"c_ns">>]), #{
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_event2">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"u_event2">>,
+        <<"my_ns">>
+    ]),
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{
         clientid => ClientId
     }),
-    ?assert(lists:member(Username, [<<"u_event">>, <<"u_event2">>, <<"my_ns">>]), #{
+    ?assert(lists:member(Username, ExpectedUsernames), #{
         username => Username
     }),
     verify_peername(PeerName),
@@ -4509,7 +4757,7 @@ verify_event_fields('client.connected', Fields) ->
     ?assert(0 =< RcvdAtElapse andalso RcvdAtElapse =< 60 * 1000),
     ?assert(EventAt =< Timestamp),
     ?assert(is_map(ClientAttrs));
-verify_event_fields('client.disconnected', Fields) ->
+verify_event_fields('client.disconnected' = Event, Fields, Opts) ->
     #{
         reason := Reason,
         clientid := ClientId,
@@ -4524,11 +4772,21 @@ verify_event_fields('client.disconnected', Fields) ->
     Now = erlang:system_time(millisecond),
     TimestampElapse = Now - Timestamp,
     RcvdAtElapse = Now - EventAt,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_event2">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"u_event2">>,
+        <<"my_ns">>
+    ]),
     ?assert(is_atom(Reason)),
-    ?assert(lists:member(ClientId, [<<"c_event">>, <<"c_event2">>, <<"c_ns">>]), #{
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{
         clientid => ClientId
     }),
-    ?assert(lists:member(Username, [<<"u_event">>, <<"u_event2">>, <<"my_ns">>]), #{
+    ?assert(lists:member(Username, ExpectedUsernames), #{
         username => Username
     }),
     verify_peername(PeerName),
@@ -4538,7 +4796,7 @@ verify_event_fields('client.disconnected', Fields) ->
     ?assert(0 =< RcvdAtElapse andalso RcvdAtElapse =< 60 * 1000),
     ?assert(EventAt =< Timestamp),
     ?assert(is_map(ClientAttrs));
-verify_event_fields(SubUnsub, Fields) when
+verify_event_fields(SubUnsub = Event, Fields, Opts) when
     SubUnsub == 'session.subscribed';
     SubUnsub == 'session.unsubscribed'
 ->
@@ -4554,9 +4812,17 @@ verify_event_fields(SubUnsub, Fields) when
     } = Fields,
     Now = erlang:system_time(millisecond),
     TimestampElapse = Now - Timestamp,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event2">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event2">>,
+        <<"my_ns">>
+    ]),
     ?assert(is_atom(reason)),
-    ?assert(lists:member(ClientId, [<<"c_event2">>, <<"c_ns">>]), #{clientid => ClientId}),
-    ?assert(lists:member(Username, [<<"u_event2">>, <<"my_ns">>]), #{username => Username}),
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{clientid => ClientId}),
+    ?assert(lists:member(Username, ExpectedUsernames), #{username => Username}),
     verify_peername(PeerName),
     verify_ipaddr(PeerHost),
     ?assertEqual(<<"t1">>, Topic),
@@ -4575,7 +4841,7 @@ verify_event_fields(SubUnsub, Fields) when
     end,
     ?assert(0 =< TimestampElapse andalso TimestampElapse =< 60 * 1000),
     ?assert(is_map(ClientAttrs));
-verify_event_fields('delivery.dropped', Fields) ->
+verify_event_fields('delivery.dropped' = Event, Fields, Opts) ->
     #{
         event := 'delivery.dropped',
         id := ID,
@@ -4599,14 +4865,22 @@ verify_event_fields('delivery.dropped', Fields) ->
     Now = erlang:system_time(millisecond),
     TimestampElapse = Now - Timestamp,
     RcvdAtElapse = Now - EventAt,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"my_ns">>
+    ]),
     ?assert(is_binary(ID)),
     ?assertEqual(<<"rule:t_events">>, RuleId),
     ?assertEqual(no_local, Reason),
     ?assertEqual(node(), Node),
-    ?assert(lists:member(ClientId, [<<"c_event">>, <<"c_ns">>]), #{clientid => ClientId}),
-    ?assert(lists:member(Username, [<<"u_event">>, <<"my_ns">>]), #{username => Username}),
-    ?assert(lists:member(FromClientId, [<<"c_event">>, <<"c_ns">>]), #{clientid => FromClientId}),
-    ?assert(lists:member(FromUsername, [<<"u_event">>, <<"my_ns">>]), #{username => FromUsername}),
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{clientid => ClientId}),
+    ?assert(lists:member(Username, ExpectedUsernames), #{username => Username}),
+    ?assert(lists:member(FromClientId, ExpectedClientIds), #{clientid => FromClientId}),
+    ?assert(lists:member(FromUsername, ExpectedUsernames), #{username => FromUsername}),
     ?assertEqual(<<"{\"id\": 1, \"name\": \"ha\"}">>, Payload),
     verify_peername(PeerName),
     verify_ipaddr(PeerHost),
@@ -4617,7 +4891,7 @@ verify_event_fields('delivery.dropped', Fields) ->
     ?assert(0 =< TimestampElapse andalso TimestampElapse =< 60 * 1000),
     ?assert(0 =< RcvdAtElapse andalso RcvdAtElapse =< 60 * 1000),
     ?assert(EventAt =< Timestamp);
-verify_event_fields('message.dropped', Fields) ->
+verify_event_fields('message.dropped' = Event, Fields, Opts) ->
     #{
         id := ID,
         reason := Reason,
@@ -4636,10 +4910,18 @@ verify_event_fields('message.dropped', Fields) ->
     Now = erlang:system_time(millisecond),
     TimestampElapse = Now - Timestamp,
     RcvdAtElapse = Now - EventAt,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"my_ns">>
+    ]),
     ?assert(is_binary(ID)),
     ?assert(is_atom(Reason)),
-    ?assert(lists:member(ClientId, [<<"c_event">>, <<"c_ns">>]), #{clientid => ClientId}),
-    ?assert(lists:member(Username, [<<"u_event">>, <<"my_ns">>]), #{username => Username}),
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{clientid => ClientId}),
+    ?assert(lists:member(Username, ExpectedUsernames), #{username => Username}),
     ?assertEqual(<<"{\"id\": 1, \"name\": \"ha\"}">>, Payload),
     verify_peername(PeerName),
     verify_ipaddr(PeerHost),
@@ -4650,7 +4932,7 @@ verify_event_fields('message.dropped', Fields) ->
     ?assert(0 =< TimestampElapse andalso TimestampElapse =< 60 * 1000),
     ?assert(0 =< RcvdAtElapse andalso RcvdAtElapse =< 60 * 1000),
     ?assert(EventAt =< Timestamp);
-verify_event_fields('message.delivered', Fields) ->
+verify_event_fields('message.delivered' = Event, Fields, Opts) ->
     #{
         id := ID,
         clientid := ClientId,
@@ -4670,11 +4952,27 @@ verify_event_fields('message.delivered', Fields) ->
     Now = erlang:system_time(millisecond),
     TimestampElapse = Now - Timestamp,
     RcvdAtElapse = Now - EventAt,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event2">>,
+        <<"c_ns">>
+    ]),
+    ExpectedFromClientIds = emqx_utils_maps:deep_get([Event, from_clientids], Opts, [
+        <<"c_event">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event2">>,
+        <<"my_ns">>
+    ]),
+    ExpectedFromUsernames = emqx_utils_maps:deep_get([Event, from_usernames], Opts, [
+        <<"u_event">>,
+        <<"my_ns">>
+    ]),
     ?assert(is_binary(ID)),
-    ?assert(lists:member(ClientId, [<<"c_event2">>, <<"c_ns">>]), #{clientid => ClientId}),
-    ?assert(lists:member(Username, [<<"u_event2">>, <<"my_ns">>]), #{username => Username}),
-    ?assert(lists:member(FromClientId, [<<"c_event">>, <<"c_ns">>]), #{clientid => FromClientId}),
-    ?assert(lists:member(FromUsername, [<<"u_event">>, <<"my_ns">>]), #{username => FromUsername}),
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{clientid => ClientId}),
+    ?assert(lists:member(Username, ExpectedUsernames), #{username => Username}),
+    ?assert(lists:member(FromClientId, ExpectedFromClientIds), #{clientid => FromClientId}),
+    ?assert(lists:member(FromUsername, ExpectedFromUsernames), #{username => FromUsername}),
     ?assertEqual(<<"{\"id\": 1, \"name\": \"ha\"}">>, Payload),
     verify_peername(PeerName),
     verify_ipaddr(PeerHost),
@@ -4685,7 +4983,7 @@ verify_event_fields('message.delivered', Fields) ->
     ?assert(0 =< TimestampElapse andalso TimestampElapse =< 60 * 1000),
     ?assert(0 =< RcvdAtElapse andalso RcvdAtElapse =< 60 * 1000),
     ?assert(EventAt =< Timestamp);
-verify_event_fields('message.acked', Fields) ->
+verify_event_fields('message.acked' = Event, Fields, Opts) ->
     #{
         id := ID,
         clientid := ClientId,
@@ -4706,11 +5004,27 @@ verify_event_fields('message.acked', Fields) ->
     Now = erlang:system_time(millisecond),
     TimestampElapse = Now - Timestamp,
     RcvdAtElapse = Now - EventAt,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event2">>,
+        <<"c_ns">>
+    ]),
+    ExpectedFromClientIds = emqx_utils_maps:deep_get([Event, from_clientids], Opts, [
+        <<"c_event">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event2">>,
+        <<"my_ns">>
+    ]),
+    ExpectedFromUsernames = emqx_utils_maps:deep_get([Event, from_usernames], Opts, [
+        <<"u_event">>,
+        <<"my_ns">>
+    ]),
     ?assert(is_binary(ID)),
-    ?assert(lists:member(ClientId, [<<"c_event2">>, <<"c_ns">>]), #{clientid => ClientId}),
-    ?assert(lists:member(Username, [<<"u_event2">>, <<"my_ns">>]), #{username => Username}),
-    ?assert(lists:member(FromClientId, [<<"c_event">>, <<"c_ns">>]), #{clientid => FromClientId}),
-    ?assert(lists:member(FromUsername, [<<"u_event">>, <<"my_ns">>]), #{username => FromUsername}),
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{clientid => ClientId}),
+    ?assert(lists:member(Username, ExpectedUsernames), #{username => Username}),
+    ?assert(lists:member(FromClientId, ExpectedFromClientIds), #{clientid => FromClientId}),
+    ?assert(lists:member(FromUsername, ExpectedFromUsernames), #{username => FromUsername}),
     ?assertEqual(<<"{\"id\": 1, \"name\": \"ha\"}">>, Payload),
     verify_peername(PeerName),
     verify_ipaddr(PeerHost),
@@ -4722,7 +5036,7 @@ verify_event_fields('message.acked', Fields) ->
     ?assert(0 =< TimestampElapse andalso TimestampElapse =< 60 * 1000),
     ?assert(0 =< RcvdAtElapse andalso RcvdAtElapse =< 60 * 1000),
     ?assert(EventAt =< Timestamp);
-verify_event_fields('client.connack', Fields) ->
+verify_event_fields('client.connack' = Event, Fields, Opts) ->
     #{
         clientid := ClientId,
         clean_start := CleanStart,
@@ -4740,22 +5054,26 @@ verify_event_fields('client.connack', Fields) ->
     } = Fields,
     Now = erlang:system_time(millisecond),
     TimestampElapse = Now - Timestamp,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_event2">>,
+        <<"c_event3">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"u_event2">>,
+        <<"u_event3">>,
+        <<"my_ns">>
+    ]),
     ?assert(lists:member(Reason, [success, bad_username_or_password])),
     ?assert(
-        lists:member(ClientId, [
-            <<"c_event">>,
-            <<"c_event2">>,
-            <<"c_event3">>,
-            <<"c_ns">>
-        ])
+        lists:member(ClientId, ExpectedClientIds),
+        #{clientid => ClientId}
     ),
     ?assert(
-        lists:member(Username, [
-            <<"u_event">>,
-            <<"u_event2">>,
-            <<"u_event3">>,
-            <<"my_ns">>
-        ])
+        lists:member(Username, ExpectedUsernames),
+        #{username => Username}
     ),
     verify_peername(PeerName),
     verify_peername(SockName),
@@ -4767,7 +5085,7 @@ verify_event_fields('client.connack', Fields) ->
     ?assertMatch(#{'Session-Expiry-Interval' := 60}, Properties),
     ?assert(is_integer(ConnectedAt) orelse ConnectedAt == undefined),
     ?assert(0 =< TimestampElapse andalso TimestampElapse =< 60 * 1000);
-verify_event_fields('client.check_authz_complete', Fields) ->
+verify_event_fields('client.check_authz_complete' = Event, Fields, Opts) ->
     #{
         clientid := ClientId,
         action := Action,
@@ -4778,6 +5096,16 @@ verify_event_fields('client.check_authz_complete', Fields) ->
         username := Username,
         client_attrs := ClientAttrs
     } = Fields,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_event2">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"u_event2">>,
+        <<"my_ns">>
+    ]),
     ?assert(lists:member(Topic, [<<"t1">>, <<"sv/fail">>, <<"mt/fail">>]), #{topic => Topic}),
     ?assert(lists:member(Action, [subscribe, publish])),
     ?assert(lists:member(Result, [allow, deny])),
@@ -4795,14 +5123,14 @@ verify_event_fields('client.check_authz_complete', Fields) ->
             built_in_database
         ])
     ),
-    ?assert(lists:member(ClientId, [<<"c_event">>, <<"c_event2">>, <<"c_ns">>]), #{
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{
         clientid => ClientId
     }),
-    ?assert(lists:member(Username, [<<"u_event">>, <<"u_event2">>, <<"my_ns">>]), #{
+    ?assert(lists:member(Username, ExpectedUsernames), #{
         username => Username
     }),
     ?assert(is_map(ClientAttrs));
-verify_event_fields('client.check_authn_complete', Fields) ->
+verify_event_fields('client.check_authn_complete' = Event, Fields, Opts) ->
     #{
         clientid := ClientId,
         peername := PeerName,
@@ -4811,17 +5139,27 @@ verify_event_fields('client.check_authn_complete', Fields) ->
         is_superuser := IsSuperuser,
         client_attrs := ClientAttrs
     } = Fields,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_event2">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"u_event2">>,
+        <<"my_ns">>
+    ]),
     verify_peername(PeerName),
-    ?assert(lists:member(ClientId, [<<"c_event">>, <<"c_event2">>, <<"c_ns">>]), #{
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{
         clientid => ClientId
     }),
-    ?assert(lists:member(Username, [<<"u_event">>, <<"u_event2">>, <<"my_ns">>]), #{
+    ?assert(lists:member(Username, ExpectedUsernames), #{
         username => Username
     }),
     ?assert(erlang:is_boolean(IsAnonymous)),
     ?assert(erlang:is_boolean(IsSuperuser)),
     ?assert(is_map(ClientAttrs));
-verify_event_fields('schema.validation_failed', Fields) ->
+verify_event_fields('schema.validation_failed' = Event, Fields, Opts) ->
     #{
         validation := ValidationName,
         clientid := ClientId,
@@ -4834,16 +5172,26 @@ verify_event_fields('schema.validation_failed', Fields) ->
         pub_props := _PubProps,
         publish_received_at := _PublishReceivedAt
     } = Fields,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_event2">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"u_event2">>,
+        <<"my_ns">>
+    ]),
     ?assertEqual(<<"v1">>, ValidationName),
     verify_peername(PeerName),
-    ?assert(lists:member(ClientId, [<<"c_event">>, <<"c_event2">>, <<"c_ns">>]), #{
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{
         clientid => ClientId
     }),
-    ?assert(lists:member(Username, [<<"u_event">>, <<"u_event2">>, <<"my_ns">>]), #{
+    ?assert(lists:member(Username, ExpectedUsernames), #{
         username => Username
     }),
     ok;
-verify_event_fields('message.transformation_failed', Fields) ->
+verify_event_fields('message.transformation_failed' = Event, Fields, Opts) ->
     #{
         transformation := TransformationName,
         clientid := ClientId,
@@ -4856,12 +5204,22 @@ verify_event_fields('message.transformation_failed', Fields) ->
         pub_props := _PubProps,
         publish_received_at := _PublishReceivedAt
     } = Fields,
+    ExpectedClientIds = emqx_utils_maps:deep_get([Event, clientids], Opts, [
+        <<"c_event">>,
+        <<"c_event2">>,
+        <<"c_ns">>
+    ]),
+    ExpectedUsernames = emqx_utils_maps:deep_get([Event, usernames], Opts, [
+        <<"u_event">>,
+        <<"u_event2">>,
+        <<"my_ns">>
+    ]),
     ?assertEqual(<<"t1">>, TransformationName),
     verify_peername(PeerName),
-    ?assert(lists:member(ClientId, [<<"c_event">>, <<"c_event2">>, <<"c_ns">>]), #{
+    ?assert(lists:member(ClientId, ExpectedClientIds), #{
         clientid => ClientId
     }),
-    ?assert(lists:member(Username, [<<"u_event">>, <<"u_event2">>, <<"my_ns">>]), #{
+    ?assert(lists:member(Username, ExpectedUsernames), #{
         username => Username
     }),
     ok.

--- a/changes/ee/fix-17957.en.md
+++ b/changes/ee/fix-17957.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where multiple rule events (for example, `$events/client/connack`) would not trigger rules in the global namespace when `rule_engine.limit_selects_in_namespace = true`.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/17953

The fix in `98d29c753c921dc1584b28880047bbbd012ca3e5` only addressed `message.publish` events, with other events not triggering global rules when `limit_selects_in_namespace = true`.

Release version:
6.0.5, 6.1.4, 6.2.3, 6.3.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
