### PR TITLE
fix(dashboard): accept unset-equivalent scopes on user write

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -50,6 +50,7 @@
     effective_scopes_of_admin/1,
     role_default_scopes/1,
     set_user_scopes/2,
+    clear_user_scopes/1,
     all_users/0,
     admin_users/0,
     check/2,
@@ -507,6 +508,19 @@ role_default_scopes(Role) ->
 set_user_scopes(Username, Scopes) when is_list(Scopes) ->
     Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
         update_extra(Username, fun(Extra) -> Extra#{scopes => Scopes} end)
+    end),
+    return(Res).
+
+%% @doc Clear a user's explicit scope list back to the "unset" state, i.e.
+%% remove the `scopes' field from the extra map entirely so `scopes_of/1'
+%% returns `undefined' and the runtime falls back to the role default.
+%% Used by the write paths when a request is "unset"-equivalent so a
+%% read-modify-write never sediments the implicit full set into a frozen
+%% explicit list.
+-spec clear_user_scopes(dashboard_username()) -> {ok, ok} | {error, term()}.
+clear_user_scopes(Username) ->
+    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        update_extra(Username, fun(Extra) -> maps:remove(scopes, Extra) end)
     end),
     return(Res).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -292,8 +292,13 @@ field(role) ->
     {role,
         mk(binary(), #{desc => ?DESC(role), default => ?ROLE_DEFAULT, example => ?ROLE_DEFAULT})};
 field(scopes_request) ->
+    %% Accept the same shapes the response emits, so a read-modify-write can
+    %% round-trip the value verbatim: an explicit array of scope names, or the
+    %% `unset' sentinel (parsed to the atom `unset', also tolerated as the
+    %% binary <<"unset">>). A list whose set equals the role default and the
+    %% `unset' sentinel are both treated as "no explicit scopes" on write.
     {scopes,
-        mk(hoconsc:array(binary()), #{
+        mk(hoconsc:union([unset, hoconsc:array(binary())]), #{
             desc => ?DESC(user_scopes_request),
             required => false,
             example => [?SCOPE_USER_MGMT, ?SCOPE_MFA_MGMT]
@@ -407,18 +412,43 @@ users(post, #{body := Params}) ->
 %% circuits to the appropriate HTTP response, keeping users(post,...)
 %% within elvis's nesting cap.
 create_user(Username, Password, Role, Desc, RawScopes) ->
-    Scopes = effective_scopes_on_create(Role, RawScopes),
-    case validate_login_user_scopes(Role, RawScopes, Scopes) of
-        ok ->
-            do_create_user(Username, Password, Role, Desc, Scopes);
+    case create_scope_intent(Role, RawScopes) of
+        {ok, Intent} ->
+            do_create_user(Username, Password, Role, Desc, Intent);
         {error, Msg} ->
             {400, ?BAD_REQUEST, Msg}
     end.
 
-do_create_user(Username, Password, Role, Desc, Scopes) ->
+%% Resolve the storage intent for POST and run validation. Returns
+%% `{ok, keep | unset | {set, [binary()]}}' or `{error, Msg}'.
+%%
+%%   * field omitted -> materialize the role default and store it (current
+%%     behavior); validation runs with `RawScopes = undefined' so the
+%%     privilege-scope mutex is not applied to the role-default mix.
+%%   * `unset' sentinel or a list whose set equals the role default ->
+%%     create the user with no explicit scopes (GET returns "unset").
+%%   * any other list -> validate and store it verbatim.
+create_scope_intent(Role, undefined) ->
+    Scopes = emqx_dashboard_admin:role_default_scopes(Role),
+    case validate_login_user_scopes(Role, undefined, Scopes) of
+        ok -> {ok, {set, Scopes}};
+        Error -> Error
+    end;
+create_scope_intent(Role, RawScopes) ->
+    case write_scope_intent(Role, RawScopes) of
+        unset ->
+            {ok, unset};
+        {set, Scopes} ->
+            case validate_login_user_scopes(Role, Scopes, Scopes) of
+                ok -> {ok, {set, Scopes}};
+                Error -> Error
+            end
+    end.
+
+do_create_user(Username, Password, Role, Desc, Intent) ->
     case emqx_dashboard_admin:add_user(Username, Password, Role, Desc) of
         {ok, Result} ->
