### PR TITLE
test(ds_shared_sub): relax durable commit budgets in t_leader_election

### DIFF
--- a/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
@@ -1077,8 +1077,19 @@ clean_local(Config) ->
     ].
 
 start_cluster(Config) ->
+    %% NOTE
+    %% The election-timing knobs (`heartbeat_interval', `realloc_interval',
+    %% `leader_timeout', `checkpoint_interval') are kept short so that the
+    %% events asserted by the tests happen promptly. The durable commit
+    %% budgets, on the other hand, are deliberately generous: they only bound
+    %% how long a transaction may take to reach consensus among the 3 sites,
+    %% and blowing them is fatal rather than slow -- an exhausted budget takes
+    %% down the session or the shared sub leader. In particular the retry
+    %% window (`commit_retries' * `commit_retry_interval') has to outlast a
+    %% DS leader re-election, which the tests trigger by killing a node.
     Conf = #{
         <<"durable_sessions">> => #{
+            <<"commit_timeout">> => 15_000,
             <<"shared_subs">> =>
                 #{
                     <<"heartbeat_interval">> => 100,
@@ -1086,9 +1097,9 @@ start_cluster(Config) ->
                     <<"leader_timeout">> => 100,
                     <<"checkpoint_interval">> => 10,
                     <<"revocation_timeout">> => 1000,
-                    <<"commit_retries">> => 10,
-                    <<"commit_retry_interval">> => 100,
-                    <<"commit_timeout">> => 1000
+                    <<"commit_retries">> => 8,
+                    <<"commit_retry_interval">> => 500,
+                    <<"commit_timeout">> => 3000
                 }
         },
         <<"log">> => #{


### PR DESCRIPTION
Release version: 6.1.3

## Summary

De-flake `emqx_ds_shared_sub_SUITE:t_leader_election`, which intermittently
hangs until its 60s timetrap on loaded CI runners.

The failures are not about leader election itself, they are about the durable
commit budgets configured for the 3-node cluster in `start_cluster/1`:

* The durable **session** state was left on the default `commit_timeout` of 5s.
  Exceeding it yields `sessds_commit_failure, reason: commit_timeout,
  recoverable: false`, and `emqx_persistent_session_ds:on_commit_reply/2` then
  does `exit(commit_failure)` — a live session is killed mid-test even though
  it was only an asynchronous checkpoint.
* The **shared sub leader** ran with `commit_timeout = 1000` and a retry window
  of only `10 * 100ms`. The retry window is the part that matters: the test
  kills a node, and until the DS raft leader has been re-elected every
  transaction fails fast with `leader_unavailable`. When the window expires
  first, the freshly elected group leader dies and the group is re-elected
  elsewhere, which also breaks the `?strict_causality` trace assertions.

So the commit budgets are widened, in particular the retry window, so it
outlasts a DS leader re-election. Worst case is bounded at ~28s, comfortably
inside the timetrap. The election-timing knobs (`heartbeat_interval`,
`realloc_interval`, `leader_timeout`, `checkpoint_interval`) are deliberately
left short so the events the test asserts on still happen promptly, and no
assertion is weakened. The timetrap is unchanged.

Verified by looping the case 10 times on a machine held at ~2-4x CPU
oversubscription: 10/10 pass. The same loop reproduced a leader crash
(`{case_clause,{error,recoverable,leader_unavailable}}` in
`emqx_ds_shared_sub_dl:open/1`) with a shorter retry window.

Test-only change, no user-facing behaviour is affected.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
