### PR TITLE
docs(kafka): update max_linger descriptions for wolff 4.1.11 behavior

### DIFF
--- a/rel/i18n/emqx_bridge_azure_event_hub.hocon
+++ b/rel/i18n/emqx_bridge_azure_event_hub.hocon
@@ -105,13 +105,15 @@ partition_count_refresh_interval.label:
 """Partition Count Refresh Interval"""
 
 max_linger_time.desc:
-"""Maximum duration for a per-partition producer to wait for messages in order to collect a batch to buffer.
-The default value `0` means no wait. For non-memory buffer mode, it's advised to configure at least `5ms` for less IOPS."""
+"""Maximum duration a per-partition producer waits to accumulate more messages into a larger batch.
+The default value `0` means no wait (messages are sent as soon as they arrive).
+The wait ends early as soon as a full batch's worth of data has accumulated, so a busy producer is never delayed.
+When buffering to disk, the wait happens before writing to the buffer; configuring at least `5ms` is advised there to reduce disk IOPS."""
 
 max_linger_time.label: "Max Linger Time"
 
 max_linger_bytes.desc:
-"""Maximum number of bytes for a per-partition producer to wait for messages in order to collect a batch to buffer."""
+"""Maximum number of bytes a per-partition producer accumulates while waiting before it stops waiting and sends the batch."""
 
 max_linger_bytes.label: "Max Linger Bytes"
 

--- a/rel/i18n/emqx_bridge_confluent_producer.hocon
+++ b/rel/i18n/emqx_bridge_confluent_producer.hocon
@@ -105,13 +105,15 @@ partition_count_refresh_interval.label:
 """Partition Count Refresh Interval"""
 
 max_linger_time.desc:
-"""Maximum duration for a per-partition producer to wait for messages in order to collect a batch to buffer.
-The default value `0` means no wait. For non-memory buffer mode, it's advised to configure at least `5ms` for less IOPS."""
+"""Maximum duration a per-partition producer waits to accumulate more messages into a larger batch.
+The default value `0` means no wait (messages are sent as soon as they arrive).
+The wait ends early as soon as a full batch's worth of data has accumulated, so a busy producer is never delayed.
+When buffering to disk, the wait happens before writing to the buffer; configuring at least `5ms` is advised there to reduce disk IOPS."""
 
 max_linger_time.label: "Max Linger Time"
 
 max_linger_bytes.desc:
-"""Maximum number of bytes for a per-partition producer to wait for messages in order to collect a batch to buffer."""
+"""Maximum number of bytes a per-partition producer accumulates while waiting before it stops waiting and sends the batch."""
 
 max_linger_bytes.label: "Max Linger Bytes"
 

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -182,13 +182,15 @@ partition_count_refresh_interval.label:
 """Partition Count Refresh Interval"""
 
 max_linger_time.desc:
-"""Maximum duration for a per-partition producer to wait for messages in order to collect a batch to buffer.
-The default value `0` means no wait. For non-memory buffer mode, it's advised to configure at least `5ms` for less IOPS."""
+"""Maximum duration a per-partition producer waits to accumulate more messages into a larger batch.
+The default value `0` means no wait (messages are sent as soon as they arrive).
+The wait ends early as soon as a full batch's worth of data has accumulated, so a busy producer is never delayed.
+When buffering to disk, the wait happens before writing to the buffer; configuring at least `5ms` is advised there to reduce disk IOPS."""
 
 max_linger_time.label: "Max Linger Time"
 
 max_linger_bytes.desc:
-"""Maximum number of bytes for a per-partition producer to wait for messages in order to collect a batch to buffer."""
+"""Maximum number of bytes a per-partition producer accumulates while waiting before it stops waiting and sends the batch."""
 
 max_linger_bytes.label: "Max Linger Bytes"
 


### PR DESCRIPTION
Follow-up to #18082 (wolff 4.1.10 -> 4.1.11): update the `max_linger_time` / `max_linger_bytes` descriptions in the Kafka, Confluent, and Azure Event Hubs producer i18n files, which still described the old behavior (lingering only before writing to the buffer, with the memory-mode caveat implied).

New wording reflects wolff 4.1.11 semantics: the producer waits up to `max_linger_time` to accumulate a larger batch in all buffer modes; the wait ends early once a full batch has accumulated (a busy producer is never delayed); the disk-IOPS advice is kept for disk-mode buffering.

Docs/i18n only; no behavior change, no changelog.