### PR TITLE
perf(essential): skip global message metrics counters when observability is off

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -100,7 +100,11 @@
     %% Forced GC thresholds, `false` if disabled
     force_gc :: false | {_EachNMessages :: pos_integer(), _EachNBytes :: pos_integer()},
     %% Forced shutdown policy
-    force_shutdown :: emqx_types:oom_policy()
+    force_shutdown :: emqx_types:oom_policy(),
+    %% Whether observability sinks (Prometheus/metrics, `$SYS`, dashboard
+    %% monitor) are enabled. When `false`, the global message counters that
+    %% only feed those sinks are skipped on the hot path.
+    observability = true :: boolean()
 }).
 
 -record(thresholds, {
@@ -1047,7 +1051,10 @@ serialize_and_inc_stats(#state{serialize = Serialize} = State, Packet) ->
             <<>>;
         Data ->
             ?TRACE("MQTT", "mqtt_packet_sent", #{packet => Packet}),
-            emqx_metrics:inc_sent(Packet, State#state.namespace),
+            case is_observability_enabled(State) of
+                true -> emqx_metrics:inc_sent(Packet, State#state.namespace);
+                false -> ok
+            end,
             inc_outgoing_stats(Packet),
             Data
     catch
@@ -1386,8 +1393,14 @@ close_socket(State = #state{transport = Transport, socket = Socket}) ->
 %%--------------------------------------------------------------------
 %% Inc incoming/outgoing stats
 
+-compile({inline, [is_observability_enabled/1]}).
+is_observability_enabled(#state{conf = #conf{observability = Enabled}}) ->
+    Enabled.
+
 -compile({inline, [inc_incoming_stats/2]}).
 inc_incoming_stats(Packet = ?PACKET(Type), State) ->
+    %% `recv_pkt` drives keepalive detection and must always be tracked; the
+    %% remaining counters only feed observability sinks.
     inc_counter(recv_pkt, 1),
     case Type of
         ?PUBLISH ->
@@ -1396,7 +1409,10 @@ inc_incoming_stats(Packet = ?PACKET(Type), State) ->
         _ ->
             ok
     end,
-    emqx_metrics:inc_recv(Packet, State#state.namespace).
+    case is_observability_enabled(State) of
+        true -> emqx_metrics:inc_recv(Packet, State#state.namespace);
+        false -> ok
+    end.
 
 -compile({inline, [inc_dropped_stats/0]}).
 inc_dropped_stats() ->
@@ -1428,13 +1444,19 @@ inc_qos_stats(Type, Packet) ->
     end.
 
 inc_metrics(Name, State, Val) ->
-    case State#state.namespace of
-        ?global_ns ->
-            emqx_metrics:inc(?global_ns, Name, Val);
-        Namespace ->
-            emqx_metrics:inc(?global_ns, Name, Val),
-            _ = emqx_metrics:inc_safe(Namespace, Name, Val),
-            ok
+    %% `bytes.received` / `bytes.sent` are observability-only byte counters.
+    case is_observability_enabled(State) of
+        false ->
+            ok;
+        true ->
+            case State#state.namespace of
+                ?global_ns ->
+                    emqx_metrics:inc(?global_ns, Name, Val);
+                Namespace ->
+                    emqx_metrics:inc(?global_ns, Name, Val),
+                    _ = emqx_metrics:inc_safe(Namespace, Name, Val),
+                    ok
+            end
     end.
 
 %%--------------------------------------------------------------------
@@ -1546,7 +1568,8 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf} = State0) ->
         sendq_watermark = get_high_watermark(Type, Listener),
         hibernate_after = maps:get(hibernate_after, Opts, get_zone_idle_timeout(Zone)),
         force_shutdown = emqx_config:get_zone_conf(Zone, [force_shutdown]),
-        force_gc = GcThresholds
+        force_gc = GcThresholds,
+        observability = emqx_features:observability_enabled()
     },
     State0#state{
         parser = Parser,

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -89,7 +89,11 @@
     %% Forced GC thresholds, `false` if disabled
     force_gc = false :: false | {_EachNMessages :: pos_integer(), _EachNBytes :: pos_integer()},
     %% Forced shutdown policy
-    force_shutdown :: undefined | emqx_types:oom_policy()
+    force_shutdown :: undefined | emqx_types:oom_policy(),
+    %% Whether observability sinks (Prometheus/metrics, `$SYS`, dashboard
+    %% monitor) are enabled. When `false`, the global message counters that
+    %% only feed those sinks are skipped on the hot path.
+    observability = true :: boolean()
 }).
 
 -record(thresholds, {
@@ -1056,7 +1060,10 @@ serialize_and_inc_stats(#state{serialize = Serialize} = State, Packet) ->
             <<>>;
         Data ->
             ?TRACE("MQTT", "mqtt_packet_sent", #{packet => Packet}),
-            emqx_metrics:inc_sent(Packet, State#state.namespace),
+            case is_observability_enabled(State) of
+                true -> emqx_metrics:inc_sent(Packet, State#state.namespace);
+                false -> ok
+            end,
             inc_outgoing_stats(Packet),
             Data
     catch
@@ -1390,8 +1397,14 @@ socket_closed(State) ->
 %%--------------------------------------------------------------------
 %% Inc incoming/outgoing stats
 
+-compile({inline, [is_observability_enabled/1]}).
+is_observability_enabled(#state{conf = #conf{observability = Enabled}}) ->
+    Enabled.
+
 -compile({inline, [inc_incoming_stats/2]}).
 inc_incoming_stats(Packet = ?PACKET(Type), State) ->
+    %% `recv_pkt` drives keepalive detection and must always be tracked; the
+    %% remaining counters only feed observability sinks.
     inc_counter(recv_pkt, 1),
     case Type of
         ?PUBLISH ->
@@ -1400,7 +1413,10 @@ inc_incoming_stats(Packet = ?PACKET(Type), State) ->
         _ ->
             ok
     end,
-    emqx_metrics:inc_recv(Packet, State#state.namespace).
+    case is_observability_enabled(State) of
+        true -> emqx_metrics:inc_recv(Packet, State#state.namespace);
+        false -> ok
+    end.
 
 -compile({inline, [inc_dropped_stats/0]}).
 inc_dropped_stats() ->
@@ -1432,13 +1448,19 @@ inc_qos_stats(Type, Packet) ->
     end.
 
 inc_metrics(Name, State, Val) ->
-    emqx_metrics:inc(?global_ns, Name, Val),
-    case State#state.namespace of
-        ?global_ns ->
+    %% `bytes.received` / `bytes.sent` are observability-only byte counters.
+    case is_observability_enabled(State) of
+        false ->
             ok;
-        Namespace ->
-            _ = emqx_metrics:inc_safe(Namespace, Name, Val),
-            ok
+        true ->
+            emqx_metrics:inc(?global_ns, Name, Val),
+            case State#state.namespace of
+                ?global_ns ->
+                    ok;
+                Namespace ->
+                    _ = emqx_metrics:inc_safe(Namespace, Name, Val),
+                    ok
+            end
     end.
 
 %%--------------------------------------------------------------------
@@ -1513,7 +1535,8 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf0} = State0) ->
         active_n = get_active_n(Conf0),
         hibernate_after = maps:get(hibernate_after, Opts, get_zone_idle_timeout(Zone)),
         force_shutdown = emqx_config:get_zone_conf(Zone, [force_shutdown]),
-        force_gc = GcThresholds
+        force_gc = GcThresholds,
+        observability = emqx_features:observability_enabled()
     },
     State0#state{
         parser = Parser,

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -72,6 +72,11 @@
     %% Tenant Namespace
     namespace = ?global_ns :: emqx_config:maybe_namespace(),
 
+    %% Whether observability sinks (Prometheus/metrics, `$SYS`, dashboard
+    %% monitor) are enabled. When `false`, the global message counters that
+    %% only feed those sinks are skipped on the hot path.
+    observability = true :: boolean(),
+
     %% Extra field for future hot-upgrade support
     extra = []
 }).
@@ -270,6 +275,7 @@ init_connection(
         mqtt_piggyback = MQTTPiggyback,
         channel = Channel,
         listener = {Type, Listener},
+        observability = emqx_features:observability_enabled(),
         extra = []
     },
     State = init_zone_specific_state(Zone, Opts, State0),
@@ -790,6 +796,9 @@ framelist_bytesize({binary, Data}, Oct) ->
     ]}
 ).
 
+is_observability_enabled(#state{observability = Enabled}) ->
+    Enabled.
+
 inc_recv_stats(Cnt, Oct, State) ->
     _ = emqx_pd:inc_counter(recv_cnt, Cnt),
     _ = emqx_pd:inc_counter(recv_oct, Oct),
@@ -805,7 +814,10 @@ inc_incoming_stats(Packet = ?PACKET(Type), State) ->
             _ ->
                 ok
         end,
-    emqx_metrics:inc_recv(Packet, State#state.namespace).
+    case is_observability_enabled(State) of
+        true -> emqx_metrics:inc_recv(Packet, State#state.namespace);
+        false -> ok
+    end.
 
 inc_outgoing_stats({error, message_too_large}, _State) ->
     _ = emqx_pd:inc_counter('send_msg.dropped', 1),
@@ -820,7 +832,10 @@ inc_outgoing_stats(Packet = ?PACKET(Type), State) ->
             _ ->
                 ok
         end,
-    emqx_metrics:inc_sent(Packet, State#state.namespace).
+    case is_observability_enabled(State) of
+        true -> emqx_metrics:inc_sent(Packet, State#state.namespace);
+        false -> ok
+    end.
 
 inc_sent_stats(Cnt, Oct, State) ->
     _ = emqx_pd:inc_counter(send_cnt, Cnt),
@@ -915,13 +930,19 @@ get_peer(Req, #{listener := {Type, Listener}}) ->
 %%--------------------------------------------------------------------
 
 inc_metrics(Name, State, Val) ->
-    case State#state.namespace of
-        ?global_ns ->
-            emqx_metrics:inc(?global_ns, Name, Val);
-        Namespace ->
-            emqx_metrics:inc(?global_ns, Name, Val),
-            _ = emqx_metrics:inc_safe(Namespace, Name, Val),
-            ok
+    %% `bytes.received` / `bytes.sent` are observability-only byte counters.
+    case is_observability_enabled(State) of
+        false ->
+            ok;
+        true ->
+            case State#state.namespace of
+                ?global_ns ->
+                    emqx_metrics:inc(?global_ns, Name, Val);
+                Namespace ->
+                    emqx_metrics:inc(?global_ns, Name, Val),
+                    _ = emqx_metrics:inc_safe(Namespace, Name, Val),
+                    ok
+            end
     end.
 
 %%--------------------------------------------------------------------

--- a/changes/ee/perf-18034.en.md
+++ b/changes/ee/perf-18034.en.md
@@ -1,0 +1,1 @@
+In `ESSENTIAL` feature mode (and any deployment with observability sinks such as Prometheus and the dashboard monitor disabled), EMQX no longer updates the global message/byte metrics counters that only feed those sinks, slightly reducing per-message CPU overhead. Keepalive tracking and per-connection statistics are unaffected.


### PR DESCRIPTION
## Summary

Follow-up to the QA feature-comparison (emqx/emqx-qa#1509). Companion to the `emqx_features` boot-time capability mechanism (merged in #18033). This one skips the **global per-packet `emqx_metrics` counters** on the hot path when observability is off.

## What it does

When the observability sinks (Prometheus/`metrics`, `$SYS`, dashboard monitor) are disabled, the connection modules skip the per-packet global `emqx_metrics` updates that only feed those sinks:

- `emqx_metrics:inc_recv/2` and `inc_sent/2` — several `counters:add` per PUBLISH in each direction (doubled under a tenant namespace).
- `bytes.received` / `bytes.sent` (`inc_metrics/3`).

The `observability` capability is read once at connection init and cached in connection state (`#conf` for `emqx_connection`/`emqx_socket_connection`, `#state` for `emqx_ws_connection`), so the hot path adds only a cached record read, not a `persistent_term` lookup per packet.

Gated in **all three** connection modules — `emqx_connection`, `emqx_socket_connection` (the default v6 TCP/TLS listener), and `emqx_ws_connection` — so the optimization actually engages for real traffic.

## What is deliberately kept

- **`recv_pkt`** — drives keepalive detection; always tracked.
- **Per-connection process-dictionary counters** (`recv_msg`/`send_msg`/qos) — cheap process-local writes feeding the per-client stats display.
- Rate limiting and flow control are unaffected — they use their own token buckets / socket backpressure and read none of these counters.

## Benchmark

Single node, `emqtt_bench` QoS 1 publishers, 16-byte payload, ~57k msg/s. Broker CPU via `recon:scheduler_usage/1`. Isolated on one FULL node by flipping `observability` and reconnecting (the flag is cached per connection):

| observability | `inc_recv`/s | broker CPU |
|---|---|---|
| on | 57 361 | 9.09 cores |
| off (this PR) | 0 | 8.86 cores (**−2.6%**) |

`inc_recv` drops to 0, confirming the gate engages on the TCP path. The saving is per-packet, so it scales with message rate (~2.6% here at ~57k msg/s; Phase B actually sustained a higher rate for lower CPU) and is negligible at low message rates — consistent with QA's ~3% overall ESSENTIAL-vs-FULL gap.
