### PR TITLE
fix(connector): accept mqtt:// and mqtts:// server schemes

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -131,6 +131,7 @@
 -export([
     parse_server/2,
     parse_servers/2,
+    mqtt_host_opts/0,
     servers_validator/2,
     servers_sc/2,
     latency_histogram_buckets_sc/1,
@@ -3531,6 +3532,24 @@ servers_validator(Opts, Required) ->
                 ok
         end
     end.
+
+-doc """
+`parse_server/2' and `servers_sc/2' options for an MQTT broker endpoint.
+
+The official MQTT URI schemes are `mqtt' for plain TCP and `mqtts' for TLS, see
+https://github.com/mqtt/mqtt.org/wiki/URI-Scheme.  A scheme-less `host[:port]' is
+accepted and defaults to `mqtt'.
+
+Everything that parses an MQTT endpoint must use these options, otherwise a value
+accepted by one parse is rejected by another.
+""".
+-spec mqtt_host_opts() -> server_parse_option().
+mqtt_host_opts() ->
+    #{
+        default_port => 1883,
+        default_scheme => "mqtt",
+        supported_schemes => ["mqtt", "mqtts"]
+    }.
 
 %% @doc Parse `host[:port]' endpoint to a `{Host, Port}' tuple or just `Host' string.
 %% `Opt' is a `map()' with below options supported:

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
@@ -39,14 +39,7 @@
 %% reject creating an unrelated valid connector whenever any sibling connector's
 %% `server' is denied by the current SSRF policy. The check is enforced per
 %% connector in `emqx_connector_resource:parse_confs/3' instead.
-%% The official MQTT URI schemes: `mqtt' for plain TCP and `mqtts' for TLS.
-%% See https://github.com/mqtt/mqtt.org/wiki/URI-Scheme
-%% A scheme-less `host:port' is accepted and defaults to `mqtt'.
--define(MQTT_HOST_OPTS, #{
-    default_port => 1883,
-    default_scheme => "mqtt",
-    supported_schemes => ["mqtt", "mqtts"]
-}).
+-define(MQTT_HOST_OPTS, emqx_schema:mqtt_host_opts()).
 
 namespace() -> "connector_mqtt".
 

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_action_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_action_SUITE.erl
@@ -1593,3 +1593,39 @@ t_corrupt_connector_raw_config(TCConfig) ->
         <<"static_clientids">> => StaticClientIds
     }),
     ok.
+
+-doc """
+Checks the accepted `server' URI schemes when creating an MQTT connector via the API.
+
+`mqtt' (plain TCP) and `mqtts' (TLS) are the official MQTT URI schemes, and a
+scheme-less `host:port' is accepted as well.  Anything else must be rejected with a
+readable 400, never a 500.
+""".
+t_connector_server_scheme(TCConfig) ->
+    lists:foreach(
+        fun(Server) ->
+            ?assertMatch(
+                {201, _},
+                create_connector_api(TCConfig, #{<<"server">> => Server}),
+                #{server => Server}
+            ),
+            {204, _} = emqx_bridge_v2_testlib:delete_connector_api(TCConfig)
+        end,
+        [
+            <<"mqtt://[::1]:1883">>,
+            <<"mqtts://[::1]:8883">>,
+            <<"mqtt://127.0.0.1:1883">>,
+            <<"[::1]:1883">>,
+            <<"127.0.0.1:1883">>
+        ]
+    ),
+    ?assertMatch(
+        {400, #{
+            <<"message">> := #{
+                <<"kind">> := <<"validation_error">>,
+                <<"reason">> := <<"unsupported_scheme">>
+            }
+        }},
+        create_connector_api(TCConfig, #{<<"server">> => <<"mqtt-tcp://[::1]:1883">>})
+    ),
+    ok.

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
@@ -11,14 +11,7 @@
 -define(LINKS_PATH, [cluster, links]).
 -define(CERTS_PATH(LinkName), filename:join(["cluster", "links", LinkName])).
 
-%% The official MQTT URI schemes: `mqtt' for plain TCP and `mqtts' for TLS.
-%% See https://github.com/mqtt/mqtt.org/wiki/URI-Scheme
-%% A scheme-less `host:port' is accepted and defaults to `mqtt'.
--define(MQTT_HOST_OPTS, #{
-    default_port => 1883,
-    default_scheme => "mqtt",
-    supported_schemes => ["mqtt", "mqtts"]
-}).
+-define(MQTT_HOST_OPTS, emqx_schema:mqtt_host_opts()).
 
 -ifndef(TEST).
 -define(DEFAULT_ACTOR_TTL, 30_000).

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
@@ -42,14 +42,7 @@
     atom() => _
 }.
 
