### PR TITLE
fix(dashboard): tolerate node sampling failures in cluster metrics

### DIFF
--- a/.github/workflows/run_helm_tests.yaml
+++ b/.github/workflows/run_helm_tests.yaml
@@ -141,8 +141,11 @@ jobs:
         nohup bash -c "while true; do kubectl port-forward service/${EMQX_NAME} 18083:18083 ; sleep 1 ; done" &
     - name: Get auth token
       run: |
-        curl --head -X GET --retry 10 --retry-connrefused --retry-delay 6 http://localhost:18083/status
-        echo "TOKEN=$(curl --silent -X 'POST' 'http://127.0.0.1:18083/api/v5/login' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"username": "admin","password": "public"}' | jq -r ".token")" >> $GITHUB_ENV
+        # kubectl port-forward accepts the local TCP connection even when the pod is
+        # not serving yet, so a not-ready dashboard yields "empty reply" (curl error
+        # 52) rather than "connection refused"; --retry-all-errors covers both.
+        curl --head -X GET --retry 10 --retry-all-errors --retry-delay 6 http://localhost:18083/status
+        echo "TOKEN=$(curl --silent --retry 10 --retry-all-errors --retry-delay 6 -X 'POST' 'http://127.0.0.1:18083/api/v5/login' -H 'accept: application/json' -H 'Content-Type: application/json' -d '{"username": "admin","password": "public"}' | jq -r ".token")" >> $GITHUB_ENV
     - name: Check cluster
       timeout-minutes: 1
       run: |

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -133,7 +133,7 @@ current_rate(Node) when Node == node() ->
                 {Key, 0}
              || Key <- ?GAUGE_SAMPLER_LIST ++ maps:values(?DELTA_SAMPLER_RATE_MAP)
             ],
-            {ok, maps:merge(maps:from_list(Rate0), non_rate_value())}
+            {ok, maps:merge(maps:from_list(Rate0), safe_non_rate_value())}
     end;
 current_rate(Node) ->
     case emqx_dashboard_proto_v2:current_rate(Node) of
@@ -729,6 +729,17 @@ stats(persisted) ->
 
 %% -------------------------------------------------------------------------------------------------
 %% Retained && License Quota
+
+%% The stats tables backing these values are absent while the node is restarting
+%% applications (e.g. when joining a cluster); return an empty map then, rather than
+%% zeros which would overwrite real values in the cluster-wide aggregate.
+safe_non_rate_value() ->
+    try
+        non_rate_value()
+    catch
+        _:_ ->
+            #{}
+    end.
 
 %% the non rate values should be same on all nodes
 non_rate_value() ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -161,7 +161,8 @@ monitor(delete, _) ->
     Nodes = emqx:running_nodes(),
     Results = emqx_dashboard_proto_v2:clear_table(Nodes),
     NodeResults = lists:zip(Nodes, Results),
