### PR TITLE
fix(dashboard): tolerate node sampling failures in cluster metrics

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -154,7 +154,7 @@ current_rate(Node) when Node == node() ->
                 {Key, 0}
              || Key <- ?GAUGE_SAMPLER_LIST ++ maps:values(?DELTA_SAMPLER_RATE_MAP)
             ],
-            {ok, maps:merge(maps:from_list(Rate0), non_rate_value())}
+            {ok, maps:merge(maps:from_list(Rate0), safe_non_rate_value())}
     end;
 current_rate(Node) ->
     case emqx_dashboard_proto_v2:current_rate(Node) of
@@ -876,6 +876,17 @@ stats(actions_executed) ->
 
 %% -------------------------------------------------------------------------------------------------
 %% Retained && License Quota
+
+%% The stats tables backing these values are absent while the node is restarting
+%% applications (e.g. when joining a cluster); return an empty map then, rather than
+%% zeros which would overwrite real values in the cluster-wide aggregate.
+safe_non_rate_value() ->
+    try
+        non_rate_value()
+    catch
+        _:_ ->
+            #{}
+    end.
 
 %% the non rate values should be same on all nodes
 non_rate_value() ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -164,7 +164,8 @@ monitor(delete, _) ->
     Nodes = emqx:running_nodes(),
     Results = emqx_dashboard_proto_v2:clear_table(Nodes),
     NodeResults = lists:zip(Nodes, Results),
