### PR TITLE
perf(essential): skip client-info table when client-info API is off [RFC]

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1726,9 +1726,16 @@ handle_cast(
     NKeepAlive = emqx_keepalive:update(Zone, Interval, KeepAlive),
     NConnInfo = maps:put(keepalive, Interval, ConnInfo),
     NChannel = Channel#channel{keepalive = NKeepAlive, conninfo = NConnInfo},
-    SockInfo = maps:get(sockinfo, emqx_cm:get_chan_info(ClientId), #{}),
-    ChanInfo1 = info(NChannel),
-    emqx_cm:set_chan_info(ClientId, ChanInfo1#{sockinfo => SockInfo}),
+    %% Refresh the client-info read model only when it is maintained; when the
+    %% client-info API is disabled the info table is not populated.
+    case emqx_features:client_info_enabled() of
+        true ->
+            SockInfo = maps:get(sockinfo, emqx_cm:get_chan_info(ClientId), #{}),
+            ChanInfo1 = info(NChannel),
+            emqx_cm:set_chan_info(ClientId, ChanInfo1#{sockinfo => SockInfo});
+        false ->
+            ok
+    end,
     reset_timer(keepalive, NChannel);
 handle_cast(Req, Channel) ->
     ?SLOG(error, #{msg => "unexpected_cast", cast => Req}),

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -160,10 +160,18 @@ start_link() ->
     emqx_types:stats()
 ) -> ok.
 insert_channel_info(ClientId, Info, Stats) when ?IS_CLIENTID(ClientId) ->
-    Chan = {ClientId, self()},
-    true = ets:insert(?CHAN_INFO_TAB, {Chan, Info, Stats}),
-    ?tp(debug, insert_channel_info, #{clientid => ClientId}),
-    ok.
+    %% `?CHAN_INFO_TAB` is a read model for the client-info REST API. When that
+    %% API is disabled we skip it entirely; eviction/rebalance enumeration falls
+    %% back to fetching info live from channel processes (see all_channels_stream/1).
+    case emqx_features:client_info_enabled() of
+        false ->
+            ok;
+        true ->
+            Chan = {ClientId, self()},
+            true = ets:insert(?CHAN_INFO_TAB, {Chan, Info, Stats}),
+            ?tp(debug, insert_channel_info, #{clientid => ClientId}),
+            ok
+    end.
 
 %% @private
 %% @doc Register a channel with pid and conn_mod.
@@ -673,6 +681,18 @@ all_channels() ->
         emqx_types:clientinfo()
     }).
 all_channels_stream(ConnModuleList) ->
+    case emqx_features:client_info_enabled() of
+        true ->
+            all_channels_stream_from_info_tab(ConnModuleList);
+        false ->
+            %% The info table is not maintained; reconstruct entries on demand
+            %% from the always-present pid registry. NOTE: this issues one
+            %% process call per channel and is intended for infrequent
+            %% enumeration (eviction/rebalance), not API listing.
+            all_channels_stream_live(ConnModuleList)
+    end.
+
+all_channels_stream_from_info_tab(ConnModuleList) ->
     Ms = ets:fun2ms(
         fun({{ClientId, ChanPid}, Info, _Stats}) ->
             {ClientId, ChanPid, Info}
@@ -702,6 +722,38 @@ all_channels_stream(ConnModuleList) ->
         end,
         WithModulesFilteredStream
     ).
+
+all_channels_stream_live(ConnModuleList) ->
+    ConnModules = sets:from_list(ConnModuleList, [{version, 2}]),
+    Ms = ets:fun2ms(
+        fun(#chan_conn{clientid = ClientId, pid = Pid, mod = Mod}) ->
+            {ClientId, Pid, Mod}
+        end
+    ),
+    ConnStream = emqx_utils_stream:ets(fun
+        (undefined) -> ets:select(?CHAN_CONN_TAB, Ms, ?CHAN_INFO_SELECT_LIMIT);
+        (Cont) -> ets:select(Cont)
+    end),
+    FilteredStream = emqx_utils_stream:filter(
+        fun({_ClientId, _Pid, Mod}) -> sets:is_element(Mod, ConnModules) end,
+        ConnStream
+    ),
+    WithInfoStream = emqx_utils_stream:map(
+        fun({ClientId, Pid, Mod}) -> fetch_live_channel_tuple(ClientId, Pid, Mod) end,
+        FilteredStream
+    ),
+    %% Drop channels that died (or timed out) while being enumerated.
+    emqx_utils_stream:filter(fun(Tuple) -> Tuple =/= undefined end, WithInfoStream).
+
+fetch_live_channel_tuple(ClientId, Pid, Mod) ->
+    try Mod:call(Pid, info, 5_000) of
+        #{conn_state := ConnState, conninfo := ConnInfo, clientinfo := ClientInfo} ->
+            {ClientId, Pid, ConnState, ConnInfo, ClientInfo};
+        _ ->
+            undefined
+    catch
+        _:_ -> undefined
+    end.
 
 %% @doc Get all local connection query handle
 -spec live_connection_stream([module()]) -> emqx_utils_stream:stream(pid()).

--- a/apps/emqx/src/emqx_features.erl
+++ b/apps/emqx/src/emqx_features.erl
@@ -1,0 +1,46 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_features).
+
+-moduledoc """
+Boot-time feature capabilities resolved from `EMQX_FEATURES` (see
+`emqx_machine_features`) and pushed down into `persistent_term` so that the
+base `emqx` application can cheaply gate optional bookkeeping on the hot path
+without an upward dependency on `emqx_machine`.
+
+Accessors default to `true` (capability enabled) when unset, so a node that has
+not resolved its feature set yet, or that runs the `FULL` preset, behaves
+exactly as before.
+""".
+
+-export([
+    set_capability/2,
+    observability_enabled/0,
+    client_info_enabled/0
+]).
+
+-define(PT(Key), {?MODULE, Key}).
+
+-doc "Set a boot-time capability flag. Called once by `emqx_machine` at boot.".
+-spec set_capability(observability | client_info, boolean()) -> ok.
+set_capability(Key, Enabled) when is_boolean(Enabled) ->
+    persistent_term:put(?PT(Key), Enabled).
+
+-doc """
+Whether observability sinks (Prometheus/metrics, dashboard monitor, telemetry,
+OpenTelemetry, `$SYS`) are available. When disabled, purely-observability
+counters on the message hot path can be skipped.
+""".
+-spec observability_enabled() -> boolean().
+observability_enabled() ->
+    persistent_term:get(?PT(observability), true).
+
+-doc """
+Whether the client-info REST API (dashboard/management `GET /clients`,
+`GET /subscriptions`) is available. When disabled, per-connection info/stats
+book-keeping that only feeds those endpoints can be skipped.
+""".
+-spec client_info_enabled() -> boolean().
+client_info_enabled() ->
+    persistent_term:get(?PT(client_info), true).

--- a/apps/emqx_machine/src/emqx_machine_features.erl
+++ b/apps/emqx_machine/src/emqx_machine_features.erl
@@ -275,7 +275,24 @@ cache_features() ->
                 parse_features(Str)
         end,
     _ = persistent_term:put(?PT_KEY, Features),
+    ok = publish_capabilities(Features),
     Features.
+
+%% Push boot-time capability flags down into the base `emqx` application so the
+%% hot path can gate optional book-keeping without depending on `emqx_machine`.
+%% `observability` follows the metrics/dashboard-monitor sinks; `client_info`
+%% follows the dashboard/management client-info REST API.
+publish_capabilities(Features) ->
+    Observability = any_app_enabled([emqx_prometheus, emqx_dashboard], Features),
+    ClientInfo = any_app_enabled([emqx_management, emqx_dashboard], Features),
+    ok = emqx_features:set_capability(observability, Observability),
+    ok = emqx_features:set_capability(client_info, ClientInfo),
+    ok.
+
+any_app_enabled(_Apps, #{preset := full}) ->
+    true;
+any_app_enabled(Apps, #{allowed_apps := Allowed}) ->
+    lists:any(fun(App) -> is_map_key(App, Allowed) end, Apps).
 
 resolve_dependent_apps(Feature, KnownFeatures) ->
     #{apps := Apps, deps := FeatDeps} = maps:get(Feature, KnownFeatures),

--- a/changes/ee/perf-18035.en.md
+++ b/changes/ee/perf-18035.en.md
@@ -1,0 +1,1 @@
+In `ESSENTIAL` feature mode (and any deployment with the dashboard/management client-info API disabled), EMQX no longer maintains the per-connection client-info table that only backs the `GET /clients` endpoint, reducing per-connection memory usage at high connection counts.


### PR DESCRIPTION
## Draft / RFC — one of three ESSENTIAL-mode hot-path perf explorations

Follow-up to emqx/emqx-qa#1509. Companion to the `emqx_features` boot-time capability mechanism. **This is the most invasive of the three and is an RFC** — it changes how eviction/rebalance enumerate channels. Opening it draft to settle the direction before investing further.

### The idea

`?CHAN_INFO_TAB` (`emqx_cm`) is the single largest per-connection ETS record — a full info map per client — and it exists **only** as a read model for the client-info REST API (`GET /clients`). Core paths (takeover, kick/discard, routing) use the pid-registry tables, never this one. So when the client-info API is disabled we should be able to skip populating it and reclaim that per-connection memory at high client counts (the QA runs already show ESSENTIAL ~1–1.4 GB lower).

### What this PR does

- Gates `insert_channel_info` on `client_info_enabled()` — the info map is not stored when the API is off. `set_chan_info` / `set_chan_stats` then naturally no-op.
- Guards the one internal reader: `emqx_channel` reads its own `sockinfo` back from the table on a keepalive-interval change (`maps:get(sockinfo, emqx_cm:get_chan_info(...), #{})`), which would crash on the now-empty table — it is skipped when the API is off.
- Keeps eviction/rebalance working: **`emqx_cm:all_channels_stream/1`** (used by `emqx_eviction_agent`, a core app) needs the full info map, so when the table is disabled it now enumerates the always-present pid registry (`?CHAN_CONN_TAB`) and fetches each channel's info **live** via `Mod:call(Pid, info)`.

### ⚠️ Open question / why this is an RFC

The live fallback issues **one process call per channel**. That is fine for the rare, deliberate eviction/rebalance enumeration, but it is O(N) synchronous calls — unacceptable if anything enumerates frequently, and slow at 100k+ channels. Options to resolve before this is mergeable:

1. **Keep a minimal always-on record** (conninfo + clientinfo + conn_state only) and gate only the heavy/mutable fields + stats — no live fallback needed, smaller memory win.
2. **Bulk live gather** for eviction (batch `erlang:process_info` / a dedicated cast) instead of per-channel `call`.
3. Accept the live fallback but assert eviction is the only caller and cap concurrency.

I lean toward **(1)** as the real design, with this PR showing the end-to-end gating. Feedback welcome.

### Validation TODO (draft)
- [ ] CI build (warnings_as_errors) + existing CT (esp. `emqx_eviction_agent`, `emqx_node_rebalance`, `emqx_mgmt_api_clients`)
- [ ] Confirm `GET /clients` works in FULL; eviction still enumerates in ESSENTIAL
- [ ] Measure per-connection memory delta at high client counts
- [ ] Decide on the open question above before un-drafting
