### PR TITLE
test(prometheus): fix flaky test

### DIFF
--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -365,7 +365,10 @@ emqtt_connect(ClientId) ->
         {ok, _} ->
             %% link again
             link(C0),
-            {ok, C0}
+            {ok, C0};
+        {error, {server_unavailable, _}} ->
+            ct:sleep(100),
+            emqtt_connect(ClientId)
     catch
         exit:{shutdown, server_unavailable} ->
             ct:sleep(100),


### PR DESCRIPTION
```
%%% emqx_prometheus_api_SUITE ==> new_config.t_listener_shutdown_count: FAILED
%%% emqx_prometheus_api_SUITE ==> {{try_clause,{error,{server_unavailable,undefined}}},
 [{emqx_prometheus_api_SUITE,emqtt_connect,1,
                             [{file,"test/emqx_prometheus_api_SUITE.erl"},
                              {line,364}]},
  {emqx_prometheus_api_SUITE,t_listener_shutdown_count,1,
                             [{file,"test/emqx_prometheus_api_SUITE.erl"},
                              {line,397}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1794}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1303}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1235}]}]}
```

https://github.com/emqx/emqx/actions/runs/29450000785/job/87621231641