### PR TITLE
test(cluster): join only after the node has fully booted

### DIFF
--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -251,11 +251,19 @@ haproxy_cid=$(docker run -d --name haproxy \
 
 haproxy_ssl_port=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8884/tcp") 0).HostPort}}' "$haproxy_cid")
 
+## Wait until the node is fully booted, not merely reachable. `emqx ctl status`
+## answers as soon as the CLI is registered (early in boot, before post_boot
+## runs the reboot app list), printing "is starting". Joining a cluster at that
+## point makes mria restart underneath the still-in-progress app boot, and any
+## mria-backed app being started right then (emqx_retainer, exclusive
+## subscription, ...) crashes with a `mria_schema` noproc, taking the node down.
+## Gate on the "is started" state so `emqx ctl cluster join` runs only against a
+## fully booted node.
 wait_for_emqx() {
     container="$1"
     wait_limit="$2"
     wait_sec=0
-    while ! docker exec "$container" emqx ctl status >/dev/null 2>&1; do
+    while ! docker exec "$container" emqx ctl status 2>/dev/null | grep -q 'is started'; do
         wait_sec=$(( wait_sec + 1 ))
         if [ $wait_sec -gt "$wait_limit" ]; then
             echo "timeout wait for EMQX"
@@ -322,7 +330,7 @@ wait_for_running_nodes() {
 }
 
 wait_for_emqx "$NODE1" 60
-wait_for_emqx "$NODE2" 30
+wait_for_emqx "$NODE2" 60
 wait_for_haproxy 30
 
 echo

--- a/scripts/test/test_emqx_boot.py
+++ b/scripts/test/test_emqx_boot.py
@@ -574,6 +574,12 @@ def test_feature_gate_full(emqx_bin_path):
 
 def test_feature_gate_essential(emqx_bin_path):
     """Verifies that essential preset starts the node successfully and with nothing enabled.
+
+    The node must also finish booting cleanly: the essential preset keeps the
+    mria-backed core apps (emqx_retainer, exclusive subscription, ...) enabled,
+    so a node that started mria only for gated features would crash their table
+    creation. Waiting for `emqx_is_running` asserts the whole reboot app list
+    started, not just that feature gates resolved.
     """
     with open_emqx_console(
             emqx_bin_path,
@@ -597,6 +603,8 @@ def test_feature_gate_essential(emqx_bin_path):
                     pass;
                 case _:
                     raise AssertionError(f"bad disabled: {disabled}")
+            # The node boots all the way through the reboot app list.
+            assert wait_until_stdout(emqx, "emqx_is_running", 30)
         finally:
             emqx.kill()
 


### PR DESCRIPTION
## Root cause

`run_cluster_tests / cluster-smoke-test (ESSENTIAL)` crashed node2 on `emqx ctl cluster join` (e.g. PR #18059).

`wait_for_emqx` in `start-two-nodes-in-docker.sh` only checked that `emqx ctl status` **exits 0**, not that the node is `started`. That CLI is registered early in boot (`emqx_machine:start` → `emqx_mgmt_cli:load`), before `post_boot` walks the reboot app list, so it answers "is starting" while apps are still coming up.

Issuing `cluster join` at that moment makes mria restart underneath the still-in-progress boot loop. Whichever mria-backed app is being started right then hits a dead `mria_schema`:

```
[notice] Application: mria. Exited: stopped. Type: temporary.
[error]  crasher: emqx_retainer:init/1 ... {noproc,{gen_server,call,[mria_schema,{create_table,emqx_retainer_index_meta,...
[critical] failed_to_start_app ... emqx_retainer -> node down
```

The window is wide under `EMQX_FEATURES=ESSENTIAL`: with only the core apps in the reboot list, `emqx_retainer` is among the last to start, so it is reliably mid-init when the join fires. Single-node ESSENTIAL boot is fine — mria is up and the retainer tables are created normally; the crash is purely the join-during-boot race. (`emqx_exclusive_subscription` hitting `mria_membership` is the same class of downstream noproc.)

## Fix

- `wait_for_emqx` now gates on the `is started` state, so `emqx ctl cluster join` runs only against a fully booted node. Bumped node2's wait to 60s to match node1.
- `test_emqx_boot.py`: the ESSENTIAL feature-gate test now waits for `emqx_is_running`, asserting the node boots all the way through the reboot app list (previously it only checked the early `feature_gates_resolved` log and killed the node).

Test-harness only; no product code change, so no changelog.