### PR TITLE
fix(kafka, pulsar connectors): switch to `connecting` on health check timeouts

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_SUITE.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_SUITE.erl
@@ -375,3 +375,9 @@ t_dynamic_topics(TCConfig) ->
 
 t_disallow_disk_mode_for_dynamic_topic(TCConfig) ->
     emqx_bridge_kafka_action_SUITE:?FUNCTION_NAME(TCConfig).
+
+t_resource_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    emqx_bridge_kafka_action_SUITE:?FUNCTION_NAME(TCConfig).
+
+t_channel_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    emqx_bridge_kafka_action_SUITE:?FUNCTION_NAME(TCConfig).

--- a/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_producer_SUITE.erl
+++ b/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_producer_SUITE.erl
@@ -367,3 +367,9 @@ t_dynamic_topics(TCConfig) ->
 
 t_disallow_disk_mode_for_dynamic_topic(TCConfig) ->
     emqx_bridge_kafka_action_SUITE:?FUNCTION_NAME(TCConfig).
+
+t_resource_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    emqx_bridge_kafka_action_SUITE:?FUNCTION_NAME(TCConfig).
+
+t_channel_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    emqx_bridge_kafka_action_SUITE:?FUNCTION_NAME(TCConfig).

--- a/apps/emqx_bridge_kafka/mix.exs
+++ b/apps/emqx_bridge_kafka/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeKafka.MixProject do
   def project do
     [
       app: :emqx_bridge_kafka,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -13,6 +13,8 @@
 %% callbacks of behaviour emqx_resource
 -export([
     resource_type/0,
+    resource_health_check_timeout_status/0,
+    channel_health_check_timeout_status/0,
     query_mode/1,
     query_opts/1,
     callback_mode/0,
@@ -45,6 +47,10 @@
 -define(PROBE_TOPIC_NAME, <<"emqx-connector-connectivity-probe">>).
 
 resource_type() -> kafka_producer.
+
+resource_health_check_timeout_status() -> ?status_connecting.
+
+channel_health_check_timeout_status() -> ?status_connecting.
 
 query_mode(#{parameters := #{query_mode := sync}}) ->
     simple_sync_internal_buffer;

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_action_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_action_SUITE.erl
@@ -1924,6 +1924,67 @@ t_fallback_actions(TCConfig) when is_list(TCConfig) ->
 
     ok.
 
+-doc """
+Verifies that, if the connector health check times out, it goes to `connecting` instead of
+the usual `disconnected`, so we don't recreate the state and its replayq.
+""".
+t_resource_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    {ok, ConnectorType} = emqx_utils:safe_to_existing_atom(get_config(connector_type, TCConfig)),
+    Mod = emqx_connector_info:resource_callback_module(ConnectorType),
+    emqx_common_test_helpers:with_mock(
+        Mod,
+        on_get_status,
+        fun(ConnResId, ConnState) ->
+            ct:sleep(300),
+            meck:passthrough([ConnResId, ConnState])
+        end,
+        fun() ->
+            ?assertMatch(
+                {201, #{
+                    <<"status">> := <<"connecting">>,
+                    <<"status_reason">> := <<"resource_health_check_timed_out">>
+                }},
+                create_connector_api(TCConfig, #{
+                    <<"resource_opts">> => #{
+                        <<"health_check_timeout">> => <<"100ms">>
+                    }
+                })
+            )
+        end
+    ),
+    ok.
+
+-doc """
+Verifies that, if the action health check times out, it goes to `connecting` instead of
+the usual `disconnected`, so we don't recreate the state and its replayq.
+""".
+t_channel_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    {ok, ConnectorType} = emqx_utils:safe_to_existing_atom(get_config(connector_type, TCConfig)),
+    Mod = emqx_connector_info:resource_callback_module(ConnectorType),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    emqx_common_test_helpers:with_mock(
+        Mod,
+        on_get_channel_status,
+        fun(ConnResId, ChanId, ConnState) ->
+            ct:sleep(300),
+            meck:passthrough([ConnResId, ChanId, ConnState])
+        end,
+        fun() ->
+            ?assertMatch(
+                {201, #{
+                    <<"status">> := <<"connecting">>,
+                    <<"status_reason">> := <<"channel_health_check_timed_out">>
+                }},
+                create_action_api(TCConfig, #{
+                    <<"resource_opts">> => #{
+                        <<"health_check_timeout">> => <<"100ms">>
+                    }
+                })
+            )
+        end
+    ),
+    ok.
+
 %% Exercises the code path where we use MSK IAM authentication.
 %% Unfortunately, there seems to be no good way to accurately test this as it would
 %% require running this in an EC2 instance to pass, and also to have a Kafka cluster

