### PR TITLE
fix(gcp_pubsub): keep an in-flight pull open until its lease expires

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
@@ -407,9 +407,9 @@ ensure_ack_timer(State = #{ack_timer := TRef, pending_acks := PendingAcks}) ->
             State
     end.
 
--spec ensure_pull_timer(state()) -> state().
-ensure_pull_timer(State = #{pull_retry_interval := PullRetryInterval}) ->
-    State#{pull_timer := emqx_utils:start_timer(PullRetryInterval, pull)}.
+-spec ensure_pull_timer(state(), timeout()) -> state().
+ensure_pull_timer(State, TimeoutMS) ->
+    State#{pull_timer := emqx_utils:start_timer(TimeoutMS, pull)}.
 
 cancel_pull_timer(State = #{pull_timer := TRef}) ->
     emqx_utils:cancel_timer(TRef),
@@ -595,10 +595,18 @@ do_pull_async(State0) ->
             ),
             case Res of
                 {ok, AsyncWorkerPid} ->
-                    State2 = ensure_pull_timer(State1),
+                    %% A pull is in flight.  `ehttpc' never expires a request once it has
+                    %% been sent, so this timer is what bounds the long poll, and firing it
+                    %% cancels the request.  It must therefore allow the server the full
+                    %% lease duration to answer: cancelling earlier tears down a healthy long
+                    %% poll and discards any messages the server already leased into its
+                    %% response, which then stay invisible until the lease expires.
+                    State2 = ensure_pull_timer(State1, AckDeadlineMS),
                     ensure_async_worker_monitored(State2, AsyncWorkerPid);
                 {error, no_pool_worker_available} ->
-                    ensure_pull_timer(State1)
+                    %% Nothing is in flight, so there is nothing to lose by retrying soon.
+                    #{pull_retry_interval := PullRetryInterval} = State1,
+                    ensure_pull_timer(State1, PullRetryInterval)
             end
         end
     ).

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -1210,6 +1210,42 @@ t_timeout_during_pull(TCConfig) ->
     ),
     ok.
 
+-doc """
+Checks that a healthy in-flight pull request is left alone until its lease expires.
+
+A pull is a long poll that legitimately stays open until a message arrives.  Cancelling it
+sooner discards whatever the server has already leased into its response, and those
+messages then stay invisible until the lease (`ack_deadline`) expires.
+""".
+t_no_premature_pull_cancel(TCConfig) ->
+    AckDeadline = <<"10s">>,
+    %% A short `request_ttl' drives `pull_retry_interval': if the in-flight pull were tied to
+    %% it, it would be cancelled every second.  It must not be while a pull is in flight.
+    RequestTTL = <<"1s">>,
+    ?check_trace(
+        begin
+            {201, _} = create_connector_api(TCConfig, #{}),
+            {201, _} = create_source_api(TCConfig, #{
+                <<"parameters">> => #{<<"ack_deadline">> => AckDeadline},
+                <<"resource_opts">> => #{<<"request_ttl">> => RequestTTL}
+            }),
+            {ok, _} = snabbkaffe:block_until(
+                ?match_event(#{?snk_kind := "gcp_pubsub_consumer_worker_subscription_ready"}),
+                10_000
+            ),
+            %% Idle well within `ack_deadline': nothing should be cancelled.
+            timer:sleep(3_000),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertEqual(
+                [], ?of_kind("gcp_consumer_worker_pull_stream_cancelled", Trace)
+            ),
+            ok
+        end
+    ),
+    ok.
+
 t_pull_worker_death(TCConfig) ->
     ?check_trace(
         begin


### PR DESCRIPTION
Release version: 6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

A GCP PubSub consumer source could repeatedly delay delivery of messages it had already
been handed by the server. This surfaced as a flaky
`emqx_bridge_gcp_pubsub_consumer_SUITE:t_cluster_subscription`, but the cause is in the
consumer worker, not the test.

`do_pull_async/1` in `emqx_bridge_gcp_pubsub_consumer_worker.erl` sends the pull request
with a TTL of `ack_deadline` — there is a comment there explaining that the pull must be
allowed to live as long as the lease. But the timer that *cancels* that request was armed
from `pull_retry_interval`, which `emqx_bridge_gcp_pubsub_impl_consumer.erl` derives from
`resource_opts.request_ttl`. Those are unrelated knobs, so the timer always pre-empted the
intended lifetime: 1s vs 10s in CT, 45s vs 60s with default settings.

That matters because:

* A pull is a long poll — with no `returnImmediately` it legitimately stays open until a
  message arrives.
* `ehttpc` never expires a request once it has been *sent*
  (`is_sent_req_expired/2`), so `request_ttl` only bounds the pending-queue wait. This
  timer is the only thing bounding the long poll.
* `ehttpc:cancel/2` drops the request *without* invoking the reply callback, so a response
  the server has already produced is discarded.

So every `pull_retry_interval` the worker tore down a healthy long poll. When the server
had just leased a message into that response, the response was thrown away but the lease
stood, making the message invisible until `ack_deadline` expired — and the next pull raced
the same short timer again.

Measured at the nginx in front of the emulator, with the source idle:

| | idle pull cadence | pulls in run | `t_cluster_subscription` |
|---|---|---|---|
| before | 2/sec (1/sec/node) | 200 | fails |
| after | 1 per 10s (= `ack_deadline`) | 16 | passes |

Publishing into that churn (a 30s idle window before the publish) reproduced the failure
100% of the time on the current code, and passes with this change.

The fix arms the timer with `ack_deadline` while a pull is in flight, and keeps
`pull_retry_interval` for the retry path where nothing is in flight and there is nothing to
lose by retrying soon. The stuck-pull cancellation added in bbe42e123f (#17966) is
preserved — it is still needed, since `ehttpc` will not time the request out on its own.

`t_no_premature_pull_cancel` covers the invariant: it fails without this change and passes
with it. Full consumer suite: 27 passed, 0 failed (1 pre-existing user-skip).

bbe42e123f has not been released yet, so this needs no release note of its own; the
existing `changes/ee/fix-17982.en.md` is annotated with this PR instead.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
