### PR TITLE
fix(listeners): treat managed_certs null as clearing managed certs

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -1020,17 +1020,25 @@ certificates would keep the stale `managed_certs' reference and fail to resolve 
 
 When `Request' supplies file-based certificate material and does not itself reference
 `managed_certs', drop any residual `managed_certs' from `MergedConf' so the result
-uses only the requested certificate source.  Both arguments are raw (binary-keyed)
-configs.
+uses only the requested certificate source.  A `managed_certs' explicitly set to JSON
+`null' (how the Dashboard clears it) or to an empty list is a request to stop using
+managed certificates, so the residual reference is dropped as well.  Both arguments
+are raw (binary-keyed) configs.
 """.
 reconcile_cert_source(Request, MergedConf) ->
     case get_ssl_options(Request) of
         RequestSSL when is_map(RequestSSL) ->
-            RequestSetsManaged = maps:is_key(<<"managed_certs">>, RequestSSL),
             RequestSetsFileCerts =
                 maps:is_key(<<"certfile">>, RequestSSL) orelse
                     maps:is_key(<<"keyfile">>, RequestSSL),
-            case (not RequestSetsManaged) andalso RequestSetsFileCerts of
+            DropManaged =
+                case maps:get(<<"managed_certs">>, RequestSSL, undefined) of
+                    undefined -> RequestSetsFileCerts;
+                    null -> true;
+                    [] -> true;
+                    _ -> false
+                end,
+            case DropManaged of
                 true -> drop_managed_certs(MergedConf);
                 false -> MergedConf
             end;

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -1491,6 +1491,59 @@ t_format_bind(_) ->
         lists:flatten(emqx_listeners:format_bind(":1883"))
     ).
 
+-doc """
+Tests `emqx_listeners:reconcile_cert_source/2`: a residual `managed_certs` in the
+merged config is dropped when the update request switches to file-based certificates
+or explicitly clears `managed_certs` (JSON `null` or an empty list), and is kept when
+the request references a managed bundle or touches neither certificate source.
+""".
+t_reconcile_cert_source(_Config) ->
+    Managed = [#{<<"bundle_name">> => <<"bundle">>}],
+    Merged = #{
+        <<"ssl_options">> => #{
+            <<"certfile">> => <<"cert.pem">>,
+            <<"keyfile">> => <<"key.pem">>,
+            <<"managed_certs">> => Managed
+        }
+    },
+    Dropped = emqx_utils_maps:deep_remove([<<"ssl_options">>, <<"managed_certs">>], Merged),
+    ReqSSL = fun(SSL) -> #{<<"ssl_options">> => SSL} end,
+    %% Request sets file certs without mentioning managed certs: drop.
+    ?assertEqual(
+        Dropped,
+        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"certfile">> => <<"cert.pem">>}), Merged)
+    ),
+    %% Request explicitly clears managed certs (JSON `null' or empty list): drop,
+    %% with or without accompanying file certs.
+    ?assertEqual(
+        Dropped,
+        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"managed_certs">> => null}), Merged)
+    ),
+    ?assertEqual(
+        Dropped,
+        emqx_listeners:reconcile_cert_source(
+            ReqSSL(#{<<"certfile">> => <<"cert.pem">>, <<"managed_certs">> => null}), Merged
+        )
+    ),
+    ?assertEqual(
+        Dropped,
+        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"managed_certs">> => []}), Merged)
+    ),
+    %% Request references a managed bundle: keep.
+    ?assertEqual(
+        Merged,
+        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"managed_certs">> => Managed}), Merged)
+    ),
+    %% Request touches neither certificate source: keep.
+    ?assertEqual(
+        Merged,
+        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"verify">> => <<"verify_none">>}), Merged)
+    ),
+    ?assertEqual(
+        Merged,
+        emqx_listeners:reconcile_cert_source(#{<<"bind">> => <<"0.0.0.0:8883">>}, Merged)
+    ).
+
 generate_tls_certs(Config) ->
     PrivDir = ?config(priv_dir, Config),
     emqx_common_test_helpers:gen_ca(PrivDir, "ca"),

--- a/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
@@ -1136,3 +1136,87 @@ t_switch_to_missing_managed_bundle(_TCConfig) ->
     ),
 
     ok.
+
+-doc """
+Verifies that a listener using a managed certificate bundle can be switched back to
+file-based certificates when the update request clears `managed_certs` by sending it
+as JSON `null` (how the Dashboard clears it), even after the bundle has been
+force-deleted.
+""".
+t_switch_off_deleted_managed_bundle_null() ->
+    [{matrix, true}].
+t_switch_off_deleted_managed_bundle_null(matrix) ->
+    [[?local]];
+t_switch_off_deleted_managed_bundle_null(_TCConfig) ->
+    #{cert_key := CertKeyRoot} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := CA} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := Cert, key_pem := Key} = gen_cert(#{key => ec, issuer => CertKeyRoot}),
+
+    Bundle = <<"switch_off_null_bundle">>,
+    Files = [
+        {?FILE_KIND_CA_BIN, <<"ca.pem">>, CA},
+        {?FILE_KIND_CHAIN_BIN, <<"chain.pem">>, Cert},
+        {?FILE_KIND_KEY_BIN, <<"key.pem">>, Key}
+    ],
+    ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
+
+    %% Original config uses file-based (default) certs.
+    {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
+    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+
+    %% Switch the listener to the managed bundle.
+    TLSListenerManaged = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        [#{<<"bundle_name">> => Bundle}]
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerManaged)),
+
+    %% Force-delete the bundle while the listener still references it.
+    ?assertMatch({204, _}, force_delete_bundle_global(Bundle)),
+
+    %% Switch back to file-based certs with an explicit `managed_certs: null` in the
+    %% request, as the Dashboard sends it.  The update must succeed and the resulting
+    %% config must no longer reference managed certs.
+    TLSListenerNull = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        null
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerNull)),
+    {200, TLSListenerFinal} = get_listener_api(<<"ssl">>, <<"default">>),
+    ?assertNot(
+        is_map_key(<<"managed_certs">>, maps:get(<<"ssl_options">>, TLSListenerFinal)),
+        TLSListenerFinal
+    ),
+
+    ok.
+
+-doc """
+Verifies that a listener update request carrying an empty `managed_certs` list is
+rejected at the API schema boundary with a clear validation error; an empty list
+never reaches the config merge.
+""".
+t_managed_certs_empty_list_rejected() ->
+    [{matrix, true}].
+t_managed_certs_empty_list_rejected(matrix) ->
+    [[?local]];
+t_managed_certs_empty_list_rejected(_TCConfig) ->
+    {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
+    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+
+    TLSListenerEmpty = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        []
+    ),
+    ?assertMatch(
+        {400, #{
+            <<"message">> := #{
+                <<"reason">> := <<"must define at least one managed cert bundle">>
+            }
+        }},
+        update_listener_api(<<"ssl">>, <<"default">>, TLSListenerEmpty)
+    ),
+
+    ok.

--- a/changes/ee/fix-18062.en.md
+++ b/changes/ee/fix-18062.en.md
@@ -1,0 +1,1 @@
+Switching a TLS/WSS listener from a managed certificate bundle back to file-based certificates now succeeds when the request clears `managed_certs` by sending it as `null` (as the Dashboard does), even if the bundle has already been deleted.


### PR DESCRIPTION
Release version: 6.1.4

## Summary

Fixes #18043; completes #17895.

When switching a TLS/WSS listener from a managed certificate bundle back to file-based certificates, the Dashboard sends `"managed_certs": null` in the PUT request. `emqx_listeners:reconcile_cert_source/2` only checked for key *presence* (`maps:is_key`), so the explicit `null` was treated as an active managed certificate source: the stale bundle reference survived the `deep_merge` and the update failed when the bundle no longer resolves.

`emqx_listeners:reconcile_cert_source/2` now inspects the requested `managed_certs` *value*: `null` (JSON null, the Dashboard's way of clearing) or `[]` is an explicit request to stop using managed certificates, so the residual reference is dropped from the merged config regardless of whether file certificates accompany the request. An absent key with file certificates keeps the #17895 behavior; a genuine bundle reference is kept (and a reference to a missing bundle still fails, so misconfiguration is not masked).

No change is needed in `emqx_tls_lib:resolve_managed_certs/2`: it only ever sees hocon-checked config, where `null` is treated as unset by the check and `[]` is rejected by the schema validator, so neither value can reach it.

Tests: the exact issue repro (bundle force-deleted, then PUT with file certs + `managed_certs: null`) in `emqx_mgmt_api_certs_SUITE`, a pure-function test of the reconcile logic in `emqx_listeners_SUITE`, and a test pinning that `managed_certs: []` is rejected at the API schema boundary (the schema requires at least one bundle, so `[]` never reaches the merge via REST).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)