### PR TITLE
fix(ft): list files with non-ASCII names without crashing

### DIFF
--- a/apps/emqx_ft/src/emqx_ft_api.erl
+++ b/apps/emqx_ft/src/emqx_ft_api.erl
@@ -252,7 +252,12 @@ format_timestamp(Timestamp) ->
 format_name(NameBin) when is_binary(NameBin) ->
     NameBin;
 format_name(Name) when is_list(Name) ->
-    iolist_to_binary(Name).
+    case unicode:characters_to_binary(Name) of
+        NameBin when is_binary(NameBin) ->
+            NameBin;
+        _Error ->
+            iolist_to_binary(Name)
+    end.
 
 limit(QueryString) ->
     maps:get(<<"limit">>, QueryString, emqx_mgmt:default_row_limit()).

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -98,6 +98,35 @@ t_list_files(Config) ->
         request_json(get, uri(["file_transfer", "files", ClientId, <<"no-such-file">>]), Config)
     ).
 
+-doc """
+Files whose names contain non-ASCII (e.g. Chinese) characters are listed
+correctly by both the global and the per-transfer file listing APIs.
+""".
+t_list_files_unicode_name(Config) ->
+    ClientId = client_id(Config),
+    FileId = <<"f1">>,
+    Name = "视觉安防产品手册.pdf",
+    NameBin = unicode:characters_to_binary(Name),
+
+    Node = lists:last(test_nodes(Config)),
+    ok = emqx_ft_test_helpers:upload_file(sync, ClientId, FileId, Name, <<"data">>, Node),
+
+    {ok, 200, #{<<"files">> := Files}} =
+        request_json(get, uri(["file_transfer", "files"]), Config),
+
+    ?assertMatch(
+        [#{<<"fileid">> := FileId, <<"name">> := NameBin}],
+        [File || File = #{<<"clientid">> := CId} <- Files, CId == ClientId]
+    ),
+
+    {ok, 200, #{<<"files">> := FilesTransfer}} =
+        request_json(get, uri(["file_transfer", "files", ClientId, FileId]), Config),
+
+    ?assertMatch(
+        [#{<<"fileid">> := FileId, <<"name">> := NameBin}],
+        FilesTransfer
+    ).
+
 t_download_transfer(Config) ->
     ClientId = client_id(Config),
     FileId = <<"f1">>,

--- a/changes/ee/fix-18069.en.md
+++ b/changes/ee/fix-18069.en.md
@@ -1,0 +1,1 @@
+Fixed the file transfer files API (`GET /api/v5/file_transfer/files`) failing with a 500 error when listing files whose names contain non-ASCII characters (e.g. Chinese).


### PR DESCRIPTION
Release version: 6.0.4, 6.1.4, 6.2.3

## Summary

Fixes #18065.

`GET /api/v5/file_transfer/files` returned a 500 error when a listed file name contained non-ASCII characters (e.g. Chinese). The file name read back from the exporter storage is a list of Unicode codepoints, and `emqx_ft_api:format_name/1` converted it with `iolist_to_binary/1`, which only accepts bytes 0–255 and thus crashed with `badarg`. It now uses `unicode:characters_to_binary/1`, falling back to `iolist_to_binary/1` for plain byte lists.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
