### PR TITLE
ci: keep redis cluster-create containers alive for compose up --wait

### DIFF
--- a/.ci/docker-compose-file/docker-compose-redis-cluster-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-cluster-tcp.yaml
@@ -33,19 +33,39 @@ services:
   redis-cluster-create:
     <<: *redis-node
     container_name: redis-cluster-create
-    command: >
-      redis-cli
+    # NOTE: keep this service alive after the one-shot cluster-create succeeds:
+    # `docker compose up --wait` fails when a waited container has exited, even
+    # with exit code 0, so exiting here is a startup race (whether the create
+    # finishes before or after the wait resolves decides pass/fail).
+    # The healthcheck also makes the wait assert the cluster actually formed,
+    # instead of merely that the create command was started.
+    command:
+      - sh
+      - -c
+      - >-
+        redis-cli
         --cluster create
-          redis-cluster-1:6379
-          redis-cluster-2:6379
-          redis-cluster-3:6379
-          redis-cluster-4:6379
-          redis-cluster-5:6379
-          redis-cluster-6:6379
+        redis-cluster-1:6379
+        redis-cluster-2:6379
+        redis-cluster-3:6379
+        redis-cluster-4:6379
+        redis-cluster-5:6379
+        redis-cluster-6:6379
         --cluster-replicas 1
         --cluster-yes
-        --pass "public"
+        --pass public
         --no-auth-warning
+        && exec tail -f /dev/null
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          redis-cli -h redis-cluster-1 -p 6379 -a public --no-auth-warning
+          cluster info | grep -q cluster_state:ok
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
     depends_on:
       - redis-cluster-1
       - redis-cluster-2

--- a/.ci/docker-compose-file/docker-compose-redis-cluster-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-cluster-tls.yaml
@@ -33,21 +33,41 @@ services:
   redis-cluster-tls-create:
     <<: *redis-node
     container_name: redis-cluster-tls-create
-    command: >
-      redis-cli
+    # NOTE: keep this service alive after the one-shot cluster-create succeeds:
+    # `docker compose up --wait` fails when a waited container has exited, even
+    # with exit code 0, so exiting here is a startup race (whether the create
+    # finishes before or after the wait resolves decides pass/fail).
+    # The healthcheck also makes the wait assert the cluster actually formed,
+    # instead of merely that the create command was started.
+    command:
+      - sh
+      - -c
+      - >-
+        redis-cli
         --cluster create
-          redis-cluster-tls-1:6389
-          redis-cluster-tls-2:6389
-          redis-cluster-tls-3:6389
-          redis-cluster-tls-4:6389
-          redis-cluster-tls-5:6389
-          redis-cluster-tls-6:6389
+        redis-cluster-tls-1:6389
+        redis-cluster-tls-2:6389
+        redis-cluster-tls-3:6389
+        redis-cluster-tls-4:6389
+        redis-cluster-tls-5:6389
+        redis-cluster-tls-6:6389
         --cluster-replicas 1
         --cluster-yes
-        --pass "public"
+        --pass public
         --no-auth-warning
         --tls
         --insecure
+        && exec tail -f /dev/null
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          redis-cli -h redis-cluster-tls-1 -p 6389 -a public --no-auth-warning
+          --tls --insecure cluster info | grep -q cluster_state:ok
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
     depends_on:
       - redis-cluster-tls-1
       - redis-cluster-tls-2


### PR DESCRIPTION
The `apps/emqx_redis` CT job intermittently fails at testbed startup with zero tests run (e.g. run 30043467992 attempt 1): the one-shot `redis-cluster-create` / `redis-cluster-tls-create` services run `redis-cli --cluster create` and exit 0, but `docker compose up --wait` (scripts/ct/run.sh) fails when a waited container has exited — even successfully. Whether the create container finishes before or after the wait resolves decides pass/fail, hence the intermittency (in the linked run the TCP create was still running and reported Healthy while the TLS one had already exited).

Fix: keep both create services alive after a successful cluster create (`&& exec tail -f /dev/null`) and give them a healthcheck that asserts `cluster_state:ok` on node 1. This removes the race and makes the wait verify the cluster actually formed (previously a create exiting 0 early passed the wait before the cluster was necessarily usable).

Verified locally: two consecutive `docker compose up --wait` cycles of both cluster files, exit 0 in ~8s, create containers report healthy.

CI-only change; no changelog.