### PR TITLE
fix(mqtt): close connection on shared subscription when disabled

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -3067,7 +3067,20 @@ check_sub_caps(
     Channel = #channel{clientinfo = ClientInfo}
 ) ->
     CheckResult = do_check_sub_caps(ClientInfo, TopicFilters),
-    {ok, ?SUBSCRIBE_PACKET(PacketId, SubProps, CheckResult), Channel}.
+    case lists:any(fun is_shared_sub_not_supported/1, CheckResult) of
+        true ->
+            %% [MQTT-4.13.1-1]: attempting a shared subscription when shared
+            %% subscriptions are not supported is a protocol error, the
+            %% network connection must be closed.
+            {error, {disconnect, ?RC_SHARED_SUBSCRIPTIONS_NOT_SUPPORTED}, Channel};
+        false ->
+            {ok, ?SUBSCRIBE_PACKET(PacketId, SubProps, CheckResult), Channel}
+    end.
+
+is_shared_sub_not_supported({{_Topic, _SubOpts}, ?RC_SHARED_SUBSCRIPTIONS_NOT_SUPPORTED}) ->
+    true;
+is_shared_sub_not_supported(_) ->
+    false.
 
 do_check_sub_caps(ClientInfo, TopicFilters) ->
     do_check_sub_caps(ClientInfo, TopicFilters, []).

--- a/apps/emqx/test/emqx_shared_sub_disabled_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_disabled_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(SHARED_TOPIC, <<"$share/g/t/1">>).
 -define(NORMAL_TOPIC, <<"t/1">>).
@@ -51,7 +52,7 @@ t_v5_shared_sub_disabled(_Config) ->
         {'DOWN', MRef, process, C,
             {shutdown, {disconnected, ?RC_SHARED_SUBSCRIPTIONS_NOT_SUPPORTED, _}}}
     ),
-    ?assertEqual([], emqx_cm:lookup_channels(clientid(v5))).
+    assert_channel_gone(clientid(v5)).
 
 -doc """
 An MQTT v3.1.1 client attempting a shared subscription while shared
@@ -64,7 +65,7 @@ t_v3_shared_sub_disabled(_Config) ->
     MRef = erlang:monitor(process, C),
     _ = catch emqtt:subscribe(C, ?SHARED_TOPIC, 0),
     ?assertReceive({'DOWN', MRef, process, C, {shutdown, tcp_closed}}),
-    ?assertEqual([], emqx_cm:lookup_channels(clientid(v4))).
+    assert_channel_gone(clientid(v4)).
 
 -doc """
 A SUBSCRIBE carrying both a normal and a shared topic filter still closes the
@@ -101,6 +102,14 @@ t_shared_sub_enabled(_Config) ->
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
+
+%% Channel deregistration happens after the socket is closed, so retry.
+assert_channel_gone(ClientId) ->
+    ?retry(
+        _Interval = 100,
+        _Attempts = 20,
+        ?assertEqual([], emqx_cm:lookup_channels(ClientId))
+    ).
 
 disable_shared_subscription() ->
     emqx_config:put_zone_conf(default, [mqtt, shared_subscription], false).

