### PR TITLE
test: move fixed test listener ports below the ephemeral range

### DIFF
--- a/apps/emqx_auth_http/test/emqx_authn_scram_restapi_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_scram_restapi_SUITE.erl
@@ -15,7 +15,10 @@
 
 -define(PATH, [authentication]).
 
--define(HTTP_PORT, 34333).
+%% Keep below the ephemeral port range (net.ipv4.ip_local_port_range, 32768-60999
+%% on CI): a port inside that range can be picked as the source port of an
+%% outbound connection, making this listener fail to bind with eaddrinuse.
+-define(HTTP_PORT, 32336).
 -define(HTTP_PATH, "/user/[...]").
 -define(ALGORITHM, sha512).
 -define(ALGORITHM_STR, <<"sha512">>).
@@ -368,7 +371,7 @@ raw_config() ->
         <<"enable">> => <<"true">>,
         <<"max_inactive">> => <<"10s">>,
         <<"method">> => <<"get">>,
-        <<"url">> => <<"http://127.0.0.1:34333/user">>,
+        <<"url">> => <<"http://127.0.0.1:32336/user">>,
         <<"body">> => #{<<"username">> => ?PH_USERNAME},
         <<"headers">> => #{<<"X-Test-Header">> => <<"Test Value">>},
         <<"algorithm">> => ?ALGORITHM_STR,

--- a/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
@@ -13,7 +13,10 @@
 -include_lib("emqx/include/emqx_placeholder.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--define(HTTP_PORT, 33333).
+%% Keep below the ephemeral port range (net.ipv4.ip_local_port_range, 32768-60999
+%% on CI): a port inside that range can be picked as the source port of an
+%% outbound connection, making this listener fail to bind with eaddrinuse.
+-define(HTTP_PORT, 32335).
 -define(HTTP_PATH, "/authz/[...]").
 
 -define(AUTHZ_HTTP_RESP(Result, Req),
@@ -219,7 +222,7 @@ t_query_params(_Config) ->
         end,
         #{
             <<"url">> => <<
-                "http://127.0.0.1:33333/authz/users/?"
+                "http://127.0.0.1:32335/authz/users/?"
                 "username=${username}&"
                 "clientid=${clientid}&"
                 "peerhost=${peerhost}&"
@@ -272,7 +275,7 @@ t_path(_Config) ->
         end,
         #{
             <<"url">> => <<
-                "http://127.0.0.1:33333/authz/use+rs/"
+                "http://127.0.0.1:32335/authz/use+rs/"
                 "${username}/"
                 "${clientid}/"
                 "${peerhost}/"
@@ -635,7 +638,7 @@ t_node_cache(_Config) ->
         end,
         #{
             <<"method">> => <<"get">>,
-            <<"url">> => <<"http://127.0.0.1:33333/authz/${clientid}?username=${username}">>,
+            <<"url">> => <<"http://127.0.0.1:32335/authz/${clientid}?username=${username}">>,
             <<"body">> => #{<<"cn">> => <<"${cert_common_name}">>}
         }
     ),
@@ -728,7 +731,7 @@ t_disallowed_placeholders_path(_Config) ->
             {ok, ?AUTHZ_HTTP_RESP(allow, Req), State}
         end,
         #{
-            <<"url">> => <<"http://127.0.0.1:33333/authz/use+rs/${typo}">>
+            <<"url">> => <<"http://127.0.0.1:32335/authz/use+rs/${typo}">>
         }
     ),
 
@@ -765,7 +768,7 @@ t_create_replace(_Config) ->
         end,
         #{
             <<"url">> =>
-                <<"http://127.0.0.1:33333/authz/users/?topic=${topic}&action=${action}">>
+                <<"http://127.0.0.1:32335/authz/users/?topic=${topic}&action=${action}">>
         }
     ),
 
@@ -777,7 +780,7 @@ t_create_replace(_Config) ->
     %% Changing to valid config
     OkConfig = ValidConfig#{
         <<"url">> =>
-            <<"http://127.0.0.1:33333/authz/users/?topic=${topic}&action=${action}">>
+            <<"http://127.0.0.1:32335/authz/users/?topic=${topic}&action=${action}">>
     },
 
     ?assertMatch(
@@ -808,7 +811,7 @@ t_create_replace(_Config) ->
         {error, _},
         emqx_authz:update({?CMD_REPLACE, http}, ValidConfig#{
             <<"url">> =>
-                <<"http://127.0.0.1:33333/authz/users/?topic=${topic}&action=${action}#fragment">>
+                <<"http://127.0.0.1:32335/authz/users/?topic=${topic}&action=${action}#fragment">>
         })
     ).
 
@@ -848,7 +851,7 @@ t_uri_normalization(_Config) ->
         raw_http_authz_config(),
         #{
             <<"url">> =>
