### PR TITLE
build: upgrade emqx-builder to 6.1-8 and add el10 packages

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -3,7 +3,7 @@ version: '3.9'
 services:
   kdc:
     hostname: kdc.emqx.net
-    image:  ghcr.io/emqx/emqx-builder/5.6-2:1.15.7-26.2.5.14-1-ubuntu22.04
+    image:  ghcr.io/emqx/emqx-builder/6.1-8:1.15.7-26.2.5.14-1-ubuntu22.04
     container_name: kdc.emqx.net
     expose:
       - 88 # kdc

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   erlang:
     hostname: erlang.emqx.net
     container_name: erlang
-    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.6-2:1.15.7-26.2.5.14-1-ubuntu22.04}
+    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/6.1-8:1.15.7-26.2.5.14-1-ubuntu22.04}
     env_file:
       - credentials.env
       - conf.env

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -67,7 +67,7 @@ on:
       builder_vsn:
         required: false
         type: string
-        default: '5.6-2'
+        default: '6.1-8'
 
 permissions:
   contents: read
@@ -122,6 +122,7 @@ jobs:
           - debian13
           - debian12
           - debian11
+          - el10
           - el9
           - el8
           - el7

--- a/changes/ee/feat-18031.en.md
+++ b/changes/ee/feat-18031.en.md
@@ -1,0 +1,1 @@
+Added Enterprise Linux 10 (EL10) packages, for Red Hat Enterprise Linux 10, Rocky Linux 10, and compatible distributions.

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.6-2:1.15.7-26.2.5.14-1-debian13
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/6.1-8:1.15.7-26.2.5.14-1-debian13
 ARG RUN_FROM=debian:13-slim
 ARG SOURCE_TYPE=src # tgz
 

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
 # https://github.com/emqx/emqx-builder
-export EMQX_BUILDER_VSN=5.6-2
+export EMQX_BUILDER_VSN=6.1-8
 export OTP_VSN=26.2.5.14-1
 export ELIXIR_VSN=1.15.7
 export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-ubuntu22.04

--- a/scripts/pkg-tests.sh
+++ b/scripts/pkg-tests.sh
@@ -164,6 +164,10 @@ emqx_test(){
                     # el9 is fine with python3
                     true
                     ;;
+                "el10")
+                    # el10 is fine with python3
+                    true
+                    ;;
                 *)
                     alternatives --list | grep python && alternatives --set python /usr/bin/python2
                     ;;


### PR DESCRIPTION
Release versions: 5.8.12

## Summary

Upgrade the `emqx-builder` image from `5.6-2` to [`6.1-8`](https://github.com/emqx/emqx-builder/releases/tag/6.1-8). OTP (`26.2.5.14-1`) and Elixir (`1.15.7`) versions are unchanged — `6.1-8` pins the identical toolchain.

Also add **EL10** to the Linux package build matrix, producing RPM packages for RHEL 10 / Rocky Linux 10 and compatible distributions. `scripts/pkg-tests.sh` is updated so el10 uses python3 (like el8/el9) during RPM install verification.

Places updated (found via `grep 5.6-2`):
- `env.sh` — `EMQX_BUILDER_VSN`
- `deploy/docker/Dockerfile` — `BUILD_FROM`
- `.ci/docker-compose-file/docker-compose.yaml`, `docker-compose-kdc.yaml` — CT runner / KDC images
- `.github/workflows/build_packages.yaml` — default `builder_vsn` + `el10` matrix entry
- `scripts/pkg-tests.sh` — el10 rpm test handling

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
