### PR TITLE
fix(multi_tenancy): purge built-in authn/authz data on namespace delete

### DIFF
--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_app.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_app.erl
@@ -15,9 +15,11 @@ start(_StartType, _StartArgs) ->
     ok = emqx_authz:register_source(?AUTHZ_TYPE, emqx_authz_mnesia),
     ok = emqx_authn:register_provider(?AUTHN_TYPE_SIMPLE, emqx_authn_mnesia),
     ok = emqx_authn:register_provider(?AUTHN_TYPE_SCRAM, emqx_authn_scram_mnesia),
+    ok = emqx_auth_mnesia_hookcb:register_hooks(),
     {ok, Sup}.
 
 stop(_State) ->
+    ok = emqx_auth_mnesia_hookcb:unregister_hooks(),
     ok = emqx_authn:deregister_provider(?AUTHN_TYPE_SIMPLE),
     ok = emqx_authn:deregister_provider(?AUTHN_TYPE_SCRAM),
     ok = emqx_authz:unregister_source(?AUTHZ_TYPE),

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_hookcb.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_hookcb.erl
@@ -1,7 +1,11 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_hookcb).
+-module(emqx_auth_mnesia_hookcb).
+
+-moduledoc """
+Hook callbacks for the built-in database authentication/authorization backends.
+""".
 
 %% API
 -export([
@@ -30,10 +34,12 @@ unregister_hooks() ->
     ok = emqx_hooks:del('namespace.delete', ?NS_DELETE_HOOK),
     ok.
 
+-doc """
+Deletes all built-in database authentication users (password-based and SCRAM) and
+authorization rules belonging to the deleted namespace.
+""".
 on_namespace_delete(Namespace) ->
-    ok = emqx_mgmt_auth:delete_all_keys_from_namespace(Namespace),
+    ok = emqx_authn_mnesia:purge_namespace(Namespace),
+    ok = emqx_authn_scram_mnesia:purge_namespace(Namespace),
+    ok = emqx_authz_mnesia:purge_rules(Namespace),
     ok.
-
-%%------------------------------------------------------------------------------
-%% Internal fns
-%%------------------------------------------------------------------------------

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -34,6 +34,8 @@
 
 -export([record_count/1, record_count_per_namespace/0]).
 
+-export([purge_namespace/1]).
+
 -export([
     run_fuzzy_filter/2,
     format_user_info/1
@@ -185,6 +187,22 @@ do_destroy(UserGroup) ->
         end,
         mnesia:select(?AUTHN_NS_TAB, all_ns_group_match_spec('_', UserGroup), write)
     ).
+
+-doc """
+Deletes all users belonging to the given namespace, across all user groups.
+
+Users in the global namespace are never touched.
+""".
+-spec purge_namespace(emqx_config:namespace()) -> ok.
+purge_namespace(Namespace) when is_binary(Namespace) ->
+    ok = lists:foreach(
+        fun(#?AUTHN_NS_TAB{user_id = Key}) ->
+            ok = mria:dirty_delete(?AUTHN_NS_TAB, Key)
+        end,
+        mnesia:dirty_select(?AUTHN_NS_TAB, all_ns_group_match_spec(Namespace, '_'))
+    ),
+    _ = ets:delete(?AUTHN_NS_COUNT_TAB, Namespace),
+    ok.
 
 import_users(ImportSource, State) ->
     import_users(ImportSource, State, #{override => true}).

--- a/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
@@ -37,6 +37,8 @@
 
 -export([backup_tables/0]).
 
+-export([purge_namespace/1]).
+
 %% Internal exports (RPC)
 -export([
     do_destroy/1,
@@ -172,6 +174,20 @@ do_destroy(UserGroup) ->
             mnesia:delete_object(?NS_TAB, UserInfo, write)
         end,
         mnesia:select(?NS_TAB, all_ns_group_match_spec('_', UserGroup), write)
+    ).
+
+-doc """
+Deletes all users belonging to the given namespace, across all user groups.
+
+Users in the global namespace are never touched.
+""".
+-spec purge_namespace(emqx_config:namespace()) -> ok.
+purge_namespace(Namespace) when is_binary(Namespace) ->
+    lists:foreach(
+        fun(#?NS_TAB{user_id = Key}) ->
+            ok = mria:dirty_delete(?NS_TAB, Key)
+        end,
+        mnesia:dirty_select(?NS_TAB, all_ns_group_match_spec(Namespace, '_'))
     ).
 
 add_user(UserInfo, State) ->

--- a/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
@@ -282,6 +282,34 @@ t_destroy(TCConfig) ->
 
     ok.
 
+-doc """
+Tests that `purge_namespace/1` deletes all users from the given namespace across all user
+groups, while leaving global and other-namespace users intact.
+""".
+t_purge_namespace(_TCConfig) ->
+    Config = config(),
+    OtherGroupConfig = Config#{user_group => <<"stomp:global">>},
+    {ok, State} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
+    {ok, StateOtherGroup} = emqx_authn_mnesia:create(?AUTHN_ID, OtherGroupConfig),
+
+    User = #{user_id => <<"u">>, password => <<"p">>},
+    {ok, _} = emqx_authn_mnesia:add_user(User, State),
+    {ok, _} = emqx_authn_mnesia:add_user(add_ns(User, ?NS), State),
+    {ok, _} = emqx_authn_mnesia:add_user(add_ns(User, ?NS), StateOtherGroup),
+    {ok, _} = emqx_authn_mnesia:add_user(add_ns(User, ?OTHER_NS), State),
+
+    ok = emqx_authn_mnesia:purge_namespace(?NS),
+
+    {error, not_found} = lookup_user(?NS, <<"u">>, State),
+    {error, not_found} = lookup_user(?NS, <<"u">>, StateOtherGroup),
+    {ok, _} = lookup_user(?global_ns, <<"u">>, State),
+    {ok, _} = lookup_user(?OTHER_NS, <<"u">>, State),
+    ?assertEqual(0, emqx_authn_mnesia:record_count(?NS)),
+
+    %% Idempotent
+    ok = emqx_authn_mnesia:purge_namespace(?NS),
+    ok.
+
 t_authenticate() ->
     [{matrix, true}].
 t_authenticate(matrix) ->

--- a/apps/emqx_auth_mnesia/test/emqx_authn_scram_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_scram_mnesia_SUITE.erl
@@ -377,6 +377,32 @@ t_destroy(TCConfig) ->
 
     ok.
 
+-doc """
+Tests that `purge_namespace/1` deletes all users from the given namespace across all user
+groups, while leaving global and other-namespace users intact.
+""".
+t_purge_namespace(_TCConfig) ->
+    Config = config(),
+    {ok, State} = emqx_authn_scram_mnesia:create(<<"id">>, Config),
+    {ok, StateOtherGroup} = emqx_authn_scram_mnesia:create(<<"id-other">>, Config),
+
+    User = #{user_id => <<"u">>, password => <<"p">>},
+    {ok, _} = emqx_authn_scram_mnesia:add_user(User, State),
+    {ok, _} = emqx_authn_scram_mnesia:add_user(add_ns(User, ?NS), State),
+    {ok, _} = emqx_authn_scram_mnesia:add_user(add_ns(User, ?NS), StateOtherGroup),
+    {ok, _} = emqx_authn_scram_mnesia:add_user(add_ns(User, ?OTHER_NS), State),
+
+    ok = emqx_authn_scram_mnesia:purge_namespace(?NS),
+
+    {error, not_found} = lookup_user(?NS, <<"u">>, State),
+    {error, not_found} = lookup_user(?NS, <<"u">>, StateOtherGroup),
+    {ok, _} = lookup_user(?global_ns, <<"u">>, State),
+    {ok, _} = lookup_user(?OTHER_NS, <<"u">>, State),
+
+    %% Idempotent
+    ok = emqx_authn_scram_mnesia:purge_namespace(?NS),
+    ok.
+
 t_add_user() ->
     [{matrix, true}].
 t_add_user(matrix) ->

--- a/apps/emqx_auth_mnesia/test/emqx_authz_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authz_mnesia_SUITE.erl
@@ -334,6 +334,36 @@ test_authz(Expected, Namespace, {Who, Rule}, {ClientInfo, Action, Topic}) ->
         ok = emqx_authz_mnesia:purge_rules(Namespace)
     end.
 
+-doc """
+Tests that `purge_rules/1` with a namespace deletes only that namespace's rules, leaving
+global and other-namespace rules intact.
+""".
+t_purge_namespace_rules(_Config) ->
+    Rule = #{
+        <<"permission">> => <<"allow">>, <<"action">> => <<"publish">>, <<"topic">> => <<"t">>
+    },
+    Ns1 = <<"tns1">>,
+    Ns2 = <<"tns2">>,
+    ok = store_rules(?global_ns, {username, <<"username">>}, [Rule]),
+    ok = store_rules(Ns1, {username, <<"username">>}, [Rule]),
+    ok = store_rules(Ns1, {clientid, <<"clientid">>}, [Rule]),
+    ok = store_rules(Ns1, all, [Rule]),
+    ok = store_rules(Ns2, {username, <<"username">>}, [Rule]),
+
+    ok = emqx_authz_mnesia:purge_rules(Ns1),
+
+    not_found = emqx_authz_mnesia:get_rules(Ns1, {username, <<"username">>}),
+    not_found = emqx_authz_mnesia:get_rules(Ns1, {clientid, <<"clientid">>}),
+    not_found = emqx_authz_mnesia:get_rules(Ns1, all),
+    {ok, _} = emqx_authz_mnesia:get_rules(?global_ns, {username, <<"username">>}),
+    {ok, _} = emqx_authz_mnesia:get_rules(Ns2, {username, <<"username">>}),
+    ?assertEqual(0, emqx_authz_mnesia:record_count(Ns1)),
+
+    %% Idempotent
+    ok = emqx_authz_mnesia:purge_rules(Ns1),
+    ok = emqx_authz_mnesia:purge_rules(Ns2),
+    ok.
+
 t_normalize_rules(_Config) ->
     ClientInfo = emqx_authz_test_lib:base_client_info(),
 

--- a/apps/emqx_management/src/emqx_mgmt_hookcb.erl
+++ b/apps/emqx_management/src/emqx_mgmt_hookcb.erl
@@ -32,8 +32,26 @@ unregister_hooks() ->
 
 on_namespace_delete(Namespace) ->
     ok = emqx_mgmt_auth:delete_all_keys_from_namespace(Namespace),
+    ok = purge_builtin_auth_data(Namespace),
     ok.
 
 %%------------------------------------------------------------------------------
 %% Internal fns
 %%------------------------------------------------------------------------------
+
+-doc """
+Deletes all built-in database authentication users (password-based and SCRAM) and
+authorization rules belonging to the deleted namespace.
+
+The built-in database tables exist only while the `emqx_auth_mnesia` application is
+running; its top supervisor creates them.
+""".
+purge_builtin_auth_data(Namespace) ->
+    case is_pid(whereis(emqx_auth_mnesia_sup)) of
+        true ->
+            ok = emqx_authn_mnesia:purge_namespace(Namespace),
+            ok = emqx_authn_scram_mnesia:purge_namespace(Namespace),
+            ok = emqx_authz_mnesia:purge_rules(Namespace);
+        false ->
+            ok
+    end.

--- a/apps/emqx_mt/mix.exs
+++ b/apps/emqx_mt/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMT.MixProject do
   def project do
     [
       app: :emqx_mt,
-      version: "6.1.2",
+      version: "6.1.3",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),
@@ -24,6 +24,7 @@ defmodule EMQXMT.MixProject do
   def deps() do
     UMP.deps([
       {:emqx, in_umbrella: true},
+      {:emqx_ctl, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_dashboard, in_umbrella: true, runtime: false},
       :minirest

--- a/apps/emqx_mt/src/emqx_mt_app.erl
+++ b/apps/emqx_mt/src/emqx_mt_app.erl
@@ -12,8 +12,10 @@ start(_StartType, _StartArgs) ->
     {ok, Sup} = emqx_mt_sup:start_link(),
     ok = emqx_mt_hookcb:register_hooks(),
     ok = emqx_mt_config:load(),
+    ok = emqx_mt_cli:load(),
     {ok, Sup}.
 
 stop(_State) ->
+    ok = emqx_mt_cli:unload(),
     ok = emqx_mt_hookcb:unregister_hooks(),
     ok.

--- a/apps/emqx_mt/src/emqx_mt_cli.erl
+++ b/apps/emqx_mt/src/emqx_mt_cli.erl
@@ -24,9 +24,13 @@ mt(["purge_ns", Ns0]) ->
     Ns = unicode:characters_to_binary(Ns0),
     case emqx_mt_config:force_purge_ns(Ns) of
         ok ->
-            emqx_ctl:print("ok~n");
+            print_json(#{result => <<"ok">>, namespace => Ns});
         {error, cleanup_incomplete} ->
-            emqx_ctl:print("Some cleanup steps failed (see logs); re-run the command to retry.~n")
+            print_json(#{
+                error => <<"cleanup_incomplete">>,
+                namespace => Ns,
+                hint => <<"some cleanup steps failed; check logs and re-run the command to retry">>
+            })
     end;
 mt(_) ->
     emqx_ctl:usage([
@@ -39,3 +43,6 @@ mt(_) ->
 -doc "No sensitive arguments to redact from the audit log.".
 mt_audit_args(Args) ->
     Args.
+
+print_json(Payload) ->
+    emqx_ctl:print("~ts~n", [emqx_utils_json:best_effort_json(Payload)]).

--- a/apps/emqx_mt/src/emqx_mt_cli.erl
+++ b/apps/emqx_mt/src/emqx_mt_cli.erl
@@ -1,0 +1,41 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_mt_cli).
+
+-moduledoc """
+CLI for multi-tenancy operations.
+""".
+
+-behaviour(emqx_ctl).
+
+-export([load/0, unload/0]).
+
+%% CLI handler
+-export([mt/1, mt_audit_args/1]).
+
+load() ->
+    ok = emqx_ctl:register_command(mt, {?MODULE, mt}, []).
+
+unload() ->
+    ok = emqx_ctl:unregister_command(mt).
+
+mt(["purge_ns", Ns0]) ->
+    Ns = unicode:characters_to_binary(Ns0),
+    case emqx_mt_config:force_purge_ns(Ns) of
+        ok ->
+            emqx_ctl:print("ok~n");
+        {error, cleanup_incomplete} ->
+            emqx_ctl:print("Some cleanup steps failed (see logs); re-run the command to retry.~n")
+    end;
+mt(_) ->
+    emqx_ctl:usage([
+        {"mt purge_ns <namespace>",
+            "Delete the namespace and purge all data belonging to it.\n"
+            "Idempotent: purges any leftover data even if the namespace does not exist,\n"
+            "e.g. if a previous deletion was interrupted halfway."}
+    ]).
+
+-doc "No sensitive arguments to redact from the audit log.".
+mt_audit_args(Args) ->
+    Args.

--- a/apps/emqx_mt/src/emqx_mt_config.erl
+++ b/apps/emqx_mt/src/emqx_mt_config.erl
@@ -20,6 +20,7 @@
 
     create_managed_ns/1,
     delete_managed_ns/1,
+    force_purge_ns/1,
     is_known_managed_ns/1,
 
     get_managed_ns_config/1,
@@ -210,6 +211,25 @@ delete_managed_ns(Ns) ->
         ok = emqx_mt_config_janitor:clean_namespace(Ns),
         ok
     end.
+
+-doc """
+Deletes the namespace and purges all of its data, regardless of whether the namespace is
+currently known, running the cleanup synchronously in the calling process.
+
+Last resort to manually purge a namespace's data, e.g. if a previous deletion was
+interrupted halfway.  Normal deletion goes through `delete_managed_ns/1`.
+""".
+-spec force_purge_ns(emqx_mt:tns()) -> ok | {error, cleanup_incomplete}.
+force_purge_ns(Ns) ->
+    case emqx_mt_state:delete_managed_ns(Ns) of
+        {ok, Configs} when map_size(Configs) > 0 ->
+            _ = emqx_mt_config_proto_v1:cleanup_managed_ns_configs(Ns, maps:to_list(Configs)),
+            ok;
+        _ ->
+            ok
+    end,
+    _ = emqx_mt_client_kicker:start_kicking(Ns),
+    emqx_mt_config_janitor:force_clean_namespace(Ns).
 
 -spec is_known_managed_ns(emqx_mt:tns()) -> boolean().
 is_known_managed_ns(Ns) ->

--- a/apps/emqx_mt/src/emqx_mt_config_janitor.erl
+++ b/apps/emqx_mt/src/emqx_mt_config_janitor.erl
@@ -14,7 +14,8 @@ it is deleted.
 -export([
     start_link/0,
 
-    clean_namespace/1
+    clean_namespace/1,
+    force_clean_namespace/1
 ]).
 
 %% `gen_server' API
@@ -59,6 +60,18 @@ clean_namespace(Namespace) ->
     Core = do_pick_core_for(Namespace),
     gen_server:cast({?MODULE, Core}, #clean_namespace{namespace = Namespace}).
 
+-doc """
+Runs the namespace cleanup synchronously in the calling process, regardless of whether
+the namespace is tombstoned.
+
+Last resort for manual cleanup (`emqx ctl mt purge_ns`); normal deletion cleans up
+asynchronously via `clean_namespace/1`.  All cleanup steps are idempotent, so racing the
+janitor process is harmless.
+""".
+-spec force_clean_namespace(emqx_mt:tns()) -> ok | {error, cleanup_incomplete}.
+force_clean_namespace(Namespace) ->
+    do_clean_up(Namespace).
+
 %%------------------------------------------------------------------------------
 %% `gen_server' API
 %%------------------------------------------------------------------------------
@@ -86,7 +99,7 @@ handle_call(Call, _From, State) ->
     {reply, {error, {unknown_call, Call}}, State}.
 
 handle_cast(#clean_namespace{namespace = Namespace}, State) ->
-    ok = handle_clean_namespace(Namespace),
+    _ = handle_clean_namespace(Namespace),
     {noreply, State};
 handle_cast(_Cast, State) ->
     {noreply, State}.
@@ -173,7 +186,10 @@ do_clean_up(Namespace) ->
     end,
     erase(?cleanup_failed),
     ?tp("mt_janitor_finished_ns", #{namespace => Namespace, failed => AnyFailed}),
-    ok.
+    case AnyFailed of
+        false -> ok;
+        true -> {error, cleanup_incomplete}
+    end.
 
 do_clean_up(Namespace, RootKey) ->
     %% Set to empty, so that any config cleanup callbacks are triggered.

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -68,7 +68,10 @@ init_per_testcase(TestCase, Config) when
     AuthHeader = ?ON(N1, emqx_mgmt_api_test_util:auth_header_()),
     put(?AUTH_HEADER_PD_KEY, AuthHeader),
     [{cluster, Cluster} | Config];
-init_per_testcase(t_namespaced_metrics = TestCase, Config) ->
+init_per_testcase(TestCase, Config) when
+    TestCase == t_namespaced_metrics;
+    TestCase == t_delete_ns_purges_builtin_auth_data
+->
     Apps = emqx_cth_suite:start(
         [
             emqx,
@@ -1615,6 +1618,58 @@ t_namespaced_authz(_TCConfig) ->
         emqtt:publish(C1, TopicPub1, <<"hi">>, [{qos, 1}])
     ),
 
+    ok.
+
+-doc """
+Tests that deleting a namespace also purges its built-in database authentication users
+and authorization rules, so a later namespace with the same name starts empty.
+
+See https://github.com/emqx/emqx/issues/17816.
+""".
+t_delete_ns_purges_builtin_auth_data(_TCConfig) ->
+    GlobalAdminHeader = emqx_dashboard_admin_SUITE:create_superuser(),
+    emqx_authn_api_mnesia_SUITE:put_auth_header(GlobalAdminHeader),
+    emqx_authz_api_mnesia_SUITE:put_auth_header(GlobalAdminHeader),
+    Ns = <<"tns">>,
+    {204, _} = create_managed_ns(Ns),
+
+    {201, _} = emqx_authn_api_mnesia_SUITE:add_user(
+        #{<<"user_id">> => <<"u1">>, <<"password">> => <<"passwd">>},
+        #{<<"ns">> => Ns}
+    ),
+    {204, _} = emqx_authz_api_mnesia_SUITE:create_all_rules(
+        #{
+            <<"rules">> => [
+                #{
+                    <<"topic">> => <<"t">>,
+                    <<"permission">> => <<"allow">>,
+                    <<"action">> => <<"publish">>
+                }
+            ]
+        },
+        #{<<"ns">> => Ns}
+    ),
+    ?assertMatch(
+        {200, #{<<"data">> := [_]}},
+        emqx_authn_api_mnesia_SUITE:list_users(#{<<"ns">> => Ns})
+    ),
+    ?assertMatch(
+        {200, #{<<"rules">> := [_]}},
+        emqx_authz_api_mnesia_SUITE:get_all_rules(#{<<"ns">> => Ns})
+    ),
+
+    {204, _} = delete_ns(Ns),
+    ?retry(250, 10, ?assertNot(emqx_mt_state:is_tombstoned(Ns))),
+    {204, _} = create_managed_ns(Ns),
+
+    ?assertMatch(
+        {200, #{<<"data">> := []}},
+        emqx_authn_api_mnesia_SUITE:list_users(#{<<"ns">> => Ns})
+    ),
+    ?assertMatch(
+        {200, #{<<"rules">> := []}},
+        emqx_authz_api_mnesia_SUITE:get_all_rules(#{<<"ns">> => Ns})
+    ),
     ok.
 
 -doc """

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -70,7 +70,8 @@ init_per_testcase(TestCase, Config) when
     [{cluster, Cluster} | Config];
 init_per_testcase(TestCase, Config) when
     TestCase == t_namespaced_metrics;
-    TestCase == t_delete_ns_purges_builtin_auth_data
+    TestCase == t_delete_ns_purges_builtin_auth_data;
+    TestCase == t_purge_ns_cli
 ->
     Apps = emqx_cth_suite:start(
         [
@@ -1670,6 +1671,55 @@ t_delete_ns_purges_builtin_auth_data(_TCConfig) ->
         {200, #{<<"rules">> := []}},
         emqx_authz_api_mnesia_SUITE:get_all_rules(#{<<"ns">> => Ns})
     ),
+    ok.
+
+-doc """
+Tests the `emqx ctl mt purge_ns` command: it deletes the namespace and purges all of its
+data regardless of the namespace's current state, and is idempotent.
+""".
+t_purge_ns_cli(_TCConfig) ->
+    GlobalAdminHeader = emqx_dashboard_admin_SUITE:create_superuser(),
+    emqx_authn_api_mnesia_SUITE:put_auth_header(GlobalAdminHeader),
+    emqx_authz_api_mnesia_SUITE:put_auth_header(GlobalAdminHeader),
+    Ns = <<"tns">>,
+    {204, _} = create_managed_ns(Ns),
+
+    {201, _} = emqx_authn_api_mnesia_SUITE:add_user(
+        #{<<"user_id">> => <<"u1">>, <<"password">> => <<"passwd">>},
+        #{<<"ns">> => Ns}
+    ),
+    {204, _} = emqx_authz_api_mnesia_SUITE:create_all_rules(
+        #{
+            <<"rules">> => [
+                #{
+                    <<"topic">> => <<"t">>,
+                    <<"permission">> => <<"allow">>,
+                    <<"action">> => <<"publish">>
+                }
+            ]
+        },
+        #{<<"ns">> => Ns}
+    ),
+
+    %% Purge without deleting the namespace first.
+    ok = emqx_mt_cli:mt(["purge_ns", binary_to_list(Ns)]),
+    ?assertMatch({404, _}, get_managed_ns_config(Ns)),
+
+    %% Cleanup is synchronous: the namespace can be recreated immediately, and starts
+    %% empty.
+    {204, _} = create_managed_ns(Ns),
+    ?assertMatch(
+        {200, #{<<"data">> := []}},
+        emqx_authn_api_mnesia_SUITE:list_users(#{<<"ns">> => Ns})
+    ),
+    ?assertMatch(
+        {200, #{<<"rules">> := []}},
+        emqx_authz_api_mnesia_SUITE:get_all_rules(#{<<"ns">> => Ns})
+    ),
+
+    %% Idempotent: purging repeatedly, including a nonexistent namespace, succeeds.
+    ok = emqx_mt_cli:mt(["purge_ns", binary_to_list(Ns)]),
+    ok = emqx_mt_cli:mt(["purge_ns", binary_to_list(Ns)]),
     ok.
 
 -doc """

--- a/changes/ee/fix-18117.en.md
+++ b/changes/ee/fix-18117.en.md
@@ -1,0 +1,1 @@
+Deleting a namespace now also removes the namespace's built-in database authentication users (both password-based and SCRAM) and authorization rules. Previously, these records persisted after namespace deletion and reappeared if a namespace with the same name was created later.

--- a/changes/ee/fix-18117.en.md
+++ b/changes/ee/fix-18117.en.md
@@ -1,1 +1,3 @@
 Deleting a namespace now also removes the namespace's built-in database authentication users (both password-based and SCRAM) and authorization rules. Previously, these records persisted after namespace deletion and reappeared if a namespace with the same name was created later.
+
+Additionally, a new `emqx ctl mt purge_ns <namespace>` CLI command deletes a namespace and purges all data belonging to it. The command is idempotent and does not require the namespace to exist, so it can be used as a last resort to clean up leftover data if a previous namespace deletion was interrupted.


### PR DESCRIPTION
Release version: 6.1.4, 6.2.3, 6.3.0

## Summary

Fixes #17816.

Deleting a managed namespace did not remove its built-in database authentication users (password-based and SCRAM) or authorization rules, so recreating a namespace with the same name showed the stale users and rules.

The `'namespace.delete'` hook (run by the namespace cleanup janitor) already has callbacks from the dashboard and management apps to clean their namespaced data, but no auth app registered one. This PR:

- Adds `purge_namespace/1` to `emqx_authn_mnesia` and `emqx_authn_scram_mnesia`, deleting all of the namespace's users across all user groups with mria dirty deletes (global-namespace records are never touched).
- Adds `emqx_auth_mnesia_hookcb`, registered at `emqx_auth_mnesia` app start, whose `'namespace.delete'` callback runs the two new purges plus the existing `emqx_authz_mnesia:purge_rules/1`.
- Adds a new `emqx ctl mt purge_ns <namespace>` CLI command (JSON output) that deletes a namespace and purges all of its data synchronously, without checking whether the namespace exists. It is idempotent — a last resort to manually clean up leftover data when a previous (API-triggered) deletion was interrupted halfway.

The purge operates on the mnesia tables directly (rather than iterating configured authenticators) since the tables are the source of truth for the namespaced data; dirty deletes replicate cluster-wide via mria.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
