### PR TITLE
fix(logging): redact raw MQTT packet data by default

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -759,13 +759,17 @@ try_set_chan_stats(State = #state{channel = Channel}) ->
 %%--------------------------------------------------------------------
 %% Parse incoming data
 -compile({inline, [on_bytes_in/3]}).
-on_bytes_in(Oct, Data, State = #state{gc_tracker = {ActiveN, {Pkts, Bytes}, Out}}) ->
-    ?LOG(debug, #{
-        msg => "raw_bin_received",
-        size => Oct,
-        bin => binary_to_list(binary:encode_hex(Data)),
-        type => "hex"
-    }),
+on_bytes_in(
+    Oct,
+    Data,
+    State = #state{channel = Channel, gc_tracker = {ActiveN, {Pkts, Bytes}, Out}}
+) ->
+    ?LOG(
+        debug,
+        emqx_packet_data_logger:add_packet_data(
+            #{msg => "raw_bin_received", size => Oct}, bin, Data, Channel, hex
+        )
+    ),
     {N, Packets, NState} = parse_incoming(Data, State),
     FState = NState#state{gc_tracker = {ActiveN, {Pkts + N, Bytes + Oct}, Out}},
     {ok, next_incoming_msgs(Packets), FState}.
@@ -778,29 +782,45 @@ next_incoming_msgs(Packets) ->
     Fun = fun(Packet, Acc) -> [{incoming, Packet} | Acc] end,
     lists:foldl(Fun, [], Packets).
 
-parse_incoming(Data, State = #state{parser = Parser}) ->
+parse_incoming(Data, State = #state{parser = Parser, channel = Channel}) ->
     try
         run_parser(Data, Parser, State)
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
             NReason = maybe_enrich_first_packet_error(Data, Reason, State),
-            ?LOG(info, #{
-                msg => "frame_parse_error",
-                reason => NReason,
-                at_state => describe_parser_state(Parser),
-                input_bytes => Data
-            }),
+            ?LOG(
+                info,
+                emqx_packet_data_logger:add_packet_data(
+                    #{
+                        msg => "frame_parse_error",
+                        reason => NReason,
+                        at_state => describe_parser_state(Parser)
+                    },
+                    input_bytes,
+                    Data,
+                    Channel,
+                    raw
+                )
+            ),
             NState = update_state_on_parse_error(Parser, NReason, State),
             {0, [{frame_error, NReason}], NState};
         error:Reason:Stacktrace ->
             NReason = maybe_enrich_first_packet_error(Data, Reason, State),
-            ?LOG(error, #{
-                msg => "frame_parse_failed",
-                at_state => describe_parser_state(Parser),
-                input_bytes => Data,
-                reason => NReason,
-                stacktrace => Stacktrace
-            }),
+            ?LOG(
+                error,
+                emqx_packet_data_logger:add_packet_data(
+                    #{
+                        msg => "frame_parse_failed",
+                        at_state => describe_parser_state(Parser),
+                        reason => NReason,
+                        stacktrace => Stacktrace
+                    },
+                    input_bytes,
+                    Data,
+                    Channel,
+                    raw
+                )
+            ),
             {0, [{frame_error, NReason}], State}
     end.
 