--- a/apps/emqx_bridge_pulsar/mix.exs
+++ b/apps/emqx_bridge_pulsar/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgePulsar.MixProject do
   def project do
     [
       app: :emqx_bridge_pulsar,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
@@ -11,6 +11,8 @@
 %% `emqx_resource' API
 -export([
     resource_type/0,
+    resource_health_check_timeout_status/0,
+    channel_health_check_timeout_status/0,
     callback_mode/0,
     query_mode/1,
     query_opts/1,
@@ -62,6 +64,10 @@
 %% `emqx_resource' API
 %%-------------------------------------------------------------------------------------
 resource_type() -> pulsar.
+
+resource_health_check_timeout_status() -> ?status_connecting.
+
+channel_health_check_timeout_status() -> ?status_connecting.
 
 callback_mode() -> async_if_possible.
 

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_SUITE.erl
@@ -1407,6 +1407,67 @@ t_overflow_rule_metrics(TCConfig) when is_list(TCConfig) ->
 
     ok.
 
+-doc """
+Verifies that, if the connector health check times out, it goes to `connecting` instead of
+the usual `disconnected`, so we don't recreate the state and its replayq.
+""".
+t_resource_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    {ok, ConnectorType} = emqx_utils:safe_to_existing_atom(get_config(connector_type, TCConfig)),
+    Mod = emqx_connector_info:resource_callback_module(ConnectorType),
+    emqx_common_test_helpers:with_mock(
+        Mod,
+        on_get_status,
+        fun(ConnResId, ConnState) ->
+            ct:sleep(300),
+            meck:passthrough([ConnResId, ConnState])
+        end,
+        fun() ->
+            ?assertMatch(
+                {201, #{
+                    <<"status">> := <<"connecting">>,
+                    <<"status_reason">> := <<"resource_health_check_timed_out">>
+                }},
+                create_connector_api(TCConfig, #{
+                    <<"resource_opts">> => #{
+                        <<"health_check_timeout">> => <<"100ms">>
+                    }
+                })
+            )
+        end
+    ),
+    ok.
+
+-doc """
+Verifies that, if the action health check times out, it goes to `connecting` instead of
+the usual `disconnected`, so we don't recreate the state and its replayq.
+""".
+t_channel_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    {ok, ConnectorType} = emqx_utils:safe_to_existing_atom(get_config(connector_type, TCConfig)),
+    Mod = emqx_connector_info:resource_callback_module(ConnectorType),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    emqx_common_test_helpers:with_mock(
+        Mod,
+        on_get_channel_status,
+        fun(ConnResId, ChanId, ConnState) ->
+            ct:sleep(300),
+            meck:passthrough([ConnResId, ChanId, ConnState])
+        end,
+        fun() ->
+            ?assertMatch(
+                {201, #{
+                    <<"status">> := <<"connecting">>,
+                    <<"status_reason">> := <<"channel_health_check_timed_out">>
+                }},
+                create_action_api(TCConfig, #{
+                    <<"resource_opts">> => #{
+                        <<"health_check_timeout">> => <<"100ms">>
+                    }
+                })
+            )
+        end
+    ),
+    ok.
+
 %% Verifies that the `actions.failed' and `actions.failed.unknown' counters are bumped
 %% when a message is dropped due to reaching its TTL (both sync and async).
 t_expired_rule_metrics() ->

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -82,6 +82,8 @@
     %% get the callback mode of a specific module
     get_callback_mode/1,
     get_resource_type/1,