-    NodeErrors = [Result || Result = {_Node, NOk} <- NodeResults, NOk =/= {atomic, ok}],
+    %% clear_table is an erpc multicall: each per-node success is {ok, {atomic, ok}}
+    NodeErrors = [Result || Result = {_Node, NOk} <- NodeResults, NOk =/= {ok, {atomic, ok}}],
     NodeErrors == [] orelse
         ?SLOG(warning, #{
             msg => "clear_monitor_metrics_rpc_errors",

--- a/apps/emqx_dashboard/src/proto/emqx_dashboard_proto_v2.erl
+++ b/apps/emqx_dashboard/src/proto/emqx_dashboard_proto_v2.erl
@@ -19,14 +19,18 @@
 introduced_in() ->
     "5.8.4".
 
+%% Uses rpc (not erpc) so that failures are returned as {badrpc, _} for the
+%% callers to tolerate, rather than raised.
 -spec do_sample(node(), Latest :: pos_integer() | infinity) -> list(map()) | emqx_rpc:badrpc().
 do_sample(Node, Latest) ->
-    erpc:call(Node, emqx_dashboard_monitor, do_sample, [Node, Latest], ?RPC_TIMEOUT).
+    rpc:call(Node, emqx_dashboard_monitor, do_sample, [Node, Latest], ?RPC_TIMEOUT).
 
 -spec clear_table(Nodes :: [node()]) -> emqx_rpc:erpc_multicall(ok).
 clear_table(Nodes) ->
     erpc:multicall(Nodes, emqx_dashboard_monitor, clear_table, [], ?RPC_TIMEOUT).
 
+%% Uses rpc (not erpc) so that failures are returned as {badrpc, _} for the
+%% callers to tolerate, rather than raised.
 -spec current_rate(node()) -> {ok, map()} | emqx_rpc:badrpc().
 current_rate(Node) ->
-    erpc:call(Node, emqx_dashboard_monitor, current_rate, [Node], ?RPC_TIMEOUT).
+    rpc:call(Node, emqx_dashboard_monitor, current_rate, [Node], ?RPC_TIMEOUT).

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -1039,6 +1039,44 @@ t_smoke_test_monitor_multiple_windows(Config) when is_list(Config) ->
     ok = emqtt:stop(PSClient2),
     ok.
 
+%% Regression test for emqx/emqx#17747: `GET /monitor_current` must not return 500 when
+%% a cluster node is restarting its applications (as happens on `emqx ctl cluster join`).
+%% While the joining node's `emqx` application is down its stats ETS tables are absent,
+%% so sampling on that node crashes with `badarg`.  The proto module used erpc, which
+%% re-raised the crash on the API node instead of returning the {badrpc, _} the callers
+%% tolerate, so it escaped `current_rate_cluster/0` and surfaced as 500 INTERNAL_ERROR.
+t_monitor_current_node_restarting_apps({init, Config0}) ->
+    Port = 28085,
+    NodeSpecs = [
+        {monitor_node_restarting1, #{apps => cluster_node_appspec(true, Port)}},
+        {monitor_node_restarting2, #{apps => cluster_node_appspec(false, Port)}}
+    ],
+    Config = emqx_common_test_helpers:start_cluster_ds(
+        Config0,
+        NodeSpecs,
+        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config0)}
+    ),
+    ok = snabbkaffe:start_trace(),
+    Config;
+t_monitor_current_node_restarting_apps({'end', Config}) ->
+    ok = snabbkaffe:stop(),
+    ok = emqx_common_test_helpers:stop_cluster_ds(Config);
+t_monitor_current_node_restarting_apps(Config) when is_list(Config) ->
+    [N1, N2 | _] = ?config(cluster_nodes, Config),
+    %% Simulate the mid-join window: N2 is alive and still a running mria cluster
+    %% node, but its `emqx' application (and thus the `emqx_stats' table) is down.
+    ok = ?ON(N2, application:stop(emqx)),
+    ?assert(lists:member(N2, ?ON(N1, mria:cluster_nodes(running)))),
+    %% The cluster-wide aggregate must degrade instead of crashing.
+    ?assertMatch({ok, #{}}, ?ON(N1, emqx_dashboard_monitor:current_rate(all))),
+    %% And the REST endpoint must respond 200 with the aggregate of healthy nodes.
+    ?assertMatch(
+        {ok, #{<<"connections">> := _}},
+        get_req_cluster(Config, ["monitor_current"], "")
+    ),
+    ok = ?ON(N2, application:start(emqx)),
+    ok.
+
 -doc """
 Simulates the following scenario:
 

--- a/changes/ee/fix-18114.en.md
+++ b/changes/ee/fix-18114.en.md
@@ -1,0 +1,5 @@
+Fixed an issue where the dashboard metrics APIs (`GET /api/v5/monitor_current` and `GET /api/v5/monitor`) returned `500 INTERNAL_ERROR` while a node was joining the cluster.
+
+While a joining node is restarting its applications, sampling its metrics fails; this failure is now tolerated: the APIs return the aggregate of the remaining reachable nodes and log a warning, instead of failing the whole request.
+
+Also fixed a spurious `clear_monitor_metrics_rpc_errors` warning that was logged on every successful `DELETE /api/v5/monitor` request.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Port of #18107 to the 6.x line. Fixes #17747 for v6.

After `emqx ctl cluster join`, the joining node restarts its `emqx` application; while it is down its stats ETS tables are absent, so sampling on that node crashes with `badarg`. `emqx_dashboard_proto_v2` called the sampling functions via `erpc`, which raises remote failures instead of returning `{badrpc, _}` (as the old `rpc`-based proto v1 did), so the crash escaped the per-node tolerance in `current_rate_cluster/0` and surfaced as `500 INTERNAL_ERROR` on `GET /api/v5/monitor_current` (and `GET /api/v5/monitor` via `do_sample`).

Changes:

- `emqx_dashboard_proto_v2`: `do_sample/2` and `current_rate/1` use `rpc:call` again so failures are returned as `{badrpc, _}` for the callers to tolerate. No proto version bump: function names and signatures are unchanged. `clear_table/1` stays `erpc:multicall`.
- `emqx_dashboard_monitor`: the local-sampling fallback now uses `safe_non_rate_value/0`, which returns an empty map (not zeros, which would overwrite cluster-synced values) when the stats tables are absent.
- `emqx_dashboard_monitor_api`: `DELETE /api/v5/monitor` now matches the erpc-multicall per-node success shape `{ok, {atomic, ok}}`, fixing a spurious `clear_monitor_metrics_rpc_errors` warning logged on every successful request.
- New regression test `t_monitor_current_node_restarting_apps` covering the mid-join window.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DnqK1GtjdZbF9nJMX4FQ2