### PR TITLE
fix(mqtt): count frame errors from connected clients as shutdowns

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1365,19 +1365,18 @@ handle_frame_error(
     end;
 %% Frame error on an established connection: send DISCONNECT and close.
 %% The close reason doubles as the connection process exit reason, so it must be
-%% a plain atom naming the cause: that is what lets the connection supervisor
-%% keep a per-cause shutdown counter instead of reporting an unidentified
-%% shutdown at error level. Details of the parse error are already logged at
-%% info level by the connection when the frame fails to parse.
+%% a plain atom: that is what lets the connection supervisor keep a shutdown
+%% counter instead of reporting an unidentified shutdown at error level. The
+%% parse error itself is reported by the connection through `emqx_trace'.
 handle_frame_error(
-    Reason,
+    _Reason,
     Channel = #channel{conn_state = ConnState}
 ) when
     ?IS_CONNECTED_OR_REAUTHENTICATING(ConnState)
 ->
     handle_out(
         disconnect,
-        {?RC_MALFORMED_PACKET, frame_error_cause(Reason)},
+        {?RC_MALFORMED_PACKET, frame_error},
         Channel
     );
 handle_frame_error(
@@ -1387,11 +1386,6 @@ handle_frame_error(
     %% Invalid client input, not a broker failure.
     ?SLOG(info, #{msg => "malformed_mqtt_message", reason => Reason}),
     {ok, Channel}.
-
--doc "Name the cause of a frame parse error as an atom, for use as a shutdown reason.".
-frame_error_cause(#{cause := Cause}) when is_atom(Cause) -> Cause;
-frame_error_cause(Cause) when is_atom(Cause) -> Cause;
-frame_error_cause(_Reason) -> frame_error.
 
 %%--------------------------------------------------------------------
 %% Handle outgoing packet
@@ -3746,9 +3740,11 @@ shutdown_count(Kind, Reason, #channel{conninfo = ConnInfo}) ->
     maps:merge(shutdown_count(Kind, Reason), ShutdownCntMeta).
 
 %% process exits with {shutdown, #{shutdown_count := Kind}} will trigger
-%% the connection supervisor (esockd) to keep a shutdown-counter grouped by Kind
-shutdown_count(_Kind, #{cause := Cause} = Reason) when is_atom(Cause) ->
-    Reason#{shutdown_count => Cause};
+%% the connection supervisor (esockd) to keep a shutdown-counter grouped by Kind.
+%% Kind must be one of a fixed set chosen here, never a value derived from client
+%% input: it names a counter, and an attacker-controlled name would let malformed
+%% packets mint unbounded counters. The specific cause stays in the reason map
+%% for the shutdown report.
 shutdown_count(Kind, Reason) when is_map(Reason) ->
     Reason#{shutdown_count => Kind};
 shutdown_count(Kind, Reason) ->

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1327,7 +1327,7 @@ handle_frame_error(
 ) when
     ?IS_CONNECTED_OR_REAUTHENTICATING(ConnState)
 ->
-    ShutdownCount = shutdown_count(frame_error, Reason, Channel),
+    ShutdownCount = shutdown_count(frame_error_kind(Reason, frame_error), Reason, Channel),
     case proto_ver(Reason, ConnInfo) of
         ?MQTT_PROTO_V5 ->
             handle_out(disconnect, {?RC_PACKET_TOO_LARGE, frame_too_large}, Channel);
@@ -1343,7 +1343,7 @@ handle_frame_error(
     Channel = #channel{conn_state = idle}
 ) ->
     shutdown(
-        shutdown_count(invalid_connect_packet, Reason, Channel),
+        shutdown_count(frame_error_kind(Reason, invalid_connect_packet), Reason, Channel),
         Channel
     );
 %% Frame error while parsing CONNECT.
@@ -1353,7 +1353,7 @@ handle_frame_error(
     Reason,
     Channel = #channel{conn_state = connecting, conninfo = ConnInfo}
 ) ->
-    ShutdownCount = shutdown_count(frame_error, Reason, Channel),
+    ShutdownCount = shutdown_count(frame_error_kind(Reason, frame_error), Reason, Channel),
     ProtoVer = proto_ver(Reason, ConnInfo),
     NChannel = Channel#channel{conninfo = ConnInfo#{proto_ver => ProtoVer}},
     case ProtoVer of
@@ -1369,14 +1369,14 @@ handle_frame_error(
 %% counter instead of reporting an unidentified shutdown at error level. The
 %% parse error itself is reported by the connection through `emqx_trace'.
 handle_frame_error(
-    _Reason,
+    Reason,
     Channel = #channel{conn_state = ConnState}
 ) when
     ?IS_CONNECTED_OR_REAUTHENTICATING(ConnState)
 ->
     handle_out(
         disconnect,
-        {?RC_MALFORMED_PACKET, frame_error},
+        {?RC_MALFORMED_PACKET, frame_error_kind(Reason, frame_error)},
         Channel
     );
 handle_frame_error(
@@ -1386,6 +1386,20 @@ handle_frame_error(
     %% Invalid client input, not a broker failure.
     ?SLOG(info, #{msg => "malformed_mqtt_message", reason => Reason}),
     {ok, Channel}.
+
+-doc """
+Name the shutdown counter for a frame error.
+
+A counter name must come from a bounded set. Errors reported as an atom are
+already such a set, fixed by the parser, so the atom names its own counter.
+Errors reported as a map carry detail derived from the offending packet, so they
+share `Default'; the specific cause remains in the shutdown reason and in the
+trace. Oversized frames keep their own counter in every connection state, being
+a distinct operational signal rather than a malformed packet.
+""".
+frame_error_kind(Reason, _Default) when is_atom(Reason) -> Reason;
+frame_error_kind(#{cause := frame_too_large}, _Default) -> frame_too_large;
+frame_error_kind(_Reason, Default) -> Default.
 
 %%--------------------------------------------------------------------
 %% Handle outgoing packet
@@ -3741,10 +3755,9 @@ shutdown_count(Kind, Reason, #channel{conninfo = ConnInfo}) ->
 
 %% process exits with {shutdown, #{shutdown_count := Kind}} will trigger
 %% the connection supervisor (esockd) to keep a shutdown-counter grouped by Kind.
-%% Kind must be one of a fixed set chosen here, never a value derived from client
-%% input: it names a counter, and an attacker-controlled name would let malformed
-%% packets mint unbounded counters. The specific cause stays in the reason map
-%% for the shutdown report.
+%% Kind names a counter, so callers must pick it from a bounded set rather than
+%% from client input; see `frame_error_kind/2'. The specific cause stays in the
+%% reason map for the shutdown report.
 shutdown_count(Kind, Reason) when is_map(Reason) ->
     Reason#{shutdown_count => Kind};
 shutdown_count(Kind, Reason) ->

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1363,6 +1363,12 @@ handle_frame_error(
         _ ->
             shutdown(ShutdownCount, NChannel)
     end;
+%% Frame error on an established connection: send DISCONNECT and close.
+%% The close reason doubles as the connection process exit reason, so it must be
+%% a plain atom naming the cause: that is what lets the connection supervisor
+%% keep a per-cause shutdown counter instead of reporting an unidentified
+%% shutdown at error level. Details of the parse error are already logged at
+%% info level by the connection when the frame fails to parse.
 handle_frame_error(
     Reason,
     Channel = #channel{conn_state = ConnState}
@@ -1371,15 +1377,21 @@ handle_frame_error(
 ->
     handle_out(
         disconnect,
-        {?RC_MALFORMED_PACKET, Reason},
+        {?RC_MALFORMED_PACKET, frame_error_cause(Reason)},
         Channel
     );
 handle_frame_error(
     Reason,
     Channel = #channel{conn_state = disconnected}
 ) ->
-    ?SLOG(error, #{msg => "malformed_mqtt_message", reason => Reason}),
+    %% Invalid client input, not a broker failure.
+    ?SLOG(info, #{msg => "malformed_mqtt_message", reason => Reason}),
     {ok, Channel}.
+
+-doc "Name the cause of a frame parse error as an atom, for use as a shutdown reason.".
+frame_error_cause(#{cause := Cause}) when is_atom(Cause) -> Cause;
+frame_error_cause(Cause) when is_atom(Cause) -> Cause;
+frame_error_cause(_Reason) -> frame_error.
 
 %%--------------------------------------------------------------------
 %% Handle outgoing packet

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -808,11 +808,10 @@ parse_incoming(Data, State = #state{parser = Parser}) ->
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
             NReason = maybe_enrich_first_packet_error(Data, Reason, State),
-            ?LOG(info, #{
-                msg => "frame_parse_error",
+            ?TRACE("MQTT", "frame_parse_error", #{
                 reason => NReason,
                 at_state => describe_parser_state(Parser),
-                input_bytes => Data
+                input_bytes => emqx_packet:format_input_bytes(Data)
             }),
             NState = update_state_on_parse_error(Parser, NReason, State),
             {0, [{frame_error, NReason}], NState};

--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -45,6 +45,8 @@
 
 -export([format_payload/2]).
 
+-export([format_input_bytes/1]).
+
 -define(TYPE_NAMES,
     {'CONNECT', 'CONNACK', 'PUBLISH', 'PUBACK', 'PUBREC', 'PUBREL', 'PUBCOMP', 'SUBSCRIBE',
         'SUBACK', 'UNSUBSCRIBE', 'UNSUBACK', 'PINGREQ', 'PINGRESP', 'DISCONNECT', 'AUTH'}
@@ -780,6 +782,20 @@ truncate_payload(text, Limit, Payload) ->
             <<Part:Limit/binary, Rest/binary>> = Payload,
             {hex, Part, size(Rest)}
     end.
+
+-doc """
+Format raw bytes received from a client for a log or trace report.
+
+Bytes that fail to parse can be as large as the configured maximum packet size,
+so only a leading window is kept; when bytes are dropped the result also carries
+the original size.
+""".
+-spec format_input_bytes(binary()) -> binary() | #{bytes := binary(), total_size := pos_integer()}.
+format_input_bytes(Bytes) when byte_size(Bytes) =< ?TRUNCATED_PAYLOAD_SIZE ->
+    Bytes;
+format_input_bytes(Bytes) ->
+    <<Part:?TRUNCATED_PAYLOAD_SIZE/binary, _/binary>> = Bytes,
+    #{bytes => Part, total_size => byte_size(Bytes)}.
 
 i(true) -> 1;
 i(false) -> 0;

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -857,11 +857,10 @@ parse_incoming(Data, State = #state{parser = Parser}) ->
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
             NReason = maybe_enrich_first_packet_error(Data, Reason, State),
-            ?LOG(info, #{
-                msg => "frame_parse_error",
+            ?TRACE("MQTT", "frame_parse_error", #{
                 reason => NReason,
                 at_state => describe_parser_state(Parser),
-                input_bytes => Data
+                input_bytes => emqx_packet:format_input_bytes(Data)
             }),
             NState = update_state_on_parse_error(NReason, State),
             {0, 0, [{frame_error, NReason}], NState};

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -568,11 +568,10 @@ parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
             parse_incoming(Rest, [Packet | Packets], NState)
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
-            ?LOG(info, #{
-                msg => "frame_parse_error",
+            ?TRACE("MQTT", "frame_parse_error", #{
                 reason => Reason,
                 at_state => emqx_frame:describe_state(ParseState),
-                input_bytes => Data
+                input_bytes => emqx_packet:format_input_bytes(Data)
             }),
             NState = update_state_on_parse_error(Reason, State),
             {[{frame_error, Reason} | Packets], NState};

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -540,7 +540,7 @@ t_handle_in_frame_error(_) ->
     ),
     %% no CONNACK packet for v4
     ?assertMatch(
-        {shutdown, #{shutdown_count := frame_too_large, cause := frame_too_large}, _Chan},
+        {shutdown, #{shutdown_count := invalid_connect_packet, cause := frame_too_large}, _Chan},
         emqx_channel:handle_in(
             {frame_error, #{cause => frame_too_large}}, v4(IdleChannelV5)
         )
@@ -551,7 +551,7 @@ t_handle_in_frame_error(_) ->
     ?assertMatch(
         {shutdown,
             #{
-                shutdown_count := frame_too_large,
+                shutdown_count := frame_error,
                 cause := frame_too_large,
                 limit := 100,
                 received := 101
@@ -568,6 +568,16 @@ t_handle_in_frame_error(_) ->
     ?assertMatch(
         {ok, [{outgoing, DisconnectPacket}, {close, frame_too_large}], _},
         emqx_channel:handle_in({frame_error, #{cause => frame_too_large}}, ConnectedChan)
+    ),
+    %% Any other frame error on an established connection closes under the
+    %% single `frame_error' kind, never under a client-derived name.
+    MalformedPacket = ?DISCONNECT_PACKET(?RC_MALFORMED_PACKET),
+    ?assertMatch(
+        {ok, [{outgoing, MalformedPacket}, {close, frame_error}], _},
+        emqx_channel:handle_in(
+            {frame_error, #{cause => invalid_property_code, property_code => 16#2B}},
+            channel(#{conn_state => connected})
+        )
     ),
     DisconnectedChan = channel(#{conn_state => disconnected}),
     {ok, DisconnectedChan} =

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -535,12 +535,12 @@ t_handle_in_auth(_) ->
 t_handle_in_frame_error(_) ->
     IdleChannelV5 = channel(#{conn_state => idle}),
     ?assertMatch(
-        {shutdown, #{shutdown_count := invalid_connect_packet, reason := bad_subqos}, _Chan},
+        {shutdown, #{shutdown_count := bad_subqos, reason := bad_subqos}, _Chan},
         emqx_channel:handle_in({frame_error, bad_subqos}, IdleChannelV5)
     ),
     %% no CONNACK packet for v4
     ?assertMatch(
-        {shutdown, #{shutdown_count := invalid_connect_packet, cause := frame_too_large}, _Chan},
+        {shutdown, #{shutdown_count := frame_too_large, cause := frame_too_large}, _Chan},
         emqx_channel:handle_in(
             {frame_error, #{cause => frame_too_large}}, v4(IdleChannelV5)
         )
@@ -551,7 +551,7 @@ t_handle_in_frame_error(_) ->
     ?assertMatch(
         {shutdown,
             #{
-                shutdown_count := frame_error,
+                shutdown_count := frame_too_large,
                 cause := frame_too_large,
                 limit := 100,
                 received := 101

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -102,7 +102,8 @@ groups() ->
             t_congestion_decongested,
             t_first_packet_not_connect,
             t_frame_error_shutdown_count_idle,
-            t_frame_error_shutdown_count_connected
+            t_frame_error_shutdown_count_connected,
+            t_frame_error_shutdown_count_is_bounded
         ]},
         {socket, [], [
             t_connection_stats,
@@ -1537,23 +1538,23 @@ t_first_packet_not_connect(Config) ->
     end.
 
 -doc """
-A non-MQTT first packet shuts the connection down with a reason the listener
-supervisor attributes to `invalid_proto_name`, so it is counted rather than
-reported as an unidentified shutdown at error level.
+A non-MQTT first packet shuts the connection down under the fixed
+`invalid_connect_packet` counter, rather than being reported as an unidentified
+shutdown at error level. The cause stays in the shutdown reason.
 """.
 t_frame_error_shutdown_count_idle(Config) ->
     Socket = socket_connect(Config, [{active, true}, binary]),
     %% CONNECT header, but the protocol name is not 'MQTT' nor 'MQIsdp'.
     Malformed = <<16#10, 12, 0, 6, "test/1", 4, 2, 0, 60>>,
-    ExitReason = assert_frame_error_shutdown(Config, Socket, Malformed, invalid_proto_name),
+    ExitReason = assert_frame_error_shutdown(Config, Socket, Malformed, invalid_connect_packet),
     ?assertMatch(
         {shutdown, #{cause := invalid_proto_name, received := <<"test/1">>}}, ExitReason
     ).
 
 -doc """
 A malformed packet from an already connected client shuts the connection down
-with a reason the listener supervisor attributes to `invalid_property_code`, so
-it is counted rather than reported as an unidentified shutdown at error level.
+under the fixed `frame_error` counter, rather than being reported as an
+unidentified shutdown at error level.
 """.
 t_frame_error_shutdown_count_connected(Config) ->
     Socket = socket_connect(Config, [{active, true}, binary]),
@@ -1569,15 +1570,57 @@ t_frame_error_shutdown_count_connected(Config) ->
     end,
     %% SUBSCRIBE carrying an unknown MQTT v5 property code (16#2B).
     Malformed = <<16#82, 9, 0, 1, 2, 16#2B, 0, 0, 1, $t, 0>>,
-    ExitReason = assert_frame_error_shutdown(Config, Socket, Malformed, invalid_property_code),
-    ?assertEqual({shutdown, invalid_property_code}, ExitReason).
+    ExitReason = assert_frame_error_shutdown(Config, Socket, Malformed, frame_error),
+    ?assertEqual({shutdown, frame_error}, ExitReason).
+
+-doc """
+Frame parse errors name a counter from a fixed set, never one derived from the
+client input that triggered them, so that malformed packets cannot mint
+unbounded shutdown counter names.
+""".
+t_frame_error_shutdown_count_is_bounded(Config) ->
+    %% Two different causes, one reported as a map and one as a bare atom.
+    Causes = [
+        %% invalid property code
+        <<16#82, 9, 0, 1, 2, 16#2B, 0, 0, 1, $t, 0>>,
+        %% bad subscribe qos
+        <<16#82, 7, 0, 1, 0, 0, 1, $t, 3>>
+    ],
+    Before = shutdown_count(Config, frame_error),
+    lists:foreach(
+        fun(Malformed) ->
+            Socket = socket_connect(Config, [{active, true}, binary]),
+            ConnPacket = ?CONNECT_PACKET(#mqtt_packet_connect{
+                proto_ver = ?MQTT_PROTO_V5,
+                clientid = atom_to_binary(?FUNCTION_NAME)
+            }),
+            ok = socket_send(Socket, emqx_frame:serialize(ConnPacket)),
+            receive
+                {tcp, _, <<32, _/binary>>} -> ok;
+                {ssl, _, <<32, _/binary>>} -> ok
+            after 5000 -> ct:fail({connack_not_received, process_info(self(), messages)})
+            end,
+            ok = socket_send(Socket, Malformed),
+            {ok, _} = ?block_until(#{?snk_kind := terminate}, 5000)
+        end,
+        Causes
+    ),
+    %% Both land on the one counter, and neither cause names a counter of its own.
+    ?WAIT(?assertEqual(Before + length(Causes), shutdown_count(Config, frame_error)), 5),
+    ?assertEqual(
+        [],
+        [
+            K
+         || K <- shutdown_count_keys(Config), lists:member(K, [invalid_property_code, bad_subqos])
+        ]
+    ).
 
 %% Send `Malformed' and assert the connection exits with a reason the connection
 %% supervisor attributes to `Cause'. Returns the exit reason.
 assert_frame_error_shutdown(Config, Socket, Malformed, Cause) ->
     CountBefore = shutdown_count(Config, Cause),
     Self = self(),
-    Reports = emqx_cth_log_capture:capture(info, fun() ->
+    Reports = emqx_cth_log_capture:capture(debug, fun() ->
         ok = socket_send(Socket, Malformed),
         {ok, #{reason := R}} = ?block_until(#{?snk_kind := terminate}, 5000),
         Self ! {exit_reason, R}
@@ -1587,10 +1630,10 @@ assert_frame_error_shutdown(Config, Socket, Malformed, Cause) ->
             {exit_reason, R0} -> R0
         after 0 -> ct:fail(no_terminate_event)
         end,
-    %% The shutdown reason only names the cause, so the full parse error and the
-    %% offending bytes must stay available at info level for troubleshooting.
+    %% The shutdown counter only names a kind, so the specific cause and the
+    %% offending bytes must stay reachable through `emqx_trace'.
     ?assertMatch(
-        [#{reason := #{cause := Cause}, input_bytes := Malformed, at_state := _} | _],
+        [#{reason := #{cause := _}, input_bytes := Malformed, at_state := _} | _],
         [R1 || #{msg := "frame_parse_error"} = R1 <- Reports]
     ),
     %% esockd attributes a shutdown to a cause when the reason is either a plain
@@ -1607,8 +1650,13 @@ assert_frame_error_shutdown(Config, Socket, Malformed, Cause) ->
     ExitReason.
 
 shutdown_count(Config, Cause) ->
-    Counts = emqx_listeners:shutdown_count(listener_id(Config), listener_port(Config)),
-    proplists:get_value(Cause, Counts, 0).
+    proplists:get_value(Cause, shutdown_counts(Config), 0).
+
+shutdown_count_keys(Config) ->
+    lists:sort(proplists:get_keys(shutdown_counts(Config))).
+
+shutdown_counts(Config) ->
+    emqx_listeners:shutdown_count(listener_id(Config), listener_port(Config)).
 
 %%--------------------------------------------------------------------
 %% Helper functions

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -1576,8 +1576,23 @@ t_frame_error_shutdown_count_connected(Config) ->
 %% supervisor attributes to `Cause'. Returns the exit reason.
 assert_frame_error_shutdown(Config, Socket, Malformed, Cause) ->
     CountBefore = shutdown_count(Config, Cause),
-    ok = socket_send(Socket, Malformed),
-    {ok, #{reason := ExitReason}} = ?block_until(#{?snk_kind := terminate}, 5000),
+    Self = self(),
+    Reports = emqx_cth_log_capture:capture(info, fun() ->
+        ok = socket_send(Socket, Malformed),
+        {ok, #{reason := R}} = ?block_until(#{?snk_kind := terminate}, 5000),
+        Self ! {exit_reason, R}
+    end),
+    ExitReason =
+        receive
+            {exit_reason, R0} -> R0
+        after 0 -> ct:fail(no_terminate_event)
+        end,
+    %% The shutdown reason only names the cause, so the full parse error and the
+    %% offending bytes must stay available at info level for troubleshooting.
+    ?assertMatch(
+        [#{reason := #{cause := Cause}, input_bytes := Malformed, at_state := _} | _],
+        [R1 || #{msg := "frame_parse_error"} = R1 <- Reports]
+    ),
     %% esockd attributes a shutdown to a cause when the reason is either a plain
     %% atom or a map tagged with `shutdown_count'; anything else is reported as
     %% an unidentified shutdown at error level and left uncounted.

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -1574,46 +1574,55 @@ t_frame_error_shutdown_count_connected(Config) ->
     ?assertEqual({shutdown, frame_error}, ExitReason).
 
 -doc """
-Frame parse errors name a counter from a fixed set, never one derived from the
-client input that triggered them, so that malformed packets cannot mint
-unbounded shutdown counter names.
+Frame parse errors reported as a map share the `frame_error` counter, so the
+detail they carry cannot mint counter names. Errors reported as a bare atom come
+from a fixed set and keep their own counter.
 """.
 t_frame_error_shutdown_count_is_bounded(Config) ->
-    %% Two different causes, one reported as a map and one as a bare atom.
-    Causes = [
-        %% invalid property code
+    MapCauses = [
+        %% #{cause => invalid_property_code, ...}
         <<16#82, 9, 0, 1, 2, 16#2B, 0, 0, 1, $t, 0>>,
-        %% bad subscribe qos
-        <<16#82, 7, 0, 1, 0, 0, 1, $t, 3>>
+        %% #{cause => invalid_proto_name, ...}, as reported in #17903
+        <<16#10, 12, 0, 6, "test/1", 4, 2, 0, 60>>
     ],
-    Before = shutdown_count(Config, frame_error),
+    %% bad_subqos, a bare atom
+    AtomCause = <<16#82, 7, 0, 1, 0, 0, 1, $t, 3>>,
+    GroupedBefore = shutdown_count(Config, frame_error),
+    NamedBefore = shutdown_count(Config, bad_subqos),
     lists:foreach(
-        fun(Malformed) ->
-            Socket = socket_connect(Config, [{active, true}, binary]),
-            ConnPacket = ?CONNECT_PACKET(#mqtt_packet_connect{
-                proto_ver = ?MQTT_PROTO_V5,
-                clientid = atom_to_binary(?FUNCTION_NAME)
-            }),
-            ok = socket_send(Socket, emqx_frame:serialize(ConnPacket)),
-            receive
-                {tcp, _, <<32, _/binary>>} -> ok;
-                {ssl, _, <<32, _/binary>>} -> ok
-            after 5000 -> ct:fail({connack_not_received, process_info(self(), messages)})
-            end,
-            ok = socket_send(Socket, Malformed),
-            {ok, _} = ?block_until(#{?snk_kind := terminate}, 5000)
-        end,
-        Causes
+        fun(Malformed) -> send_malformed_when_connected(Config, Malformed) end,
+        [AtomCause | MapCauses]
     ),
-    %% Both land on the one counter, and neither cause names a counter of its own.
-    ?WAIT(?assertEqual(Before + length(Causes), shutdown_count(Config, frame_error)), 5),
+    %% Every map cause lands on the one counter ...
+    ?WAIT(
+        ?assertEqual(GroupedBefore + length(MapCauses), shutdown_count(Config, frame_error)),
+        5
+    ),
     ?assertEqual(
         [],
         [
             K
-         || K <- shutdown_count_keys(Config), lists:member(K, [invalid_property_code, bad_subqos])
+         || K <- shutdown_count_keys(Config),
+            lists:member(K, [invalid_property_code, invalid_proto_name])
         ]
-    ).
+    ),
+    %% ... while an atom cause keeps its own.
+    ?assertEqual(NamedBefore + 1, shutdown_count(Config, bad_subqos)).
+
+send_malformed_when_connected(Config, Malformed) ->
+    Socket = socket_connect(Config, [{active, true}, binary]),
+    ConnPacket = ?CONNECT_PACKET(#mqtt_packet_connect{
+        proto_ver = ?MQTT_PROTO_V5,
+        clientid = atom_to_binary(?FUNCTION_NAME)
+    }),
+    ok = socket_send(Socket, emqx_frame:serialize(ConnPacket)),
+    receive
+        {tcp, _, <<32, _/binary>>} -> ok;
+        {ssl, _, <<32, _/binary>>} -> ok
+    after 5000 -> ct:fail({connack_not_received, process_info(self(), messages)})
+    end,
+    ok = socket_send(Socket, Malformed),
+    {ok, _} = ?block_until(#{?snk_kind := terminate}, 5000).
 
 %% Send `Malformed' and assert the connection exits with a reason the connection
 %% supervisor attributes to `Cause'. Returns the exit reason.

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -100,7 +100,9 @@ groups() ->
             t_congestion_send_timeout,
             t_congestion_qos0_no_send_timeout,
             t_congestion_decongested,
-            t_first_packet_not_connect
+            t_first_packet_not_connect,
+            t_frame_error_shutdown_count_idle,
+            t_frame_error_shutdown_count_connected
         ]},
         {socket, [], [
             t_connection_stats,
@@ -1533,6 +1535,65 @@ t_first_packet_not_connect(Config) ->
     after 5000 ->
         ct:fail("Expected socket to be closed")
     end.
+
+-doc """
+A non-MQTT first packet shuts the connection down with a reason the listener
+supervisor attributes to `invalid_proto_name`, so it is counted rather than
+reported as an unidentified shutdown at error level.
+""".
+t_frame_error_shutdown_count_idle(Config) ->
+    Socket = socket_connect(Config, [{active, true}, binary]),
+    %% CONNECT header, but the protocol name is not 'MQTT' nor 'MQIsdp'.
+    Malformed = <<16#10, 12, 0, 6, "test/1", 4, 2, 0, 60>>,
+    ExitReason = assert_frame_error_shutdown(Config, Socket, Malformed, invalid_proto_name),
+    ?assertMatch(
+        {shutdown, #{cause := invalid_proto_name, received := <<"test/1">>}}, ExitReason
+    ).
+
+-doc """
+A malformed packet from an already connected client shuts the connection down
+with a reason the listener supervisor attributes to `invalid_property_code`, so
+it is counted rather than reported as an unidentified shutdown at error level.
+""".
+t_frame_error_shutdown_count_connected(Config) ->
+    Socket = socket_connect(Config, [{active, true}, binary]),
+    ConnPacket = ?CONNECT_PACKET(#mqtt_packet_connect{
+        proto_ver = ?MQTT_PROTO_V5,
+        clientid = atom_to_binary(?FUNCTION_NAME)
+    }),
+    ok = socket_send(Socket, emqx_frame:serialize(ConnPacket)),
+    receive
+        {tcp, _, <<32, _/binary>>} -> ok;
+        {ssl, _, <<32, _/binary>>} -> ok
+    after 5000 -> ct:fail({connack_not_received, process_info(self(), messages)})
+    end,
+    %% SUBSCRIBE carrying an unknown MQTT v5 property code (16#2B).
+    Malformed = <<16#82, 9, 0, 1, 2, 16#2B, 0, 0, 1, $t, 0>>,
+    ExitReason = assert_frame_error_shutdown(Config, Socket, Malformed, invalid_property_code),
+    ?assertEqual({shutdown, invalid_property_code}, ExitReason).
+
+%% Send `Malformed' and assert the connection exits with a reason the connection
+%% supervisor attributes to `Cause'. Returns the exit reason.
+assert_frame_error_shutdown(Config, Socket, Malformed, Cause) ->
+    CountBefore = shutdown_count(Config, Cause),
+    ok = socket_send(Socket, Malformed),
+    {ok, #{reason := ExitReason}} = ?block_until(#{?snk_kind := terminate}, 5000),
+    %% esockd attributes a shutdown to a cause when the reason is either a plain
+    %% atom or a map tagged with `shutdown_count'; anything else is reported as
+    %% an unidentified shutdown at error level and left uncounted.
+    case ExitReason of
+        {shutdown, Cause} -> ok;
+        {shutdown, #{shutdown_count := Cause}} -> ok;
+        Other -> ct:fail({unattributable_shutdown_reason, Other})
+    end,
+    %% Counter only moves on the info-level branch, so this also proves no
+    %% error-level supervisor report was emitted.
+    ?WAIT(?assertEqual(CountBefore + 1, shutdown_count(Config, Cause)), 5),
+    ExitReason.
+
+shutdown_count(Config, Cause) ->
+    Counts = emqx_listeners:shutdown_count(listener_id(Config), listener_port(Config)),
+    proplists:get_value(Cause, Counts, 0).
 
 %%--------------------------------------------------------------------
 %% Helper functions

--- a/apps/emqx/test/emqx_packet_SUITE.erl
+++ b/apps/emqx/test/emqx_packet_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx/include/emqx_trace.hrl").
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -479,3 +480,16 @@ t_parse_empty_publish(_) ->
     %% 52: 0011(type=PUBLISH) 0100 (QoS=2)
     Packet = #mqtt_packet_publish{topic_name = <<>>},
     ?assertEqual({error, ?RC_PROTOCOL_ERROR}, emqx_packet:check(Packet)).
+
+-doc "Input bytes are kept verbatim when small, and capped with the original size when large.".
+t_format_input_bytes(_) ->
+    Small = <<1, 2, 3>>,
+    ?assertEqual(Small, emqx_packet:format_input_bytes(Small)),
+    AtLimit = binary:copy(<<0>>, ?TRUNCATED_PAYLOAD_SIZE),
+    ?assertEqual(AtLimit, emqx_packet:format_input_bytes(AtLimit)),
+    TotalSize = ?TRUNCATED_PAYLOAD_SIZE * 10,
+    Large = binary:copy(<<7>>, TotalSize),
+    ?assertEqual(
+        #{bytes => binary:copy(<<7>>, ?TRUNCATED_PAYLOAD_SIZE), total_size => TotalSize},
+        emqx_packet:format_input_bytes(Large)
+    ).

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -438,13 +438,13 @@ t_parse_incoming_fragment_then_bad_subqos_idle(_) ->
     ?assertEqual([], Packets1),
     {Packets2, St2} = ?ws_conn:parse_incoming(Frag2, Packets1, St1),
     ?assertMatch([{frame_error, bad_subqos}], Packets2),
-    {[{shutdown, #{shutdown_count := invalid_connect_packet, reason := bad_subqos}}], _St3} =
+    {[{shutdown, #{shutdown_count := bad_subqos, reason := bad_subqos}}], _St3} =
         ?ws_conn:handle_incoming(Packets2, St2).
 
 t_handle_incomming_frame_error(_) ->
     FrameError = {frame_error, bad_qos},
     Serialize = #{version => 5, max_size => 16#FFFF, strict_mode => false},
-    {[{binary, IoData}, {close, <<"frame_error">>}], _St} =
+    {[{binary, IoData}, {close, <<"bad_qos">>}], _St} =
         ?ws_conn:handle_incoming([FrameError], st(#{serialize => Serialize})),
     ?assertEqual(<<224, 2, 129, 0>>, iolist_to_binary(IoData)).
 

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -342,7 +342,7 @@ t_websocket_incoming(_) ->
     {[{binary, IoData4}, {close, CauseReq}], _St4} =
         ?ws_conn:handle_incoming([FrameError], St3),
     ?assertEqual(<<224, 2, ?RC_MALFORMED_PACKET, 0>>, iolist_to_binary(IoData4)),
-    ?assertEqual(<<"invalid_property_code">>, CauseReq).
+    ?assertEqual(<<"frame_error">>, CauseReq).
 
 t_websocket_info_check_gc(_) ->
     Stats = #{cnt => 10, oct => 1000},
@@ -444,7 +444,7 @@ t_parse_incoming_fragment_then_bad_subqos_idle(_) ->
 t_handle_incomming_frame_error(_) ->
     FrameError = {frame_error, bad_qos},
     Serialize = #{version => 5, max_size => 16#FFFF, strict_mode => false},
-    {[{binary, IoData}, {close, <<"bad_qos">>}], _St} =
+    {[{binary, IoData}, {close, <<"frame_error">>}], _St} =
         ?ws_conn:handle_incoming([FrameError], st(#{serialize => Serialize})),
     ?assertEqual(<<224, 2, 129, 0>>, iolist_to_binary(IoData)).
 

--- a/changes/ee/fix-18010.en.md
+++ b/changes/ee/fix-18010.en.md
@@ -1,5 +1,5 @@
 Malformed MQTT packets sent by clients are no longer logged as broker errors.
 
-Such invalid input is now counted in the connection shutdown counters of the listener, reducing alert noise from port scanners, protocol fuzzers and misbehaving clients. All frame parse errors share a single `frame_error` counter, so malformed packets can no longer create new counter names.
+Such invalid input is now counted in the connection shutdown counters of the listener, reducing alert noise from port scanners, protocol fuzzers and misbehaving clients. Parse errors that carry packet-specific detail share a single `frame_error` counter, so malformed packets can no longer create new counter names.
 
 Details of the parse error, including the offending bytes, are reported through tracing: start a trace on the client ID, IP address or topic to inspect them.

--- a/changes/ee/fix-18010.en.md
+++ b/changes/ee/fix-18010.en.md
@@ -1,0 +1,3 @@
+Malformed MQTT packets sent by connected clients are no longer logged as broker errors.
+
+Such invalid input is now grouped in the per-reason connection shutdown counters of the listener, reducing alert noise from port scanners, protocol fuzzers and misbehaving clients. Details of the parse error remain available at info level.

--- a/changes/ee/fix-18010.en.md
+++ b/changes/ee/fix-18010.en.md
@@ -1,3 +1,5 @@
-Malformed MQTT packets sent by connected clients are no longer logged as broker errors.
+Malformed MQTT packets sent by clients are no longer logged as broker errors.
 
-Such invalid input is now grouped in the per-reason connection shutdown counters of the listener, reducing alert noise from port scanners, protocol fuzzers and misbehaving clients. Details of the parse error remain available at info level.
+Such invalid input is now counted in the connection shutdown counters of the listener, reducing alert noise from port scanners, protocol fuzzers and misbehaving clients. All frame parse errors share a single `frame_error` counter, so malformed packets can no longer create new counter names.
+
+Details of the parse error, including the offending bytes, are reported through tracing: start a trace on the client ID, IP address or topic to inspect them.


### PR DESCRIPTION
Release version: 6.3.0

Fixes #17903

## Summary

Frame parse errors triggered by client input were reported at error level by the
listener supervisor, e.g.

```
[error] supervisor: {esockd_connection_sup,<..>}, errorContext: connection_shutdown,
  reason: #{cause => invalid_proto_name, expected => <<"'MQTT' or 'MQIsdp'">>, received => <<"test/1">>},
  offender: [{pid,<..>},{name,connection},{mfargs,{emqx_connection,start_link,[...]}}]
```

Three related changes.

### 1. Frame errors on established connections were never counted

`esockd_connection_sup` attributes a shutdown to a kind when the exit reason is
either a plain atom or a map tagged with `shutdown_count`; those are counted and
logged at info. Anything else falls through to the `connection_shutdown` clause,
which logs at error and keeps no counter.

`emqx_channel:handle_frame_error/2` already tagged the `idle` and `connecting`
clauses. The clause for established connections did not: it passed the raw parse
error map as the DISCONNECT reason name, and since the close reason doubles as
the connection process exit reason, the process exited with the untagged map.
This covers every frame error raised after CONNECT completes, which is the bulk
of what a protocol fuzzer produces.

An atom rather than a tagged map is what `?REPLY_CLOSE(ReasonName)` expects here:
on WebSocket listeners the close reason is serialized into the close frame, so a
map there yields a malformed payload.

### 2. Counter names were derived from packet detail

`shutdown_count/2` preferred the parse error `cause` over the kind chosen at the
call site, so map-shaped errors named counters after whatever detail they
carried: `invalid_property_code`, `user_property_not_enough_bytes`,
`invalid_server_reference`, and so on.

New rule, in `frame_error_kind/2`:

- errors reported as a **bare atom** come from a fixed set in the parser, so the
  atom keeps naming its own counter (`bad_qos`, `bad_subqos`, `bad_packet_id`, ...);
- errors reported as a **map** share the kind chosen at the call site
  (`frame_error`, or `invalid_connect_packet` for junk arriving before CONNECT),
  with the specific cause kept in the shutdown reason;
- **oversized frames** keep their own `frame_too_large` counter in every
  connection state.

### 3. Per-packet info log

Every parse error produced an unconditional info-level report carrying the whole
input buffer. Under a fuzzer that is one line per malformed packet, and the
buffer can be as large as the configured maximum packet size. It is now reported
through `emqx_trace`, so the detail is reachable by tracing a client ID, IP or
topic, and the input bytes are truncated via `emqx_packet:format_input_bytes/1`.

### Behavior note

The `'client.disconnected'` hook reason for a map-shaped frame error on an
established connection is now the atom `frame_error` rather than the parse error
map, consistent with every other disconnect reason. Atom-shaped errors are
unchanged.

Relevant files: `apps/emqx/src/emqx_channel.erl`, `emqx_connection.erl`,
`emqx_socket_connection.erl`, `emqx_ws_connection.erl`, `emqx_packet.erl`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)