### PR TITLE
perf(socket): fire minor GC after incoming / outgoing packets

### DIFF
--- a/apps/emqx/include/emqx_mqtt.hrl
+++ b/apps/emqx/include/emqx_mqtt.hrl
@@ -328,7 +328,7 @@ end).
         | #mqtt_packet_auth{}
         | pos_integer()
         | undefined,
-    payload :: binary() | undefined
+    payload :: iodata() | undefined
 }).
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1574,9 +1574,10 @@ wrap_list(X) ->
 %% Deliver publish: broker -> client
 %%--------------------------------------------------------------------
 
-%% return list(emqx_types:packet())
+-spec do_deliver(emqx_session:replies(), channel()) ->
+    {emqx_types:packet() | [emqx_types:packet()], channel()}.
 do_deliver({pubrel, PacketId}, Channel) ->
-    {[?PUBREL_PACKET(PacketId, ?RC_SUCCESS)], Channel};
+    {?PUBREL_PACKET(PacketId, ?RC_SUCCESS), Channel};
 do_deliver(
     {PacketId, Msg},
     Channel = #channel{
@@ -1592,20 +1593,24 @@ do_deliver(
     Msg2 = emqx_mountpoint:unmount(MountPoint, Msg1),
     Packet = emqx_message:to_packet(PacketId, Msg2),
     {NPacket, NChannel} = packing_alias(Packet, Channel),
-    {[NPacket], NChannel};
+    {NPacket, NChannel};
 do_deliver([Publish], Channel) ->
     do_deliver(Publish, Channel);
-do_deliver(Publishes, Channel) when is_list(Publishes) ->
-    {Packets, NChannel} =
-        lists:foldl(
-            fun(Publish, {Acc, Chann}) ->
-                {Packets, NChann} = do_deliver(Publish, Chann),
-                {Packets ++ Acc, NChann}
-            end,
-            {[], Channel},
-            Publishes
-        ),
-    {lists:reverse(Packets), NChannel}.
+do_deliver([], Channel) ->
+    {[], Channel};
+do_deliver(Publishes, Channel) ->
+    do_deliver_many(Publishes, [], Channel).
+
+-spec do_deliver_many([emqx_session:reply()], channel()) ->
+    {[emqx_types:packet()], channel()}.
+do_deliver_many(Publishes, Channel) ->
+    do_deliver_many(Publishes, [], Channel).
+
+do_deliver_many([Publish | Rest], Acc, Channel) ->
+    {Packet, NChannel} = do_deliver(Publish, Channel),
+    do_deliver_many(Rest, [Packet | Acc], NChannel);
+do_deliver_many([], Packets, Channel) ->
+    {lists:reverse(Packets), Channel}.
 
 %%--------------------------------------------------------------------
 %% Handle out suback
@@ -1769,7 +1774,7 @@ handle_info(continue, Channel0) ->
         ignore ->
             ok;
         {Publishes, Channel1} ->
-            {Packets, Channel} = do_deliver(Publishes, Channel1),
+            {Packets, Channel} = do_deliver_many(Publishes, Channel1),
             Outgoing = [?REPLY_OUTGOING(Packets) || length(Packets) > 0],
             %% Refresh chan-info / chan-stats so the dashboard and REST API
             %% reflect post-replay inflight immediately, not on the next stats tick.

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -23,6 +23,7 @@
     serialize_opts/1,
     serialize_opts/2,
     serialize_pkt/2,
+    serialize_iovec/2,
     serialize/1,
     serialize/2,
     serialize/3
@@ -912,6 +913,13 @@ serialize_pkt(Packet, #{version := Ver, max_size := MaxSize, strict_mode := Stri
         false -> IoData
     end.
 
+serialize_iovec(Packet, #{version := Ver, max_size := MaxSize, strict_mode := StrictMode}) ->
+    IoVec = serialize_iovec(Packet, Ver, StrictMode),
+    case is_too_large(IoVec, MaxSize) of
+        true -> [];
+        false -> IoVec
+    end.
+
 -spec serialize(emqx_types:packet()) -> iodata().
 serialize(Packet) ->
     serialize(Packet, ?MQTT_PROTO_V4, false).
@@ -929,27 +937,71 @@ serialize(
     Ver,
     StrictMode
 ) ->
-    VariableBin = serialize_variable(Variable, Ver, StrictMode),
-    PayloadBin = serialize_payload(Payload),
-    RemLen = iolist_size(VariableBin) + iolist_size(PayloadBin),
-    [
-        serialize_header(Header),
-        serialize_remaining_len(RemLen),
-        VariableBin,
-        PayloadBin
-    ].
+    HeaderByte = serialize_header(Header),
+    VariableIoData = serialize_variable(Variable, Ver, StrictMode),
+    PayloadLen =
+        case Payload of
+            undefined -> 0;
+            _IoData -> iolist_size(Payload)
+        end,
+    RemLen = iolist_size(VariableIoData) + PayloadLen,
+    HeaderBin = serialize_remaining_len(HeaderByte, RemLen),
+    case Payload of
+        undefined ->
+            [HeaderBin, VariableIoData];
+        IoData ->
+            [HeaderBin, VariableIoData, IoData]
+    end.
+
+-doc "Serialize MQTT packet into an IO vector, i.e. plain list of binaries".
+-spec serialize_iovec(emqx_types:packet(), emqx_types:proto_ver(), boolean()) -> erlang:iovec().
+serialize_iovec(
+    #mqtt_packet{
+        header = Header,
+        variable = Variable,
+        payload = Payload
+    },
+    Ver,
+    StrictMode
+) ->
+    HeaderByte = serialize_header(Header),
+    VariableIoData = serialize_variable(Variable, Ver, StrictMode),
+    PayloadLen =
+        case Payload of
+            undefined -> 0;
+            _IoData -> iolist_size(Payload)
+        end,
+    RemLen = iolist_size(VariableIoData) + PayloadLen,
+    HeaderBin = serialize_remaining_len(HeaderByte, RemLen),
+    PreludeBin =
+        case VariableIoData of
+            L when is_list(L) ->
+                iolist_to_binary([HeaderBin | VariableIoData]);
+            _Binary ->
+                <<HeaderBin/binary, VariableIoData/binary>>
+        end,
+    case Payload of
+        undefined ->
+            [PreludeBin];
+        <<>> ->
+            [PreludeBin];
+        Binary when is_binary(Binary) ->
+            [PreludeBin, Binary];
+        IoList ->
+            [PreludeBin, iolist_to_binary(IoList)]
+    end.
 
 -compile(
     {inline, [
         serialize_header/1,
-        serialize_payload/1,
-        serialize_remaining_len/1,
-        serialize_variable_byte_integer/1
+        serialize_remaining_len/2,
+        serialize_variable_byte_integer/1,
+        serialize_variable_byte_integer/2
     ]}
 ).
 
 %% erlfmt-ignore
--define(bool(B), (case B of true -> 1; false -> 0; undefined -> 0 end):1).
+-define(bool(B), (case B of true -> 1; false -> 0; undefined -> 0 end)).
 
 %% erlfmt-ignore
 -define(utf8string(X, STRICT),
@@ -965,7 +1017,10 @@ serialize(
 serialize_header(
     #mqtt_packet_header{type = Type, dup = Dup, qos = QoS, retain = Retain}
 ) when ?CONNECT =< Type andalso Type =< ?AUTH ->
-    <<Type:4, ?bool(Dup), QoS:2, ?bool(Retain)>>.
+    ((Type band 2#1111) bsl 4) bor
+        (?bool(Dup) bsl 3) bor
+        ((QoS band 2#11) bsl 1) bor
+        (?bool(Retain)).
 
 serialize_variable(
     #mqtt_packet_connect{
@@ -1159,9 +1214,6 @@ serialize_variable(PacketId, ?MQTT_PROTO_V4, _StrictMode) when is_integer(Packet
 serialize_variable(undefined, _Ver, _StrictMode) ->
     <<>>.
 
-serialize_payload(undefined) -> <<>>;
-serialize_payload(Bin) -> Bin.
-
 serialize_properties(_Props, Ver, _StrictMode) when Ver =/= ?MQTT_PROTO_V5 ->
     <<>>;
 serialize_properties(Props, ?MQTT_PROTO_V5, StrictMode) ->
@@ -1196,7 +1248,7 @@ serialize_property('Response-Topic', Val, StrictMode) ->
 serialize_property('Correlation-Data', Val, _StrictMode) ->
     <<16#09, (byte_size(Val)):16, Val/binary>>;
 serialize_property('Subscription-Identifier', Val, _StrictMode) ->
-    <<16#0B, (serialize_variable_byte_integer(Val))/binary>>;
+    serialize_variable_byte_integer(<<16#0B>>, Val);
 serialize_property('Session-Expiry-Interval', Val, _StrictMode) ->
     <<16#11, Val:32/big>>;
 serialize_property('Assigned-Client-Identifier', Val, StrictMode) ->
@@ -1276,23 +1328,28 @@ serialize_utf8_pair(Name, Value, StrictMode) ->
 serialize_binary_data(Bin) ->
     [<<(byte_size(Bin)):16/big-unsigned-integer>>, Bin].
 
-serialize_remaining_len(I) ->
-    serialize_variable_byte_integer(I).
+serialize_remaining_len(HeaderByte, N) ->
+    serialize_variable_byte_integer(<<HeaderByte>>, N).
 
-serialize_variable_byte_integer(N) when N < (1 bsl 7) ->
-    <<0:1, N:7>>;
-serialize_variable_byte_integer(N) when N < (1 bsl 14) ->
-    <<1:1, (N band 2#1111111):7, (N bsr 7):8>>;
-serialize_variable_byte_integer(N) when N < (1 bsl 21) ->
+serialize_variable_byte_integer(N) ->
+    serialize_variable_byte_integer(<<>>, N).
+
+serialize_variable_byte_integer(Acc, N) when N < (1 bsl 7) ->
+    <<Acc/binary, 0:1, N:7>>;
+serialize_variable_byte_integer(Acc, N) when N < (1 bsl 14) ->
+    <<Acc/binary, 1:1, (N band 2#1111111):7, (N bsr 7):8>>;
+serialize_variable_byte_integer(Acc, N) when N < (1 bsl 21) ->
     <<
+        Acc/binary,
         1:1,
         (N band 2#1111111):7,
         1:1,
         ((N bsr 7) band 2#1111111):7,
         (N bsr 14):8
     >>;
-serialize_variable_byte_integer(N) when N < (1 bsl 28) ->
+serialize_variable_byte_integer(Acc, N) when N < (1 bsl 28) ->
     <<
+        Acc/binary,
         1:1,
         (N band 2#1111111):7,
         1:1,

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -711,10 +711,10 @@ parse_property(<<16#26, Bin/binary>>, Props, StrictMode) ->
     {Pair, Rest} = parse_utf8_pair(Bin, StrictMode),
     %% Accumulate in reverse order to keep this O(1) per entry; the list is
     %% reversed back to wire order in parse_properties/3 once parsing finishes.
-    case maps:find('User-Property', Props) of
-        {ok, UserProps} ->
+    case Props of
+        #{'User-Property' := UserProps} ->
             parse_property(Rest, Props#{'User-Property' := [Pair | UserProps]}, StrictMode);
-        error ->
+        #{} ->
             parse_property(Rest, Props#{'User-Property' => [Pair]}, StrictMode)
     end;
 parse_property(<<16#27, Val:32, Bin/binary>>, Props, StrictMode) ->

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -392,17 +392,21 @@ do_parse_connect(
     >>,
     StrictMode
 ) ->
+    WillFlag = bool(WillFlagB),
+    WillRetain = bool(WillRetainB),
     _ = validate_connect_reserved(Reserved),
     _ = validate_connect_will(
-        WillFlag = bool(WillFlagB),
-        WillRetain = bool(WillRetainB),
+        WillFlag,
+        WillRetain,
         WillQoS
     ),
+    UsernameFlag = bool(UsernameFlagB),
+    PasswordFlag = bool(PasswordFlagB),
     _ = validate_connect_password_flag(
         StrictMode,
         ProtoVer,
-        UsernameFlag = bool(UsernameFlagB),
-        PasswordFlag = bool(PasswordFlagB)
+        UsernameFlag,
+        PasswordFlag
     ),
     {Properties, Rest3} = parse_properties(Rest, ProtoVer, StrictMode),
     {ClientId, Rest4} = parse_utf8_string(Rest3, StrictMode, invalid_clientid),

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -1018,13 +1018,17 @@ serialize_iovec(
     end):16/big-unsigned-integer, X/bytes
 ).
 
+%% erlfmt-ignore
 serialize_header(
     #mqtt_packet_header{type = Type, dup = Dup, qos = QoS, retain = Retain}
 ) when ?CONNECT =< Type andalso Type =< ?AUTH ->
+    %% MQTT fixed header byte 1, per MQTT 3.1.1/5.0 "Fixed header":
+    %% | Control Packet type | DUP | QoS | RETAIN |
+    %% |        4 bits       |  1  |  2  |   1    |
     ((Type band 2#1111) bsl 4) bor
-        (?bool(Dup) bsl 3) bor
-        ((QoS band 2#11) bsl 1) bor
-        (?bool(Retain)).
+    (?bool(Dup)         bsl 3) bor
+    ((QoS band 2#11)    bsl 1) bor
+    (?bool(Retain)).
 
 serialize_variable(
     #mqtt_packet_connect{

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -840,7 +840,7 @@ handle_data_ready(Socket, State) ->
         {ok, Data} ->
             handle_data(Data, true, State);
         {select, {_Info, Data}} ->
-            handle_data(Data, true, State);
+            handle_data(Data, false, State);
         {select, _Info} ->
             {ok, State};
         {error, {closed, Data}} ->

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1019,14 +1019,14 @@ do_handle_outgoing(Packets, State) when is_list(Packets) ->
     MaxBufSize = 16#100_000,
     do_handle_outgoing_loop(MaxBufSize, Packets, State, 0, 0, []);
 do_handle_outgoing(Packet, State) ->
-    IOList = serialize_and_inc_stats(State, Packet),
-    send(1, IOList, State).
+    IoVec = serialize_and_inc_stats(State, Packet),
+    send(1, IoVec, State).
 
 -spec do_handle_outgoing_loop(
     pos_integer(), [emqx_types:packet()], state(), non_neg_integer(), non_neg_integer(), iolist()
 ) -> {ok, state()} | {ok, {sock_error, _}, state()}.
 do_handle_outgoing_loop(_, [], State, N, _BufOctets, Buf) ->
-    send(N, lists:reverse(Buf), State);
+    send(N, flatten_reverse_iovec(Buf, []), State);
 do_handle_outgoing_loop(MaxBufFize, [Packet | Rest], State, N, BufOctets, Buf0) when
     BufOctets =< MaxBufFize
 ->
@@ -1041,16 +1041,21 @@ do_handle_outgoing_loop(MaxBufFize, [Packet | Rest], State, N, BufOctets, Buf0) 
         Buf
     );
 do_handle_outgoing_loop(MaxBufSize, Rest, State0, N, _BufOctets, Buf) ->
-    case send(N, lists:reverse(Buf), State0) of
+    case send(N, flatten_reverse_iovec(Buf, []), State0) of
         {ok, State} ->
             do_handle_outgoing_loop(MaxBufSize, Rest, State, 0, 0, []);
         {ok, {sock_error, _}, _State} = Error ->
             Error
     end.
 
+flatten_reverse_iovec([IoVec | Rest], Acc) ->
+    flatten_reverse_iovec(Rest, IoVec ++ Acc);
+flatten_reverse_iovec([], Acc) ->
+    Acc.
+
 serialize_and_inc_stats(#state{serialize = Serialize} = State, Packet) ->
-    try emqx_frame:serialize_pkt(Packet, Serialize) of
-        <<>> ->
+    try emqx_frame:serialize_iovec(Packet, Serialize) of
+        [] ->
             ?LOG(warning, #{
                 msg => "packet_is_discarded",
                 reason => "frame_is_too_large",
@@ -1059,12 +1064,12 @@ serialize_and_inc_stats(#state{serialize = Serialize} = State, Packet) ->
             emqx_metrics:inc_global('delivery.dropped.too_large'),
             emqx_metrics:inc_global('delivery.dropped'),
             inc_dropped_stats(),
-            <<>>;
-        Data ->
+            [];
+        IoVec ->
             ?TRACE("MQTT", "mqtt_packet_sent", #{packet => Packet}),
             emqx_metrics:inc_sent(Packet, State#state.namespace),
             inc_outgoing_stats(Packet),
-            Data
+            IoVec
     catch
         %% Maybe Never happen.
         throw:{?FRAME_SERIALIZE_ERROR, Reason} ->
@@ -1085,23 +1090,23 @@ serialize_and_inc_stats(#state{serialize = Serialize} = State, Packet) ->
 %%--------------------------------------------------------------------
 %% Send data
 
--spec send(non_neg_integer(), iodata(), state()) ->
+-spec send(non_neg_integer(), erlang:iovec(), state()) ->
     {ok, state()} | {ok, {sock_error, _Reason}, state()}.
 send(
     Num,
-    IoData,
+    IoVec,
     #state{socket = Socket, sockstate = idle} = State
 ) ->
-    Oct = iolist_size(IoData),
+    Oct = iolist_size(IoVec),
     Handle = make_ref(),
-    case socket:send(Socket, IoData, [], Handle) of
+    case send_iovec(Socket, IoVec, Handle) of
         ok ->
             {ok, sent(Num, Oct, State)};
         {select, {_Info, Rest}} ->
             NState = queue_send(Handle, Rest, iolist_size(Rest), State),
             {ok, sent(Num, Oct, NState)};
         {select, _Info} ->
-            NState = queue_send(Handle, IoData, Oct, State),
+            NState = queue_send(Handle, IoVec, Oct, State),
             {ok, sent(Num, Oct, NState)};
         {error, {Reason, _Rest}} ->
             %% Defer error handling:
@@ -1111,16 +1116,16 @@ send(
     end;
 send(
     Num,
-    IoData,
+    IoVec,
     State = #state{
         sockstate = SS = #congested{sendq = SQ, deadline = Deadline, queued = NOctets},
         conf = Conf
     }
 ) ->
-    Oct = iolist_size(IoData),
+    Oct = iolist_size(IoVec),
     case Deadline =:= infinity orelse erlang:monotonic_time(millisecond) < Deadline of
         true ->
-            NSS = SS#congested{sendq = [IoData | SQ], queued = NOctets + Oct},
+            NSS = SS#congested{sendq = [IoVec | SQ], queued = NOctets + Oct},
             NState = State#state{sockstate = maybe_arm_send_deadline(NSS, Conf)},
             {ok, sent(Num, Oct, NState)};
         false ->
@@ -1129,24 +1134,34 @@ send(
 send(_Num, _IoVec, #state{sockstate = closed} = State) ->
     {ok, State}.
 
+send_iovec(Socket, IoVec, Handle) ->
+    case socket:sendv(Socket, IoVec, Handle) of
+        ok ->
+            ok;
+        {ok, Rest} ->
+            send_iovec(Socket, Rest, Handle);
+        Otherwise ->
+            Otherwise
+    end.
+
 -compile({inline, [handle_send_ready/2]}).
 handle_send_ready(
     Socket,
     State = #state{sockstate = SS = #congested{sendq = SQ, watermark = WM}}
 ) ->
-    IoData = sendq_to_iodata(SQ, []),
+    IoVec = flatten_reverse_iovec(SQ, []),
     Handle = make_ref(),
-    case socket:send(Socket, IoData, [], Handle) of
+    case socket:send(Socket, IoVec, [], Handle) of
         ok ->
             Signal = {connection, decongested, #{sendq_size => 0}},
             signal_channel(Signal, State#state{sockstate = idle});
         {select, {_Info, Rest}} ->
             %% Partially accepted, renew deadline.
-            NState = queue_send(Handle, Rest, iolist_size(Rest), WM, State),
+            NState = queue_send(Handle, [Rest], iolist_size(Rest), WM, State),
             maybe_signal_congestion(NState);
         {select, _Info} ->
             %% Totally congested, keep the deadline.
-            NSS = SS#congested{handle = Handle, sendq = [IoData]},
+            NSS = SS#congested{handle = Handle, sendq = [IoVec]},
             NState = State#state{sockstate = NSS},
             {ok, NState};
         {error, {Reason, _Rest}} ->
@@ -1156,15 +1171,15 @@ handle_send_ready(
             {ok, {sock_error, Reason}, State}
     end.
 
-queue_send(Handle, IoData, NOctets, State = #state{conf = Conf}) ->
+queue_send(Handle, IoVec, NOctets, State = #state{conf = Conf}) ->
     Watermark = get_high_watermark(Conf),
-    queue_send(Handle, IoData, NOctets, {high, Watermark}, State).
+    queue_send(Handle, IoVec, NOctets, {high, Watermark}, State).
 
-queue_send(Handle, IoData, NOctets, WM, State = #state{conf = Conf}) ->
+queue_send(Handle, IoVec, NOctets, WM, State = #state{conf = Conf}) ->
     SS = #congested{
         handle = Handle,
         deadline = infinity,
-        sendq = [IoData],
+        sendq = [IoVec],
         queued = NOctets,
         watermark = WM
     },
@@ -1216,11 +1231,6 @@ check_send_timeout(#congested{deadline = Deadline}, State) when is_integer(Deadl
     end;
 check_send_timeout(_, State) ->
     {ok, State}.
-
-sendq_to_iodata([IoData | Rest], Acc) ->
-    sendq_to_iodata(Rest, [IoData | Acc]);
-sendq_to_iodata([], Acc) ->
-    Acc.
 
 sendq_bytesize(#congested{queued = NOctets}) ->
     NOctets;

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1150,13 +1150,13 @@ handle_send_ready(
 ) ->
     IoVec = flatten_reverse_iovec(SQ, []),
     Handle = make_ref(),
-    case socket:send(Socket, IoVec, [], Handle) of
+    case send_iovec(Socket, IoVec, Handle) of
         ok ->
             Signal = {connection, decongested, #{sendq_size => 0}},
             signal_channel(Signal, State#state{sockstate = idle});
         {select, {_Info, Rest}} ->
             %% Partially accepted, renew deadline.
-            NState = queue_send(Handle, [Rest], iolist_size(Rest), WM, State),
+            NState = queue_send(Handle, Rest, iolist_size(Rest), WM, State),
             maybe_signal_congestion(NState);
         {select, _Info} ->
             %% Totally congested, keep the deadline.

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -574,6 +574,13 @@ handle_msg({recv, Data}, State) ->
     handle_data(Data, false, State);
 handle_msg({recv_more, Data}, State) ->
     handle_data(Data, true, State);
+handle_msg({request_more_data, More}, State = #state{socket = Socket, sockstate = SS}) ->
+    case SS =/= closed of
+        true ->
+            request_more_data(Socket, More, State);
+        false ->
+            {ok, State}
+    end;
 handle_msg({incoming, Packet}, State) ->
     ?TRACE("MQTT", "mqtt_packet_received", #{packet => Packet}),
     handle_incoming(Packet, State);
@@ -767,7 +774,6 @@ handle_data(
     Data,
     RequestMore,
     State0 = #state{
-        socket = Socket,
         sockstate = SS,
         thresholds = T0,
         channel = Channel
@@ -787,41 +793,34 @@ handle_data(
         gc_packets = dec_threshold(T0#thresholds.gc_packets, N)
     },
     State = trigger_gc(State1#state{thresholds = Thresholds}),
-    Msgs = next_incoming_msgs(Packets),
-    case RequestMore of
-        false ->
-            {ok, Msgs, State};
-        true when SS =/= closed ->
-            request_more_data(Socket, More, Msgs, State);
-        _ ->
-            {ok, Msgs, State}
-    end.
+    Msgs = next_incoming_msgs(RequestMore andalso SS =/= closed, More, Packets),
+    {ok, Msgs, State}.
 
 %% Dialyzer warns that {error, {closed, DataMore}} can never match, but this pattern
 %% can occur at runtime in OTP 27 or under certain error conditions where the socket
 %% closes with data available. We keep this clause for backward compatibility.
--dialyzer({nowarn_function, request_more_data/4}).
--compile({inline, [request_more_data/4]}).
-request_more_data(Socket, More, Acc, State) ->
+-dialyzer({nowarn_function, request_more_data/3}).
+-compile({inline, [request_more_data/3]}).
+request_more_data(Socket, More, State) ->
     %% TODO: `{otp, select_read}`.
     case sock_async_recv(Socket, More) of
         {ok, DataMore} ->
-            {ok, [Acc, {recv_more, DataMore}], State};
+            {ok, {recv_more, DataMore}, State};
         {select, {_Info, DataMore}} ->
-            {ok, [Acc, {recv, DataMore}], State};
+            {ok, {recv, DataMore}, State};
         {select, _Info} ->
-            {ok, Acc, State};
+            {ok, State};
         {error, {closed, DataMore}} ->
             %% This is dead code starting from OTP 28
             NState = socket_closed(State),
-            {ok, [Acc, {recv, DataMore}, {sock_closed, tcp_closed}], NState};
+            {ok, [{recv, DataMore}, {sock_closed, tcp_closed}], NState};
         {error, closed} ->
             NState = socket_closed(State),
-            {ok, [Acc, {sock_closed, tcp_closed}], NState};
+            {ok, {sock_closed, tcp_closed}, NState};
         {error, {Reason, DataMore}} ->
-            {ok, [Acc, {recv, DataMore}, {sock_error, Reason}], State};
+            {ok, [{recv, DataMore}, {sock_error, Reason}], State};
         {error, Reason} ->
-            {ok, [Acc, {sock_error, Reason}], State}
+            {ok, {sock_error, Reason}, State}
     end.
 
 %% Dialyzer warns that {error, {closed, Data}} can never match, but this pattern
@@ -855,12 +854,19 @@ handle_data_ready(Socket, State) ->
     end.
 
 %% @doc: return a reversed Msg list
--compile({inline, [next_incoming_msgs/1]}).
-next_incoming_msgs([Packet]) ->
+-compile({inline, [next_incoming_msgs/3]}).
+next_incoming_msgs(false, _More, [Packet]) ->
     {incoming, Packet};
-next_incoming_msgs(Packets) ->
+next_incoming_msgs(true, More, [Packet]) ->
+    [{incoming, Packet}, {request_more_data, More}];
+next_incoming_msgs(RequestMore, More, Packets) ->
     Fun = fun(Packet, Acc) -> [{incoming, Packet} | Acc] end,
-    lists:foldl(Fun, [], Packets).
+    Acc0 =
+        case RequestMore of
+            false -> [];
+            true -> [{request_more_data, More}]
+        end,
+    lists:foldl(Fun, Acc0, Packets).
 
 parse_incoming(Data, State = #state{parser = Parser, channel = Channel}) ->
     try

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -587,8 +587,12 @@ handle_msg({incoming, Packet}, State) ->
 handle_msg({outgoing, Packets}, State) ->
     case handle_outgoing(Packets, State) of
         {ok, NState} ->
-            run_minor_gc(),
-            maybe_signal_congestion(NState);
+            case maybe_signal_congestion(NState) of
+                {ok, FState} ->
+                    {ok, run_minor_gc, FState};
+                {ok, Msgs, FState} ->
+                    {ok, [Msgs, run_minor_gc], FState}
+            end;
         {ok, {sock_error, _}, _State} = Error ->
             Error
     end;

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -587,12 +587,16 @@ handle_msg({incoming, Packet}, State) ->
 handle_msg({outgoing, Packets}, State) ->
     case handle_outgoing(Packets, State) of
         {ok, NState} ->
+            run_minor_gc(),
             maybe_signal_congestion(NState);
         {ok, {sock_error, _}, _State} = Error ->
             Error
     end;
+handle_msg(run_minor_gc, State) ->
+    run_minor_gc(),
+    {ok, State};
 handle_msg(
-    Deliver = {deliver, _Topic, _Msg},
+    Deliver = #deliver{message = _Msg},
     #state{conf = #conf{active_n = ActiveN}} = State
 ) ->
     ?BROKER_INSTR_SETMARK(t0_deliver, {_Msg#message.extra, ?BROKER_INSTR_TS()}),
@@ -793,7 +797,9 @@ handle_data(
         gc_packets = dec_threshold(T0#thresholds.gc_packets, N)
     },
     State = trigger_gc(State1#state{thresholds = Thresholds}),
-    Msgs = next_incoming_msgs(RequestMore andalso SS =/= closed, More, Packets),
+    NeedMore = RequestMore andalso SS =/= closed,
+    Tail = [run_minor_gc || N > 0] ++ [{request_more_data, More} || NeedMore],
+    Msgs = next_incoming_msgs(Tail, Packets),
     {ok, Msgs, State}.
 
 %% Dialyzer warns that {error, {closed, DataMore}} can never match, but this pattern
@@ -854,19 +860,12 @@ handle_data_ready(Socket, State) ->
     end.
 
 %% @doc: return a reversed Msg list
--compile({inline, [next_incoming_msgs/3]}).
-next_incoming_msgs(false, _More, [Packet]) ->
-    {incoming, Packet};
-next_incoming_msgs(true, More, [Packet]) ->
-    [{incoming, Packet}, {request_more_data, More}];
-next_incoming_msgs(RequestMore, More, Packets) ->
+-compile({inline, [next_incoming_msgs/2]}).
+next_incoming_msgs(Tail, [Packet]) ->
+    [{incoming, Packet} | Tail];
+next_incoming_msgs(Tail, Packets) ->
     Fun = fun(Packet, Acc) -> [{incoming, Packet} | Acc] end,
-    Acc0 =
-        case RequestMore of
-            false -> [];
-            true -> [{request_more_data, More}]
-        end,
-    lists:foldl(Fun, Acc0, Packets).
+    lists:foldl(Fun, Tail, Packets).
 
 parse_incoming(Data, State = #state{parser = Parser, channel = Channel}) ->
     try
@@ -1359,11 +1358,16 @@ handle_cast(Req, State) ->
 %%--------------------------------------------------------------------
 %% Run GC and Check OOM
 
+-compile({inline, [run_minor_gc/0]}).
+
 run_gc(#state{conf = #conf{zone = Zone}}) ->
     case emqx_olp:backoff_gc(Zone) of
         false -> erlang:garbage_collect();
         true -> ok
     end.
+
+run_minor_gc() ->
+    erlang:garbage_collect(self(), [{type, minor}]).
 
 check_oom(Pubs, Bytes, #state{conf = #conf{force_shutdown = ShutdownPolicy}}) ->
     case emqx_utils:check_oom(ShutdownPolicy) of

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -781,7 +781,7 @@ t_handle_out_publish(_) ->
 
 t_handle_out_publish_1(_) ->
     Msg = emqx_message:make(<<"clientid">>, ?QOS_1, <<"t">>, <<"payload">>),
-    {ok, {outgoing, [?PUBLISH_PACKET(?QOS_1, <<"t">>, 1, <<"payload">>)]}, _Chan} =
+    {ok, {outgoing, ?PUBLISH_PACKET(?QOS_1, <<"t">>, 1, <<"payload">>)}, _Chan} =
         emqx_channel:handle_out(publish, [{1, Msg}], channel()).
 
 t_handle_out_connack_success(_) ->
@@ -1134,10 +1134,10 @@ t_handle_custom_timers(_) ->
     {timeout, T1Ref, T1Msg} =
         ?assertReceive({timeout, _, {emqx_session, signal1}}, ?CUSTOM_TIMER_TIMEOUT * 2),
     %% Sets `msg1` timer:
-    {ok, {outgoing, [?PUBLISH_PACKET(0, <<"a/b">>, 1, <<"1">>)]}, Chan4} =
+    {ok, {outgoing, ?PUBLISH_PACKET(0, <<"a/b">>, 1, <<"1">>)}, Chan4} =
         emqx_channel:handle_timeout(T1Ref, T1Msg, Chan3),
     %% Resets `msg1` timer to a shorter timeout:
-    {ok, {outgoing, [?PUBLISH_PACKET(0, <<"c/d">>, 2, <<"2">>)]}, Chan5} =
+    {ok, {outgoing, ?PUBLISH_PACKET(0, <<"c/d">>, 2, <<"2">>)}, Chan5} =
         emqx_channel:handle_timeout(make_ref(), retry_delivery, Chan4),
     {timeout, T2Ref, T2Msg} =
         ?assertReceive({timeout, _, {emqx_session, msg1}}, ?CUSTOM_TIMER_TIMEOUT_SHORT * 2),

--- a/apps/emqx/test/emqx_socket_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_socket_connection_SUITE.erl
@@ -34,7 +34,7 @@ t_send_congestion_times_out(_) ->
     Self = self(),
     ok = meck_esockd_socket([no_history]),
     ok = meck:new(socket, [unstick, passthrough, no_history]),
-    ok = meck:expect(socket, send, fun(_Socket, IoData, [], _Handle) ->
+    ok = meck:expect(socket, sendv, fun(_Socket, IoData, _Handle) ->
         Data = iolist_to_binary(IoData),
         Self ! {socket, send, Data},
         {_, Ret} = erlang:process_info(Self, {dictionary, ?FUNCTION_NAME}),
@@ -44,19 +44,19 @@ t_send_congestion_times_out(_) ->
         %% Init a minimal connection state:
         State0 = mk_connstate(),
         %% Simulate entering congested socket state:
-        State1 = emqx_socket_connection:queue_send(make_ref(), <<"aaaaa">>, 5, State0),
-        {ok, State2} = emqx_socket_connection:send(1, <<"b">>, State1),
-        {ok, State3} = emqx_socket_connection:send(1, <<"c">>, State2),
+        State1 = emqx_socket_connection:queue_send(make_ref(), [<<"aaaaa">>], 5, State0),
+        {ok, State2} = emqx_socket_connection:send(1, [<<"b">>], State1),
+        {ok, State3} = emqx_socket_connection:send(1, [<<"c">>], State2),
         ?assertNotEqual(idle, emqx_socket_connection:info(sockstate, State3)),
         %% Simulate partially decongested socket after 1.5 seconds:
         ok = timer:sleep(1500),
-        erlang:put(?FUNCTION_NAME, {select, {info1, _Rest = <<"c">>}}),
+        erlang:put(?FUNCTION_NAME, {select, {info1, _Rest = [<<"c">>]}}),
         {ok, State4} = emqx_socket_connection:handle_send_ready(sock, State3),
         ?assertReceive({socket, send, <<"aaaaabc">>}),
         ?assertNotEqual(idle, emqx_socket_connection:info(sockstate, State4)),
         %% Put more packets in the send queue:
-        {ok, State5} = emqx_socket_connection:send(3, <<"ddd">>, State4),
-        {ok, State6} = emqx_socket_connection:send(3, <<"eee">>, State5),
+        {ok, State5} = emqx_socket_connection:send(3, [<<"ddd">>], State4),
+        {ok, State6} = emqx_socket_connection:send(3, [<<"eee">>], State5),
         %% Simulate totally congested socket after 1.5 seconds:
         %% This still succeeds because partial decongestion reset the deadline.
         ok = timer:sleep(1500),
@@ -65,12 +65,12 @@ t_send_congestion_times_out(_) ->
         ?assertReceive({socket, send, <<"cdddeee">>}),
         ?assertNotEqual(idle, emqx_socket_connection:info(sockstate, State7)),
         %% Queue another packet:
-        {ok, State8} = emqx_socket_connection:send(5, <<"fffff">>, State7),
+        {ok, State8} = emqx_socket_connection:send(5, [<<"fffff">>], State7),
         %% Sending more packets after 1.5 seconds fails because of send timeout:
         ok = timer:sleep(1500),
         ?assertMatch(
             {ok, {sock_error, send_timeout}, _},
-            emqx_socket_connection:send(1, <<"last">>, State8)
+            emqx_socket_connection:send(1, [<<"last">>], State8)
         )
     after
         ok = meck:unload(socket),
@@ -81,7 +81,7 @@ t_repeated_send_congestion_preserves_send_order(_) ->
     Self = self(),
     ok = meck_esockd_socket([no_history]),
     ok = meck:new(socket, [unstick, passthrough, no_history]),
-    ok = meck:expect(socket, send, fun(_Socket, IoData, [], _Handle) ->
+    ok = meck:expect(socket, sendv, fun(_Socket, IoData, _Handle) ->
         Self ! {socket, send, iolist_to_binary(IoData)},
         case get(?FUNCTION_NAME) of
             undefined ->
@@ -95,9 +95,9 @@ t_repeated_send_congestion_preserves_send_order(_) ->
         %% Init a minimal connection state:
         State0 = mk_connstate(),
         %% Simulate entering congested socket state:
-        State1 = emqx_socket_connection:queue_send(make_ref(), <<"a">>, 1, State0),
+        State1 = emqx_socket_connection:queue_send(make_ref(), [<<"a">>], 1, State0),
         %% Queue one more packet:
-        {ok, State2} = emqx_socket_connection:send(1, <<"b">>, State1),
+        {ok, State2} = emqx_socket_connection:send(1, [<<"b">>], State1),
         %% Simulate socket getting ready, it goes back unready w/o sending anything:
         {ok, State3} = emqx_socket_connection:handle_send_ready(sock, State2),
         ?assertReceive({socket, send, <<"ab">>}),


### PR DESCRIPTION
Release version: 6.3.0

## Summary

This PR addresses apparent memory utilization inefficiency of MQTT channels running on socket-backed TCP listeners. The core of the approach is pretty dumb but demonstrates consistent improvement with no noticeable impact on other performance characteristics.
1. Run minor GC each time at least one incoming packet is processed.
2. Run minor GC each time at least one outgoing packet is processed.

Moreover, this PR:
1. Changes the backend to use `iovec`-based APIs, accompanied by `iovec` frame serialization.
    * The goal is to avoid copying binary payloads where possible.
2. Changes a couple of internal functions to (potentially) decrease heap lifetime of "heavy" terms.

Followup to #17854.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible