### PR TITLE
fix(sessmem): preserve order by stopping delivery on rate limit

### DIFF
--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -546,10 +546,13 @@ do_deliver(_ClientInfo, [], Publishes, _CheckLimiter, Session) ->
     {ok, lists:reverse(Publishes), Session};
 do_deliver(ClientInfo, [Msg | More], Acc, CheckLimiter, Session) ->
     case deliver_msg(ClientInfo, Msg, CheckLimiter, Session) of
-        {ok, [], Session1} ->
+        {ok, Session1} ->
             do_deliver(ClientInfo, More, Acc, CheckLimiter, Session1);
         {ok, [Publish], Session1} ->
-            do_deliver(ClientInfo, More, [Publish | Acc], CheckLimiter, Session1)
+            do_deliver(ClientInfo, More, [Publish | Acc], CheckLimiter, Session1);
+        {blocked, Session1} ->
+            Session2 = enqueue(ClientInfo, More, Session1),
+            {ok, lists:reverse(Acc), Session2}
     end.
 
 deliver_msg(_ClientInfo, Msg = #message{qos = ?QOS_0}, CheckLimiter, Session) ->
@@ -562,7 +565,7 @@ deliver_msg(_ClientInfo, Msg = #message{qos = ?QOS_0}, CheckLimiter, Session) ->
             {ok, Publishes, Session};
         {error, Reason} ->
             log_rate_limit_reason(Reason, Msg),
-            {ok, [], Session}
+            {ok, Session}
     end;
 deliver_msg(
     ClientInfo,
@@ -580,11 +583,11 @@ deliver_msg(
                     true -> Session;
                     false -> enqueue_msg(ClientInfo, Msg, Session)
                 end,
-            {ok, [], Session1};
+            {ok, Session1};
         {false, {error, Reason}} ->
             log_rate_limit_reason(Reason, Msg),
             Session1 = enqueue_msg(ClientInfo, Msg, Session),
-            {ok, [], Session1};
+            {blocked, Session1};
         {false, _} ->
             %% `RateLimiterRes :: false | ok` here.
             %%

--- a/apps/emqx/test/emqx_session_mem_SUITE.erl
+++ b/apps/emqx/test/emqx_session_mem_SUITE.erl
@@ -639,6 +639,45 @@ test_retry_dequeue(QoS, _TCConfig) ->
     ok.
 
 -doc """
+Verifies that delivery limits do not compromise message ordering.
+""".
+t_delivery_rate_limit_preserves_qos12_order(_TCConfig) ->
+    ListenerId = 'tcp:ordering',
+    LimiterConfig0 = #{<<"delivery_bytes_rate">> => <<"10KB/5s">>},
+    Limiter0 = create_limiters(ListenerId, LimiterConfig0),
+    Session0 = session(),
+    %% Out of 3 messages, either `t1` fits into delivery limit or `t0` & `t2`.
+    Delivers = enrich(
+        [
+            delivery(?QOS_1, <<"t0">>, binary:copy(<<"x">>, 4000)),
+            delivery(?QOS_1, <<"t1">>, binary:copy(<<"x">>, 8000)),
+            delivery(?QOS_1, <<"t2">>, <<"x">>)
+        ],
+        Session0
+    ),
+    put_context(#{limiter => Limiter0}),
+    %% Delivery limit admits `t0` delivery but not `t1`, this should make both `t1` & `t2`
+    %% enter mqueue.
+    {ok, [_Msg1], Session1} = emqx_session_mem:deliver(clientinfo(), Delivers, Session0),
+    Ctx1 = pop_context(),
+    ?assertMatch(#{limiter := _, ?RETRY_DEQUEUE_TIMER := _}, Ctx1),
+    ?assertEqual(1, emqx_session_mem:info(inflight_cnt, Session1)),
+    ?assertEqual(2, emqx_session_mem:info(mqueue_len, Session1)),
+    ?assertMatch(
+        {[#message{topic = <<"t1">>}, #message{topic = <<"t2">>}], _},
+        emqx_session_mem:info({mqueue_msgs, #{position => none, limit => 10}}, Session1)
+    ),
+    %% After cooldown, both `t1` and `t2` should pass through.
+    Limiter1 = restart_limiters(ListenerId, LimiterConfig0),
+    put_context(#{limiter => Limiter1}),
+    {ok, Publishes, _Session2} =
+        emqx_session_mem:handle_timeout(clientinfo(), ?RETRY_DEQUEUE_TIMER, Session1),
+    ?assertMatch(
+        [{_, #message{topic = <<"t1">>}}, {_, #message{topic = <<"t2">>}}],
+        Publishes
+    ).
+
+-doc """
 Verifies that we apply delivery rate limiters when processing a `PUBACK`.
 """.
 t_delivery_rate_limit_puback(_TCConfig) ->
@@ -829,6 +868,9 @@ subopts(Init) ->
 
 delivery(QoS, Topic) ->
     Payload = emqx_guid:to_hexstr(emqx_guid:gen()),
+    {deliver, Topic, emqx_message:make(test, QoS, Topic, Payload)}.
+
+delivery(QoS, Topic, Payload) ->
     {deliver, Topic, emqx_message:make(test, QoS, Topic, Payload)}.
 
 delivery(QoS, Topic, Payload, ExpiryInterval) ->

--- a/changes/ee/fix-18102.en.md
+++ b/changes/ee/fix-18102.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where MQTT clients could receive QoS 1 and QoS 2 messages out of order when a delivery rate limit was active. EMQX now keeps later messages queued until the blocked message can be sent.


### PR DESCRIPTION
Release version: 6.1.4, 6.2.3

## Summary

Before this fix, `emqx_session_mem:deliver/4` could effectively reorder messages by pushing messages into the socket after hitting a delivery rate limit and putting one or more message into the mqueue.

See also #17870 and 302786d1e7e0230ed5528fad6a9568fe2bb9a542.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
