### PR TITLE
fix(connector): limit SSRF checks to http/mqtt connectors at create/update

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -485,4 +485,4 @@ server_name_indication_converter(SNI, _HoconOpts) ->
     SNI.
 
 host_opts() ->
-    #{default_port => 9093, ssrf_check => true}.
+    #{default_port => 9093}.

--- a/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
+++ b/apps/emqx_bridge_bigquery/src/emqx_bridge_bigquery_impl.erl
@@ -109,7 +109,7 @@ on_start(ConnResId, ConnConfig0) ->
     ),
     {Transport, HostPort} = emqx_bridge_gcp_pubsub_client:get_transport(bigquery),
     #{hostname := Host, port := Port} = emqx_schema:parse_server(HostPort, #{
-        default_port => 443, ssrf_check => true
+        default_port => 443
     }),
     ConnConfig = ConnConfig1#{
         jwt_opts => #{

--- a/apps/emqx_bridge_cassandra/mix.exs
+++ b/apps/emqx_bridge_cassandra/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeCassandra.MixProject do
   def project do
     [
       app: :emqx_bridge_cassandra,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra_connector.erl
+++ b/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra_connector.erl
@@ -53,7 +53,7 @@
         channels := #{}
     }.
 
--define(DEFAULT_SERVER_OPTION, #{default_port => ?CASSANDRA_DEFAULT_PORT, ssrf_check => true}).
+-define(DEFAULT_SERVER_OPTION, #{default_port => ?CASSANDRA_DEFAULT_PORT}).
 
 %%--------------------------------------------------------------------
 %% schema

--- a/apps/emqx_bridge_confluent/src/emqx_bridge_confluent_producer.erl
+++ b/apps/emqx_bridge_confluent/src/emqx_bridge_confluent_producer.erl
@@ -409,4 +409,4 @@ override(Fields, Overrides) ->
     ).
 
 host_opts() ->
-    #{default_port => 9092, ssrf_check => true}.
+    #{default_port => 9092}.

--- a/apps/emqx_bridge_couchbase/src/emqx_bridge_couchbase.hrl
+++ b/apps/emqx_bridge_couchbase/src/emqx_bridge_couchbase.hrl
@@ -12,8 +12,7 @@
 -define(ACTION_TYPE_BIN, <<"couchbase">>).
 
 -define(SERVER_OPTIONS, #{
-    default_port => 8093,
-    ssrf_check => true
+    default_port => 8093
 }).
 
 %% END ifndef(__EMQX_BRIDGE_COUCHBASE_HRL__)

--- a/apps/emqx_bridge_datalayers/include/emqx_bridge_datalayers.hrl
+++ b/apps/emqx_bridge_datalayers/include/emqx_bridge_datalayers.hrl
@@ -7,13 +7,11 @@
 
 %% datalayers servers don't need parse
 -define(DATALAYERS_HOST_ARROW_OPTIONS, #{
-    default_port => ?DATALAYERS_DEFAULT_ARROW_PORT,
-    ssrf_check => true
+    default_port => ?DATALAYERS_DEFAULT_ARROW_PORT
 }).
 
 -define(DATALAYERS_HOST_HTTP_OPTIONS, #{
-    default_port => ?DATALAYERS_DEFAULT_HTTP_PORT,
-    ssrf_check => true
+    default_port => ?DATALAYERS_DEFAULT_HTTP_PORT
 }).
 
 -define(DATALAYERS_DRIVER_TYPE_INFLUX, influxdb_v1).

--- a/apps/emqx_bridge_doris/src/emqx_bridge_doris_impl.erl
+++ b/apps/emqx_bridge_doris/src/emqx_bridge_doris_impl.erl
@@ -69,7 +69,7 @@ callback_mode() ->
 on_start(ConnResId, ConnConfig0) ->
     ConnConfig = ConnConfig0#{
         basic_capabilities => #{?CLIENT_TRANSACTIONS => false},
-        parse_server_opts => #{default_port => 9030, ssrf_check => true}
+        parse_server_opts => #{default_port => 9030}
     },
     emqx_bridge_mysql_connector:on_start(ConnResId, ConnConfig).
 

