### PR TITLE
feat(dashboard): add collapsible endpoints to API spec explorer

### DIFF
--- a/apps/emqx_dashboard/priv/api-spec.html
+++ b/apps/emqx_dashboard/priv/api-spec.html
@@ -432,6 +432,19 @@
       letter-spacing: 0.25px;
     }
 
+    .panel-actions {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 6px;
+    }
+
+    .panel-actions .btn {
+      height: 28px;
+      padding: 0 9px;
+      font-size: 12px;
+    }
+
     .panel-hd-toggle {
       cursor: pointer;
       user-select: none;
@@ -579,14 +592,56 @@
       background: rgba(255, 255, 255, 0.02);
     }
 
+    .endpoint-list {
+      display: grid;
+      gap: 8px;
+    }
+
     .endpoint-hd {
       display: grid;
-      grid-template-columns: auto 1fr auto;
+      grid-template-columns: auto minmax(0, 1fr) minmax(0, 300px) auto;
       align-items: center;
       gap: 10px;
       padding: 10px;
-      border-bottom: 1px solid var(--color-border-primary);
       background: rgba(255, 255, 255, 0.03);
+      cursor: pointer;
+      list-style: none;
+      user-select: none;
+    }
+
+    .endpoint-hd::-webkit-details-marker {
+      display: none;
+    }
+
+    .endpoint-hd::marker {
+      content: "";
+    }
+
+    .endpoint-hd::after {
+      content: "\203A";
+      grid-column: 4;
+      grid-row: 1;
+      color: var(--color-text-secondary);
+      font-size: 20px;
+      line-height: 1;
+      transition: transform 0.15s ease;
+    }
+
+    .endpoint-hd:hover {
+      background: rgba(94, 123, 255, 0.08);
+    }
+
+    .endpoint-hd:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: -2px;
+    }
+
+    .endpoint-card[open] > .endpoint-hd {
+      border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    .endpoint-card[open] > .endpoint-hd::after {
+      transform: rotate(90deg);
     }
 
     .endpoint-hd .title {
@@ -1009,9 +1064,16 @@
         grid-template-columns: 1fr;
       }
 
-      .op-row,
-      .endpoint-hd {
+      .op-row {
         grid-template-columns: auto 1fr;
+      }
+
+      .endpoint-hd {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+      }
+
+      .endpoint-hd::after {
+        grid-column: 3;
       }
 
       .op-row .summary,
@@ -1589,7 +1651,9 @@
 
     function renderEndpointsPanel(paths) {
       const panel = panelEl('Endpoints');
+      const hd = panel.querySelector('.panel-hd');
       const bd = panel.querySelector('.panel-bd');
+      bd.classList.add('endpoint-list');
 
       const methodOrder = ['get', 'post', 'put', 'delete', 'patch', 'options', 'head'];
       const cards = [];
@@ -1615,11 +1679,30 @@
       }
 
       for (const c of cards) bd.appendChild(c);
+
+      const actions = document.createElement('div');
+      actions.className = 'panel-actions';
+      actions.innerHTML = `
+        <button type="button" class="btn" data-action="expand-all">Expand All</button>
+        <button type="button" class="btn" data-action="collapse-all">Collapse All</button>
+      `;
+      actions.querySelector('[data-action="expand-all"]').addEventListener('click', () => {
+        bd.querySelectorAll('.endpoint-card').forEach((card) => {
+          card.open = true;
+        });
+      });
+      actions.querySelector('[data-action="collapse-all"]').addEventListener('click', () => {
+        bd.querySelectorAll('.endpoint-card').forEach((card) => {
+          card.open = false;
+        });
+      });
+      hd.appendChild(actions);
+
       return panel;
     }
 
     function endpointCard(path, method, op) {
-      const card = document.createElement('article');
+      const card = document.createElement('details');
       card.className = 'endpoint-card';
 
       const m = method.toLowerCase();
@@ -1632,11 +1715,11 @@
       const respCodes = Object.keys(responses).sort();
 
       card.innerHTML = `
-        <header class="endpoint-hd">
+        <summary class="endpoint-hd">
           <span class="method ${methodClass}">${escapeHtml(method.toUpperCase())}</span>
-          <h4 class="title">${escapeHtml(path)}</h4>
+          <span class="title">${escapeHtml(path)}</span>
           <span class="summary" title="${escapeHtml(summary)}">${escapeHtml(summary || '-')}</span>
-        </header>
+        </summary>
         <div class="endpoint-bd"></div>
       `;
 


### PR DESCRIPTION
Render endpoint cards collapsed by default so users can scan the API list and expand individual operations as needed.

Add expand-all and collapse-all controls, card spacing, responsive layout, and keyboard focus styles.

Release version:
6.3.0

## Summary

The previous fully expanded view was a bit overwhelming, so I made it collapsible. Let me know if you have any better ideas!

https://github.com/user-attachments/assets/c64ac4ce-e7d4-4bec-ba54-49d80c30cdef



## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
