### PR TITLE
fix(snowflake streaming): generate unique channel name when in cluster

### DIFF
--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_channel_client.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_channel_client.erl
@@ -195,7 +195,8 @@ handle_info(_Info, State) ->
 %%------------------------------------------------------------------------------
 
 channel_name(ActionResId, N) ->
-    <<ActionResId/binary, ":", (integer_to_binary(N))/binary>>.
+    NodeBin = atom_to_binary(node()),
+    <<NodeBin/binary, ":", ActionResId/binary, ":", (integer_to_binary(N))/binary>>.
 
 %%------------------------------------------------------------------------------
 %% Internal fns

--- a/changes/ee/fix-18055.en.md
+++ b/changes/ee/fix-18055.en.md
@@ -1,0 +1,5 @@
+Fixed an issue where Snowflake Streaming Actions on different nodes in a cluster would start to fail with the following error:
+
+```
+{unrecoverable_error,#{body => <<"{\"code\":\"STALE_CONTINUATION_TOKEN_SEQUENCER\",\"message\":\"Channel sequencer in the continuation token is stale. Please reopen the channel\"}">>,...
+```


### PR DESCRIPTION
Otherwise, channels will step over each other...

```
{unrecoverable_error,#{body => <<"{\"code\":\"STALE_CONTINUATION_TOKEN_SEQUENCER\",\"message\":\"Channel sequencer in the continuation token is stale. Please reopen the channel\"}"...
```

Release version:
6.0.4, 6.1.4, 6.2.4

## Summary

Fixes https://github.com/emqx/emqx/issues/18056

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests (tested manually)
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