--- a/apps/emqx/src/emqx_packet_data_logger.erl
+++ b/apps/emqx/src/emqx_packet_data_logger.erl
@@ -1,0 +1,46 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_packet_data_logger).
+
+-export([add_packet_data/5]).
+
+-define(REDACTED, <<"******">>).
+
+-spec add_packet_data(
+    map(), atom(), binary(), emqx_channel:channel(), raw | hex
+) -> map().
+add_packet_data(Log, Key, Data, Channel, Format) ->
+    case is_allowed(Channel) of
+        true ->
+            add_raw_packet_data(Log, Key, Data, Format);
+        false ->
+            add_redacted_packet_data(Log, Key, Format)
+    end.
+
+add_raw_packet_data(Log, Key, Data, raw) ->
+    Log#{Key => Data};
+add_raw_packet_data(Log, Key, Data, hex) ->
+    Log#{Key => binary_to_list(binary:encode_hex(Data)), type => "hex"}.
+
+add_redacted_packet_data(Log, Key, raw) ->
+    Log#{Key => ?REDACTED};
+add_redacted_packet_data(Log, Key, hex) ->
+    Log#{Key => ?REDACTED, type => "hidden"}.
+
+is_allowed(Channel) ->
+    ClientInfo = emqx_channel:info(clientinfo, Channel),
+    PeerHost = maps:get(peerhost, ClientInfo),
+    {Type, Name} = listener(maps:get(listener, ClientInfo)),
+    IPMasks = emqx_config:get_listener_conf(Type, Name, [allow_log_packet_data_from], []),
+    lists:any(
+        fun(IPMask) -> esockd_cidr:match(PeerHost, IPMask) end,
+        IPMasks
+    ).
+
+listener({Type, Name}) ->
+    {Type, Name};
+listener(ListenerId) ->
+    {ok, #{type := Type, name := Name}} = emqx_listeners:parse_listener_id(ListenerId),
+    {Type, Name}.

--- a/apps/emqx/src/emqx_quic_data_stream.erl
+++ b/apps/emqx/src/emqx_quic_data_stream.erl
@@ -133,7 +133,9 @@ handle_stream_data(
     %% assert get stream data only after channel is created
     Channel =/= undefined
 ->
-    {MQTTPackets, NewPS} = parse_incoming(list_to_binary(lists:reverse([Bin | QueuedData])), PS),
+    {MQTTPackets, NewPS} = parse_incoming(
+        list_to_binary(lists:reverse([Bin | QueuedData])), PS, Channel
+    ),
     NewTQ = lists:foldl(
         fun(Item, Acc) ->
             queue:in(Item, Acc)
@@ -373,24 +375,37 @@ do_handle_call(_Call, _S) ->
     {error, unimpl}.
 
 %% @doc return reserved order of Packets
-parse_incoming(Data, PS) ->
+parse_incoming(Data, PS, Channel) ->
     try
         do_parse_incoming(Data, [], PS)
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
-            ?SLOG(info, #{
-                msg => "frame_parse_error",
-                reason => Reason,
-                input_bytes => Data
-            }),
+            ?SLOG(
+                info,
+                emqx_packet_data_logger:add_packet_data(
+                    #{msg => "frame_parse_error", reason => Reason},
+                    input_bytes,
+                    Data,
+                    Channel,
+                    raw
+                )
+            ),
             {[{frame_error, Reason}], PS};
         error:Reason:Stacktrace ->
-            ?SLOG(error, #{
-                msg => "frame_parse_failed",
-                input_bytes => Data,
-                reason => Reason,
-                stacktrace => Stacktrace
-            }),
+            ?SLOG(
+                error,
+                emqx_packet_data_logger:add_packet_data(
+                    #{
+                        msg => "frame_parse_failed",
+                        reason => Reason,
+                        stacktrace => Stacktrace
+                    },
+                    input_bytes,
+                    Data,
+                    Channel,
+                    raw
+                )
+            ),
             {[{frame_error, Reason}], PS}
     end.
 

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2230,6 +2230,24 @@ access_rules_validator(AccessRules) ->
             {error, MsgBin}
     end.
 
