### PR TITLE
feat(disk_log): support daily/hourly rotation with date-stamped filenames

### DIFF
--- a/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
+++ b/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
@@ -32,6 +32,8 @@
     on_batch_query/3
 ]).
 
+-export([timezone_offset_seconds/1]).
+
 -ifdef(TEST).
 -export([flush/1, get_wrap_logs/2]).
 -endif.
@@ -46,19 +48,29 @@
 -define(disk_log, disk_log).
 
 -define(filepath, filepath).
+-define(conn_config, conn_config).
 -define(installed_actions, installed_actions).
 
 -define(template, template).
 -define(write_mode, write_mode).
 
+-define(SECONDS_PER_DAY, 86400).
+
+-type period() :: none | hour | day.
+-type rotation() :: #{
+    period := period(),
+    retain_period_for_days => pos_integer(),
+    timezone := binary()
+}.
 -type connector_config() :: #{
     filepath := binary(),
     max_file_size := pos_integer(),
-    max_file_number := pos_integer()
+    max_file_number := pos_integer(),
+    rotation => rotation()
 }.
 -type connector_state() :: #{
-    deleteme := true,
     ?filepath := binary(),
+    ?conn_config := connector_config(),
     ?installed_actions := #{action_resource_id() => action_state()}
 }.
 
@@ -94,10 +106,14 @@ callback_mode() ->
     {ok, connector_state()} | {error, _Reason}.
 on_start(ConnResId, ConnConfig) ->
     #{filepath := FilepathBin} = ConnConfig,
+    NowS = now_s(),
+    ActiveFilepath = active_filepath(ConnConfig, NowS),
     maybe
-        ok ?= do_open_log(ConnResId, ConnConfig),
+        ok ?= do_open_log(ConnResId, ConnConfig#{filepath := ActiveFilepath}),
+        ok = sweep_expired_period_files(ConnConfig, NowS),
         ConnState = #{
             ?filepath => FilepathBin,
+            ?conn_config => ConnConfig,
             ?installed_actions => #{}
         },
         {ok, ConnState}
@@ -112,13 +128,13 @@ on_stop(ConnResId, _ConnState) ->
     ok.
 
 -spec on_get_status(connector_resource_id(), connector_state()) ->