-%% The official MQTT URI schemes: `mqtt' for plain TCP and `mqtts' for TLS.
-%% See https://github.com/mqtt/mqtt.org/wiki/URI-Scheme
-%% A scheme-less `host:port' is accepted and defaults to `mqtt'.
--define(MQTT_HOST_OPTS, #{
-    default_port => 1883,
-    default_scheme => "mqtt",
-    supported_schemes => ["mqtt", "mqtts"]
-}).
+-define(MQTT_HOST_OPTS, emqx_schema:mqtt_host_opts()).
 
 namespace() -> "cluster".
 

--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -509,7 +509,14 @@ do_create_or_update_connector(Namespace, ConnectorType, ConnectorName, Conf, Htt
             %% When root validators fail, the returned value is the whole config root.  We
             %% focus down to the config from the request to avoid returning a huge map.
             Reason = maybe_focus_on_request_connector(Reason0, ConnectorType, ConnectorName),
-            ?BAD_REQUEST(emqx_mgmt_api_lib:to_json(redact(Reason)))
+            ?BAD_REQUEST(emqx_mgmt_api_lib:to_json(redact(Reason)));
+        {error, {config_update_crashed, Reason}} ->
+            ?INTERNAL_ERROR(emqx_utils:readable_error_msg(redact(Reason)));
+        {error, Reason} ->
+            %% Catch-all for error terms that are neither a config update handler error
+            %% nor a structured validation error, e.g. a bare string thrown by a schema
+            %% validator such as `"unsupported_scheme"'.
+            ?BAD_REQUEST(emqx_utils:readable_error_msg(redact(Reason)))
     end.
 
 '/connectors/:id/enable/:enable'(put, #{bindings := #{id := Id, enable := Enable}} = Req) ->

--- a/apps/emqx_connector/src/emqx_connector_resource.erl
+++ b/apps/emqx_connector/src/emqx_connector_resource.erl
@@ -364,10 +364,23 @@ check_ssrf(Host) ->
         {error, Err} -> invalid_data(emqx_utils_ssrf:format_error(Err))
     end.
 
+%% Must accept the same `server' values as the `mqtt' connector schema
+%% (`emqx_bridge_mqtt_connector_schema''s `?MQTT_HOST_OPTS'), otherwise a server that
+%% passed schema validation is rejected here.
+-define(MQTT_HOST_OPTS, #{
+    default_port => 1883,
+    default_scheme => "mqtt",
+    supported_schemes => ["mqtt", "mqtts"]
+}).
+
 parse_mqtt_host(Server) ->
-    case emqx_schema:parse_server(Server, #{default_port => 1883}) of
+    %% The server has already been validated by the schema at this point; if parsing
+    %% still fails, there is no host to check and the schema reports the real error.
+    try emqx_schema:parse_server(Server, ?MQTT_HOST_OPTS) of
         #{hostname := Host} -> Host;
         _ -> undefined
+    catch
+        throw:_ -> undefined
     end.
 
 -spec invalid_data(binary()) -> no_return().

--- a/apps/emqx_connector/src/emqx_connector_resource.erl
+++ b/apps/emqx_connector/src/emqx_connector_resource.erl
@@ -364,19 +364,10 @@ check_ssrf(Host) ->
         {error, Err} -> invalid_data(emqx_utils_ssrf:format_error(Err))
     end.
 
-%% Must accept the same `server' values as the `mqtt' connector schema
-%% (`emqx_bridge_mqtt_connector_schema''s `?MQTT_HOST_OPTS'), otherwise a server that
-%% passed schema validation is rejected here.
--define(MQTT_HOST_OPTS, #{
-    default_port => 1883,
-    default_scheme => "mqtt",
-    supported_schemes => ["mqtt", "mqtts"]
-}).
-
 parse_mqtt_host(Server) ->
     %% The server has already been validated by the schema at this point; if parsing
     %% still fails, there is no host to check and the schema reports the real error.
-    try emqx_schema:parse_server(Server, ?MQTT_HOST_OPTS) of
+    try emqx_schema:parse_server(Server, emqx_schema:mqtt_host_opts()) of
         #{hostname := Host} -> Host;
         _ -> undefined
     catch

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -151,7 +151,8 @@ groups() ->
         t_fail_delete_with_action,
         t_actions_field,
         t_update_with_failed_validation,
-        t_create_with_failed_root_validation
+        t_create_with_failed_root_validation,
+        t_create_or_update_with_unexpected_error_term
     ],
     ClusterOnlyTests = [
         t_inconsistent_state,
@@ -1331,6 +1332,39 @@ t_create_with_failed_root_validation(Config) ->
             <<"value">> := #{<<"bootstrap_hosts">> := _}
         },
         Message
+    ),
+    ok.
+
+-doc """
+Checks that an unexpected error term from the config update is reported as a readable
+400, and not as a `case_clause' 500.
+
+A schema validator may `throw' a bare string (e.g. `"not_expecting_scheme"'), which the
+config handler surfaces verbatim as `{error, String}'.
+""".
+t_create_or_update_with_unexpected_error_term(Config) ->
+    Params = ?KAFKA_CONNECTOR(?CONNECTOR_NAME),
+    ?assertMatch(
+        {ok, 201, _},
+        request_json(post, uri(["connectors"]), Params, Config)
+    ),
+    ok = meck:new(emqx_conf, [passthrough, no_history, no_link]),
+    ok = meck:expect(emqx_conf, update, fun(_Path, _Conf, _Opts) ->
+        {error, "not_expecting_scheme"}
+    end),
+    ConnectorID = emqx_connector_resource:connector_id(?CONNECTOR_TYPE, ?CONNECTOR_NAME),
+    ?assertMatch(
+        {ok, 400, #{<<"message">> := <<"not_expecting_scheme">>}},
+        request_json(
+            put,
+            uri(["connectors", ConnectorID]),
+            maps:without([<<"type">>, <<"name">>], Params),
+            Config
+        )
+    ),
+    ?assertMatch(
+        {ok, 400, #{<<"message">> := <<"not_expecting_scheme">>}},
+        request_json(post, uri(["connectors"]), Params#{<<"name">> := <<"other">>}, Config)
     ),
     ok.
 


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Fixes #18022: `POST /api/v5/connectors` for an `mqtt` connector with
`server = "mqtt://[::1]:1883"` returned HTTP 500
`{case_clause,{error,"not_expecting_scheme"}}`.

Two independent defects:

1. `emqx_connector_resource:parse_mqtt_host/1` extracts the host for the SSRF
   check by re-parsing `server` with `#{default_port => 1883}` — no scheme
   support. The `mqtt` connector schema field, however, uses `?MQTT_HOST_OPTS`
   (`default_scheme = "mqtt"`, `supported_schemes = ["mqtt", "mqtts"]`) since
   #17859. So `mqtt://…` / `mqtts://…` passed schema validation and was then
   rejected by the SSRF host extraction with a bare
   `throw("not_expecting_scheme")`. The two option sets are now consistent, and
   the parse is wrapped so a throw here can never escape (the schema already
   validated the value and reports the real error).

2. `emqx_connector_api:do_create_or_update_connector/5` only matched
   `{error, {pre|post_config_update, _, _}}` and `{error, Map}`. Any other error
   term — e.g. the bare string above, which `emqx_config_handler` surfaces
   verbatim — fell through to a `case_clause` crash and a 500. A catch-all now
   returns a readable 400 (`emqx_utils:readable_error_msg/1`), and
   `{error, {config_update_crashed, _}}` returns a 500 with a readable message
   rather than a crash dump.

Behaviour after the fix (covered by the new tests):
`mqtt://…`, `mqtts://…` and scheme-less `host:port` → 201;
`mqtt-tcp://…` → 400 `unsupported_scheme` (unchanged);
any unexpected error term → 400 with a readable message, never a 500.

No changelog: the `server` scheme support (#17859) is not in a GA release yet.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

## Follow-up commit

The MQTT host parse options were duplicated in four modules across three apps
(`emqx_bridge_mqtt_connector_schema`, `emqx_connector_resource`,
`emqx_cluster_link_schema`, `emqx_cluster_link_config`) with nothing
cross-referencing them — which is how defect 1 above came about. They now live in
`emqx_schema:mqtt_host_opts/0`, next to the `parse_server/2` and `servers_sc/2`
that consume them.
