### PR TITLE
fix(kafka): bump wolff to 4.1.11 to restore memory-mode linger

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.1.10"},
+    {wolff, "4.1.11"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.5.5"},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.1.10"},
+    {wolff, "4.1.11"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.5.5"},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.1.10"},
+    {wolff, "4.1.11"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.5.5"},

--- a/changes/ee/fix-18082.en.md
+++ b/changes/ee/fix-18082.en.md
@@ -1,0 +1,3 @@
+Kafka producer: `max_linger_time` is honored again for memory-mode buffers (upgraded the Kafka client library wolff to 4.1.11). When less than a full batch is buffered, the producer waits up to `max_linger_time` for more messages before forming a produce request, reducing the produce request rate at high message rates; sending is immediate whenever a full batch's worth of data is available, and the publish path is never delayed. The default `max_linger_time = 0` keeps the previous send-immediately behavior.
+
+This also applies to Azure Event Hubs and Confluent producer connectors, which use the same client library.

--- a/mix.exs
+++ b/mix.exs
@@ -281,7 +281,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.1.10"}
+  def common_dep(:wolff), do: {:wolff, "4.1.11"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

## Summary

Dependency-only bump: wolff 4.1.10 -> 4.1.11 (no EMQX code change).

wolff 4.1.11 makes `max_linger_time` apply to memory-mode buffers again (lost since wolff 4.1.1 / EMQX 5.8.9): when less than a full batch is buffered, the producer waits up to `max_linger_time` before forming a produce request, reducing the produce request rate at high message rates. Sending is immediate whenever a full batch's worth of data is buffered, and the publish path is never delayed. The default `max_linger_time = 0` keeps the previous send-immediately behavior, so with default settings behavior is unchanged.

Applies to the Kafka, Azure Event Hubs, and Confluent producer connectors (all use wolff).

### Note

The "lost" of linger was intentional, this fix is not a simple restore but an improvement too.

In wolff, the linger was introduced to optimize `disk` mode IOPS (linger before enqueue), and it's not expected to be used for `memory` mode. A few abuse of it for `memory` mode caused some confusion when publish latency increased towards MQTT clients (PUBACK after linger) -- which is why `wolff-4.1.1` optimized the linger to happen only when writing to disk.

`wolff-4.1.11` added back the linger from before enqueue to before dequeue, so PUBACK will not be delayed.

See details here: https://github.com/kafka4beam/wolff/pull/119

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