-    ?status_connected | ?status_disconnected.
-on_get_status(ConnResId, #{?filepath := Filepath} = _ConnState) ->
+    ?status_connected | ?status_disconnected | {?status_disconnected, binary()}.
+on_get_status(ConnResId, #{?conn_config := ConnConfig} = _ConnState) ->
     case disk_log:info(ConnResId) of
         {error, no_such_log} ->
             ?status_disconnected;
         LogInfo when is_list(LogInfo) ->
-            check_file_status(Filepath, LogInfo, ConnResId)
+            check_period_and_file_status(ConnResId, ConnConfig, LogInfo)
     end.
 
 -spec on_get_channels(connector_resource_id()) ->
@@ -260,6 +276,170 @@ maybe_rotate(ConnResId, ConnConfig) ->
         false ->
             ok
     end.
+
+%% Checks whether the log is still writing to the current period's file, rotating to a
+%% new date-stamped file if the period (day / hour) has changed, before performing the
+%% usual file status checks.
+check_period_and_file_status(ConnResId, ConnConfig, LogInfo0) ->
+    case maybe_rotate_period(ConnResId, ConnConfig, LogInfo0) of
+        not_rotated ->
+            check_file_status(open_filepath(LogInfo0), LogInfo0, ConnResId);
+        rotated ->
+            case disk_log:info(ConnResId) of
+                LogInfo when is_list(LogInfo) ->
+                    check_file_status(open_filepath(LogInfo), LogInfo, ConnResId);
+                {error, no_such_log} ->
+                    ?status_disconnected
+            end;
+        {error, Reason} ->
+            ?SLOG(warning, #{
+                msg => "failed_to_rotate_disk_log_period",
+                reason => Reason,
+                connector_resource_id => ConnResId
+            }),
+            Msg = iolist_to_binary(
+                io_lib:format("Failed to rotate log file: ~0p", [Reason])
+            ),
+            {?status_disconnected, Msg}
+    end.
+
+maybe_rotate_period(ConnResId, ConnConfig, LogInfo) ->
+    NowS = now_s(),
+    ExpectedFilepath = active_filepath(ConnConfig, NowS),
+    case open_filepath(LogInfo) =:= ExpectedFilepath of
+        true ->
+            not_rotated;
+        false ->
+            rotate_period(ConnResId, ConnConfig, ExpectedFilepath, NowS)
+    end.
+
+rotate_period(ConnResId, ConnConfig, NewFilepath, NowS) ->
+    maybe
+        ok ?= stop_disk_log(ConnResId),
+        ok ?= do_open_log(ConnResId, ConnConfig#{filepath := NewFilepath}),
+        ok = sweep_expired_period_files(ConnConfig, NowS),
+        ?SLOG(info, #{
+            msg => "disk_log_connector_period_rotation",
+            new_filepath => NewFilepath,
+            connector_resource_id => ConnResId
+        }),
+        ?tp("disk_log_connector_period_rotated", #{new_filepath => NewFilepath}),
+        rotated
+    end.
+
+%% The file the underlying `disk_log' is currently open with.
+open_filepath(LogInfo) ->
+    {file, File} = lists:keyfind(file, 1, LogInfo),
+    unicode:characters_to_binary(File).
+
+%% The filepath the log should currently be writing to: the configured filepath, or,
+%% when time-based rotation is enabled, the configured filepath with the current
+%% period's date stamp inserted before the file extension (if any).
+active_filepath(ConnConfig, TimeS) ->
+    #{filepath := FilepathBin} = ConnConfig,
+    Rotation = maps:get(rotation, ConnConfig, #{}),
+    case maps:get(period, Rotation, none) of
+        none ->
+            FilepathBin;
+        Period ->
+            Timezone = maps:get(timezone, Rotation, <<"UTC">>),
+            period_filepath(FilepathBin, period_key(Period, Timezone, TimeS))
+    end.
+
+period_filepath(BaseFilepath, PeriodKey) ->
+    Root = filename:rootname(BaseFilepath),
+    Ext = filename:extension(BaseFilepath),
+    <<Root/binary, "-", PeriodKey/binary, Ext/binary>>.
+
+%% Date stamp identifying the rotation period `TimeS' falls in, in the configured
+%% timezone: e.g. `20260624' for `day', `2026062413' for `hour'.
+period_key(day, Timezone, TimeS) ->
+    format_date(TimeS, Timezone, <<"%Y%m%d">>);
+period_key(hour, Timezone, TimeS) ->
+    format_date(TimeS, Timezone, <<"%Y%m%d%H">>).
+
+format_date(TimeS, Timezone, Format) ->
+    Offset = timezone_offset_seconds(Timezone),
+    unicode:characters_to_binary(emqx_utils_calendar:format(TimeS, second, Offset, Format)).
+
+-spec timezone_offset_seconds(binary()) -> integer().
+timezone_offset_seconds(<<"UTC">>) ->
+    0;
+timezone_offset_seconds(Timezone) ->
+    emqx_utils_calendar:offset_second(Timezone).
+
+%% Deletes files from periods older than the configured retention window.  Called after
+%% each period rotation (and on start); no-op unless both `period' and
+%% `retain_period_for_days' are configured.
+sweep_expired_period_files(ConnConfig, NowS) ->
+    #{filepath := FilepathBin} = ConnConfig,
+    Rotation = maps:get(rotation, ConnConfig, #{}),
+    RetainDays = maps:get(retain_period_for_days, Rotation, undefined),
+    case maps:get(period, Rotation, none) of
+        Period when Period =/= none, is_integer(RetainDays) ->
+            Timezone = maps:get(timezone, Rotation, <<"UTC">>),
+            CutoffKey = period_key(Period, Timezone, NowS - RetainDays * ?SECONDS_PER_DAY),
+            delete_expired_period_files(FilepathBin, CutoffKey);
+        _ ->
+            ok
+    end.
+
+delete_expired_period_files(BaseFilepath, CutoffKey) ->
+    Root = filename:rootname(BaseFilepath),
+    Ext = filename:extension(BaseFilepath),
+    Wildcard = unicode:characters_to_list(<<Root/binary, "-*", Ext/binary, ".*">>),
+    Files = filelib:wildcard(Wildcard),
+    lists:foreach(
+        fun(File) ->
+            case is_expired_period_file(File, Root, Ext, CutoffKey) of
+                true ->
+                    _ = file:delete(File),
+                    ?SLOG(info, #{
+                        msg => "disk_log_connector_expired_log_file_deleted",
+                        file => File
+                    });
+                false ->
+                    ok
+            end
+        end,
+        Files
+    ).
+
+%% Matches `<Root>-<Stamp><Ext>.<Suffix>' where `Stamp' is a `period_key/3'-shaped date
+%% stamp older than `CutoffKey', and `Suffix' is a wrap log suffix (`N', `idx' or
+%% `siz').  Anything else is left alone.
+is_expired_period_file(File, Root, Ext, CutoffKey) ->
+    FileBin = unicode:characters_to_binary(File),
+    Prefix = <<Root/binary, "-">>,
+    PrefixSize = byte_size(Prefix),
+    ExtSize = byte_size(Ext),
+    maybe
+        <<Prefix:PrefixSize/binary, Rest/binary>> ?= FileBin,
+        {Stamp, <<Ext:ExtSize/binary, $., Suffix/binary>>} ?=
+            string:take(Rest, lists:seq($0, $9)),
+        is_period_key(Stamp) andalso Stamp < CutoffKey andalso is_wrap_log_suffix(Suffix)
+    else
+        _ -> false
+    end.
+
+is_period_key(Stamp) ->
+    byte_size(Stamp) =:= 8 orelse byte_size(Stamp) =:= 10.
+
+is_wrap_log_suffix(<<"idx">>) ->
+    true;
+is_wrap_log_suffix(<<"siz">>) ->
+    true;
+is_wrap_log_suffix(Suffix) ->
+    Suffix =/= <<>> andalso {Suffix, <<>>} =:= string:take(Suffix, lists:seq($0, $9)).
+
+-ifdef(TEST).
+%% Clock seam for tests: allows fixing "now" to exercise period boundaries.
+now_s() ->
+    persistent_term:get({?MODULE, now_s}, erlang:system_time(second)).
+-else.
+now_s() ->
+    erlang:system_time(second).
+-endif.
 
 -spec create_action(action_config()) -> action_state().
 create_action(#{parameters := Parameters} = _ActionConfig) ->
@@ -428,8 +608,15 @@ log_when_error(Fun, Log) ->
             })
     end.
 
-map_error(ok) -> ok;
-map_error({error, Reason}) -> {error, {unrecoverable_error, Reason}}.
+map_error(ok) ->
+    ok;
+map_error({error, no_such_log}) ->
+    %% May happen transiently while the log is closed and reopened with a new
+    %% date-stamped filepath by a concurrent period rotation; retried by the buffer
+    %% worker.
+    {error, {recoverable_error, no_such_log}};
+map_error({error, Reason}) ->
+    {error, {unrecoverable_error, Reason}}.
 
 map_start_error({error, {file_error, _Filepath, Reason}}) ->
     {error, emqx_utils:explain_posix(Reason)};

--- a/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
+++ b/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
@@ -350,9 +350,11 @@ period_filepath(BaseFilepath, PeriodKey) ->
     <<Root/binary, "-", PeriodKey/binary, Ext/binary>>.
 
 %% Date stamp identifying the rotation period `TimeS' falls in, in the configured
-%% timezone: e.g. `20260624' for `day', `2026062413' for `hour'.
+%% timezone: e.g. `2026062413' for `hour'.  For `day', a literal `00' hour is appended
+%% (`2026062400') so that the stamp format stays the same if `period' is later switched
+%% between `day' and `hour'.
 period_key(day, Timezone, TimeS) ->
-    format_date(TimeS, Timezone, <<"%Y%m%d">>);
+    format_date(TimeS, Timezone, <<"%Y%m%d00">>);
 period_key(hour, Timezone, TimeS) ->
     format_date(TimeS, Timezone, <<"%Y%m%d%H">>).
 
@@ -421,7 +423,7 @@ is_expired_period_file(File, Root, Ext, CutoffKey) ->
     end.
 
 is_period_key(Stamp) ->
-    byte_size(Stamp) =:= 8 orelse byte_size(Stamp) =:= 10.
+    byte_size(Stamp) =:= 10.
 
 is_wrap_log_suffix(<<"idx">>) ->
     true;

--- a/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
+++ b/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
@@ -54,12 +54,10 @@
 -define(template, template).
 -define(write_mode, write_mode).
 
--define(SECONDS_PER_DAY, 86400).
-
 -type period() :: none | hour | day.
 -type rotation() :: #{
     period := period(),
-    retain_period_for_days => pos_integer(),
+    retention_period => timeout(),
     timezone := binary()
 }.
 -type connector_config() :: #{
@@ -369,16 +367,16 @@ timezone_offset_seconds(Timezone) ->
     emqx_utils_calendar:offset_second(Timezone).
 
 %% Deletes files from periods older than the configured retention window.  Called after
-%% each period rotation (and on start); no-op unless both `period' and
-%% `retain_period_for_days' are configured.
+%% each period rotation (and on start); no-op unless `period' is set and
+%% `retention_period' is finite.
 sweep_expired_period_files(ConnConfig, NowS) ->
     #{filepath := FilepathBin} = ConnConfig,
     Rotation = maps:get(rotation, ConnConfig, #{}),
-    RetainDays = maps:get(retain_period_for_days, Rotation, undefined),
+    RetentionMs = maps:get(retention_period, Rotation, infinity),
     case maps:get(period, Rotation, none) of
-        Period when Period =/= none, is_integer(RetainDays) ->
+        Period when Period =/= none, is_integer(RetentionMs) ->
             Timezone = maps:get(timezone, Rotation, <<"UTC">>),
-            CutoffKey = period_key(Period, Timezone, NowS - RetainDays * ?SECONDS_PER_DAY),
+            CutoffKey = period_key(Period, Timezone, NowS - RetentionMs div 1000),
             delete_expired_period_files(FilepathBin, CutoffKey);
         _ ->
             ok

--- a/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
+++ b/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
@@ -47,7 +47,6 @@
 %% Allocatable resources
 -define(disk_log, disk_log).
 
--define(filepath, filepath).
 -define(conn_config, conn_config).
 -define(installed_actions, installed_actions).
 
@@ -70,7 +69,6 @@
     rotation => rotation()
 }.
 -type connector_state() :: #{
-    ?filepath := binary(),
     ?conn_config := connector_config(),
     ?installed_actions := #{action_resource_id() => action_state()}
 }.
@@ -106,14 +104,12 @@ callback_mode() ->
 -spec on_start(connector_resource_id(), connector_config()) ->
     {ok, connector_state()} | {error, _Reason}.
 on_start(ConnResId, ConnConfig) ->
-    #{filepath := FilepathBin} = ConnConfig,
     NowS = now_s(),
     ActiveFilepath = active_filepath(ConnConfig, NowS),
     maybe
         ok ?= do_open_log(ConnResId, ConnConfig#{filepath := ActiveFilepath}),
         ok = sweep_expired_period_files(ConnConfig, NowS),
         ConnState = #{
-            ?filepath => FilepathBin,
             ?conn_config => ConnConfig,
             ?installed_actions => #{}
         },
@@ -129,7 +125,7 @@ on_stop(ConnResId, _ConnState) ->
     ok.
 
 -spec on_get_status(connector_resource_id(), connector_state()) ->
-    ?status_connected | ?status_disconnected | {?status_disconnected, binary()}.
+    ?status_connected | ?status_disconnected | {?status_disconnected, binary() | no_such_log}.
 on_get_status(ConnResId, #{?conn_config := ConnConfig} = _ConnState) ->
     case disk_log:info(ConnResId) of
         {error, no_such_log} ->
@@ -290,7 +286,7 @@ check_period_and_file_status(ConnResId, ConnConfig, LogInfo0) ->
                 LogInfo when is_list(LogInfo) ->
                     check_file_status(open_filepath(LogInfo), LogInfo, ConnResId);
                 {error, no_such_log} ->
-                    ?status_disconnected
+                    {?status_disconnected, no_such_log}
             end;
         {error, Reason} ->
             ?SLOG(warning, #{

--- a/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
+++ b/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl
@@ -54,6 +54,9 @@
 -define(template, template).
 -define(write_mode, write_mode).
 
+%% Byte size of `period_key/3' date stamps (`YYYYMMDDHH').
+-define(PERIOD_KEY_BYTES, 10).
+
 -type period() :: none | hour | day.
 -type rotation() :: #{
     period := period(),
@@ -414,23 +417,24 @@ is_expired_period_file(File, Root, Ext, CutoffKey) ->
     PrefixSize = byte_size(Prefix),
     ExtSize = byte_size(Ext),
     maybe
-        <<Prefix:PrefixSize/binary, Rest/binary>> ?= FileBin,
-        {Stamp, <<Ext:ExtSize/binary, $., Suffix/binary>>} ?=
-            string:take(Rest, lists:seq($0, $9)),
-        is_period_key(Stamp) andalso Stamp < CutoffKey andalso is_wrap_log_suffix(Suffix)
+        <<Prefix:PrefixSize/binary, Stamp:?PERIOD_KEY_BYTES/binary, Ext:ExtSize/binary, $.,
+            Suffix/binary>> ?= FileBin,
+        is_decimal_str(Stamp) andalso Stamp < CutoffKey andalso is_wrap_log_suffix(Suffix)
     else
         _ -> false
     end.
-
-is_period_key(Stamp) ->
-    byte_size(Stamp) =:= 10.
 
 is_wrap_log_suffix(<<"idx">>) ->
     true;
 is_wrap_log_suffix(<<"siz">>) ->
     true;
 is_wrap_log_suffix(Suffix) ->
-    Suffix =/= <<>> andalso {Suffix, <<>>} =:= string:take(Suffix, lists:seq($0, $9)).
+    is_decimal_str(Suffix).
+
+is_decimal_str(<<>>) ->
+    false;
+is_decimal_str(Str) ->
+    {Str, <<>>} =:= string:take(Str, lists:seq($0, $9)).
 
 -ifdef(TEST).
 %% Clock seam for tests: allows fixing "now" to exercise period boundaries.

--- a/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector_schema.erl
+++ b/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector_schema.erl
@@ -75,10 +75,10 @@ fields(rotation) ->
                 default => none,
                 desc => ?DESC("rotation_period")
             })},
-        {retain_period_for_days,
-            mk(pos_integer(), #{
-                required => false,
-                desc => ?DESC("rotation_retain_period_for_days")
+        {retention_period,
+            mk(hoconsc:union([infinity, emqx_schema:duration()]), #{
+                default => infinity,
+                desc => ?DESC("rotation_retention_period")
             })},
         {timezone,
             mk(binary(), #{
@@ -141,7 +141,7 @@ connector_example(put) ->
         max_file_number => 7,
         rotation => #{
             period => <<"day">>,
-            retain_period_for_days => 30,
+            retention_period => <<"30d">>,
             timezone => <<"UTC">>
         },
         resource_opts => #{

--- a/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector_schema.erl
+++ b/apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector_schema.erl
@@ -59,14 +59,41 @@ fields(connector_config) ->
         {filepath, mk(binary(), #{required => true, desc => ?DESC("filepath")})},
         {max_file_size,
             mk(emqx_schema:bytesize(), #{required => true, desc => ?DESC("max_file_size")})},
-        {max_file_number, mk(pos_integer(), #{required => true, desc => ?DESC("max_file_number")})}
+        {max_file_number, mk(pos_integer(), #{required => true, desc => ?DESC("max_file_number")})},
+        {rotation,
+            mk(hoconsc:ref(?MODULE, rotation), #{
+                required => false,
+                default => #{},
+                desc => ?DESC("rotation")
+            })}
     ] ++
-        emqx_connector_schema:resource_opts().
+        emqx_connector_schema:resource_opts();
+fields(rotation) ->
+    [
+        {period,
+            mk(hoconsc:enum([none, hour, day]), #{
+                default => none,
+                desc => ?DESC("rotation_period")
+            })},
+        {retain_period_for_days,
+            mk(pos_integer(), #{
+                required => false,
+                desc => ?DESC("rotation_retain_period_for_days")
+            })},
+        {timezone,
+            mk(binary(), #{
+                default => <<"UTC">>,
+                validator => fun timezone_validator/1,
+                desc => ?DESC("rotation_timezone")
+            })}
+    ].
 
 desc("config_connector") ->
     ?DESC("config_connector");
 desc(resource_opts) ->
     ?DESC(emqx_resource_schema, resource_opts);
+desc(rotation) ->
+    ?DESC("rotation");
 desc(_Name) ->
     undefined.
 
@@ -112,6 +139,11 @@ connector_example(put) ->
         filepath => <<"/tmp/my_log">>,
         max_file_size => <<"10MB">>,
         max_file_number => 7,
+        rotation => #{
+            period => <<"day">>,
+            retain_period_for_days => 30,
+            timezone => <<"UTC">>
+        },
         resource_opts => #{
             health_check_interval => <<"45s">>,
             start_after_created => true,
@@ -166,6 +198,18 @@ unique_filepath_validator(_X) ->
 %%------------------------------------------------------------------------------
 
 mk(Type, Meta) -> hoconsc:mk(Type, Meta).
+
+timezone_validator(Timezone) ->
+    try
+        _ = emqx_bridge_disk_log_connector:timezone_offset_seconds(Timezone),
+        ok
+    catch
+        error:_ ->
+            {error, <<
+                "bad timezone; must be \"UTC\", \"local\","
+                " or a fixed offset such as \"+02:00\""
+            >>}
+    end.
 
 format_duplicated_name_groups(DuplicatedNameGroups) ->
     lists:join(

--- a/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
+++ b/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
@@ -346,6 +346,19 @@ list_files_for_stamp(TCConfig, Stamp) ->
     Wildcard = binary_to_list(<<Base/binary, "-", Stamp/binary, ".*">>),
     lists:sort(filelib:wildcard(Wildcard)).
 
+%% All entries across all periods' file sets, in no particular order.
+read_all_period_logs(TCConfig) ->
+    Base = get_filepath_from_config(TCConfig),
+    Wildcard = binary_to_list(<<Base/binary, "-*">>),
+    Files = filter_wrap_logs(filelib:wildcard(Wildcard)),
+    lists:flatmap(
+        fun(File) ->
+            {ok, Contents} = file:read_file(File),
+            emqx_connector_aggreg_json_lines_test_utils:decode(Contents)
+        end,
+        Files
+    ).
+
 %% Since we run test suites in CI as `root', it's though to create a file/dir which cannot
 %% be read by the current user...
 if_root(YesFun, NoFun) ->
@@ -944,6 +957,75 @@ t_period_rotation_hour(Config) ->
     ),
     ?assertMatch([_ | _], list_files_for_stamp(Config, <<"2026070112">>)),
     ?assertMatch({200, #{<<"status">> := <<"connected">>}}, get_connector_api(Config)),
+    ok.
+
+-doc """
+Entries written concurrently (in both `sync` and `async` write modes) while a period
+rotation happens are not lost: writes hitting the close/reopen window are retried by
+the buffer worker, and every published payload ends up in one of the period's file
+sets.
+""".
+t_period_rotation_concurrent_writes() ->
+    [{matrix, true}].
+t_period_rotation_concurrent_writes(matrix) ->
+    [[sync], [async]];
+t_period_rotation_concurrent_writes(Config) when is_list(Config) ->
+    [WriteMode] = group_path(Config, [sync]),
+    set_now_s(?JUL1_NOON_S),
+    {201, #{<<"status">> := <<"connected">>}} =
+        create_connector_api(Config, #{<<"rotation">> => #{<<"period">> => <<"day">>}}),
+    {201, _} =
+        create_action_api(
+            Config,
+            #{
+                <<"parameters">> => #{
+                    <<"template">> => <<"${.payload}">>,
+                    <<"write_mode">> => atom_to_binary(WriteMode)
+                }
+            }
+        ),
+    RuleTopic = <<"period/concurrent">>,
+    {ok, _} = create_rule(Config, RuleTopic),
+    Base = get_filepath_from_config(Config),
+    ?assertEqual(<<Base/binary, "-2026070100">>, get_active_filepath(Config)),
+    %% Publish a continuous stream of messages while the day boundary is crossed.
+    NumMessages = 200,
+    TestPid = self(),
+    _Publisher = spawn_link(fun() ->
+        lists:foreach(
+            fun(N) ->
+                publish(RuleTopic, <<"m-", (integer_to_binary(N))/binary>>),
+                timer:sleep(10)
+            end,
+            lists:seq(1, NumMessages)
+        ),
+        TestPid ! publisher_done
+    end),
+    set_now_s(?JUL1_NOON_S + ?SECONDS_PER_DAY),
+    ?retry(
+        500,
+        20,
+        ?assertEqual(<<Base/binary, "-2026070200">>, get_active_filepath(Config))
+    ),
+    receive
+        publisher_done -> ok
+    after 20_000 -> ct:fail("publisher did not finish")
+    end,
+    ?assertMatch({200, #{<<"status">> := <<"connected">>}}, get_connector_api(Config)),
+    %% Every single published payload is found in one of the two periods' file sets.
+    Expected = lists:sort([
+        <<"m-", (integer_to_binary(N))/binary>>
+     || N <- lists:seq(1, NumMessages)
+    ]),
+    ConnResId = connector_resource_id(Config),
+    ?retry(
+        500,
+        20,
+        begin
+            ok = emqx_bridge_disk_log_connector:flush(ConnResId),
+            ?assertEqual(Expected, lists:sort(read_all_period_logs(Config)))
+        end
+    ),
     ok.
 
 -doc """

--- a/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
+++ b/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
@@ -18,6 +18,10 @@
 
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
 
+%% 2026-07-01T12:00:00Z
+-define(JUL1_NOON_S, 1782907200).
+-define(SECONDS_PER_DAY, 86400).
+
 %%------------------------------------------------------------------------------
 %% CT boilerplate
 %%------------------------------------------------------------------------------
@@ -308,6 +312,39 @@ publish_and_flush(TCConfig, Topic, Payload) ->
     ConnResId = connector_resource_id(TCConfig),
     ok = emqx_bridge_disk_log_connector:flush(ConnResId),
     ok.
+
+%% Fixes the connector's notion of "now" so tests can deterministically cross period
+%% boundaries.
+set_now_s(TimeS) ->
+    Key = {emqx_bridge_disk_log_connector, now_s},
+    persistent_term:put(Key, TimeS),
+    on_exit(fun() -> persistent_term:erase(Key) end),
+    ok.
+
+%% The base filepath the underlying `disk_log' is currently open with (date-stamped when
+%% time-based rotation is active).
+get_active_filepath(TCConfig) ->
+    ConnResId = connector_resource_id(TCConfig),
+    LogInfo = disk_log:info(ConnResId),
+    {file, File} = lists:keyfind(file, 1, LogInfo),
+    unicode:characters_to_binary(File).
+
+%% Like `read_current_log/1', but based on the currently open (date-stamped) filepath
+%% instead of the configured one.
+read_active_log(TCConfig) ->
+    ConnResId = connector_resource_id(TCConfig),
+    LogInfo = disk_log:info(ConnResId),
+    ActiveFilepath = get_active_filepath(TCConfig),
+    [Current | _] = emqx_bridge_disk_log_connector:get_wrap_logs(ActiveFilepath, LogInfo),
+    {ok, Contents} = file:read_file(Current),
+    emqx_connector_aggreg_json_lines_test_utils:decode(Contents).
+
+%% All files (including `.idx' / `.siz' bookkeeping files) belonging to the given
+%% period's date stamp.
+list_files_for_stamp(TCConfig, Stamp) ->
+    Base = get_filepath_from_config(TCConfig),
+    Wildcard = binary_to_list(<<Base/binary, "-", Stamp/binary, ".*">>),
+    lists:sort(filelib:wildcard(Wildcard)).
 
 %% Since we run test suites in CI as `root', it's though to create a file/dir which cannot
 %% be read by the current user...
@@ -854,3 +891,203 @@ t_reopen_log(Config) ->
 t_rule_test_trace(Config) ->
     Opts = #{},
     emqx_bridge_v2_testlib:t_rule_test_trace(Config, Opts).
+
+-doc """
+Daily rotation: the connector writes to a date-stamped file, and switches to the next
+day's file (keeping the previous day's files) once the day boundary is crossed.
+""".
+t_period_rotation_day(Config) ->
+    set_now_s(?JUL1_NOON_S),
+    {201, #{<<"status">> := <<"connected">>}} =
+        create_connector_api(Config, #{<<"rotation">> => #{<<"period">> => <<"day">>}}),
+    {201, _} =
+        create_action_api(
+            Config,
+            #{<<"parameters">> => #{<<"template">> => <<"${.payload}">>}}
+        ),
+    RuleTopic = <<"period/day">>,
+    {ok, _} = create_rule(Config, RuleTopic),
+    Base = get_filepath_from_config(Config),
+    ?assertEqual(<<Base/binary, "-20260701">>, get_active_filepath(Config)),
+    publish_and_flush(Config, RuleTopic, <<"before">>),
+    ?retry(500, 10, ?assertMatch([<<"before">>], read_active_log(Config))),
+    %% Cross the day boundary; the health check should rotate to the new day's file.
+    set_now_s(?JUL1_NOON_S + ?SECONDS_PER_DAY),
+    ?retry(
+        500,
+        20,
+        ?assertEqual(<<Base/binary, "-20260702">>, get_active_filepath(Config))
+    ),
+    ?assertMatch({200, #{<<"status">> := <<"connected">>}}, get_connector_api(Config)),
+    %% New writes land in the new day's file.
+    publish_and_flush(Config, RuleTopic, <<"after">>),
+    ?retry(500, 10, ?assertMatch([<<"after">>], read_active_log(Config))),
+    %% Previous day's files are left alone (no retention configured).
+    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"20260701">>)),
+    ok.
+
+-doc """
+Hourly rotation: the date stamp has hour granularity and rotation happens at hour
+boundaries.
+""".
+t_period_rotation_hour(Config) ->
+    set_now_s(?JUL1_NOON_S),
+    {201, #{<<"status">> := <<"connected">>}} =
+        create_connector_api(Config, #{<<"rotation">> => #{<<"period">> => <<"hour">>}}),
+    Base = get_filepath_from_config(Config),
+    ?assertEqual(<<Base/binary, "-2026070112">>, get_active_filepath(Config)),
+    set_now_s(?JUL1_NOON_S + 3600),
+    ?retry(
+        500,
+        20,
+        ?assertEqual(<<Base/binary, "-2026070113">>, get_active_filepath(Config))
+    ),
+    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"2026070112">>)),
+    ?assertMatch({200, #{<<"status">> := <<"connected">>}}, get_connector_api(Config)),
+    ok.
+
+-doc """
+A fixed timezone offset shifts the period boundary: at 23:00 UTC with a `+02:00`
+timezone, the active file is already stamped with the next day's date.
+""".
+t_period_rotation_timezone(Config) ->
+    %% 2026-07-01T23:00:00Z == 2026-07-02T01:00:00+02:00
+    set_now_s(?JUL1_NOON_S + 11 * 3600),
+    {201, #{<<"status">> := <<"connected">>}} =
+        create_connector_api(
+            Config,
+            #{
+                <<"rotation">> => #{
+                    <<"period">> => <<"day">>,
+                    <<"timezone">> => <<"+02:00">>
+                }
+            }
+        ),
+    Base = get_filepath_from_config(Config),
+    ?assertEqual(<<Base/binary, "-20260702">>, get_active_filepath(Config)),
+    ok.
+
+-doc """
+An invalid timezone is rejected at config validation time.
+""".
+t_period_bad_timezone(Config) ->
+    ?assertMatch(
+        {400, _},
+        create_connector_api(
+            Config,
+            #{
+                <<"rotation">> => #{
+                    <<"period">> => <<"day">>,
+                    <<"timezone">> => <<"not-a-timezone">>
+                }
+            }
+        )
+    ),
+    ok.
+
+-doc """
+Retention: after a period rotation, files (including `.idx` / `.siz` bookkeeping files)
+from periods older than `retain_period_for_days` are deleted, while newer ones are kept.
+""".
+t_period_retention(Config) ->
+    set_now_s(?JUL1_NOON_S),
+    {201, #{<<"status">> := <<"connected">>}} =
+        create_connector_api(
+            Config,
+            #{
+                <<"rotation">> => #{
+                    <<"period">> => <<"day">>,
+                    <<"retain_period_for_days">> => 1
+                }
+            }
+        ),
+    {201, _} =
+        create_action_api(
+            Config,
+            #{<<"parameters">> => #{<<"template">> => <<"${.payload}">>}}
+        ),
+    RuleTopic = <<"period/retention">>,
+    {ok, _} = create_rule(Config, RuleTopic),
+    Base = get_filepath_from_config(Config),
+    publish_and_flush(Config, RuleTopic, <<"day1">>),
+    Day1Files = list_files_for_stamp(Config, <<"20260701">>),
+    ?assertMatch([_ | _], Day1Files),
+    %% `.idx' / `.siz' bookkeeping files are part of the day's file set.
+    ?assert(lists:member(binary_to_list(<<Base/binary, "-20260701.idx">>), Day1Files)),
+    ?assert(lists:member(binary_to_list(<<Base/binary, "-20260701.siz">>), Day1Files)),
+    %% Next day: day 1 files are within the retention window and are kept.
+    set_now_s(?JUL1_NOON_S + ?SECONDS_PER_DAY),
+    ?retry(
+        500,
+        20,
+        ?assertEqual(<<Base/binary, "-20260702">>, get_active_filepath(Config))
+    ),
+    publish_and_flush(Config, RuleTopic, <<"day2">>),
+    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"20260701">>)),
+    %% Day after: day 1 files fall out of the retention window and are deleted.
+    set_now_s(?JUL1_NOON_S + 2 * ?SECONDS_PER_DAY),
+    ?retry(
+        500,
+        20,
+        ?assertEqual(<<Base/binary, "-20260703">>, get_active_filepath(Config))
+    ),
+    ?assertEqual([], list_files_for_stamp(Config, <<"20260701">>)),
+    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"20260702">>)),
+    ok.
+
+-doc """
+Size-based rotation still applies within a period: exceeding `max_file_size` rotates to
+the next `.N` slot of the same date-stamped file set.
+""".
+t_period_size_cap(Config) ->
+    set_now_s(?JUL1_NOON_S),
+    {201, #{<<"status">> := <<"connected">>}} =
+        create_connector_api(
+            Config,
+            #{
+                <<"max_file_size">> => <<"10B">>,
+                <<"max_file_number">> => 3,
+                <<"rotation">> => #{<<"period">> => <<"day">>}
+            }
+        ),
+    {201, _} =
+        create_action_api(
+            Config,
+            #{<<"parameters">> => #{<<"template">> => <<"${.payload}">>}}
+        ),
+    RuleTopic = <<"period/sizecap">>,
+    {ok, _} = create_rule(Config, RuleTopic),
+    Base = get_filepath_from_config(Config),
+    Payload1 = binary:copy(<<"a">>, 100),
+    publish_and_flush(Config, RuleTopic, Payload1),
+    ?retry(500, 10, ?assertMatch([Payload1], read_active_log(Config))),
+    %% Next write exceeds `max_file_size' and rotates to the next slot within the same
+    %% date-stamped file set.
+    Payload2 = <<"b">>,
+    publish_and_flush(Config, RuleTopic, Payload2),
+    ?retry(500, 10, ?assertMatch([Payload2], read_active_log(Config))),
+    Day1Files = list_files_for_stamp(Config, <<"20260701">>),
+    ?assert(lists:member(binary_to_list(<<Base/binary, "-20260701.1">>), Day1Files)),
+    ?assert(lists:member(binary_to_list(<<Base/binary, "-20260701.2">>), Day1Files)),
+    ok.
+
+-doc """
+`period = none` (the default) keeps today's behavior: the log is opened with the
+configured filepath verbatim, and no date-stamped files are created.
+""".
+t_period_none(Config) ->
+    {201, #{<<"status">> := <<"connected">>}} = create_connector_api(Config),
+    {201, _} =
+        create_action_api(
+            Config,
+            #{<<"parameters">> => #{<<"template">> => <<"${.payload}">>}}
+        ),
+    RuleTopic = <<"period/none">>,
+    {ok, _} = create_rule(Config, RuleTopic),
+    Base = get_filepath_from_config(Config),
+    ?assertEqual(Base, get_active_filepath(Config)),
+    publish_and_flush(Config, RuleTopic, <<"hello">>),
+    ?retry(500, 10, ?assertMatch([<<"hello">>], read_current_log(Config))),
+    %% Still on the configured (un-stamped) filepath after health checks.
+    ?assertEqual(Base, get_active_filepath(Config)),
+    ok.

--- a/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
+++ b/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
@@ -1072,6 +1072,43 @@ t_period_size_cap(Config) ->
     ok.
 
 -doc """
+The connector notices when its log files are deleted behind its back (e.g. by an
+operator or an external logrotate), reports itself disconnected, and then auto-recovers
+by recreating the log files on the automatic restart.
+""".
+t_files_purged_externally(Config) ->
+    {201, #{<<"status">> := <<"connected">>}} = create_connector_api(Config),
+    {201, _} =
+        create_action_api(
+            Config,
+            #{<<"parameters">> => #{<<"template">> => <<"${.payload}">>}}
+        ),
+    RuleTopic = <<"purged">>,
+    {ok, _} = create_rule(Config, RuleTopic),
+    publish_and_flush(Config, RuleTopic, <<"before">>),
+    ?retry(500, 10, ?assertMatch([<<"before">>], read_current_log(Config))),
+    %% Purge all log files (including `.idx' / `.siz') behind the connector's back.
+    Base = get_filepath_from_config(Config),
+    Files = filelib:wildcard(binary_to_list(<<Base/binary, ".*">>)),
+    ?assertMatch([_ | _], Files),
+    lists:foreach(fun(F) -> ok = file:delete(F) end, Files),
+    %% The health check notices the missing files...
+    ?retry(
+        700,
+        20,
+        ?assertMatch({200, #{<<"status">> := <<"disconnected">>}}, get_connector_api(Config))
+    ),
+    %% ... and the automatic restart recreates them and reconnects.
+    ?retry(
+        700,
+        20,
+        ?assertMatch({200, #{<<"status">> := <<"connected">>}}, get_connector_api(Config))
+    ),
+    publish_and_flush(Config, RuleTopic, <<"after">>),
+    ?retry(500, 10, ?assertMatch([<<"after">>], read_current_log(Config))),
+    ok.
+
+-doc """
 `period = none` (the default) keeps today's behavior: the log is opened with the
 configured filepath verbatim, and no date-stamped files are created.
 """.

--- a/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
+++ b/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
@@ -908,7 +908,7 @@ t_period_rotation_day(Config) ->
     RuleTopic = <<"period/day">>,
     {ok, _} = create_rule(Config, RuleTopic),
     Base = get_filepath_from_config(Config),
-    ?assertEqual(<<Base/binary, "-20260701">>, get_active_filepath(Config)),
+    ?assertEqual(<<Base/binary, "-2026070100">>, get_active_filepath(Config)),
     publish_and_flush(Config, RuleTopic, <<"before">>),
     ?retry(500, 10, ?assertMatch([<<"before">>], read_active_log(Config))),
     %% Cross the day boundary; the health check should rotate to the new day's file.
@@ -916,14 +916,14 @@ t_period_rotation_day(Config) ->
     ?retry(
         500,
         20,
-        ?assertEqual(<<Base/binary, "-20260702">>, get_active_filepath(Config))
+        ?assertEqual(<<Base/binary, "-2026070200">>, get_active_filepath(Config))
     ),
     ?assertMatch({200, #{<<"status">> := <<"connected">>}}, get_connector_api(Config)),
     %% New writes land in the new day's file.
     publish_and_flush(Config, RuleTopic, <<"after">>),
     ?retry(500, 10, ?assertMatch([<<"after">>], read_active_log(Config))),
     %% Previous day's files are left alone (no retention configured).
-    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"20260701">>)),
+    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"2026070100">>)),
     ok.
 
 -doc """
@@ -964,7 +964,7 @@ t_period_rotation_timezone(Config) ->
             }
         ),
     Base = get_filepath_from_config(Config),
-    ?assertEqual(<<Base/binary, "-20260702">>, get_active_filepath(Config)),
+    ?assertEqual(<<Base/binary, "-2026070200">>, get_active_filepath(Config)),
     ok.
 
 -doc """
@@ -1010,29 +1010,29 @@ t_period_retention(Config) ->
     {ok, _} = create_rule(Config, RuleTopic),
     Base = get_filepath_from_config(Config),
     publish_and_flush(Config, RuleTopic, <<"day1">>),
-    Day1Files = list_files_for_stamp(Config, <<"20260701">>),
+    Day1Files = list_files_for_stamp(Config, <<"2026070100">>),
     ?assertMatch([_ | _], Day1Files),
     %% `.idx' / `.siz' bookkeeping files are part of the day's file set.
-    ?assert(lists:member(binary_to_list(<<Base/binary, "-20260701.idx">>), Day1Files)),
-    ?assert(lists:member(binary_to_list(<<Base/binary, "-20260701.siz">>), Day1Files)),
+    ?assert(lists:member(binary_to_list(<<Base/binary, "-2026070100.idx">>), Day1Files)),
+    ?assert(lists:member(binary_to_list(<<Base/binary, "-2026070100.siz">>), Day1Files)),
     %% Next day: day 1 files are within the retention window and are kept.
     set_now_s(?JUL1_NOON_S + ?SECONDS_PER_DAY),
     ?retry(
         500,
         20,
-        ?assertEqual(<<Base/binary, "-20260702">>, get_active_filepath(Config))
+        ?assertEqual(<<Base/binary, "-2026070200">>, get_active_filepath(Config))
     ),
     publish_and_flush(Config, RuleTopic, <<"day2">>),
-    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"20260701">>)),
+    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"2026070100">>)),
     %% Day after: day 1 files fall out of the retention window and are deleted.
     set_now_s(?JUL1_NOON_S + 2 * ?SECONDS_PER_DAY),
     ?retry(
         500,
         20,
-        ?assertEqual(<<Base/binary, "-20260703">>, get_active_filepath(Config))
+        ?assertEqual(<<Base/binary, "-2026070300">>, get_active_filepath(Config))
     ),