-            finalise_create_user(Username, Scopes, Result);
+            finalise_create_user(Username, Intent, Result);
         {error, Reason} ->
             ?SLOG(info, #{
                 msg => "create_dashboard_user_failed",
@@ -428,8 +458,8 @@ do_create_user(Username, Password, Role, Desc, Scopes) ->
             {400, ?BAD_REQUEST, Reason}
     end.
 
-finalise_create_user(Username, Scopes, Result) ->
-    case maybe_set_user_scopes(Username, Scopes) of
+finalise_create_user(Username, Intent, Result) ->
+    case apply_scope_intent(Username, Intent) of
         ok ->
             ?SLOG(info, #{
                 msg => "create_dashboard_user_success",
@@ -449,11 +479,12 @@ finalise_create_user(Username, Scopes, Result) ->
 user(put, #{bindings := #{username := Username0}, body := Params} = Req) ->
     Role = maps:get(<<"role">>, Params, ?ROLE_DEFAULT),
     Desc = maps:get(<<"description">>, Params),
-    Scopes = maps:get(<<"scopes">>, Params, undefined),
+    RawScopes = maps:get(<<"scopes">>, Params, undefined),
     Username = username(Req, Username0),
-    case is_default_admin_modification(Username, Role, Scopes) of
+    Intent = write_scope_intent(Role, RawScopes),
+    case is_default_admin_modification(Username, Role, Intent) of
         ok ->
-            update_user(Username, Role, Desc, Scopes);
+            update_user(Username, Role, Desc, Intent);
         {error, Msg} ->
             {400, ?NOT_ALLOWED, Msg}
     end;
@@ -479,19 +510,27 @@ user(delete, #{bindings := #{username := Username0}} = Req) ->
 
 %% The default administrator (configured via `dashboard.default_username')
 %% is a break-glass account. Reject any modification that would weaken
-%% it: role changes away from administrator, and explicit scope lists
-%% (the role's implicit defaults must always apply). Empty
+%% it: role changes away from administrator, and a genuinely different
+%% explicit scope list (the role's implicit defaults must always apply).
+%% `Intent' is the normalized write intent from `write_scope_intent/2':
+%% `keep' (field omitted) and `unset' (the `unset' sentinel or a list
+%% whose set equals the role default) are both "no explicit scopes" and
+%% therefore accepted — this makes a read-modify-write of the admin (which
+%% round-trips the expanded full catalog) succeed. Only `{set, _}' — a
+%% list that differs from the role default — is rejected. Empty
 %% `dashboard.default_username' means no default user is in effect, so
 %% the protection is a no-op.
-is_default_admin_modification(Username, Role, Scopes) ->
+is_default_admin_modification(Username, Role, Intent) ->
     case is_default_admin(Username) of
         false ->
             ok;
         true ->
-            case {Role, Scopes} of
-                {?ROLE_SUPERUSER, undefined} ->
+            case {Role, Intent} of
+                {?ROLE_SUPERUSER, keep} ->
                     ok;
-                {?ROLE_SUPERUSER, _} ->
+                {?ROLE_SUPERUSER, unset} ->
+                    ok;
+                {?ROLE_SUPERUSER, {set, _}} ->
                     {error, <<
                         "The default administrator cannot have an explicit "
                         "scope list; it always holds the full catalog."
@@ -646,27 +685,60 @@ register_unsuccessful_login(_, _) ->
 %%     mfa_management is intentionally allowed for any role — non-
 %%     admin holders can self-exempt their own MFA but cannot manage
 %%     other users' MFA (handler-level enforcement).
-%% @doc Resolve the role-default scopes that should be materialized into
-%% the persisted record when the caller did not explicitly supply a
-%% scope list (POST without `scopes', SSO auto-provisioning).
+%% @doc Normalize a `scopes' request value to a storage intent:
+%%   * `keep'       - field omitted (`undefined'): leave persisted scopes
+%%                    unchanged (PUT read-modify-write of another field).
+%%   * `unset'      - the `unset' sentinel (atom or binary <<"unset">>), or
+%%                    a list whose set equals the role default: store NO
+%%                    explicit `scopes' field, so `scopes_of/1' stays
+%%                    `undefined' and GET keeps returning "unset".
+%%   * `{set, L}'   - store the explicit list `L' verbatim.
 %%
-%% After this PR, `undefined' is never written into mnesia by any
-%% creation path; the `<<"unset">>' state in the GET response is only
-%% possible for records that survived an upgrade from a release where
-%% the dashboard-user scopes feature did not exist (#17235).
-%%
-%%   * administrator -> `?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES'
-%%   * viewer        -> `?GENERIC_SCOPES'
-%%
-%% Explicit `[]' (deny-all) and explicit lists pass through unchanged.
-effective_scopes_on_create(Role, undefined) ->
-    emqx_dashboard_admin:role_default_scopes(Role);
-effective_scopes_on_create(_Role, Scopes) when is_list(Scopes) ->
-    Scopes;
-effective_scopes_on_create(_Role, Other) ->
-    %% Any non-list, non-undefined value is left as-is; downstream
-    %% validation will reject it with the appropriate 400.
-    Other.
+%% The role-default comparison is order-insensitive (set equality), so a
+%% read-modify-write that round-trips GET's expanded full catalog never
+%% sediments the role's implicit full set into a frozen explicit list.
+%% A non-list, non-sentinel value falls through to `{set, Other}' so the
+%% downstream validation rejects it with the appropriate 400.
+write_scope_intent(_Role, undefined) ->
+    keep;
+write_scope_intent(_Role, unset) ->
+    unset;
+write_scope_intent(_Role, <<"unset">>) ->
+    unset;
+write_scope_intent(Role, Scopes) when is_list(Scopes) ->
+    case is_role_default_scopes(Role, Scopes) of
+        true -> unset;
+        false -> {set, Scopes}
+    end;
+write_scope_intent(_Role, Other) ->
+    {set, Other}.
+
+%% Order-insensitive set comparison of a write scope list against the
+%% role's implicit default (`role_default_scopes/1'). The dashboard may
+%% send the scopes in any order.
+is_role_default_scopes(Role, Scopes) ->
+    Default = emqx_dashboard_admin:role_default_scopes(Role),
+    lists:usort(Scopes) =:= lists:usort(Default).
+
+%% Persist the resolved scope intent (`keep' | `unset' | `{set, L}').
+%% Returns `ok' or `{error, Reason}'; the caller maps errors to the
+%% proper HTTP status (never crashes the handler).
+apply_scope_intent(_Username, keep) ->
+    ok;
+apply_scope_intent(Username, unset) ->
+    handle_scope_write(Username, emqx_dashboard_admin:clear_user_scopes(Username));
+apply_scope_intent(Username, {set, Scopes}) ->
+    handle_scope_write(Username, emqx_dashboard_admin:set_user_scopes(Username, Scopes)).
+
+handle_scope_write(_Username, {ok, ok}) ->
+    ok;
+handle_scope_write(Username, {error, Reason}) ->
+    ?SLOG(warning, #{
+        msg => "set_user_scopes_failed",
+        username => Username,
+        reason => Reason
+    }),
+    {error, Reason}.
 
 %% `RawScopes' is the value the client supplied (before role-default /
 %% persisted-scope materialisation); `EffectiveScopes' is the
@@ -763,40 +835,44 @@ validate_role_scope_compat(Role, Scopes) ->
 
 %% Run the validate → update_user → set_scopes pipeline. Mirrors
 %% create_user/5 above, also kept as a helper to stay within elvis's
-%% nesting cap.
-%%
-%% Validation runs against the *effective* scope list — the request
-%% body's `scopes' field when present, otherwise the persisted scopes —
-%% so a role demotion can never silently keep stale admin-only scopes
-%% just because the client omitted the `scopes' field.
-update_user(Username, Role, Desc, RawScopes) ->
-    EffectiveScopes = effective_request_scopes(Username, RawScopes),
-    case validate_login_user_scopes(Role, RawScopes, EffectiveScopes) of
+%% nesting cap. `Intent' is the normalized write intent from
+%% `write_scope_intent/2'.
+update_user(Username, Role, Desc, Intent) ->
+    case validate_update_scopes(Role, Username, Intent) of
         ok ->
-            do_update_user(Username, Role, Desc, RawScopes);
+            do_update_user(Username, Role, Desc, Intent);
         {error, Msg} ->
             {400, ?BAD_REQUEST, Msg}
     end.
 
-%% Fall back to persisted scopes only when the body did not supply a
-%% `scopes' field. An explicit list (including `[]') is taken verbatim.
-effective_request_scopes(_Username, Scopes) when is_list(Scopes) ->
-    Scopes;
-effective_request_scopes(Username, undefined) ->
-    emqx_dashboard_admin:scopes_of(Username).
+%% Validate the effective scope list for a PUT:
+%%   * `keep'      - validate the *persisted* scopes against the (possibly
+%%                   changed) role, so a role demotion can never silently
+%%                   keep stale admin-only scopes when the client omitted
+%%                   the `scopes' field.
+%%   * `unset'     - clears to the role default, which is valid by
+%%                   construction; nothing to check.
+%%   * `{set, L}'  - validate the explicit list `L'.
+validate_update_scopes(_Role, _Username, unset) ->
+    ok;
+validate_update_scopes(Role, Username, keep) ->
+    Persisted = emqx_dashboard_admin:scopes_of(Username),
+    validate_login_user_scopes(Role, undefined, Persisted);
+validate_update_scopes(Role, _Username, {set, Scopes}) ->
+    validate_login_user_scopes(Role, Scopes, Scopes).
 
-do_update_user(Username, Role, Desc, Scopes) ->
+do_update_user(Username, Role, Desc, Intent) ->
     case emqx_dashboard_admin:update_user(Username, Role, Desc) of
         {ok, Result} ->
-            finalise_update_user(Username, Scopes, Result);
+            finalise_update_user(Username, Intent, Result);
         {error, <<"username_not_found">> = Reason} ->
             {404, ?USER_NOT_FOUND, Reason};
         {error, Reason} ->
             {400, ?BAD_REQUEST, Reason}
     end.
 
-finalise_update_user(Username, Scopes, Result) ->
-    case maybe_set_user_scopes(Username, Scopes) of
+finalise_update_user(Username, Intent, Result) ->
+    case apply_scope_intent(Username, Intent) of
         ok ->
             {200, to_json_out(reload_external_user(Username, Result))};
         {error, <<"username_not_found">> = Reason} ->
@@ -815,27 +891,6 @@ reload_external_user(Username, Fallback) ->
     case emqx_dashboard_admin:lookup_user(Username) of
         [Admin] -> emqx_dashboard_admin:to_external_user(Admin);
         _ -> Fallback
-    end.
-
-%% Persist scopes to the admin record's extra map. Skip when scopes is
-%% absent (no body field) — keeps the existing extra.scopes value.
-%%
-%% Returns {error, Reason} when the user record is missing (e.g. concurrent
-%% deletion between add_user/update_user and this call). Callers must
-%% translate to the proper HTTP status; never crash the handler.
-maybe_set_user_scopes(_Username, undefined) ->
-    ok;
-maybe_set_user_scopes(Username, Scopes) when is_list(Scopes) ->
-    case emqx_dashboard_admin:set_user_scopes(Username, Scopes) of
-        {ok, ok} ->
-            ok;
-        {error, Reason} ->
-            ?SLOG(warning, #{
-                msg => "set_user_scopes_failed",
-                username => Username,
-                reason => Reason
-            }),
-            {error, Reason}
     end.
 
 %% --- MFA self-lock authorization ---

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -291,6 +291,175 @@ t_put_users_response_includes_updated_scopes(_Config) ->
     ?assertEqual([<<"mfa_management">>], maps:get(<<"scopes">>, Resp)),
     ?assertEqual(<<"updated">>, maps:get(<<"description">>, Resp)).
 
+%%--------------------------------------------------------------------
+%% "unset"-equivalent write handling (issue #17931)
+%%
+%% The default administrator holds no explicit scopes (GET => "unset");
+%% a read-modify-write from the dashboard round-trips GET's *expanded*
+%% full catalog. The write paths must treat that expanded list (and the
+%% `unset' sentinel) as "no explicit scopes" so a plain note edit does
+%% not fail, and such users keep their forward-compatible implicit set
+%% rather than a frozen explicit list.
+%%--------------------------------------------------------------------
+
+%% Editing only the note of the default admin while sending back GET's
+%% expanded full catalog list succeeds (200) and does not sediment: GET
+%% keeps returning "unset".
+t_default_admin_note_only_edit_full_list(_Config) ->
+    Default = emqx_dashboard_admin:default_username(),
+    add_admin(Default),
+    Token = jwt(Default, test_password()),
+    FullList = emqx_dashboard_admin:role_default_scopes(?ROLE_SUPERUSER),
+    PutBody = #{
+        <<"role">> => ?ROLE_SUPERUSER,
+        <<"description">> => <<"edited note">>,
+        <<"scopes">> => FullList
+    },
+    {ok, 200, RespBody} = request_api(
+        put, api_path(["users", binary_to_list(Default)]), auth_header(Token), PutBody
+    ),
+    Resp = emqx_utils_json:decode(RespBody),
+    ?assertEqual(<<"edited note">>, maps:get(<<"description">>, Resp)),
+    ?assertEqual(<<"unset">>, maps:get(<<"scopes">>, Resp)),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Default)).
+
+%% The default admin can round-trip the `unset' sentinel verbatim; it
+%% stays unset.
+t_default_admin_put_unset_sentinel(_Config) ->
+    Default = emqx_dashboard_admin:default_username(),
+    add_admin(Default),
+    Token = jwt(Default, test_password()),
+    PutBody = #{
+        <<"role">> => ?ROLE_SUPERUSER,
+        <<"description">> => <<"note">>,
+        <<"scopes">> => <<"unset">>
+    },
+    {ok, 200, RespBody} = request_api(
+        put, api_path(["users", binary_to_list(Default)]), auth_header(Token), PutBody
+    ),
+    Resp = emqx_utils_json:decode(RespBody),
+    ?assertEqual(<<"unset">>, maps:get(<<"scopes">>, Resp)),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Default)).
+
+%% The role-default equivalence is order-insensitive: the full catalog
+%% sent in a shuffled order is still recognised as "unset".
+t_default_admin_put_full_list_shuffled(_Config) ->
+    Default = emqx_dashboard_admin:default_username(),
+    add_admin(Default),
+    Token = jwt(Default, test_password()),
+    Shuffled = lists:reverse(emqx_dashboard_admin:role_default_scopes(?ROLE_SUPERUSER)),
+    PutBody = #{
+        <<"role">> => ?ROLE_SUPERUSER,
+        <<"description">> => <<"note">>,
+        <<"scopes">> => Shuffled
+    },
+    {ok, 200, RespBody} = request_api(
+        put, api_path(["users", binary_to_list(Default)]), auth_header(Token), PutBody
+    ),
+    Resp = emqx_utils_json:decode(RespBody),
+    ?assertEqual(<<"unset">>, maps:get(<<"scopes">>, Resp)),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Default)).
+
+%% A genuinely different explicit list (a strict subset of the catalog)
+%% for the default admin is still rejected with 400 NOT_ALLOWED.
+t_default_admin_put_different_list_rejected(_Config) ->
+    Default = emqx_dashboard_admin:default_username(),
+    add_admin(Default),
+    Token = jwt(Default, test_password()),
+    PutBody = #{
+        <<"role">> => ?ROLE_SUPERUSER,
+        <<"description">> => <<"note">>,
+        <<"scopes">> => [?SCOPE_USER_MGMT]
+    },
+    ?assertMatch(
+        {ok, 400, _},
+        request_api(
+            put, api_path(["users", binary_to_list(Default)]), auth_header(Token), PutBody
+        )
+    ),
+    %% Storage untouched — still no explicit scopes.
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Default)).
+
+%% Changing the default admin's role away from administrator is still
+%% rejected (unchanged break-glass protection).
+t_default_admin_role_change_rejected(_Config) ->
+    Default = emqx_dashboard_admin:default_username(),
+    add_admin(Default),
+    Token = jwt(Default, test_password()),
+    PutBody = #{
+        <<"role">> => ?ROLE_VIEWER,
+        <<"description">> => <<"note">>
+    },
+    ?assertMatch(
+        {ok, 400, _},
+        request_api(
+            put, api_path(["users", binary_to_list(Default)]), auth_header(Token), PutBody
+        )
+    ).
+
+%% A regular (non-default) user with unset scopes round-tripping the
+%% expanded full catalog stays unset — the implicit set is not sedimented.
+t_regular_user_round_trip_full_list_stays_unset(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"reguser">>, test_password(), ?ROLE_SUPERUSER, "u"
+    ),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(<<"reguser">>)),
+    FullList = emqx_dashboard_admin:role_default_scopes(?ROLE_SUPERUSER),
+    PutBody = #{
+        <<"role">> => ?ROLE_SUPERUSER,
+        <<"description">> => <<"note">>,
+        <<"scopes">> => FullList
+    },
+    {ok, 200, RespBody} = request_api(
+        put, api_path(["users", "reguser"]), auth_header(Token), PutBody
+    ),
+    Resp = emqx_utils_json:decode(RespBody),
+    ?assertEqual(<<"unset">>, maps:get(<<"scopes">>, Resp)),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(<<"reguser">>)).
+
+%% PUT `scopes: "unset"' on a regular user clears a previously-explicit
+%% list back to the unset state.
+t_regular_user_put_unset_clears_explicit(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"reguser2">>, test_password(), ?ROLE_SUPERUSER, "u"
+    ),
+    {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"reguser2">>, [?SCOPE_MFA_MGMT]),
+    ?assertEqual([?SCOPE_MFA_MGMT], emqx_dashboard_admin:scopes_of(<<"reguser2">>)),
+    PutBody = #{
+        <<"role">> => ?ROLE_SUPERUSER,
+        <<"description">> => <<"note">>,
+        <<"scopes">> => <<"unset">>
+    },
+    {ok, 200, RespBody} = request_api(
+        put, api_path(["users", "reguser2"]), auth_header(Token), PutBody
+    ),
+    Resp = emqx_utils_json:decode(RespBody),
+    ?assertEqual(<<"unset">>, maps:get(<<"scopes">>, Resp)),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(<<"reguser2">>)).
+
+%% POST create with `scopes: "unset"' creates the user with no explicit
+%% scopes (GET returns "unset").
+t_post_create_unset_sentinel(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    Body = #{
+        <<"username">> => <<"created_unset">>,
+        <<"password">> => test_password(),
+        <<"role">> => ?ROLE_SUPERUSER,
+        <<"description">> => <<"u">>,
+        <<"scopes">> => <<"unset">>
+    },
+    {ok, 200, RespBody} = request_api(
+        post, api_path(["users"]), auth_header(Token), Body
+    ),
+    Resp = emqx_utils_json:decode(RespBody),
+    ?assertEqual(<<"unset">>, maps:get(<<"scopes">>, Resp)),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(<<"created_unset">>)).
+
 %% Viewer cannot hold user_management.
 t_viewer_cannot_hold_user_management(_Config) ->
     add_admin(<<"admin">>),

