### PR TITLE
fix(topic_metrics): reject shared-subscription topic filters

### DIFF
--- a/apps/emqx_topic_metrics/src/emqx_topic_metrics2_api.erl
+++ b/apps/emqx_topic_metrics/src/emqx_topic_metrics2_api.erl
@@ -347,8 +347,13 @@ parse_create(#{<<"name">> := Name, <<"topic_filter">> := TF}) ->
     case emqx_topic_metrics_schema:validate_name(Name) of
         ok ->
             case emqx_topic_metrics_schema:validate_topic_filter(TF) of
-                ok -> {ok, Name, TF};
-                {error, _} -> {error, ?BAD_TOPIC_FILTER, <<"Invalid topic filter">>}
+                ok ->
+                    {ok, Name, TF};
+                {error, #{cause := shared_topic_filter_not_allowed}} ->
+                    {error, ?BAD_TOPIC_FILTER,
+                        <<"Shared subscription topic filters ($share/, $queue/) are not allowed">>};
+                {error, _} ->
+                    {error, ?BAD_TOPIC_FILTER, <<"Invalid topic filter">>}
             end;
         {error, _} ->
             {error, ?BAD_NAME, <<"Invalid name">>}

--- a/apps/emqx_topic_metrics/src/emqx_topic_metrics_schema.erl
+++ b/apps/emqx_topic_metrics/src/emqx_topic_metrics_schema.erl
@@ -35,9 +35,23 @@ validate_topic_filter(Filter) when is_binary(Filter) ->
     %% path.
     try
         true = emqx_topic:validate({filter, Filter}),
-        ok
+        case is_shared_filter(Filter) of
+            false -> ok;
+            true -> {error, #{cause => shared_topic_filter_not_allowed, filter => Filter}}
+        end
     catch
         _:Reason -> {error, #{cause => bad_topic_filter, reason => Reason}}
     end;
 validate_topic_filter(_) ->
     {error, #{cause => bad_topic_filter}}.
+
+%% Shared-subscription filters (`$share/<group>/<topic>' and the
+%% `$queue/<topic>' alias) are valid *subscription* filters but never
+%% match a published `#message.topic' (the share prefix lives on the
+%% subscription, not the message). A collection stored with such a
+%% filter would silently count nothing, so we reject it at creation.
+%% Deliveries to shared subscribers are still counted under the plain
+%% topic filter via the `message.delivered' hook.
+is_shared_filter(<<"$share/", _/binary>>) -> true;
+is_shared_filter(<<"$queue/", _/binary>>) -> true;
+is_shared_filter(_) -> false.

--- a/apps/emqx_topic_metrics/test/emqx_topic_metrics2_api_SUITE.erl
+++ b/apps/emqx_topic_metrics/test/emqx_topic_metrics2_api_SUITE.erl
@@ -128,6 +128,42 @@ t_create_bad_topic_filter(Config) ->
 t_wildcard_filter_ok(Config) ->
     {201, _} = create(Config, ?global_ns, <<"wild">>, <<"sensor/+/temp">>).
 
+-doc "Ordinary and wildcard topic filters are accepted (no regression).".
+t_ordinary_filters_ok(Config) ->
+    {201, _} = create(Config, ?global_ns, <<"exact">>, <<"sensor/1">>),
+    {201, _} = create(Config, ?global_ns, <<"hash">>, <<"sensor/#">>),
+    {201, _} = create(Config, ?global_ns, <<"plus">>, <<"sensor/+/temp">>).
+
+-doc """
+Creating a collection with a shared-subscription topic filter
+($share/, $queue/) is rejected with 400 BAD_TOPIC_FILTER.
+""".
+t_create_shared_filter_rejected(Config) ->
+    ?assertMatch(
+        {400, #{<<"code">> := <<"BAD_TOPIC_FILTER">>}},
+        create(Config, ?global_ns, <<"s1">>, <<"$share/group/sensor/1">>)
+    ),
+    ?assertMatch(
+        {400, #{<<"code">> := <<"BAD_TOPIC_FILTER">>}},
+        create(Config, ?global_ns, <<"s2">>, <<"$queue/sensor/1">>)
+    ),
+    %% Rejected shared filters must not leave a collection behind.
+    ?assertEqual({200, []}, list(Config, ?global_ns)).
+
+-doc """
+The facade register/3 path also rejects shared-subscription topic
+filters (config/import/rehydrate share this validator).
+""".
+t_register_shared_filter_rejected(_Config) ->
+    ?assertMatch(
+        {error, #{cause := shared_topic_filter_not_allowed}},
+        emqx_topic_metrics2:register(<<"s">>, <<"$share/g/sensor/1">>, ?global_ns)
+    ),
+    ?assertMatch(
+        {error, #{cause := shared_topic_filter_not_allowed}},
+        emqx_topic_metrics2:register(<<"q">>, <<"$queue/sensor/1">>, ?global_ns)
+    ).
+
 t_delete_all(Config) ->
     [
         {201, _} =

--- a/apps/emqx_topic_metrics/test/emqx_topic_metrics_publish_SUITE.erl
+++ b/apps/emqx_topic_metrics/test/emqx_topic_metrics_publish_SUITE.erl
@@ -19,7 +19,7 @@ init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
             emqx_conf,
-            {emqx, #{override_env => [{boot_modules, [broker]}]}},
+            {emqx, #{override_env => [{boot_modules, [broker, listeners]}]}},
             emqx_topic_metrics
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
@@ -103,6 +103,38 @@ t_delivered_and_dropped(_Config) ->
             'messages.in.count' := 0
         }
     }} = emqx_topic_metrics2:lookup(<<"a">>, ?global_ns).
+
+-doc """
+A plain-topic collection (sensor/1) counts a real publish under
+messages.in and a delivery to a $share/group/sensor/1 subscriber
+under messages.out — the delivered hook sees the real topic.
+""".
+t_shared_subscription_delivery_counted(_Config) ->
+    ok = emqx_topic_metrics2:register(<<"s">>, <<"sensor/1">>, ?global_ns),
+    {ok, Sub} = emqtt:start_link(#{clientid => <<"sub">>, proto_ver => v5}),
+    {ok, _} = emqtt:connect(Sub),
+    {ok, _, [0]} = emqtt:subscribe(Sub, <<"$share/group/sensor/1">>, ?QOS_0),
+    {ok, Pub} = emqtt:start_link(#{clientid => <<"pub">>, proto_ver => v5}),
+    {ok, _} = emqtt:connect(Pub),
+    {ok, _} = emqtt:publish(Pub, <<"sensor/1">>, <<"payload">>, ?QOS_1),
+    %% Wait for the message to reach the shared subscriber, which is
+    %% when the `message.delivered' hook has run.
+    receive
+        {publish, #{topic := <<"sensor/1">>}} -> ok
+    after 5000 ->
+        ct:fail(delivery_timeout)
+    end,
+    ok = emqtt:disconnect(Sub),
+    ok = emqtt:disconnect(Pub),
+    ?assertMatch(
+        {ok, #{
+            metrics := #{
+                'messages.in.count' := 1,
+                'messages.out.count' := 1
+            }
+        }},
+        emqx_topic_metrics2:lookup(<<"s">>, ?global_ns)
+    ).
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/rel/i18n/emqx_topic_metrics2_api.hocon
+++ b/rel/i18n/emqx_topic_metrics2_api.hocon
@@ -65,6 +65,8 @@ field_name.label:
 field_topic_filter.desc:
 """MQTT topic filter that messages are matched against. Wildcards (`+`, `#`) are allowed.
 
+Shared-subscription topic filters (`$share/<group>/...` and the `$queue/...` alias) are not allowed: the share prefix lives on the subscription, not on the published message, so such a filter would never match and the collection would count nothing. Use the plain topic filter instead (e.g. `sensor/1` rather than `$share/group/sensor/1`) — deliveries to shared subscribers of that topic are still counted under it.
+
 For a namespaced collection, the filter is matched against the published topic *after* the tenant mountpoint has been applied — so an `acme` namespace admin who wants to track `t/x` must use a filter that includes the mountpoint (e.g. `acme/t/x`)."""
 field_topic_filter.label:
 """Topic filter"""


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Fixes #17965.

Topic metrics v2 (`apps/emqx_topic_metrics`) accepted a collection whose `topic_filter` was a shared-subscription filter (`$share/<group>/<topic>` or the `$queue/<topic>` alias). Such a filter is a valid *subscription* filter but never matches a published `#message.topic` — the share prefix lives on the subscription, not on the message — so the collection was created but counted nothing.

Crucial changes:

* `emqx_topic_metrics_schema:validate_topic_filter/1` now rejects shared-subscription filters after the existing `emqx_topic:validate/1` check. Both the REST create path and the facade `register/3` (config / import / rehydrate) funnel through this validator, so both now return an error. The REST handler maps it to `400 BAD_TOPIC_FILTER` with a specific message explaining shared filters are not allowed.
* i18n (`rel/i18n/emqx_topic_metrics2_api.hocon`): the `topic_filter` field doc now states shared filters are not allowed and points users at the plain topic filter.

Deliveries to shared subscribers are unaffected: a plain-topic collection (e.g. `sensor/1`) still counts deliveries to a `$share/group/sensor/1` subscriber under `messages.out`, because the `message.delivered` hook sees the real topic. This is verified by a new end-to-end CT (`t_shared_subscription_delivery_counted`) using real MQTT clients — no topic stripping was needed.

Tests: `$share/` and `$queue/` create → 400; `sensor/1`, `sensor/#`, `sensor/+/temp` still 201; facade `register/3` rejects shared filters; publish-in + shared-delivery-out counting.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (N/A — topic metrics v2 is not yet released)
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