-    ?assertEqual([], list_files_for_stamp(Config, <<"20260701">>)),
-    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"20260702">>)),
+    ?assertEqual([], list_files_for_stamp(Config, <<"2026070100">>)),
+    ?assertMatch([_ | _], list_files_for_stamp(Config, <<"2026070200">>)),
     ok.
 
 -doc """
@@ -1066,9 +1066,9 @@ t_period_size_cap(Config) ->
     Payload2 = <<"b">>,
     publish_and_flush(Config, RuleTopic, Payload2),
     ?retry(500, 10, ?assertMatch([Payload2], read_active_log(Config))),
-    Day1Files = list_files_for_stamp(Config, <<"20260701">>),
-    ?assert(lists:member(binary_to_list(<<Base/binary, "-20260701.1">>), Day1Files)),
-    ?assert(lists:member(binary_to_list(<<Base/binary, "-20260701.2">>), Day1Files)),
+    Day1Files = list_files_for_stamp(Config, <<"2026070100">>),
+    ?assert(lists:member(binary_to_list(<<Base/binary, "-2026070100.1">>), Day1Files)),
+    ?assert(lists:member(binary_to_list(<<Base/binary, "-2026070100.2">>), Day1Files)),
     ok.
 
 -doc """

--- a/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
+++ b/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
@@ -987,7 +987,7 @@ t_period_bad_timezone(Config) ->
 
 -doc """
 Retention: after a period rotation, files (including `.idx` / `.siz` bookkeeping files)
-from periods older than `retain_period_for_days` are deleted, while newer ones are kept.
+from periods older than `retention_period` are deleted, while newer ones are kept.
 """.
 t_period_retention(Config) ->
     set_now_s(?JUL1_NOON_S),
