### PR TITLE
feat(kafka): add max_batch_age and max_retries producer options (wolff 4.2.1)

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
@@ -183,5 +183,15 @@ aeh_producer_test_() ->
                         }
                     }
                 )
+            )},
+        {"reconnect_delay defaults to 2s and is settable",
+            ?_assertMatch(
+                #{<<"parameters">> := #{<<"reconnect_delay">> := <<"1500ms">>}},
+                check_action(#{<<"parameters">> => #{<<"reconnect_delay">> => <<"1500ms">>}})
+            )},
+        {"connector request_timeout defaults to 30s",
+            ?_assertMatch(
+                #{<<"request_timeout">> := <<"30s">>},
+                check_connector(#{})
             )}
     ].

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
@@ -184,7 +184,12 @@ aeh_producer_test_() ->
                     }
                 )
             )},
-        {"reconnect_delay defaults to 2s and is settable",
+        {"reconnect_delay defaults to 2s",
+            ?_assertMatch(
+                #{<<"parameters">> := #{<<"reconnect_delay">> := <<"2s">>}},
+                check_action(#{})
+            )},
+        {"reconnect_delay is settable",
             ?_assertMatch(
                 #{<<"parameters">> := #{<<"reconnect_delay">> := <<"1500ms">>}},
                 check_action(#{<<"parameters">> => #{<<"reconnect_delay">> => <<"1500ms">>}})

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
@@ -156,5 +156,32 @@ aeh_producer_test_() ->
             ?_assertThrow(
                 ?action_validation_error("Expected: no_compression" ++ _, <<"gzip">>),
                 check_action(#{<<"parameters">> => #{<<"compression">> => <<"gzip">>}})
+            )},
+        {"max_batch_age and max_retries default to infinity",
+            ?_assertMatch(
+                #{
+                    <<"parameters">> := #{
+                        <<"max_batch_age">> := <<"infinity">>,
+                        <<"max_retries">> := <<"infinity">>
+                    }
+                },
+                check_action(#{})
+            )},
+        {"max_batch_age and max_retries are settable",
+            ?_assertMatch(
+                #{
+                    <<"parameters">> := #{
+                        <<"max_batch_age">> := <<"500ms">>,
+                        <<"max_retries">> := 3
+                    }
+                },
+                check_action(
+                    #{
+                        <<"parameters">> => #{
+                            <<"max_batch_age">> => <<"500ms">>,
+                            <<"max_retries">> => 3
+                        }
+                    }
+                )
             )}
     ].

--- a/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_tests.erl
+++ b/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_tests.erl
@@ -204,5 +204,10 @@ confluent_producer_action_test_() ->
                 check_action(
                     Override(#{<<"max_batch_age">> => <<"500ms">>, <<"max_retries">> => 3})
                 )
+            )},
+        {"reconnect_delay defaults to 2s and is settable",
+            ?_assertMatch(
+                ?ok_action_config(#{<<"parameters">> := #{<<"reconnect_delay">> := 1500}}),
+                check_action(Override(#{<<"reconnect_delay">> => <<"1500ms">>}))
             )}
     ].

--- a/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_tests.erl
+++ b/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_tests.erl
@@ -205,7 +205,12 @@ confluent_producer_action_test_() ->
                     Override(#{<<"max_batch_age">> => <<"500ms">>, <<"max_retries">> => 3})
                 )
             )},
-        {"reconnect_delay defaults to 2s and is settable",
+        {"reconnect_delay defaults to 2s",
+            ?_assertMatch(
+                ?ok_action_config(#{<<"parameters">> := #{<<"reconnect_delay">> := 2000}}),
+                check_action(BaseConf)
+            )},
+        {"reconnect_delay is settable",
             ?_assertMatch(
                 ?ok_action_config(#{<<"parameters">> := #{<<"reconnect_delay">> := 1500}}),
                 check_action(Override(#{<<"reconnect_delay">> => <<"1500ms">>}))

--- a/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_tests.erl
+++ b/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_tests.erl
@@ -165,10 +165,44 @@ confluent_producer_connector_test_() ->
 confluent_producer_action_test_() ->
     emqx_utils:interactive_load(emqx_bridge_enterprise),
     BaseConf = parse(confluent_producer_action_hocon()),
+    Override = fun(Params) ->
+        emqx_utils_maps:deep_merge(
+            BaseConf,
+            #{
+                <<"actions">> => #{
+                    <<"confluent_producer">> => #{
+                        <<"my_producer">> => #{<<"parameters">> => Params}
+                    }
+                }
+            }
+        )
+    end,
     [
         {"base config",
             ?_assertMatch(
                 ?ok_action_config(_),
                 check_action(BaseConf)
+            )},
+        {"max_batch_age and max_retries default to infinity",
+            ?_assertMatch(
+                ?ok_action_config(#{
+                    <<"parameters">> := #{
+                        <<"max_batch_age">> := infinity,
+                        <<"max_retries">> := infinity
+                    }
+                }),
+                check_action(BaseConf)
+            )},
+        {"max_batch_age and max_retries are settable",
+            ?_assertMatch(
+                ?ok_action_config(#{
+                    <<"parameters">> := #{
+                        <<"max_batch_age">> := 500,
+                        <<"max_retries">> := 3
+                    }
+                }),
+                check_action(
+                    Override(#{<<"max_batch_age">> => <<"500ms">>, <<"max_retries">> => 3})
+                )
             )}
     ].

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -428,6 +428,14 @@ fields(producer_kafka_opts) ->
                     desc => ?DESC(max_retries)
                 }
             )},
+        {reconnect_delay,
+            mk(
+                emqx_schema:timeout_duration_ms(),
+                #{
+                    default => <<"2s">>,
+                    desc => ?DESC(reconnect_delay)
+                }
+            )},
         {buffer,
             mk(ref(producer_buffer), #{
                 required => false,
@@ -619,6 +627,11 @@ kafka_connector_config_fields() ->
             mk(emqx_schema:timeout_duration_ms(), #{
                 default => <<"5s">>,
                 desc => ?DESC(metadata_request_timeout)
+            })},
+        {request_timeout,
+            mk(emqx_schema:timeout_duration_ms(), #{
+                default => <<"30s">>,
+                desc => ?DESC(request_timeout)
             })},
         {authentication,
             mk(

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -412,6 +412,22 @@ fields(producer_kafka_opts) ->
                     desc => ?DESC(max_inflight)
                 }
             )},
