### PR TITLE
fix(cluster): refuse join before node boot is complete

### DIFF
--- a/apps/emqx/src/emqx_cluster.erl
+++ b/apps/emqx/src/emqx_cluster.erl
@@ -10,7 +10,8 @@
     force_leave/1,
     ensure_normal_mode/0,
     ensure_singleton_mode/0,
-    is_single_node_mode/0
+    is_single_node_mode/0,
+    set_booting/1
 ]).
 
 %% RPC callback functions
@@ -29,6 +30,16 @@
 -endif.
 
 join(PeerNode) ->
+    case is_booting() of
+        true ->
+            {error,
+                "This node has not fully booted yet. "
+                "Please retry after it is started."};
+        false ->
+            do_join(PeerNode)
+    end.
+
+do_join(PeerNode) ->
     %% Local node starts with default license (singleton mode),
     %% But the peer node(s) may have a license which allows local node to join.
     %% So we do not check the license locally.
@@ -38,6 +49,27 @@ join(PeerNode) ->
         {error, Message} ->
             {error, Message}
     end.
+
+-doc """
+Mark boot as in progress (`true`) or complete (`false`).
+
+Called by `emqx_machine`: set at boot entry and cleared once the boot app list
+has been started and the ekka join callbacks are registered. While the flag is
+set, `join/1` refuses to run: joining makes mria restart, and doing that under
+a boot in progress crashes whichever mria-backed application is starting at
+that moment, taking the node down.
+
+Environments that boot without `emqx_machine` (e.g. common tests) never set
+the flag, so `join/1` is not restricted there.
+""".
+-spec set_booting(boolean()) -> ok.
+set_booting(Bool) when is_boolean(Bool) ->
+    %% persistent: the value must survive a later `application:load(emqx)'
+    %% because it can be set before the `emqx' application is loaded
+    application:set_env(emqx, boot_in_progress, Bool, [{persistent, true}]).
+
+is_booting() ->
+    application:get_env(emqx, boot_in_progress, false).
 
 leave() ->
     ekka:leave().

--- a/apps/emqx_machine/src/emqx_machine.erl
+++ b/apps/emqx_machine/src/emqx_machine.erl
@@ -26,6 +26,10 @@
 
 %% @doc EMQX boot entrypoint.
 start() ->
+    %% Refuse cluster joins until emqx_machine_boot:post_boot/0 declares
+    %% boot complete; a join restarts mria, which is fatal to apps that
+    %% are still starting.
+    ok = emqx_cluster:set_booting(true),
     emqx_mgmt_cli:load(),
     case os:type() of
         {win32, nt} ->

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -43,6 +43,9 @@ post_boot() ->
     ok = ensure_apps_started(),
     ok = print_vsn(),
     ok = start_autocluster(),
+    %% Boot is complete and the ekka join callbacks are registered
+    %% (start_autocluster/0 above): joining is safe from here on.
+    ok = emqx_cluster:set_booting(false),
     ignore.
 
 -ifdef(TEST).

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -126,6 +126,27 @@ t_cluster(_Config) ->
     meck:unload(mria_mnesia),
     ok.
 
+-doc """
+Verifies that `cluster join' is refused with a readable error while node
+boot is still in progress, and allowed again once boot is complete.
+""".
+t_cluster_join_refused_while_booting(_Config) ->
+    ok = emqx_cluster:set_booting(true),
+    try
+        ?assertMatch(
+            {error, "This node has not fully booted" ++ _},
+            emqx_ctl:run_command(["cluster", "join", "nosuchnode@127.0.0.1"])
+        )
+    after
+        ok = emqx_cluster:set_booting(false)
+    end,
+    %% after boot completes the same command proceeds to the peer check
+    ?assertEqual(
+        {error, {node_down, 'nosuchnode@127.0.0.1'}},
+        emqx_ctl:run_command(["cluster", "join", "nosuchnode@127.0.0.1"])
+    ),
+    ok.
+
 t_clients(_Config) ->
     %% clients list            # List all clients
     emqx_ctl:run_command(["clients", "list"]),

--- a/changes/ee/fix-18077.en.md
+++ b/changes/ee/fix-18077.en.md
@@ -1,0 +1,1 @@
+Fixed a crash when a node received a `cluster join` request (CLI or API) before it had fully booted: joining restarts the internal database while applications are still starting, which could bring the whole node down. Such requests are now rejected with a clear error message; retry after the node is fully started.

--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -300,6 +300,26 @@ wait_for_haproxy 30
 
 echo
 
-docker exec "${NODE2}" emqx ctl cluster join "emqx@$NODE1"
+## `emqx ctl` answers before the node has fully booted, and a join issued at
+## that point is refused with a non-zero exit and a readable error (joining
+## restarts mria, which is fatal to applications that are still starting).
+## Retry until the join is accepted.
+join_cluster() {
+    local joiner="$1"
+    local seed="$2"
+    local wait_limit="$3"
+    local wait_sec=0
+    until docker exec "$joiner" emqx ctl cluster join "$seed"; do
+        wait_sec=$(( wait_sec + 1 ))
+        if [ $wait_sec -gt "$wait_limit" ]; then
+            echo "timeout waiting for cluster join to be accepted"
+            docker logs "$joiner"
+            exit 1
+        fi
+        sleep 1
+    done
+}
+
+join_cluster "$NODE2" "emqx@$NODE1" 60
 
 wait_for_running_nodes "$NODE1" "${EXPECTED_RUNNING_NODES:-2}" 30


### PR DESCRIPTION
Release version:
6.0.4
6.1.4
6.2.3

## Summary

A `cluster join` request (CLI or dashboard invite RPC) reaching a node that is still starting its applications makes mria restart underneath the in-progress boot loop; whichever mria-backed app is being started at that moment crashes with a `mria_schema` noproc and takes the whole node down. Observed in the two-node cluster smoke test under `EMQX_FEATURES=ESSENTIAL` on dev-63 (e.g. PR #18059), where `emqx_retainer` is among the last apps to start and was reliably mid-init when the join arrived:

```
[notice] Application: mria. Exited: stopped. Type: temporary.
[error]  crasher: emqx_retainer:init/1 ... {noproc,{gen_server,call,[mria_schema,{create_table,...
[critical] failed_to_start_app ... emqx_retainer -> node down
```

The race is not specific to feature gates (they only widen the window), so the fix targets dev-60 and forward-syncs up the chain.

Change:

- `emqx_machine:start/0` marks boot as in progress; `emqx_machine_boot:post_boot/0` clears the mark only after the boot app list has started **and** `start_autocluster/0` has registered the ekka join callbacks — that registration is what makes a join safe (it stops the apps before mria restarts), so the mark models the real invariant.
- `emqx_cluster:join/1` refuses while the mark is set:
  ```
  Failed to join the cluster: "This node has not fully booted yet. Please retry after it is started."
  ```
  Both `emqx ctl cluster join` and the dashboard invite RPC funnel through `emqx_cluster:join/1`, so both are covered. Environments that boot without `emqx_machine` (common tests) never set the mark and are unaffected.
- The two-node smoke test now retries `emqx ctl cluster join` until it is accepted, so CI exercises the refusal path end-to-end and the node-crash flake is gone.

Verified: compiles clean on the 6.0 base; single-node `EMQX_FEATURES=ESSENTIAL` boot clean with the guard in place (6.3 build); new CT case `t_cluster_join_refused_while_booting` asserts the refusal while booting and that the command proceeds to the normal peer check afterwards.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)