### PR TITLE
ci: build macos 26 packages

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -126,8 +126,8 @@ jobs:
         os: ${{ matrix.os }}
         apple_id_password: ${{ secrets.APPLE_ID_PASSWORD }}
         apple_developer_identity: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
-        apple_developer_id_bundle: ${{ (matrix.os == 'macos-15' || matrix.os == 'macos-26') && secrets.APPLE_DEVELOPER_ID_BUNDLE_NEW || secrets.APPLE_DEVELOPER_ID_BUNDLE }}
-        apple_developer_id_bundle_password: ${{ (matrix.os == 'macos-15' || matrix.os == 'macos-26') && secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD_NEW || secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD }}
+        apple_developer_id_bundle: ${{ (matrix.os == 'macos-14') && secrets.APPLE_DEVELOPER_ID_BUNDLE || secrets.APPLE_DEVELOPER_ID_BUNDLE_NEW }}
+        apple_developer_id_bundle_password: ${{ (matrix.os == 'macos-14') && secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD || secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD_NEW }}
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success()

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -109,6 +109,7 @@ jobs:
         os:
           - macos-14
           - macos-15
+          - macos-26
         otp:
           - ${{ inputs.otp_vsn }}
     runs-on: ${{ matrix.os }}
@@ -125,8 +126,8 @@ jobs:
         os: ${{ matrix.os }}
         apple_id_password: ${{ secrets.APPLE_ID_PASSWORD }}
         apple_developer_identity: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
-        apple_developer_id_bundle: ${{ matrix.os == 'macos-15' && secrets.APPLE_DEVELOPER_ID_BUNDLE_NEW || secrets.APPLE_DEVELOPER_ID_BUNDLE }}
-        apple_developer_id_bundle_password: ${{ matrix.os == 'macos-15' && secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD_NEW || secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD }}
+        apple_developer_id_bundle: ${{ (matrix.os == 'macos-15' || matrix.os == 'macos-26') && secrets.APPLE_DEVELOPER_ID_BUNDLE_NEW || secrets.APPLE_DEVELOPER_ID_BUNDLE }}
+        apple_developer_id_bundle_password: ${{ (matrix.os == 'macos-15' || matrix.os == 'macos-26') && secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD_NEW || secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD }}
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success()
@@ -145,6 +146,7 @@ jobs:
         os:
           - macos-14
           - macos-15
+          - macos-26
         otp:
           - ${{ inputs.otp_vsn }}
 

--- a/.github/workflows/build_packages_cron.yaml
+++ b/.github/workflows/build_packages_cron.yaml
@@ -81,7 +81,7 @@ jobs:
           - master
           - release-510
         os:
-          - macos-15
+          - macos-26
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -87,7 +87,7 @@ jobs:
         profile:
         - emqx-enterprise
         os:
-        - macos-15
+        - macos-26
 
     runs-on: ${{ matrix.os }}
     env:

--- a/changes/ee/feat-18118.en.md
+++ b/changes/ee/feat-18118.en.md
@@ -1,0 +1,1 @@
+Start releasing macOS 26 (Tahoe) packages.


### PR DESCRIPTION
Release versions:
5.10.5

## Summary

Start releasing macOS 26 (Tahoe) packages on the 5.10 line — port of #16499 (v6 counterpart, base release-61) to `dev-510`:

- `build_packages.yaml`: add `macos-26` to both the `mac` build matrix and the `test-mac` smoke-test matrix, and extend the Apple signing-bundle selection so `macos-26` uses the NEW developer-ID bundle secrets (like `macos-15`).
- `build_packages_cron.yaml`: `macos-15` → `macos-26`.
- `build_slim_packages.yaml`: `macos-15` → `macos-26`.

Intentional deviations from #16499:
- `performance_test.yaml` is left untouched: v5 keeps the `emqx-ee/e${version}/` S3 path (the `e` prefix is the v5 package-naming convention; v6 dropped it, which is why #16499 changed that path there).
- `test-mac` also gains `macos-26` so the new package is smoke-tested (dev-510 has separate build/test matrices).

Note for maintainers: please trigger the manual `build_packages.yaml` workflow against this ref to verify the macOS 26 build/signing end to end.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyC5e51AUx2xww3LgDkHXK