### PR TITLE
test(takeover): accumulate durable-replay messages in t_takeover

### DIFF
--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -177,7 +177,11 @@ t_takeover(Config) ->
 
     assert_client_exit(CPid1, ?config(mqtt_vsn, Config), takenover),
     ?assertReceive({'EXIT', CPid2, normal}),
-    Received = [Msg || {publish, Msg} <- ?drainMailbox(Sleep)],
+    %% Durable-session replay around a takeover can deliver the boundary batch
+    %% late and out of order, so a single fixed-window drain may return before
+    %% every message arrives. Accumulate until all expected payloads are
+    %% received (or a deadline), so a genuine loss still fails.
+    Received = drain_until_received(AllMsgs, undefined, 30_000),
     ct:pal("middle: ~p", [Middle]),
     ct:pal("received: ~p", [[P || #{payload := P} <- Received]]),
     assert_messages_missed(AllMsgs, Received),
@@ -230,7 +234,11 @@ t_takeover_willmsg(Config) ->
     #{client := [CPid2, CPidSub, CPid1]} = FCtx,
     assert_client_exit(CPid1, ?config(mqtt_vsn, Config), takenover),
     ?assertReceive({'EXIT', CPid2, normal}),
-    Received = [Msg || {publish, Msg} <- ?drainMailbox(Sleep)],
+    %% Durable-session replay around a takeover can deliver the boundary batch
+    %% late and out of order, so a single fixed-window drain may return before
+    %% every message arrives. Accumulate until all expected payloads plus the
+    %% will are received (or a deadline), so a genuine loss still fails.
+    Received = drain_until_received(AllMsgs, <<"willpayload">>, 30_000),
     ct:pal("received: ~p", [[P || #{payload := P} <- Received]]),
     {IsWill, ReceivedNoWill} = filter_payload(Received, <<"willpayload">>),
     assert_messages_missed(AllMsgs, ReceivedNoWill),
@@ -1063,6 +1071,34 @@ start_connect_client(ClientId, Opts) ->
         {error, Reason} ->
             error(Reason)
     end.
+
+%% Drain published messages, accumulating across short quiet-window rounds,
+%% until every expected payload (and the will payload, unless `undefined`) has
+%% been received, or a hard deadline passes. Returns whatever was collected so
+%% the usual missed/order assertions still run (and fail) on a genuine loss.
+drain_until_received(ExpectedMsgs, WillPayload, MaxWaitMs) ->
+    Deadline = erlang:monotonic_time(millisecond) + MaxWaitMs,
+    drain_until_received(ExpectedMsgs, WillPayload, Deadline, []).
+
+drain_until_received(ExpectedMsgs, WillPayload, Deadline, Acc0) ->
+    Acc = Acc0 ++ [Msg || {publish, Msg} <- ?drainMailbox(200)],
+    WillPresent =
+        WillPayload == undefined orelse
+            lists:any(fun(#{payload := P}) -> P == WillPayload end, Acc),
+    Complete = all_payloads_present(ExpectedMsgs, Acc) andalso WillPresent,
+    case Complete orelse erlang:monotonic_time(millisecond) >= Deadline of
+        true -> Acc;
+        false -> drain_until_received(ExpectedMsgs, WillPayload, Deadline, Acc)
+    end.
+
+all_payloads_present(Expected, Received) ->
+    lists:all(
+        fun(Msg) ->
+            P = emqx_message:payload(Msg),
+            lists:any(fun(#{payload := P1}) -> P1 == P end, Received)
+        end,
+        Expected
+    ).
 
 assert_messages_missed(Ls1, Ls2) ->
     Missed = lists:filtermap(


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

De-flake `emqx_takeover_SUITE:t_takeover` (and `t_takeover_willmsg`) in the
`persistence_enabled` groups. This is the v6 port of the same fix landing on the
v5 line (dev-59 PR #18040); the v5→v6 sync chain does not carry it across, so it
needs its own PR here.

The subscriber's received messages were drained with a single fixed-window
`?drainMailbox/1` (3 s / 2 s). With durable sessions, replay around a takeover
can deliver the boundary batch late and out of order, so the fixed window
sometimes returned before the last messages arrived and they were reported as
"Miss messages" even though nothing was actually lost.

Replace the fixed window with an accumulate-until-received drain: collect
published messages across short quiet-window rounds until every expected
payload has arrived (plus the will payload for the willmsg case, `undefined`
otherwise) or a 30 s deadline passes — so a genuine loss still fails.

Test-only change; no runtime behavior change.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
