### PR TITLE
fix(mqtt): authorize internal subscriptions

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -112,6 +112,16 @@
     pendings :: [emqx_types:deliver()]
 }).
 
+-type subscribe_filter() ::
+    {emqx_types:topic() | emqx_types:share(), emqx_types:subopts()}.
+-type subscribe_topic_filters() ::
+    [subscribe_filter()] | [{subscribe_filter(), emqx_types:reason_code()}].
+-record(subscribe_operation, {
+    properties = #{} :: emqx_types:properties(),
+    topic_filters = [] :: subscribe_topic_filters()
+}).
+-type subscribe_operation() :: #subscribe_operation{}.
+
 -opaque channel() :: #channel{}.
 
 -type opts() :: #{
@@ -957,21 +967,11 @@ after_message_acked(Msg, PubAckProps, Channel) ->
 %%--------------------------------------------------------------------
 
 process_subscribe(SubPkt = ?SUBSCRIBE_PACKET(PacketId, _Properties, _TopicFilters0), Channel0) ->
-    Pipe = emqx_utils:pipeline(
-        [
-            fun check_subscribe/2,
-            fun enrich_subscribe/2,
-            %% TODO && FIXME (EMQX-10786): mount topic before authz check.
-            fun check_sub_authzs/2,
-            fun check_sub_caps/2
-        ],
-        SubPkt,
-        Channel0
-    ),
-    case Pipe of
-        {ok, NPkt = ?SUBSCRIBE_PACKET(_PacketId, TFChecked), Channel} ->
+    Operation0 = subscribe_operation(SubPkt),
+    case prepare_subscribe(Operation0, Channel0) of
+        {ok, Operation = #subscribe_operation{topic_filters = TFChecked}, Channel} ->
             {TFSubedWithNRC, NChannel} = post_process_subscribe(
-                run_sub_hooks(NPkt, Channel), Channel
+                run_sub_hooks(Operation, Channel), Channel
             ),
             ReasonCodes = gen_reason_codes(TFChecked, TFSubedWithNRC),
             handle_out(suback, {PacketId, ReasonCodes}, NChannel);
@@ -980,6 +980,26 @@ process_subscribe(SubPkt = ?SUBSCRIBE_PACKET(PacketId, _Properties, _TopicFilter
             %% And Only one ReasonCode in DISCONNECT packet
             handle_out(disconnect, RC, Channel)
     end.
+
+prepare_subscribe(Operation, Channel) ->
+    emqx_utils:pipeline(
+        [
+            fun check_subscribe/2,
+            fun enrich_subscribe/2,
+            %% TODO && FIXME (EMQX-10786): mount topic before authz check.
+            fun check_sub_authzs/2,
+            fun check_sub_caps/2
+        ],
+        Operation,
+        Channel
+    ).
+
+-spec subscribe_operation(emqx_types:packet() | [subscribe_filter()]) ->
+    subscribe_operation().
+subscribe_operation(?SUBSCRIBE_PACKET(_PacketId, Properties, TopicFilters)) ->
+    #subscribe_operation{properties = Properties, topic_filters = TopicFilters};
+subscribe_operation(TopicFilters) when is_list(TopicFilters) ->
+    #subscribe_operation{topic_filters = TopicFilters}.
 
 -compile(
     {inline, [
@@ -1748,7 +1768,26 @@ handle_info({subscribe, TopicFilters}, Channel) ->
             maps:merge(basic_attrs(Channel), topic_attrs({subscribe, TopicFilters}))
         ),
         fun() ->
-            NTopicFilters = enrich_subscribe(TopicFilters, Channel),
+            Operation = subscribe_operation(TopicFilters),
+            case prepare_subscribe(Operation, Channel) of
+                {ok, NOperation, Channel1} ->
+                    {_TopicFiltersWithRC, Channel2} = post_process_subscribe(
+                        run_sub_hooks(NOperation, Channel1), Channel1
+                    ),
+                    {ok, Channel2};
+                {error, {disconnect, RC}, Channel1} ->
+                    handle_out(disconnect, RC, Channel1)
+            end
+        end,
+        []
+    );
+handle_info({force_subscribe, TopicFilters}, Channel) ->
+    ?EXT_TRACE_BROKER_SUBSCRIBE(
+        ?EXT_TRACE_ATTR(
+            maps:merge(basic_attrs(Channel), topic_attrs({subscribe, TopicFilters}))
+        ),
+        fun() ->
+            NTopicFilters = do_enrich_subscribe(#{}, TopicFilters, Channel),
             {_TopicFiltersWithRC, NChannel} = post_process_subscribe(NTopicFilters, Channel),
             {ok, NChannel}
         end,
@@ -2840,10 +2879,14 @@ check_pub_caps(
 %%--------------------------------------------------------------------
 %% Check Subscribe Packet
 
-check_subscribe(SubPkt, #channel{clientinfo = #{zone := Zone}}) ->
+check_subscribe(
+    #subscribe_operation{properties = Properties, topic_filters = TopicFilters},
+    #channel{clientinfo = #{zone := Zone}}
+) ->
     case
-        emqx_packet:check(
-            SubPkt,
+        emqx_packet:check_subscribe(
+            Properties,
+            TopicFilters,
             #{
                 subscription_message_filter => get_mqtt_conf(
                     Zone, subscription_message_filter, disable
@@ -2858,15 +2901,15 @@ check_subscribe(SubPkt, #channel{clientinfo = #{zone := Zone}}) ->
 %%--------------------------------------------------------------------
 %% Check Sub Authorization
 
-check_sub_authzs(Packet, Channel) ->
+check_sub_authzs(Operation, Channel) ->
     ?EXT_TRACE_CLIENT_AUTHZ(
         ?EXT_TRACE_ATTR((basic_attrs(Channel))#{'authz.action_type' => subscribe}),
-        fun(NPacket) -> _Res = do_check_sub_authzs(NPacket, Channel) end,
-        [Packet]
+        fun(NOperation) -> _Res = do_check_sub_authzs(NOperation, Channel) end,
+        [Operation]
     ).
 
 do_check_sub_authzs(
-    ?SUBSCRIBE_PACKET(PacketId, SubProps, TopicFilters0),
+    Operation = #subscribe_operation{topic_filters = TopicFilters0},
     Channel = #channel{clientinfo = ClientInfo}
 ) ->
     CheckResult = do_check_sub_authzs2(TopicFilters0, ClientInfo),
@@ -2889,10 +2932,10 @@ do_check_sub_authzs(
                 'authz.deny_action' => ignore
             }),
             ?EXT_TRACE_SET_STATUS_ERROR(),
-            {ok, ?SUBSCRIBE_PACKET(PacketId, SubProps, CheckResult), Channel};
+            {ok, Operation#subscribe_operation{topic_filters = CheckResult}, Channel};
         {false, _} ->
             ?EXT_TRACE_SET_STATUS_OK(),
-            {ok, ?SUBSCRIBE_PACKET(PacketId, SubProps, CheckResult), Channel}
+            {ok, Operation#subscribe_operation{topic_filters = CheckResult}, Channel}
     end.
 
 do_check_sub_authzs2(TopicFilters, ClientInfo) ->
@@ -2926,11 +2969,11 @@ do_check_sub_authzs2(ClientInfo, [TopicFilter = {Topic, _SubOpts} | More], Acc) 
 %% Check Sub Caps
 
 check_sub_caps(
-    ?SUBSCRIBE_PACKET(PacketId, SubProps, TopicFilters),
+    Operation = #subscribe_operation{topic_filters = TopicFilters},
     Channel = #channel{clientinfo = ClientInfo}
 ) ->
     CheckResult = do_check_sub_caps(ClientInfo, TopicFilters),
-    {ok, ?SUBSCRIBE_PACKET(PacketId, SubProps, CheckResult), Channel}.
+    {ok, Operation#subscribe_operation{topic_filters = CheckResult}, Channel}.
 
 do_check_sub_caps(ClientInfo, TopicFilters) ->
     do_check_sub_caps(ClientInfo, TopicFilters, []).
@@ -2971,7 +3014,7 @@ do_check_sub_caps(ClientInfo, [TopicFilter = {{_Topic, _SubOpts}, _OtherRC} | Mo
 %% Run Subscribe Hooks
 
 run_sub_hooks(
-    ?SUBSCRIBE_PACKET(_PacketId, Properties, TopicFilters0),
+    #subscribe_operation{properties = Properties, topic_filters = TopicFilters0},
     Channel = #channel{clientinfo = ClientInfo}
 ) ->
     TopicFilters = [
@@ -2983,13 +3026,12 @@ run_sub_hooks(
 %%--------------------------------------------------------------------
 %% Enrich SubOpts
 
-%% for api subscribe without sub-authz check and sub-caps check.
-enrich_subscribe(TopicFilters, Channel) when is_list(TopicFilters) ->
-    do_enrich_subscribe(#{}, TopicFilters, Channel);
-%% for mqtt clients sent subscribe packet.
-enrich_subscribe(?SUBSCRIBE_PACKET(PacketId, Properties, TopicFilters), Channel) ->
+enrich_subscribe(
+    Operation = #subscribe_operation{properties = Properties, topic_filters = TopicFilters},
+    Channel
+) ->
     NTopicFilters = do_enrich_subscribe(Properties, TopicFilters, Channel),
-    {ok, ?SUBSCRIBE_PACKET(PacketId, Properties, NTopicFilters), Channel}.
+    {ok, Operation#subscribe_operation{topic_filters = NTopicFilters}, Channel}.
 
 do_enrich_subscribe(Properties, TopicFilters, Channel) ->
     _NTopicFilters = emqx_utils:run_fold(

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -115,7 +115,7 @@
 -type subscribe_filter() ::
     {emqx_types:topic() | emqx_types:share(), emqx_types:subopts()}.
 -type subscribe_topic_filters() ::
-    [subscribe_filter()] | [{subscribe_filter(), emqx_types:reason_code()}].
+    [subscribe_filter() | {subscribe_filter(), emqx_types:reason_code()}].
 -record(subscribe_operation, {
     properties = #{} :: emqx_types:properties(),
     topic_filters = [] :: subscribe_topic_filters()
@@ -1768,15 +1768,24 @@ handle_info({subscribe, TopicFilters}, Channel) ->
             maps:merge(basic_attrs(Channel), topic_attrs({subscribe, TopicFilters}))
         ),
         fun() ->
-            Operation = subscribe_operation(TopicFilters),
-            case prepare_subscribe(Operation, Channel) of
-                {ok, NOperation, Channel1} ->
-                    {_TopicFiltersWithRC, Channel2} = post_process_subscribe(
-                        run_sub_hooks(NOperation, Channel1), Channel1
+            case emqx_security_profile:policy(internal_subscription_checks) of
+                true ->
+                    Operation = subscribe_operation(TopicFilters),
+                    case prepare_subscribe(Operation, Channel) of
+                        {ok, NOperation, Channel1} ->
+                            {_TopicFiltersWithRC, Channel2} = post_process_subscribe(
+                                run_sub_hooks(NOperation, Channel1), Channel1
+                            ),
+                            {ok, Channel2};
+                        {error, {disconnect, RC}, Channel1} ->
+                            handle_out(disconnect, RC, Channel1)
+                    end;
+                false ->
+                    NTopicFilters = do_enrich_subscribe(#{}, TopicFilters, Channel),
+                    {_TopicFiltersWithRC, NChannel} = post_process_subscribe(
+                        NTopicFilters, Channel
                     ),
-                    {ok, Channel2};
-                {error, {disconnect, RC}, Channel1} ->
-                    handle_out(disconnect, RC, Channel1)
+                    {ok, NChannel}
             end
         end,
         []

--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -30,7 +30,8 @@
 %% Check API
 -export([
     check/1,
-    check/2
+    check/2,
+    check_subscribe/3
 ]).
 
 -export([
@@ -279,21 +280,8 @@ check(#mqtt_packet{variable = #mqtt_packet_subscribe{} = SubPkt}, Opts) ->
     check(SubPkt, Opts);
 check(#mqtt_packet{variable = #mqtt_packet_unsubscribe{} = UnsubPkt}, Opts) ->
     check(UnsubPkt, Opts);
-check(#mqtt_packet_subscribe{properties = #{'Subscription-Identifier' := I}}, _Opts) when
-    I =< 0; I > 16#FFFFFFF
-->
-    {error, ?RC_SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED};
-check(#mqtt_packet_subscribe{topic_filters = []}, _Opts) ->
-    {error, ?RC_TOPIC_FILTER_INVALID};
-check(#mqtt_packet_subscribe{topic_filters = TopicFilters}, Opts) ->
-    try
-        validate_subscribe_topic_filters(TopicFilters, Opts)
-    catch
-        error:{error, RC} ->
-            {error, RC};
-        error:_Error ->
-            {error, ?RC_TOPIC_FILTER_INVALID}
-    end;
+check(#mqtt_packet_subscribe{properties = Properties, topic_filters = TopicFilters}, Opts) ->
+    check_subscribe(Properties, TopicFilters, Opts);
 check(#mqtt_packet_unsubscribe{topic_filters = []}, _Opts) ->
     {error, ?RC_TOPIC_FILTER_INVALID};
 check(#mqtt_packet_unsubscribe{topic_filters = TopicFilters}, Opts) ->
@@ -316,6 +304,28 @@ check(ConnPkt, Opts) when is_record(ConnPkt, mqtt_packet_connect) ->
         ConnPkt,
         Opts
     ).
+
+-spec check_subscribe(
+    emqx_types:properties(),
+    [{emqx_types:topic() | emqx_types:share(), emqx_types:subopts()}],
+    map()
+) ->
+    ok | {error, emqx_types:reason_code()}.
+check_subscribe(#{'Subscription-Identifier' := I}, _TopicFilters, _Opts) when
+    I =< 0; I > 16#FFFFFFF
+->
+    {error, ?RC_SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED};
+check_subscribe(_Properties, [], _Opts) ->
+    {error, ?RC_TOPIC_FILTER_INVALID};
+check_subscribe(_Properties, TopicFilters, Opts) ->
+    try
+        validate_subscribe_topic_filters(TopicFilters, Opts)
+    catch
+        error:{error, RC} ->
+            {error, RC};
+        error:_Error ->
+            {error, ?RC_TOPIC_FILTER_INVALID}
+    end.
 
 check_pub_props(#{'Topic-Alias' := 0}) ->
     {error, ?RC_TOPIC_ALIAS_INVALID};
@@ -431,6 +441,8 @@ run_checks([Check | More], Packet, Options) ->
 validate_subscribe_topic_filters(TopicFilters, Opts) ->
     lists:foreach(
         fun
+            ({#share{}, #{nl := 1}}) ->
+                error({error, ?RC_PROTOCOL_ERROR});
             %% Protocol Error and Should Disconnect
             %% MQTT-5.0 [MQTT-3.8.3-4] and [MQTT-4.13.1-1]
             ({TopicFilter, #{nl := 1}}) ->

--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -53,7 +53,8 @@ Returns policy depending on the current security profile.
     (access_control_hook_failure) -> ignore | interrupt;
     (outbound_tls_verify) -> verify_none | verify_peer;
     (authn_jwt_missing) -> ignore | deny;
-    (saml_signature_verification) -> boolean().
+    (saml_signature_verification) -> boolean();
+    (internal_subscription_checks) -> boolean().
 policy(mqtt_default_bind) ->
     case profile() of
         legacy -> any;
@@ -100,6 +101,11 @@ policy(authn_jwt_missing) ->
         hardened -> deny
     end;
 policy(saml_signature_verification) ->
+    case profile() of
+        legacy -> false;
+        hardened -> true
+    end;
+policy(internal_subscription_checks) ->
     case profile() of
         legacy -> false;
         hardened -> true

--- a/apps/emqx/src/emqx_topic.erl
+++ b/apps/emqx/src/emqx_topic.erl
@@ -6,6 +6,9 @@
 
 -include("emqx_mqtt.hrl").
 
+%% "$share" plus the two separators around the group name.
+-define(SHARE_FILTER_OVERHEAD, 8).
+
 %% APIs
 -export([
     match/2,
@@ -217,9 +220,18 @@ match_share(Name, #share{topic = Filter}) when is_binary(Name) ->
 match_any(Topic, Filters) ->
     lists:any(fun(Filter) -> match(Topic, Filter) end, Filters).
 
-%% TODO: validate share topic #share{} for emqx_trace.erl
 %% @doc Validate topic name or filter
--spec validate(topic() | {name | filter, topic()}) -> true.
+-spec validate(topic() | share() | {name | filter, topic()}) -> true.
+validate(#share{group = ShareName, topic = Filter}) when
+    byte_size(ShareName) + byte_size(Filter) + ?SHARE_FILTER_OVERHEAD > ?MAX_TOPIC_LEN
+->
+    error(topic_too_long);
+validate(#share{group = <<>>}) ->
+    error(?SHARE_EMPTY_GROUP);
+validate(#share{topic = <<>>}) ->
+    error(?SHARE_EMPTY_FILTER);
+validate(#share{group = ShareName, topic = Filter}) ->
+    validate_share(ShareName, Filter);
 validate(Topic) when is_binary(Topic) ->
     validate(filter, Topic);
 validate({Type, Topic}) when Type =:= name; Type =:= filter ->

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -24,20 +24,7 @@ all() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    %% CM Meck
-    ok = meck:new(emqx_cm, [passthrough, no_history, no_link]),
-    ok = meck:expect(emqx_cm, mark_channel_connected, fun(_) -> ok end),
-    ok = meck:expect(emqx_cm, mark_channel_disconnected, fun(_) -> ok end),
-    %% Broker Meck
-    ok = meck:new(emqx_broker, [passthrough, no_history, no_link]),
-    %% Session Meck
-    ok = meck:new(emqx_session, [passthrough, no_history, no_link]),
-    %% Ban
-    ok = meck:new(emqx_banned, [passthrough, no_history, no_link]),
-    ok = meck:expect(emqx_banned, check, fun(_ConnInfo) -> false end),
     %% Authz
-    ok = meck:new(emqx_access_control, [passthrough, no_history, no_link]),
-    ok = meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end),
     Apps = emqx_cth_suite:start(
         [
             {emqx, #{
@@ -66,21 +53,51 @@ init_per_suite(Config) ->
     [{suite_apps, Apps} | Config].
 
 end_per_suite(Config) ->
-    ok = emqx_cth_suite:stop(?config(suite_apps, Config)),
-    meck:unload([
-        emqx_session,
-        emqx_broker,
-        emqx_cm,
-        emqx_banned,
-        emqx_access_control
-    ]).
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
 
-init_per_testcase(_TestCase, TCConfig) ->
+init_per_testcase(TestCase, TCConfig) ->
+    case internal_subscribe_test_profile(TestCase) of
+        undefined -> ok;
+        Profile -> emqx_common_test_helpers:set_security_profile(Profile)
+    end,
+    %% Authz Meck
+    ok = meck:new(emqx_access_control, [passthrough, no_history, no_link]),
+    ok = meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end),
+    %% CM Meck
+    ok = meck:new(emqx_cm, [passthrough, no_history, no_link]),
+    ok = meck:expect(emqx_cm, mark_channel_connected, fun(_) -> ok end),
+    ok = meck:expect(emqx_cm, mark_channel_disconnected, fun(_) -> ok end),
+    %% Broker Meck
+    ok = meck:new(emqx_broker, [passthrough, no_history, no_link]),
+    %% Session Meck
+    ok = meck:new(emqx_session, [passthrough, no_history, no_link]),
+    %% Ban
+    ok = meck:new(emqx_banned, [passthrough, no_history, no_link]),
+    ok = meck:expect(emqx_banned, check, fun(_ConnInfo) -> false end),
     TCConfig.
 
 end_per_testcase(_TestCase, _TCConfig) ->
+    meck:unload([
+        emqx_access_control,
+        emqx_session,
+        emqx_broker,
+        emqx_cm,
+        emqx_banned
+    ]),
+    emqx_common_test_helpers:clear_security_profile(),
     emqx_common_test_helpers:call_janitor(),
     ok.
+
+internal_subscribe_test_profile(t_internal_subscribe_bypasses_checks_in_legacy) ->
+    "legacy";
+internal_subscribe_test_profile(t_internal_subscribe_checks_authz_and_runs_hook) ->
+    "hardened";
+internal_subscribe_test_profile(t_internal_subscribe_checks_caps) ->
+    "hardened";
+internal_subscribe_test_profile(t_handle_info_subscribe_honors_disconnect_deny_action) ->
+    "hardened";
+internal_subscribe_test_profile(_) ->
+    undefined.
 
 %%--------------------------------------------------------------------
 %% Test cases for channel info/stats/caps
@@ -890,9 +907,31 @@ t_handle_call_unexpected(_) ->
 %%--------------------------------------------------------------------
 
 t_handle_info_subscribe(_) ->
-    on_exit(fun() -> meck:delete(emqx_session, subscribe, 4) end),
     ok = meck:expect(emqx_session, subscribe, fun(_, _, _, Session) -> {ok, Session} end),
     {ok, _Chan} = emqx_channel:handle_info({subscribe, topic_filters()}, channel()).
+
+t_internal_subscribe_bypasses_checks_in_legacy(_) ->
+    TestPid = self(),
+    ok = meck:expect(emqx_access_control, authorize, fun(_, _, _) ->
+        TestPid ! authorization_checked,
+        deny
+    end),
+    ok = meck:expect(emqx_session, subscribe, fun(_, Topic, _, Session) ->
+        TestPid ! {subscribed, Topic},
+        {ok, Session}
+    end),
+    ok = emqx_hooks:add(
+        'client.subscribe', {?MODULE, on_client_subscribe, [TestPid]}, ?HP_HIGHEST
+    ),
+    on_exit(fun() ->
+        emqx_hooks:del('client.subscribe', {?MODULE, on_client_subscribe})
+    end),
+    {ok, _Channel} = emqx_channel:handle_info(
+        {subscribe, [{<<"legacy">>, ?DEFAULT_SUBOPTS}]}, channel()
+    ),
+    ?assertReceive({subscribed, <<"legacy">>}),
+    ?assertNotReceive(authorization_checked),
+    ?assertNotReceive({client_subscribe, _, _}).
 
 t_internal_subscribe_checks_authz_and_runs_hook(_) ->
     TestPid = self(),
@@ -904,7 +943,6 @@ t_internal_subscribe_checks_authz_and_runs_hook(_) ->
     AllowedShare = #share{group = <<"group">>, topic = AllowedSharedTopic},
     AllowedTopics = [AllowedTopic, AllowedShare],
     on_exit(fun() ->
-        meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end),
         emqx_hooks:del('client.subscribe', {?MODULE, on_client_subscribe})
     end),
     ok = meck:expect(emqx_access_control, authorize, fun
@@ -976,13 +1014,9 @@ t_handle_info_subscribe_honors_disconnect_deny_action(_) ->
     OldDenyAction = emqx:get_config([authorization, deny_action], ignore),
     {ok, _} = emqx:update_config([authorization, deny_action], disconnect),
     on_exit(fun() ->
-        {ok, _} = emqx:update_config([authorization, deny_action], OldDenyAction),
-        meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end)
+        {ok, _} = emqx:update_config([authorization, deny_action], OldDenyAction)
     end),
     ok = meck:expect(emqx_access_control, authorize, fun(_, _, _) -> deny end),
-    on_exit(fun() ->
-        meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end)
-    end),
     ?assertMatch(
         {ok, [{outgoing, ?DISCONNECT_PACKET(?RC_NOT_AUTHORIZED)}, {close, not_authorized}], _},
         emqx_channel:handle_info(
@@ -993,15 +1027,9 @@ t_handle_info_subscribe_honors_disconnect_deny_action(_) ->
 t_handle_info_force_subscribe_bypasses_checks_and_hooks(_) ->
     TestPid = self(),
     ok = meck:expect(emqx_access_control, authorize, fun(_, _, _) -> deny end),
-    on_exit(fun() ->
-        meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end)
-    end),
     ok = meck:expect(emqx_session, subscribe, fun(_, Topic, _, Session) ->
         TestPid ! {subscribed, Topic},
         {ok, Session}
-    end),
-    on_exit(fun() ->
-        meck:delete(emqx_session, subscribe, 4)
     end),
     ok = emqx_hooks:add(
         'client.subscribe', {?MODULE, on_client_subscribe, [TestPid]}, ?HP_HIGHEST

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -890,8 +890,130 @@ t_handle_call_unexpected(_) ->
 %%--------------------------------------------------------------------
 
 t_handle_info_subscribe(_) ->
+    on_exit(fun() -> meck:delete(emqx_session, subscribe, 4) end),
     ok = meck:expect(emqx_session, subscribe, fun(_, _, _, Session) -> {ok, Session} end),
     {ok, _Chan} = emqx_channel:handle_info({subscribe, topic_filters()}, channel()).
+
+t_internal_subscribe_checks_authz_and_runs_hook(_) ->
+    TestPid = self(),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    AllowedTopic = <<"regular/allowed">>,
+    DeniedTopic = <<"regular/denied">>,
+    AllowedSharedTopic = <<"shared/allowed">>,
+    DeniedSharedTopic = <<"shared/denied">>,
+    AllowedShare = #share{group = <<"group">>, topic = AllowedSharedTopic},
+    AllowedTopics = [AllowedTopic, AllowedShare],
+    on_exit(fun() ->
+        meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end),
+        emqx_hooks:del('client.subscribe', {?MODULE, on_client_subscribe})
+    end),
+    ok = meck:expect(emqx_access_control, authorize, fun
+        (_, _, Denied) when Denied =:= DeniedTopic; Denied =:= DeniedSharedTopic -> deny;
+        (_, _, _) -> allow
+    end),
+    ok = emqx_hooks:add(
+        'client.subscribe', {?MODULE, on_client_subscribe, [TestPid]}, ?HP_HIGHEST
+    ),
+    TopicFilters = [
+        {AllowedTopic, ?DEFAULT_SUBOPTS},
+        {DeniedTopic, ?DEFAULT_SUBOPTS},
+        {<<"$share/group/", AllowedSharedTopic/binary>>, ?DEFAULT_SUBOPTS},
+        {<<"$share/group/", DeniedSharedTopic/binary>>, ?DEFAULT_SUBOPTS}
+    ],
+    ListenerId = 'tcp:default',
+    ok = emqx_listeners:start_listener(ListenerId),
+    on_exit(fun() ->
+        emqx_listeners:stop_listener(ListenerId),
+        emqx_limiter:create_listener_limiters(ListenerId, #{})
+    end),
+    {ok, Client} = emqtt:start_link(#{clientid => ClientId}),
+    {ok, _} = emqtt:connect(Client),
+    [ChannelPid] = emqx_cm:lookup_channels(ClientId),
+    ChannelPid ! {subscribe, TopicFilters},
+    {client_subscribe, #{}, HookTopicFilters} = ?assertReceive(
+        {client_subscribe, #{}, _}, 1_000
+    ),
+    ok = snabbkaffe_diff:assert_lists_eq(
+        AllowedTopics,
+        [Topic || {Topic, _SubOpts} <- HookTopicFilters]
+    ),
+    snabbkaffe_diff:assert_lists_eq(
+        lists:sort(AllowedTopics),
+        channel_subscriptions(ChannelPid)
+    ),
+    emqtt:disconnect(Client).
+
+t_internal_subscribe_checks_caps(_) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    SimpleTopic = <<"simple">>,
+    WildcardTopic = <<"wildcard/#">>,
+    OldValue = emqx_config:get_zone_conf(default, [mqtt, wildcard_subscription]),
+    on_exit(fun() ->
+        emqx_config:put_zone_conf(default, [mqtt, wildcard_subscription], OldValue)
+    end),
+    emqx_config:put_zone_conf(default, [mqtt, wildcard_subscription], false),
+    ListenerId = 'tcp:default',
+    ok = emqx_listeners:start_listener(ListenerId),
+    on_exit(fun() ->
+        emqx_listeners:stop_listener(ListenerId),
+        emqx_limiter:create_listener_limiters(ListenerId, #{})
+    end),
+    {ok, Client} = emqtt:start_link(#{clientid => ClientId}),
+    {ok, _} = emqtt:connect(Client),
+    [ChannelPid] = emqx_cm:lookup_channels(ClientId),
+    ChannelPid !
+        {subscribe, [
+            {SimpleTopic, ?DEFAULT_SUBOPTS},
+            {WildcardTopic, ?DEFAULT_SUBOPTS}
+        ]},
+    snabbkaffe_diff:assert_lists_eq(
+        [SimpleTopic],
+        channel_subscriptions(ChannelPid)
+    ),
+    emqtt:disconnect(Client).
+
+t_handle_info_subscribe_honors_disconnect_deny_action(_) ->
+    OldDenyAction = emqx:get_config([authorization, deny_action], ignore),
+    {ok, _} = emqx:update_config([authorization, deny_action], disconnect),
+    on_exit(fun() ->
+        {ok, _} = emqx:update_config([authorization, deny_action], OldDenyAction),
+        meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end)
+    end),
+    ok = meck:expect(emqx_access_control, authorize, fun(_, _, _) -> deny end),
+    on_exit(fun() ->
+        meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end)
+    end),
+    ?assertMatch(
+        {ok, [{outgoing, ?DISCONNECT_PACKET(?RC_NOT_AUTHORIZED)}, {close, not_authorized}], _},
+        emqx_channel:handle_info(
+            {subscribe, [{<<"deny">>, ?DEFAULT_SUBOPTS}]}, channel()
+        )
+    ).
+
+t_handle_info_force_subscribe_bypasses_checks_and_hooks(_) ->
+    TestPid = self(),
+    ok = meck:expect(emqx_access_control, authorize, fun(_, _, _) -> deny end),
+    on_exit(fun() ->
+        meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end)
+    end),
+    ok = meck:expect(emqx_session, subscribe, fun(_, Topic, _, Session) ->
+        TestPid ! {subscribed, Topic},
+        {ok, Session}
+    end),
+    on_exit(fun() ->
+        meck:delete(emqx_session, subscribe, 4)
+    end),
+    ok = emqx_hooks:add(
+        'client.subscribe', {?MODULE, on_client_subscribe, [TestPid]}, ?HP_HIGHEST
+    ),
+    on_exit(fun() ->
+        emqx_hooks:del('client.subscribe', {?MODULE, on_client_subscribe})
+    end),
+    {ok, _Channel} = emqx_channel:handle_info(
+        {force_subscribe, [{<<"forced">>, ?DEFAULT_SUBOPTS}]}, channel()
+    ),
+    ?assertReceive({subscribed, <<"forced">>}),
+    ?assertNotReceive({client_subscribe, _, _}).
 
 t_handle_info_unsubscribe(_) ->
     ok = meck:expect(emqx_session, unsubscribe, fun(_, _, _, Session) -> {ok, Session} end),
@@ -1093,12 +1215,9 @@ t_check_sub_authzs(_) ->
     emqx_config:put_zone_conf(default, [authorization, enable], true),
     TopicFilter = {<<"t">>, ?DEFAULT_SUBOPTS},
     SubPkt = ?SUBSCRIBE_PACKET(1, #{}, [TopicFilter]),
-    CheckedSubPkt = ?SUBSCRIBE_PACKET(1, #{}, [{TopicFilter, ?RC_SUCCESS}]),
+    Operation = emqx_channel:subscribe_operation(SubPkt),
     Channel = channel(),
-    ?assertEqual(
-        {ok, CheckedSubPkt, Channel},
-        emqx_channel:check_sub_authzs(SubPkt, Channel)
-    ).
+    ?assertMatch({ok, _, Channel}, emqx_channel:check_sub_authzs(Operation, Channel)).
 
 t_parse_raw_topic_filters_subscription_filter_enabled(_) ->
     OldMode = emqx_config:get_zone_conf(default, [mqtt, subscription_message_filter], disable),
@@ -1470,3 +1589,11 @@ v4(Channel) ->
 authenticate_continue(Credential, _DefaultRes, TestRunnerPid, Agent) ->
     TestRunnerPid ! {authenticate, Credential},
     emqx_utils_agent:get(Agent).
+
+on_client_subscribe(_ClientInfo, Properties, TopicFilters, TestPid) ->
+    TestPid ! {client_subscribe, Properties, TopicFilters},
+    {ok, TopicFilters}.
+
+channel_subscriptions(ChannelPid) ->
+    #{session := #{subscriptions := Subscriptions}} = emqx_connection:info(ChannelPid),
+    lists:sort(maps:keys(Subscriptions)).

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -48,6 +48,7 @@ t_legacy(_) ->
     ?assertEqual(verify_none, emqx_security_profile:policy(outbound_tls_verify)),
     ?assertEqual(ignore, emqx_security_profile:policy(authn_jwt_missing)),
     ?assertEqual(false, emqx_security_profile:policy(saml_signature_verification)),
+    ?assertEqual(false, emqx_security_profile:policy(internal_subscription_checks)),
 
     %% Full defaults
     ?assertEqual({{0, 0, 0, 0}, 1883}, emqx:get_config([listeners, tcp, default, bind])),
@@ -89,6 +90,7 @@ t_hardened(_) ->
     ?assertEqual(verify_peer, emqx_security_profile:policy(outbound_tls_verify)),
     ?assertEqual(deny, emqx_security_profile:policy(authn_jwt_missing)),
     ?assertEqual(true, emqx_security_profile:policy(saml_signature_verification)),
+    ?assertEqual(true, emqx_security_profile:policy(internal_subscription_checks)),
 
     %% Full defaults are secure in hardened profile
     ?assertEqual({{127, 0, 0, 1}, 1883}, emqx:get_config([listeners, tcp, default, bind])),

--- a/apps/emqx/test/emqx_topic_SUITE.erl
+++ b/apps/emqx/test/emqx_topic_SUITE.erl
@@ -237,7 +237,12 @@ t_validate(_) ->
     ?assertError(?SHARE_NAME_INVALID_CHAR, validate({filter, <<"$share/#y/1">>})),
     %% share recursively
     ?assertError(?SHARE_RECURSIVELY, validate({filter, <<"$share/g1/$share/t">>})),
-    true = validate({filter, <<"$share/g1/topic/$share">>}).
+    true = validate({filter, <<"$share/g1/topic/$share">>}),
+
+    true = validate(#share{group = <<"g1">>, topic = <<"topic/$share">>}),
+    ?assertError(?SHARE_EMPTY_GROUP, validate(#share{group = <<>>, topic = <<"t">>})),
+    ?assertError(?SHARE_EMPTY_FILTER, validate(#share{group = <<"g">>, topic = <<>>})),
+    ?assertError(topic_too_long, validate(#share{group = <<"g">>, topic = long_topic()})).
 
 t_sigle_level_validate(_) ->
     true = validate({filter, <<"+">>}),

--- a/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
+++ b/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
@@ -96,6 +96,12 @@ init_per_testcase(t_get_basic_usage_info, Config) ->
 init_per_testcase(t_auto_subscribe_reload_from_file, Config) ->
     {ok, _} = emqx_auto_subscribe:update([]),
     Config;
+init_per_testcase(TestCase, Config) when
+    TestCase =:= t_auto_subscribe_respects_authorization;
+    TestCase =:= t_auto_subscribe_shared_topic
+->
+    emqx_common_test_helpers:set_security_profile("hardened"),
+    Config;
 init_per_testcase(_TestCase, Config) ->
     Config.
 
@@ -105,6 +111,13 @@ end_per_testcase(t_get_basic_usage_info, _Config) ->
     ok;
 end_per_testcase(t_auto_subscribe_reload_from_file, _Config) ->
     {ok, _} = emqx_auto_subscribe:update([]),
+    emqx_common_test_helpers:call_janitor(),
+    ok;
+end_per_testcase(TestCase, _Config) when
+    TestCase =:= t_auto_subscribe_respects_authorization;
+    TestCase =:= t_auto_subscribe_shared_topic
+->
+    emqx_common_test_helpers:clear_security_profile(),
     emqx_common_test_helpers:call_janitor(),
     ok;
 end_per_testcase(_TestCase, _Config) ->

--- a/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
+++ b/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
@@ -6,9 +6,12 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+-include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx/include/asserts.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -import(emqx_config_SUITE, [prepare_conf_file/3]).
+-import(emqx_common_test_helpers, [on_exit/1]).
 
 -define(TOPIC_C, <<"/c/${clientid}">>).
 -define(TOPIC_U, <<"/u/${username}">>).
@@ -46,34 +49,35 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, update, fun(_, _, _, _) -> {ok, meck_data} end),
     meck:expect(emqx_resource, remove, fun(_) -> ok end),
 
-    ASCfg = <<
-        "auto_subscribe {\n"
-        "            topics = [\n"
-        "                {\n"
-        "                    topic = \"/c/${clientid}\"\n"
-        "                },\n"
-        "                {\n"
-        "                    topic = \"/u/${username}\"\n"
-        "                },\n"
-        "                {\n"
-        "                    topic = \"/h/${host}\"\n"
-        "                },\n"
-        "                {\n"
-        "                    topic = \"/p/${port}\"\n"
-        "                },\n"
-        "                {\n"
-        "                    topic = \"/client/${clientid}/username/${username}/host/${host}/port/${port}\"\n"
-        "                },\n"
-        "                {\n"
-        "                    topic = \"/topic/simple\"\n"
-        "                    qos   = 1\n"
-        "                    rh    = 0\n"
-        "                    rap   = 0\n"
-        "                    nl    = 0\n"
-        "                }\n"
-        "            ]\n"
-        "        }"
-    >>,
+    ASCfg =
+        ~b"""
+    auto_subscribe {
+        topics = [
+            {
+                topic = "/c/${clientid}"
+            },
+            {
+                topic = "/u/${username}"
+            },
+            {
+                topic = "/h/${host}"
+            },
+            {
+                topic = "/p/${port}"
+            },
+            {
+                topic = "/client/${clientid}/username/${username}/host/${host}/port/${port}"
+            },
+            {
+                topic = "/topic/simple"
+                qos   = 1
+                rh    = 0
+                rap   = 0
+                nl    = 0
+            }
+        ]
+    }
+    """,
     Apps = emqx_cth_suite:start(
         [
             emqx,
@@ -97,11 +101,14 @@ init_per_testcase(_TestCase, Config) ->
 
 end_per_testcase(t_get_basic_usage_info, _Config) ->
     {ok, _} = emqx_auto_subscribe:update([]),
+    emqx_common_test_helpers:call_janitor(),
     ok;
 end_per_testcase(t_auto_subscribe_reload_from_file, _Config) ->
     {ok, _} = emqx_auto_subscribe:update([]),
+    emqx_common_test_helpers:call_janitor(),
     ok;
 end_per_testcase(_TestCase, _Config) ->
+    emqx_common_test_helpers:call_janitor(),
     ok.
 
 topic_config(T) ->
@@ -126,6 +133,41 @@ t_auto_subscribe(_) ->
     ?assertEqual(check_subs(length(?TOPICS)), ok),
     emqtt:disconnect(Client),
     ok.
+
+t_auto_subscribe_respects_authorization(_) ->
+    TestPid = self(),
+    TopicTemplate = <<"/denied/${clientid}">>,
+    DeniedTopic = <<"/denied/auto_sub_c">>,
+    {ok, _} = emqx_auto_subscribe:update([#{<<"topic">> => TopicTemplate}]),
+    on_exit(fun() -> {ok, _} = emqx_auto_subscribe:update([]) end),
+    ok = meck:new(emqx_access_control, [passthrough, no_history, no_link]),
+    ok = meck:expect(emqx_access_control, authorize, fun
+        (_ClientInfo, #{action_type := subscribe}, Topic) when Topic =:= DeniedTopic ->
+            TestPid ! authorization_checked,
+            deny;
+        (ClientInfo, Action, Topic) ->
+            meck:passthrough([ClientInfo, Action, Topic])
+    end),
+    on_exit(fun() -> meck:unload(emqx_access_control) end),
+    {ok, Client} = emqtt:start_link(#{username => ?CLIENT_USERNAME, clientid => ?CLIENT_ID}),
+    {ok, _} = emqtt:connect(Client),
+    ?assertReceive(authorization_checked, 1_000),
+    snabbkaffe_diff:assert_lists_eq([], client_subscriptions(?CLIENT_ID)),
+    emqtt:disconnect(Client).
+
+t_auto_subscribe_shared_topic(_) ->
+    Topic = <<"$share/group/auto/${clientid}">>,
+    RenderedTopic = <<"auto/auto_sub_c">>,
+    {ok, _} = emqx_auto_subscribe:update([#{<<"topic">> => Topic}]),
+    on_exit(fun() -> {ok, _} = emqx_auto_subscribe:update([]) end),
+    {ok, Client} = emqtt:start_link(#{username => ?CLIENT_USERNAME, clientid => ?CLIENT_ID}),
+    {ok, _} = emqtt:connect(Client),
+    snabbkaffe_diff:assert_lists_eq(
+        [#share{group = <<"group">>, topic = RenderedTopic}],
+        client_subscriptions(?CLIENT_ID)
+    ),
+    emqtt:disconnect(Client).
+
 t_auto_subscribe_reload_from_file(Config) ->
     ConfBin = hocon_pp:do(
         #{<<"auto_subscribe">> => #{<<"topics">> => [#{<<"topic">> => Topic} || Topic <- ?TOPICS]}},
@@ -199,6 +241,11 @@ t_get_basic_usage_info(_Config) ->
     {ok, _} = emqx_auto_subscribe:update(AutoSubscribeTopics),
     ?assertEqual(#{auto_subscribe_count => 3}, emqx_auto_subscribe:get_basic_usage_info()),
     ok.
+
+client_subscriptions(ClientId) ->
+    [ChannelPid] = emqx_cm:lookup_channels(ClientId),
+    #{session := #{subscriptions := Subscriptions}} = emqx_connection:info(ChannelPid),
+    maps:keys(Subscriptions).
 
 check_subs(Count) ->
     Subs = ets:tab2list(emqx_suboption),

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -615,7 +615,8 @@ do_subscribe(ClientId, TopicTables) ->
             %% Hand the subscription straight to the channel process.
             %% No emqx_access_control:authorize/3 call is made on this path -- the
             %% ACL bypass is intentional; see -doc on subscribe/2.
-            Pid ! {subscribe, TopicTables}
+            Pid ! {force_subscribe, TopicTables},
+            {subscribe, TopicTables}
     end.
 
 publish(Message) ->

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -453,7 +453,7 @@ subscriptions(["add", ClientId, Topic, QoS]) ->
                 emqx_ctl:print("Error: Channel not found!");
             [{_, Pid}] ->
                 {Topic1, Options} = emqx_topic:parse(bin(Topic)),
-                Pid ! {subscribe, [{Topic1, Options#{qos => IntQos}}]},
+                Pid ! {force_subscribe, [{Topic1, Options#{qos => IntQos}}]},
                 emqx_ctl:print("ok~n")
         end
     end);

--- a/changes/ee/feat-17980.en.md
+++ b/changes/ee/feat-17980.en.md
@@ -1,0 +1,1 @@
+In the hardened security profile, respect topic validation, authorization, MQTT capability checks, and client subscribe hooks for internal subscriptions.


### PR DESCRIPTION
Release version: 6.2.3, 6.3

Fixes emqx/emqx-dev-team-tasks#283

## Summary

Route server-initiated subscriptions through the same topic validation, authorization,
MQTT capability, and `client.subscribe` hook pipeline as client-issued SUBSCRIBE packets.

Keep REST and CLI force-subscribe operations bypass unchanged. 

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
