### PR TITLE
fix(mqtt): reject duplicate non-repeatable MQTT v5 properties in strict mode

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1396,7 +1396,7 @@ handle_frame_error(
 ->
     handle_out(
         disconnect,
-        {?RC_MALFORMED_PACKET, frame_error_kind(Reason, frame_error)},
+        {frame_error_reason_code(Reason), frame_error_kind(Reason, frame_error)},
         Channel
     );
 handle_frame_error(
@@ -3897,6 +3897,7 @@ proto_ver(_, _) ->
     ?MQTT_PROTO_V4.
 
 frame_error_reason_code(#{cause := frame_too_large}) -> ?RC_PACKET_TOO_LARGE;
+frame_error_reason_code(#{cause := duplicate_property}) -> ?RC_PROTOCOL_ERROR;
 frame_error_reason_code(_) -> ?RC_MALFORMED_PACKET.
 
 handle_heal_partition(

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -645,57 +645,63 @@ parse_properties(Bin, ?MQTT_PROTO_V5, StrictMode) ->
 parse_property(<<>>, Props, _StrictMode) ->
     Props;
 parse_property(<<16#01, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Payload-Format-Indicator' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Payload-Format-Indicator', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#02, Val:32/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Message-Expiry-Interval' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Message-Expiry-Interval', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#03, Bin/binary>>, Props, StrictMode) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_content_type),
-    parse_property(Rest, Props#{'Content-Type' => Val}, StrictMode);
+    parse_property(Rest, put_prop('Content-Type', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#08, Bin/binary>>, Props, StrictMode) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_response_topic),
-    parse_property(Rest, Props#{'Response-Topic' => Val}, StrictMode);
+    parse_property(Rest, put_prop('Response-Topic', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#09, Len:16/big, Val:Len/binary, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Correlation-Data' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Correlation-Data', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#0B, Bin/binary>>, Props, StrictMode) ->
     {Val, Rest} = parse_variable_byte_integer(Bin),
-    parse_property(Rest, Props#{'Subscription-Identifier' => Val}, StrictMode);
+    parse_property(Rest, put_prop('Subscription-Identifier', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#11, Val:32/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Session-Expiry-Interval' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Session-Expiry-Interval', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#12, Bin/binary>>, Props, StrictMode) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_assigned_client_id),
-    parse_property(Rest, Props#{'Assigned-Client-Identifier' => Val}, StrictMode);
+    parse_property(
+        Rest, put_prop('Assigned-Client-Identifier', Val, Props, StrictMode), StrictMode
+    );
 parse_property(<<16#13, Val:16, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Server-Keep-Alive' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Server-Keep-Alive', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#15, Bin/binary>>, Props, StrictMode) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_authn_method),
-    parse_property(Rest, Props#{'Authentication-Method' => Val}, StrictMode);
+    parse_property(Rest, put_prop('Authentication-Method', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#16, Len:16/big, Val:Len/binary, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Authentication-Data' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Authentication-Data', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#17, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Request-Problem-Information' => Val}, StrictMode);
+    parse_property(
+        Bin, put_prop('Request-Problem-Information', Val, Props, StrictMode), StrictMode
+    );
 parse_property(<<16#18, Val:32, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Will-Delay-Interval' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Will-Delay-Interval', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#19, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Request-Response-Information' => Val}, StrictMode);
+    parse_property(
+        Bin, put_prop('Request-Response-Information', Val, Props, StrictMode), StrictMode
+    );
 parse_property(<<16#1A, Bin/binary>>, Props, StrictMode) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_response_info),
-    parse_property(Rest, Props#{'Response-Information' => Val}, StrictMode);
+    parse_property(Rest, put_prop('Response-Information', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#1C, Bin/binary>>, Props, StrictMode) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_server_reference),
-    parse_property(Rest, Props#{'Server-Reference' => Val}, StrictMode);
+    parse_property(Rest, put_prop('Server-Reference', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#1F, Bin/binary>>, Props, StrictMode) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_reason_string),
-    parse_property(Rest, Props#{'Reason-String' => Val}, StrictMode);
+    parse_property(Rest, put_prop('Reason-String', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#21, Val:16/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Receive-Maximum' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Receive-Maximum', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#22, Val:16/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Topic-Alias-Maximum' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Topic-Alias-Maximum', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#23, Val:16/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Topic-Alias' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Topic-Alias', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#24, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Maximum-QoS' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Maximum-QoS', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#25, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Retain-Available' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Retain-Available', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#26, Bin/binary>>, Props, StrictMode) ->
     {Pair, Rest} = parse_utf8_pair(Bin, StrictMode),
     %% Accumulate in reverse order to keep this O(1) per entry; the list is
@@ -707,16 +713,34 @@ parse_property(<<16#26, Bin/binary>>, Props, StrictMode) ->
             parse_property(Rest, Props#{'User-Property' => [Pair]}, StrictMode)
     end;
 parse_property(<<16#27, Val:32, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Maximum-Packet-Size' => Val}, StrictMode);
+    parse_property(Bin, put_prop('Maximum-Packet-Size', Val, Props, StrictMode), StrictMode);
 parse_property(<<16#28, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Wildcard-Subscription-Available' => Val}, StrictMode);
+    parse_property(
+        Bin, put_prop('Wildcard-Subscription-Available', Val, Props, StrictMode), StrictMode
+    );
 parse_property(<<16#29, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Subscription-Identifier-Available' => Val}, StrictMode);
+    parse_property(
+        Bin, put_prop('Subscription-Identifier-Available', Val, Props, StrictMode), StrictMode
+    );
 parse_property(<<16#2A, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, Props#{'Shared-Subscription-Available' => Val}, StrictMode);
+    parse_property(
+        Bin, put_prop('Shared-Subscription-Available', Val, Props, StrictMode), StrictMode
+    );
 parse_property(<<Property:8, _Rest/binary>>, _Props, _StrictMode) ->
     ?PARSE_ERR(#{cause => invalid_property_code, property_code => Property}).
 %% TODO: invalid property in specific packet.
+
+-doc """
+Insert a non-repeatable property into the properties map.
+
+Only 'User-Property' may appear more than once in a packet [MQTT-2.2.2-2];
+in strict mode a duplicate of any other property is a Protocol Error.
+In non-strict mode the last occurrence wins.
+""".
+put_prop(Key, _Val, Props, _StrictMode = true) when is_map_key(Key, Props) ->
+    ?PARSE_ERR(#{cause => duplicate_property, property => Key});
+put_prop(Key, Val, Props, _StrictMode) ->
+    Props#{Key => Val}.
 
 -doc """
 Restore wire order for the 'User-Property' list, which parse_property/3

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -47,6 +47,9 @@ groups() ->
             t_serialize_parse_v4_connect,
             t_serialize_parse_v5_connect,
             t_parse_many_user_properties_is_linear,
+            t_parse_duplicate_connect_property_strict,
+            t_parse_duplicate_connect_property_lenient,
+            t_parse_repeated_user_property_strict,
             t_serialize_parse_connect_without_clientid,
             t_serialize_parse_connect_with_will,
             t_serialize_parse_connect_with_malformed_will,
@@ -72,7 +75,8 @@ groups() ->
             t_serialize_parse_qos1_publish,
             t_serialize_parse_qos2_publish,
             t_serialize_parse_with_dup_flag,
-            t_serialize_parse_publish_v5
+            t_serialize_parse_publish_v5,
+            t_parse_duplicate_publish_property
         ]},
         {puback, [parallel], [
             t_serialize_parse_puback,
@@ -422,6 +426,68 @@ encode_vbi(N) when N < 16#80 ->
 encode_vbi(N) ->
     <<1:1, (N rem 16#80):7, (encode_vbi(N div 16#80))/binary>>.
 
+%% Build a raw MQTT v5 CONNECT frame (clean start, empty client id) carrying
+%% the given raw properties bytes.
+make_v5_connect_frame(PropsBin) ->
+    PropsSection = <<(encode_vbi(byte_size(PropsBin)))/binary, PropsBin/binary>>,
+    VarHeader = <<4:16, "MQTT", ?MQTT_PROTO_V5:8, 2:8, 60:16, PropsSection/binary>>,
+    Body = <<VarHeader/binary, 0:16>>,
+    <<16#10, (encode_vbi(byte_size(Body)))/binary, Body/binary>>.
+
+-doc """
+In strict mode, an MQTT v5 CONNECT that includes a non-repeatable property
+more than once (two Session-Expiry-Interval, two Receive-Maximum, or two
+Maximum-Packet-Size) is rejected with a duplicate_property frame parse error.
+""".
+t_parse_duplicate_connect_property_strict(_) ->
+    Strict = emqx_frame:initial_parse_state(#{strict_mode => true}),
+    lists:foreach(
+        fun({Key, PropsBin}) ->
+            Frame = make_v5_connect_frame(PropsBin),
+            ?assertException(
+                throw,
+                {frame_parse_error, #{cause := duplicate_property, property := Key}},
+                emqx_frame:parse(Frame, Strict),
+                #{property => Key}
+            )
+        end,
+        [
+            {'Session-Expiry-Interval', <<16#11, 1:32, 16#11, 2:32>>},
+            {'Receive-Maximum', <<16#21, 1:16, 16#21, 2:16>>},
+            {'Maximum-Packet-Size', <<16#27, 1024:32, 16#27, 2048:32>>}
+        ]
+    ).
+
+-doc """
+Without strict mode, a duplicated non-repeatable property is still accepted
+and the last occurrence wins.
+""".
+t_parse_duplicate_connect_property_lenient(_) ->
+    Lenient = emqx_frame:initial_parse_state(#{strict_mode => false}),
+    Frame = make_v5_connect_frame(<<16#11, 1:32, 16#11, 2:32>>),
+    {Packet, <<>>, _} = emqx_frame:parse(Frame, Lenient),
+    #mqtt_packet{variable = #mqtt_packet_connect{properties = Props}} = Packet,
+    ?assertEqual(2, maps:get('Session-Expiry-Interval', Props)).
+
+-doc """
+'User-Property' is the only property allowed to repeat: in strict mode,
+repeated entries (interleaved with a non-repeatable property appearing once)
+parse successfully and keep wire order.
+""".
+t_parse_repeated_user_property_strict(_) ->
+    UP1 = <<16#26, 1:16, "k", 1:16, "1">>,
+    UP2 = <<16#26, 1:16, "k", 1:16, "2">>,
+    SEI = <<16#11, 7:32>>,
+    Frame = make_v5_connect_frame(<<UP1/binary, SEI/binary, UP2/binary>>),
+    Strict = emqx_frame:initial_parse_state(#{strict_mode => true}),
+    {Packet, <<>>, _} = emqx_frame:parse(Frame, Strict),
+    #mqtt_packet{variable = #mqtt_packet_connect{properties = Props}} = Packet,
+    ?assertEqual(7, maps:get('Session-Expiry-Interval', Props)),
+    ?assertEqual(
+        [{<<"k">>, <<"1">>}, {<<"k">>, <<"2">>}],
+        maps:get('User-Property', Props)
+    ).
+
 t_serialize_parse_connect_without_clientid(_) ->
     Bin = <<16, 12, 0, 4, 77, 81, 84, 84, 4, 2, 0, 60, 0, 0>>,
     Packet = ?CONNECT_PACKET(#mqtt_packet_connect{
@@ -671,6 +737,34 @@ t_serialize_parse_publish_v5(_) ->
     },
     Packet = ?PUBLISH_PACKET(?QOS_1, <<"$share/group/topic">>, 1, Props, <<"payload">>),
     ?assertEqual(Packet, parse_serialize(Packet, #{version => ?MQTT_PROTO_V5})).
+
+-doc """
+An MQTT v5 PUBLISH carrying two Response-Topic properties is rejected with a
+duplicate_property frame parse error in strict mode, while without strict
+mode it parses with the last occurrence winning.
+""".
+t_parse_duplicate_publish_property(_) ->
+    RT1 = <<16#08, 2:16, "r1">>,
+    RT2 = <<16#08, 2:16, "r2">>,
+    PropsBin = <<RT1/binary, RT2/binary>>,
+    Topic = <<"t">>,
+    Body = <<
+        (byte_size(Topic)):16,
+        Topic/binary,
+        (encode_vbi(byte_size(PropsBin)))/binary,
+        PropsBin/binary,
+        "payload"
+    >>,
+    Frame = <<16#30, (encode_vbi(byte_size(Body)))/binary, Body/binary>>,
+    Strict = emqx_frame:initial_parse_state(#{version => ?MQTT_PROTO_V5, strict_mode => true}),
+    ?ASSERT_FRAME_THROW(
+        #{cause := duplicate_property, property := 'Response-Topic'},
+        emqx_frame:parse(Frame, Strict)
+    ),
+    Lenient = emqx_frame:initial_parse_state(#{version => ?MQTT_PROTO_V5, strict_mode => false}),
+    {Packet, <<>>, _} = emqx_frame:parse(Frame, Lenient),
+    #mqtt_packet{variable = #mqtt_packet_publish{properties = ParsedProps}} = Packet,
+    ?assertEqual(<<"r2">>, maps:get('Response-Topic', ParsedProps)).
 
 t_serialize_parse_puback(_) ->
     Packet = ?PUBACK_PACKET(1),

--- a/changes/ee/fix-18116.en.md
+++ b/changes/ee/fix-18116.en.md
@@ -1,0 +1,3 @@
+When `strict_mode` is enabled (the default), an MQTT v5 packet that includes a non-repeatable property more than once (for example, two `Session-Expiry-Interval` properties in a CONNECT packet) is now rejected as a protocol error, instead of silently using the last value. `User-Property`, which the MQTT specification allows to repeat, is not affected.
+
+Operators can restore the previous lenient behavior by setting `strict_mode = false` in the listener configuration.


### PR DESCRIPTION
Release version:
6.3.0

## Summary

Completes the fix of #8029 (bug 2 — the remaining open part; bug 1 was fixed by #16782 and bug 3 by #11074).

Per the MQTT 5.0 specification, it is a Protocol Error to include any property other than `User-Property` more than once in a packet. The frame parser (`emqx_frame:parse_property/3`) silently accepted duplicates with last-value-wins, so the duplication was invisible to any later check.

Changes:

* `emqx_frame`: all non-repeatable property inserts now go through a `put_prop/4` helper — when `strict_mode` is enabled (the default), a duplicated property raises a frame parse error with `cause => duplicate_property`; when disabled, the previous last-value-wins behavior is kept. The repeatable `User-Property` accumulation is unchanged.
* `emqx_channel`: the `duplicate_property` cause is mapped to reason code 0x82 (Protocol Error) in the resulting DISCONNECT (or CONNACK while connecting), instead of the generic 0x81 (Malformed Packet).

`Subscription-Identifier` is treated as non-repeatable here as well: the inbound parser only sees client-to-server packets, where the spec allows it at most once (SUBSCRIBE) or not at all (client PUBLISH, already rejected elsewhere). The server-to-client forwarding path is built by serialization and is not affected.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGSjk9yDzxGLdA91PyrCVT