--- a/changes/ee/fix-18009.en.md
+++ b/changes/ee/fix-18009.en.md
@@ -1,0 +1,3 @@
+Fixed an error when editing only the note (description) of the default administrator via the Dashboard user API.
+
+The user API now accepts a scope list that matches the role's implicit full set (and the `unset` value) as equivalent to "no explicit scopes", so a read-modify-write of an administrator no longer fails. Such users also keep their forward-compatible implicit scopes instead of a frozen list.

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -96,6 +96,8 @@ user_scopes_request.desc:
 
 If this field is omitted when a user is created, the server applies the default scopes for the role. An administrator receives all management scopes plus the four login-only scopes. A viewer receives all management scopes. A publisher, where applicable, receives only the `publish` scope. To create a deny-all user, send an explicit empty list `[]`; only anonymous endpoints such as `/status` remain reachable.
 
+On write (create or update) this field also accepts the literal string `unset`, and a scope list that matches the role's implicit default set is treated the same way: both are stored as \"no explicit scopes\", so the user keeps the forward-compatible role default instead of a frozen list. This lets a read-modify-write (for example editing only the description) round-trip the `unset` value or the expanded scope list returned by a `GET` without error.
+
 Login users may be assigned any API key catalog scope plus the four login-only scopes: `user_management`, `mfa_management`, `sso_management`, and `api_key_management`. Among these four scopes, `user_management`, `sso_management`, and `api_key_management` are administrator-only. `mfa_management` may also be assigned to non-administrator users. For non-administrator users, it acts only as a self-exemption key that allows the user to bypass `force_mfa` and `admin_required` locks for their own MFA."""
 
 user_scopes_response.desc:


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Fixes #17931. Editing only the note (description) of the default
administrator returned `NOT_ALLOWED`: the dashboard does a
read-modify-write of the whole user object, and `GET` returns the
default admin's implicit scopes expanded to the full catalog. `PUT`ing
that list back tripped the break-glass guard, which rejected any
non-`undefined` `scopes` value for the default admin.

The user API write paths (POST and PUT) now normalize the `scopes` field
to a write intent before applying it:

- `keep` — field omitted: leave persisted scopes unchanged (PUT).
- `unset` — the `unset` sentinel, or a scope list whose set equals the
  role's implicit default (`role_default_scopes/1`): store **no** explicit
  `scopes` field so `GET` keeps returning `"unset"` and the user keeps the
  forward-compatible role default instead of a frozen list. The comparison
  is order-insensitive.
- `{set, L}` — any other explicit list: validated and stored verbatim.

`is_default_admin_modification/3` now accepts `keep` and `unset` and
rejects only a genuinely different explicit list; the role-change
protection is unchanged. `emqx_dashboard_admin` gains `clear_user_scopes/1`
(removes the `scopes` key from the record's extra map) so unset-equivalent
writes never sediment. The `scopes` request schema now also accepts the
`unset` value so it can be round-tripped verbatim, matching the response
shape (forward-compat: a dashboard that predates newly-added scopes can
round-trip `unset` instead of an out-of-date list).

Most relevant files: `apps/emqx_dashboard/src/emqx_dashboard_api.erl`,
`apps/emqx_dashboard/src/emqx_dashboard_admin.erl`.

Out of scope: the dashboard frontend will be updated separately to display
and PUT/POST back `unset`. This backend change makes that possible and also
makes the current dashboard's full-list round-trip work with no frontend
change.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