-                <<"http://127.0.0.1:33333?topic=${topic}&action=${action}">>
+                <<"http://127.0.0.1:32335?topic=${topic}&action=${action}">>
         }
     ).
 
@@ -862,7 +865,7 @@ raw_http_authz_config() ->
         <<"type">> => <<"http">>,
         <<"max_inactive">> => <<"10s">>,
         <<"method">> => <<"get">>,
-        <<"url">> => <<"http://127.0.0.1:33333/authz/users/?topic=${topic}&action=${action}">>,
+        <<"url">> => <<"http://127.0.0.1:32335/authz/users/?topic=${topic}&action=${action}">>,
         <<"headers">> => #{<<"X-Test-Header">> => <<"Test Value">>}
     }.
 

--- a/apps/emqx_gateway/test/emqx_gateway_auth_ct.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_auth_ct.erl
@@ -33,10 +33,13 @@
 
 -define(CALL(Msg), gen_server:call(?MODULE, {?FUNCTION_NAME, Msg}, 15000)).
 
--define(AUTHN_HTTP_PORT, 37333).
+%% Keep below the ephemeral port range (net.ipv4.ip_local_port_range, 32768-60999
+%% on CI): a port inside that range can be picked as the source port of an
+%% outbound connection, making these listeners fail to bind with eaddrinuse.
+-define(AUTHN_HTTP_PORT, 32337).
 -define(AUTHN_HTTP_PATH, "/auth").
 
--define(AUTHZ_HTTP_PORT, 38333).
+-define(AUTHZ_HTTP_PORT, 32338).
 -define(AUTHZ_HTTP_PATH, "/authz/[...]").
 
 -define(GATEWAYS, [coap, lwm2m, mqttsn, stomp, exproto]).
@@ -196,7 +199,7 @@ http_authn_config() ->
         <<"enable">> => <<"true">>,
         <<"backend">> => <<"http">>,
         <<"method">> => <<"get">>,
-        <<"url">> => <<"http://127.0.0.1:37333/auth">>,
+        <<"url">> => <<"http://127.0.0.1:32337/auth">>,
         <<"body">> => #{<<"username">> => ?PH_USERNAME, <<"password">> => ?PH_PASSWORD},
         <<"headers">> => #{<<"X-Test-Header">> => <<"Test Value">>}
     }.
@@ -207,7 +210,7 @@ http_authz_config() ->
         <<"type">> => <<"http">>,
         <<"method">> => <<"get">>,
         <<"url">> =>
-            <<"http://127.0.0.1:38333/authz/users/?topic=${topic}&action=${action}&username=${username}">>,
+            <<"http://127.0.0.1:32338/authz/users/?topic=${topic}&action=${action}&username=${username}">>,
         <<"headers">> => #{<<"X-Test-Header">> => <<"Test Value">>}
     }.
 


### PR DESCRIPTION
Release version: 6.0.3

## Summary

De-flakes the intermittent `eaddrinuse` that auto-skipped all 14 cases of
`emqx_authz_http_SUITE` (seen in `apps/emqx_auth_http-1_1`, attempt 1 of run
29831468812).

Root cause is the port number, not the listener options. Suites that bind a
**fixed** port had picked values inside `net.ipv4.ip_local_port_range`
(32768-60999 on CI runners). A port in that range can be handed out by the
kernel as the **source port of an outbound connection made by the tests
themselves**; the later `listen()` on it then fails with `eaddrinuse`, and
every case in the suite auto-skips in a burst.

`SO_REUSEADDR` is not a fix here — it only relaxes `TIME_WAIT` conflicts, never
a live `ESTABLISHED` socket. (It is also already set: `ranch_tcp:listen/1`
passes `{reuseaddr, true}` by default and lists `reuseaddr` in
`disallowed_listen_options/0`, so supplying it is stripped and warned about.)

The tell was inside the failing job itself: of its four suites, the two that
never flaked used 32333/32334 — below the ephemeral range — while the two using
33333/34333 sat inside it.

Ports moved below 32768, each with a comment explaining why:

| File | Was | Now |
|---|---|---|
| `emqx_authz_http_SUITE.erl` | 33333 | 32335 |
| `emqx_authn_scram_restapi_SUITE.erl` | 34333 | 32336 |
| `emqx_gateway_auth_ct.erl` | 37333 / 38333 | 32337 / 32338 |

The `emqx_gateway_auth_ct` pair had not been observed failing, but a repo-wide
sweep for fixed test ports inside the ephemeral range found them as the only
other instances of the same latent flake.

Validation: the four `emqx_auth_http` suites were run 20x locally, 45/45 cases
passing with zero `eaddrinuse` on the new ports.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
