### PR TITLE
perf(topic_metrics): install message hooks lazily

### DIFF
--- a/apps/emqx_topic_metrics/src/emqx_topic_metrics2.erl
+++ b/apps/emqx_topic_metrics/src/emqx_topic_metrics2.erl
@@ -64,11 +64,13 @@ cluster via the read-side proto when it wants aggregated counters.
 
 -spec load() -> ok.
 load() ->
-    %% Hooks are installed after the registry has rehydrated from
-    %% mria (which happens synchronously in
-    %% emqx_topic_metrics_registry:init/1). The supervisor brings
-    %% the registry up before this call returns.
-    ok = emqx_topic_metrics_hooks:enable(),
+    %% Hooks are NOT installed here. They are installed lazily by
+    %% emqx_topic_metrics_registry when the first collection appears
+    %% on this node — either from
+    %% `emqx_topic_metrics_registry:rehydrate/0' (which runs
+    %% synchronously in the registry's `init/1', before this call
+    %% returns) or from a later create. With zero collections the
+    %% message hooks stay off the hot path entirely.
     ok.
 
 -spec unload() -> ok.

--- a/apps/emqx_topic_metrics/src/emqx_topic_metrics_registry.erl
+++ b/apps/emqx_topic_metrics/src/emqx_topic_metrics_registry.erl
@@ -444,7 +444,15 @@ rehydrate() ->
 %% row already exists locally with a live counter_ref, the counter_ref
 %% is preserved — re-registering or rehydrating must never zero a live
 %% counter.