@@ -997,7 +997,7 @@ t_period_retention(Config) ->
             #{
                 <<"rotation">> => #{
                     <<"period">> => <<"day">>,
-                    <<"retain_period_for_days">> => 1
+                    <<"retention_period">> => <<"1d">>
                 }
             }
         ),

--- a/changes/ee/feat-18119.en.md
+++ b/changes/ee/feat-18119.en.md
@@ -3,7 +3,7 @@ The Disk Log connector now supports time-based file rotation in addition to size
 A new optional `rotation` setting was added to the connector configuration:
 
 - `rotation.period`: `none` (default), `day`, or `hour`.  When set to `day` or `hour`, the connector starts a new set of log files at each period boundary, with the period's date stamp encoded in the file names (e.g. `mqtt-trace-20260624.log.1` for daily rotation of `mqtt-trace.log`).  Size-based rotation (`max_file_size` / `max_file_number`) still applies within each period.
-- `rotation.retain_period_for_days`: how many days to keep files from previous periods; older date-stamped files are deleted automatically after each period rotation.  If not set, old files are kept.
+- `rotation.retention_period`: how long to keep files from previous periods (e.g. `30d`); older date-stamped files are deleted automatically after each period rotation.  Defaults to `infinity` (old files are kept).
 - `rotation.timezone`: timezone used to determine period boundaries: `UTC` (default), `local`, or a fixed offset such as `+02:00`.
 
 The default behavior (no `rotation` configured, or `rotation.period = none`) is unchanged.

