### PR TITLE
fix(rule events): trigger global rules for alarms when `limit_selects_in_namespace = true`

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -158,9 +158,12 @@ unload(EventName) ->
 on_alarm_activated(AlarmActivatedContext, Conf) ->
     case get_limit_selects_in_namespace() of
         true ->
-            %% we don't trigger alarm events when limiting events to namespaces, as these
-            %% events do not belong to a particular namespace other than `?global_ns`.
-            ok;
+            apply_event_namespaced(
+                ?global_ns,
+                'alarm.activated',
+                fun() -> eventmsg_alarm_activated(AlarmActivatedContext) end,
+                Conf
+            );
         false ->
             apply_event_all_namespaces(
                 'alarm.activated',
@@ -172,9 +175,12 @@ on_alarm_activated(AlarmActivatedContext, Conf) ->
 on_alarm_deactivated(AlarmDeactivatedContext, Conf) ->
     case get_limit_selects_in_namespace() of
         true ->
-            %% we don't trigger alarm events when limiting events to namespaces, as these
-            %% events do not belong to a particular namespace other than `?global_ns`.
-            ok;
+            apply_event_namespaced(
+                ?global_ns,
+                'alarm.deactivated',
+                fun() -> eventmsg_alarm_deactivated(AlarmDeactivatedContext) end,
+                Conf
+            );
         false ->
             apply_event_all_namespaces(
                 'alarm.deactivated',

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -1386,6 +1386,38 @@ t_alarm_events_hash(Config) ->
     ?assertNotReceive({rule_called, _}),
     ok.
 
+%% Smoke tests for `$events/sys/alarm_activated' and `$events/sys/alarm_deactivated', when
+%% `limit_selects_in_namespace = true`.
+t_alarm_events_limit_selects_in_namespace(Config) ->
+    on_exit(fun() ->
+        {ok, _} = emqx_conf:update(
+            [rule_engine, limit_selects_in_namespace],
+            false,
+            #{override_to => cluster}
+        )
+    end),
+    {ok, _} = emqx_conf:update(
+        [rule_engine, limit_selects_in_namespace],
+        true,
+        #{override_to => cluster}
+    ),
+    TestPidBin = list_to_binary(pid_to_list(self())),
+    {201, _} = create_rule(#{
+        <<"id">> => <<"alarms">>,
+        <<"sql">> => iolist_to_binary([
+            <<" select * from ">>,
+            <<" \"$events/sys/alarm_activated\", ">>,
+            <<" \"$events/sys/alarm_deactivated\" ">>
+        ]),
+        <<"actions">> => [
+            #{
+                <<"function">> => <<?MODULE_STRING, ":spy_action">>,
+                <<"args">> => #{<<"pid">> => TestPidBin}
+            }
+        ]
+    }),
+    do_t_alarm_events(Config).
+
 do_t_alarm_events(_Config) ->
     AlarmName = <<"some_alarm">>,
     Details = #{more => details},

--- a/changes/ee/fix-18049.en.md
+++ b/changes/ee/fix-18049.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where setting `rule_engine.limit_selects_in_namespace = true` would prevent alarm activated/deactivated-triggered global rules from firing.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/18045

Release version:
6.0.4, 6.1.3, 6.2.2

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
