### PR TITLE
test(license): de-flake session hwm history http api suite

### DIFF
--- a/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -378,6 +378,12 @@ validate_setting(Res, ExpectLow, ExpectHigh, DynMax) ->
 %%------------------------------------------------------------------------------
 
 session_hwm_setup(Config) ->
+    %% Suspend the background license sampler for the duration of the test so it
+    %% cannot write a live current-day row into the table while we assert on a
+    %% fixed set of seeded rows. Without this, a sampler tick landing between
+    %% setup and the GET prepends an extra {period => today, high_watermark => 0}
+    %% row and flakes the exact-match assertions.
+    ok = suspend_license_sampler(),
     %% Pin timezone so the period labels are host-independent.
     OrigTz = emqx_config:get([license, high_watermark_timezone], system),
     emqx_config:put([license, high_watermark_timezone], <<"+00:00">>),
@@ -397,13 +403,26 @@ session_hwm_setup(Config) ->
 session_hwm_teardown(Config) ->
     {atomic, ok} = mria:clear_table(emqx_license_session_hwm),
     emqx_config:put([license, high_watermark_timezone], ?config(orig_tz, Config)),
+    ok = resume_license_sampler(),
     ok.
+
+%% Pause/resume the periodic resource sampler (`emqx_license_resources`). Only
+%% its timer-driven `update_resources` tick is affected; other license machinery
+%% does not depend on a synchronous reply from this process.
+suspend_license_sampler() ->
+    case whereis(emqx_license_resources) of
+        undefined -> ok;
+        Pid -> sys:suspend(Pid)
+    end.
+
+resume_license_sampler() ->
+    case whereis(emqx_license_resources) of
+        undefined -> ok;
+        Pid -> sys:resume(Pid)
+    end.
 
 session_hwm_uri(Query) ->
     uri(["license", "session_hwm_history"]) ++ Query.
-
-filter_by_period(Rows, ExpectedPeriods) ->
-    [R || R <- Rows, lists:member(maps:get(<<"period">>, R), ExpectedPeriods)].
 
 t_session_hwm_history_default_monthly({init, Config}) ->
     session_hwm_setup(Config);
@@ -416,7 +435,7 @@ t_session_hwm_history_default_monthly(_Config) ->
     ?assertEqual(<<"monthly">>, Period),
     ?assertMatch(
         [#{<<"period">> := <<"2026-05">>}, #{<<"period">> := <<"2026-04">>}],
-        filter_by_period(Rows, [<<"2026-05">>, <<"2026-04">>])
+        Rows
     ).
 
 t_session_hwm_history_monthly({init, Config}) ->
@@ -432,7 +451,7 @@ t_session_hwm_history_monthly(_Config) ->
             #{<<"period">> := <<"2026-05">>, <<"high_watermark">> := 5},
             #{<<"period">> := <<"2026-04">>, <<"high_watermark">> := 20}
         ],
-        filter_by_period(Rows, [<<"2026-05">>, <<"2026-04">>])
+        Rows
     ).
 
 t_session_hwm_history_daily({init, Config}) ->
@@ -449,7 +468,7 @@ t_session_hwm_history_daily(_Config) ->
             #{<<"period">> := <<"2026-04-19">>, <<"high_watermark">> := 20},
             #{<<"period">> := <<"2026-04-18">>, <<"high_watermark">> := 10}
         ],
-        filter_by_period(Rows, [<<"2026-05-01">>, <<"2026-04-19">>, <<"2026-04-18">>])
+        Rows
     ).
 
 t_session_hwm_history_limit({init, Config}) ->


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Test-only change to de-flake `emqx_license_http_api_SUITE`'s session HWM
history cases.

The `t_session_hwm_history_*` cases seed a fixed set of historical rows into
`emqx_license_session_hwm` and then assert on the exact response of the
`session_hwm_history` HTTP API. Meanwhile the background sampler
(`emqx_license_resources`) fires a periodic `update_resources` tick that calls
`emqx_license_session_hwm:observe/2` with the current wall-clock time and the
live session count. When such a tick landed between setup and the GET, it wrote
an extra `{period => today, high_watermark => 0}` row, which — sorted newest
first — was prepended to the response and broke the exact-match assertions.

The fix suspends `emqx_license_resources` in `session_hwm_setup/1` (guarded by
`whereis/1`) and resumes it in `session_hwm_teardown/1`, so no live row can be
written during the assertions. Suspending only pauses the timer-driven resource
refresh; nothing else depends on a synchronous reply from that process. With the
table now deterministic, the assertions are restored to strict exact-list
matches (dropping the earlier period-filtering workaround), so an unexpected row
would now fail the test instead of being silently ignored.

Product behavior is unchanged.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
