### PR TITLE
fix(kafka, pulsar connectors): switch to `connecting` on health check timeouts (d510)

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
@@ -1739,7 +1739,6 @@ t_fallback_actions_republish_filtered_sql(_TCConfig) ->
                 {error, {unrecoverable_error, fallback_time}}
             end),
 
-            ActionTypeBin = atom_to_binary(bridge_type()),
             PrimaryActionName = <<"primary">>,
 
             RepublishTopic = <<"republish/fallback">>,

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_v2_SUITE.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_v2_SUITE.erl
@@ -423,3 +423,9 @@ t_disallow_disk_mode_for_dynamic_topic(Config) ->
             ]
         ),
     ok.
+
+t_resource_health_check_timeout_status(Config) when is_list(Config) ->
+    emqx_bridge_v2_kafka_producer_SUITE:?FUNCTION_NAME(Config).
+
+t_channel_health_check_timeout_status(Config) when is_list(Config) ->
+    emqx_bridge_v2_kafka_producer_SUITE:?FUNCTION_NAME(Config).

--- a/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_producer_SUITE.erl
+++ b/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_producer_SUITE.erl
@@ -75,9 +75,6 @@ end_per_suite(Config) ->
     ok.
 
 init_per_testcase(TestCase, Config) ->
-    common_init_per_testcase(TestCase, Config).
-
-common_init_per_testcase(TestCase, Config) ->
     ct:timetrap(timer:seconds(60)),
     emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
     emqx_config:delete_override_conf_files(),
@@ -92,6 +89,7 @@ common_init_per_testcase(TestCase, Config) ->
     ok = snabbkaffe:start_trace(),
     ExtraConfig ++
         [
+            {bridge_kind, action},
             {connector_type, ?CONNECTOR_TYPE},
             {connector_name, Name},
             {connector_config, ConnectorConfig},
@@ -432,3 +430,9 @@ t_disallow_disk_mode_for_dynamic_topic(Config) ->
             ]
         ),
     ok.
