### PR TITLE
fix(datalayers): handle missing prepared ref after ecpool reconnect

### DIFF
--- a/apps/emqx_bridge_datalayers/mix.exs
+++ b/apps/emqx_bridge_datalayers/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeDatalayers.MixProject do
   def project do
     [
       app: :emqx_bridge_datalayers,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       erlc_options: UMP.strict_erlc_options(),

--- a/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
+++ b/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
@@ -363,6 +363,7 @@ proc_sql_params(
     emqx_trace:rendered_action_template(ChannelId, #{record_rows => RenderedRows}),
     [
         maps:get(prepared_refs, ChannelState),
+        PrepStmtTemplate,
         RenderedRows
         | InitArgs
     ];
@@ -434,9 +435,16 @@ connect(Opts) ->
     end.
 
 call_driver(Client, {_QueryMode, true} = FuncMode, Args0) ->
-    [PreparedRefs | Args] = Args0,
-    %% Prepared statements
-    PreparedRef = maps:get(Client, PreparedRefs),
+    [PreparedRefs, {SqlStatement0, _RowTemplates} | Args] = Args0,
+    PreparedRef =
+        case maps:find(Client, PreparedRefs) of
+            {ok, Ref} ->
+                Ref;
+            error ->
+                SqlStatement = bin(SqlStatement0),
+                {ok, Ref0} = prepare_sql_to_conn(Client, SqlStatement),
+                Ref0
+        end,
     do_call_driver(Client, driver_fun_name(FuncMode), [PreparedRef | Args]);
 call_driver(Client, {_QueryMode, false} = FuncMode, Args) ->
     do_call_driver(Client, driver_fun_name(FuncMode), Args).

--- a/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
+++ b/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
@@ -449,6 +449,11 @@ call_driver(Client, {_QueryMode, true} = FuncMode, Args0) ->
                 {ok, Ref0} = prepare_sql_to_conn(Client, SqlStatement),
                 Ref0
         end,
+    %% Clean up dead pids from the local PreparedRefs copy.
+    %% Worker pids that are no longer alive still hold prepared statement
+    %% handles on the Datalayers server (no Close action was sent).
+    %% They will be cleaned up by the server-side TTL (~1 day).
+    _ = prune_dead_refs(Client, PreparedRefs),
     do_call_driver(Client, driver_fun_name(FuncMode), [PreparedRef | Args]);
 call_driver(Client, {_QueryMode, false} = FuncMode, Args) ->
     do_call_driver(Client, driver_fun_name(FuncMode), Args).
@@ -585,6 +590,14 @@ prepare_sql_to_conn(Client, SqlStatement) ->
 
 close_statement_on_conn(Client, PrepareRef) ->
     datalayers:close_prepared(Client, PrepareRef).
+
+prune_dead_refs(CurrentClient, PreparedRefs) ->
+    maps:filter(
+        fun(Client, _Ref) ->
+            Client =:= CurrentClient orelse is_process_alive(Client)
+        end,
+        PreparedRefs
+    ).
 
 ssl_opts(InstId, #{enable := true, verify := verify_none}) ->
     ?SLOG(error, #{msg => "ssl_verify_none_not_supported", connector => InstId}),

--- a/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
+++ b/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
@@ -38,6 +38,10 @@
     prepare_sql_to_conn/2
 ]).
 
+-ifdef(TEST).
+-export([prune_dead_refs/2]).
+-endif.
+
 -type state() :: #{
     driver_type := atom(),
     channels => #{channel_id() := channel_state()},

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_SUITE.erl
@@ -342,6 +342,44 @@ t_on_get_status(Config) ->
     emqx_bridge_v2_testlib:t_on_get_status(Config1),
     ok.
 
+t_reconnect_and_write(Config) ->
+    ResourceOpts = #{<<"resource_opts">> => #{<<"health_check_interval">> => <<"1s">>}},
+    Config1 = [
+        {connector_overrides, ResourceOpts},
+        {action_overrides, ResourceOpts}
+        | Config
+    ],
+    ConnOverrides = proplists:get_value(connector_overrides, Config1, #{}),
+    KindOverrides = proplists:get_value(action_overrides, Config1, #{}),
+    ProxyHost = ?config(proxy_host, Config1),
+    ProxyPort = ?config(proxy_port, Config1),
+    ProxyName = ?config(proxy_name, Config1),
+    ?assertMatch({201, _}, emqx_bridge_v2_testlib:create_connector_api2(Config1, ConnOverrides)),
+    ?assertMatch({201, _}, emqx_bridge_v2_testlib:create_action_api2(Config1, KindOverrides)),
+    BridgeId = emqx_bridge_v2_testlib:bridge_id(Config1),
+    ResourceId = emqx_bridge_v2_testlib:connector_resource_id(Config1),
+    ?retry(
+        _Sleep1 = 200,
+        _Attempts1 = 100,
+        ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
+    ),
+    {ok, _} = emqx_resource:simple_sync_query(ResourceId, {BridgeId, make_message()}),
+    %% Simulate Datalayers restart
+    emqx_common_test_helpers:enable_failure(down, ProxyName, ProxyHost, ProxyPort),
+    ?retry(
+        _Sleep2 = 100,
+        _Attempts2 = 20,
+        ?assertEqual({ok, disconnected}, emqx_resource_manager:health_check(ResourceId))
+    ),
+    emqx_common_test_helpers:heal_failure(down, ProxyName, ProxyHost, ProxyPort),
+    ?retry(
+        _Sleep3 = 200,
+        _Attempts3 = 100,
+        ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
+    ),
+    {ok, _} = emqx_resource:simple_sync_query(ResourceId, {BridgeId, make_message()}),
+    ok.
+
 t_start_action_or_source_with_disabled_connector(Config) ->
     ok = emqx_bridge_v2_testlib:t_start_action_or_source_with_disabled_connector(Config),
     ok.
@@ -550,6 +588,20 @@ make_message(ClientId, Topic, Payload) ->
     From = emqx_message:from(Message),
     Msg = emqx_message:to_map(Message),
     Msg#{id => Id, clientid => From}.
+
+t_prune_dead_refs(_Config) ->
+    DeadPid = spawn(fun() -> ok end),
+    AlivePid = self(),
+    timer:sleep(100),
+    ?assert(not is_process_alive(DeadPid)),
+    ?assert(is_process_alive(AlivePid)),
+    RefMap = #{AlivePid => ref1, DeadPid => ref2, self() => ref3},
+    Pruned = emqx_bridge_datalayers_arrow_flight_connector:prune_dead_refs(self(), RefMap),
+    ?assertEqual(2, map_size(Pruned)),
+    ?assert(is_map_key(AlivePid, Pruned)),
+    ?assert(is_map_key(self(), Pruned)),
+    ?assertNot(is_map_key(DeadPid, Pruned)),
+    ok.
 
 cacert_file() ->
     %% XXX:

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_SUITE.erl
@@ -35,12 +35,13 @@
 
 all() ->
     [
+        t_prune_dead_refs,
         {group, with_batch},
         {group, without_batch}
     ].
 
 groups() ->
-    TCs = emqx_common_test_helpers:all(?MODULE),
+    TCs = emqx_common_test_helpers:all(?MODULE) -- [t_prune_dead_refs],
     [
         {with_batch, [
             {group, sync_query},
@@ -181,6 +182,9 @@ end_per_group(GroupName, Config) when
 end_per_group(_Group, _Config) ->
     ok.
 
+%% t_prune_dead_refs is a pure unit test, no EMQX infra needed
+init_per_testcase(t_prune_dead_refs, Config) ->
+    Config;
 init_per_testcase(Testcase, Config) when
     Testcase =/= t_start_ok
 ->
@@ -193,6 +197,8 @@ init_per_testcase(Config) ->
     emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
     Config.
 
+end_per_testcase(t_prune_dead_refs, _Config) ->
+    ok;
 end_per_testcase(_Testcase, Config) ->
     ProxyHost = ?config(proxy_host, Config),
     ProxyPort = ?config(proxy_port, Config),
@@ -591,16 +597,18 @@ make_message(ClientId, Topic, Payload) ->
 
 t_prune_dead_refs(_Config) ->
     DeadPid = spawn(fun() -> ok end),
-    AlivePid = self(),
+    CurrentPid = self(),
+    AlivePid = spawn(fun() -> timer:sleep(infinity) end),
     timer:sleep(100),
     ?assert(not is_process_alive(DeadPid)),
     ?assert(is_process_alive(AlivePid)),
-    RefMap = #{AlivePid => ref1, DeadPid => ref2, self() => ref3},
-    Pruned = emqx_bridge_datalayers_arrow_flight_connector:prune_dead_refs(self(), RefMap),
+    RefMap = #{AlivePid => ref1, DeadPid => ref2, CurrentPid => ref3},
+    Pruned = emqx_bridge_datalayers_arrow_flight_connector:prune_dead_refs(CurrentPid, RefMap),
     ?assertEqual(2, map_size(Pruned)),
     ?assert(is_map_key(AlivePid, Pruned)),
-    ?assert(is_map_key(self(), Pruned)),
+    ?assert(is_map_key(CurrentPid, Pruned)),
     ?assertNot(is_map_key(DeadPid, Pruned)),
+    exit(AlivePid, kill),
     ok.
 
 cacert_file() ->


### PR DESCRIPTION
Follow-up to #18014.

After Datalayers server restart, the old prepared statement references in `prepared_refs` map become stale. When ecpool workers reconnect, their new client pids are not in the old `prepared_refs` map, causing write failures.

### Fixes
- `call_driver`: when client pid is not found in `prepared_refs`, call `prepare_sql_to_conn` on-the-fly to create a new prepared statement
- `prune_dead_refs`: filter dead worker pids from `prepared_refs` on each query to prevent stale entry accumulation

### Tests
- `t_reconnect_and_write`: toxiproxy disconnect + reconnect verifies writes succeed after recovery
- `t_prune_dead_refs`: unit test for dead pid cleanup behavior