### PR TITLE
fix(coap): redact sensitive packet debug logs

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_frame.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_frame.erl
@@ -478,7 +478,7 @@ class_code_to_method({5, 05}) -> {error, proxying_not_supported};
 class_code_to_method(_) -> undefined.
 
 format(Msg) ->
-    io_lib:format("~p", [Msg]).
+    io_lib:format("~p", [emqx_utils:redact(Msg)]).
 
 type(_) ->
     coap.

--- a/apps/emqx_gateway_coap/test/emqx_coap_frame_tests.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_frame_tests.erl
@@ -1,0 +1,26 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_coap_frame_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+format_redacts_sensitive_uri_query_test() ->
+    Query = #{
+        <<"password">> => <<"password-value">>,
+        <<"secret">> => <<"secret-value">>,
+        <<"private_key">> => <<"private-key-value">>,
+        <<"access_token">> => <<"access-token-value">>
+    },
+    Msg = emqx_coap_message:request(
+        con, post, <<>>, #{uri_path => [<<"rd">>], uri_query => Query}
+    ),
+    Formatted = iolist_to_binary(emqx_coap_frame:format(Msg)),
+    lists:foreach(
+        fun(Value) ->
+            ?assertEqual(nomatch, binary:match(Formatted, Value))
+        end,
+        maps:values(Query)
+    ),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"******">>)).

--- a/changes/ce/fix-18051.en.md
+++ b/changes/ce/fix-18051.en.md
@@ -1,0 +1,1 @@
+Fix CoAP debug logs leaking sensitive URI-query values.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Port #18044 to `dev-60`: redact sensitive URI-query values before CoAP packets are formatted for debug logging. The target branch already protects the connection-mode and invalid REGISTER logs, so this port adds the remaining generic formatting path and a focused regression test.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)