--- a/changes/ee/feat-18119.en.md
+++ b/changes/ee/feat-18119.en.md
@@ -2,7 +2,7 @@ The Disk Log connector now supports time-based file rotation in addition to size
 
 A new optional `rotation` setting was added to the connector configuration:
 
-- `rotation.period`: `none` (default), `day`, or `hour`.  When set to `day` or `hour`, the connector starts a new set of log files at each period boundary, with the period's date stamp encoded in the file names (e.g. `mqtt-trace-20260624.log.1` for daily rotation of `mqtt-trace.log`).  Size-based rotation (`max_file_size` / `max_file_number`) still applies within each period.
+- `rotation.period`: `none` (default), `day`, or `hour`.  When set to `day` or `hour`, the connector starts a new set of log files at each period boundary, with the period's date stamp (`YYYYMMDDHH`) encoded in the file names (e.g. `mqtt-trace-2026062400.log.1` for daily rotation of `mqtt-trace.log`).  Size-based rotation (`max_file_size` / `max_file_number`) still applies within each period.
 - `rotation.retention_period`: how long to keep files from previous periods (e.g. `30d`); older date-stamped files are deleted automatically after each period rotation.  Defaults to `infinity` (old files are kept).
 - `rotation.timezone`: timezone used to determine period boundaries: `UTC` (default), `local`, or a fixed offset such as `+02:00`.
 

