### PR TITLE
chore(scripts): rel-versions prints M.N.0 for GA-less lines, on one line

### DIFF
--- a/scripts/rel-versions
+++ b/scripts/rel-versions
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # Print the next-to-be-released EMQX version on the current branch and every
-# downstream branch in the forward-sync chain.
+# downstream branch in the forward-sync chain, on a single comma-separated line.
 #
 # Example: if HEAD is on a v6.0 topic branch (last reachable GA tag is 6.0.3),
 # this prints
 #
-#     6.0.4
-#     6.1.3
-#     6.2.2
+#     6.0.4, 6.1.4, 6.2.3, 6.3.0
+#
+# A downstream line that has no GA tag yet (e.g. dev-63 before 6.3.0 ships)
+# contributes its first GA version, M.N.0 (6.3.0 above).
 #
 # computed by running `git describe <remote>/dev-XX --tags --match 'X.Y.*'
 # --exclude '*-*'` against the matching dev-XX branch (so the answers reflect
@@ -28,8 +29,9 @@ usage() {
     cat <<EOF
 Usage: $0
 
-Prints, one per line, the next release version on the current branch's release
-line and every downstream branch it would forward-sync to.
+Prints, on a single comma-separated line, the next release version on the
+current branch's release line and every downstream branch it would forward-sync
+to. A line with no GA tag yet contributes its first release, M.N.0.
 
 No arguments. The starting point is determined by the most recent GA tag
 reachable from HEAD (e.g. 6.0.3 -> start from the v6.0 line).
@@ -110,8 +112,10 @@ start_key="${start_major}${start_minor}"
 
 # ---------------------------------------------------------------------------
 # For each step in the chain >= start, look up dev-<N>'s latest GA tag and
-# print the next patch version.
+# collect the next patch version. A line with no GA tag yet (e.g. dev-63
+# before 6.3.0 ships) contributes its first GA version, M.N.0.
 # ---------------------------------------------------------------------------
+versions=()
 seen_start=0
 for step in "${chain[@]}"; do
     if [[ "$step" != "$start_key" && "$seen_start" -eq 0 ]]; then
@@ -131,7 +135,8 @@ for step in "${chain[@]}"; do
     branch="${REMOTE}/dev-${step}"
     desc=$(git describe "$branch" --tags --match "${major}.${minor}.*" --exclude '*-*' --abbrev=0 2>/dev/null || true)
     if [[ -z "$desc" ]]; then
-        echo "warning: no GA tag (${major}.${minor}.*) on ${branch} -- skipping" >&2
+        # No GA tag on this line yet -> the first release will be M.N.0.
+        versions+=("${major}.${minor}.0")
         continue
     fi
 
@@ -142,5 +147,12 @@ for step in "${chain[@]}"; do
     fi
     patch="${BASH_REMATCH[3]}"
     next_patch=$((patch + 1))
-    echo "${major}.${minor}.${next_patch}"
+    versions+=("${major}.${minor}.${next_patch}")
 done
+
+# Print all collected versions on a single comma-separated line.
+out=""
+for v in "${versions[@]}"; do
+    out="${out:+$out, }$v"
+done
+echo "$out"


### PR DESCRIPTION
Fix `scripts/rel-versions`:

- A downstream line with no GA tag yet (e.g. `dev-63` before 6.3.0 ships) now contributes its first release `M.N.0` (so `6.3.0` is printed) instead of emitting a `warning ... skipping` and being dropped.
- Print all versions on a single comma-separated line (e.g. `6.0.4, 6.1.4, 6.2.3, 6.3.0`) so the value can be pasted straight into the PR template `Release version:` field.

Internal dev-tooling only; no runtime/user impact, no changelog.