### PR TITLE
test(a2a): wait for card online status in t_list_cards

### DIFF
--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_cli_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_cli_SUITE.erl
@@ -291,9 +291,15 @@ t_list_cards(TCConfig) ->
         ?CAPTURE(list_cards(["--status", "offline"], TCConfig))
     ),
     C = start_client(#{clientid => Id1}),
-    ?assertMatch(
-        {ok, [[#{<<"name">> := Id2}]]},
-        ?CAPTURE(list_cards(["--status", "offline"], TCConfig))
+    %% The card status is derived from the client's connection state, which is registered
+    %% asynchronously, so we retry until `Id1' is seen as online.
+    ?retry(
+        _Sleep = 200,
+        _Attempts = 25,
+        ?assertMatch(
+            {ok, [[#{<<"name">> := Id2}]]},
+            ?CAPTURE(list_cards(["--status", "offline"], TCConfig))
+        )
     ),
     ?assertMatch(
         {ok, [[#{<<"name">> := Id1}]]},


### PR DESCRIPTION
Release version: 6.2.2

## Summary

Fix flaky `emqx_a2a_registry_cli_SUITE:t_list_cards`.

A card's `online`/`offline` status is derived from the agent client's live
connection state (`emqx_a2a_registry:lookup_agent_status/1` →
`emqx_mgmt:lookup_client/2`). `emqtt:connect/1` returns on CONNACK, which does
not guarantee the channel is already registered as `connected`, so the
immediately following `list_cards --status offline` could still return both
cards and fail the assertion.

Wrap that assertion in `?retry` so it polls until the newly connected agent's
card is no longer listed as offline. Test-only change.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
