### PR TITLE
fix(ft): list files with non-ASCII names without crashing

### DIFF
--- a/apps/emqx_ft/src/emqx_ft.app.src
+++ b/apps/emqx_ft/src/emqx_ft.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ft, [
     {description, "EMQX file transfer over MQTT"},
-    {vsn, "0.1.15"},
+    {vsn, "0.1.16"},
     {registered, []},
     {mod, {emqx_ft_app, []}},
     {applications, [

--- a/apps/emqx_ft/src/emqx_ft_api.erl
+++ b/apps/emqx_ft/src/emqx_ft_api.erl
@@ -269,7 +269,12 @@ format_timestamp(Timestamp) ->
 format_name(NameBin) when is_binary(NameBin) ->
     NameBin;
 format_name(Name) when is_list(Name) ->
-    iolist_to_binary(Name).
+    case unicode:characters_to_binary(Name) of
+        NameBin when is_binary(NameBin) ->
+            NameBin;
+        Error ->
+            error(Error)
+    end.
 
 limit(QueryString) ->
     maps:get(<<"limit">>, QueryString, emqx_mgmt:default_row_limit()).

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -110,6 +110,33 @@ t_list_files(Config) ->
         request_json(get, uri(["file_transfer", "files", ClientId, <<"no-such-file">>]), Config)
     ).
 
+%% Verifies that files whose names contain non-ASCII (e.g. Chinese) characters
+%% are listed correctly instead of crashing the API handler.
+t_list_files_unicode_name(Config) ->
+    ClientId = client_id(Config),
+    FileId = <<"f1">>,
+    Name = "视觉安防产品手册.pdf",
+    NameBin = unicode:characters_to_binary(Name),
+
+    Node = lists:last(test_nodes(Config)),
+    ok = emqx_ft_test_helpers:upload_file(sync, ClientId, FileId, Name, <<"data">>, Node),
+
+    {ok, 200, #{<<"files">> := Files}} =
+        request_json(get, uri(["file_transfer", "files"]), Config),
+
+    ?assertMatch(
+        [#{<<"fileid">> := FileId, <<"name">> := NameBin}],
+        [File || File = #{<<"clientid">> := CId} <- Files, CId == ClientId]
+    ),
+
+    {ok, 200, #{<<"files">> := FilesTransfer}} =
+        request_json(get, uri(["file_transfer", "files", ClientId, FileId]), Config),
+
+    ?assertMatch(
+        [#{<<"clientid">> := ClientId, <<"fileid">> := FileId, <<"name">> := NameBin}],
+        FilesTransfer
+    ).
+
 t_download_transfer(Config) ->
     ClientId = client_id(Config),
     FileId = <<"f1">>,

--- a/changes/ee/fix-18067.en.md
+++ b/changes/ee/fix-18067.en.md
@@ -1,0 +1,1 @@
+Fixed the file transfer files API (`GET /api/v5/file_transfer/files`) failing to list files whose names contain non-ASCII characters (e.g. Chinese).


### PR DESCRIPTION
Release versions: 5.8.12, 5.9.4, 5.10.5

## Summary

Fixes #18065 (for the 5.x line).

`GET /api/v5/file_transfer/files` returned a 500 error when an exported file name contained non-ASCII characters (e.g. Chinese). Such names reach `emqx_ft_api:format_name/1` as a list of Unicode codepoints, and `iolist_to_binary/1` fails with `badarg` on codepoints above 255. The name is now converted with `unicode:characters_to_binary/1`; if that conversion ever fails, an error is raised instead of silently degrading the name.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
