### PR TITLE
fix(certs): never delete managed cert bundles that are still referenced

### DIFF
--- a/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
@@ -1051,12 +1051,11 @@ t_managed_certs(TCConfig) when is_list(TCConfig) ->
         }
     }),
     {201, _} = create_action_api(TCConfig, #{}),
-    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    #{topic := Topic, id := RuleId} = simple_create_rule_api(TCConfig),
     C = start_client(),
     emqtt:publish(C, Topic, <<"hey">>, [{qos, 1}]),
     ?assertReceive({http, _, _}, 2_000),
-    %% When configurations depend on the managed certs, unless we force it, we deny
-    %% deleting them.
+    %% When configurations depend on the managed certs, we deny deleting them.
     ?assertMatch(
         {400, #{
             <<"referencing_configs">> := #{<<"global">> := [[<<"connectors">>, <<"http">>, _]]}
@@ -1069,16 +1068,32 @@ t_managed_certs(TCConfig) when is_list(TCConfig) ->
         }},
         delete_global_managed_certs_file(BundleName, <<"ca">>, #{})
     ),
-    %% Override check
+    %% `force_delete' is ignored: deletion is refused while the connector still
+    %% references the bundle.
     ?assertMatch(
-        {204, _},
+        {400, #{
+            <<"referencing_configs">> := #{<<"global">> := [[<<"connectors">>, <<"http">>, _]]}
+        }},
         delete_global_managed_certs_file(
             BundleName,
             <<"ca">>,
             #{force_delete => true}
         )
     ),
-    ?assertMatch({204, _}, delete_global_managed_certs_bundle(BundleName, #{force_delete => true})),
+    ?assertMatch(
+        {400, #{
+            <<"referencing_configs">> := #{<<"global">> := [[<<"connectors">>, <<"http">>, _]]}
+        }},
+        delete_global_managed_certs_bundle(BundleName, #{force_delete => true})
+    ),
+    %% Once the referencing connector is gone, deletion succeeds.
+    #{type := ActionType, name := ActionName} = emqx_bridge_v2_testlib:get_common_values(
+        TCConfig
+    ),
+    {204, _} = emqx_bridge_v2_testlib:delete_rule_api(RuleId),
+    {204, _} = emqx_bridge_v2_testlib:delete_kind_api(action, ActionType, ActionName),
+    {204, _} = emqx_bridge_v2_testlib:delete_connector_api(TCConfig),
+    ?assertMatch({204, _}, delete_global_managed_certs_bundle(BundleName, #{})),
     ok.
 
 -doc """

--- a/apps/emqx_management/src/emqx_mgmt_api_certs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_certs.erl
@@ -110,10 +110,11 @@ schema("/certs/global/name/:name") ->
         delete => #{
             tags => ?TAGS,
             description => ?DESC("global_bundle_delete"),
-            parameters => [param_path_bundle_name(), param_qs_file_kind(), param_qs_force_delete()],
+            parameters => [param_path_bundle_name(), param_qs_file_kind()],
             responses =>
                 #{
                     204 => <<"">>,
+                    400 => bad_request(?DESC("bad_request")),
                     500 => internal_error(?DESC("internal_error"))
                 }
         }
@@ -173,12 +174,12 @@ schema("/certs/ns/:namespace/name/:name") ->
             parameters => [
                 param_path_ns(),
                 param_path_bundle_name(),
-                param_qs_file_kind(),
-                param_qs_force_delete()
+                param_qs_file_kind()
             ],
             responses =>
                 #{
                     204 => <<"">>,
+                    400 => bad_request(?DESC("bad_request")),
                     500 => internal_error(?DESC("internal_error"))
                 }
         }
@@ -243,9 +244,6 @@ param_qs_file_kind() ->
             }
         )}.
 
-param_qs_force_delete() ->
-    {force_delete, mk(boolean(), #{in => query, default => false, required => false})}.
-
 upload_files_request_body() ->
     hoconsc:mk(ref(files_in), #{
         converter => fun upload_files_request_body_converter/2,
@@ -297,9 +295,9 @@ internal_error(Desc) -> emqx_dashboard_swagger:error_codes([?INTERNAL_ERROR], De
     #{query_string := QueryParams} = Req,
     case QueryParams of
         #{<<"kind">> := Kind} ->
-            handle_delete_file(?global_ns, BundleName, Kind, QueryParams);
+            handle_delete_file(?global_ns, BundleName, Kind);
         _ ->
-            handle_delete_bundle(?global_ns, BundleName, QueryParams)
+            handle_delete_bundle(?global_ns, BundleName)
     end.
 
 '/certs/ns/:namespace/list'(get, #{bindings := #{namespace := Namespace}} = _Req) ->
@@ -319,9 +317,9 @@ internal_error(Desc) -> emqx_dashboard_swagger:error_codes([?INTERNAL_ERROR], De
     } = Req,
     case QueryParams of
         #{<<"kind">> := Kind} ->
-            handle_delete_file(Namespace, BundleName, Kind, QueryParams);
+            handle_delete_file(Namespace, BundleName, Kind);
         _ ->
-            handle_delete_bundle(Namespace, BundleName, QueryParams)
+            handle_delete_bundle(Namespace, BundleName)
     end.
 
 %%-------------------------------------------------------------------------------------------------
@@ -377,8 +375,8 @@ handle_list_files(Namespace, BundleName) ->
             ?INTERNAL_ERROR(emqx_utils:explain_posix(Reason))
     end.
 
-handle_delete_bundle(Namespace, BundleName, QueryParams) ->
-    case validate_no_dependencies(QueryParams, Namespace, BundleName) of
+handle_delete_bundle(Namespace, BundleName) ->
+    case validate_no_dependencies(Namespace, BundleName) of
         ok ->
             do_handle_delete_bundle(Namespace, BundleName);
         {error, Return} ->
@@ -393,8 +391,8 @@ do_handle_delete_bundle(Namespace, BundleName) ->
             ?INTERNAL_ERROR(Errors)
     end.
 
-handle_delete_file(Namespace, BundleName, Kind, QueryParams) ->
-    case validate_no_dependencies(QueryParams, Namespace, BundleName) of
+handle_delete_file(Namespace, BundleName, Kind) ->
+    case validate_no_dependencies(Namespace, BundleName) of
         ok ->
             do_handle_delete_file(Namespace, BundleName, Kind);
         {error, Return} ->
@@ -409,9 +407,7 @@ do_handle_delete_file(Namespace, BundleName, Kind) ->
             ?INTERNAL_ERROR(Errors)
     end.
 
-validate_no_dependencies(#{<<"force_delete">> := true}, _Namespace, _BundleName) ->
-    ok;
-validate_no_dependencies(_QueryParams, Namespace, BundleName) ->
+validate_no_dependencies(Namespace, BundleName) ->
     case emqx_managed_certs:find_references(Namespace, BundleName) of
         [] ->
             ok;

--- a/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
@@ -1334,3 +1334,69 @@ t_delete_referenced_bundle_ns(_TCConfig) ->
     ?assertMatch({204, _}, delete_bundle_ns(Ns, Bundle)),
 
     ok.
+
+-doc """
+Verifies that the Prometheus stats scrape does not fail entirely when a listener
+references a managed certificate bundle that no longer exists on disk: the scrape
+returns 200 with the other metrics present, and the affected listener simply
+contributes no cert-expiry point.
+""".
+t_prometheus_stats_dangling_managed_certs() ->
+    [{matrix, true}].
+t_prometheus_stats_dangling_managed_certs(matrix) ->
+    [[?local]];
+t_prometheus_stats_dangling_managed_certs(_TCConfig) ->
+    #{cert_key := CertKeyRoot} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := CA} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := Cert, key_pem := Key} = gen_cert(#{key => ec, issuer => CertKeyRoot}),
+
+    Bundle = <<"dangling_bundle">>,
+    Files = [
+        {?FILE_KIND_CA_BIN, <<"ca.pem">>, CA},
+        {?FILE_KIND_CHAIN_BIN, <<"chain.pem">>, Cert},
+        {?FILE_KIND_KEY_BIN, <<"key.pem">>, Key}
+    ],
+    ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
+
+    {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
+    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    TLSListenerManaged = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        [#{<<"bundle_name">> => Bundle}]
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerManaged)),
+
+    %% Remove the bundle directory behind the API's back, simulating a dangling
+    %% reference (e.g. left behind by an older release that allowed force-deleting a
+    %% referenced bundle).
+    ok = file:del_dir_r(emqx_managed_certs:dir(?global_ns, Bundle)),
+
+    {200, Metrics} = get_prometheus_stats(
+        ?PROM_DATA_MODE__ALL_NODES_UNAGGREGATED, prometheus
+    ),
+    Expiry = maps:get(<<"emqx_cert_expiry_at">>, Metrics),
+    %% The listener with the dangling reference contributes no point.
+    ?assertNot(
+        is_map_key(
+            #{
+                <<"listener_name">> => <<"default">>,
+                <<"listener_type">> => <<"ssl">>
+            },
+            Expiry
+        ),
+        Expiry
+    ),
+    %% Other listeners' points are still collected.
+    ?assert(
+        is_map_key(
+            #{
+                <<"listener_name">> => <<"default">>,
+                <<"listener_type">> => <<"wss">>
+            },
+            Expiry
+        ),
+        Expiry
+    ),
+
+    ok.

--- a/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
@@ -234,6 +234,22 @@ force_delete_bundle_global(BundleName) ->
         query_params => #{<<"force_delete">> => <<"true">>}
     }).
 
+force_delete_file_global(BundleName, Kind) ->
+    URL = emqx_mgmt_api_test_util:api_path(["certs", "global", "name", BundleName]),
+    simple_request(#{
+        method => delete,
+        url => URL,
+        query_params => #{<<"kind">> => Kind, <<"force_delete">> => <<"true">>}
+    }).
+
+force_delete_bundle_ns(Ns, BundleName) ->
+    URL = emqx_mgmt_api_test_util:api_path(["certs", "ns", Ns, "name", BundleName]),
+    simple_request(#{
+        method => delete,
+        url => URL,
+        query_params => #{<<"force_delete">> => <<"true">>}
+    }).
+
 delete_file_global(BundleName, Kind) ->
     URL = emqx_mgmt_api_test_util:api_path(["certs", "global", "name", BundleName]),
     simple_request(#{
@@ -1018,8 +1034,8 @@ t_managed_certs_prometheus_expiry_date(_TCConfig) ->
 
 -doc """
 Verifies that a listener using a managed certificate bundle can be switched back to
-file-based (default) certificates even after the bundle has been force-deleted.  The
-stale `managed_certs` reference must not survive the update and block it.
+file-based (default) certificates even after the bundle has been deleted out-of-band.
+The stale `managed_certs` reference must not survive the update and block it.
 """.
 t_switch_off_deleted_managed_bundle() ->
     [{matrix, true}].
@@ -1050,8 +1066,9 @@ t_switch_off_deleted_managed_bundle(_TCConfig) ->
     ),
     ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerManaged)),
 
-    %% Force-delete the bundle while the listener still references it.
-    ?assertMatch({204, _}, force_delete_bundle_global(Bundle)),
+    %% Delete the bundle out-of-band while the listener still references it; the API
+    %% refuses to delete a referenced bundle.
+    ok = emqx_managed_certs:delete_bundle(?global_ns, Bundle),
 
     %% Switching back to the original file-based config must succeed even though the
     %% bundle is gone, and the resulting config must no longer reference managed certs.
@@ -1140,8 +1157,8 @@ t_switch_to_missing_managed_bundle(_TCConfig) ->
 -doc """
 Verifies that a listener using a managed certificate bundle can be switched back to
 file-based certificates when the update request clears `managed_certs` by sending it
-as JSON `null` (how the Dashboard clears it), even after the bundle has been
-force-deleted.
+as JSON `null` (how the Dashboard clears it), even after the bundle has been deleted
+out-of-band.
 """.
 t_switch_off_deleted_managed_bundle_null() ->
     [{matrix, true}].
@@ -1172,8 +1189,9 @@ t_switch_off_deleted_managed_bundle_null(_TCConfig) ->
     ),
     ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerManaged)),
 
-    %% Force-delete the bundle while the listener still references it.
-    ?assertMatch({204, _}, force_delete_bundle_global(Bundle)),
+    %% Delete the bundle out-of-band while the listener still references it; the API
+    %% refuses to delete a referenced bundle.
+    ok = emqx_managed_certs:delete_bundle(?global_ns, Bundle),
 
     %% Switch back to file-based certs with an explicit `managed_certs: null` in the
     %% request, as the Dashboard sends it.  The update must succeed and the resulting
@@ -1218,5 +1236,101 @@ t_managed_certs_empty_list_rejected(_TCConfig) ->
         }},
         update_listener_api(<<"ssl">>, <<"default">>, TLSListenerEmpty)
     ),
+
+    ok.
+
+-doc """
+Verifies that a bundle (or a single file in it) that is still referenced by some
+configuration can never be deleted: the delete endpoint returns 400, and the
+`force_delete` query parameter no longer bypasses the reference check.
+""".
+t_delete_referenced_bundle() ->
+    [{matrix, true}].
+t_delete_referenced_bundle(matrix) ->
+    [[?local]];
+t_delete_referenced_bundle(_TCConfig) ->
+    #{cert_key := CertKeyRoot} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := CA} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := Cert, key_pem := Key} = gen_cert(#{key => ec, issuer => CertKeyRoot}),
+
+    Bundle = <<"referenced_bundle">>,
+    Files = [
+        {?FILE_KIND_CA_BIN, <<"ca.pem">>, CA},
+        {?FILE_KIND_CHAIN_BIN, <<"chain.pem">>, Cert},
+        {?FILE_KIND_KEY_BIN, <<"key.pem">>, Key}
+    ],
+    ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
+
+    {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
+    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    TLSListenerManaged = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        [#{<<"bundle_name">> => Bundle}]
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerManaged)),
+
+    %% While referenced, deletion is refused, with or without `force_delete`.
+    ExpectedRefs = #{<<"global">> => [[<<"listeners">>, <<"ssl">>, <<"default">>]]},
+    ?assertMatch(
+        {400, #{<<"referencing_configs">> := ExpectedRefs}},
+        delete_bundle_global(Bundle)
+    ),
+    ?assertMatch(
+        {400, #{<<"referencing_configs">> := ExpectedRefs}},
+        force_delete_bundle_global(Bundle)
+    ),
+    ?assertMatch(
+        {400, #{<<"referencing_configs">> := ExpectedRefs}},
+        delete_file_global(Bundle, ?FILE_KIND_CA_BIN)
+    ),
+    ?assertMatch(
+        {400, #{<<"referencing_configs">> := ExpectedRefs}},
+        force_delete_file_global(Bundle, ?FILE_KIND_CA_BIN)
+    ),
+
+    %% Once unreferenced, deletion succeeds, with or without the (ignored) parameter.
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListener0)),
+    ?assertMatch({204, _}, force_delete_file_global(Bundle, ?FILE_KIND_CA_BIN)),
+    ?assertMatch({204, _}, delete_bundle_global(Bundle)),
+
+    ok.
+
+-doc """
+Verifies that a namespaced bundle that is still referenced by some configuration
+cannot be deleted via the namespaced endpoint, even with `force_delete=true`.
+""".
+t_delete_referenced_bundle_ns() ->
+    [{matrix, true}].
+t_delete_referenced_bundle_ns(matrix) ->
+    [[?local]];
+t_delete_referenced_bundle_ns(_TCConfig) ->
+    #{cert_key := CertKeyRoot} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := CA} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := Cert, key_pem := Key} = gen_cert(#{key => ec, issuer => CertKeyRoot}),
+
+    Ns = <<"ns1">>,
+    Bundle = <<"referenced_ns_bundle">>,
+    Files = [
+        {?FILE_KIND_CA_BIN, <<"ca.pem">>, CA},
+        {?FILE_KIND_CHAIN_BIN, <<"chain.pem">>, Cert},
+        {?FILE_KIND_KEY_BIN, <<"key.pem">>, Key}
+    ],
+    ?assertMatch({204, _}, upload_files_multipart_ns(Ns, Bundle, Files)),
+
+    {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
+    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    TLSListenerManaged = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        [#{<<"bundle_name">> => Bundle, <<"namespace">> => Ns}]
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerManaged)),
+
+    ?assertMatch({400, #{<<"referencing_configs">> := _}}, delete_bundle_ns(Ns, Bundle)),
+    ?assertMatch({400, #{<<"referencing_configs">> := _}}, force_delete_bundle_ns(Ns, Bundle)),
+
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListener0)),
+    ?assertMatch({204, _}, delete_bundle_ns(Ns, Bundle)),
 
     ok.

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -1272,7 +1272,7 @@ do_points_of_listeners(Type, Listeners) ->
     lists:foldl(
         fun(Name, PointsAcc) ->
             #{Name := Listener} = Listeners,
-            case resolve_listener_certfile(Listener) of
+            case resolve_listener_certfile(Type, Name, Listener) of
                 error ->
                     PointsAcc;
                 {ok, Certfile} ->
@@ -1287,15 +1287,29 @@ do_points_of_listeners(Type, Listeners) ->
 gen_point_cert_expiry_at(Type, Name, Path) ->
     {[{listener_type, Type}, {listener_name, Name}], cert_expiry_at_from_path(Path)}.
 
-resolve_listener_certfile(#{enable := true, ssl_options := #{} = SSLOpts0}) ->
-    SSLOpts = emqx_tls_lib:to_server_opts(tls, SSLOpts0),
-    case lists:keyfind(certfile, 1, SSLOpts) of
-        {certfile, Certfile} ->
-            {ok, Certfile};
-        _ ->
+resolve_listener_certfile(Type, Name, #{enable := true, ssl_options := #{} = SSLOpts0}) ->
+    %% `to_server_opts' throws when a `managed_certs' reference cannot be resolved
+    %% (e.g. the bundle was deleted out-of-band); one bad listener must not fail the
+    %% whole scrape.
+    try emqx_tls_lib:to_server_opts(tls, SSLOpts0) of
+        SSLOpts ->
+            case lists:keyfind(certfile, 1, SSLOpts) of
+                {certfile, Certfile} ->
+                    {ok, Certfile};
+                _ ->
+                    error
+            end
+    catch
+        throw:Reason ->
+            ?SLOG(warning, #{
+                msg => "failed_to_resolve_listener_certfile",
+                listener_type => Type,
+                listener_name => Name,
+                reason => Reason
+            }),
             error
     end;