+ip_masks_converter(undefined, _Opts) ->
+    undefined;
+ip_masks_converter(IPMasks, #{make_serializable := true}) when is_binary(IPMasks) ->
+    IPMasks;
+ip_masks_converter(IPMasks, #{make_serializable := true}) ->
+    iolist_to_binary(lists:join(<<", ">>, [esockd_cidr:to_string(IPMask) || IPMask <- IPMasks]));
+ip_masks_converter(IPMasks, _Opts) when is_binary(IPMasks) ->
+    [parse_ip_mask(IPMask) || IPMask <- string:tokens(binary_to_list(IPMasks), ", ")];
+ip_masks_converter(IPMasks, _Opts) ->
+    throw({invalid_ip_address_or_cidr, IPMasks}).
+
+parse_ip_mask(IPMask) ->
+    try esockd_cidr:parse(IPMask, true) of
+        CIDR -> CIDR
+    catch
+        _:_ -> throw({invalid_ip_address_or_cidr, IPMask})
+    end.
+
 is_invalid_rule(S) ->
     try
         [Action, CIDR] = string:tokens(S, " "),
@@ -2310,6 +2328,16 @@ base_listener(Bind) ->
                 #{
                     desc => ?DESC(base_listener_enable_authn),
                     default => true
+                }
+            )},
+        {"allow_log_packet_data_from",
+            sc(
+                typerefl:alias("string", any()),
+                #{
+                    desc => ?DESC(base_listener_allow_log_packet_data_from),
+                    default => <<>>,
+                    importance => ?IMPORTANCE_LOW,
+                    converter => fun ip_masks_converter/2
                 }
             )}
     ] ++ emqx_limiter_schema:fields(mqtt).

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -744,17 +744,18 @@ handle_data(
     State0 = #state{
         socket = Socket,
         sockstate = SS,
+        channel = Channel,
         gc_tracker = {ActiveN, {Pubs, Bytes}, Out}
     }
 ) ->
     Oct = iolist_size(Data),
     emqx_metrics:inc('bytes.received', Oct),
-    ?LOG(debug, #{
-        msg => "raw_bin_received",
-        size => Oct,
-        bin => binary_to_list(binary:encode_hex(Data)),
-        type => "hex"
-    }),
+    ?LOG(
+        debug,
+        emqx_packet_data_logger:add_packet_data(
+            #{msg => "raw_bin_received", size => Oct}, bin, Data, Channel, hex
+        )
+    ),
     {More, N, Packets, State1} = parse_incoming(Data, State0),
     State = State1#state{gc_tracker = {ActiveN, {Pubs + N, Bytes + Oct}, Out}},
     Msgs = next_incoming_msgs(Packets),
@@ -812,29 +813,45 @@ next_incoming_msgs(Packets) ->
     Fun = fun(Packet, Acc) -> [{incoming, Packet} | Acc] end,
     lists:foldl(Fun, [], Packets).
 
-parse_incoming(Data, State = #state{parser = Parser}) ->
+parse_incoming(Data, State = #state{parser = Parser, channel = Channel}) ->
     try
         run_parser(Data, Parser, State)
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
             NReason = maybe_enrich_first_packet_error(Data, Reason, State),
-            ?LOG(info, #{
-                msg => "frame_parse_error",
-                reason => NReason,
-                at_state => describe_parser_state(Parser),
-                input_bytes => Data
-            }),
+            ?LOG(
+                info,
+                emqx_packet_data_logger:add_packet_data(
+                    #{
+                        msg => "frame_parse_error",
+                        reason => NReason,
+                        at_state => describe_parser_state(Parser)
+                    },
+                    input_bytes,
+                    Data,
+                    Channel,
+                    raw
+                )
+            ),
             NState = update_state_on_parse_error(NReason, State),
             {0, 0, [{frame_error, NReason}], NState};
         error:Reason:Stacktrace ->
             NReason = maybe_enrich_first_packet_error(Data, Reason, State),