+    get_resource_health_check_timeout_status/1,
+    get_channel_health_check_timeout_status/1,
     get_callback_mode/2,
     get_query_opts/2,
     %% start the instance
@@ -163,7 +165,9 @@
     query_mode/1,
     on_format_query_result/1,
     callback_mode/1,
-    query_opts/1
+    query_opts/1,
+    resource_health_check_timeout_status/0,
+    channel_health_check_timeout_status/0
 ]).
 
 -type namespace() :: binary().
@@ -255,6 +259,18 @@
 
 %% Used for tagging log entries.
 -callback resource_type() -> atom().
+
+%% When a health check times out, set this status for the resource.
+%%
+%% Most modules should not tamper with this; exceptions are those which must not destroy
+%% their queues (kafka and pulsar, currently)
+-callback resource_health_check_timeout_status() -> health_check_status().
+
+%% When a health check times out, set this status for the channel.
+%%
+%% Most modules should not tamper with this; exceptions are those which must not destroy
+%% their queues (kafka and pulsar, currently)
+-callback channel_health_check_timeout_status() -> health_check_status().
 
 -elvis([{elvis_style, no_match_in_condition, disable}]).
 
@@ -532,6 +548,22 @@ get_callback_mode(Mod) ->
 -spec get_resource_type(module()) -> resource_type().
 get_resource_type(Mod) ->
     Mod:resource_type().
+
+get_resource_health_check_timeout_status(Mod) ->
+    case erlang:function_exported(Mod, resource_health_check_timeout_status, 0) of
+        true ->
+            Mod:resource_health_check_timeout_status();
+        _ ->
+            ?status_disconnected
+    end.
+
+get_channel_health_check_timeout_status(Mod) ->
+    case erlang:function_exported(Mod, channel_health_check_timeout_status, 0) of
+        true ->
+            Mod:resource_health_check_timeout_status();
+        _ ->
+            ?status_disconnected
+    end.
 
 -spec get_callback_mode(module(), resource_state()) -> callback_mode() | undefined.
 get_callback_mode(Mod, State) ->

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -560,7 +560,7 @@ get_resource_health_check_timeout_status(Mod) ->
 get_channel_health_check_timeout_status(Mod) ->
     case erlang:function_exported(Mod, channel_health_check_timeout_status, 0) of
         true ->
-            Mod:resource_health_check_timeout_status();
+            Mod:channel_health_check_timeout_status();
         _ ->
             ?status_disconnected
     end.

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -1570,7 +1570,8 @@ worker_resource_health_check(Data) ->
         emqx_utils:nolink_apply(Fn, ResourceHCTimeout)
     catch
         exit:timeout ->
-            exit({ok, {?status_disconnected, <<"resource_health_check_timed_out">>}})
+            HCTimeoutStatus = emqx_resource:get_resource_health_check_timeout_status(Data#data.mod),
+            exit({ok, {HCTimeoutStatus, <<"resource_health_check_timed_out">>}})
     end.
 
 %% Defined as a standalone function so that dialyzer doesn't complain that it only
@@ -2095,7 +2096,8 @@ worker_channel_health_check(Data, ChannelId) ->
         emqx_utils:nolink_apply(Fn, ChanHCTimeout)
     catch
         exit:timeout ->
-            Res = {?status_disconnected, <<"resource_health_check_timed_out">>},
+            HCTimeoutStatus = emqx_resource:get_channel_health_check_timeout_status(Data#data.mod),
+            Res = {HCTimeoutStatus, <<"channel_health_check_timed_out">>},
             ChanStatus = channel_status(Res, ChannelConfig),
             exit({ok, ChanStatus})
     end.

--- a/changes/ee/fix-17961.en.md
+++ b/changes/ee/fix-17961.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where a Kafka or Pulsar Connector would transition to a `disconnected` state on health check timeouts, potentially recreating its internal queue.  Now, they transition to `connecting`.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/17916

Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
