### PR TITLE
fix(authz): authorize delayed message replay

### DIFF
--- a/apps/emqx/src/emqx_access_control.erl
+++ b/apps/emqx/src/emqx_access_control.erl
@@ -11,6 +11,7 @@
 -export([
     authenticate/1,
     authorize/3,
+    authorize/4,
     format_action/1
 ]).
 
@@ -135,10 +136,16 @@ authenticate(Credential) ->
 %% @doc Check Authorization
 -spec authorize(emqx_types:clientinfo(), emqx_types:pubsub(), emqx_types:topic()) ->
     authz_result().
-authorize(ClientInfo, Action, <<"$delayed/", Data/binary>> = RawTopic) ->
+authorize(ClientInfo, Action, Topic) ->
+    authorize(ClientInfo, Action, Topic, #{}).
+
+-spec authorize(
+    emqx_types:clientinfo(), emqx_types:pubsub(), emqx_types:topic(), #{cache => boolean()}
+) -> authz_result().
+authorize(ClientInfo, Action, <<"$delayed/", Data/binary>> = RawTopic, Opts) ->
     case binary:split(Data, <<"/">>) of
         [_, Topic] ->
-            authorize(ClientInfo, Action, Topic);
+            authorize(ClientInfo, Action, Topic, Opts);
         _ ->
             ?SLOG(warning, #{
                 msg => "invalid_delayed_topic_format",
@@ -148,9 +155,9 @@ authorize(ClientInfo, Action, <<"$delayed/", Data/binary>> = RawTopic) ->
             inc_authz_metrics(deny),
             deny
     end;
-authorize(ClientInfo, Action, Topic) ->
+authorize(ClientInfo, Action, Topic, Opts) ->
     {Result, _Cacheable} =
-        case emqx_authz_cache:is_enabled(Topic) of
+        case maps:get(cache, Opts, true) andalso emqx_authz_cache:is_enabled(Topic) of
             true -> check_authorization_cache(ClientInfo, Action, Topic);
             false -> do_authorize_with_cache_policy(ClientInfo, Action, Topic)
         end,

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -288,10 +288,13 @@ eval_hook_and_publish(Msg, Opts) ->
                     []
             end;
         Msg1 = #message{} ->
-            do_publish(Msg1);
+            do_publish(cleanup_publish_context(Msg1));
         Msgs when is_list(Msgs) ->
-            do_publish_many(Msgs)
+            do_publish_many([cleanup_publish_context(Msg1) || Msg1 <- Msgs])
     end.
+
+cleanup_publish_context(Msg) ->
+    emqx_message:remove_header(authz_context, Msg).
 
 do_publish_many([]) ->
     [];

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -726,21 +726,19 @@ packet_to_message(Packet, #channel{
         } = ClientInfo
 }) ->
     ClientAttrs = maps:get(client_attrs, ClientInfo, #{}),
-    emqx_mountpoint:mount(
-        MountPoint,
-        emqx_packet:to_message(
-            Packet,
-            ClientId,
-            #{
-                client_attrs => ClientAttrs,
-                peername => PeerName,
-                proto_ver => ProtoVer,
-                protocol => Protocol,
-                username => Username,
-                peerhost => PeerHost
-            }
-        )
-    ).
+    Msg = emqx_packet:to_message(
+        Packet,
+        ClientId,
+        #{
+            client_attrs => ClientAttrs,
+            peername => PeerName,
+            proto_ver => ProtoVer,
+            protocol => Protocol,
+            username => Username,
+            peerhost => PeerHost
+        }
+    ),
+    emqx_message:set_authz_context(ClientInfo, emqx_mountpoint:mount(MountPoint, Msg)).
 
 do_publish(_PacketId, Msg = #message{qos = ?QOS_0}, Channel) ->
     Result = emqx_broker:publish(Msg),
@@ -3281,7 +3279,8 @@ prepare_will_message_for_publishing(
             {error, #{client_banned => ClientBanned, publishing_disallowed => PublishingDisallowed}};
         false ->
             NMsg = emqx_mountpoint:mount(MountPoint, Msg),
-            PreparedMessage = NMsg#message{timestamp = emqx_message:timestamp_now()},
+            PreparedMessage0 = NMsg#message{timestamp = emqx_message:timestamp_now()},
+            PreparedMessage = emqx_message:set_authz_context(ClientInfo, PreparedMessage0),
             {ok, PreparedMessage}
     end.
 

--- a/apps/emqx/src/emqx_message.erl
+++ b/apps/emqx/src/emqx_message.erl
@@ -50,6 +50,8 @@
     get_header/3,
     set_header/3,
     set_headers/2,
+    make_authz_context/1,
+    set_authz_context/2,
     remove_header/2
 ]).
 
@@ -88,6 +90,22 @@
 %% Message timestamp
 %% Granularity: milliseconds.
 -type timestamp() :: non_neg_integer().
+
+-define(AUTHZ_CONTEXT_KEYS, [
+    acl,
+    anonymous,
+    client_attrs,
+    clientid,
+    cn,
+    dn,
+    is_bridge,
+    listener,
+    mountpoint,
+    peerhost,
+    protocol,
+    username,
+    zone
+]).
 
 -elvis([{elvis_style, god_modules, disable}]).
 
@@ -252,6 +270,15 @@ unset_flag(Flag, Msg = #message{flags = Flags}) ->
 -spec set_headers(map(), emqx_types:message()) -> emqx_types:message().
 set_headers(New, Msg = #message{headers = Old}) when is_map(New) ->
     Msg#message{headers = maps:merge(Old, New)}.
+
+-spec make_authz_context(emqx_types:clientinfo()) -> emqx_types:clientinfo().
+make_authz_context(ClientInfo) ->
+    Context = maps:with(?AUTHZ_CONTEXT_KEYS, ClientInfo),
+    Context#{is_superuser => false}.
+
+-spec set_authz_context(emqx_types:clientinfo(), emqx_types:message()) -> emqx_types:message().
+set_authz_context(ClientInfo, Msg) ->
+    set_header(authz_context, make_authz_context(ClientInfo), Msg).
 
 -spec get_headers(emqx_types:message()) -> option(map()).
 get_headers(Msg) -> Msg#message.headers.

--- a/apps/emqx/src/emqx_message.erl
+++ b/apps/emqx/src/emqx_message.erl
@@ -103,9 +103,20 @@
     mountpoint,
     peerhost,
     protocol,
+    sockport,
     username,
     zone
 ]).
+
+-define(DEFAULT_AUTHZ_CONTEXT, #{
+    zone => undefined,
+    protocol => none,
+    peerhost => {0, 0, 0, 0},
+    sockport => 0,
+    username => undefined,
+    is_bridge => false,
+    mountpoint => undefined
+}).
 
 -elvis([{elvis_style, god_modules, disable}]).
 
