### PR TITLE
test(cm): de-flake clientid registration throttle tests

### DIFF
--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -894,6 +894,8 @@ clean_down([Pid | Pids]) ->
     ok = clean_down(Pid),
     clean_down(Pids);
 clean_down(Pid) when is_pid(Pid) ->
+    %% test-only trace point (compiles to a no-op in prod builds)
+    ?tp(emqx_cm_clean_down_start, #{pid => Pid}),
     try ets:lookup_element(?CHAN_CONN_TAB, Pid, #chan_conn.clientid) of
         ClientId ->
             do_clean_down(ClientId, Pid)

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -505,14 +505,7 @@ t_clientid_registration_throttled(_) ->
         username => <<"username">>,
         peerhost => {127, 0, 0, 1}
     },
-    {DeadPid, MRef} = spawn_monitor(fun() -> exit(normal) end),
-    ChanInfo = ?ChanInfo,
-    #{conninfo := ConnInfo} = ChanInfo,
-    ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
-    ok = emqx_cm:register_channel(ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}),
-    ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
-    true = emqx_cm:do_unregister_channel({ClientId, DeadPid}),
-    ok.
+    assert_open_session_throttled(ClientId, ClientInfo).
 
 %% Stale registry rows can survive a partition + autoheal (the unregister
 %% dirty_delete was on the loser side and got thrown away). When a kick or
@@ -566,14 +559,7 @@ t_open_session_throttled_on_inflight_local_cleanup(_) ->
         username => <<"username">>,
         peerhost => {127, 0, 0, 1}
     },
-    {DeadPid, MRef} = spawn_monitor(fun() -> exit(normal) end),
-    ChanInfo = ?ChanInfo,
-    #{conninfo := ConnInfo} = ChanInfo,
-    ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
-    ok = emqx_cm:register_channel(ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}),
-    ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
-    %% Idempotent cleanup in case cm pool didn't get there first.
-    true = emqx_cm:do_unregister_channel({ClientId, DeadPid}).
+    assert_open_session_throttled(ClientId, ClientInfo).
 
 %% A stale local tombstone (registry row pointing at a dead pid that this
 %% node never registered) used to block the same clientid on this node
@@ -602,6 +588,45 @@ t_open_session_reaps_local_tombstone(_) ->
     %% process is the only remaining row.
     ?assertEqual([self()], emqx_cm_registry:lookup_all_channels(ClientId)),
     ok = emqx_cm:unregister_channel(ClientId).
+
+%% Drive the production registration path (emqx_cm:register_channel/3) for a
+%% channel whose process has already exited, then assert open_session throttles
+%% the reconnect with client_id_unavailable.
+%%
+%% register_channel/3 casts {registered, Pid}, which makes emqx_cm monitor the
+%% (already dead) pid. That fires a DOWN immediately and emqx_cm asynchronously
+%% submits clean_down/1, which deletes the chan-conn row the throttle keys on.
+%% Whether the throttle fires therefore races that async cleanup. force_ordering
+%% holds clean_down (at the emqx_cm_clean_down_start trace point, before the row
+%% is deleted) until the assertion has run, so open_session deterministically
+%% observes the transient "pid dead, row still present" state. We then release
+%% the cleanup, wait for it to complete, and confirm the row is reaped.
+assert_open_session_throttled(ClientId, ClientInfo) ->
+    ?check_trace(
+        begin
+            #{conninfo := ConnInfo} = ChanInfo = ?ChanInfo,
+            {DeadPid, MRef} = spawn_monitor(fun() -> exit(normal) end),
+            ?assertReceive({'DOWN', MRef, process, DeadPid, _}),
+            ?force_ordering(
+                #{?snk_kind := open_session_throttle_asserted},
+                #{?snk_kind := emqx_cm_clean_down_start, pid := DeadPid}
+            ),
+            ok = emqx_cm:register_channel(
+                ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}
+            ),
+            ?assertEqual(
+                {error, client_id_unavailable},
+                open_session(true, ClientInfo, ConnInfo)
+            ),
+            ?tp(open_session_throttle_asserted, #{}),
+            {ok, _} = ?block_until(
+                #{?snk_kind := emqx_cm_clean_down, client_id := ClientId}
+            ),
+            ?assertEqual([], emqx_cm:lookup_channels(ClientId)),
+            ok
+        end,
+        []
+    ).
 
 spawn_dummy_chann(Mod, Count) ->
     #{conninfo := ConnInfo0} = ?ChanInfo,


### PR DESCRIPTION
Release versions: 5.8.9

## Summary

`emqx_cm_SUITE:t_clientid_registration_throttled` and its sibling
`t_open_session_throttled_on_inflight_local_cleanup` register a channel for
an already-dead pid via `emqx_cm:register_channel/3`, then assert that
`open_session` throttles the reconnect with `client_id_unavailable`.

`register_channel/3` casts `{registered, Pid}`, which makes `emqx_cm`
monitor the pid. Since it is already dead, the monitor fires a `DOWN`
immediately and `emqx_cm` asynchronously submits `clean_down/1`, which
deletes the `?CHAN_CONN_TAB` row the throttle keys on. Whether the throttle
fired therefore raced that async cleanup — `open_session` wins →
`client_id_unavailable` (pass); `clean_down` wins → fresh session
(`{ok, ...}`, the flake).

Rather than bypassing the production registration path in the test, this
keeps exercising it and makes the transient window deterministic:

- add an `emqx_cm_clean_down_start` trace point at the start of
  `clean_down/1`, before the row is deleted;
- in the test, use snabbkaffe `?force_ordering` to hold `clean_down` until
  the throttle assertion has run, so `open_session` deterministically
  observes the "pid dead, row still present" state;
- then release the cleanup, `?block_until` it completes, and confirm the
  row is reaped.

Both cases now share a single `assert_open_session_throttled` helper.
Verified with 30 consecutive runs of each case (60/60 pass).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)