### PR TITLE
test: de-flake t_frame_error_shutdown_count_is_bounded (unique clientids)

### DIFF
--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -1607,13 +1607,20 @@ t_frame_error_shutdown_count_is_bounded(Config) ->
         ]
     ),
     %% ... while an atom cause keeps its own.
-    ?assertEqual(NamedBefore + 1, shutdown_count(Config, bad_subqos)).
+    ?WAIT(?assertEqual(NamedBefore + 1, shutdown_count(Config, bad_subqos)), 5).
 
 send_malformed_when_connected(Config, Malformed) ->
     Socket = socket_connect(Config, [{active, true}, binary]),
+    %% Each connection needs its own clientid: reusing one would trip the
+    %% clientid registration throttle and let a takeover, rather than the frame
+    %% error, decide the exit reason.
+    ClientId = iolist_to_binary([
+        "send_malformed_when_connected-",
+        integer_to_binary(erlang:unique_integer([positive]))
+    ]),
     ConnPacket = ?CONNECT_PACKET(#mqtt_packet_connect{
         proto_ver = ?MQTT_PROTO_V5,
-        clientid = atom_to_binary(?FUNCTION_NAME)
+        clientid = ClientId
     }),
     ok = socket_send(Socket, emqx_frame:serialize(ConnPacket)),
     receive


### PR DESCRIPTION
Test-only change.

`send_malformed_when_connected/2` (used only by `t_frame_error_shutdown_count_is_bounded`) built its clientid from `atom_to_binary(?FUNCTION_NAME)`, so all three malformed connections connected with the *same* clientid. Re-registering it in quick succession trips `emqx_cm`'s registration throttle (`clientid_registration_throttled`) and can cause a same-clientid takeover, so one connection exits with a reason other than `frame_error` and the shutdown counter reads 2 instead of 3.

Each connection now gets a unique clientid. The trailing wait on the `bad_subqos` counter was added for symmetry with the `frame_error` one. Asserted counts and causes are unchanged.

Verified: 40 consecutive runs of the case pass, and the whole `gen_tcp_listener.misbehaving` group passes.