### PR TITLE
test(syskeeper): wait for forwarder disconnect in t_write_failure

### DIFF
--- a/apps/emqx_bridge_syskeeper/test/emqx_bridge_syskeeper_SUITE.erl
+++ b/apps/emqx_bridge_syskeeper/test/emqx_bridge_syskeeper_SUITE.erl
@@ -368,6 +368,16 @@ t_get_status(Config) ->
 t_write_failure(Config) ->
     create_both_bridges(Config),
     delete_connectors(syskeeper_proxy, ?SYSKEEPER_PROXY_NAME),
+    %% wait until the forwarder actually notices the proxy is gone, otherwise the
+    %% write can race ahead of the connection teardown and succeed
+    ?retry(
+        _Sleep = 500,
+        _Attempts = 10,
+        ?assertMatch(
+            #{status := disconnected},
+            health_check(syskeeper_forwarder, ?SYSKEEPER_NAME)
+        )
+    ),
     SentData = make_message(),
     Result =
         ?wait_async_action(


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Test-only fix for a flaky `emqx_bridge_syskeeper_SUITE:t_write_failure`.

The case deletes the syskeeper proxy connector and then expects the next
write through the forwarder to fail with `resource_error`. But right after
the proxy is deleted the forwarder resource is still marked `connected`
(its health check has not re-run yet), so the write could race ahead of the
teardown and flush successfully.

Added the same health-check barrier `t_get_status` already uses in this
file: retry the forwarder health check until it reports `disconnected`
before sending the message.

No production behavior change.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
