### PR TITLE
sync r59 to r510

### DIFF
--- a/apps/emqx/test/emqx_routing_SUITE.erl
+++ b/apps/emqx/test/emqx_routing_SUITE.erl
@@ -258,12 +258,21 @@ t_concurrent_routing_updates(_Config) ->
      || I <- lists:seq(1, NClients)
     ],
     ok = lists:foreach(fun ping_concurrent_client/1, Clients),
-    ok = timer:sleep(200),
+    0 = ?retry(
+        _Interval = 500,
+        _NTimes = 10,
+        0 = lists:sum([S || #{size := S} <- emqx_router_syncer:stats()])
+    ),
     Subscribers = ets:tab2list(?SUBSCRIBER),
     Topics = maps:keys(maps:from_list(Subscribers)),
     ?assertEqual(lists:sort(Topics), lists:sort(emqx_router:topics())),
     ok = lists:foreach(fun stop_concurrent_client/1, Clients),
-    ok = timer:sleep(1000),
+    ok = timer:sleep(100),
+    0 = ?retry(
+        500,
+        10,
+        0 = lists:sum([S || #{size := S} <- emqx_router_syncer:stats()])
+    ),
     ct:pal("Trace: ~p", [?of_kind(router_syncer_new_batch, snabbkaffe:collect_trace())]),
     ?assertEqual([], ets:tab2list(?SUBSCRIBER)),
     ?assertEqual([], emqx_router:topics()).

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -161,7 +161,11 @@ t_takeover(Config) ->
 
     assert_client_exit(CPid1, ?config(mqtt_vsn, Config), takenover),
     ?assertReceive({'EXIT', CPid2, normal}),
-    Received = [Msg || {publish, Msg} <- ?drainMailbox(Sleep)],
+    %% Durable-session replay around a takeover can deliver the boundary batch
+    %% late and out of order, so a single fixed-window drain may return before
+    %% every message arrives. Accumulate until all expected payloads are
+    %% received (or a deadline), so a genuine loss still fails.
+    Received = drain_until_received(AllMsgs, undefined, 30_000),
     ct:pal("middle: ~p", [Middle]),
     ct:pal("received: ~p", [[P || #{payload := P} <- Received]]),
     assert_messages_missed(AllMsgs, Received),
@@ -217,7 +221,11 @@ t_takeover_willmsg(Config) ->
     #{client := [CPid2, CPidSub, CPid1]} = FCtx,
     assert_client_exit(CPid1, ?config(mqtt_vsn, Config), takenover),
     ?assertReceive({'EXIT', CPid2, normal}),
-    Received = [Msg || {publish, Msg} <- ?drainMailbox(Sleep)],
+    %% Durable-session replay around a takeover can deliver the boundary batch
+    %% late and out of order, so a single fixed-window drain may return before
+    %% every message arrives. Accumulate until all expected payloads plus the
+    %% will are received (or a deadline), so a genuine loss still fails.
+    Received = drain_until_received(AllMsgs, <<"willpayload">>, 30_000),
     ct:pal("received: ~p", [[P || #{payload := P} <- Received]]),
     {IsWill, ReceivedNoWill} = filter_payload(Received, <<"willpayload">>),
     assert_messages_missed(AllMsgs, ReceivedNoWill),
@@ -1134,6 +1142,34 @@ stop_the_last_client(Ctx = #{client := [CPid | _], sleep := Sleep}) ->
 
 %%--------------------------------------------------------------------
 %% Helpers
+
+%% Drain published messages, accumulating across short quiet-window rounds,
+%% until every expected payload (and the will payload, unless `undefined`) has
+%% been received, or a hard deadline passes. Returns whatever was collected so
+%% the usual missed/order assertions still run (and fail) on a genuine loss.
+drain_until_received(ExpectedMsgs, WillPayload, MaxWaitMs) ->
+    Deadline = erlang:monotonic_time(millisecond) + MaxWaitMs,
+    drain_until_received(ExpectedMsgs, WillPayload, Deadline, []).
+
+drain_until_received(ExpectedMsgs, WillPayload, Deadline, Acc0) ->
+    Acc = Acc0 ++ [Msg || {publish, Msg} <- ?drainMailbox(200)],
+    WillPresent =
+        WillPayload == undefined orelse
+            lists:any(fun(#{payload := P}) -> P == WillPayload end, Acc),
+    Complete = all_payloads_present(ExpectedMsgs, Acc) andalso WillPresent,
+    case Complete orelse erlang:monotonic_time(millisecond) >= Deadline of
+        true -> Acc;
+        false -> drain_until_received(ExpectedMsgs, WillPayload, Deadline, Acc)
+    end.
+
+all_payloads_present(Expected, Received) ->
+    lists:all(
+        fun(Msg) ->
+            P = emqx_message:payload(Msg),
+            lists:any(fun(#{payload := P1}) -> P1 == P end, Received)
+        end,
+        Expected
+    ).
 
 assert_messages_missed(Ls1, Ls2) ->
     Missed = lists:filtermap(

--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.1.10"},
+    {wolff, "4.1.11"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.5.5"},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.1.10"},
+    {wolff, "4.1.11"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.5.5"},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.1.10"},
+    {wolff, "4.1.11"},
     {kafka_protocol, "4.3.2"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.5.5"},

--- a/apps/emqx_ft/src/emqx_ft.app.src
+++ b/apps/emqx_ft/src/emqx_ft.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ft, [
     {description, "EMQX file transfer over MQTT"},
-    {vsn, "0.1.15"},
+    {vsn, "0.1.16"},
     {registered, []},
     {mod, {emqx_ft_app, []}},
     {applications, [

--- a/apps/emqx_ft/src/emqx_ft_api.erl
+++ b/apps/emqx_ft/src/emqx_ft_api.erl
@@ -269,7 +269,12 @@ format_timestamp(Timestamp) ->
 format_name(NameBin) when is_binary(NameBin) ->
     NameBin;
 format_name(Name) when is_list(Name) ->
-    iolist_to_binary(Name).
+    case unicode:characters_to_binary(Name) of
+        NameBin when is_binary(NameBin) ->
+            NameBin;
+        Error ->
+            error(Error)
+    end.
 
 limit(QueryString) ->
     maps:get(<<"limit">>, QueryString, emqx_mgmt:default_row_limit()).

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -110,6 +110,33 @@ t_list_files(Config) ->
         request_json(get, uri(["file_transfer", "files", ClientId, <<"no-such-file">>]), Config)
     ).
 
+%% Verifies that files whose names contain non-ASCII (e.g. Chinese) characters
+%% are listed correctly instead of crashing the API handler.
+t_list_files_unicode_name(Config) ->
+    ClientId = client_id(Config),
+    FileId = <<"f1">>,
+    Name = "视觉安防产品手册.pdf",
+    NameBin = unicode:characters_to_binary(Name),
+
+    Node = lists:last(test_nodes(Config)),
+    ok = emqx_ft_test_helpers:upload_file(sync, ClientId, FileId, Name, <<"data">>, Node),
+
+    {ok, 200, #{<<"files">> := Files}} =
+        request_json(get, uri(["file_transfer", "files"]), Config),
+
+    ?assertMatch(
+        [#{<<"fileid">> := FileId, <<"name">> := NameBin}],
+        [File || File = #{<<"clientid">> := CId} <- Files, CId == ClientId]
+    ),
+
+    {ok, 200, #{<<"files">> := FilesTransfer}} =
+        request_json(get, uri(["file_transfer", "files", ClientId, FileId]), Config),
+
+    ?assertMatch(
+        [#{<<"clientid">> := ClientId, <<"fileid">> := FileId, <<"name">> := NameBin}],
+        FilesTransfer
+    ).
+
 t_download_transfer(Config) ->
     ClientId = client_id(Config),
     FileId = <<"f1">>,

--- a/changes/ee/fix-18067.en.md
+++ b/changes/ee/fix-18067.en.md
@@ -1,0 +1,1 @@
+Fixed the file transfer files API (`GET /api/v5/file_transfer/files`) failing to list files whose names contain non-ASCII characters (e.g. Chinese).

--- a/changes/ee/fix-18082.en.md
+++ b/changes/ee/fix-18082.en.md
@@ -1,0 +1,3 @@
+Kafka producer: `max_linger_time` is honored again for memory-mode buffers (upgraded the Kafka client library wolff to 4.1.11). When less than a full batch is buffered, the producer waits up to `max_linger_time` for more messages before forming a produce request, reducing the produce request rate at high message rates; sending is immediate whenever a full batch's worth of data is available, and the publish path is never delayed. The default `max_linger_time = 0` keeps the previous send-immediately behavior.
+
+This also applies to Azure Event Hubs and Confluent producer connectors, which use the same client library.

--- a/mix.exs
+++ b/mix.exs
@@ -281,7 +281,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.1.10"}
+  def common_dep(:wolff), do: {:wolff, "4.1.11"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),


### PR DESCRIPTION
Includes the r58->r59 sync (zmstone:260723-sync-r58-to-r59, PR #18083) so the dev-58 fixes flow through to dev-510.