+
+t_resource_health_check_timeout_status(Config) when is_list(Config) ->
+    emqx_bridge_v2_kafka_producer_SUITE:?FUNCTION_NAME(Config).
+
+t_channel_health_check_timeout_status(Config) when is_list(Config) ->
+    emqx_bridge_v2_kafka_producer_SUITE:?FUNCTION_NAME(Config).

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.6.2"},
+    {vsn, "0.6.3"},
     {registered, [emqx_bridge_kafka_sup, emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -13,6 +13,8 @@
 %% callbacks of behaviour emqx_resource
 -export([
     resource_type/0,
+    resource_health_check_timeout_status/0,
+    channel_health_check_timeout_status/0,
     query_mode/1,
     query_opts/1,
     callback_mode/0,
@@ -45,6 +47,10 @@
 -define(PROBE_TOPIC_NAME, <<"emqx-connector-connectivity-probe">>).
 
 resource_type() -> kafka_producer.
+
+resource_health_check_timeout_status() -> ?status_connecting.
+
+channel_health_check_timeout_status() -> ?status_connecting.
 
 query_mode(#{parameters := #{query_mode := sync}}) ->
     simple_sync_internal_buffer;

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
@@ -84,7 +84,10 @@ init_per_suite(Config) ->
         {kafka_host, KafkaHost},
         {kafka_port, KafkaPort},
         {direct_kafka_host, DirectKafkaHost},
-        {direct_kafka_port, DirectKafkaPort}
+        {direct_kafka_port, DirectKafkaPort},
+        {bridge_kind, action},
+        {connector_type, ?TYPE},
+        {action_type, ?TYPE}
         | Config
     ].
 
@@ -102,6 +105,20 @@ init_per_testcase(t_ancient_v1_config_migration_with_local_topic = TestCase, Con
 init_per_testcase(t_ancient_v1_config_migration_without_local_topic = TestCase, Config) ->
     Cluster = setup_cluster_ancient_config(TestCase, Config, #{with_local_topic => false}),
     [{cluster, Cluster} | Config];
+init_per_testcase(TestCase, Config) when
+    TestCase == t_resource_health_check_timeout_status;
+    TestCase == t_channel_health_check_timeout_status
+->
+    Name = atom_to_binary(TestCase),
+    ConnectorConfig = connector_config(),
+    ActionConfig = action_config(Name, #{}),
+    [
+        {connector_name, Name},
+        {connector_config, ConnectorConfig},
+        {action_name, Name},
+        {action_config, ActionConfig}
+        | Config
+    ];
 init_per_testcase(_TestCase, Config) ->
     Config.
 
@@ -329,6 +346,9 @@ toxiproxy_bootstrap_hosts(Config) ->
     Port = ?config(kafka_port, Config),
     iolist_to_binary([Host, ":", integer_to_binary(Port)]).
 
+get_config(K, TCConfig) -> emqx_bridge_v2_testlib:get_value(K, TCConfig).
+get_config(K, TCConfig, Default) -> proplists:get_value(K, TCConfig, Default).
+
 create_connector(Name, Config) ->
     Res = emqx_connector:create(?TYPE, Name, Config),
     on_exit(fun() -> emqx_connector:remove(?TYPE, Name) end),
@@ -336,6 +356,9 @@ create_connector(Name, Config) ->
 
 create_connector_api(ConnectorParams) ->
     simplify_result(emqx_bridge_v2_testlib:create_connector_api(ConnectorParams)).
+
+create_connector_api(ConnectorParams, Overrides) ->
+    simplify_result(emqx_bridge_v2_testlib:create_connector_api(ConnectorParams, Overrides)).
 
 create_action(Name, Config) ->
     Res = emqx_bridge_v2_testlib:create_kind_api([
@@ -346,6 +369,11 @@ create_action(Name, Config) ->
     ]),
     on_exit(fun() -> emqx_bridge_v2:remove(?TYPE, Name) end),
     Res.
+
+create_action_api(TCConfig, Overrides) ->
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:create_action_api(TCConfig, Overrides)
+    ).
 
 bridge_api_spec_props_for_get() ->
     #{
@@ -1875,6 +1903,63 @@ t_msk_iam_authn(Config) ->
                     {_, {_, token_callback, _}, {ok, #{token := B}}}
                 ] when A /= B,
                 meck:history(emqx_bridge_kafka_msk_iam_authn)
+            )
+        end
+    ),
+    ok.
+
+%% Verifies that, if the connector health check times out, it goes to `connecting` instead of
+%% the usual `disconnected`, so we don't recreate the state and its replayq.
+t_resource_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    {ok, ConnectorType} = emqx_utils:safe_to_existing_atom(get_config(connector_type, TCConfig)),
+    Mod = emqx_connector_info:resource_callback_module(ConnectorType),
+    emqx_common_test_helpers:with_mock(
+        Mod,
+        on_get_status,
+        fun(ConnResId, ConnState) ->
+            ct:sleep(300),
+            meck:passthrough([ConnResId, ConnState])
+        end,
+        fun() ->
+            ?assertMatch(
+                {201, #{
+                    <<"status">> := <<"connecting">>,
+                    <<"status_reason">> := <<"resource_health_check_timed_out">>
+                }},
+                create_connector_api(TCConfig, #{
+                    <<"resource_opts">> => #{
+                        <<"health_check_timeout">> => <<"100ms">>
+                    }
+                })
+            )
+        end
+    ),
+    ok.
+
+%% Verifies that, if the action health check times out, it goes to `connecting` instead of
+%% the usual `disconnected`, so we don't recreate the state and its replayq.
+t_channel_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    {ok, ConnectorType} = emqx_utils:safe_to_existing_atom(get_config(connector_type, TCConfig)),
+    Mod = emqx_connector_info:resource_callback_module(ConnectorType),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    emqx_common_test_helpers:with_mock(
+        Mod,
+        on_get_channel_status,
+        fun(ConnResId, ChanId, ConnState) ->
+            ct:sleep(300),
+            meck:passthrough([ConnResId, ChanId, ConnState])
+        end,
+        fun() ->
+            ?assertMatch(
+                {201, #{
+                    <<"status">> := <<"connecting">>,
+                    <<"status_reason">> := <<"channel_health_check_timed_out">>
+                }},
+                create_action_api(TCConfig, #{
+                    <<"resource_opts">> => #{
+                        <<"health_check_timeout">> => <<"100ms">>
+                    }
+                })
             )
         end
     ),

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_pulsar, [
     {description, "EMQX Pulsar Bridge"},
-    {vsn, "0.2.10"},
+    {vsn, "0.2.11"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
@@ -11,6 +11,8 @@
 %% `emqx_resource' API
 -export([
     resource_type/0,
+    resource_health_check_timeout_status/0,
+    channel_health_check_timeout_status/0,
     callback_mode/0,
     query_mode/1,
     query_opts/1,
@@ -62,6 +64,10 @@
 %% `emqx_resource' API
 %%-------------------------------------------------------------------------------------
 resource_type() -> pulsar.
+
+resource_health_check_timeout_status() -> ?status_connecting.
+
+channel_health_check_timeout_status() -> ?status_connecting.
 
 callback_mode() -> async_if_possible.
 

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_v2_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_v2_SUITE.erl
@@ -157,6 +157,9 @@ common_init_per_testcase(TestCase, Config0) ->
 %% Helper fns
 %%------------------------------------------------------------------------------
 
+get_config(K, TCConfig) -> emqx_bridge_v2_testlib:get_value(K, TCConfig).
+get_config(K, TCConfig, Default) -> proplists:get_value(K, TCConfig, Default).
+
 create_connector(Config) ->
     {201, _} = create_connector_api([
         {connector_type, ?TYPE},
@@ -1132,4 +1135,61 @@ t_expired_rule_metrics(Config) when is_list(Config) ->
         )
     ),
 
+    ok.
+
+%% Verifies that, if the connector health check times out, it goes to `connecting` instead of
+%% the usual `disconnected`, so we don't recreate the state and its replayq.
+t_resource_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    {ok, ConnectorType} = emqx_utils:safe_to_existing_atom(get_config(connector_type, TCConfig)),
+    Mod = emqx_connector_info:resource_callback_module(ConnectorType),
+    emqx_common_test_helpers:with_mock(
+        Mod,
+        on_get_status,
+        fun(ConnResId, ConnState) ->
+            ct:sleep(300),
+            meck:passthrough([ConnResId, ConnState])
+        end,
+        fun() ->
+            ?assertMatch(
+                {201, #{
+                    <<"status">> := <<"connecting">>,
+                    <<"status_reason">> := <<"resource_health_check_timed_out">>
+                }},
+                create_connector_api(TCConfig, #{
+                    <<"resource_opts">> => #{
+                        <<"health_check_timeout">> => <<"100ms">>
+                    }
+                })
+            )
+        end
+    ),
+    ok.
+
+%% Verifies that, if the action health check times out, it goes to `connecting` instead of
+%% the usual `disconnected`, so we don't recreate the state and its replayq.
+t_channel_health_check_timeout_status(TCConfig) when is_list(TCConfig) ->
+    {ok, ConnectorType} = emqx_utils:safe_to_existing_atom(get_config(connector_type, TCConfig)),
+    Mod = emqx_connector_info:resource_callback_module(ConnectorType),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    emqx_common_test_helpers:with_mock(
+        Mod,
+        on_get_channel_status,
+        fun(ConnResId, ChanId, ConnState) ->
+            ct:sleep(300),
+            meck:passthrough([ConnResId, ChanId, ConnState])
+        end,
+        fun() ->
+            ?assertMatch(
+                {201, #{
+                    <<"status">> := <<"connecting">>,
+                    <<"status_reason">> := <<"channel_health_check_timed_out">>
+                }},
+                create_action_api(TCConfig, #{
+                    <<"resource_opts">> => #{
+                        <<"health_check_timeout">> => <<"100ms">>
+                    }
+                })
+            )
+        end
+    ),
     ok.

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -84,6 +84,8 @@
     %% get the callback mode of a specific module
     get_callback_mode/1,
     get_resource_type/1,