-            ?LOG(error, #{
-                msg => "frame_parse_failed",
-                at_state => describe_parser_state(Parser),
-                input_bytes => Data,
-                reason => NReason,
-                stacktrace => Stacktrace
-            }),
+            ?LOG(
+                error,
+                emqx_packet_data_logger:add_packet_data(
+                    #{
+                        msg => "frame_parse_failed",
+                        at_state => describe_parser_state(Parser),
+                        reason => NReason,
+                        stacktrace => Stacktrace
+                    },
+                    input_bytes,
+                    Data,
+                    Channel,
+                    raw
+                )
+            ),
             {0, 0, [{frame_error, NReason}], State}
     end.
 

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -549,13 +549,13 @@ check_oom(State = #state{zone = Zone}) ->
 
 on_frame_in(Data, State) when is_list(Data) ->
     on_frame_in(iolist_to_binary(Data), State);
-on_frame_in(Data, State) ->
-    ?LOG(debug, #{
-        msg => "raw_bin_received",
-        size => byte_size(Data),
-        bin => binary_to_list(binary:encode_hex(Data)),
-        type => "hex"
-    }),
+on_frame_in(Data, State = #state{channel = Channel}) ->
+    ?LOG(
+        debug,
+        emqx_packet_data_logger:add_packet_data(
+            #{msg => "raw_bin_received", size => byte_size(Data)}, bin, Data, Channel, hex
+        )
+    ),
     State2 = ensure_stats_timer(State),
     {Packets, State3} = parse_incoming(Data, [], State2),
     inc_recv_stats(length(Packets), byte_size(Data)),
@@ -563,7 +563,7 @@ on_frame_in(Data, State) ->
 
 parse_incoming(<<>>, Packets, State) ->
     {lists:reverse(Packets), State};
-parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
+parse_incoming(Data, Packets, State = #state{parse_state = ParseState, channel = Channel}) ->
     try emqx_frame:parse(Data, ParseState) of
         {_More, NParseState} ->
             {Packets, State#state{parse_state = NParseState}};
@@ -572,22 +572,38 @@ parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
             parse_incoming(Rest, [Packet | Packets], NState)
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
-            ?LOG(info, #{
-                msg => "frame_parse_error",
-                reason => Reason,
-                at_state => emqx_frame:describe_state(ParseState),
-                input_bytes => Data
-            }),
+            ?LOG(
+                info,
+                emqx_packet_data_logger:add_packet_data(
+                    #{
+                        msg => "frame_parse_error",
+                        reason => Reason,
+                        at_state => emqx_frame:describe_state(ParseState)
+                    },
+                    input_bytes,
+                    Data,
+                    Channel,
+                    raw
+                )
+            ),
             NState = update_state_on_parse_error(Reason, State),
             {[{frame_error, Reason} | Packets], NState};
         error:Reason:Stacktrace ->
-            ?LOG(error, #{
-                msg => "frame_parse_failed",
-                at_state => emqx_frame:describe_state(ParseState),
-                input_bytes => Data,
-                exception => Reason,
-                stacktrace => Stacktrace
-            }),
+            ?LOG(
+                error,
+                emqx_packet_data_logger:add_packet_data(
+                    #{
+                        msg => "frame_parse_failed",
+                        at_state => emqx_frame:describe_state(ParseState),
+                        exception => Reason,
+                        stacktrace => Stacktrace
+                    },
+                    input_bytes,
+                    Data,
+                    Channel,
+                    raw
+                )
+            ),
             {[{frame_error, Reason} | Packets], State}
     end.
 

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -379,6 +379,48 @@ t_socket_parse_incoming_first_packet_hints(_) ->
     ),
     ok = meck:unload(emqx_frame).
 
