### PR TITLE
fix(trace): restrict tracing config updates to global admins

### DIFF
--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -343,6 +343,10 @@ do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := Namespace}, _Req, ?RULE_
     %% is enforced by the handlers themselves, by only fetching/acting on the appropriate
     %% namespace.
     true;
+do_check_rbac(#{?namespace := Namespace}, _Req, ?TRACE_API(put, config)) when
+    is_binary(Namespace)
+->
+    {error, <<"Namespaced users may not update global tracing configuration">>};
 do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := Namespace}, _Req, ?TRACE_API(_, _)) when
     is_binary(Namespace)
 ->

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -744,6 +744,28 @@ t_global_only_message_endpoints_reject_namespaced_actors(_) ->
         global_only_message_endpoint_handlers()
     ).
 
+t_tracing_config_update_rejects_namespaced_actors(_) ->
+    Req = #{},
+    HandlerInfo = #{method => put, module => emqx_mgmt_api_trace, function => config},
+    Expected = {error, <<"Namespaced users may not update global tracing configuration">>},
+    lists:foreach(
+        fun(ActorContext) ->
+            ?assertEqual(
+                Expected,
+                emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, ActorContext)
+            )
+        end,
+        namespaced_actor_contexts()
+    ),
+    ?assertMatch(
+        {ok, _},
+        emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, global_admin_actor_context())
+    ),
+    ?assertMatch(
+        {error, _},
+        emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, global_viewer_actor_context())
+    ).
+
 global_only_message_endpoint_handlers() ->
     [
         #{method => get, module => emqx_mgmt_api_clients, function => mqueue_msgs},

--- a/apps/emqx_management/src/emqx_mgmt_api_trace.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_trace.erl
@@ -224,6 +224,9 @@ schema("/tracing") ->
                 200 => ConfigSchema,
                 400 => emqx_dashboard_swagger:error_codes(
                     ['INVALID_CONFIG'], ?DESC("provided_configuration_invalid")
+                ),
+                403 => emqx_dashboard_swagger:error_codes(
+                    ['UNAUTHORIZED_ROLE'], ?DESC("trace_config_global_only")
                 )
             }
         }

--- a/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
@@ -877,6 +877,51 @@ t_namespaced_user_cross_ns_isolation(_TCConfig) ->
     ?assertMatch({200, []}, list_traces_simple(NsViewer)),
     ok.
 
+-doc """
+Checks the namespace boundary on `PUT /tracing` (the global trace
+configuration endpoint).
+
+A namespaced administrator must not mutate the global `[trace]`
+configuration; RBAC gates the operation on `?global_ns` and
+returns `403 UNAUTHORIZED_ROLE`. A namespaced viewer is also
+rejected (RBAC blocks `PUT` for viewers before the handler is reached).
+A global administrator retains full read/write access (regression) and
+the namespaced write leaves the config unchanged.
+""".
+t_namespaced_user_cannot_update_config(_TCConfig) ->
+    %% Snapshot the current global trace config; we'll assert it is
+    %% unchanged after the rejected namespaced write, and restore it
+    %% at the end.
+    GlobalAdmin = emqx_bridge_v2_testlib:create_superuser(),
+    {200, Conf0} = tracing_simple(get, GlobalAdmin),
+    try
+        %% Namespaced administrator: 403 UNAUTHORIZED_ROLE from RBAC.
+        NsAdmin = namespaced_admin_headers(),
+        {StatusAdm, BodyAdm} = tracing_simple(put, #{<<"max_traces">> => 1}, NsAdmin),
+        ?assertEqual(403, StatusAdm),
+        ?assertMatch(#{<<"code">> := <<"UNAUTHORIZED_ROLE">>}, BodyAdm),
+        %% Config is left untouched.
+        {200, Conf1} = tracing_simple(get, GlobalAdmin),
+        ?assertEqual(Conf0, Conf1),
+        %% Namespaced viewer: RBAC rejects `PUT` for viewers before the
+        %% handler is reached; the response is still a 403.
+        NsViewer = namespaced_viewer_headers(),
+        {StatusViewer, _} = tracing_simple(put, #{<<"max_traces">> => 1}, NsViewer),
+        ?assertEqual(403, StatusViewer),
+        %% Positive regression: a global dashboard administrator can
+        %% update both visible fields, and each update persists on GET.
+        {200, Conf2} = tracing_simple(put, #{<<"max_traces">> => 1}, GlobalAdmin),
+        ?assertMatch(#{<<"max_traces">> := 1}, Conf2),
+        {200, Conf3} = tracing_simple(get, GlobalAdmin),
+        ?assertMatch(#{<<"max_traces">> := 1}, Conf3),
+        {200, Conf4} = tracing_simple(put, #{<<"max_file_size">> => <<"64MB">>}, GlobalAdmin),
+        ?assertMatch(#{<<"max_file_size">> := 64 * 1024 * 1024}, Conf4),
+        {200, Conf5} = tracing_simple(get, GlobalAdmin),
+        ?assertMatch(#{<<"max_file_size">> := 64 * 1024 * 1024}, Conf5)
+    after
+        {200, _} = tracing_simple(put, Conf0, GlobalAdmin)
+    end.
+
 namespaced_admin_headers() ->
     emqx_bridge_v2_testlib:create_namespaced_admin_headers(#{}).
 
@@ -934,6 +979,21 @@ clear_traces_simple(AuthHeader) ->
     emqx_mgmt_api_test_util:simple_request(#{
         method => delete,
         url => emqx_mgmt_api_test_util:api_path(["trace"]),
+        auth_header => AuthHeader
+    }).
+
+tracing_simple(get, AuthHeader) ->
+    emqx_mgmt_api_test_util:simple_request(#{
+        method => get,
+        url => emqx_mgmt_api_test_util:api_path(["tracing"]),
+        auth_header => AuthHeader
+    }).
+
+tracing_simple(put, Body, AuthHeader) ->
+    emqx_mgmt_api_test_util:simple_request(#{
+        method => put,
+        url => emqx_mgmt_api_test_util:api_path(["tracing"]),
+        body => Body,
         auth_header => AuthHeader
     }).
 

--- a/changes/ee/fix-17975.en.md
+++ b/changes/ee/fix-17975.en.md
@@ -1,0 +1,1 @@
+The `/tracing` configuration endpoint (`PUT /api/v5/tracing`) is now restricted to the global administrator. Namespaced dashboard administrators and API keys can no longer mutate the global `[trace]` configuration; such requests are rejected with HTTP 403.

--- a/rel/i18n/emqx_mgmt_api_trace.hocon
+++ b/rel/i18n/emqx_mgmt_api_trace.hocon
@@ -183,6 +183,11 @@ provided_configuration_invalid.desc:
 provided_configuration_invalid.label:
 """Provided Configuration Invalid"""
 
+trace_config_global_only.desc:
+"""Only the global administrator may update the tracing configuration."""
+trace_config_global_only.label:
+"""Tracing Configuration Is Global Only"""
+
 payload_encode.desc:
 """Determine the format of the payload format in the trace file.<br/>
 `text`: Text-based protocol or plain text protocol.


### PR DESCRIPTION
Release version: 6.0.4

Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/215

## Summary

Reject namespaced callers of `PUT /api/v5/tracing` in `emqx_dashboard_rbac`. 

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (the new 403 response documents existing authorization behavior)