+    get_resource_health_check_timeout_status/1,
+    get_channel_health_check_timeout_status/1,
     get_callback_mode/2,
     get_query_opts/2,
     %% start the instance
@@ -159,7 +161,9 @@
     query_mode/1,
     on_format_query_result/1,
     callback_mode/1,
-    query_opts/1
+    query_opts/1,
+    resource_health_check_timeout_status/0,
+    channel_health_check_timeout_status/0
 ]).
 
 %% when calling emqx_resource:start/1
@@ -249,6 +253,20 @@
 
 %% Used for tagging log entries.
 -callback resource_type() -> atom().
+
+%% When a health check times out, set this status for the resource.
+%%
+%% Most modules should not tamper with this; exceptions are those which must not destroy
+%% their queues (kafka and pulsar, currently)
+-callback resource_health_check_timeout_status() -> health_check_status().
+
+%% When a health check times out, set this status for the channel.
+%%
+%% Most modules should not tamper with this; exceptions are those which must not destroy
+%% their queues (kafka and pulsar, currently)
+-callback channel_health_check_timeout_status() -> health_check_status().
+
+-elvis([{elvis_style, no_match_in_condition, disable}]).
 
 -define(SAFE_CALL(EXPR),
     (fun() ->
@@ -519,6 +537,22 @@ get_callback_mode(Mod) ->
 -spec get_resource_type(module()) -> resource_type().
 get_resource_type(Mod) ->
     Mod:resource_type().
+
+get_resource_health_check_timeout_status(Mod) ->
+    case erlang:function_exported(Mod, resource_health_check_timeout_status, 0) of
+        true ->
+            Mod:resource_health_check_timeout_status();
+        _ ->
+            ?status_disconnected
+    end.
+
+get_channel_health_check_timeout_status(Mod) ->
+    case erlang:function_exported(Mod, channel_health_check_timeout_status, 0) of
+        true ->
+            Mod:channel_health_check_timeout_status();
+        _ ->
+            ?status_disconnected
+    end.
 
 -spec get_callback_mode(module(), resource_state()) -> callback_mode() | undefined.
 get_callback_mode(Mod, State) ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -1519,7 +1519,8 @@ worker_resource_health_check(Data) ->
         emqx_utils:nolink_apply(Fn, ResourceHCTimeout)
     catch
         exit:timeout ->
-            exit({ok, {?status_disconnected, <<"resource_health_check_timed_out">>}})
+            HCTimeoutStatus = emqx_resource:get_resource_health_check_timeout_status(Data#data.mod),
+            exit({ok, {HCTimeoutStatus, <<"resource_health_check_timed_out">>}})
     end.
 
 %% Defined as a standalone function so that dialyzer doesn't complain that it only
@@ -2037,7 +2038,8 @@ worker_channel_health_check(Data, ChannelId) ->
         emqx_utils:nolink_apply(Fn, ChanHCTimeout)
     catch
         exit:timeout ->
-            Res = {?status_disconnected, <<"resource_health_check_timed_out">>},
+            HCTimeoutStatus = emqx_resource:get_channel_health_check_timeout_status(Data#data.mod),
+            Res = {HCTimeoutStatus, <<"channel_health_check_timed_out">>},
             ChanStatus = channel_status(Res, ChannelConfig),
             exit({ok, ChanStatus})
     end.

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -5394,7 +5394,7 @@ t_add_large_number_of_channels_oom(_TCConfig) ->
     ResManPid = emqx_resource_cache:read_manager_pid(ConnResId),
     true = is_pid(ResManPid),
     ok = sys:suspend(ResManPid),
-    ChanIds = lists:map(
+    lists:foreach(
         fun(I) ->
             IBin = integer_to_binary(I),
             ChanId = iolist_to_binary([
@@ -5410,8 +5410,7 @@ t_add_large_number_of_channels_oom(_TCConfig) ->
                     #{
                         resource_opts => #{health_check_interval => 45_000}
                     }
-                ),
-            ChanId
+                )
         end,
         lists:seq(1, NumChannels)
     ),

--- a/changes/ee/fix-17961.en.md
+++ b/changes/ee/fix-17961.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where a Kafka or Pulsar Connector would transition to a `disconnected` state on health check timeouts, potentially recreating its internal queue.  Now, they transition to `connecting`.


### PR DESCRIPTION

Fixes https://github.com/emqx/emqx/issues/17916

Port of https://github.com/emqx/emqx/pull/17961

Release version:
5.10.5

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