--- a/changes/ee/feat-18119.en.md
+++ b/changes/ee/feat-18119.en.md
@@ -1,0 +1,9 @@
+The Disk Log connector now supports time-based file rotation in addition to size-based rotation.
+
+A new optional `rotation` setting was added to the connector configuration:
+
+- `rotation.period`: `none` (default), `day`, or `hour`.  When set to `day` or `hour`, the connector starts a new set of log files at each period boundary, with the period's date stamp encoded in the file names (e.g. `mqtt-trace-20260624.log.1` for daily rotation of `mqtt-trace.log`).  Size-based rotation (`max_file_size` / `max_file_number`) still applies within each period.
+- `rotation.retain_period_for_days`: how many days to keep files from previous periods; older date-stamped files are deleted automatically after each period rotation.  If not set, old files are kept.
+- `rotation.timezone`: timezone used to determine period boundaries: `UTC` (default), `local`, or a fixed offset such as `+02:00`.
+
+The default behavior (no `rotation` configured, or `rotation.period = none`) is unchanged.

--- a/rel/i18n/emqx_bridge_disk_log_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_disk_log_connector_schema.hocon
@@ -17,7 +17,7 @@ emqx_bridge_disk_log_connector_schema {
   max_file_number.label:
   """Maximum Number of Files"""
   max_file_number.desc:
-  """Maximum number of log files to be used.  When time-based rotation (`rotation.period`) is enabled, this limit applies to each rotation period's file set separately.  Once the maximum number of files is reached and a new rotation is required, the log wraps around: the oldest file's contents are discarded and the file is reused as the new current file."""
+  """Maximum number of log files to be used.  When time-based rotation (`rotation.period`) is enabled, this limit applies to each rotation period's file set separately.  Once the maximum number of files is reached and a new rotation is required, the log wraps around: the oldest file's contents are discarded, and the file is reused as the new current file."""
 
   rotation.label:
   """Time-Based Rotation"""

--- a/rel/i18n/emqx_bridge_disk_log_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_disk_log_connector_schema.hocon
@@ -7,7 +7,7 @@ emqx_bridge_disk_log_connector_schema {
   filepath.label:
   """Log filepath"""
   filepath.desc:
-  """Base file path to the log file to be written to.  Actual log files will have the format `filepath.N`, where `N` is `1..max_file_number`.  The currently used file can be found by taking the file with the most recent modification date.  Note that the directory containing it must also be writable by the EMQX application user, as it'll also contain extra files for internal use (ending in `.siz` and `.idx`)."""
+  """Base file path to the log file to be written to.  Actual log files will have the format `filepath.N`, where `N` is `1..max_file_number`.  When time-based rotation (`rotation.period`) is enabled, the current period's date stamp is additionally inserted before the file extension: with `filepath = /var/log/emqx/mqtt-trace.log`, files are named `mqtt-trace-20260624.log.N`.  The currently used file can be found by taking the file with the most recent modification date.  Note that the directory containing it must also be writable by the EMQX application user, as it'll also contain extra files for internal use (ending in `.siz` and `.idx`)."""
 
   max_file_size.label:
   """Maximum File Size"""
@@ -17,7 +17,7 @@ emqx_bridge_disk_log_connector_schema {
   max_file_number.label:
   """Maximum Number of Files"""
   max_file_number.desc:
-  """Maximum number of log files to be used.  Once the maximum number of files is reached and a new rotation is required, the oldest such file is truncated and used as the new current file."""
+  """Maximum number of log files to be used.  When time-based rotation (`rotation.period`) is enabled, this limit applies to each rotation period's file set separately.  Once the maximum number of files is reached and a new rotation is required, the log wraps around: the oldest file's contents are discarded and the file is reused as the new current file."""
 
   rotation.label:
   """Time-Based Rotation"""
@@ -29,10 +29,10 @@ emqx_bridge_disk_log_connector_schema {
   rotation_period.desc:
   """When set to `day` or `hour`, the connector starts a new set of log files at each period boundary, with the period's date stamp inserted before the file extension: with `filepath = /var/log/emqx/mqtt-trace.log` and `period = day`, files are named `mqtt-trace-20260624.log.N`.  The `.N` suffix (`N` is `1..max_file_number`) comes from the underlying wrap log and is always present; each period's file set also includes `.idx` and `.siz` bookkeeping files.  Within a period, files still rotate by size (`max_file_size`), so size `max_file_size × max_file_number` for the worst-case period to avoid losing data to within-period wrap-around.  The period boundary is detected on the connector's health check tick, so the new period's file appears within `health_check_interval` after the boundary.  When set to `none` (default), only size-based rotation is used."""
 
-  rotation_retain_period_for_days.label:
-  """Retain Period Files For Days"""
-  rotation_retain_period_for_days.desc:
-  """Number of days to keep files from previous rotation periods.  After each period rotation, date-stamped log files (including their `.idx` and `.siz` bookkeeping files) older than this many days are deleted.  If not set, files from old periods are kept forever.  Has no effect when `period` is `none`."""
+  rotation_retention_period.label:
+  """Retention Period"""
+  rotation_retention_period.desc:
+  """How long to keep files from previous rotation periods.  After each period rotation, date-stamped log files (including their `.idx` and `.siz` bookkeeping files) from periods older than this are deleted.  The default `infinity` keeps them forever.  Has no effect when `period` is `none`."""
 
   rotation_timezone.label:
   """Rotation Timezone"""

--- a/rel/i18n/emqx_bridge_disk_log_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_disk_log_connector_schema.hocon
@@ -18,4 +18,24 @@ emqx_bridge_disk_log_connector_schema {
   """Maximum Number of Files"""
   max_file_number.desc:
   """Maximum number of log files to be used.  Once the maximum number of files is reached and a new rotation is required, the oldest such file is truncated and used as the new current file."""
+
+  rotation.label:
+  """Time-Based Rotation"""
+  rotation.desc:
+  """Settings for rotating to a new set of log files at calendar period (day or hour) boundaries, with the period's date encoded in the file names, and for cleaning up files from old periods."""
+
+  rotation_period.label:
+  """Rotation Period"""
+  rotation_period.desc:
+  """When set to `day` or `hour`, the connector starts a new set of log files at each period boundary, with the period's date stamp inserted before the file extension: with `filepath = /var/log/emqx/mqtt-trace.log` and `period = day`, files are named `mqtt-trace-20260624.log.N`.  The `.N` suffix (`N` is `1..max_file_number`) comes from the underlying wrap log and is always present; each period's file set also includes `.idx` and `.siz` bookkeeping files.  Within a period, files still rotate by size (`max_file_size`), so size `max_file_size × max_file_number` for the worst-case period to avoid losing data to within-period wrap-around.  The period boundary is detected on the connector's health check tick, so the new period's file appears within `health_check_interval` after the boundary.  When set to `none` (default), only size-based rotation is used."""
+
+  rotation_retain_period_for_days.label:
+  """Retain Period Files For Days"""
+  rotation_retain_period_for_days.desc:
+  """Number of days to keep files from previous rotation periods.  After each period rotation, date-stamped log files (including their `.idx` and `.siz` bookkeeping files) older than this many days are deleted.  If not set, files from old periods are kept forever.  Has no effect when `period` is `none`."""
+
+  rotation_timezone.label:
+  """Rotation Timezone"""
+  rotation_timezone.desc:
+  """Timezone used to determine period boundaries and date stamps.  `UTC` (default), `local` (the server's local time), or a fixed UTC offset such as `+02:00`."""
 }

--- a/rel/i18n/emqx_bridge_disk_log_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_disk_log_connector_schema.hocon
@@ -7,7 +7,7 @@ emqx_bridge_disk_log_connector_schema {
   filepath.label:
   """Log filepath"""
   filepath.desc:
-  """Base file path to the log file to be written to.  Actual log files will have the format `filepath.N`, where `N` is `1..max_file_number`.  When time-based rotation (`rotation.period`) is enabled, the current period's date stamp is additionally inserted before the file extension: with `filepath = /var/log/emqx/mqtt-trace.log`, files are named `mqtt-trace-20260624.log.N`.  The currently used file can be found by taking the file with the most recent modification date.  Note that the directory containing it must also be writable by the EMQX application user, as it'll also contain extra files for internal use (ending in `.siz` and `.idx`)."""
+  """Base file path to the log file to be written to.  Actual log files will have the format `filepath.N`, where `N` is `1..max_file_number`.  When time-based rotation (`rotation.period`) is enabled, the current period's date stamp is additionally inserted before the file extension: with `filepath = /var/log/emqx/mqtt-trace.log`, files are named `mqtt-trace-2026062400.log.N`.  The currently used file can be found by taking the file with the most recent modification date.  Note that the directory containing it must also be writable by the EMQX application user, as it'll also contain extra files for internal use (ending in `.siz` and `.idx`)."""
 
   max_file_size.label:
   """Maximum File Size"""
@@ -27,7 +27,7 @@ emqx_bridge_disk_log_connector_schema {
   rotation_period.label:
   """Rotation Period"""
   rotation_period.desc:
-  """When set to `day` or `hour`, the connector starts a new set of log files at each period boundary, with the period's date stamp inserted before the file extension: with `filepath = /var/log/emqx/mqtt-trace.log` and `period = day`, files are named `mqtt-trace-20260624.log.N`.  The `.N` suffix (`N` is `1..max_file_number`) comes from the underlying wrap log and is always present; each period's file set also includes `.idx` and `.siz` bookkeeping files.  Within a period, files still rotate by size (`max_file_size`), so size `max_file_size × max_file_number` for the worst-case period to avoid losing data to within-period wrap-around.  The period boundary is detected on the connector's health check tick, so the new period's file appears within `health_check_interval` after the boundary.  When set to `none` (default), only size-based rotation is used."""
+  """When set to `day` or `hour`, the connector starts a new set of log files at each period boundary, with the period's date stamp (`YYYYMMDDHH`) inserted before the file extension: with `filepath = /var/log/emqx/mqtt-trace.log`, files are named `mqtt-trace-2026062413.log.N` for `hour`, and `mqtt-trace-2026062400.log.N` for `day` (daily stamps always carry a `00` hour, so the file name format stays the same if `period` is later changed).  The `.N` suffix (`N` is `1..max_file_number`) comes from the underlying wrap log and is always present; each period's file set also includes `.idx` and `.siz` bookkeeping files.  Within a period, files still rotate by size (`max_file_size`), so size `max_file_size × max_file_number` for the worst-case period to avoid losing data to within-period wrap-around.  The period boundary is detected on the connector's health check tick, so the new period's file appears within `health_check_interval` after the boundary.  When set to `none` (default), only size-based rotation is used."""
 
   rotation_retention_period.label:
   """Retention Period"""


### PR DESCRIPTION
Release version:
6.3.0

## Summary

Implements date-based (daily / hourly) rotation for the Disk Log connector, per #17727.

- New optional `rotation` block in the connector config: `period = none | hour | day` (default `none`, backward compatible), `retention_period` (duration, default `infinity`), and `timezone` (`UTC`, `local`, or a fixed offset such as `+02:00`, resolved via `emqx_utils_calendar`).
- When `period` is `day`/`hour`, the log is opened with the current period's date stamp inserted into the filename. The stamp is always `YYYYMMDDHH` — daily files carry a literal `00` hour (`mqtt-trace.log` → `mqtt-trace-2026062400.log`), so the name format stays the same if `period` is later switched between `day` and `hour`. Files on disk are `mqtt-trace-2026062400.log.N` plus the `.idx`/`.siz` bookkeeping files, as imposed by OTP `disk_log` wrap mode — documented in the schema descriptions.
- Period boundary detection piggy-backs on `on_get_status/2` (path 1 recommended in the issue; no resource-framework change). Since health check results cannot carry updated connector state, the currently open file is read from `disk_log:info/1` and compared against the expected dated path computed from "now"; on mismatch the log is closed and reopened with the new dated path.
- Size-based rotation (`max_file_size` / `max_file_number`) is unchanged and keeps acting as a within-period cap.
- Retention: after each period rotation (and on connector start), date-stamped file sets from periods older than `retention_period` are deleted (only files whose name matches the `<base>-<stamp><ext>.<N|idx|siz>` shape). No-op when `infinity`.
- Writes hitting the brief close/reopen window during a period rotation now map to a recoverable error, so the buffer worker retries them instead of dropping.

Decisions taken:

- The existing flat `max_file_size` / `max_file_number` fields stay where they are (the connector shipped in 6.0, so moving them under `rotation{}` would break released configs); the `rotation` block is purely additive.
- The trace log handler is **not** covered here: it rotates via `logger_disk_log_h` handler config, a different mechanism, and will be handled as a follow-up if still desired.

Main files: `apps/emqx_bridge_disk_log/src/emqx_bridge_disk_log_connector.erl`, `emqx_bridge_disk_log_connector_schema.erl`, `rel/i18n/emqx_bridge_disk_log_connector_schema.hocon`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
