### PR TITLE
feat(dashboard): add collapsible endpoints to API spec explorer

### DIFF
--- a/apps/emqx_dashboard/priv/api-spec.html
+++ b/apps/emqx_dashboard/priv/api-spec.html
@@ -432,6 +432,19 @@
       letter-spacing: 0.25px;
     }
 
+    .panel-actions {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 6px;
+    }
+
+    .panel-actions .btn {
+      height: 28px;
+      padding: 0 9px;
+      font-size: 12px;
+    }
+
     .panel-hd-toggle {
       cursor: pointer;
       user-select: none;
@@ -579,14 +592,56 @@
       background: rgba(255, 255, 255, 0.02);
     }
 
+    .endpoint-list {
+      display: grid;
+      gap: 8px;
+    }
+
     .endpoint-hd {
       display: grid;
-      grid-template-columns: auto 1fr auto;
+      grid-template-columns: auto minmax(0, 1fr) minmax(0, 300px) auto;
       align-items: center;
       gap: 10px;
       padding: 10px;
-      border-bottom: 1px solid var(--color-border-primary);
       background: rgba(255, 255, 255, 0.03);
+      cursor: pointer;
+      list-style: none;
+      user-select: none;
+    }
+
+    .endpoint-hd::-webkit-details-marker {
+      display: none;
+    }
+
+    .endpoint-hd::marker {
+      content: "";
+    }
+
+    .endpoint-hd::after {
+      content: "\203A";
+      grid-column: 4;
+      grid-row: 1;
+      color: var(--color-text-secondary);
+      font-size: 20px;
+      line-height: 1;
+      transition: transform 0.15s ease;
+    }
+
+    .endpoint-hd:hover {
+      background: rgba(94, 123, 255, 0.08);
+    }
+
+    .endpoint-hd:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: -2px;
+    }
+
+    .endpoint-card[open] > .endpoint-hd {
+      border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    .endpoint-card[open] > .endpoint-hd::after {
+      transform: rotate(90deg);
     }
 
     .endpoint-hd .title {
@@ -943,9 +998,16 @@
         grid-template-columns: 1fr;
       }
 
-      .op-row,
-      .endpoint-hd {
+      .op-row {
         grid-template-columns: auto 1fr;
+      }
+
+      .endpoint-hd {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+      }
+
+      .endpoint-hd::after {
+        grid-column: 3;
       }
 
       .op-row .summary,
@@ -1382,7 +1444,9 @@
 
     function renderEndpointsPanel(paths) {
       const panel = panelEl('Endpoints');
+      const hd = panel.querySelector('.panel-hd');
       const bd = panel.querySelector('.panel-bd');
+      bd.classList.add('endpoint-list');
 
       const methodOrder = ['get', 'post', 'put', 'delete', 'patch', 'options', 'head'];
       const cards = [];
@@ -1408,11 +1472,30 @@
       }
 
       for (const c of cards) bd.appendChild(c);
+
+      const actions = document.createElement('div');
+      actions.className = 'panel-actions';
+      actions.innerHTML = `
+        <button type="button" class="btn" data-action="expand-all">Expand All</button>
+        <button type="button" class="btn" data-action="collapse-all">Collapse All</button>
+      `;
+      actions.querySelector('[data-action="expand-all"]').addEventListener('click', () => {
+        bd.querySelectorAll('.endpoint-card').forEach((card) => {
+          card.open = true;
+        });
+      });
+      actions.querySelector('[data-action="collapse-all"]').addEventListener('click', () => {
+        bd.querySelectorAll('.endpoint-card').forEach((card) => {
+          card.open = false;
+        });
+      });
+      hd.appendChild(actions);
+
       return panel;
     }
 
     function endpointCard(path, method, op) {
-      const card = document.createElement('article');
+      const card = document.createElement('details');
       card.className = 'endpoint-card';
 
       const m = method.toLowerCase();
@@ -1425,11 +1508,11 @@
       const respCodes = Object.keys(responses).sort();
 
       card.innerHTML = `
-        <header class="endpoint-hd">
+        <summary class="endpoint-hd">
           <span class="method ${methodClass}">${escapeHtml(method.toUpperCase())}</span>
-          <h4 class="title">${escapeHtml(path)}</h4>
+          <span class="title">${escapeHtml(path)}</span>
           <span class="summary" title="${escapeHtml(summary)}">${escapeHtml(summary || '-')}</span>
-        </header>
+        </summary>
         <div class="endpoint-bd"></div>
       `;
 


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Ports emqx/emqx#17996 (merged to `dev-63`) to `dev-60`.

Dashboard API spec explorer (`apps/emqx_dashboard/priv/api-spec.html`) now renders
endpoint cards collapsed by default, with Expand All / Collapse All controls:

* `endpointCard/3` builds a `<details>`/`<summary>` instead of `<article>`/`<header>`;
  the path title becomes a `<span class="title">` (a heading inside `<summary>` is not
  appropriate now that it is the disclosure control).
* `renderEndpointsPanel/1` appends a `.panel-actions` block with the two buttons to the
  panel header, and marks the panel body as `.endpoint-list` for card spacing.
* CSS: disclosure-marker suppression, a rotating `\203A` arrow, hover/`:focus-visible`
  styles, `[open]`-scoped header border, and a responsive-layout split so the arrow
  column tracks the narrowed grid.

`dev-60`'s copy of the file has diverged from `dev-63`'s, so the upstream hunks were
applied by anchor rather than cherry-picked. The resulting change set is byte-identical
to the upstream diff (+91/-8).

Static asset only — no Erlang code changed. Verified the inline `<script>` still parses
(`node --check` on the extracted block).

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
