### PR TITLE
fix(mqtt): reject v3.1.1 CONNECT with password but no username

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -1344,16 +1344,15 @@ validate_connect_will(false, WillRetain, _) when WillRetain -> ?PARSE_ERR(invali
 validate_connect_will(_, _, _) -> ok.
 
 -compile({inline, [validate_connect_password_flag/4]}).
-%% MQTT-v3.1
-%% Username flag and password flag are not strongly related
+%% MQTT-v3.1: username and password flags are not strongly related; no check.
 %% https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#connect
-validate_connect_password_flag(true, ?MQTT_PROTO_V3, _, _) ->
+validate_connect_password_flag(_, ?MQTT_PROTO_V3, _, _) ->
     ok;
-%% MQTT-v3.1.1-[MQTT-3.1.2-22]
-validate_connect_password_flag(true, ?MQTT_PROTO_V4, UsernameFlag, PasswordFlag) ->
-    %% BUG-FOR-BUG compatible, only check when `strict-mode`
+%% MQTT-v3.1.1-[MQTT-3.1.2-22]: a password requires a username. Enforced
+%% unconditionally (previously only in strict mode).
+validate_connect_password_flag(_, ?MQTT_PROTO_V4, UsernameFlag, PasswordFlag) ->
     UsernameFlag orelse PasswordFlag andalso ?PARSE_ERR(invalid_password_flag);
-validate_connect_password_flag(true, ?MQTT_PROTO_V5, _, _) ->
+validate_connect_password_flag(_, ?MQTT_PROTO_V5, _, _) ->
     ok;
 validate_connect_password_flag(_, _, _, _) ->
     ok.

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -59,6 +59,9 @@ groups() ->
             t_reserved_connect_flag,
             t_invalid_clientid,
             t_undefined_password,
+            t_invalid_password_flag,
+            t_valid_password_flag_v4,
+            t_password_flag_v3_no_username,
             t_invalid_will_retain,
             t_invalid_will_qos
         ]},
@@ -982,6 +985,10 @@ t_undefined_password(_) ->
     ),
     ok.
 
+-doc """
+MQTT v3.1.1 CONNECT with password flag set but username flag clear is
+rejected regardless of strict mode (MQTT-3.1.2-22).
+""".
 t_invalid_password_flag(_) ->
     %% Username Flag = false
     %% Password Flag = true
@@ -989,17 +996,59 @@ t_invalid_password_flag(_) ->
     ConnectFlags = <<2#0100:4, 2#0010:4>>,
     ConnectBin =
         <<16, 17, 0, 4, 77, 81, 84, 84, 4, ConnectFlags/binary, 0, 60, 0, 2, 97, 49, 0, 1, 97>>,
+    %% Non-strict mode now rejects too (previously accepted); the check is no
+    %% longer gated on strict mode.
     LenientParseState = emqx_frame:initial_parse_state(#{strict_mode => false}),
-    ?assertMatch(
-        {_, _, _},
+    ?assertException(
+        throw,
+        {frame_parse_error, #{
+            cause := invalid_password_flag, proto_ver := ?MQTT_PROTO_V4, proto_name := <<"MQTT">>
+        }},
         emqx_frame:parse(ConnectBin, LenientParseState)
     ),
-
+    %% Strict mode still rejects (unchanged).
     StrictModeParseState = emqx_frame:initial_parse_state(#{strict_mode => true}),
     ?assertException(
         throw,
-        {frame_parse_error, invalid_password_flag},
+        {frame_parse_error, #{
+            cause := invalid_password_flag, proto_ver := ?MQTT_PROTO_V4, proto_name := <<"MQTT">>
+        }},
         emqx_frame:parse(ConnectBin, StrictModeParseState)
+    ).
+
+-doc """
+MQTT v3.1.1 CONNECT with both username and password flags set parses fine
+(fix is scoped to the password-without-username case).
+""".
+t_valid_password_flag_v4(_) ->
+    %% Username Flag = true
+    %% Password Flag = true
+    %% Clean Session = true
+    ConnectFlags = <<2#1100:4, 2#0010:4>>,
+    ConnectBin =
+        <<16, 20, 0, 4, 77, 81, 84, 84, 4, ConnectFlags/binary, 0, 60, 0, 2, 97, 49, 0, 1, 97, 0, 1,
+            98>>,
+    ?assertMatch(
+        {_, _, _},
+        emqx_frame:parse(ConnectBin)
+    ).
+
+-doc """
+MQTT v3.1 (level 3) CONNECT with password but no username is still
+accepted; the v3.1 spec does not couple the flags.
+""".
+t_password_flag_v3_no_username(_) ->
+    %% Proto level = 3 (MQTT v3.1), Proto name = MQIsdp
+    %% Username Flag = false
+    %% Password Flag = true
+    %% Clean Session = true
+    ConnectFlags = <<2#0100:4, 2#0010:4>>,
+    ConnectBin =
+        <<16, 19, 0, 6, 77, 81, 73, 115, 100, 112, 3, ConnectFlags/binary, 0, 60, 0, 2, 97, 49, 0,
+            1, 97>>,
+    ?assertMatch(
+        {_, _, _},
+        emqx_frame:parse(ConnectBin)
     ).
 
 t_invalid_will_retain(_) ->

--- a/changes/ee/fix-17971.en.md
+++ b/changes/ee/fix-17971.en.md
@@ -1,0 +1,1 @@
+EMQX now rejects MQTT v3.1.1 CONNECT packets that supply a password without a username, as required by the protocol. Previously these were accepted unless strict mode was enabled.


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Fixes https://github.com/emqx/emqx/issues/17913.

Enforce **[MQTT-3.1.2-22]** ("If the User Name Flag is set to 0, the
Password Flag MUST be set to 0") for MQTT v3.1.1 (protocol level 4)
unconditionally, i.e. regardless of `mqtt.strict_mode`.

Change in `apps/emqx/src/emqx_frame.erl`,
`validate_connect_password_flag/4`: the v3.1.1 clause now fires
independently of the strict-mode argument. It throws exactly when the
username flag is clear and the password flag is set; the other three flag
combinations parse cleanly. v3.1 (level 3) is unchanged (its spec does not
couple the flags), and v5 is unchanged.

### Context on dev-63 / strict mode

On this branch `mqtt.strict_mode` already defaults to `true`, so a CONNECT
that sets the password flag while clearing the username flag is already
rejected by default. This change closes the remaining gap: the check was
previously gated on strict mode, so a listener with `strict_mode = false`
would still accept such packets. With this change the [MQTT-3.1.2-22]
violation is rejected in both modes.

Note: a CONNECT that sets the username flag with an empty username string
plus a password remains protocol-legal and is still accepted; that is not
a [MQTT-3.1.2-22] violation.

Tests (`emqx_frame_SUITE`): `t_invalid_password_flag` now asserts rejection
in both non-strict and strict mode; added `t_valid_password_flag_v4`
(password + username still parses) and `t_password_flag_v3_no_username`
(v3.1 still accepted) to confirm the fix is scoped. Full suite: 58 ok.

Note: the older v6 lines (dev-60/61/62) still default `strict_mode` to
`false`; if this behavior tightening is wanted there too, it can be
backported. This PR targets dev-63 (the line the report was filed against,
6.3.0-beta.1).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