--- a/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector.erl
+++ b/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector.erl
@@ -91,8 +91,7 @@ on_start(
 
     {Scheme, Server, DefaultPort} = get_host_info(to_str(Url)),
     #{hostname := Host, port := Port} = emqx_schema:parse_server(Server, #{
-        default_port => DefaultPort,
-        ssrf_check => true
+        default_port => DefaultPort
     }),
 
     Options = [

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -98,7 +98,7 @@ on_start(ConnectorResId, Config0) ->
     ),
     {Transport, HostPort} = emqx_bridge_gcp_pubsub_client:get_transport(pubsub),
     #{hostname := Host, port := Port} = emqx_schema:parse_server(HostPort, #{
-        default_port => 443, ssrf_check => true
+        default_port => 443
     }),
     Config = Config1#{
         jwt_opts => #{

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -81,7 +81,7 @@ on_start(InstanceId, Config0) ->
     ),
     {Transport, HostPort} = emqx_bridge_gcp_pubsub_client:get_transport(pubsub),
     #{hostname := Host, port := Port} = emqx_schema:parse_server(HostPort, #{
-        default_port => 443, ssrf_check => true
+        default_port => 443
     }),
     Config = Config1#{
         jwt_opts => #{

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
@@ -57,8 +57,7 @@
 -define(DEFAULT_DB, <<"public">>).
 
 -define(GREPTIMEDB_HOST_OPTIONS, #{
-    default_port => ?GREPTIMEDB_DEFAULT_PORT,
-    ssrf_check => true
+    default_port => ?GREPTIMEDB_DEFAULT_PORT
 }).
 
 -define(DEFAULT_TIMESTAMP_TMPL, "${timestamp}").

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -55,8 +55,7 @@
 
 %% influxdb servers don't need parse
 -define(INFLUXDB_HOST_OPTIONS, #{
-    default_port => ?INFLUXDB_DEFAULT_PORT,
-    ssrf_check => true
+    default_port => ?INFLUXDB_DEFAULT_PORT
 }).
 
 -define(DEFAULT_TIMESTAMP_TMPL, "${timestamp}").

--- a/apps/emqx_bridge_iotdb/include/emqx_bridge_iotdb.hrl
+++ b/apps/emqx_bridge_iotdb/include/emqx_bridge_iotdb.hrl
@@ -13,8 +13,7 @@
 -define(VSN_0_13_X, 'v0.13.x').
 
 -define(THRIFT_HOST_OPTIONS, #{
-    default_port => 6667,
-    ssrf_check => true
+    default_port => 6667
 }).
 
 -define(PROTOCOL_V1, 'protocol_v1').

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -213,7 +213,7 @@ ssl_client_opts_fields() ->
     override(emqx_schema:client_ssl_opts_schema(#{}), ssl_overrides()).
 
 host_opts() ->
-    #{default_port => 9092, ssrf_check => true}.
+    #{default_port => 9092}.
 
 namespace() -> "bridge_kafka".
 

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_connector_client.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_connector_client.erl
@@ -103,8 +103,7 @@ init(#{
             Endpoint,
             #{
                 default_port => ?DEFAULT_PORT,
-                supported_schemes => ["http", "https"],
-                ssrf_check => true
+                supported_schemes => ["http", "https"]
             }
         ),
     State = #{

--- a/apps/emqx_bridge_pulsar/include/emqx_bridge_pulsar.hrl
+++ b/apps/emqx_bridge_pulsar/include/emqx_bridge_pulsar.hrl
@@ -8,8 +8,7 @@
 -define(PULSAR_HOST_OPTIONS, #{
     default_port => 6650,
     default_scheme => "pulsar",
-    supported_schemes => ["pulsar", "pulsar+ssl"],
-    ssrf_check => true
+    supported_schemes => ["pulsar", "pulsar+ssl"]
 }).
 
 -endif.

