### PR TITLE
feat(saml): enable signature verification defaults in hardened profile

### DIFF
--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -52,7 +52,8 @@ Returns policy depending on the current security profile.
     (dashboard_unchanged_default_credentials) -> allow | deny;
     (access_control_hook_failure) -> ignore | interrupt;
     (outbound_tls_verify) -> verify_none | verify_peer;
-    (authn_jwt_missing) -> ignore | deny.
+    (authn_jwt_missing) -> ignore | deny;
+    (saml_signature_verification) -> boolean().
 policy(mqtt_default_bind) ->
     case profile() of
         legacy -> any;
@@ -97,6 +98,11 @@ policy(authn_jwt_missing) ->
     case profile() of
         legacy -> ignore;
         hardened -> deny
+    end;
+policy(saml_signature_verification) ->
+    case profile() of
+        legacy -> false;
+        hardened -> true
     end.
 
 -doc """

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -47,6 +47,7 @@ t_legacy(_) ->
     ?assertEqual(ignore, emqx_security_profile:policy(authz_backend_failure)),
     ?assertEqual(verify_none, emqx_security_profile:policy(outbound_tls_verify)),
     ?assertEqual(ignore, emqx_security_profile:policy(authn_jwt_missing)),
+    ?assertEqual(false, emqx_security_profile:policy(saml_signature_verification)),
 
     %% Full defaults
     ?assertEqual({{0, 0, 0, 0}, 1883}, emqx:get_config([listeners, tcp, default, bind])),
@@ -87,6 +88,7 @@ t_hardened(_) ->
     ?assertEqual(deny, emqx_security_profile:policy(authz_backend_failure)),
     ?assertEqual(verify_peer, emqx_security_profile:policy(outbound_tls_verify)),
     ?assertEqual(deny, emqx_security_profile:policy(authn_jwt_missing)),
+    ?assertEqual(true, emqx_security_profile:policy(saml_signature_verification)),
 
     %% Full defaults are secure in hardened profile
     ?assertEqual({{127, 0, 0, 1}, 1883}, emqx:get_config([listeners, tcp, default, bind])),

--- a/apps/emqx_dashboard_sso/mix.exs
+++ b/apps/emqx_dashboard_sso/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDashboardSso.MixProject do
   def project do
     [
       app: :emqx_dashboard_sso,
-      version: "6.2.2",
+      version: "6.2.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
@@ -110,16 +110,12 @@ sp_private_key(_) -> undefined.
 
 idp_signs_envelopes(type) -> boolean();
 idp_signs_envelopes(desc) -> ?DESC(idp_signs_envelopes);
-%% Default to false for backwards compatibility - signature verification
-%% was not working correctly before this fix was introduced.
-idp_signs_envelopes(default) -> false;
+idp_signs_envelopes(default) -> emqx_security_profile:policy(saml_signature_verification);
 idp_signs_envelopes(_) -> undefined.
 
 idp_signs_assertions(type) -> boolean();
 idp_signs_assertions(desc) -> ?DESC(idp_signs_assertions);
-%% Default to false for backwards compatibility - signature verification
-%% was not working correctly before this fix was introduced.
-idp_signs_assertions(default) -> false;
+idp_signs_assertions(default) -> emqx_security_profile:policy(saml_signature_verification);
 idp_signs_assertions(_) -> undefined.
 
 desc(saml) ->

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
@@ -43,6 +43,7 @@ all() ->
 groups() ->
     [
         {unit, [sequence], [
+            t_signature_defaults,
             t_validate_signature_config,
             t_maybe_load_cert_or_key,
             t_callback_rejects_xxe_response,
@@ -139,6 +140,27 @@ end_per_testcase(Case, _Config) ->
 %%------------------------------------------------------------------------------
 %% Unit Tests
 %%------------------------------------------------------------------------------
+
+t_signature_defaults(_Config) ->
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ?assertMatch(
+            #{idp_signs_envelopes := false, idp_signs_assertions := false},
+            checked_saml_config(#{})
+        )
+    end),
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ?assertMatch(
+            #{idp_signs_envelopes := true, idp_signs_assertions := true},
+            checked_saml_config(#{})
+        ),
+        ?assertMatch(
+            #{idp_signs_envelopes := false, idp_signs_assertions := false},
+            checked_saml_config(#{
+                <<"idp_signs_envelopes">> => false,
+                <<"idp_signs_assertions">> => false
+            })
+        )
+    end).
 
 t_validate_signature_config(_Config) ->
     %% Test signature configuration validation
@@ -491,6 +513,16 @@ t_sig_combo_sp_sign_both_idp(_Config) ->
 %%------------------------------------------------------------------------------
 %% Helper Functions
 %%------------------------------------------------------------------------------
+
+checked_saml_config(Overrides) ->
+    Config = maps:merge(#{<<"backend">> => <<"saml">>}, Overrides),
+    RawConf = #{<<"dashboard">> => #{<<"sso">> => #{<<"saml">> => Config}}},
+    #{dashboard := #{sso := #{saml := Checked}}} = hocon_tconf:check_plain(
+        emqx_dashboard_schema,
+        RawConf,
+        #{required => false, atom_key => true, make_serializable => false}
+    ),
+    Checked.
 
 uri(Parts) ->
     ?BASE_URL ++ "/" ++ filename:join(["api", "v5" | Parts]).

--- a/changes/ee/feat-18002.en.md
+++ b/changes/ee/feat-18002.en.md
@@ -1,0 +1,1 @@
+Enabled SAML response and assertion signature verification by default in the hardened security profile.


### PR DESCRIPTION
Fixes emqx/emqx-dev-team-tasks#175

Release version: 6.2.3

## Summary

Enable SAML response-envelope and assertion signature verification by default when EMQX runs with the hardened security profile. 

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
