### PR TITLE
fix(mqttsn): handle remote UDP proxy cleanup

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -175,7 +175,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.0", override: true}
 
-  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.1", override: true}
+  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.2", override: true}
 
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.9", override: true}


### PR DESCRIPTION
Release version:

- 6.1.4

## Summary

Upgrade esockd to 5.17.2 so cross-node MQTT-SN UDP proxy cleanup supports remote process identifiers without crashing. Proxy close is idempotent during concurrent termination and force-kills an unresponsive proxy after the close timeout.

Fixes https://github.com/emqx/emqx/issues/18058

Dependency fix: https://github.com/emqx/esockd/pull/223

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] A change log is not needed because the regression was introduced by an unreleased change
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)