--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
@@ -32,8 +32,7 @@
 -import(hoconsc, [mk/2]).
 
 -define(ROCKETMQ_HOST_OPTIONS, #{
-    default_port => 9876,
-    ssrf_check => true
+    default_port => 9876
 }).
 
 %%=====================================================================

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.hrl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.hrl
@@ -18,8 +18,7 @@
 -define(ACTION_TYPE_STREAM_BIN, <<"snowflake_streaming">>).
 
 -define(SERVER_OPTS, #{
-    default_port => 443,
-    ssrf_check => true
+    default_port => 443
 }).
 
 -define(AGGREG_SUP, emqx_bridge_snowflake_sup).

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -67,8 +67,7 @@
 
 %% We use -1 to differentiate between default port and explicitly defined port.
 -define(SQLSERVER_HOST_OPTIONS, #{
-    default_port => -1,
-    ssrf_check => true
+    default_port => -1
 }).
 
 -define(REQUEST_TTL(RESOURCE_OPTS),

--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_connector.erl
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_connector.erl
@@ -40,8 +40,7 @@
 
 -define(CONNECTOR_TYPE, syskeeper_forwarder).
 -define(SYSKEEPER_HOST_OPTIONS, #{
-    default_port => 9092,
-    ssrf_check => true
+    default_port => 9092
 }).
 
 -define(EXTRA_CALL_TIMEOUT, 2000).

--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_proxy.erl
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_proxy.erl
@@ -27,8 +27,7 @@
 -define(CONNECTOR_TYPE, syskeeper_proxy).
 
 -define(SYSKEEPER_HOST_OPTIONS, #{
-    default_port => 9092,
-    ssrf_check => true
+    default_port => 9092
 }).
 
 %% -------------------------------------------------------------------------------------------------

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
@@ -42,14 +42,12 @@
 -define(TD_DEFAULT_PORT, 6041).
 
 -define(TD_HOST_OPTIONS, #{
-    default_port => ?TD_DEFAULT_PORT,
-    ssrf_check => true
+    default_port => ?TD_DEFAULT_PORT
 }).
 
 -define(TD_HOST_OPTIONS_CLOUD, #{
     default_port => 443,
-    supported_schemes => ["https"],
-    ssrf_check => true
+    supported_schemes => ["https"]
 }).
 
 -define(CONNECTOR_TYPE, tdengine).

--- a/apps/emqx_connector/src/emqx_connector_resource.erl
+++ b/apps/emqx_connector/src/emqx_connector_resource.erl
@@ -163,7 +163,6 @@ update(Namespace, Type, Name, {OldConf, Conf0}, Opts) ->
     %% without restarting the connector.
     %%
     Conf = Conf0#{connector_type => bin(Type), connector_name => bin(Name)},
-    TypeBin = bin(Type),
     case emqx_utils_maps:if_only_to_toggle_enable(OldConf, Conf0) of
         false ->
             ?SLOG(info, #{
@@ -194,10 +193,6 @@ update(Namespace, Type, Name, {OldConf, Conf0}, Opts) ->
             _ =
                 case maps:get(enable, Conf, true) of
                     true ->
-                        %% Re-validate the connector (incl. SSRF policy) before
-                        %% re-enabling; disabling is always allowed so admins can
-                        %% always take down a now-denied connector.
-                        _ = parse_confs(TypeBin, Name, Conf),
                         restart(Namespace, Type, Name);
                     false ->
                         stop(Namespace, Type, Name)

--- a/apps/emqx_connector/test/emqx_connector_ssrf_lifecycle_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_ssrf_lifecycle_SUITE.erl
@@ -2,10 +2,16 @@
 %% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
-%% Regression tests for two SSRF-policy bugs:
-%%   #17483 — HTTP enable/disable toggle bypassed SSRF re-validation.
-%%   #17484 — Creating a new MQTT connector failed when an unrelated
-%%            existing MQTT connector targeted a denied server.
+%% Lifecycle tests for the connector SSRF policy.
+%%
+%% The policy is enforced only for HTTP (`url') and MQTT (`server') connectors,
+%% and only when a connector is created or updated. Enabling/disabling and
+%% deleting a connector, and any other connector's re-validation, are never
+%% blocked by it. Other connector types are not subject to the policy at all.
+%%
+%% Includes a regression for #17940: with SSRF enabled, deleting or otherwise
+%% touching a connector must not fail because an unrelated connector's stored
+%% address is now denied.
 -module(emqx_connector_ssrf_lifecycle_SUITE).
 
 -compile(nowarn_export_all).
@@ -29,6 +35,7 @@ init_per_suite(Config) ->
             emqx_connector,
             emqx_bridge_http,
             emqx_bridge_mqtt,
+            emqx_bridge_greptimedb,
             emqx_bridge
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
@@ -114,6 +121,15 @@ mqtt_config(Server) ->
         <<"resource_opts">> => #{<<"health_check_interval">> => <<"15s">>}
     }.
 
+%% A connector type that is NOT http/mqtt, i.e. not subject to the SSRF policy.
+greptimedb_config(Server) ->
+    #{
+        <<"server">> => Server,
+        <<"dbname">> => <<"public">>,
+        <<"enable">> => true,
+        <<"resource_opts">> => #{<<"health_check_interval">> => <<"15s">>}
+    }.
+
 %%--------------------------------------------------------------------
 %% HTTP cases
 %%--------------------------------------------------------------------
