### PR TITLE
fix(license): tolerate license sync race when single-node node joins a cluster

### DIFF
--- a/apps/emqx_license/mix.exs
+++ b/apps/emqx_license/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXLicense.MixProject do
   def project do
     [
       app: :emqx_license,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_license/src/emqx_license_app.erl
+++ b/apps/emqx_license/src/emqx_license_app.erl
@@ -7,7 +7,22 @@
 
 -behaviour(application).
 
+-include_lib("emqx/include/logger.hrl").
+
 -export([start/2, stop/1]).
+
+%% Exported for tests: exercises the boot-time grace/retry logic without
+%% starting the supervisor tree.
+-export([validate_license/1]).
+
+%% Grace window for the boot-time race where a single-node (community/default)
+%% license node legitimately joins a cluster whose peers hold a clustering
+%% license: cluster membership is established quickly, but the peer's license
+%% only reaches this node later via config replication. During this window we
+%% keep the current (still single-node) license as the last-seen error and poll
+%% for the synced license before failing with SINGLE_NODE_LICENSE.
+-define(DEFAULT_GRACE_PERIOD_MS, timer:seconds(30)).
+-define(DEFAULT_GRACE_POLL_INTERVAL_MS, timer:seconds(1)).
 
 start(_Type, _Args) ->
     Reader = fun emqx_license:read_license/0,
@@ -32,5 +47,60 @@ stop(_State) ->
 validate_license(Reader) ->
     maybe
         {ok, License} ?= Reader(),
+        ok ?= no_violation_within_grace(Reader, License)
+    end.
+
+%% A single-node license on an already-clustered node may be a transient
+%% boot-time race (the peer's clustering license has not been replicated into
+%% this node's config yet) rather than a genuine misconfiguration. Tolerate it
+%% for a bounded grace window, re-reading the license, before failing. A truly
+%% misconfigured cluster (all nodes single-node) never obtains a clustering
+%% license and still fails, just after the grace window elapses.
+no_violation_within_grace(Reader, License) ->
+    case emqx_license_checker:no_violation(License) of
+        ok ->
+            ok;
+        {error, 'SINGLE_NODE_LICENSE'} = Error ->
+            GracePeriod = grace_period_ms(),
+            ?SLOG(
+                notice,
+                #{
+                    msg => "single_node_license_on_clustered_node_waiting_for_license_sync",
+                    grace_period_ms => GracePeriod
+                },
+                #{tag => "LICENSE"}
+            ),
+            Deadline = erlang:monotonic_time(millisecond) + GracePeriod,
+            wait_for_clustering_license(Reader, Error, Deadline)
+    end.
+
+wait_for_clustering_license(Reader, Error, Deadline) ->
+    ok = timer:sleep(grace_poll_interval_ms()),
+    case no_violation_once(Reader) of
+        ok ->
+            ?SLOG(
+                notice,
+                #{msg => "single_node_license_cleared_after_license_sync"},
+                #{tag => "LICENSE"}
+            ),
+            ok;
+        {error, _} ->
+            case erlang:monotonic_time(millisecond) >= Deadline of
+                true ->
+                    Error;
+                false ->
+                    wait_for_clustering_license(Reader, Error, Deadline)
+            end
+    end.
+
+no_violation_once(Reader) ->
+    maybe
+        {ok, License} ?= Reader(),
         ok ?= emqx_license_checker:no_violation(License)
     end.
+
+grace_period_ms() ->
+    application:get_env(emqx_license, boot_grace_period_ms, ?DEFAULT_GRACE_PERIOD_MS).
+
+grace_poll_interval_ms() ->
+    application:get_env(emqx_license, boot_grace_poll_interval_ms, ?DEFAULT_GRACE_POLL_INTERVAL_MS).

--- a/apps/emqx_license/test/emqx_license_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_SUITE.erl
@@ -237,6 +237,58 @@ t_app_cannot_start_with_invalid_license(_Config) ->
         meck:unload(emqx_license)
     end.
 
+%% A single-node (community/default) license node that legitimately joins a
+%% cluster sees `SINGLE_NODE_LICENSE` at boot only until the peer's clustering
+%% license is replicated into its config. The boot gate must tolerate this
+%% transient race within the grace window instead of crashing.
+t_app_tolerates_license_sync_race(_Config) ->
+    ok = application:set_env(emqx_license, boot_grace_period_ms, 5_000),
+    ok = application:set_env(emqx_license, boot_grace_poll_interval_ms, 10),
+    Counter = counters:new(1, []),
+    meck:new(emqx_license_checker, [passthrough, no_history]),
+    %% First two checks still see a single-node license on a clustered node,
+    %% then config sync delivers the clustering license and the check passes.
+    meck:expect(emqx_license_checker, no_violation, fun(_License) ->
+        ok = counters:add(Counter, 1, 1),
+        case counters:get(Counter, 1) >= 3 of
+            true -> ok;
+            false -> {error, 'SINGLE_NODE_LICENSE'}
+        end
+    end),
+    Reader = fun() -> {ok, fake_license} end,
+    try
+        ?assertEqual(ok, emqx_license_app:validate_license(Reader)),
+        ?assert(counters:get(Counter, 1) >= 3)
+    after
+        meck:unload(emqx_license_checker),
+        ok = application:unset_env(emqx_license, boot_grace_period_ms),
+        ok = application:unset_env(emqx_license, boot_grace_poll_interval_ms)
+    end.
+
+%% A genuinely misconfigured cluster (every node holds a single-node license)
+%% never obtains a clustering license, so the boot gate must still fail with
+%% SINGLE_NODE_LICENSE once the grace window elapses.
+t_app_fails_after_grace_when_license_never_upgrades(_Config) ->
+    GracePeriod = 300,
+    ok = application:set_env(emqx_license, boot_grace_period_ms, GracePeriod),
+    ok = application:set_env(emqx_license, boot_grace_poll_interval_ms, 50),
+    meck:new(emqx_license_checker, [passthrough, no_history]),
+    meck:expect(emqx_license_checker, no_violation, fun(_License) ->
+        {error, 'SINGLE_NODE_LICENSE'}
+    end),
+    try
+        T0 = erlang:monotonic_time(millisecond),
+        Result = emqx_license_app:start(normal, permanent),
+        Elapsed = erlang:monotonic_time(millisecond) - T0,
+        ?assertMatch({error, "SINGLE_NODE_LICENSE," ++ _}, Result),
+        %% the grace window must actually be honored before failing
+        ?assert(Elapsed >= GracePeriod)
+    after
+        meck:unload(emqx_license_checker),
+        ok = application:unset_env(emqx_license, boot_grace_period_ms),
+        ok = application:unset_env(emqx_license, boot_grace_poll_interval_ms)
+    end.
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/changes/ee/fix-17999.en.md
+++ b/changes/ee/fix-17999.en.md
@@ -1,0 +1,3 @@
+Fixed a startup crash-loop that could occur when a node using the community (single-node) license joins a cluster whose peers hold a clustering-capable license.
+
+Previously, if cluster membership was established before the peer's license was replicated to the joining node, the node would refuse to start with a `SINGLE_NODE_LICENSE` error and, under an automatic-restart supervisor, keep crash-looping. The node now waits a bounded grace period for the clustering license to sync before it starts. A cluster in which no node ever obtains a clustering license is still rejected after the grace period elapses.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

A node carrying the community/default single-node license that legitimately
joins a cluster whose peers hold a clustering-capable license could hard-crash
at boot with `SINGLE_NODE_LICENSE`, and under an auto-restart supervisor
(e.g. `docker run --restart=always`) enter an indefinite crash-loop.

Root cause is a startup ordering race in `emqx_license_app:start/2`: cluster
membership (`emqx:cluster_nodes(running) > 1`) is established quickly once mria
connects, but the peer's clustering license only reaches the joining node later
via config replication. When membership wins the race, the boot gate sees
"single-node AND clustered" and refuses to start.

Fix: when `emqx_license_checker:no_violation/1` reports `SINGLE_NODE_LICENSE`
at boot, poll the license for a bounded grace window (default 30s, 1s interval)
before failing, returning `ok` as soon as the synced clustering license lands.
A genuinely misconfigured cluster (every node single-node) never obtains a
clustering license and still fails after the window elapses, preserving the
guard.

Blocking in the start callback is safe: config replication runs in the
independent `emqx_cluster_rpc` process and keeps updating `emqx_config` while
the license app's start callback is blocked, so the poll loop observes the
synced license and cannot deadlock the sync it waits for. The grace window and
poll interval are read from application env so tests can shrink them.

Most relevant changes: `apps/emqx_license/src/emqx_license_app.erl`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