-    NodeErrors = [Result || Result = {_Node, NOk} <- NodeResults, NOk =/= {atomic, ok}],
+    %% clear_table is an erpc multicall: each per-node success is {ok, {atomic, ok}}
+    NodeErrors = [Result || Result = {_Node, NOk} <- NodeResults, NOk =/= {ok, {atomic, ok}}],
     NodeErrors == [] orelse
         ?SLOG(warning, #{
             msg => "clear_monitor_metrics_rpc_errors",

--- a/apps/emqx_dashboard/src/proto/emqx_dashboard_proto_v2.erl
+++ b/apps/emqx_dashboard/src/proto/emqx_dashboard_proto_v2.erl
@@ -31,14 +31,18 @@
 introduced_in() ->
     "5.8.4".
 
+%% Uses rpc (not erpc) so that failures are returned as {badrpc, _} for the
+%% callers to tolerate, rather than raised.
 -spec do_sample(node(), Latest :: pos_integer() | infinity) -> list(map()) | emqx_rpc:badrpc().
 do_sample(Node, Latest) ->
-    erpc:call(Node, emqx_dashboard_monitor, do_sample, [Node, Latest], ?RPC_TIMEOUT).
+    rpc:call(Node, emqx_dashboard_monitor, do_sample, [Node, Latest], ?RPC_TIMEOUT).
 
 -spec clear_table(Nodes :: [node()]) -> emqx_rpc:erpc_multicall(ok).
 clear_table(Nodes) ->
     erpc:multicall(Nodes, emqx_dashboard_monitor, clear_table, [], ?RPC_TIMEOUT).
 
+%% Uses rpc (not erpc) so that failures are returned as {badrpc, _} for the
+%% callers to tolerate, rather than raised.
 -spec current_rate(node()) -> {ok, map()} | emqx_rpc:badrpc().
 current_rate(Node) ->
-    erpc:call(Node, emqx_dashboard_monitor, current_rate, [Node], ?RPC_TIMEOUT).
+    rpc:call(Node, emqx_dashboard_monitor, current_rate, [Node], ?RPC_TIMEOUT).

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -123,6 +123,19 @@ end_per_group(common, Config) ->
     emqx_cth_suite:stop(Apps),
     ok.
 
+init_per_testcase(t_monitor_current_node_restarting_apps = TestCase, Config) ->
+    Port = 28085,
+    NodeSpecs = [
+        {monitor_node_restarting1, #{apps => cluster_node_appspec(true, Port)}},
+        {monitor_node_restarting2, #{apps => cluster_node_appspec(false, Port)}}
+    ],
+    Nodes =
+        [N1 | _] = emqx_cth_cluster:start(
+            NodeSpecs,
+            #{work_dir => emqx_cth_suite:work_dir(TestCase, Config)}
+        ),
+    ok = snabbkaffe:start_trace(),
+    [{nodes, Nodes}, {api_node, N1} | Config];
 init_per_testcase(t_smoke_test_monitor_multiple_windows = TestCase, Config) ->
     Port = 28083,
     NodeSpecs = [
@@ -141,6 +154,11 @@ init_per_testcase(_TestCase, Config) ->
     ct:timetrap({seconds, 30}),
     Config.
 
+end_per_testcase(t_monitor_current_node_restarting_apps, Config) ->
+    Nodes = ?config(nodes, Config),
+    ok = snabbkaffe:stop(),
+    ok = emqx_cth_cluster:stop(Nodes),
+    ok;
 end_per_testcase(t_smoke_test_monitor_multiple_windows, Config) ->
     Nodes = ?config(nodes, Config),
     ok = snabbkaffe:stop(),
@@ -858,6 +876,28 @@ t_smoke_test_monitor_multiple_windows(Config) ->
         )
     end),
     ok = emqtt:stop(PSClient2),
+    ok.
+
+%% Regression test for emqx/emqx#17747: `GET /monitor_current` must not return 500 when
+%% a cluster node is restarting its applications (as happens on `emqx ctl cluster join`).
+%% While the joining node's `emqx` application is down its stats ETS tables are absent,
+%% so sampling on that node crashes with `badarg`.  The proto module used erpc, which
+%% re-raised the crash on the API node instead of returning the {badrpc, _} the callers
+%% tolerate, so it escaped `current_rate_cluster/0` and surfaced as 500 INTERNAL_ERROR.
+t_monitor_current_node_restarting_apps(Config) ->
+    [N1, N2 | _] = ?config(nodes, Config),
+    %% Simulate the mid-join window: N2 is alive and still a running mria cluster
+    %% node, but its `emqx' application (and thus the `emqx_stats' table) is down.
+    ok = ?ON(N2, application:stop(emqx)),
+    ?assert(lists:member(N2, ?ON(N1, mria:cluster_nodes(running)))),
+    %% The cluster-wide aggregate must degrade instead of crashing.
+    ?assertMatch({ok, #{}}, ?ON(N1, emqx_dashboard_monitor:current_rate(all))),
+    %% And the REST endpoint must respond 200 with the aggregate of healthy nodes.
+    ?assertMatch(
+        {ok, #{<<"connections">> := _}},
+        get_req_cluster(Config, ["monitor_current"], "")
+    ),
+    ok = ?ON(N2, application:start(emqx)),
     ok.
 
 request(Path) ->

--- a/changes/ee/fix-18107.en.md
+++ b/changes/ee/fix-18107.en.md
@@ -1,0 +1,5 @@
+Fixed an issue where the dashboard metrics APIs (`GET /api/v5/monitor_current` and `GET /api/v5/monitor`) returned `500 INTERNAL_ERROR` while a node was joining the cluster.
+
+While a joining node is restarting its applications, sampling its metrics fails; this failure is now tolerated: the APIs return the aggregate of the remaining reachable nodes and log a warning, instead of failing the whole request.
+
+Also fixed a spurious `clear_monitor_metrics_rpc_errors` warning that was logged on every successful `DELETE /api/v5/monitor` request.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

## Summary

Fixes #17747.

After `emqx_ctl cluster join`, the master's dashboard `GET /api/v5/monitor_current` returned `500 INTERNAL_ERROR` while the joining node was restarting its applications.

Root cause: while the joining node's `emqx` application is down, its stats ETS tables are absent, so sampling on that node crashes with `badarg` (`ets:lookup(emqx_stats, 'retained.count')`). `emqx_dashboard_proto_v2` calls the sampling functions via `erpc`, which **raises** remote failures instead of returning `{badrpc, _}` like the `rpc`-based proto v1 did — but the callers still match `{badrpc, _}` returns. The crash therefore escaped the per-node failure tolerance in `current_rate_cluster/0` and surfaced as a 500. `GET /api/v5/monitor` is affected the same way via `do_sample`.

Fix:
- Restore `rpc` in proto v2 for `current_rate` and `do_sample`, so failures are returned as `{badrpc, _}` and the existing caller-side tolerance works again: the failing node is partitioned out of the aggregate (logged as `failed_to_sample_current_rate`) and the API responds with the data of the remaining nodes. The BPAPI target functions and signatures are unchanged, so no proto version bump is needed.
- Make the local sampling fallback tolerate absent stats tables: degrade to an empty non-rate-value map rather than crashing (or fabricating zeros that would overwrite cluster-synced values such as the retained message count).
- Fix `DELETE /api/v5/monitor` result matching: `clear_table` is an erpc multicall whose per-node success is `{ok, {atomic, ok}}`, but the handler compared against `{atomic, ok}`, logging a spurious `clear_monitor_metrics_rpc_errors` warning on every successful call.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
