### PR TITLE
perf(essential): skip per-connection stats reporting when client-info API is off

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -458,12 +458,7 @@ wakeup_from_hib(Parent, State) ->
 %% Ensure/cancel stats timer
 
 init_stats_timer(#state{conf = #conf{zone = Zone}}) ->
-    %% The per-connection stats reported here only feed the client-info REST API
-    %% (`GET /clients`); skip them entirely when that API is disabled.
-    case
-        emqx_config:get_zone_conf(Zone, [stats, enable]) andalso
-            emqx_features:client_info_enabled()
-    of
+    case emqx_config:get_zone_conf(Zone, [stats, enable]) of
         true -> undefined;
         false -> disabled
     end.
@@ -644,7 +639,7 @@ handle_msg({event, _Other}, State = #state{channel = Channel}) ->
             ok;
         ClientId ->
             emqx_cm:set_chan_info(ClientId, info(State)),
-            emqx_cm:set_chan_stats(ClientId, stats(State))
+            maybe_set_chan_stats(ClientId, State)
     end,
     {ok, State};
 handle_msg({timeout, TRef, TMsg}, State) ->
@@ -755,7 +750,7 @@ handle_timeout(
 ) ->
     ClientId = emqx_channel:info(clientid, Channel),
     {Msgs, NState} = check_sendq_congestion(State),
-    emqx_cm:set_chan_stats(ClientId, stats(NState)),
+    maybe_set_chan_stats(ClientId, NState),
     emqx_congestion:maybe_alarm_conn_congestion(?MODULE, NState),
     {ok, Msgs, NState#state{stats_timer = undefined}};
 handle_timeout(
@@ -778,7 +773,18 @@ try_set_chan_stats(State = #state{channel = Channel}) ->
     case emqx_channel:info(clientid, Channel) of
         %% ClientID is not yet known, nothing to report.
         undefined -> false;
-        ClientId -> emqx_cm:set_chan_stats(ClientId, stats(State))
+        ClientId -> maybe_set_chan_stats(ClientId, State)
+    end.
+
+%% Report per-connection stats to the client-info table, unless the client-info
+%% REST API (`GET /clients`) is disabled -- then nothing reads them, so skip both
+%% the stats gathering and the ETS write. The stats timer itself keeps running,
+%% so its other duties (send-queue congestion recovery, congestion alarms) are
+%% unaffected.
+maybe_set_chan_stats(ClientId, State) ->
+    case emqx_features:client_info_enabled() of
+        true -> emqx_cm:set_chan_stats(ClientId, stats(State));
+        false -> ok
     end.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -458,7 +458,12 @@ wakeup_from_hib(Parent, State) ->
 %% Ensure/cancel stats timer
 
 init_stats_timer(#state{conf = #conf{zone = Zone}}) ->
-    case emqx_config:get_zone_conf(Zone, [stats, enable]) of
+    %% The per-connection stats reported here only feed the client-info REST API
+    %% (`GET /clients`); skip them entirely when that API is disabled.
+    case
+        emqx_config:get_zone_conf(Zone, [stats, enable]) andalso
+            emqx_features:client_info_enabled()
+    of
         true -> undefined;
         false -> disabled
     end.

--- a/apps/emqx/src/emqx_features.erl
+++ b/apps/emqx/src/emqx_features.erl
@@ -1,0 +1,46 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_features).
+
+-moduledoc """
+Boot-time feature capabilities resolved from `EMQX_FEATURES` (see
+`emqx_machine_features`) and pushed down into `persistent_term` so that the
+base `emqx` application can cheaply gate optional bookkeeping on the hot path
+without an upward dependency on `emqx_machine`.
+
+Accessors default to `true` (capability enabled) when unset, so a node that has
+not resolved its feature set yet, or that runs the `FULL` preset, behaves
+exactly as before.
+""".
+
+-export([
+    set_capability/2,
+    observability_enabled/0,
+    client_info_enabled/0
+]).
+
+-define(PT(Key), {?MODULE, Key}).
+
+-doc "Set a boot-time capability flag. Called once by `emqx_machine` at boot.".
+-spec set_capability(observability | client_info, boolean()) -> ok.
+set_capability(Key, Enabled) when is_boolean(Enabled) ->
+    persistent_term:put(?PT(Key), Enabled).
+
+-doc """
+Whether observability sinks (Prometheus/metrics, dashboard monitor, telemetry,
+OpenTelemetry, `$SYS`) are available. When disabled, purely-observability
+counters on the message hot path can be skipped.
+""".
+-spec observability_enabled() -> boolean().
+observability_enabled() ->
+    persistent_term:get(?PT(observability), true).
+
+-doc """
+Whether the client-info REST API (dashboard/management `GET /clients`,
+`GET /subscriptions`) is available. When disabled, per-connection info/stats
+book-keeping that only feeds those endpoints can be skipped.
+""".
+-spec client_info_enabled() -> boolean().
+client_info_enabled() ->
+    persistent_term:get(?PT(client_info), true).

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -455,12 +455,7 @@ sock_setopts(_Sock, []) ->
 %% Ensure/cancel stats timer
 
 init_stats_timer(#state{conf = #conf{zone = Zone}}) ->
-    %% The per-connection stats reported here only feed the client-info REST API
-    %% (`GET /clients`); skip them entirely when that API is disabled.
-    case
-        emqx_config:get_zone_conf(Zone, [stats, enable]) andalso
-            emqx_features:client_info_enabled()
-    of
+    case emqx_config:get_zone_conf(Zone, [stats, enable]) of
         true -> undefined;
         false -> disabled
     end.
@@ -623,7 +618,7 @@ handle_msg({event, _Other}, State = #state{channel = Channel}) ->
             ok;
         ClientId ->
             emqx_cm:set_chan_info(ClientId, info(State)),
-            emqx_cm:set_chan_stats(ClientId, stats(State))
+            maybe_set_chan_stats(ClientId, State)
     end,
     {ok, State};
 handle_msg({timeout, TRef, TMsg}, State) ->
@@ -729,7 +724,7 @@ handle_timeout(
     }
 ) ->
     ClientId = emqx_channel:info(clientid, Channel),
-    emqx_cm:set_chan_stats(ClientId, stats(State)),
+    maybe_set_chan_stats(ClientId, State),
     emqx_congestion:maybe_alarm_conn_congestion(?MODULE, State),
     check_send_timeout(SS, State#state{stats_timer = undefined});
 handle_timeout(
@@ -752,7 +747,17 @@ try_set_chan_stats(State = #state{channel = Channel}) ->
     case emqx_channel:info(clientid, Channel) of
         %% ClientID is not yet known, nothing to report.
         undefined -> false;
-        ClientId -> emqx_cm:set_chan_stats(ClientId, stats(State))
+        ClientId -> maybe_set_chan_stats(ClientId, State)
+    end.
+
+%% Report per-connection stats to the client-info table, unless the client-info
+%% REST API (`GET /clients`) is disabled -- then nothing reads them, so skip both
+%% the stats gathering and the ETS write. The stats timer itself keeps running,
+%% so its other duties (congestion alarms, send-timeout checks) are unaffected.
+maybe_set_chan_stats(ClientId, State) ->
+    case emqx_features:client_info_enabled() of
+        true -> emqx_cm:set_chan_stats(ClientId, stats(State));
+        false -> ok
     end.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -455,7 +455,12 @@ sock_setopts(_Sock, []) ->
 %% Ensure/cancel stats timer
 
 init_stats_timer(#state{conf = #conf{zone = Zone}}) ->
-    case emqx_config:get_zone_conf(Zone, [stats, enable]) of
+    %% The per-connection stats reported here only feed the client-info REST API
+    %% (`GET /clients`); skip them entirely when that API is disabled.
+    case
+        emqx_config:get_zone_conf(Zone, [stats, enable]) andalso
+            emqx_features:client_info_enabled()
+    of
         true -> undefined;
         false -> disabled
     end.

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -288,12 +288,7 @@ tune_heap_size(Channel) ->
     end.
 
 get_stats_enable(Zone) ->
-    %% The per-connection stats reported here only feed the client-info REST API
-    %% (`GET /clients`); skip them entirely when that API is disabled.
-    case
-        emqx_config:get_zone_conf(Zone, [stats, enable]) andalso
-            emqx_features:client_info_enabled()
-    of
+    case emqx_config:get_zone_conf(Zone, [stats, enable]) of
         true -> paused;
         false -> disabled
     end.
@@ -451,7 +446,7 @@ handle_event({event, _Other}, State = #state{channel = Channel}) ->
             ok;
         ClientId ->
             emqx_cm:set_chan_info(ClientId, info(State)),
-            emqx_cm:set_chan_stats(ClientId, stats(State))
+            maybe_set_chan_stats(ClientId, State)
     end,
     State.
 
@@ -470,10 +465,19 @@ handle_timeout(
     }
 ) ->
     ClientId = emqx_channel:info(clientid, Channel),
-    emqx_cm:set_chan_stats(ClientId, stats(State)),
+    maybe_set_chan_stats(ClientId, State),
     {ok, State#state{stats_timer = undefined}};
 handle_timeout(TRef, TMsg, State) ->
     commands(with_channel(handle_timeout, [TRef, TMsg], {[], State})).
+
+%% Report per-connection stats to the client-info table, unless the client-info
+%% REST API (`GET /clients`) is disabled -- then nothing reads them, so skip both
+%% the stats gathering and the ETS write.
+maybe_set_chan_stats(ClientId, State) ->
+    case emqx_features:client_info_enabled() of
+        true -> emqx_cm:set_chan_stats(ClientId, stats(State));
+        false -> ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Run GC, Check OOM

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -288,7 +288,12 @@ tune_heap_size(Channel) ->
     end.
 
 get_stats_enable(Zone) ->
-    case emqx_config:get_zone_conf(Zone, [stats, enable]) of
+    %% The per-connection stats reported here only feed the client-info REST API
+    %% (`GET /clients`); skip them entirely when that API is disabled.
+    case
+        emqx_config:get_zone_conf(Zone, [stats, enable]) andalso
+            emqx_features:client_info_enabled()
+    of
         true -> paused;
         false -> disabled
     end.

--- a/apps/emqx_machine/src/emqx_machine_features.erl
+++ b/apps/emqx_machine/src/emqx_machine_features.erl
@@ -280,19 +280,25 @@ cache_features() ->
 
 %% Push boot-time capability flags down into the base `emqx` application so the
 %% hot path can gate optional book-keeping without depending on `emqx_machine`.
-%% `observability` follows the metrics/dashboard-monitor sinks; `client_info`
-%% follows the dashboard/management client-info REST API.
+%% Keyed on the governance features rather than concrete app names, so moving or
+%% renaming an app within a feature does not change the resolved capabilities.
+%% `observability` follows the metrics/dashboard-monitor sinks (the `metrics`
+%% feature, or `dashboard` for the dashboard monitor); `client_info` follows the
+%% dashboard/management client-info REST API (the `dashboard` feature, which
+%% owns `emqx_management`).
 publish_capabilities(Features) ->
-    Observability = any_app_enabled([emqx_prometheus, emqx_dashboard], Features),
-    ClientInfo = any_app_enabled([emqx_management, emqx_dashboard], Features),
+    Observability = any_feature_enabled([metrics, dashboard], Features),
+    ClientInfo = any_feature_enabled([dashboard], Features),
     ok = emqx_features:set_capability(observability, Observability),
     ok = emqx_features:set_capability(client_info, ClientInfo),
     ok.
 
-any_app_enabled(_Apps, #{preset := full}) ->
+any_feature_enabled(_Features, #{preset := full}) ->
     true;
-any_app_enabled(Apps, #{allowed_apps := Allowed}) ->
-    lists:any(fun(App) -> is_map_key(App, Allowed) end, Apps).
+any_feature_enabled(Features, #{enabled_features := Enabled}) ->
+    lists:any(fun(Feature) -> is_map_key(Feature, Enabled) end, Features);
+any_feature_enabled(_Features, _Other) ->
+    false.
 
 resolve_dependent_apps(Feature, KnownFeatures) ->
     #{apps := Apps, deps := FeatDeps} = maps:get(Feature, KnownFeatures),

--- a/apps/emqx_machine/src/emqx_machine_features.erl
+++ b/apps/emqx_machine/src/emqx_machine_features.erl
@@ -275,7 +275,24 @@ cache_features() ->
                 parse_features(Str)
         end,
     _ = persistent_term:put(?PT_KEY, Features),
+    ok = publish_capabilities(Features),
     Features.
+
+%% Push boot-time capability flags down into the base `emqx` application so the
+%% hot path can gate optional book-keeping without depending on `emqx_machine`.
+%% `observability` follows the metrics/dashboard-monitor sinks; `client_info`
+%% follows the dashboard/management client-info REST API.
+publish_capabilities(Features) ->
+    Observability = any_app_enabled([emqx_prometheus, emqx_dashboard], Features),
+    ClientInfo = any_app_enabled([emqx_management, emqx_dashboard], Features),
+    ok = emqx_features:set_capability(observability, Observability),
+    ok = emqx_features:set_capability(client_info, ClientInfo),
+    ok.
+
+any_app_enabled(_Apps, #{preset := full}) ->
+    true;
+any_app_enabled(Apps, #{allowed_apps := Allowed}) ->
+    lists:any(fun(App) -> is_map_key(App, Allowed) end, Apps).
 
 resolve_dependent_apps(Feature, KnownFeatures) ->
     #{apps := Apps, deps := FeatDeps} = maps:get(Feature, KnownFeatures),

--- a/changes/ee/perf-18033.en.md
+++ b/changes/ee/perf-18033.en.md
@@ -1,0 +1,1 @@
+In `ESSENTIAL` feature mode (and any deployment with the dashboard/management client-info API disabled), EMQX no longer performs the periodic per-connection statistics reporting that only feeds the `GET /clients` endpoint, reducing per-connection overhead at high connection counts.


### PR DESCRIPTION
## Summary

Follow-up to the QA feature-comparison (emqx/emqx-qa#1509), which showed `ESSENTIAL` and `FULL` within ~3% CPU because feature-gating only stops *apps* from booting — the core `emqx` hot path still does all of its observability/API bookkeeping regardless of which features are on.

This PR skips one piece of that bookkeeping — **per-connection stats reporting** — when the feature it feeds (the dashboard/management client-info API) is disabled.

## What it does

- **`emqx_features`** (new, base `emqx` app): reads boot-time capability booleans from `persistent_term`, defaulting to `true` (so `FULL` / unset behaves exactly as today). No upward dependency on `emqx_machine`.
- **`emqx_machine_features`**: after resolving `EMQX_FEATURES`, publishes the `observability` and `client_info` capabilities into `persistent_term`.
- **Connection modules** (`emqx_connection`, `emqx_socket_connection`, `emqx_ws_connection`): each connection periodically reports its stats into `?CHAN_INFO_TAB` (via `emqx_cm:set_chan_stats`), which only feeds the `GET /clients` stats columns. When `client_info` is disabled, `maybe_set_chan_stats/2` skips both the `stats/1` gathering and the ETS write.

### Why gate the push, not the timer

The `emit_stats` timer is intentionally left running. Besides reporting stats it also drives **send-queue congestion recovery** (`check_sendq_congestion`, `congested → running`), **connection-congestion alarms**, and (in `emqx_socket_connection`) the **send-timeout check**. Disabling the whole timer would suppress those — notably, a quiet sendq-congested connection could fail to recover and keep buffering QoS0. So only the stats push is gated; all other timer duties are unaffected.

## Why it is safe

`?CHAN_INFO_TAB`'s stats column is read only by the management/dashboard client-info API. Core paths (takeover, kick/discard, routing) use the pid-registry tables; node eviction/rebalance read the *info* column, not the *stats* column. Rate limiting and flow control are independent mechanisms (own token buckets / socket backpressure) and read none of this.

## Benchmark

Single node, `emqtt_bench` (1:1 pub/sub, QoS 1, 256-byte payload). Broker CPU measured inside EMQX via `recon:scheduler_usage/1`. The effect was isolated on **one running node** by flipping the `client_info` capability at runtime (same apps, same connections, timer firing in both phases):

**12 000 connections, `idle_timeout=2s` (amplified push cadence to lift the signal above noise):**

| stats push | `set_chan_stats`/s | broker CPU |
|---|---|---|
| on | 7 956 | 2.84 cores |
| gated (this PR) | 0 | 2.32 cores (**−18%**) |

This gives a per-push cost of **~6.6×10⁻⁵ cores** (the `stats/1` computation + the `?CHAN_INFO_TAB` write). The saving scales with the report rate ≈ `connections / idle_timeout` (plus socket-event-driven reports). At the **default** `idle_timeout`, e.g. 16 000 connections ≈ 1 600 reports/s ≈ **0.1 cores** — a few percent of broker CPU at these loads, more for connection-heavy deployments, and negligible at very high message rates (consistent with QA's ~3% overall gap). Keeping the timer running for congestion handling costs ~0.004 cores, so correctness here is essentially free. Throughput is unaffected.

End-to-end in `ESSENTIAL` mode (`client_info` resolved off), `emqx_cm:set_chan_stats` drops to **0 calls/s** across all connection modules while the timers keep firing.

## Notes

- The default v6 TCP listener uses `emqx_socket_connection`; the gate is applied there as well as in `emqx_connection`/`emqx_ws_connection`.
