### PR TITLE
test(router): wait for syncer drain in t_concurrent_routing_updates

### DIFF
--- a/apps/emqx/test/emqx_routing_SUITE.erl
+++ b/apps/emqx/test/emqx_routing_SUITE.erl
@@ -258,12 +258,21 @@ t_concurrent_routing_updates(_Config) ->
      || I <- lists:seq(1, NClients)
     ],
     ok = lists:foreach(fun ping_concurrent_client/1, Clients),
-    ok = timer:sleep(200),
+    0 = ?retry(
+        _Interval = 500,
+        _NTimes = 10,
+        0 = lists:sum([S || #{size := S} <- emqx_router_syncer:stats()])
+    ),
     Subscribers = ets:tab2list(?SUBSCRIBER),
     Topics = maps:keys(maps:from_list(Subscribers)),
     ?assertEqual(lists:sort(Topics), lists:sort(emqx_router:topics())),
     ok = lists:foreach(fun stop_concurrent_client/1, Clients),
-    ok = timer:sleep(1000),
+    ok = timer:sleep(100),
+    0 = ?retry(
+        500,
+        10,
+        0 = lists:sum([S || #{size := S} <- emqx_router_syncer:stats()])
+    ),
     ct:pal("Trace: ~p", [?of_kind(router_syncer_new_batch, snabbkaffe:collect_trace())]),
     ?assertEqual([], ets:tab2list(?SUBSCRIBER)),
     ?assertEqual([], emqx_router:topics()).


### PR DESCRIPTION
Release versions: 5.9.4

## Summary

Fix flaky `emqx_routing_SUITE:t_concurrent_routing_updates`.

The test spawned 400 clients doing concurrent subscribe/unsubscribe churn, then
compared `emqx_router:topics()` against the subscriber table after a fixed
`timer:sleep(200)`. Route updates are applied asynchronously in batches by
`emqx_router_syncer`, so the sleep often expired before the last batch was
flushed and the assertion failed.

Replaced the fixed sleeps with the syncer-drain barrier already used by the
sibling test `t_concurrent_routing_updates_with_errors`:

    0 = ?retry(500, 10, 0 = lists:sum([S || #{size := S} <- emqx_router_syncer:stats()]))

Test-only change; no product behaviour is affected. Verified with 30 loops of
both group variants (`single_batch_on` and `single`, covering routing schema
v1/v2 and all batch-sync modes) — 60/60 green.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