@@ -133,12 +149,11 @@ t_http_create_denied_rejected(_Config) ->
     ok.
 
 -doc """
-Regression for #17483: `PUT /connectors/{id}/enable/true` must re-validate
-the connector against the current SSRF policy. The toggle fast-path
-previously skipped `parse_confs/3`, so a connector created under a
-permissive policy could be re-enabled after the policy tightened.
+Enabling a connector whose stored URL is now denied is allowed: the SSRF
+policy is enforced only when creating or updating a connector, not on the
+enable/disable toggle.
 """.
-t_http_enable_re_validates(_Config) ->
+t_http_enable_now_allowed(_Config) ->
     {ok, _} = emqx_connector:create(
         ?global_ns,
         http,
@@ -148,7 +163,7 @@ t_http_enable_re_validates(_Config) ->
     set_ssrf_deny([<<"127.0.0.0/8">>]),
     {ok, _} = emqx_connector:disable_enable(?global_ns, disable, http, http_revalidate),
     ?assertMatch(
-        {error, #{kind := validation_error}},
+        {ok, _},
         emqx_connector:disable_enable(?global_ns, enable, http, http_revalidate)
     ),
     ok.
@@ -215,8 +230,8 @@ t_mqtt_create_valid_with_existing_denied(_Config) ->
     ?assert(lists:member(mqtt_valid_new, Names)),
     ok.
 
--doc "Mirror of #17483 for MQTT: re-enable toggle re-runs SSRF validation.".
-t_mqtt_enable_re_validates(_Config) ->
+-doc "Mirror for MQTT: enabling a now-denied connector is allowed.".
+t_mqtt_enable_now_allowed(_Config) ->
     {ok, _} = emqx_connector:create(
         ?global_ns,
         mqtt,
@@ -226,7 +241,7 @@ t_mqtt_enable_re_validates(_Config) ->
     set_ssrf_deny([<<"127.0.0.0/8">>]),
     {ok, _} = emqx_connector:disable_enable(?global_ns, disable, mqtt, mqtt_revalidate),
     ?assertMatch(
-        {error, #{kind := validation_error}},
+        {ok, _},
         emqx_connector:disable_enable(?global_ns, enable, mqtt, mqtt_revalidate)
     ),
     ok.
@@ -244,4 +259,73 @@ t_mqtt_disable_always_allowed(_Config) ->
         {ok, _},
         emqx_connector:disable_enable(?global_ns, disable, mqtt, mqtt_disable_ok)
     ),
+    ok.
+
+-doc "Updating an HTTP connector to a denied URL is rejected.".
+t_http_update_denied_rejected(_Config) ->
+    {ok, _} = emqx_connector:create(
+        ?global_ns,
+        http,
+        http_upd,
+        http_config(<<"http://8.8.8.8:18083">>)
+    ),
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_connector:create(
+            ?global_ns,
+            http,
+            http_upd,
+            http_config(<<"http://127.0.0.1:18083">>)
+        )
+    ),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Other connector types (not subject to the SSRF policy) and #17940
+%%--------------------------------------------------------------------
+
+-doc """
+Connector types other than http/mqtt are not subject to the SSRF policy:
+creating one targeting a denied address succeeds, and it remains deletable.
+""".
+t_schema_connector_not_ssrf_checked(_Config) ->
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    ?assertMatch(
+        {ok, _},
+        emqx_connector:create(
+            ?global_ns,
+            greptimedb,
+            greptime_denied,
+            greptimedb_config(<<"127.0.0.1:4001">>)
+        )
+    ),
+    ?assertEqual(ok, emqx_connector:remove(?global_ns, greptimedb, greptime_denied)),
+    ok.
+
+-doc """
+Regression for #17940: with SSRF enabled, deleting a connector must succeed
+even when an unrelated, pre-existing connector's stored address is now denied.
+The whole `connectors' subtree is re-validated on every change, and a denied
+sibling used to abort the delete and leave a residual connector.
+""".
+t_delete_unrelated_with_denied_sibling(_Config) ->
+    %% pre-existing connectors, created while the policy is permissive
+    {ok, _} = emqx_connector:create(
+        ?global_ns,
+        greptimedb,
+        denied_sibling,
+        greptimedb_config(<<"127.0.0.1:4001">>)
+    ),
+    {ok, _} = emqx_connector:create(
+        ?global_ns,
+        mqtt,
+        to_delete,
+        mqtt_config(<<"8.8.8.8:1883">>)
+    ),
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    ?assertEqual(ok, emqx_connector:remove(?global_ns, mqtt, to_delete)),
+    Names = [Name || #{name := Name} <- emqx_connector:list(?global_ns)],
+    ?assertNot(lists:member(to_delete, Names)),
+    ?assert(lists:member(denied_sibling, Names)),
     ok.

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -40,8 +40,7 @@
 -export([do_get_status/1]).
 
 -define(MYSQL_HOST_OPTIONS, #{
-    default_port => ?MYSQL_DEFAULT_PORT,
-    ssrf_check => true
+    default_port => ?MYSQL_DEFAULT_PORT
 }).
 
 -type template() :: {unicode:chardata(), emqx_template:str()}.

--- a/changes/ee/fix-17970.en.md
+++ b/changes/ee/fix-17970.en.md
@@ -1,0 +1,5 @@
+When SSRF protection is enabled, managing connectors is no longer disrupted by an existing connector whose address is now blocked by the policy.
+
+Previously, enabling SSRF protection (or extending its deny list) after connectors were created could make unrelated connector operations fail with an internal error, and deleting an affected connector could leave it behind after its actions and rules were already removed.
+
+SSRF protection now applies to HTTP and MQTT connectors and is enforced when a connector is created or updated: creating or updating such a connector with a blocked address is rejected. Enabling, disabling and deleting connectors are never blocked, and other connector types are not subject to the policy.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Fixes #17940.

With SSRF protection enabled, deleting a webhook whose connector's address was denied by the policy returned a 500 and left a residual connector while its action and rule were removed. The trigger was an *unrelated* connector: EMQX re-validates the whole `connectors` config subtree on every change, and ~20 connector schemas (greptimedb, kafka, mysql, influxdb, …) enforced the SSRF check on their `server`/`servers` field via the shared `emqx_schema:servers_sc/2`. Once a stored sibling address became denied, that whole-subtree re-validation threw, so creating, updating, enabling **or deleting** any connector could fail.

### Change

Rather than police SSRF across every connector type and operation, this scopes it back:

- Remove the `ssrf_check` option from the ~20 connector host-option definitions, so the shared `servers_sc`/`parse_server` schema check no longer enforces SSRF. Whole-config re-validation therefore never fails on a now-denied sibling, and deletes are unaffected.
- SSRF is now enforced only for **HTTP** (`url`) and **MQTT** (`server`) connectors, via `emqx_connector_resource:parse_confs/3`, which runs when a connector is **created or updated**. Creating/updating such a connector with a denied address is still rejected.
- Enabling/disabling and deleting connectors are no longer subject to the policy. This reverts the re-enable re-validation previously added for #17483.

### Behavior change / scope

- Connector types other than HTTP/MQTT (greptimedb, kafka, mysql, influxdb, cassandra, pulsar, tdengine, …) are **no longer** SSRF-checked.
- Re-enabling a connector whose stored address is now denied is allowed again.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