+%%
+%% The message hooks are installed lazily on the 0 -> 1 transition, so
+%% a node with no collections pays nothing per message. `?REGISTRY_TAB'
+%% is kept in lockstep with `?INDEX_TAB', so its emptiness is the
+%% signal. `ets:first/1' (not `ets:info(_, size)') is used because the
+%% table has decentralized counters, for which `size' is not cheap;
+%% this only runs on admin create/delete, never per message.
 install_local(#topic_metric{} = Rec) ->
+    WasEmpty = is_registry_empty(),
     #topic_metric{
         name = Name,
         topic_filter = TopicFilter,
@@ -462,19 +470,25 @@ install_local(#topic_metric{} = Rec) ->
     },
     true = ets:insert(?REGISTRY_TAB, {Name, LocalRec}),
     true = emqx_topic_index:insert(TopicFilter, Name, CRef, ?INDEX_TAB),
+    WasEmpty andalso emqx_topic_metrics_hooks:enable(),
     ok.
 
 %% Idempotent: a missing local row is fine (e.g. a deregister on a
-%% node that never had this collection installed).
+%% node that never had this collection installed). The message hooks
+%% are uninstalled on the 1 -> 0 transition — see `install_local/1'.
 uninstall_local(Name) ->
     case ets:lookup(?REGISTRY_TAB, Name) of
         [{Name, #{topic_filter := TF}}] ->
             true = emqx_topic_index:delete(TF, Name, ?INDEX_TAB),
             true = ets:delete(?REGISTRY_TAB, Name),
+            is_registry_empty() andalso emqx_topic_metrics_hooks:disable(),
             ok;
         [] ->
             ok
     end.
+
+is_registry_empty() ->
+    ets:first(?REGISTRY_TAB) =:= '$end_of_table'.
 
 clear_local_counters(Name) ->
     case ets:lookup(?REGISTRY_TAB, Name) of

--- a/apps/emqx_topic_metrics/test/emqx_topic_metrics_lazy_hooks_SUITE.erl
+++ b/apps/emqx_topic_metrics/test/emqx_topic_metrics_lazy_hooks_SUITE.erl
@@ -1,0 +1,144 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_topic_metrics_lazy_hooks_SUITE).
+-moduledoc """
+The v2 topic-metrics message hooks are installed lazily: they are put
+when the first collection appears on a node and deleted when the last
+one is gone, so a node with no collections pays no per-message cost.
+""".
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
+
+-define(HOOK_POINTS, ['message.publish', 'message.delivered', 'message.dropped']).
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            emqx_conf,
+            {emqx, #{override_env => [{boot_modules, [broker]}]}},
+            emqx_topic_metrics
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    Apps = ?config(apps, Config),
+    emqx_cth_suite:stop(Apps),
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    ok = emqx_topic_metrics2:deregister_all(),
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    ok = emqx_topic_metrics2:deregister_all(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Cases
+%%--------------------------------------------------------------------
+
+-doc "With no collections registered, none of the message hooks are installed.".
+t_no_hooks_without_metrics(_Config) ->
+    assert_hooks_absent().
+
+-doc "Registering the first collection installs the message hooks.".
+t_hooks_installed_on_first_register(_Config) ->
+    assert_hooks_absent(),
+    ok = emqx_topic_metrics2:register(<<"alpha">>, <<"alpha/#">>, ?global_ns),
+    assert_hooks_present().
+
+-doc "Deregistering the only collection uninstalls the message hooks.".
+t_hooks_removed_on_last_deregister(_Config) ->
+    ok = emqx_topic_metrics2:register(<<"alpha">>, <<"alpha/#">>, ?global_ns),
+    assert_hooks_present(),
+    ok = emqx_topic_metrics2:deregister(<<"alpha">>, ?global_ns),
+    assert_hooks_absent().
+
+-doc "Hooks stay installed while any collection remains, and go only with the last one.".
+t_hooks_follow_last_metric(_Config) ->
+    ok = emqx_topic_metrics2:register(<<"alpha">>, <<"alpha/#">>, ?global_ns),
+    ok = emqx_topic_metrics2:register(<<"beta">>, <<"beta/#">>, ?global_ns),
+    assert_hooks_present(),
+    ok = emqx_topic_metrics2:deregister(<<"alpha">>, ?global_ns),
+    assert_hooks_present(),
+    ok = emqx_topic_metrics2:deregister(<<"beta">>, ?global_ns),
+    assert_hooks_absent().
+
+-doc "`deregister_all/0' uninstalls the hooks once the table is emptied.".
+t_hooks_removed_on_deregister_all(_Config) ->
+    ok = emqx_topic_metrics2:register(<<"alpha">>, <<"alpha/#">>, ?global_ns),
+    ok = emqx_topic_metrics2:register(<<"beta">>, <<"beta/#">>, ?global_ns),
+    assert_hooks_present(),
+    ok = emqx_topic_metrics2:deregister_all(),
+    assert_hooks_absent().
+
+-doc "Re-registering an already installed collection does not disturb the hooks.".
+t_reregister_is_idempotent(_Config) ->
+    ok = emqx_topic_metrics2:register(<<"alpha">>, <<"alpha/#">>, ?global_ns),
+    ok = emqx_topic_metrics2:register(<<"alpha">>, <<"alpha/#">>, ?global_ns),
+    assert_hooks_present(),
+    ok = emqx_topic_metrics2:deregister(<<"alpha">>, ?global_ns),
+    assert_hooks_absent().
+
+-doc """
+The local cluster_rpc callbacks — the code every follower node runs
+when a collection is created or deleted elsewhere — toggle the hooks
+on that node too.
+""".
+t_replicated_side_effects_toggle_hooks(_Config) ->
+    Name = {?global_ns, <<"gamma">>},
+    ok = emqx_topic_metrics_registry:do_install_local(Name, <<"gamma/#">>, <<"2026-07-22">>),
+    assert_hooks_present(),
+    ok = emqx_topic_metrics_registry:do_uninstall_local(Name),
+    assert_hooks_absent().
+
+-doc "Resetting a collection's counters leaves the hooks installed.".
+t_reset_keeps_hooks(_Config) ->
+    ok = emqx_topic_metrics2:register(<<"alpha">>, <<"alpha/#">>, ?global_ns),
+    ok = emqx_topic_metrics2:reset(<<"alpha">>, ?global_ns),
+    assert_hooks_present().
+
+-doc "Counting still works once the hooks have been installed lazily.".
+t_counting_works_after_lazy_install(_Config) ->
+    ok = emqx_topic_metrics2:register(<<"alpha">>, <<"alpha/#">>, ?global_ns),
+    emqx:publish(emqx_message:make(<<"alpha/1">>, <<"hello">>)),
+    {ok, #{metrics := #{'messages.in.count' := In}}} =
+        emqx_topic_metrics2:lookup(<<"alpha">>, ?global_ns),
+    ?assertEqual(1, In).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+assert_hooks_present() ->
+    ?assertEqual(?HOOK_POINTS, hooked_points()).
+
+assert_hooks_absent() ->
+    ?assertEqual([], hooked_points()).
+
+hooked_points() ->
+    [HookPoint || HookPoint <- ?HOOK_POINTS, has_hook(HookPoint)].
+
+%% `#callback{}' is defined in emqx_hooks.erl (not in a public header),
+%% so the action is picked out positionally.
+has_hook(HookPoint) ->
+    lists:any(
+        fun(Callback) ->
+            case element(2, Callback) of
+                {emqx_topic_metrics_hooks, _F, _A} -> true;
+                _ -> false
+            end
+        end,
+        emqx_hooks:lookup(HookPoint)
+    ).


### PR DESCRIPTION
Release version: 6.3.0

## Summary

The v2 topic-metrics app (`apps/emqx_topic_metrics/`, new in 6.3) installed its `message.publish` / `message.delivered` / `message.dropped` hooks unconditionally at app boot. Each message then ran a wildcard topic-index (trie) search even when no topic metric was configured — profiling 6.3 vs 6.2.2 attributed ~5-6% of samples to this baseline overhead on an idle-feature broker.

The hooks are now installed lazily, driven by the local registry table:

- `emqx_topic_metrics2:load/0` no longer force-installs the hooks at boot.
- `emqx_topic_metrics_registry:install_local/1` enables the hooks on the 0 → 1 transition (first collection created on the node, or the first row replayed by `rehydrate/0`).
- `emqx_topic_metrics_registry:uninstall_local/1` disables them on the 1 → 0 transition (last collection removed).

Emptiness is probed with `ets:first/1` on the ordered_set `?REGISTRY_TAB` (kept in lockstep with the index table), which runs only on admin create/delete paths — never per message. `ets:info(_, size)` is deliberately avoided because that table uses decentralized counters. Because the toggles live in the local ETS side-effect functions that `emqx_cluster_rpc` fans out to every node, the hooks track collection presence cluster-wide.

The feature is new in 6.3 and not yet released, so no changelog entry is included.

Most relevant files:
- `apps/emqx_topic_metrics/src/emqx_topic_metrics2.erl`
- `apps/emqx_topic_metrics/src/emqx_topic_metrics_registry.erl`
- `apps/emqx_topic_metrics/test/emqx_topic_metrics_lazy_hooks_SUITE.erl` (new)

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
