### PR TITLE
feat(snowflake streaming): reopen channel if continuation token sequencer becomes stale

### DIFF
--- a/apps/emqx_bridge_snowflake/docs/dev-quick-ref.md
+++ b/apps/emqx_bridge_snowflake/docs/dev-quick-ref.md
@@ -82,8 +82,7 @@ CREATE PIPE IF NOT EXISTS testdatabase.public.emqxstreaming AS
 COPY INTO testdatabase.public.emqx FROM (
   SELECT $1:clientid, $1:topic, $1:payload, $1:publish_received_at
   FROM TABLE(DATA_SOURCE(TYPE => 'STREAMING')
-)
-MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE;
+));
 
 
 -- Grant the USAGE privilege on the database and schema that contain the pipe object.

--- a/apps/emqx_bridge_snowflake/mix.exs
+++ b/apps/emqx_bridge_snowflake/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeSnowflake.MixProject do
   def project do
     [
       app: :emqx_bridge_snowflake,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_channel_client.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_channel_client.erl
@@ -57,6 +57,8 @@ Therefore, we spawn one of these clients for each channel used.
 -define(continuation_token, continuation_token).
 -define(open_channel_error, open_channel_error).
 -define(undefined, undefined).
+-define(continue, continue).
+-define(reopen_channel, reopen_channel).
 
 -type start_opts() :: #{
     ecpool_worker_id := pos_integer(),
@@ -179,8 +181,13 @@ handle_call(#open_channel{}, _From, State0) ->
     {Reply, State} = do_open_channel(State0),
     {reply, Reply, State};
 handle_call(#append_rows{records = Records}, _From, State0) ->
-    {Reply, State} = do_append_rows(State0, Records),
-    {reply, Reply, State};
+    {Action, Reply, State} = do_append_rows(State0, Records),
+    case Action of
+        ?continue ->
+            {reply, Reply, State};
+        ?reopen_channel ->
+            {reply, Reply, State, {continue, #open_channel{}}}
+    end;
 handle_call(Call, _From, State) ->
     {reply, {error, {unknown_call, Call}}, State}.
 
@@ -307,19 +314,27 @@ do_append_rows(State0, Records) ->
         {ok, 200, _Headers, BodyRaw} ?= emqx_bridge_http_connector:transform_result(Resp),
         #{<<"next_continuation_token">> := NextContinuationToken} =
             RespBody = emqx_utils_json:decode(BodyRaw),
-        ?SLOG(debug, #{msg => "snowflake_streaming_append_rows_success", response => RespBody}),
+        ?tp(debug, "snowflake_streaming_append_rows_success", #{response => RespBody}),
         State = State0#{?continuation_token := NextContinuationToken},
-        {{ok, Body}, State}
+        {?continue, {ok, Body}, State}
     else
+        {error, {unrecoverable_error, #{status_code := 400, body := RespBody0} = Reason}} = Error ->
+            case emqx_utils_json:safe_decode(RespBody0) of
+                {ok, #{<<"code">> := <<"STALE_CONTINUATION_TOKEN_SEQUENCER">>}} ->
+                    ?tp("snowflake_streaming_stale_continuation_token_sequencer", #{}),
+                    {?reopen_channel, {error, {recoverable_error, Reason}}, State0};
+                _ ->
+                    {?continue, Error, State0}
+            end;
         {error, Reason} ->
-            {{error, Reason}, State0};
+            {?continue, {error, Reason}, State0};
         Response ->
             Error =
                 {error,
                     {unrecoverable_error, #{
                         reason => <<"append_rows_unexpected_response">>, response => Response
                     }}},
-            {Error, State0}
+            {?continue, Error, State0}
     end.
 
 %% Internal export exposed ONLY for mocking

--- a/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_streaming_SUITE.erl
+++ b/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_streaming_SUITE.erl
@@ -152,11 +152,14 @@ end_per_testcase(_Testcase, Config) ->
     emqx_bridge_snowflake_aggregated_SUITE:stop_odbc_client(Config),
     emqx_common_test_helpers:call_janitor(),
     ok = snabbkaffe:stop(),
+    meck:unload(),
     ok.
 
 %%------------------------------------------------------------------------------
 %% Helper fns
 %%------------------------------------------------------------------------------
+
+get_config(K, TCConfig) -> emqx_bridge_v2_testlib:get_value(K, TCConfig).
 
 timetrap(Config) ->
     case ?config(mock, Config) of
@@ -217,13 +220,14 @@ mock_snowflake() ->
         ?tp("mock_snowflake_get_streaming_hostname", #{}),
         {ok, 200, Headers, Body}
     end),
-    meck:expect(?CHAN_CLIENT_MOD, do_open_channel, fun(_HTTPPool, _Req, _RequestTTL, _MaxRetries) ->
+    DoOpenChannel = fun(_HTTPPool, _Req, _RequestTTL, _MaxRetries) ->
         Headers = [],
         Body = emqx_utils_json:encode(#{<<"next_continuation_token">> => <<"0_1">>}),
         ?tp("mock_snowflake_open_channel", #{}),
         {ok, 200, Headers, Body}
-    end),
-    meck:expect(?CHAN_CLIENT_MOD, do_append_rows, fun(_HTTPPool, Req, _RequestTTL, _MaxRetries) ->
+    end,
+    meck:expect(?CHAN_CLIENT_MOD, do_open_channel, DoOpenChannel),
+    DoAppendRows = fun(_HTTPPool, Req, _RequestTTL, _MaxRetries) ->
         {_, _, BodyRaw} = Req,
         Records = emqx_connector_aggreg_json_lines_test_utils:decode(iolist_to_binary(BodyRaw)),
         Rows = lists:map(fun streaming_record_to_mocked_row/1, Records),
@@ -231,9 +235,15 @@ mock_snowflake() ->
         Headers = [],
         Body = emqx_utils_json:encode(#{<<"next_continuation_token">> => <<"1_1">>}),
         ?tp("mock_snowflake_append_rows", #{}),
+        ?tp("snowflake_streaming_append_rows_success", #{}),
         {ok, 200, Headers, Body}
-    end),
-    [{mocked_table, TId}].
+    end,
+    meck:expect(?CHAN_CLIENT_MOD, do_append_rows, DoAppendRows),
+    [
+        {mocked_table, TId},
+        {mocked_do_append_rows, DoAppendRows},
+        {mocked_do_open_channel, DoOpenChannel}
+    ].
 
 generate_dummy_jwt() ->
     NowS = erlang:system_time(second),
@@ -487,6 +497,21 @@ create_connector_api(Config, Overrides) ->
         emqx_bridge_v2_testlib:create_connector_api(Config, Overrides)
     ).
 
+create_action_api(Config, Overrides) ->
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:create_action_api(Config, Overrides)
+    ).
+
+simple_create_rule_api(TCConfig) ->
+    emqx_bridge_v2_testlib:simple_create_rule_api(TCConfig).
+
+start_client(Opts0) ->
+    Opts = maps:merge(#{proto_ver => v5}, Opts0),
+    {ok, C} = emqtt:start_link(Opts),
+    on_exit(fun() -> emqtt:stop(C) end),
+    {ok, _} = emqtt:connect(C),
+    C.
+
 %%------------------------------------------------------------------------------
 %% Test cases
 %%------------------------------------------------------------------------------
@@ -533,3 +558,62 @@ t_streaming(TCConfig) when is_list(TCConfig) ->
         post_publish_fn => PostPublishFn
     },
     emqx_bridge_v2_testlib:t_rule_action(TCConfig, Opts).
+
+-doc """
+If a client receives an STALE_CONTINUATION_TOKEN_SEQUENCER error when appending rows, for
+whatever reason, it needs to reopen the channel to recover.
+
+Also, this error may be treated as recoverable.
+""".
+t_reopen_channel_if_continuation_token_is_stale(TCConfig) ->
+    IsMock = get_config(mock, TCConfig),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{}),
+    {ok, Agent} = emqx_utils_agent:start_link(error),
+    meck:expect(?CHAN_CLIENT_MOD, do_append_rows, fun(HTTPPoolAndId, Req, RequestTTL, MaxRetries) ->
+        case emqx_utils_agent:get(Agent) of
+            error ->
+                Error = emqx_utils_json:encode(#{
+                    <<"code">> => <<"STALE_CONTINUATION_TOKEN_SEQUENCER">>,
+                    <<"message">> =>
+                        <<
+                            "Channel sequencer in the continuation token is stale."
+                            "Please reopen the channel"
+                        >>
+                }),
+                {ok, 400, [], Error};
+            continue when IsMock ->
+                DoAppendRows = get_config(mocked_do_append_rows, TCConfig),
+                DoAppendRows(HTTPPoolAndId, Req, RequestTTL, MaxRetries);
+            continue ->
+                meck:passthrough([HTTPPoolAndId, Req, RequestTTL, MaxRetries])
+        end
+    end),
+    meck:expect(?CHAN_CLIENT_MOD, do_open_channel, fun(HTTPPool, Req, RequestTTL, MaxRetries) ->
+        emqx_utils_agent:set(Agent, continue),
+        case IsMock of
+            true ->
+                DoOpenChannel = get_config(mocked_do_open_channel, TCConfig),
+                DoOpenChannel(HTTPPool, Req, RequestTTL, MaxRetries);
+            false ->
+                meck:passthrough([HTTPPool, Req, RequestTTL, MaxRetries])
+        end
+    end),
+    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    C = start_client(#{}),
+    ?check_trace(
+        ?wait_async_action(
+            emqtt:publish(C, Topic, <<"hey">>, [{qos, 1}]),
+            #{?snk_kind := "snowflake_streaming_append_rows_success"},
+            10_000
+        ),
+        fun(Res, Trace) ->
+            ?assertMatch({_, {ok, _}}, Res),
+            ?assertMatch(
+                [_],
+                ?of_kind(["snowflake_streaming_open_channel_success"], Trace)
+            ),
+            ok
+        end
+    ),
+    ok.

--- a/changes/ee/feat-18081.en.md
+++ b/changes/ee/feat-18081.en.md
@@ -1,0 +1,1 @@
+Improved resiliency of Snowflake Streaming Action.  Under certain error types when appending rows (specifically, when the channel internal states becomes out of sync), the Action will retry the rows that failed and attempt to re-open the channel without manual intervention.


### PR DESCRIPTION
Improves the connector so it attempts to recover by itself if the sequencer becomes stale/corrupt for whatever reason.

Release version:
6.0.4, 6.1.3, 6.2.2

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests (also ran against real snowflake)
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
