### PR TITLE
fix(listeners): skip zone updates while listeners are stopped

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -616,6 +616,12 @@ post_config_update(_Path, _Request, _NewConf, _OldConf, _AppEnvs) ->
     ok.
 
 post_zone_config_update(OldZones, NewZones) ->
+    ListenersRunning = emqx:is_running() andalso emqx_boot:is_enabled(listeners),
+    do_post_zone_config_update(ListenersRunning, OldZones, NewZones).
+
+do_post_zone_config_update(false, _OldZones, _NewZones) ->
+    ok;
+do_post_zone_config_update(true, OldZones, NewZones) ->
     Zones0 = maps:keys(OldZones),
     case find_zones_with_relevant_changes(Zones0, OldZones, NewZones, []) of
         [] ->

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -617,24 +617,23 @@ post_config_update(_Path, _Request, _NewConf, _OldConf, _AppEnvs) ->
 
 post_zone_config_update(OldZones, NewZones) ->
     %% Cluster config may update zones before listener dependencies start; skip runtime refreshes.
-    ListenersRunning = emqx:is_running() andalso emqx_boot:is_enabled(listeners),
-    do_post_zone_config_update(ListenersRunning, OldZones, NewZones).
-
-do_post_zone_config_update(false, _OldZones, _NewZones) ->
-    ok;
-do_post_zone_config_update(true, OldZones, NewZones) ->
-    Zones0 = maps:keys(OldZones),
-    case find_zones_with_relevant_changes(Zones0, OldZones, NewZones, []) of
-        [] ->
+    case emqx:is_running() andalso emqx_boot:is_enabled(listeners) of
+        false ->
             ok;
-        Zones ->
-            Listeners = emqx_config:get([listeners], #{}),
-            maps:foreach(
-                fun(Type, NameConfig) ->
-                    update_listeners_in_zones(Type, NameConfig, Zones)
-                end,
-                Listeners
-            )
+        true ->
+            Zones0 = maps:keys(OldZones),
+            case find_zones_with_relevant_changes(Zones0, OldZones, NewZones, []) of
+                [] ->
+                    ok;
+                Zones ->
+                    Listeners = emqx_config:get([listeners], #{}),
+                    maps:foreach(
+                        fun(Type, NameConfig) ->
+                            update_listeners_in_zones(Type, NameConfig, Zones)
+                        end,
+                        Listeners
+                    )
+            end
     end.
 
 find_zones_with_relevant_changes([], _OldZones, _NewZones, Acc) ->

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -616,6 +616,7 @@ post_config_update(_Path, _Request, _NewConf, _OldConf, _AppEnvs) ->
     ok.
 
 post_zone_config_update(OldZones, NewZones) ->
+    %% Cluster config may update zones before listener dependencies start; skip runtime refreshes.
     ListenersRunning = emqx:is_running() andalso emqx_boot:is_enabled(listeners),
     do_post_zone_config_update(ListenersRunning, OldZones, NewZones).
 

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -621,19 +621,22 @@ post_zone_config_update(OldZones, NewZones) ->
         false ->
             ok;
         true ->
-            Zones0 = maps:keys(OldZones),
-            case find_zones_with_relevant_changes(Zones0, OldZones, NewZones, []) of
-                [] ->
-                    ok;
-                Zones ->
-                    Listeners = emqx_config:get([listeners], #{}),
-                    maps:foreach(
-                        fun(Type, NameConfig) ->
-                            update_listeners_in_zones(Type, NameConfig, Zones)
-                        end,
-                        Listeners
-                    )
-            end
+            do_post_zone_config_update(true, OldZones, NewZones)
+    end.
+
+do_post_zone_config_update(true, OldZones, NewZones) ->
+    Zones0 = maps:keys(OldZones),
+    case find_zones_with_relevant_changes(Zones0, OldZones, NewZones, []) of
+        [] ->
+            ok;
+        Zones ->
+            Listeners = emqx_config:get([listeners], #{}),
+            maps:foreach(
+                fun(Type, NameConfig) ->
+                    update_listeners_in_zones(Type, NameConfig, Zones)
+                end,
+                Listeners
+            )
     end.
 
 find_zones_with_relevant_changes([], _OldZones, _NewZones, Acc) ->

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -887,6 +887,21 @@ test_max_packet_size_update() ->
     ?assertNotReceive({update, _, default, _}, 200),
     %% restore the original value
     emqx_config:put_zone_conf(default, KeyPath, MaxPacketSize),
+    ?assertReceive({update, Type, default, _} when Type =:= tcp orelse Type =:= ssl, 1000),
+    ?assertReceive({update, Type, default, _} when Type =:= tcp orelse Type =:= ssl, 1000),
+    %% Zone updates must not touch listeners when listener boot is disabled.
+    BootModules = application:get_env(emqx, boot_modules),
+    try
+        ok = application:set_env(emqx, boot_modules, [broker]),
+        emqx_config:put_zone_conf(default, KeyPath, MaxPacketSize + 1),
+        ?assertNotReceive({update, _, default, _}, 200)
+    after
+        emqx_config:put_zone_conf(default, KeyPath, MaxPacketSize),
+        case BootModules of
+            {ok, Value} -> application:set_env(emqx, boot_modules, Value);
+            undefined -> application:unset_env(emqx, boot_modules)
+        end
+    end,
     ok.
 
 t_symlink_certs(Config) ->

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -186,6 +186,51 @@ t_sync_data_from_node_with_bad_symlinks(Config) ->
         stop_cluster(Nodes)
     end.
 
+t_init_load_with_changed_max_packet_size_before_listeners_start(Config) ->
+    [NodeSpec] = cluster(?FUNCTION_NAME, [cluster_spec(15)], Config),
+    [Node] = start_cluster([NodeSpec]),
+    try
+        ?ON(Node, begin
+            MaxPacketSizePath = [mqtt, max_packet_size],
+            MaxPacketSize0 = emqx_config:get_zone_conf(default, MaxPacketSizePath),
+            ?assertNotEqual(4194304, MaxPacketSize0),
+
+            RawConf0 = emqx_config_handler:get_raw_cluster_override_conf(),
+            RawConf1 = emqx_utils_maps:deep_put(
+                [<<"mqtt">>, <<"max_packet_size">>],
+                RawConf0,
+                <<"4MB">>
+            ),
+            RawConf2 = emqx_utils_maps:deep_put(
+                [<<"node">>, <<"cookie">>],
+                RawConf1,
+                atom_to_binary(erlang:get_cookie())
+            ),
+            RawConf = emqx_utils_maps:deep_put(
+                [<<"node">>, <<"data_dir">>],
+                RawConf2,
+                unicode:characters_to_binary(emqx:data_dir())
+            ),
+            ok = emqx_config:save_to_override_conf(
+                emqx_config:has_deprecated_file(),
+                RawConf,
+                #{override_to => cluster}
+            ),
+            ?assertEqual(MaxPacketSize0, emqx_config:get_zone_conf(default, MaxPacketSizePath)),
+
+            ok = application:stop(emqx),
+            ok = application:stop(esockd),
+            ok = emqx_config:init_load(emqx_conf:schema_module()),
+            ?assertEqual(4194304, emqx_config:get_zone_conf(default, MaxPacketSizePath)),
+
+            {ok, _} = application:ensure_all_started(emqx),
+            ?assert(emqx:is_running()),
+            ok
+        end)
+    after
+        stop_cluster([Node])
+    end.
+
 %%------------------------------------------------------------------------------
 %% Helper functions
 %%------------------------------------------------------------------------------

--- a/changes/ee/fix-17995.en.md
+++ b/changes/ee/fix-17995.en.md
@@ -1,0 +1,1 @@
+Fixed an issue that could terminate a node while it joined a cluster whose persisted `mqtt.max_packet_size` differed from its local configuration. EMQX now skips listener refresh side effects before listener startup and creates the listeners from the synchronized configuration when the EMQX application starts.


### PR DESCRIPTION
Release version: 6.0.4

Fixes #17992

## Summary

Skip listener refresh side effects from global zone changes until the EMQX application is running and listener boot is enabled. This prevents `emqx_conf` initialization during cluster join from calling `esockd` before `esockd_sup` starts; listeners are later created directly from the synchronized configuration.

Keep runtime zone updates unchanged after listeners start. Add regression coverage for configuration loading before listener startup and for nodes where listener boot is disabled.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)