### PR TITLE
fix(mqtt): strict_mode rejects v3.1 CONNECT with password but no username

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -1344,17 +1344,15 @@ validate_connect_will(false, WillRetain, _) when WillRetain -> ?PARSE_ERR(invali
 validate_connect_will(_, _, _) -> ok.
 
 -compile({inline, [validate_connect_password_flag/4]}).
-%% MQTT-v3.1
-%% Username flag and password flag are not strongly related
+%% MQTT-v3.1: "It is not valid to supply a password without supplying a user name."
 %% https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#connect
-validate_connect_password_flag(true, ?MQTT_PROTO_V3, _, _) ->
-    ok;
-%% MQTT-v3.1.1-[MQTT-3.1.2-22]
-validate_connect_password_flag(true, ?MQTT_PROTO_V4, UsernameFlag, PasswordFlag) ->
-    %% BUG-FOR-BUG compatible, only check when `strict-mode`
+%% MQTT-v3.1.1: [MQTT-3.1.2-22]
+%% MQTT-v5 allows password without username.
+%% Only check when `strict-mode` (BUG-FOR-BUG compatible otherwise).
+validate_connect_password_flag(true, Ver, UsernameFlag, PasswordFlag) when
+    Ver =:= ?MQTT_PROTO_V3 orelse Ver =:= ?MQTT_PROTO_V4
+->
     UsernameFlag orelse PasswordFlag andalso ?PARSE_ERR(invalid_password_flag);
-validate_connect_password_flag(true, ?MQTT_PROTO_V5, _, _) ->
-    ok;
 validate_connect_password_flag(_, _, _, _) ->
     ok.
 

--- a/apps/emqx/src/emqx_logger_textfmt.erl
+++ b/apps/emqx/src/emqx_logger_textfmt.erl
@@ -136,7 +136,7 @@ enrich_report(ReportRaw0, Meta, Config) ->
             {pid, Pid},
             {topic, try_format_unicode(Topic)},
             {username, try_format_unicode(Username)},
-            {peername, Peer},
+            {peername, try_format_unicode(Peer)},
             {mfa, try_format_unicode(MFA)},
             {msg, Msg},
             {clientid, try_format_unicode(ClientId)},

--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -618,7 +618,7 @@ format_variable(#mqtt_packet_auth{reason_code = ReasonCode}, _) ->
 format_variable(PacketId, _) when is_integer(PacketId) ->
     io_lib:format("PacketId=~p", [PacketId]).
 
-format_password(undefined) -> "";
+format_password(undefined) -> "undefined";
 format_password(<<>>) -> "";
 format_password(_Password) -> "******".
 

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -359,7 +359,7 @@ run_loop(
     }
 ) ->
     Peername = emqx_channel:info(peername, Channel),
-    emqx_logger:set_proc_metadata(#{peername => Peername, connmod => ?MODULE}),
+    emqx_logger:set_proc_metadata(#{peername => esockd:format(Peername), connmod => ?MODULE}),
     proc_lib:set_label({Listener, Peername}),
     ShutdownPolicy = emqx_config:get_zone_conf(Zone, [force_shutdown]),
     _ = emqx_utils:tune_heap_size(ShutdownPolicy),

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -58,6 +58,7 @@ groups() ->
             t_reserved_connect_flag,
             t_invalid_clientid,
             t_undefined_password,
+            t_invalid_password_flag,
             t_invalid_will_retain,
             t_invalid_will_qos
         ]},
@@ -959,23 +960,52 @@ t_undefined_password(_) ->
     ),
     ok.
 
+-doc """
+Password flag without username flag is rejected in strict mode for MQTT v3.1
+and v3.1.1, and stays accepted in lenient mode (bug-for-bug compatibility).
+MQTT v5 allows a password without a username in either mode.
+""".
 t_invalid_password_flag(_) ->
     %% Username Flag = false
     %% Password Flag = true
     %% Clean Session = true
     ConnectFlags = <<2#0100:4, 2#0010:4>>,
