### PR TITLE
build(greptime): move dependency to root mix.exs to ease branch syncing

### DIFF
--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -32,7 +32,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
-      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1"}
+      :greptimedb
     ])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -315,6 +315,9 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:parquer),
     do: {:parquer, github: "emqx/parquer", tag: "0.1.8", manager: :rebar3}
 
+  def common_dep(:greptimedb),
+    do: {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1"}
+
   def common_dep(:thrift),
     do: {:thrift, github: "emqx/thrift.erl", tag: "0.1.4", override: true}
 


### PR DESCRIPTION
Just a build config refactoring to simplify syncing, no real change.