-resolve_listener_certfile(#{}) ->
+resolve_listener_certfile(_Type, _Name, #{}) ->
     error.
 
 %% TODO: cert manager for more generic utils functions

--- a/changes/ee/fix-18108.en.md
+++ b/changes/ee/fix-18108.en.md
@@ -1,0 +1,3 @@
+Deleting a managed certificate bundle (or a single file in it) that is still referenced by some configuration now always fails with a clear error listing the referencing configurations; the `force_delete` query parameter no longer bypasses this check and has been removed from the API schema.
+
+Additionally, the Prometheus stats endpoint no longer fails entirely when a listener references a certificate bundle that is missing from disk; the affected listener is skipped in the certificate expiry metric and a warning is logged.

--- a/rel/i18n/emqx_mgmt_api_certs.hocon
+++ b/rel/i18n/emqx_mgmt_api_certs.hocon
@@ -37,13 +37,15 @@ emqx_mgmt_api_certs {
 
     global_bundle_delete {
         desc: """~
-            Delete a global namespace bundle.~"""
+            Delete a global namespace bundle, or a single file in it when the `kind` query parameter is set.
+            Deletion is refused while any configuration still references the bundle.~"""
         label: "Delete Bundle"
     }
 
     ns_bundle_delete {
         desc: """~
-            Delete a managed namespace bundle.~"""
+            Delete a managed namespace bundle, or a single file in it when the `kind` query parameter is set.
+            Deletion is refused while any configuration still references the bundle.~"""
         label: "Delete Bundle"
     }
 


### PR DESCRIPTION
Release version:
6.1.4, 6.2.3, 6.3.0

## Summary

Fixes #18046.

A managed cert bundle (or a file in it) that is still referenced by any configuration can no longer be deleted: the delete endpoints always return 400 listing the referencing config paths.  The `force_delete` query parameter, which bypassed the reference check since #16447, is removed from the API schema.  Removal (rather than accept-but-ignore) was chosen because the API framework validates only declared query parameters, so existing callers passing `force_delete=true` simply have it ignored and get the new refusing behavior instead of a request error; keeping a parameter whose name promises a bypass that no longer exists would be misleading.

Additionally, the Prometheus stats scrape no longer fails entirely when a listener's `managed_certs` reference cannot be resolved (e.g. the bundle directory was removed out-of-band, or was force-deleted by an older release).  `emqx_prometheus:resolve_listener_certfile/3` now catches the resolution error, logs a warning with the listener and bundle, and skips that listener's cert-expiry point, keeping the rest of the metrics available.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