--- a/apps/emqx/test/emqx_shared_sub_disabled_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_disabled_SUITE.erl
@@ -1,0 +1,114 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2018-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_shared_sub_disabled_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(SHARED_TOPIC, <<"$share/g/t/1">>).
+-define(NORMAL_TOPIC, <<"t/1">>).
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start([emqx], #{work_dir => emqx_cth_suite:work_dir(Config)}),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(apps, Config)).
+
+init_per_testcase(_TestCase, Config) ->
+    process_flag(trap_exit, true),
+    [{old_zones, emqx:get_config([zones], #{})} | Config].
+
+end_per_testcase(_TestCase, Config) ->
+    emqx_config:put([zones], ?config(old_zones, Config)),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+-doc """
+An MQTT v5 client attempting a shared subscription while shared subscriptions
+are disabled receives DISCONNECT with reason code 0x9E and the connection is
+closed, no SUBACK is delivered.
+""".
+t_v5_shared_sub_disabled(_Config) ->
+    ok = disable_shared_subscription(),
+    C = connect(v5),
+    MRef = erlang:monitor(process, C),
+    _ = catch emqtt:subscribe(C, ?SHARED_TOPIC, 0),
+    ?assertReceive({disconnected, ?RC_SHARED_SUBSCRIPTIONS_NOT_SUPPORTED, _}),
+    ?assertReceive(
+        {'DOWN', MRef, process, C,
+            {shutdown, {disconnected, ?RC_SHARED_SUBSCRIPTIONS_NOT_SUPPORTED, _}}}
+    ),
+    ?assertEqual([], emqx_cm:lookup_channels(clientid(v5))).
+
+-doc """
+An MQTT v3.1.1 client attempting a shared subscription while shared
+subscriptions are disabled has its connection closed, v3 has no DISCONNECT
+packet from server to client.
+""".
+t_v3_shared_sub_disabled(_Config) ->
+    ok = disable_shared_subscription(),
+    C = connect(v4),
+    MRef = erlang:monitor(process, C),
+    _ = catch emqtt:subscribe(C, ?SHARED_TOPIC, 0),
+    ?assertReceive({'DOWN', MRef, process, C, {shutdown, tcp_closed}}),
+    ?assertEqual([], emqx_cm:lookup_channels(clientid(v4))).
+
+-doc """
+A SUBSCRIBE carrying both a normal and a shared topic filter still closes the
+connection when shared subscriptions are disabled.
+""".
+t_mixed_sub_disabled(_Config) ->
+    ok = disable_shared_subscription(),
+    C = connect(v5),
+    MRef = erlang:monitor(process, C),
+    _ = catch emqtt:subscribe(C, [{?NORMAL_TOPIC, 0}, {?SHARED_TOPIC, 0}]),
+    ?assertReceive({disconnected, ?RC_SHARED_SUBSCRIPTIONS_NOT_SUPPORTED, _}),
+    ?assertReceive({'DOWN', MRef, process, C, {shutdown, {disconnected, _, _}}}).
+
+-doc """
+A normal (non-shared) subscription is unaffected when shared subscriptions are
+disabled.
+""".
+t_normal_sub_unaffected(_Config) ->
+    ok = disable_shared_subscription(),
+    C = connect(v5),
+    ?assertMatch({ok, _, [0]}, emqtt:subscribe(C, ?NORMAL_TOPIC, 0)),
+    ok = emqtt:disconnect(C).
+
+-doc """
+With shared subscriptions enabled (the default) a shared subscription still
+succeeds and the connection is kept.
+""".
+t_shared_sub_enabled(_Config) ->
+    C = connect(v5),
+    ?assertMatch({ok, _, [0]}, emqtt:subscribe(C, ?SHARED_TOPIC, 0)),
+    ?assertMatch([_], emqx_cm:lookup_channels(clientid(v5))),
+    ok = emqtt:disconnect(C).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+disable_shared_subscription() ->
+    emqx_config:put_zone_conf(default, [mqtt, shared_subscription], false).
+
+clientid(Vsn) ->
+    iolist_to_binary([atom_to_list(Vsn), "-shared-sub-disabled"]).
+
+connect(Vsn) ->
+    {ok, C} = emqtt:start_link([{clientid, clientid(Vsn)}, {proto_ver, Vsn}]),
+    {ok, _} = emqtt:connect(C),
+    C.

--- a/changes/ee/fix-18027.en.md
+++ b/changes/ee/fix-18027.en.md
@@ -1,0 +1,5 @@
+Disconnect clients that attempt a shared subscription while shared subscriptions are disabled.
+
+When `mqtt.shared_subscription` is set to `false` and a client sends a SUBSCRIBE containing a shared topic filter (`$share/...` or `$queue/...`), EMQX now closes the network connection, as required by the MQTT specification for protocol errors. MQTT 5.0 clients first receive a DISCONNECT packet with reason code `0x9E` (Shared Subscriptions not supported); MQTT 3.1/3.1.1 clients simply get the connection closed.
+
+Previously such a SUBSCRIBE was answered with a failure reason code in the SUBACK and the connection was kept open.


### PR DESCRIPTION
Release version: 6.3.0

## Summary

Fixes #3640.

When `mqtt.shared_subscription = false` and a client sends a SUBSCRIBE containing a shared topic
filter (`$share/...` / `$queue/...`), EMQX now closes the network connection instead of only
returning `0x9E Shared Subscriptions not supported` in the SUBACK and keeping the session alive.

This follows MQTT 5.0 [MQTT-4.13.1-1]: when the server detects a protocol error for which a reason
code is specified, it must close the network connection.

* `emqx_channel:check_sub_caps/2` short-circuits the SUBSCRIBE pipeline with
  `{error, {disconnect, ?RC_SHARED_SUBSCRIPTIONS_NOT_SUPPORTED}, Channel}` if any topic filter in
  the packet was rejected with that reason code. The existing pipeline handling in
  `process_subscribe/2` + `handle_out(disconnect, ...)` already sends DISCONNECT then closes for
  MQTT v5, and closes the socket for v3.1/v3.1.1.
* Scope is limited to shared subscriptions; wildcard-not-supported (`0xA2`) and exclusive
  subscription behavior are unchanged.
* Only reachable when an operator explicitly opts out of shared subscriptions (the capability is
  enabled by default).

New suite `apps/emqx/test/emqx_shared_sub_disabled_SUITE.erl` covers: v5 gets DISCONNECT `0x9E` and
the channel is gone; v3.1.1 gets the socket closed; a mixed normal+shared SUBSCRIBE still closes;
normal subscriptions are unaffected; and shared subscriptions still work with the default config.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