+t_packet_data_logging(_) ->
+    Data = <<16#10, 0, "secret">>,
+    Channel = channel(),
+    OldIPMasks = emqx_config:get_listener_conf(
+        tcp, default, [allow_log_packet_data_from]
+    ),
+    try
+        ok = emqx_config:put_listener_conf(
+            tcp, default, [allow_log_packet_data_from], [esockd_cidr:parse("10.0.0.0/8", true)]
+        ),
+        ?assertEqual(
+            #{bin => <<"******">>, type => "hidden"},
+            emqx_packet_data_logger:add_packet_data(#{}, bin, Data, Channel, hex)
+        ),
+        DeniedReports = emqx_cth_log_capture:capture(info, fun() ->
+            emqx_connection:parse_incoming(Data, st())
+        end),
+        ?assertMatch(
+            [#{input_bytes := <<"******">>}],
+            [Report || #{msg := "frame_parse_error"} = Report <- DeniedReports]
+        ),
+
+        ok = emqx_config:put_listener_conf(
+            tcp, default, [allow_log_packet_data_from], [esockd_cidr:parse("127.0.0.0/24", true)]
+        ),
+        ?assertEqual(
+            #{bin => binary_to_list(binary:encode_hex(Data)), type => "hex"},
+            emqx_packet_data_logger:add_packet_data(#{}, bin, Data, Channel, hex)
+        ),
+        AllowedReports = emqx_cth_log_capture:capture(info, fun() ->
+            emqx_connection:parse_incoming(Data, st())
+        end),
+        ?assertMatch(
+            [#{input_bytes := Data}],
+            [Report || #{msg := "frame_parse_error"} = Report <- AllowedReports]
+        )
+    after
+        ok = emqx_config:put_listener_conf(
+            tcp, default, [allow_log_packet_data_from], OldIPMasks
+        )
+    end.
+
 t_next_incoming_msgs(_) ->
     ?assertEqual(
         {incoming, packet},

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -175,6 +175,48 @@ fail_if_no_peer_cert_test_() ->
         )
     ].
 
+listener_allow_log_packet_data_from_test_() ->
+    Sc = #{
+        roots => [mqtt_tcp_listener],
+        fields => #{mqtt_tcp_listener => emqx_schema:fields("mqtt_tcp_listener")}
+    },
+    Check = fun(Listener) ->
+        hocon_tconf:check_plain(
+            Sc,
+            #{<<"mqtt_tcp_listener">> => Listener},
+            #{atom_key => true, required => false}
+        )
+    end,
+    [
+        ?_assertMatch(
+            #{mqtt_tcp_listener := #{allow_log_packet_data_from := []}},
+            Check(#{})
+        ),
+        ?_assertMatch(
+            #{
+                mqtt_tcp_listener := #{
+                    allow_log_packet_data_from := [
+                        {{127, 0, 0, 1}, {127, 0, 0, 1}, 32},
+                        {{10, 20, 0, 0}, {10, 20, 255, 255}, 16},
+                        {
+                            {16#2001, 16#db8, 0, 0, 0, 0, 0, 0},
+                            {16#2001, 16#db8, 16#ffff, 16#ffff, 16#ffff, 16#ffff, 16#ffff, 16#ffff},
+                            32
+                        }
+                    ]
+                }
+            },
+            Check(#{
+                <<"allow_log_packet_data_from">> =>
+                    <<"127.0.0.1, 10.20.0.0/16, 2001:db8::/32">>
+            })
+        ),
+        ?_assertThrow(
+            {_, [#{kind := validation_error}]},
+            Check(#{<<"allow_log_packet_data_from">> => <<"127.0.0.1, invalid">>})
+        )
+    ].
+
 validate(Schema, Data0) ->
     Sc = #{
         roots => [ssl_opts],

--- a/changes/ee/fix-17974.en.md
+++ b/changes/ee/fix-17974.en.md
@@ -1,0 +1,1 @@
+Raw MQTT packet data is now redacted by default in connection logs; trusted client IP addresses can be allowlisted per listener for diagnostics.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1729,6 +1729,20 @@ For example:
 mqtt_listener_access_rules.label:
 """Access rules"""
 
+base_listener_allow_log_packet_data_from.desc:
+"""~
+A comma-separated allowlist of client IP addresses and CIDR ranges for logging raw MQTT packet data.
+Packet data from other addresses is redacted. This option may expose credentials and other sensitive data in logs and should only be enabled temporarily for trusted client addresses.
+
+For example:
+
+```
+listeners.tcp.default.allow_log_packet_data_from = "127.0.0.1, 192.168.1.0/24, 2001:db8::/32"
+```~"""
+
+base_listener_allow_log_packet_data_from.label:
+"""Allow Packet Data Logging From"""
+
 server_ssl_opts_schema_enable_ocsp_stapling.desc:
 """Whether to enable Online Certificate Status Protocol (OCSP) stapling for the listener.  If set to true, requires defining the OCSP responder URL and issuer PEM path."""
 

--- a/scripts/spellcheck/dicts/emqx.txt
+++ b/scripts/spellcheck/dicts/emqx.txt
@@ -5,6 +5,7 @@ ACL
 addr
 AES
 aliyun
+allowlist
 AlloyDB
 api
 APIs


### PR DESCRIPTION
Release version: 6.0.4

Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/269 

## Summary
- Redact raw MQTT packet data in connection and parser-error logs by default.
- Add listener-scoped `allow_log_packet_data_from` CIDR allowlists for temporary trusted-client diagnostics.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)