+        {max_batch_age,
+            mk(
+                hoconsc:union([infinity, emqx_schema:duration_ms()]),
+                #{
+                    default => infinity,
+                    desc => ?DESC(max_batch_age)
+                }
+            )},
+        {max_retries,
+            mk(
+                hoconsc:union([infinity, non_neg_integer()]),
+                #{
+                    default => infinity,
+                    desc => ?DESC(max_retries)
+                }
+            )},
         {buffer,
             mk(ref(producer_buffer), #{
                 required => false,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -581,8 +581,6 @@ do_send_msg(async, KafkaTopic, KafkaMessage, Producers, AsyncReplyFn) ->
     %% See emqx_resource_buffer_worker:simple_async_internal_buffer
     {ok, Pid}.
 
-%% Wolff producer never gives up retrying
-%% so there can only be 'ok' results.
 on_kafka_ack(_Partition, Offset, ReplyFnAndArgs) when is_integer(Offset) ->
     %% `emqx_rule_runtime:inc_action_metrics/2' is embedded inside reply function
     emqx_resource:apply_reply_fun(ReplyFnAndArgs, ok);
@@ -594,6 +592,20 @@ on_kafka_ack(_Partition, message_too_large, ReplyFnAndArgs) ->
     %% however 'dropped' is not mapped to EMQX metrics name
     %% so we reply error here
     emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, message_too_large});
+on_kafka_ack(_Partition, message_expired, ReplyFnAndArgs) ->
+    %% Dropped because it stayed in the buffer longer than 'max_batch_age'.
+    %% The 'dropped' and 'dropped.expired' resource metrics are bumped by the
+    %% [wolff, dropped_expired] handler in handle_telemetry_event/4; replying
+    %% 'request_expired' concludes the rule action (and triggers fallback
+    %% actions) without bumping any resource metric, so each message is
+    %% counted exactly once.
+    emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, request_expired});
+on_kafka_ack(_Partition, max_retry_exceeded, ReplyFnAndArgs) ->
+    %% Dropped after 'max_retries' Kafka error responses.  wolff bumps only its
+    %% own (unmapped) 'dropped' counter for this case, so like message_too_large
+    %% the resource 'dropped' metric is left untouched and the error reply
+    %% counts the message as 'failed'.
+    emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, max_retry_exceeded});
 on_kafka_ack(_Partition, partition_lost, ReplyFnAndArgs) ->
     emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, partition_lost}).
 
@@ -782,6 +794,8 @@ producers_config(BridgeType, BridgeName, Input, IsDryRun, ActionResId) ->
         required_acks := RequiredAcks,
         partition_count_refresh_interval := PCntRefreshInterval,
         max_inflight := MaxInflight,
+        max_batch_age := MaxBatchAge,
+        max_retries := MaxRetries,
         partitions_limit := MaxPartitions,
         buffer := #{
             mode := BufferMode0,
@@ -816,6 +830,8 @@ producers_config(BridgeType, BridgeName, Input, IsDryRun, ActionResId) ->
         max_linger_ms => MaxLingerTime,
         max_linger_bytes => MaxLingerBytes,
         max_batch_bytes => MaxBatchBytes,
+        max_batch_age => MaxBatchAge,
+        max_retry => MaxRetries,
         max_send_ahead => MaxInflight - 1,
         compression => Compression,
         group => ActionResId,
@@ -922,6 +938,16 @@ handle_telemetry_event(
 ) when is_integer(Val) ->
     emqx_resource_metrics:dropped_queue_full_inc(ID, Val);
 handle_telemetry_event(
+    [wolff, dropped_expired],
+    #{counter_inc := Val},
+    #{bridge_id := ID},
+    #{bridge_id := ID}
+) when is_integer(Val) ->
+    %% Bumps both 'dropped' and 'dropped.expired'.  wolff emits [wolff, dropped]
+    %% for the same messages, but that event is not subscribed, so expired
+    %% messages are counted as dropped exactly once.
+    emqx_resource_metrics:dropped_expired_inc(ID, Val);
+handle_telemetry_event(
     [wolff, queuing],
     #{gauge_set := Val},
     #{bridge_id := ID, partition_id := PartitionID},
@@ -982,6 +1008,7 @@ maybe_install_wolff_telemetry_handlers(TelemetryId) ->
         telemetry_handler_id(TelemetryId),
         [
             [wolff, dropped_queue_full],
+            [wolff, dropped_expired],
             [wolff, queuing],
             [wolff, queuing_bytes],
             [wolff, retried_success],

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -92,14 +92,13 @@ on_start(InstId, Config) ->
     }),
     C = fun(Key) -> check_config(Key, Config) end,
     Hosts = C(bootstrap_hosts),
-    MetadataRequestTimeout = C(metadata_request_timeout),
     ClientConfig = #{
         min_metadata_refresh_interval => C(min_metadata_refresh_interval),
         connect_timeout => C(connect_timeout),
-        metadata_request_timeout => MetadataRequestTimeout,
+        metadata_request_timeout => C(metadata_request_timeout),
         %% Request timeout is the max age limit for a pending reply from Kafka
         %% once reached, wolff_client will force reconnect
-        request_timeout => max(MetadataRequestTimeout * 2, timer:seconds(30)),
+        request_timeout => C(request_timeout),
         extra_sock_opts => C(socket_opts),
         sasl => C(authentication),
         ssl => C(ssl),
@@ -559,10 +558,16 @@ render_timestamp(Template, Message) ->
 
 do_send_msg(sync, KafkaTopic, KafkaMessage, Producers, SyncTimeout) ->
     try
-        {_Partition, _Offset} = wolff:send_sync2(
-            Producers, KafkaTopic, [KafkaMessage], SyncTimeout
-        ),
-        ok
+        case wolff:send_sync2(Producers, KafkaTopic, [KafkaMessage], SyncTimeout) of
+            {_Partition, message_expired} ->
+                %% dropped because it stayed in the buffer longer than 'max_batch_age'
+                {error, request_expired};
+            {_Partition, max_retry_exceeded} ->
+                %% dropped after 'max_retries' Kafka error responses
+                {error, max_retry_exceeded};
+            {_Partition, _Offset} ->
+                ok
+        end
     catch
         error:{producer_down, _} = Reason ->
             {error, Reason};
@@ -796,6 +801,7 @@ producers_config(BridgeType, BridgeName, Input, IsDryRun, ActionResId) ->
         max_inflight := MaxInflight,
         max_batch_age := MaxBatchAge,
         max_retries := MaxRetries,
+        reconnect_delay := ReconnectDelay,
         partitions_limit := MaxPartitions,
         buffer := #{
             mode := BufferMode0,
@@ -832,6 +838,7 @@ producers_config(BridgeType, BridgeName, Input, IsDryRun, ActionResId) ->
         max_batch_bytes => MaxBatchBytes,
         max_batch_age => MaxBatchAge,
         max_retry => MaxRetries,
+        reconnect_delay_ms => ReconnectDelay,
         max_send_ahead => MaxInflight - 1,
         compression => Compression,
         group => ActionResId,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -559,14 +559,12 @@ render_timestamp(Template, Message) ->
 do_send_msg(sync, KafkaTopic, KafkaMessage, Producers, SyncTimeout) ->
     try
         case wolff:send_sync2(Producers, KafkaTopic, [KafkaMessage], SyncTimeout) of
+            {_Partition, Offset} when is_integer(Offset) ->
+                ok;
             {_Partition, message_expired} ->
-                %% dropped because it stayed in the buffer longer than 'max_batch_age'
                 {error, request_expired};
-            {_Partition, max_retry_exceeded} ->
-                %% dropped after 'max_retries' Kafka error responses
-                {error, max_retry_exceeded};
-            {_Partition, _Offset} ->
-                ok
+            {_Partition, DropReason} ->
+                {error, DropReason}
         end
     catch
         error:{producer_down, _} = Reason ->

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_action_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_action_SUITE.erl
@@ -315,6 +315,21 @@ get_kafka_messages(Opts, TCConfig) ->
         {ok, {NewOffset, Msgs}}
     end.
 
+-doc """
+Fetch the state of the partition-0 wolff producer worker of the action under
+test, to assert config values that EMQX passed through to wolff.
+""".
+get_wolff_producer_state(TCConfig) ->
+    ActionResId = emqx_bridge_v2_testlib:resource_id(TCConfig),
+    #{<<"parameters">> := #{<<"topic">> := Topic}} =
+        get_config(action_config, TCConfig),
+    %% The client id argument is irrelevant: producers are namespaced by the
+    %% group (the action resource id).
+    {ok, Pid} = wolff_producers:find_producer_by_partition(
+        <<"unused">>, ActionResId, Topic, _Partition = 0
+    ),
+    sys:get_state(Pid).
+
 kpro_message_to_map(#kafka_message{} = Msg) ->
     lists:foldl(
         fun({I, Name}, Acc) ->
@@ -687,6 +702,148 @@ t_smoke_metrics(TCConfig) ->
             get_rule_metrics(RuleId)
         )
     ),
+    ok.
+
+-doc """
+`max_batch_age` and `max_retries` action parameters are translated and passed
+through to the wolff producer config (`max_batch_age` in milliseconds,
+`max_retries` as wolff's `max_retry`).
+""".
+t_max_batch_age_max_retries_passthrough(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{
+            <<"max_batch_age">> => <<"500ms">>,
+            <<"max_retries">> => 3
+        }
+    }),
+    ?assertMatch(
+        #{config := #{max_batch_age := 500, max_retry := 3}},
+        get_wolff_producer_state(TCConfig)
+    ),
+    ok.
+
+-doc """
+Actions created without the new `max_batch_age` / `max_retries` parameters
+behave as before: wolff gets `infinity` for both (never drop by age, retry
+forever) and messages are produced as usual.
+""".
+t_max_batch_age_max_retries_defaults(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{}),
+    ?assertMatch(
+        #{config := #{max_batch_age := infinity, max_retry := infinity}},
+        get_wolff_producer_state(TCConfig)
+    ),
+    #{topic := RuleTopic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    {ok, Offset} = resolve_kafka_offset(TCConfig),
+    emqtt:publish(C, RuleTopic, <<"hey">>, [{qos, 1}]),
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            {ok, {_, [#{value := <<"hey">>}]}},
+            get_kafka_messages(#{offset => Offset}, TCConfig)
+        )
+    ),
+    ok.
+
+-doc """
+End-to-end `max_batch_age` expiry: messages buffered while the brokers are
+unreachable are dropped once they are older than `max_batch_age` instead of
+being sent on reconnect.  Each dropped message bumps `dropped` and
+`dropped.expired` exactly once and must NOT be counted as `failed` or
+`success` (the rule action is concluded via the `request_expired` reply,
+which bypasses resource metrics).  Fresh messages produced after recovery
+are delivered normally.
+""".
+t_max_batch_age_expiry_drop() ->
+    [{matrix, true}].
+t_max_batch_age_expiry_drop(matrix) ->
+    [[?tcp_plain, ?no_auth]];
+t_max_batch_age_expiry_drop(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{
+            <<"max_batch_age">> => <<"700ms">>,
+            <<"query_mode">> => <<"async">>
+        }
+    }),
+    #{topic := RuleTopic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    {ok, Offset} = resolve_kafka_offset(TCConfig),
+    with_brokers_down(TCConfig, fun() ->
+        %% Buffer messages while the connection is down.
+        lists:foreach(
+            fun(_) -> emqtt:publish(C, RuleTopic, <<"stale">>, [{qos, 1}]) end,
+            lists:seq(1, 3)
+        ),
+        %% Let the buffered messages grow older than `max_batch_age'.
+        ct:sleep(1_000),
+        ok
+    end),
+    %% On reconnect, wolff drops the expired messages instead of sending them.
+    ?retry(
+        1_000,
+        20,
+        ?assertMatch(
+            {200, #{
+                <<"metrics">> := #{
+                    <<"dropped">> := 3,
+                    <<"dropped.expired">> := 3,
+                    <<"failed">> := 0,
+                    <<"success">> := 0
+                }
+            }},
+            get_action_metrics_api(TCConfig)
+        )
+    ),
+    %% The expired messages never reach Kafka; fresh ones do.
+    emqtt:publish(C, RuleTopic, <<"fresh">>, [{qos, 1}]),
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            {ok, {_, [#{value := <<"fresh">>}]}},
+            get_kafka_messages(#{offset => Offset}, TCConfig)
+        )
+    ),
+    ok.
+
+-doc """
+The `[wolff, dropped_expired]` telemetry handler bumps the action's `dropped`
+and `dropped.expired` counters and nothing else.  wolff emits `[wolff,
+dropped]` alongside `[wolff, dropped_expired]` for the same messages; that
+event is intentionally NOT subscribed, so expired messages are counted as
+dropped exactly once (the double-count guard).
+""".
+t_dropped_expired_metrics_split(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{}),
+    ActionResId = emqx_bridge_v2_testlib:resource_id(TCConfig),
+    %% wolff carries `partition_id' in the event metadata alongside `bridge_id';
+    %% the handler must match on `bridge_id' regardless.
+    Meta = #{bridge_id => ActionResId, partition_id => 1},
+    ?assertEqual(0, emqx_resource_metrics:dropped_get(ActionResId)),
+    ?assertEqual(0, emqx_resource_metrics:dropped_expired_get(ActionResId)),
+    Success0 = emqx_resource_metrics:success_get(ActionResId),
+    Failed0 = emqx_resource_metrics:failed_get(ActionResId),
+    %% Simulate wolff's expiry-drop telemetry: both events fire for the same
+    %% two messages.
+    telemetry:execute([wolff, dropped_expired], #{counter_inc => 2}, Meta),
+    telemetry:execute([wolff, dropped], #{counter_inc => 2}, Meta),
+    ?retry(
+        100,
+        10,
+        begin
+            ?assertEqual(2, emqx_resource_metrics:dropped_expired_get(ActionResId)),
+            ?assertEqual(2, emqx_resource_metrics:dropped_get(ActionResId))
+        end
+    ),
+    %% Double-count guard: expiry drops must not move success/failed.
+    ?assertEqual(Success0, emqx_resource_metrics:success_get(ActionResId)),
+    ?assertEqual(Failed0, emqx_resource_metrics:failed_get(ActionResId)),
     ok.
 
 -doc """

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_action_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_action_SUITE.erl
@@ -330,6 +330,15 @@ get_wolff_producer_state(TCConfig) ->
     ),
     sys:get_state(Pid).
 
+-doc """
+Fetch the state of the wolff client of the connector under test, to assert
+config values that EMQX passed through to wolff.
+""".
+get_wolff_client_state(TCConfig) ->
+    ConnResId = emqx_bridge_v2_testlib:connector_resource_id(TCConfig),
+    {ok, Pid} = wolff_client_sup:find_client(ConnResId),
+    sys:get_state(Pid).
+
 kpro_message_to_map(#kafka_message{} = Msg) ->
     lists:foldl(
         fun({I, Name}, Acc) ->
@@ -705,35 +714,61 @@ t_smoke_metrics(TCConfig) ->
     ok.
 
 -doc """
-`max_batch_age` and `max_retries` action parameters are translated and passed
-through to the wolff producer config (`max_batch_age` in milliseconds,
-`max_retries` as wolff's `max_retry`).
+The `max_batch_age`, `max_retries` and `reconnect_delay` action parameters and
+the connector `request_timeout` are translated and passed through to the wolff
+producer / client configs (`max_batch_age` and `reconnect_delay` in
+milliseconds, `max_retries` as wolff's `max_retry`).
 """.
-t_max_batch_age_max_retries_passthrough(TCConfig) ->
-    {201, _} = create_connector_api(TCConfig, #{}),
+t_wolff_producer_opts_passthrough(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{
+        <<"request_timeout">> => <<"45s">>
+    }),
     {201, _} = create_action_api(TCConfig, #{
         <<"parameters">> => #{
             <<"max_batch_age">> => <<"500ms">>,
-            <<"max_retries">> => 3
+            <<"max_retries">> => 3,
+            <<"reconnect_delay">> => <<"1500ms">>
         }
     }),
     ?assertMatch(
-        #{config := #{max_batch_age := 500, max_retry := 3}},
+        #{
+            config := #{
+                max_batch_age := 500,
+                max_retry := 3,
+                reconnect_delay_ms := 1500
+            }
+        },
         get_wolff_producer_state(TCConfig)
+    ),
+    ?assertMatch(
+        #{conn_config := #{request_timeout := 45_000}},
+        get_wolff_client_state(TCConfig)
     ),
     ok.
 
 -doc """
-Actions created without the new `max_batch_age` / `max_retries` parameters
-behave as before: wolff gets `infinity` for both (never drop by age, retry
-forever) and messages are produced as usual.
+Connectors and actions created without the new `max_batch_age` /
+`max_retries` / `reconnect_delay` / `request_timeout` fields behave as
+before: wolff gets `infinity` for the first two (never drop by age, retry
+forever), 2s reconnect delay, 30s client request timeout, and messages are
+produced as usual.
 """.
-t_max_batch_age_max_retries_defaults(TCConfig) ->
+t_wolff_producer_opts_defaults(TCConfig) ->
     {201, _} = create_connector_api(TCConfig, #{}),
     {201, _} = create_action_api(TCConfig, #{}),
     ?assertMatch(
-        #{config := #{max_batch_age := infinity, max_retry := infinity}},
+        #{
+            config := #{
+                max_batch_age := infinity,
+                max_retry := infinity,
+                reconnect_delay_ms := 2_000
+            }
+        },
         get_wolff_producer_state(TCConfig)
+    ),
+    ?assertMatch(
+        #{conn_config := #{request_timeout := 30_000}},
+        get_wolff_client_state(TCConfig)
     ),
     #{topic := RuleTopic} = simple_create_rule_api(TCConfig),
     C = start_client(),

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_action_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_action_SUITE.erl
@@ -796,13 +796,17 @@ are delivered normally.
 t_max_batch_age_expiry_drop() ->
     [{matrix, true}].
 t_max_batch_age_expiry_drop(matrix) ->
-    [[?tcp_plain, ?no_auth]];
+    [
+        [?tcp_plain, ?no_auth, Sync]
+     || Sync <- [?sync, ?async]
+    ];
 t_max_batch_age_expiry_drop(TCConfig) ->
     {201, _} = create_connector_api(TCConfig, #{}),
     {201, _} = create_action_api(TCConfig, #{
         <<"parameters">> => #{
             <<"max_batch_age">> => <<"700ms">>,
-            <<"query_mode">> => <<"async">>
+            %% keep sync-mode publishes fast while the brokers are down
+            <<"sync_query_timeout">> => <<"1s">>
         }
     }),
     #{topic := RuleTopic} = simple_create_rule_api(TCConfig),
@@ -842,6 +846,58 @@ t_max_batch_age_expiry_drop(TCConfig) ->
         ?assertMatch(
             {ok, {_, [#{value := <<"fresh">>}]}},
             get_kafka_messages(#{offset => Offset}, TCConfig)
+        )
+    ),
+    ok.
+
+-doc """
+End-to-end `max_retries`: a batch that keeps getting explicit error responses
+from Kafka is dropped after the configured number of retries.  The error is
+provoked without mocking, by producing to a topic whose
+`min.insync.replicas` exceeds its replication factor, which makes every
+produce request fail with `not_enough_replicas` while `required_acks` is
+`all_isr`.  The dropped message is counted as `failed` via the
+`max_retry_exceeded` ack reply, and must NOT be counted as `dropped` (wolff's
+parent `dropped` counter is not mapped for this reason).
+""".
+t_max_retries_exceeded_drop() ->
+    [{matrix, true}].
+t_max_retries_exceeded_drop(matrix) ->
+    [
+        [?tcp_plain, ?no_auth, Sync]
+     || Sync <- [?sync, ?async]
+    ];
+t_max_retries_exceeded_drop(TCConfig) ->
+    %% This topic can never satisfy `all_isr': every produce request is
+    %% rejected with the retryable `not_enough_replicas' error.
+    Topic = <<"t_max_retries_exceeded_drop_isr">>,
+    emqx_bridge_kafka_testlib:ensure_kafka_topic(Topic, #{
+        configs => [#{name => <<"min.insync.replicas">>, value => <<"2">>}]
+    }),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{
+            <<"topic">> => Topic,
+            <<"max_retries">> => 1,
+            %% the final ack takes a couple of reconnect cycles to arrive
+            <<"sync_query_timeout">> => <<"15s">>
+        }
+    }),
+    #{topic := RuleTopic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    emqtt:publish(C, RuleTopic, <<"doomed">>, [{qos, 1}]),
+    ?retry(
+        1_000,
+        20,
+        ?assertMatch(
+            {200, #{
+                <<"metrics">> := #{
+                    <<"failed">> := 1,
+                    <<"dropped">> := 0,
+                    <<"success">> := 0
+                }
+            }},
+            get_action_metrics_api(TCConfig)
         )
     ),
     ok.

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_testlib.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_testlib.erl
@@ -218,6 +218,7 @@ ensure_kafka_topic(KafkaTopic) ->
 
 ensure_kafka_topic(KafkaTopic, Opts) ->
     NumPartitions = maps:get(num_partitions, Opts, 1),
+    Configs = maps:get(configs, Opts, []),
     on_exit(fun() -> delete_kafka_topic(KafkaTopic) end),
     TopicConfigs = [
         #{
@@ -225,7 +226,7 @@ ensure_kafka_topic(KafkaTopic, Opts) ->
             num_partitions => NumPartitions,
             replication_factor => 1,
             assignments => [],
-            configs => []
+            configs => Configs
         }
     ],
     RequestConfig = #{timeout => 5_000},

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
@@ -93,6 +93,42 @@ producer_max_batch_age_max_retries_schema_test_() ->
             ?_assertThrow(_, Check(#{<<"max_batch_age">> => <<"not_a_duration">>}))}
     ].
 
+%% `reconnect_delay' (producer) defaults to 2s; `request_timeout' (connector)
+%% defaults to 30s; both accept durations.
+producer_reconnect_delay_request_timeout_schema_test_() ->
+    CheckAction = fun(Overrides) ->
+        emqx_bridge_kafka_testlib:action_config(#{<<"parameters">> => Overrides})
+    end,
+    CheckConnector = fun(Overrides) ->
+        check_action_connector(
+            emqx_utils_maps:deep_merge(
+                emqx_bridge_kafka_testlib:action_connector_config(#{}), Overrides
+            )
+        )
+    end,
+    [
+        {"reconnect_delay default is 2s",
+            ?_assertMatch(
+                #{<<"parameters">> := #{<<"reconnect_delay">> := <<"2s">>}},
+                CheckAction(#{})
+            )},
+        {"reconnect_delay is settable",
+            ?_assertMatch(
+                #{<<"parameters">> := #{<<"reconnect_delay">> := <<"1500ms">>}},
+                CheckAction(#{<<"reconnect_delay">> => <<"1500ms">>})
+            )},
+        {"request_timeout default is 30s",
+            ?_assertMatch(
+                #{<<"request_timeout">> := <<"30s">>},
+                CheckConnector(#{})
+            )},
+        {"request_timeout is settable",
+            ?_assertMatch(
+                #{<<"request_timeout">> := <<"1m">>},
+                CheckConnector(#{<<"request_timeout">> => <<"1m">>})
+            )}
+    ].
+
 %% The wolff ack callback for the wolff 4.2.0 drop reasons: `message_expired'
 %% is reported as `request_expired' (concludes the rule action without bumping
 %% resource metrics; `dropped'/`dropped.expired' are bumped via the

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
@@ -56,6 +56,66 @@ test_keepalive_validation(Kind, Conf) ->
     [?_assertMatch(#{}, Check(C)) || C <- ValidConfs] ++
         [?_assertThrow(_, Check(C)) || C <- InvalidConfs].
 
+%% `max_batch_age' and `max_retries' accept `infinity' (the default) or a
+%% duration / non-negative integer, and are rejected otherwise.
+producer_max_batch_age_max_retries_schema_test_() ->
+    Check = fun(Overrides) ->
+        emqx_bridge_kafka_testlib:action_config(#{<<"parameters">> => Overrides})
+    end,
+    [
+        {"defaults are infinity",
+            ?_assertMatch(
+                #{
+                    <<"parameters">> := #{
+                        <<"max_batch_age">> := <<"infinity">>,
+                        <<"max_retries">> := <<"infinity">>
+                    }
+                },
+                Check(#{})
+            )},
+        {"duration and integer accepted",
+            ?_assertMatch(
+                #{
+                    <<"parameters">> := #{
+                        <<"max_batch_age">> := <<"500ms">>,
+                        <<"max_retries">> := 3
+                    }
+                },
+                Check(#{<<"max_batch_age">> => <<"500ms">>, <<"max_retries">> => 3})
+            )},
+        {"zero retries accepted",
+            ?_assertMatch(
+                #{<<"parameters">> := #{<<"max_retries">> := 0}},
+                Check(#{<<"max_retries">> => 0})
+            )},
+        {"negative retries rejected", ?_assertThrow(_, Check(#{<<"max_retries">> => -1}))},
+        {"bad duration rejected",
+            ?_assertThrow(_, Check(#{<<"max_batch_age">> => <<"not_a_duration">>}))}
+    ].
+
+%% The wolff ack callback for the wolff 4.2.0 drop reasons: `message_expired'
+%% is reported as `request_expired' (concludes the rule action without bumping
+%% resource metrics; `dropped'/`dropped.expired' are bumped via the
+%% [wolff, dropped_expired] telemetry handler), while `max_retry_exceeded' is
+%% reported as a regular error (counted as `failed' by the reply path).
+on_kafka_ack_drop_reasons_test_() ->
+    AckResult = fun(Reason) ->
+        Ref = make_ref(),
+        Self = self(),
+        ReplyFn = {fun(R) -> Self ! {Ref, R} end, []},
+        ok = emqx_bridge_kafka_impl_producer:on_kafka_ack(0, Reason, ReplyFn),
+        receive
+            {Ref, Result} -> Result
+        after 1_000 -> timeout
+        end
+    end,
+    [
+        {"message_expired -> request_expired",
+            ?_assertEqual({error, request_expired}, AckResult(message_expired))},
+        {"max_retry_exceeded -> max_retry_exceeded",
+            ?_assertEqual({error, max_retry_exceeded}, AckResult(max_retry_exceeded))}
+    ].
+
 custom_group_id_test() ->
     BadSourceConfig = emqx_bridge_kafka_testlib:source_config(#{
         <<"parameters">> =>

--- a/changes/ee/feat-18085.en.md
+++ b/changes/ee/feat-18085.en.md
@@ -1,0 +1,13 @@
+Added two producer options to the Kafka, Confluent, and Azure Event Hubs actions:
+
+- `max_batch_age`: maximum duration a message may stay in the producer buffer before it is dropped instead of being sent.
+  This bounds the delivery latency of buffered messages across long broker outages, instead of sending arbitrarily stale data after reconnecting.
+  Dropped messages are counted in the `dropped.expired` metric.
+  The default `infinity` keeps the previous behavior (messages never expire).
+
+- `max_retries`: maximum number of times to retry sending a message batch after a retryable Kafka error response (for example, when the partition leader has changed) before dropping it.
+  Dropped messages are counted in the `failed` metric.
+  Reconnect-triggered resends after a connection loss are not counted against this limit; they are bounded by `max_batch_age` instead.
+  The default `infinity` keeps the previous behavior (retry forever).
+
+Additionally, `max_linger_time` is honored again for memory-mode buffers (upgraded the Kafka client library wolff to 4.2.0). When less than a full batch is buffered, the producer waits up to `max_linger_time` for more messages before forming a produce request, reducing the produce request rate at high message rates; sending is immediate whenever a full batch's worth of data is available, and the publish path is never delayed. The default `max_linger_time = 0` keeps the previous send-immediately behavior.

--- a/changes/ee/feat-18085.en.md
+++ b/changes/ee/feat-18085.en.md
@@ -1,19 +1,8 @@
-Added two producer options to the Kafka, Confluent, and Azure Event Hubs actions:
+Added new configuration options for the Kafka, Confluent, and Azure Event Hubs producers:
 
-- `max_batch_age`: maximum duration a message may stay in the producer buffer before it is dropped instead of being sent.
-  This bounds the delivery latency of buffered messages across long broker outages, instead of sending arbitrarily stale data after reconnecting.
-  Dropped messages are counted in the `dropped.expired` metric.
-  The default `infinity` keeps the previous behavior (messages never expire).
+- `max_batch_age` (action): drop messages that stay in the producer buffer longer than this duration instead of sending them; counted in the `dropped.expired` metric. Default: `infinity` (never drop).
+- `max_retries` (action): drop a message batch after this many failed retries; counted in the `failed` metric. The retry counter is incremented only when Kafka explicitly responds with an error code; resends after a connection loss do not increment it. Default: `infinity` (retry forever).
+- `reconnect_delay` (action): delay before the producer reconnects after a connection loss. Default: `2s` (previously hard-coded).
+- `request_timeout` (connector): how long to wait for a reply from Kafka before the connection is considered stale and gets re-established. Default: `30s`.
 
-- `max_retries`: maximum number of times to retry sending a message batch after a retryable Kafka error response (for example, when the partition leader has changed) before dropping it.
-  Dropped messages are counted in the `failed` metric.
-  Reconnect-triggered resends after a connection loss are not counted against this limit; they are bounded by `max_batch_age` instead.
-  The default `infinity` keeps the previous behavior (retry forever).
-
-- `reconnect_delay`: delay before the producer attempts to reconnect after a connection loss.
-  The default `2s` keeps the previous (hard-coded) behavior.
-
-Also added a `request_timeout` option to the corresponding connectors: the maximum duration to wait for a reply from Kafka for a pending request before the connection is considered stale and re-established.
-The default `30s` matches the previous behavior for default configurations (it used to be derived as at least 30 seconds).
-
-Additionally, `max_linger_time` is honored again for memory-mode buffers (upgraded the Kafka client library wolff to 4.2.0). When less than a full batch is buffered, the producer waits up to `max_linger_time` for more messages before forming a produce request, reducing the produce request rate at high message rates; sending is immediate whenever a full batch's worth of data is available, and the publish path is never delayed. The default `max_linger_time = 0` keeps the previous send-immediately behavior.
+Additionally, the Kafka client library upgrade (wolff 4.2.1) restores `max_linger_time` support for memory-mode buffers: an under-sized batch now waits up to `max_linger_time` for more messages, reducing the produce request rate; full batches are sent without delay.

--- a/changes/ee/feat-18085.en.md
+++ b/changes/ee/feat-18085.en.md
@@ -10,4 +10,10 @@ Added two producer options to the Kafka, Confluent, and Azure Event Hubs actions
   Reconnect-triggered resends after a connection loss are not counted against this limit; they are bounded by `max_batch_age` instead.
   The default `infinity` keeps the previous behavior (retry forever).
 
+- `reconnect_delay`: delay before the producer attempts to reconnect after a connection loss.
+  The default `2s` keeps the previous (hard-coded) behavior.
+
+Also added a `request_timeout` option to the corresponding connectors: the maximum duration to wait for a reply from Kafka for a pending request before the connection is considered stale and re-established.
+The default `30s` matches the previous behavior for default configurations (it used to be derived as at least 30 seconds).
+
 Additionally, `max_linger_time` is honored again for memory-mode buffers (upgraded the Kafka client library wolff to 4.2.0). When less than a full batch is buffered, the producer waits up to `max_linger_time` for more messages before forming a produce request, reducing the produce request rate at high message rates; sending is immediate whenever a full batch's worth of data is available, and the publish path is never delayed. The default `max_linger_time = 0` keeps the previous send-immediately behavior.

--- a/mix.exs
+++ b/mix.exs
@@ -277,7 +277,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.18", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.2.0"}
+  def common_dep(:wolff), do: {:wolff, "4.2.1"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),

--- a/mix.exs
+++ b/mix.exs
@@ -277,7 +277,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.18", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.1.10"}
+  def common_dep(:wolff), do: {:wolff, "4.2.0"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),

--- a/rel/i18n/emqx_bridge_azure_event_hub.hocon
+++ b/rel/i18n/emqx_bridge_azure_event_hub.hocon
@@ -115,6 +115,22 @@ max_linger_bytes.desc:
 
 max_linger_bytes.label: "Max Linger Bytes"
 
+max_batch_age.desc:
+"""Maximum duration a message may stay in the producer buffer before it is dropped instead of being sent to Azure Event Hubs.
+A message batch is dropped only when all of its messages have stayed in the buffer longer than this duration; this applies both to messages still queued (including while the connection is down) and to messages awaiting acknowledgement when the connection is lost.
+Each dropped message counts towards the <code>dropped.expired</code> metric.
+The default value <code>infinity</code> means messages never expire (retained until sent or the buffer overflows)."""
+
+max_batch_age.label: "Max Batch Age"
+
+max_retries.desc:
+"""Maximum number of times to retry sending a message batch after Azure Event Hubs responds with a retryable error (for example, when the partition leader has changed).
+After the initial attempt and this many retries have all failed, the batch is dropped and each of its messages counts towards the <code>failed</code> metric.
+Reconnect-triggered resends after a connection loss are not counted against this limit; they are bounded by <code>max_batch_age</code> instead.
+The default value <code>infinity</code> means retry forever."""
+
+max_retries.label: "Max Retries"
+
 max_batch_bytes.desc:
 """Maximum bytes to collect in an Azure Event Hubs message batch."""
 

--- a/rel/i18n/emqx_bridge_azure_event_hub.hocon
+++ b/rel/i18n/emqx_bridge_azure_event_hub.hocon
@@ -111,13 +111,15 @@ partition_count_refresh_interval.label:
 """Partition Count Refresh Interval"""
 
 max_linger_time.desc:
-"""Maximum duration for a per-partition producer to wait for messages in order to collect a batch to buffer.
-The default value `0` means no wait. For non-memory buffer mode, it's advised to configure at least `5ms` for less IOPS."""
+"""Maximum duration a per-partition producer waits to accumulate more messages into a larger batch.
+The default value `0` means no wait (messages are sent as soon as they arrive).
+The wait ends early as soon as a full batch's worth of data has accumulated, so a busy producer is never delayed.
+When buffering to disk, the wait happens before writing to the buffer; configuring at least `5ms` is advised there to reduce disk IOPS."""
 
 max_linger_time.label: "Max Linger Time"
 
 max_linger_bytes.desc:
-"""Maximum number of bytes for a per-partition producer to wait for messages in order to collect a batch to buffer."""
+"""Maximum number of bytes a per-partition producer accumulates while waiting before it stops waiting and sends the batch."""
 
 max_linger_bytes.label: "Max Linger Bytes"
 

--- a/rel/i18n/emqx_bridge_azure_event_hub.hocon
+++ b/rel/i18n/emqx_bridge_azure_event_hub.hocon
@@ -20,7 +20,8 @@ min_metadata_refresh_interval.label:
 
 request_timeout.desc:
 """Maximum duration to wait for a reply from Azure Event Hubs for a pending request.
-When exceeded, the connection is considered stale and is re-established."""
+When exceeded, the connection is considered stale and is re-established.
+Note: if set too small, Azure Event Hubs may have ingested a produce request while the acknowledgement is delayed; EMQX then resends the already-accepted batch after reconnecting, which can result in duplicates and an overwhelming data volume for downstream consumers."""
 
 request_timeout.label: "Request Timeout"
 
@@ -112,7 +113,8 @@ partition_count_refresh_interval.label:
 
 max_linger_time.desc:
 """Maximum duration a per-partition producer waits to accumulate more messages into a larger batch.
-The default value `0` means no wait (messages are sent as soon as they arrive).
+The default value `0` means no wait (messages are sent as soon as they arrive); it is optimized for messaging latency.
+If a small delay is acceptable, configuring one is encouraged to help lower the number of requests per second towards Azure Event Hubs.
 The wait ends early as soon as a full batch's worth of data has accumulated, so a busy producer is never delayed.
 When buffering to disk, the wait happens before writing to the buffer; configuring at least `5ms` is advised there to reduce disk IOPS."""
 
@@ -127,15 +129,15 @@ max_batch_age.desc:
 """Maximum duration a message may stay in the producer buffer before it is dropped instead of being sent to Azure Event Hubs.
 A message batch is dropped only when all of its messages have stayed in the buffer longer than this duration; this applies both to messages still queued (including while the connection is down) and to messages awaiting acknowledgement when the connection is lost.
 Each dropped message counts towards the <code>dropped.expired</code> metric.
-The default value <code>infinity</code> means messages never expire (retained until sent or the buffer overflows)."""
+When set to <code>infinity</code>, messages never expire (they are retained until sent, or until the buffer overflows)."""
 
 max_batch_age.label: "Max Batch Age"
 
 max_retries.desc:
 """Maximum number of times to retry sending a message batch after Azure Event Hubs responds with a retryable error (for example, when the partition leader has changed).
 After the initial attempt and this many retries have all failed, the batch is dropped and each of its messages counts towards the <code>failed</code> metric.
-Reconnect-triggered resends after a connection loss are not counted against this limit; they are bounded by <code>max_batch_age</code> instead.
-The default value <code>infinity</code> means retry forever."""
+The retry counter is incremented only when Azure Event Hubs explicitly responds with an error code; resends triggered by a connection loss do not increment it (those are bounded by <code>max_batch_age</code>).
+When set to <code>infinity</code>, retries are unlimited."""
 
 max_retries.label: "Max Retries"
 

--- a/rel/i18n/emqx_bridge_azure_event_hub.hocon
+++ b/rel/i18n/emqx_bridge_azure_event_hub.hocon
@@ -18,6 +18,12 @@ min_metadata_refresh_interval.desc:
 min_metadata_refresh_interval.label:
 """Min Metadata Refresh Interval"""
 
+request_timeout.desc:
+"""Maximum duration to wait for a reply from Azure Event Hubs for a pending request.
+When exceeded, the connection is considered stale and is re-established."""
+
+request_timeout.label: "Request Timeout"
+
 kafka_producer.desc:
 """Azure Event Hubs Producer configuration."""
 
@@ -130,6 +136,12 @@ Reconnect-triggered resends after a connection loss are not counted against this
 The default value <code>infinity</code> means retry forever."""
 
 max_retries.label: "Max Retries"
+
+reconnect_delay.desc:
+"""Delay before the producer attempts to reconnect to Azure Event Hubs after a connection loss.
+While disconnected, messages continue to accumulate in the buffer, subject to the buffer limits and <code>max_batch_age</code>."""
+
+reconnect_delay.label: "Reconnect Delay"
 
 max_batch_bytes.desc:
 """Maximum bytes to collect in an Azure Event Hubs message batch."""

--- a/rel/i18n/emqx_bridge_confluent_producer.hocon
+++ b/rel/i18n/emqx_bridge_confluent_producer.hocon
@@ -115,6 +115,22 @@ max_linger_bytes.desc:
 
 max_linger_bytes.label: "Max Linger Bytes"
 
+max_batch_age.desc:
+"""Maximum duration a message may stay in the producer buffer before it is dropped instead of being sent to Confluent.
+A message batch is dropped only when all of its messages have stayed in the buffer longer than this duration; this applies both to messages still queued (including while the connection is down) and to messages awaiting acknowledgement when the connection is lost.
+Each dropped message counts towards the <code>dropped.expired</code> metric.
+The default value <code>infinity</code> means messages never expire (retained until sent or the buffer overflows)."""
+
+max_batch_age.label: "Max Batch Age"
+
+max_retries.desc:
+"""Maximum number of times to retry sending a message batch after Confluent responds with a retryable error (for example, when the partition leader has changed).
+After the initial attempt and this many retries have all failed, the batch is dropped and each of its messages counts towards the <code>failed</code> metric.
+Reconnect-triggered resends after a connection loss are not counted against this limit; they are bounded by <code>max_batch_age</code> instead.
+The default value <code>infinity</code> means retry forever."""
+
+max_retries.label: "Max Retries"
+
 max_batch_bytes.desc:
 """Maximum bytes to collect in a Confluent message batch. Most of the Kafka brokers default to a limit of 1 MB batch size. EMQX's default value is less than 1 MB in order to compensate Kafka message encoding overheads (especially when each individual message is very small). When a single message is over the limit, it is still sent (as a single element batch)."""
 

--- a/rel/i18n/emqx_bridge_confluent_producer.hocon
+++ b/rel/i18n/emqx_bridge_confluent_producer.hocon
@@ -20,7 +20,8 @@ min_metadata_refresh_interval.label:
 
 request_timeout.desc:
 """Maximum duration to wait for a reply from Confluent for a pending request.
-When exceeded, the connection is considered stale and is re-established."""
+When exceeded, the connection is considered stale and is re-established.
+Note: if set too small, Confluent may have ingested a produce request while the acknowledgement is delayed; EMQX then resends the already-accepted batch after reconnecting, which can result in duplicates and an overwhelming data volume for downstream consumers."""
 
 request_timeout.label: "Request Timeout"
 
@@ -112,7 +113,8 @@ partition_count_refresh_interval.label:
 
 max_linger_time.desc:
 """Maximum duration a per-partition producer waits to accumulate more messages into a larger batch.
-The default value `0` means no wait (messages are sent as soon as they arrive).
+The default value `0` means no wait (messages are sent as soon as they arrive); it is optimized for messaging latency.
+If a small delay is acceptable, configuring one is encouraged to help lower the number of requests per second towards Confluent.
 The wait ends early as soon as a full batch's worth of data has accumulated, so a busy producer is never delayed.
 When buffering to disk, the wait happens before writing to the buffer; configuring at least `5ms` is advised there to reduce disk IOPS."""
 
@@ -127,15 +129,15 @@ max_batch_age.desc:
 """Maximum duration a message may stay in the producer buffer before it is dropped instead of being sent to Confluent.
 A message batch is dropped only when all of its messages have stayed in the buffer longer than this duration; this applies both to messages still queued (including while the connection is down) and to messages awaiting acknowledgement when the connection is lost.
 Each dropped message counts towards the <code>dropped.expired</code> metric.
-The default value <code>infinity</code> means messages never expire (retained until sent or the buffer overflows)."""
+When set to <code>infinity</code>, messages never expire (they are retained until sent, or until the buffer overflows)."""
 
 max_batch_age.label: "Max Batch Age"
 
 max_retries.desc:
 """Maximum number of times to retry sending a message batch after Confluent responds with a retryable error (for example, when the partition leader has changed).
 After the initial attempt and this many retries have all failed, the batch is dropped and each of its messages counts towards the <code>failed</code> metric.
-Reconnect-triggered resends after a connection loss are not counted against this limit; they are bounded by <code>max_batch_age</code> instead.
-The default value <code>infinity</code> means retry forever."""
+The retry counter is incremented only when Confluent explicitly responds with an error code; resends triggered by a connection loss do not increment it (those are bounded by <code>max_batch_age</code>).
+When set to <code>infinity</code>, retries are unlimited."""
 
 max_retries.label: "Max Retries"
 

--- a/rel/i18n/emqx_bridge_confluent_producer.hocon
+++ b/rel/i18n/emqx_bridge_confluent_producer.hocon
@@ -18,6 +18,12 @@ min_metadata_refresh_interval.desc:
 min_metadata_refresh_interval.label:
 """Min Metadata Refresh Interval"""
 
+request_timeout.desc:
+"""Maximum duration to wait for a reply from Confluent for a pending request.
+When exceeded, the connection is considered stale and is re-established."""
+
+request_timeout.label: "Request Timeout"
+
 kafka_producer.desc:
 """Confluent Producer configuration."""
 
@@ -130,6 +136,12 @@ Reconnect-triggered resends after a connection loss are not counted against this
 The default value <code>infinity</code> means retry forever."""
 
 max_retries.label: "Max Retries"
+
+reconnect_delay.desc:
+"""Delay before the producer attempts to reconnect to Confluent after a connection loss.
+While disconnected, messages continue to accumulate in the buffer, subject to the buffer limits and <code>max_batch_age</code>."""
+
+reconnect_delay.label: "Reconnect Delay"
 
 max_batch_bytes.desc:
 """Maximum bytes to collect in a Confluent message batch. Most of the Kafka brokers default to a limit of 1 MB batch size. EMQX's default value is less than 1 MB in order to compensate Kafka message encoding overheads (especially when each individual message is very small). When a single message is over the limit, it is still sent (as a single element batch)."""

--- a/rel/i18n/emqx_bridge_confluent_producer.hocon
+++ b/rel/i18n/emqx_bridge_confluent_producer.hocon
@@ -111,13 +111,15 @@ partition_count_refresh_interval.label:
 """Partition Count Refresh Interval"""
 
 max_linger_time.desc:
-"""Maximum duration for a per-partition producer to wait for messages in order to collect a batch to buffer.
-The default value `0` means no wait. For non-memory buffer mode, it's advised to configure at least `5ms` for less IOPS."""
+"""Maximum duration a per-partition producer waits to accumulate more messages into a larger batch.
+The default value `0` means no wait (messages are sent as soon as they arrive).
+The wait ends early as soon as a full batch's worth of data has accumulated, so a busy producer is never delayed.
+When buffering to disk, the wait happens before writing to the buffer; configuring at least `5ms` is advised there to reduce disk IOPS."""
 
 max_linger_time.label: "Max Linger Time"
 
 max_linger_bytes.desc:
-"""Maximum number of bytes for a per-partition producer to wait for messages in order to collect a batch to buffer."""
+"""Maximum number of bytes a per-partition producer accumulates while waiting before it stops waiting and sends the batch."""
 
 max_linger_bytes.label: "Max Linger Bytes"
 

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -170,13 +170,15 @@ partition_count_refresh_interval.label:
 """Partition Count Refresh Interval"""
 
 max_linger_time.desc:
-"""Maximum duration for a per-partition producer to wait for messages in order to collect a batch to buffer.
-The default value `0` means no wait. For non-memory buffer mode, it's advised to configure at least `5ms` for less IOPS."""
+"""Maximum duration a per-partition producer waits to accumulate more messages into a larger batch.
+The default value `0` means no wait (messages are sent as soon as they arrive).
+The wait ends early as soon as a full batch's worth of data has accumulated, so a busy producer is never delayed.
+When buffering to disk, the wait happens before writing to the buffer; configuring at least `5ms` is advised there to reduce disk IOPS."""
 
 max_linger_time.label: "Max Linger Time"
 
 max_linger_bytes.desc:
-"""Maximum number of bytes for a per-partition producer to wait for messages in order to collect a batch to buffer."""
+"""Maximum number of bytes a per-partition producer accumulates while waiting before it stops waiting and sends the batch."""
 
 max_linger_bytes.label: "Max Linger Bytes"
 

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -12,6 +12,12 @@ min_metadata_refresh_interval.desc:
 min_metadata_refresh_interval.label:
 """Min Metadata Refresh Interval"""
 
+request_timeout.desc:
+"""Maximum duration to wait for a reply from Kafka for a pending request.
+When exceeded, the connection is considered stale and is re-established."""
+
+request_timeout.label: "Request Timeout"
+
 kafka_producer.desc:
 """Kafka Producer configuration."""
 
@@ -189,6 +195,12 @@ Reconnect-triggered resends after a connection loss are not counted against this
 The default value <code>infinity</code> means retry forever."""
 
 max_retries.label: "Max Retries"
+
+reconnect_delay.desc:
+"""Delay before the producer attempts to reconnect to Kafka after a connection loss.
+While disconnected, messages continue to accumulate in the buffer, subject to the buffer limits and <code>max_batch_age</code>."""
+
+reconnect_delay.label: "Reconnect Delay"
 
 max_batch_bytes.desc:
 """Maximum bytes to collect in a Kafka message batch. Most of the Kafka brokers default to a limit of 1 MB batch size. EMQX's default value is less than 1 MB in order to compensate Kafka message encoding overheads (especially when each individual message is very small). When a single message is over the limit, it is still sent (as a single element batch)."""

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -14,7 +14,8 @@ min_metadata_refresh_interval.label:
 
 request_timeout.desc:
 """Maximum duration to wait for a reply from Kafka for a pending request.
-When exceeded, the connection is considered stale and is re-established."""
+When exceeded, the connection is considered stale and is re-established.
+Note: if set too small, Kafka may have ingested a produce request while the acknowledgement is delayed; EMQX then resends the already-accepted batch after reconnecting, which can result in duplicates and an overwhelming data volume for downstream consumers."""
 
 request_timeout.label: "Request Timeout"
 
@@ -171,7 +172,8 @@ partition_count_refresh_interval.label:
 
 max_linger_time.desc:
 """Maximum duration a per-partition producer waits to accumulate more messages into a larger batch.
-The default value `0` means no wait (messages are sent as soon as they arrive).
+The default value `0` means no wait (messages are sent as soon as they arrive); it is optimized for messaging latency.
+If a small delay is acceptable, configuring one is encouraged to help lower the number of requests per second towards Kafka.
 The wait ends early as soon as a full batch's worth of data has accumulated, so a busy producer is never delayed.
 When buffering to disk, the wait happens before writing to the buffer; configuring at least `5ms` is advised there to reduce disk IOPS."""
 
@@ -186,15 +188,15 @@ max_batch_age.desc:
 """Maximum duration a message may stay in the producer buffer before it is dropped instead of being sent to Kafka.
 A message batch is dropped only when all of its messages have stayed in the buffer longer than this duration; this applies both to messages still queued (including while the connection is down) and to messages awaiting acknowledgement when the connection is lost.
 Each dropped message counts towards the <code>dropped.expired</code> metric.
-The default value <code>infinity</code> means messages never expire (retained until sent or the buffer overflows)."""
+When set to <code>infinity</code>, messages never expire (they are retained until sent, or until the buffer overflows)."""
 
 max_batch_age.label: "Max Batch Age"
 
 max_retries.desc:
 """Maximum number of times to retry sending a message batch after Kafka responds with a retryable error (for example, when the partition leader has changed).
 After the initial attempt and this many retries have all failed, the batch is dropped and each of its messages counts towards the <code>failed</code> metric.
-Reconnect-triggered resends after a connection loss are not counted against this limit; they are bounded by <code>max_batch_age</code> instead.
-The default value <code>infinity</code> means retry forever."""
+The retry counter is incremented only when Kafka explicitly responds with an error code; resends triggered by a connection loss do not increment it (those are bounded by <code>max_batch_age</code>).
+When set to <code>infinity</code>, retries are unlimited."""
 
 max_retries.label: "Max Retries"
 

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -174,6 +174,22 @@ max_linger_bytes.desc:
 
 max_linger_bytes.label: "Max Linger Bytes"
 
+max_batch_age.desc:
+"""Maximum duration a message may stay in the producer buffer before it is dropped instead of being sent to Kafka.
+A message batch is dropped only when all of its messages have stayed in the buffer longer than this duration; this applies both to messages still queued (including while the connection is down) and to messages awaiting acknowledgement when the connection is lost.
+Each dropped message counts towards the <code>dropped.expired</code> metric.
+The default value <code>infinity</code> means messages never expire (retained until sent or the buffer overflows)."""
+
+max_batch_age.label: "Max Batch Age"
+
+max_retries.desc:
+"""Maximum number of times to retry sending a message batch after Kafka responds with a retryable error (for example, when the partition leader has changed).
+After the initial attempt and this many retries have all failed, the batch is dropped and each of its messages counts towards the <code>failed</code> metric.
+Reconnect-triggered resends after a connection loss are not counted against this limit; they are bounded by <code>max_batch_age</code> instead.
+The default value <code>infinity</code> means retry forever."""
+
+max_retries.label: "Max Retries"
+
 max_batch_bytes.desc:
 """Maximum bytes to collect in a Kafka message batch. Most of the Kafka brokers default to a limit of 1 MB batch size. EMQX's default value is less than 1 MB in order to compensate Kafka message encoding overheads (especially when each individual message is very small). When a single message is over the limit, it is still sent (as a single element batch)."""
 

--- a/scripts/spellcheck/dicts/emqx.txt
+++ b/scripts/spellcheck/dicts/emqx.txt
@@ -254,6 +254,7 @@ replicant
 repo
 Req
 RESTful
+retryable
 reuseaddr
 RFC1918
 rh


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Bump wolff 4.1.10 → 4.2.1 and integrate its two new producer options end-to-end for the Kafka, Confluent, and Azure Event Hubs actions:

- `max_batch_age` (default `infinity`): maximum duration a message may stay in the producer buffer before it is dropped instead of being sent. Applies both to still-queued messages (even while disconnected) and to messages that were in-flight when the connection dropped.
- `max_retries` (default `infinity`, wolff option name `max_retry`): maximum number of retries after Kafka error responses (e.g. `not_leader_for_partition`) before a batch is dropped. Connection-loss resends are not counted against this limit; they are bounded by `max_batch_age`.

Additionally exposes two previously hard-coded / derived wolff settings:

- Action `parameters.reconnect_delay` (default `2s`, the previous hard-coded value): wolff producer `reconnect_delay_ms`, the delay before reconnecting after a connection loss.
- Connector `request_timeout` (default `30s`): the wolff client request timeout, previously derived as `max(2 * metadata_request_timeout, 30s)`.

All new fields are added in `emqx_bridge_kafka` and flow into the Confluent and Azure Event Hubs schemas via their existing field derivation; each bridge gets its own i18n descs. `producers_config/5` / `on_start` pass them through to wolff.

Drop-outcome accounting (`emqx_bridge_kafka_impl_producer`), designed so each message is counted exactly once per counter family:

- `message_expired` ack → reply `{error, request_expired}`: the internal-buffer reply path concludes the rule action (and triggers fallback actions) without bumping resource metrics; `dropped` and `dropped.expired` are bumped by the new `[wolff, dropped_expired]` telemetry subscription. The parallel `[wolff, dropped]` event is intentionally not subscribed, so expiry drops do not double-count `dropped` (same division of labor as `buffer_overflow_discarded`, and same reply reason as the Pulsar connector uses for its expiry drops).
- `max_retry_exceeded` ack → reply `{error, max_retry_exceeded}`: counted as `failed` via the reply path, mirroring `message_too_large`; wolff's parent `dropped` counter remains unmapped, keeping `dropped >= dropped.expired` coherent. The final failed attempt's `[wolff, retried_failed]` event bumps only `retried`/`retried.failed` (as before), so no double count there either.
- The sync send path (`wolff:send_sync2/4`) maps the same two drop reasons; wolff 4.2.1 fixed the stale `offset_reply()` type spec that previously made this fail dialyzer.

Also rides along:
- wolff 4.1.11's `max_linger_time` restore for memory-mode buffers (same fix that went to v5 in #18082), and the corresponding `max_linger_time`/`max_linger_bytes` i18n description updates from #18101.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
