### PR TITLE
perf(auth): don't spawn buffer workers for authenticator/authorizer resources

### DIFF
--- a/apps/emqx_auth/src/emqx_auth.app.src
+++ b/apps/emqx_auth/src/emqx_auth.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth, [
     {description, "EMQX Authentication and authorization"},
-    {vsn, "0.4.7"},
+    {vsn, "0.4.8"},
     {modules, []},
     {registered, [emqx_auth_sup]},
     {applications, [

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
@@ -37,8 +37,11 @@
     to_bool/1
 ]).
 
+%% Authenticator resources always query through `emqx_resource:simple_sync_query/2',
+%% which bypasses the buffer workers, so we don't spawn a buffer worker pool for them.
 -define(DEFAULT_RESOURCE_OPTS, #{
-    start_after_created => false
+    start_after_created => false,
+    spawn_buffer_workers => false
 }).
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
@@ -39,8 +39,11 @@
     content_type/1
 ]).
 
+%% Authorizer resources always query through `emqx_resource:simple_sync_query/2',
+%% which bypasses the buffer workers, so we don't spawn a buffer worker pool for them.
 -define(DEFAULT_RESOURCE_OPTS, #{
-    start_after_created => false
+    start_after_created => false,
+    spawn_buffer_workers => false
 }).
 
 -include_lib("emqx/include/logger.hrl").

--- a/changes/ce/perf-17964.en.md
+++ b/changes/ce/perf-17964.en.md
@@ -1,0 +1,1 @@
+No longer spawn buffer worker pools for authenticator and authorizer resources.  These resources always query through `simple_sync_query`, which bypasses the buffer workers, so the previously spawned workers were idle and never used.


### PR DESCRIPTION
Authenticator and authorizer resources always query through `emqx_resource:simple_sync_query/2', which calls the resource callback directly and bypasses the buffer worker processes (see the note in `emqx_resource_buffer_worker:simple_sync_query/3').  Spawning a buffer worker pool for them only creates idle workers that are never used.

Set `spawn_buffer_workers => false' in the authn/authz default resource opts, the same way connectors already do in `emqx_connector_resource'.

Release version:
<!-- uncomment for v5:
5.8.12, 5.10.5
-->

<!-- uncomment for v6:
6.0.4, 6.1.3, 6.2.2
-->

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
