### PR TITLE
feat(topic_metrics): add ns query param to topic_metrics2 :name endpoints

### DIFF
--- a/apps/emqx_topic_metrics/src/emqx_topic_metrics2_api.erl
+++ b/apps/emqx_topic_metrics/src/emqx_topic_metrics2_api.erl
@@ -103,18 +103,20 @@ schema("/mqtt/topic_metrics2/:name") ->
         get => #{
             tags => ?TAGS,
             description => ?DESC(get_collection),
-            parameters => [name_param()],
+            parameters => [name_param(), ns_param()],
             responses => #{
                 200 => mk(ref(collection_view), #{desc => ?DESC(collection_view_resp)}),
+                403 => error_codes([?FORBIDDEN], ?DESC(forbidden_ns_resp)),
                 404 => error_codes([?NAME_NOT_FOUND], ?DESC(not_found_resp))
             }
         },
         delete => #{
             tags => ?TAGS,
             description => ?DESC(delete_collection),
-            parameters => [name_param()],
+            parameters => [name_param(), ns_param()],
             responses => #{
                 204 => <<"Deleted.">>,
+                403 => error_codes([?FORBIDDEN], ?DESC(forbidden_ns_resp)),
                 404 => error_codes([?NAME_NOT_FOUND], ?DESC(not_found_resp))
             }
         }
@@ -125,9 +127,10 @@ schema("/mqtt/topic_metrics2/:name/reset") ->
         put => #{
             tags => ?TAGS,
             description => ?DESC(reset_collection),
-            parameters => [name_param()],
+            parameters => [name_param(), ns_param()],
             responses => #{
                 204 => <<"Reset.">>,
+                403 => error_codes([?FORBIDDEN], ?DESC(forbidden_ns_resp)),
                 404 => error_codes([?NAME_NOT_FOUND], ?DESC(not_found_resp))
             }
         }
@@ -170,6 +173,18 @@ name_param() ->
             required => true,
             desc => ?DESC(field_name),
             example => <<"alpha">>
+        })}.
+
+%% Optional query param letting a global admin target a namespaced
+%% collection. A namespaced admin may only name their own namespace;
+%% naming a foreign one is rejected (see resolve_ns/1).
+ns_param() ->
+    {ns,
+        mk(binary(), #{
+            in => query,
+            required => false,
+            desc => ?DESC(field_namespace),
+            example => <<"tenant_foo">>
         })}.
 
 count_keys() ->