-    ConnectBin =
+    ConnectBinV4 =
         <<16, 17, 0, 4, 77, 81, 84, 84, 4, ConnectFlags/binary, 0, 60, 0, 2, 97, 49, 0, 1, 97>>,
+    %% Proto name = MQIsdp, proto level = 3
+    ConnectBinV3 =
+        <<16, 19, 0, 6, 77, 81, 73, 115, 100, 112, 3, ConnectFlags/binary, 0, 60, 0, 2, 97, 49, 0,
+            1, 97>>,
+    %% Proto level = 5, zero-length properties
+    ConnectBinV5 =
+        <<16, 18, 0, 4, 77, 81, 84, 84, 5, ConnectFlags/binary, 0, 60, 0, 0, 2, 97, 49, 0, 1, 97>>,
     ?assertMatch(
         {_, _, _},
-        emqx_frame:parse(ConnectBin)
+        emqx_frame:parse(ConnectBinV4)
+    ),
+    ?assertMatch(
+        {_, _, _},
+        emqx_frame:parse(ConnectBinV3)
     ),
 
     StrictModeParseState = emqx_frame:initial_parse_state(#{strict_mode => true}),
     ?assertException(
         throw,
-        {frame_parse_error, invalid_password_flag},
-        emqx_frame:parse(ConnectBin, StrictModeParseState)
+        {frame_parse_error, #{
+            cause := invalid_password_flag, proto_ver := ?MQTT_PROTO_V4, proto_name := <<"MQTT">>
+        }},
+        emqx_frame:parse(ConnectBinV4, StrictModeParseState)
+    ),
+    ?assertException(
+        throw,
+        {frame_parse_error, #{
+            cause := invalid_password_flag, proto_ver := ?MQTT_PROTO_V3, proto_name := <<"MQIsdp">>
+        }},
+        emqx_frame:parse(ConnectBinV3, StrictModeParseState)
+    ),
+    ?assertMatch(
+        {_, _, _},
+        emqx_frame:parse(ConnectBinV5, StrictModeParseState)
     ).
 
 t_invalid_will_retain(_) ->

--- a/changes/ee/fix-18111.en.md
+++ b/changes/ee/fix-18111.en.md
@@ -1,0 +1,3 @@
+When `mqtt.strict_mode` is enabled, MQTT v3.1 CONNECT packets that set the password flag without the username flag are now rejected, matching the existing behavior for MQTT v3.1.1. The MQTT v3.1 specification states that it is not valid to supply a password without a user name.
+
+Additionally improved connection log readability: the CONNECT packet trace now prints `Password=undefined` when no password was supplied (previously indistinguishable from an empty password), and the `peername` field in logs is now always rendered as a plain string such as `10.0.0.1:54123`.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Fixes #17913.

When `mqtt.strict_mode` is enabled, MQTT v3.1 (protocol level 3) CONNECT packets that set the password flag without the username flag are now rejected, same as v3.1.1 already was. The v3.1 specification states "It is not valid to supply a password without supplying a user name". Lenient (non-strict) mode keeps accepting such packets for bug-for-bug compatibility with old clients (see the discussion in #17971), and MQTT v5 continues to allow password without username as the v5 spec permits it.

The crucial change is in `emqx_frame:validate_connect_password_flag/4`. The `t_invalid_password_flag` test case was never referenced from the suite's `groups()`, so it silently rotted with a stale assertion on the parse-error shape; it is now wired in, fixed, and extended to cover v3.1, v3.1.1 and v5.

Log readability improvements found while investigating the issue report's debug trace:

* `emqx_packet` now formats an absent password as `Password=undefined`, distinguishable from an empty password (`Password=`). The trace in the issue turned out to show a CONNECT with neither username nor password flag set (a fully valid packet — the test client silently dropped the password), which was impossible to tell from the log.
* `peername` is now always rendered as a plain string (e.g. `10.42.0.0:54123`) in logs: `emqx_socket_connection` stored the raw `{IP, Port}` tuple in logger process metadata (which also breaks the trace formatter's iolist construction), and the text formatter printed binary peernames as `<<"...">>`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQ7GPjWpkweJvHKteK1j5D