@@ -271,9 +282,10 @@ unset_flag(Flag, Msg = #message{flags = Flags}) ->
 set_headers(New, Msg = #message{headers = Old}) when is_map(New) ->
     Msg#message{headers = maps:merge(Old, New)}.
 
--spec make_authz_context(emqx_types:clientinfo()) -> emqx_types:clientinfo().
+-spec make_authz_context(#{clientid := emqx_types:clientid(), atom() => term()}) ->
+    emqx_types:clientinfo().
 make_authz_context(ClientInfo) ->
-    Context = maps:with(?AUTHZ_CONTEXT_KEYS, ClientInfo),
+    Context = maps:merge(?DEFAULT_AUTHZ_CONTEXT, maps:with(?AUTHZ_CONTEXT_KEYS, ClientInfo)),
     Context#{is_superuser => false}.
 
 -spec set_authz_context(emqx_types:clientinfo(), emqx_types:message()) -> emqx_types:message().

--- a/apps/emqx/test/emqx_access_control_SUITE.erl
+++ b/apps/emqx/test/emqx_access_control_SUITE.erl
@@ -77,6 +77,17 @@ t_authorize_cache_skip_non_cacheable(_) ->
     ?assertEqual(deny, emqx_access_control:authorize(clientinfo(), ?AUTHZ_PUBLISH, Topic)),
     ?assertEqual(not_found, emqx_authz_cache:get_authz_cache(?AUTHZ_PUBLISH, Topic)).
 
+t_authorize_cache_bypass(_) ->
+    Topic = <<"cache/bypass">>,
+    ok = emqx_authz_cache:empty_authz_cache(),
+    ok = emqx_authz_cache:put_authz_cache(?AUTHZ_PUBLISH, Topic, deny),
+    ok = emqx_hooks:put('client.authorize', {?MODULE, authz_stub, [Topic]}, ?HP_AUTHZ),
+    ?assertEqual(
+        allow,
+        emqx_access_control:authorize(clientinfo(), ?AUTHZ_PUBLISH, Topic, #{cache => false})
+    ),
+    ?assertEqual(deny, emqx_authz_cache:get_authz_cache(?AUTHZ_PUBLISH, Topic)).
+
 t_quick_deny_anonymous(_) ->
     ok = emqx_hooks:put(
         'client.authenticate',

--- a/apps/emqx/test/emqx_message_SUITE.erl
+++ b/apps/emqx/test/emqx_message_SUITE.erl
@@ -124,9 +124,15 @@ t_get_set_header(_) ->
 
 t_set_authz_context(_) ->
     ClientInfo = #{
+        zone => default,
+        protocol => mqtt,
+        peerhost => {127, 0, 0, 1},
+        sockport => 1883,
         clientid => <<"clientid">>,
         username => <<"username">>,
+        is_bridge => false,
         is_superuser => false,
+        mountpoint => undefined,
         acl => #{rules => []},
         client_attrs => #{<<"role">> => <<"reader">>},
         password => <<"secret">>,

--- a/apps/emqx/test/emqx_message_SUITE.erl
+++ b/apps/emqx/test/emqx_message_SUITE.erl
@@ -122,6 +122,23 @@ t_get_set_header(_) ->
     Msg4 = emqx_message:remove_header(a, Msg4),
     ?assertEqual(#{b => 2, c => 3}, emqx_message:get_headers(Msg4)).
 
+t_set_authz_context(_) ->
+    ClientInfo = #{
+        clientid => <<"clientid">>,
+        username => <<"username">>,
+        is_superuser => false,
+        acl => #{rules => []},
+        client_attrs => #{<<"role">> => <<"reader">>},
+        password => <<"secret">>,
+        conn_state => connected
+    },
+    Msg0 = emqx_message:make(<<"clientid">>, <<"topic">>, <<"payload">>),
+    Msg = emqx_message:set_authz_context(ClientInfo, Msg0),
+    ?assertEqual(
+        maps:without([password, conn_state], ClientInfo#{is_superuser => false}),
+        emqx_message:get_header(authz_context, Msg)
+    ).
+
 t_undefined_headers(_) ->
     Msg = #message{id = <<"id">>, qos = ?QOS_0},
     Msg1 = emqx_message:set_headers(#{a => 1, b => 2}, Msg),

--- a/apps/emqx_gateway_coap/src/emqx_coap_pubsub_handler.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_pubsub_handler.erl
@@ -53,9 +53,9 @@ handle_method(post, Topic, #coap_message{payload = Payload} = Msg, Ctx, CInfo) -
         allow ->
             #{clientid := ClientId} = CInfo,
             MountTopic = mount(CInfo, Topic),
-            %% TODO: Append message metadata into headers
             MQTTMsg = emqx_message:make(ClientId, Qos, MountTopic, Payload),
-            MQTTMsg2 = apply_publish_opts(PublishOpts, MQTTMsg),
+            MQTTMsg1 = apply_publish_opts(PublishOpts, MQTTMsg),
+            MQTTMsg2 = emqx_message:set_authz_context(CInfo, MQTTMsg1),
             _ = emqx_broker:publish(MQTTMsg2),
             reply({ok, changed}, Msg);
         _ ->

--- a/apps/emqx_gateway_exproto/src/emqx_exproto_channel.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_exproto_channel.erl
@@ -425,7 +425,9 @@ handle_call(
             {reply, {error, ?RESP_PERMISSION_DENY, <<"Authorization deny">>}, Channel};
         _ ->
             Msg = emqx_message:make(From, Qos, Topic, Payload),
-            NMsg = emqx_mountpoint:mount(Mountpoint, Msg),
+            NMsg = emqx_message:set_authz_context(
+                ClientInfo, emqx_mountpoint:mount(Mountpoint, Msg)
+            ),
             _ = emqx:publish(NMsg),
             {reply, ok, Channel}
     end;

--- a/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
+++ b/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
@@ -763,7 +763,8 @@ upstreaming(
             log(
                 debug, #{msg => "upstreaming_to_topic", topic => Topic, payload => Payload}, Channel
             ),
-            emqx:publish(emqx_message:make(ClientId, ?QOS_1, Topic, Payload));
+            Msg = emqx_message:make(ClientId, ?QOS_1, Topic, Payload),
+            emqx:publish(emqx_message:set_authz_context(ClientInfo, Msg));
         deny ->
             log(info, #{msg => "upstream_publish_denied", topic => Topic}, Channel),
             ok

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -421,7 +421,8 @@ do_publish(
     case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic) of
         allow ->
             ?SLOG(debug, #{msg => "publish_msg", to_topic => Topic, farme => Frame}),
-            emqx:publish(emqx_message:make(jt808, ?QOS_1, Topic, emqx_utils_json:encode(Frame)));
+            Msg = emqx_message:make(jt808, ?QOS_1, Topic, emqx_utils_json:encode(Frame)),
+            emqx:publish(emqx_message:set_authz_context(ClientInfo, Msg));
         deny ->
             ?SLOG(info, #{msg => "publish_msg_denied", to_topic => Topic}),
             ok

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_channel.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_channel.erl
@@ -566,7 +566,7 @@ auth_connect(
         {ok, NClientInfo} ->
             {ok, Channel#channel{
                 clientinfo = NClientInfo,
-                with_context = with_context(Ctx, ClientInfo)
+                with_context = with_context(Ctx, NClientInfo)
             }};
         {error, Reason} ->
             ?SLOG(warning, #{
@@ -653,7 +653,7 @@ with_context(publish, [Topic, Msg], Ctx, ClientInfo) ->
     Action = publish_action(Msg),
     case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic) of
         allow ->
-            _ = emqx_broker:publish(Msg),
+            _ = emqx_broker:publish(emqx_message:set_authz_context(ClientInfo, Msg)),
             ok;
         _ ->
             ?SLOG(error, #{

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -493,11 +493,14 @@ handle_in(
                 end,
             case TopicName =/= undefined of
                 true ->
-                    Msg = emqx_message:make(
-                        ?NEG_QOS_CLIENT_ID,
-                        ?QOS_0,
-                        TopicName,
-                        Data
+                    Msg = emqx_message:set_authz_context(
+                        Channel#channel.clientinfo,
+                        emqx_message:make(
+                            ?NEG_QOS_CLIENT_ID,
+                            ?QOS_0,
+                            TopicName,
+                            Data
+                        )
                     ),
                     ?SLOG(debug, #{
                         msg => "receive_qo3_message_in_idle_mode",
@@ -1171,13 +1174,14 @@ convert_pub_to_msg(
 
 put_message_headers(Msg, #channel{
     conninfo = #{proto_ver := ProtoVer},
-    clientinfo = #{
-        protocol := Protocol,
-        username := Username,
-        peerhost := PeerHost
-    }
+    clientinfo =
+        ClientInfo = #{
+            protocol := Protocol,
+            username := Username,
+            peerhost := PeerHost
+        }
 }) ->
-    emqx_message:set_headers(
+    Msg1 = emqx_message:set_headers(
         #{
             proto_ver => ProtoVer,
             protocol => Protocol,
@@ -1185,7 +1189,8 @@ put_message_headers(Msg, #channel{
             peerhost => PeerHost
         },
         Msg
-    ).
+    ),
+    emqx_message:set_authz_context(ClientInfo, Msg1).
 
 get_corrected_qos(?QOS_NEG1) -> ?QOS_0;
 get_corrected_qos(QoS) -> QoS.

--- a/apps/emqx_gateway_nats/src/emqx_nats_channel.erl
+++ b/apps/emqx_gateway_nats/src/emqx_nats_channel.erl
@@ -1071,13 +1071,14 @@ frame2message(
     Frame,
     Channel = #channel{
         conninfo = ConnInfo,
-        clientinfo = #{
-            protocol := Protocol,
-            clientid := ClientId,
-            username := Username,
-            peerhost := PeerHost,
-            mountpoint := Mountpoint
-        }
+        clientinfo =
+            ClientInfo = #{
+                protocol := Protocol,
+                clientid := ClientId,
+                username := Username,
+                peerhost := PeerHost,
+                mountpoint := Mountpoint
+            }
     }
 ) ->
     ProtoVer = maps:get(proto_ver, ConnInfo, <<"1">>),
@@ -1109,7 +1110,7 @@ frame2message(
                 Headers0#{reply_to => ReplyTo}
         end,
     NMsg = emqx_message:set_headers(Headers1, Msg),
-    emqx_mountpoint:mount(Mountpoint, NMsg).
+    emqx_message:set_authz_context(ClientInfo, emqx_mountpoint:mount(Mountpoint, NMsg)).
 
 process_pub_frame(Frame, Channel) ->
     Msg = frame2message(Frame, Channel),

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
@@ -379,18 +379,21 @@ publish(
     case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic0) of
         allow ->
             emqx_broker:publish(
-                emqx_message:make(
-                    ClientId,
-                    ?QOS_2,
-                    Topic,
-                    Payload,
-                    #{},
-                    #{
-                        protocol => Protocol,
-                        proto_ver => ProtoVer,
-                        username => Username,
-                        peerhost => PeerHost
-                    }
+                emqx_message:set_authz_context(
+                    ClientInfo,
+                    emqx_message:make(
+                        ClientId,
+                        ?QOS_2,
+                        Topic,
+                        Payload,
+                        #{},
+                        #{
+                            protocol => Protocol,
+                            proto_ver => ProtoVer,
+                            username => Username,
+                            peerhost => PeerHost
+                        }
+                    )
                 )
             );
         deny ->

--- a/apps/emqx_gateway_stomp/src/emqx_stomp_channel.erl
+++ b/apps/emqx_gateway_stomp/src/emqx_stomp_channel.erl
@@ -1236,13 +1236,14 @@ frame2message(
     ?PACKET(?CMD_SEND, Headers, Body),
     #channel{
         conninfo = #{proto_ver := ProtoVer},
-        clientinfo = #{
-            protocol := Protocol,
-            clientid := ClientId,
-            username := Username,
-            peerhost := PeerHost,
-            mountpoint := Mountpoint
-        }
+        clientinfo =
+            ClientInfo = #{
+                protocol := Protocol,
+                clientid := ClientId,
+                username := Username,
+                peerhost := PeerHost,
+                mountpoint := Mountpoint
+            }
     }
 ) ->
     Topic = header(<<"destination">>, Headers),
@@ -1270,7 +1271,7 @@ frame2message(
         },
         Msg
     ),
-    emqx_mountpoint:mount(Mountpoint, NMsg).
+    emqx_message:set_authz_context(ClientInfo, emqx_mountpoint:mount(Mountpoint, NMsg)).
 
 receipt_id(Headers) ->
     header(<<"receipt">>, Headers).

--- a/apps/emqx_modules/mix.exs
+++ b/apps/emqx_modules/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXModules.MixProject do
   def project do
     [
       app: :emqx_modules,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_modules/src/emqx_delayed.erl
+++ b/apps/emqx_modules/src/emqx_delayed.erl
@@ -12,6 +12,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 
 -export([
     create_tables/0,
@@ -463,22 +464,65 @@ do_publish(Key = {Ts, _Id}, Now, Acc) when Ts =< Now ->
         [] ->
             ok;
         [#delayed_message{msg = Msg}] ->
-            case emqx_banned:check_clientid(Msg#message.from) of
-                false ->
-                    emqx_pool:async_submit(fun emqx:publish/1, [Msg]);
-                true ->
-                    ?tp(
-                        notice,
-                        ignore_delayed_message_publish,
-                        #{
-                            reason => "client is banned",
-                            clientid => Msg#message.from
-                        }
-                    ),
-                    ok
-            end
+            emqx_pool:async_submit(fun publish_delayed_message/1, [Msg])
     end,
     do_publish(mnesia:dirty_next(?TAB, Key), Now, [Key | Acc]).
+
+publish_delayed_message(Msg = #message{from = ClientId, topic = Topic, qos = QoS}) ->
+    ClientInfo = get_authz_context(Msg),
+    case is_banned(ClientInfo, ClientId) of
+        true ->
+            ignore_delayed_message_publish("client is banned", ClientId, Topic);
+        false ->
+            maybe_publish_authorized(ClientInfo, Msg, ClientId, Topic, QoS)
+    end.
+
+is_banned(undefined, ClientId) ->
+    emqx_banned:check_clientid(ClientId);
+is_banned(ClientInfo, _ClientId) ->
+    emqx_banned:check(ClientInfo).
+
+get_authz_context(Msg = #message{from = ClientId, headers = Headers}) ->
+    case emqx_message:get_header(authz_context, Msg, undefined) of
+        undefined ->
+            case
+                maps:is_key(protocol, Headers) orelse
+                    maps:is_key(username, Headers) orelse
+                    maps:is_key(peerhost, Headers)
+            of
+                true ->
+                    emqx_message:make_authz_context(Headers#{clientid => ClientId});
+                false when is_binary(ClientId); ClientId =:= jt808 ->
+                    emqx_message:make_authz_context(#{clientid => ClientId});
+                false ->
+                    undefined
+            end;
+        ClientInfo ->
+            ClientInfo
+    end.
+
+maybe_publish_authorized(undefined, Msg, _ClientId, _Topic, _QoS) ->
+    emqx:publish(Msg);
+maybe_publish_authorized(ClientInfo, Msg, ClientId, Topic, QoS) ->
+    Retain = emqx_message:get_flag(retain, Msg),
+    Action = ?AUTHZ_PUBLISH(QoS, Retain),
+    case emqx_access_control:authorize(ClientInfo, Action, Topic, #{cache => false}) of
+        allow ->
+            case emqx_banned:check(ClientInfo) of
+                false -> emqx:publish(Msg);
+                true -> ignore_delayed_message_publish("client is banned", ClientId, Topic)
+            end;
+        deny ->
+            ignore_delayed_message_publish("authorization denied", ClientId, Topic)
+    end.
+
+ignore_delayed_message_publish(Reason, ClientId, Topic) ->
+    ?tp(notice, ignore_delayed_message_publish, #{
+        reason => Reason,
+        clientid => ClientId,
+        topic => Topic
+    }),
+    ok.
 
 do_load_or_unload(true, State) ->
     emqx_hooks:put('message.publish', {?MODULE, on_message_publish, []}, ?HP_DELAY_PUB),

--- a/apps/emqx_modules/src/emqx_delayed.erl
+++ b/apps/emqx_modules/src/emqx_delayed.erl
@@ -468,13 +468,13 @@ do_publish(Key = {Ts, _Id}, Now, Acc) when Ts =< Now ->
     end,
     do_publish(mnesia:dirty_next(?TAB, Key), Now, [Key | Acc]).
 
-publish_delayed_message(Msg = #message{from = ClientId, topic = Topic, qos = QoS}) ->
+publish_delayed_message(Msg = #message{from = ClientId, topic = Topic, qos = Qos}) ->
     ClientInfo = get_authz_context(Msg),
     case is_banned(ClientInfo, ClientId) of
         true ->
             ignore_delayed_message_publish("client is banned", ClientId, Topic);
         false ->
-            maybe_publish_authorized(ClientInfo, Msg, ClientId, Topic, QoS)
+            maybe_publish_authorized(ClientInfo, Msg, ClientId, Topic, Qos)
     end.
 
 is_banned(undefined, ClientId) ->
@@ -501,11 +501,11 @@ get_authz_context(Msg = #message{from = ClientId, headers = Headers}) ->
             ClientInfo
     end.
 
-maybe_publish_authorized(undefined, Msg, _ClientId, _Topic, _QoS) ->
+maybe_publish_authorized(undefined, Msg, _ClientId, _Topic, _Qos) ->
     emqx:publish(Msg);
-maybe_publish_authorized(ClientInfo, Msg, ClientId, Topic, QoS) ->
+maybe_publish_authorized(ClientInfo, Msg, ClientId, Topic, Qos) ->
     Retain = emqx_message:get_flag(retain, Msg),
-    Action = ?AUTHZ_PUBLISH(QoS, Retain),
+    Action = ?AUTHZ_PUBLISH(Qos, Retain),
     case emqx_access_control:authorize(ClientInfo, Action, Topic, #{cache => false}) of
         allow ->
             case emqx_banned:check(ClientInfo) of

--- a/apps/emqx_modules/test/emqx_delayed_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_delayed_SUITE.erl
@@ -14,6 +14,9 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
+-include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 %%--------------------------------------------------------------------
@@ -50,6 +53,8 @@ init_per_testcase(_Case, Config) ->
     Config.
 
 end_per_testcase(_Case, _Config) ->
+    persistent_term:erase({?MODULE, replay_authz_result}),
+    emqx_hooks:del('client.authorize', {?MODULE, replay_authz}),
     {atomic, ok} = mria:clear_table(emqx_delayed),
     ok = emqx_delayed:unload().
 
@@ -207,6 +212,104 @@ t_delayed_precision(_) ->
     _ = on_message_publish(DelayedMsg0),
     ?assert(FutureDiff() =< MaxSpan).
 
+t_reauthorize_delayed_message(_) ->
+    ClientInfo = #{
+        zone => default,
+        listener => 'tcp:default',
+        protocol => mqtt,
+        peerhost => {127, 0, 0, 1},
+        clientid => <<"reauthorize-client">>,
+        username => <<"reauthorize-user">>,
+        is_superuser => false,
+        mountpoint => undefined
+    },
+    Topic = <<"reauthorize/target">>,
+    DelayedTopic = <<"$delayed/1/", Topic/binary>>,
+    Action = ?AUTHZ_PUBLISH(?QOS_1, true),
+    Msg0 = emqx_message:make(
+        maps:get(clientid, ClientInfo),
+        ?QOS_1,
+        DelayedTopic,
+        <<"payload">>,
+        #{retain => true},
+        #{}
+    ),
+    Msg = emqx_message:set_authz_context(ClientInfo, Msg0),
+    ok = emqx_hooks:put('client.authorize', {?MODULE, replay_authz, []}, ?HP_HIGHEST),
+    persistent_term:put({?MODULE, replay_authz_result}, allow),
+    ?assertEqual(allow, emqx_access_control:authorize(ClientInfo, Action, DelayedTopic)),
+
+    snabbkaffe:start_trace(),
+    {ok, SubRef} = snabbkaffe:subscribe(
+        ?match_event(#{
+            ?snk_kind := ignore_delayed_message_publish,
+            reason := "authorization denied"
+        }),
+        1,
+        5000,
+        0
+    ),
+    {stop, _} = on_message_publish(Msg),
+    persistent_term:put({?MODULE, replay_authz_result}, deny),
+    {ok, [_]} = snabbkaffe:receive_events(SubRef),
+    snabbkaffe:stop(),
+    ?assertEqual([], mnesia:dirty_all_keys(emqx_delayed)).
+
+t_authorized_delayed_message(_) ->
+    ClientInfo = #{
+        zone => default,
+        listener => 'tcp:default',
+        protocol => mqtt,
+        peerhost => {127, 0, 0, 1},
+        clientid => <<"authorized-client">>,
+        username => <<"authorized-user">>,
+        is_superuser => false,
+        mountpoint => undefined
+    },
+    Topic = <<"authorized/target">>,
+    Msg0 = emqx_message:make(
+        maps:get(clientid, ClientInfo),
+        ?QOS_1,
+        <<"$delayed/1/", Topic/binary>>,
+        <<"payload">>
+    ),
+    Msg = emqx_message:set_authz_context(ClientInfo, Msg0),
+    ok = emqx_hooks:put('client.authorize', {?MODULE, replay_authz, []}, ?HP_HIGHEST),
+    persistent_term:put({?MODULE, replay_authz_result}, allow),
+    ok = emqx_broker:subscribe(Topic),
+    try
+        {stop, _} = on_message_publish(Msg),
+        receive
+            {deliver, Topic, Delivered} ->
+                ?assertEqual(undefined, emqx_message:get_header(authz_context, Delivered))
+        after 5000 ->
+            ct:fail(delayed_message_not_delivered)
+        end
+    after
+        emqx_broker:unsubscribe(Topic)
+    end.
+
+t_reauthorize_legacy_delayed_message(_) ->
+    ok = emqx_hooks:put('client.authorize', {?MODULE, replay_authz, []}, ?HP_HIGHEST),
+    persistent_term:put({?MODULE, replay_authz_result}, deny),
+    snabbkaffe:start_trace(),
+    {ok, SubRef} = snabbkaffe:subscribe(
+        ?match_event(#{
+            ?snk_kind := ignore_delayed_message_publish,
+            reason := "authorization denied"
+        }),
+        1,
+        5000,
+        0
+    ),
+    Msg = emqx_message:make(
+        <<"legacy-client">>, ?QOS_1, <<"$delayed/1/legacy/target">>, <<"payload">>
+    ),
+    {stop, _} = on_message_publish(Msg),
+    {ok, [_]} = snabbkaffe:receive_events(SubRef),
+    snabbkaffe:stop(),
+    ?assertEqual([], mnesia:dirty_all_keys(emqx_delayed)).
+
 t_banned_delayed(_) ->
     emqx:update_config([delayed, max_delayed_messages], 10000),
     ClientId1 = <<"bc1">>,
@@ -296,3 +399,7 @@ t_delayed_load_unload(_Config) ->
 is_hooks_exist() ->
     Hooks = emqx_hooks:lookup('message.publish'),
     false =/= lists:keyfind({emqx_delayed, on_message_publish, []}, 2, Hooks).
+
+replay_authz(_ClientInfo, _Action, _Topic, _Default) ->
+    Result = persistent_term:get({?MODULE, replay_authz_result}),
+    {stop, #{result => Result, from => test}}.

--- a/changes/ee/fix-18019.en.md
+++ b/changes/ee/fix-18019.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where delayed messages from MQTT and gateway clients could bypass current publish authorization rules when replayed.

--- a/scripts/apps-version-check.exs
+++ b/scripts/apps-version-check.exs
@@ -396,7 +396,7 @@ defmodule AppsVersionCheck do
           "Errors were found\n",
           "Invalid apps/plugin-apps: \n",
           [inspect(invalid_entries, pretty: true), "\n"],
-          "Run this script again with `--auto-fix` to automatically fix issues,",
+          "Run `./scripts/apps-version-check.exs --auto-fix` to automatically fix issues,",
           " or fix them manually."
         ])
 


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/111

Release version: 6.0.4

## Summary

Delayed messages originating from MQTT and gateway clients are now authorized
against the current publish rules immediately before replay. The original
client info for the delayed message is preserved into message header.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