@@ -227,24 +242,27 @@ collections(delete, Req) ->
     ?NO_CONTENT.
 
 collection(get, #{bindings := #{name := BinName}} = Req) ->
-    OwnerNs = actor_ns(Req),
-    case emqx_topic_metrics2:lookup(BinName, OwnerNs) of
-        {ok, Rec} -> ?OK(view(with_cluster_counters(Rec)));
-        {error, not_found} -> not_found(BinName)
-    end;
+    with_ns(Req, fun(OwnerNs) ->
+        case emqx_topic_metrics2:lookup(BinName, OwnerNs) of
+            {ok, Rec} -> ?OK(view(with_cluster_counters(Rec)));
+            {error, not_found} -> not_found(BinName)
+        end
+    end);
 collection(delete, #{bindings := #{name := BinName}} = Req) ->
-    OwnerNs = actor_ns(Req),
-    case emqx_topic_metrics2:deregister(BinName, OwnerNs) of
-        ok -> ?NO_CONTENT;
-        {error, not_found} -> not_found(BinName)
-    end.
+    with_ns(Req, fun(OwnerNs) ->
+        case emqx_topic_metrics2:deregister(BinName, OwnerNs) of
+            ok -> ?NO_CONTENT;
+            {error, not_found} -> not_found(BinName)
+        end
+    end).
 
 reset(put, #{bindings := #{name := BinName}} = Req) ->
-    OwnerNs = actor_ns(Req),
-    case emqx_topic_metrics2:reset(BinName, OwnerNs) of
-        ok -> ?NO_CONTENT;
-        {error, not_found} -> not_found(BinName)
-    end.
+    with_ns(Req, fun(OwnerNs) ->
+        case emqx_topic_metrics2:reset(BinName, OwnerNs) of
+            ok -> ?NO_CONTENT;
+            {error, not_found} -> not_found(BinName)
+        end
+    end).
 
 %%--------------------------------------------------------------------
 %% Internal
@@ -252,6 +270,43 @@ reset(put, #{bindings := #{name := BinName}} = Req) ->
 
 actor_ns(Req) ->
     emqx_dashboard:get_namespace(Req).
+
+%% Resolve the effective namespace, then run `Fun' with it. Returns a
+%% 403 when a namespaced admin tries to address a foreign namespace.
+with_ns(Req, Fun) ->
+    case resolve_ns(Req) of
+        {ok, OwnerNs} ->
+            Fun(OwnerNs);
+        {error, forbidden} ->
+            ?FORBIDDEN(<<"not allowed to address another namespace's collection">>)
+    end.
+
+%% Resolve the namespace an actor may operate on for a `:name' op.
+%% - No `ns' param  -> the actor's own namespace (unchanged behavior).
+%% - Global admin   -> may target any namespace named in `ns'.
+%% - Namespaced admin naming their OWN ns -> allowed (no-op).
+%% - Namespaced admin naming a FOREIGN ns -> forbidden (no escalation).
+resolve_ns(Req) ->
+    ActorNs = actor_ns(Req),
+    case req_ns(Req) of
+        undefined ->
+            {ok, ActorNs};
+        ReqNs when ActorNs =:= ?global_ns ->
+            {ok, ReqNs};
+        ReqNs when ReqNs =:= ActorNs ->
+            {ok, ActorNs};
+        _ReqNs ->
+            {error, forbidden}
+    end.
+
+req_ns(#{query_string := Qs}) ->
+    case maps:get(<<"ns">>, Qs, undefined) of
+        undefined -> undefined;
+        <<>> -> undefined;
+        NS when is_binary(NS) -> NS
+    end;
+req_ns(_Req) ->
+    undefined.
 
 %% Cluster-aggregated list. Short-circuits the RPC when this node is
 %% the only cluster member. A global admin sees every collection; a

--- a/apps/emqx_topic_metrics/test/emqx_topic_metrics2_api_SUITE.erl
+++ b/apps/emqx_topic_metrics/test/emqx_topic_metrics2_api_SUITE.erl
@@ -252,6 +252,51 @@ t_namespace_isolation(Config) ->
     ?assertEqual(lists:sort(Keys), lists:usort(Keys)),
     ?assertEqual(4, length(AllForGlobal)).
 
+-doc "Global admin GETs/resets/deletes a namespaced collection via `?ns='.".
+t_global_targets_namespace_via_ns_param(Config) ->
+    %% acme owns a collection.
+    {201, _} = create(Config, ?NS_ACME, <<"n">>, <<"acme/n/#">>),
+    %% Global admin, no ns -> its own (global) namespace, which has no `n'.
+    ?assertMatch({404, _}, get_one(Config, ?global_ns, <<"n">>)),
+    %% Global admin with ?ns=acme -> reaches acme's collection.
+    {200, One} = get_one_ns(Config, ?global_ns, <<"n">>, ?NS_ACME),
+    ?assertMatch(#{<<"name">> := <<"n">>, <<"namespace">> := ?NS_ACME}, One),
+    %% Reset it (204), then delete it (204), then it's gone.
+    {204, _} = reset_one_ns(Config, ?global_ns, <<"n">>, ?NS_ACME),
+    {204, _} = delete_one_ns(Config, ?global_ns, <<"n">>, ?NS_ACME),
+    ?assertMatch({404, _}, get_one_ns(Config, ?global_ns, <<"n">>, ?NS_ACME)).
+
+-doc "Namespaced admin naming a FOREIGN ns is rejected with 403 and mutates nothing.".
+t_namespaced_admin_foreign_ns_forbidden(Config) ->
+    %% acme owns a collection.
+    {201, _} = create(Config, ?NS_ACME, <<"n">>, <<"acme/n/#">>),
+    %% bravo tries to reach acme's collection by passing ?ns=acme.
+    ?assertMatch(
+        {403, #{<<"code">> := <<"FORBIDDEN">>}},
+        get_one_ns(Config, ?NS_BRAVO, <<"n">>, ?NS_ACME)
+    ),
+    ?assertMatch(
+        {403, #{<<"code">> := <<"FORBIDDEN">>}},
+        reset_one_ns(Config, ?NS_BRAVO, <<"n">>, ?NS_ACME)
+    ),
+    ?assertMatch(
+        {403, #{<<"code">> := <<"FORBIDDEN">>}},
+        delete_one_ns(Config, ?NS_BRAVO, <<"n">>, ?NS_ACME)
+    ),
+    %% acme's collection is untouched.
+    {200, Still} = get_one(Config, ?NS_ACME, <<"n">>),
+    ?assertMatch(#{<<"name">> := <<"n">>, <<"namespace">> := ?NS_ACME}, Still).
+
+-doc "Namespaced admin naming their OWN ns behaves exactly like no param.".
+t_namespaced_admin_own_ns_ok(Config) ->
+    {201, _} = create(Config, ?NS_ACME, <<"n">>, <<"acme/n/#">>),
+    {200, ViaParam} = get_one_ns(Config, ?NS_ACME, <<"n">>, ?NS_ACME),
+    {200, ViaNoParam} = get_one(Config, ?NS_ACME, <<"n">>),
+    ?assertEqual(ViaNoParam, ViaParam),
+    {204, _} = reset_one_ns(Config, ?NS_ACME, <<"n">>, ?NS_ACME),
+    {204, _} = delete_one_ns(Config, ?NS_ACME, <<"n">>, ?NS_ACME),
+    ?assertMatch({404, _}, get_one(Config, ?NS_ACME, <<"n">>)).
+
 %%------------------------------------------------------------------------------
 %% Helpers — real HTTP via dashboard listener
 %%------------------------------------------------------------------------------
@@ -276,12 +321,34 @@ reset_one(Config, Ns, Name) ->
     %% PUT with no body — `[]' tells the helper to take the body-less branch.
     request(Config, Ns, put, ["mqtt", "topic_metrics2", b2l(Name), "reset"], []).
 
+%% Same as get_one/delete_one/reset_one, but keep the actor's token
+%% (`Ns') while addressing `TargetNs' via the `?ns=' query parameter.
+get_one_ns(Config, Ns, Name, TargetNs) ->
+    request_ns(Config, Ns, get, ["mqtt", "topic_metrics2", b2l(Name)], TargetNs, []).
+
+delete_one_ns(Config, Ns, Name, TargetNs) ->
+    request_ns(Config, Ns, delete, ["mqtt", "topic_metrics2", b2l(Name)], TargetNs, []).
+
+reset_one_ns(Config, Ns, Name, TargetNs) ->
+    request_ns(Config, Ns, put, ["mqtt", "topic_metrics2", b2l(Name), "reset"], TargetNs, []).
+
 %% Real HTTP request through the dashboard listener. Returns
 %% `{StatusCode, DecodedBody}'.
 request(Config, Ns, Method, PathParts, Body) ->
     emqx_mgmt_api_test_util:simple_request(#{
         method => Method,
         url => emqx_mgmt_api_test_util:api_path(PathParts),
+        body => Body,
+        auth_header => auth_header(Config, Ns)
+    }).
+
+%% Like request/5 but adds an `ns=<TargetNs>' query parameter, keeping
+%% the actor's own token from `Ns'.
+request_ns(Config, Ns, Method, PathParts, TargetNs, Body) ->
+    emqx_mgmt_api_test_util:simple_request(#{
+        method => Method,
+        url => emqx_mgmt_api_test_util:api_path(PathParts),
+        query_params => #{<<"ns">> => TargetNs},
         body => Body,
         auth_header => auth_header(Config, Ns)
     }).

--- a/changes/ee/feat-17607.en.md
+++ b/changes/ee/feat-17607.en.md
@@ -1,4 +1,4 @@
-Added a v2 topic-metrics surface with named collections, wildcard topic filters,
+[#17998](https://github.com/emqx/emqx/pull/17998) Added a v2 topic-metrics surface with named collections, wildcard topic filters,
 namespace ownership, REST CRUD and a Prometheus scrape endpoint.
 
 - New routes under `/api/v5/mqtt/topic_metrics2/:name` let operators register
@@ -9,7 +9,11 @@ namespace ownership, REST CRUD and a Prometheus scrape endpoint.
 - Collections are namespace-scoped: a collection created by a namespaced admin
   only counts publishers whose `client_attrs.tns` matches. Global collections
   (created by a non-namespaced admin) count every publisher. Namespaced admins
-  see and modify only their own collections.
+  see and modify only their own collections. A global administrator can address
+  an individual namespaced collection on the per-collection endpoints (`GET`,
+  `DELETE`, `PUT .../reset`) by passing an `ns` query parameter; a namespaced
+  admin passing another namespace's name is rejected with `403 Forbidden`, and
+  omitting `ns` keeps the actor's own namespace.
 - Counters are exposed in Prometheus exposition format at
   `/api/v5/prometheus/topic_metrics` with labels `name`, `topic_filter`,
   `namespace`. Rates can be derived via Prometheus `rate()`.

--- a/rel/i18n/emqx_topic_metrics2_api.hocon
+++ b/rel/i18n/emqx_topic_metrics2_api.hocon
@@ -57,6 +57,11 @@ not_found_resp.desc:
 not_found_resp.label:
 """Not found"""
 
+forbidden_ns_resp.desc:
+"""A namespaced administrator attempted to address another namespace's collection via the `ns` query parameter. Only a global administrator may target an arbitrary namespace."""
+forbidden_ns_resp.label:
+"""Forbidden"""
+
 field_name.desc:
 """Collection name, unique within its namespace. Allowed characters: letters, digits, dash, and underscore. Maximum 64 characters. NOT globally unique on its own — the same name may be reused under a different namespace, so consumers must key on the `(namespace, name)` pair, not on `name` alone."""
 field_name.label:


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Follow-up to #17607 (topic-metrics v2). A global admin can list all
collections (each namespaced row carrying its `namespace`), but the
per-collection detail endpoints could not address a namespaced
collection, so the dashboard could not fetch/refresh an individual
namespaced row.

This adds an optional `ns` query parameter to the three per-collection
endpoints in `emqx_topic_metrics2_api.erl`:

- `GET  /mqtt/topic_metrics2/:name`
- `DELETE /mqtt/topic_metrics2/:name`
- `PUT  /mqtt/topic_metrics2/:name/reset`

Resolution rules (`resolve_ns/1` + `with_ns/2`):

- No `ns` param → the actor's own namespace (unchanged behavior).
- Global admin → may target any namespace named in `ns`.
- Namespaced admin naming their own ns → allowed (no-op).
- Namespaced admin naming a foreign ns → `403 Forbidden` (no namespace
  escalation).

The query-param mechanics mirror the sibling `emqx_prometheus_api`
(`{ns, mk(binary(), #{in => query, required => false})}` read from
`#{query_string := Qs}`). The list and collection-level bulk
`POST`/`DELETE` endpoints are unchanged — list already shows a global
admin everything and the bulk delete already scopes correctly.

The 403 namespace-escalation guard is covered by a dedicated test
(`t_namespaced_admin_foreign_ns_forbidden`), alongside cases for a
global admin targeting a namespace and a namespaced admin naming its own
namespace.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
