### PR TITLE
fix: handle plugin validation errors

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -63,6 +63,7 @@
 {emqx_mgmt_api_plugins,2}.
 {emqx_mgmt_api_plugins,3}.
 {emqx_mgmt_api_plugins,4}.
+{emqx_mgmt_api_plugins,5}.
 {emqx_mgmt_cluster,1}.
 {emqx_mgmt_cluster,2}.
 {emqx_mgmt_cluster,3}.

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -1099,8 +1099,8 @@ operation_response(start, {error, {plugin_start_enable_failed, Reason}}) ->
         "plugin_start_enable_failed",
         #{reason => Reason},
         <<
-            "Plugin started, but enabling it in the cluster configuration failed. "
-            "Check server logs and plugin status."
+            "Plugin start was rolled back because enabling it in the cluster configuration failed. "
+            "Check server logs for details."
         >>
     );
 operation_response(start, {error, {plugin_start_failed, NodeErrors}}) ->
@@ -1193,33 +1193,26 @@ format_node_error(Node, Error) ->
 
 classify_start_preflight_errors(NodeErrors) ->
     Errors = [Error || {_Node, Error} <- NodeErrors],
-    case lists:all(fun is_invalid_plugin_config_error/1, Errors) of
-        true ->
-            invalid_config;
+    Kinds = lists:filtermap(fun validation_error_kind/1, Errors),
+    case length(Kinds) =:= length(Errors) of
         false ->
-            case lists:all(fun is_conflicting_plugin_version_error/1, Errors) of
-                true ->
-                    conflicting_version;
-                false ->
-                    case lists:all(fun is_start_client_error/1, Errors) of
-                        true -> mixed_client_errors;
-                        false -> internal_error
-                    end
+            internal_error;
+        true ->
+            case lists:usort(Kinds) of
+                [] -> internal_error;
+                [invalid_config] -> invalid_config;
+                [conflicting_version] -> conflicting_version;
+                [_ | _] -> mixed_client_errors
             end
     end.
 
-is_start_client_error(Error) ->
-    is_invalid_plugin_config_error(Error) orelse
-        is_conflicting_plugin_version_error(Error).
-
-is_invalid_plugin_config_error({error, #{msg := "invalid_plugin_config"}}) -> true;
-is_invalid_plugin_config_error(_) -> false.
-
-is_conflicting_plugin_version_error(
-    {error, #{msg := "conflicting_plugin_version_running"}}
-) ->
-    true;
-is_conflicting_plugin_version_error(_) ->
+validation_error_kind({error, #{kind := Kind}}) when
+    Kind =:= invalid_config;
+    Kind =:= invalid_package;
+    Kind =:= conflicting_version
+->
+    {true, Kind};
+validation_error_kind(_) ->
     false.
 
 readable_error_msg(#{

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -146,7 +146,10 @@ schema("/plugins/:name") ->
             responses => #{
                 204 => ?DESC("uninstall_success"),
                 400 => emqx_dashboard_swagger:error_codes(['PARAM_ERROR'], ?DESC("bad_parameter")),
-                404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'], ?DESC("plugin_not_found"))
+                404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'], ?DESC("plugin_not_found")),
+                500 => emqx_dashboard_swagger:error_codes(
+                    ['INTERNAL_ERROR'], ?DESC("internal_error")
+                )
             }
         }
     };
@@ -163,8 +166,13 @@ schema("/plugins/:name/:action") ->
             ],
             responses => #{
                 204 => ?DESC("trigger_success"),
-                400 => emqx_dashboard_swagger:error_codes(['PARAM_ERROR'], ?DESC("bad_parameter")),
-                404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'], ?DESC("plugin_not_found"))
+                400 => emqx_dashboard_swagger:error_codes(
+                    ['PARAM_ERROR', 'BAD_CONFIG'], ?DESC("bad_parameter")
+                ),
+                404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'], ?DESC("plugin_not_found")),
+                500 => emqx_dashboard_swagger:error_codes(
+                    ['INTERNAL_ERROR'], ?DESC("internal_error")
+                )
             }
         }
     };
@@ -601,31 +609,55 @@ forget_allow_after_install(_NameVsn, _Other) ->
     ok.
 
 do_install_package_on_nodes(NameVsn, Bin) ->
-    %% TODO: handle bad nodes
     Nodes = emqx:running_nodes(),
-    {[_ | _] = Res, []} = emqx_mgmt_api_plugins_proto_v4:install_package(Nodes, NameVsn, Bin),
-    case lists:filter(fun(R) -> R =/= ok end, Res) of
-        [] ->
+    {Responses, BadNodes} =
+        emqx_mgmt_api_plugins_proto_v4:install_package(Nodes, NameVsn, Bin),
+    GoodNodes = Nodes -- BadNodes,
+    NodeErrors = [
+        {Node, Response}
+     || {Node, Response} <- lists:zip(GoodNodes, Responses),
+        Response =/= ok
+    ],
+    case {NodeErrors, BadNodes} of
+        {[], []} ->
             {204};
-        Filtered ->
-            %% crash if we have unexpected errors or results
-            [] = lists:filter(
-                fun
-                    ({error, {failed, _}}) -> true;
-                    ({error, _}) -> false
-                end,
-                Filtered
-            ),
-            Reason =
-                case hd(Filtered) of
-                    {error, #{msg := Reason0}} -> Reason0;
-                    {error, #{reason := Reason0}} -> Reason0
-                end,
-            {400, #{
-                code => 'BAD_PLUGIN_INFO',
-                message => iolist_to_binary([bin(Reason), ": ", NameVsn])
+        {NodeErrors, []} when NodeErrors =/= [] ->
+            case lists:any(fun({_Node, Error}) -> is_rpc_error(Error) end, NodeErrors) of
+                true ->
+                    ?SLOG(error, #{
+                        msg => "plugin_install_failed",
+                        node_errors => NodeErrors
+                    }),
+                    {500, #{
+                        code => 'INTERNAL_ERROR',
+                        message => format_node_errors(NodeErrors)
+                    }};
+                false ->
+                    ?SLOG(warning, #{
+                        msg => "invalid_plugin_package",
+                        node_errors => NodeErrors
+                    }),
+                    {400, #{
+                        code => 'BAD_PLUGIN_INFO',
+                        message => format_node_errors(NodeErrors)
+                    }}
+            end;
+        {NodeErrors, BadNodes} ->
+            ?SLOG(error, #{
+                msg => "plugin_install_failed",
+                node_errors => NodeErrors,
+                bad_nodes => BadNodes
+            }),
+            {500, #{
+                code => 'INTERNAL_ERROR',
+                message => format_node_errors(
+                    NodeErrors ++ [{Node, {badnode, Node}} || Node <- BadNodes]
+                )
             }}
     end.
+
+is_rpc_error({badrpc, _}) -> true;
+is_rpc_error(_) -> false.
 
 plugin(get, #{bindings := #{name := NameVsn}}) ->
     Nodes = emqx:running_nodes(),
@@ -638,7 +670,7 @@ plugin(delete, #{bindings := #{name := NameVsn}}) ->
     case api_visible_on_any_node(NameVsn) of
         true ->
             Res = emqx_mgmt_api_plugins_proto_v4:delete_package(NameVsn),
-            return(204, Res);
+            operation_response(delete, Res);
         false ->
             {404, plugin_not_found_msg()}
     end.
@@ -646,8 +678,8 @@ plugin(delete, #{bindings := #{name := NameVsn}}) ->
 update_plugin(put, #{bindings := #{name := NameVsn, action := Action}}) ->
     case api_visible_on_any_node(NameVsn) of
         true ->
-            Res = emqx_mgmt_api_plugins_proto_v4:ensure_action(NameVsn, Action),
-            return(204, Res);
+            Res = ensure_cluster_action(NameVsn, Action),
+            operation_response(Action, Res);
         false ->
             {404, plugin_not_found_msg()}
     end.
@@ -797,7 +829,10 @@ install_package_v4(NameVsn, Bin) ->
         {error, #{reason := plugin_not_found}} = NotFound ->
             NotFound;
         {error, Reason} = Error ->
-            ?SLOG(error, Reason#{msg => "failed_to_install_plugin"}),
+            ?SLOG(error, #{
+                msg => "failed_to_install_plugin",
+                reason => Reason
+            }),
             _ = emqx_plugins:delete_package(NameVsn),
             Error;
         Result ->
@@ -840,6 +875,135 @@ ensure_action(Name, restart, _Opts) ->
         {error, _} = Error -> Error
     end.
 
+ensure_cluster_action(Name, stop) ->
+    emqx_mgmt_api_plugins_proto_v4:ensure_action(Name, stop);
+ensure_cluster_action(Name, start) ->
+    Nodes = emqx:running_nodes(),
+    ensure_start_packages_on_nodes(Nodes, Name).
+
+ensure_start_packages_on_nodes(Nodes, Name) ->
+    {Responses, BadNodes} =
+        emqx_mgmt_api_plugins_proto_v5:ensure_start_package(Nodes, Name),
+    GoodNodes = Nodes -- BadNodes,
+    NodeErrors = [
+        {Node, Response}
+     || {Node, Response} <- lists:zip(GoodNodes, Responses),
+        Response =/= ok
+    ],
+    case {lists:any(fun is_node_rpc_error/1, NodeErrors), BadNodes, NodeErrors} of
+        {false, [], []} ->
+            validate_and_start_on_nodes(Nodes, Name);
+        {false, [], _} ->
+            {error, {plugin_start_failed, NodeErrors}};
+        _ ->
+            {error, {plugin_start_unavailable, package, NodeErrors, BadNodes}}
+    end.
+
+%% Start validation is deliberately side-effect free, but it is not an atomic
+%% transaction with the following starts.  Each node revalidates in
+%% `emqx_plugins:ensure_started/1', and rollback is best effort if concurrent
+%% lifecycle or configuration operations make these status hints stale.
+validate_and_start_on_nodes(Nodes, Name) ->
+    {Responses, BadNodes} = emqx_mgmt_api_plugins_proto_v5:validate_start(Nodes, Name),
+    GoodNodes = Nodes -- BadNodes,
+    NodeResponses = lists:zip(GoodNodes, Responses),
+    NodeErrors = [
+        {Node, Response}
+     || {Node, Response} <- NodeResponses,
+        not is_start_validation_result(Response)
+    ],
+    case {lists:any(fun is_node_rpc_error/1, NodeErrors), BadNodes, NodeErrors} of
+        {false, [], []} ->
+            NodeStates = [
+                {Node, RunningStatus}
+             || {Node, {ok, RunningStatus}} <- NodeResponses
+            ],
+            start_on_nodes(Name, NodeStates);
+        {false, [], _} ->
+            {error, {plugin_start_preflight_failed, NodeErrors}};
+        _ ->
+            {error, {plugin_start_unavailable, validation, NodeErrors, BadNodes}}
+    end.
+
+start_on_nodes(Name, NodeStates) ->
+    Nodes = [Node || {Node, _RunningStatus} <- NodeStates],
+    {Responses, BadNodes} = emqx_mgmt_api_plugins_proto_v5:ensure_started(Nodes, Name),
+    GoodNodes = Nodes -- BadNodes,
+    Errors = [
+        {Node, Response}
+     || {Node, Response} <- lists:zip(GoodNodes, Responses),
+        Response =/= ok
+    ],
+    case {lists:any(fun is_node_rpc_error/1, Errors), BadNodes, Errors} of
+        {false, [], []} ->
+            enable_if_membership_unchanged(Name, NodeStates);
+        {false, [], _} ->
+            rollback_after_start_error(Name, NodeStates, {plugin_start_failed, Errors});
+        _ ->
+            rollback_after_start_error(
+                Name,
+                NodeStates,
+                {plugin_start_unavailable, start, Errors, BadNodes}
+            )
+    end.
+
+enable_if_membership_unchanged(Name, NodeStates) ->
+    ValidatedNodes = lists:sort([Node || {Node, _} <- NodeStates]),
+    CurrentNodes = lists:sort(emqx:running_nodes()),
+    case CurrentNodes =:= ValidatedNodes of
+        true ->
+            case emqx_plugins:ensure_enabled(Name, no_move, global) of
+                ok ->
+                    ok;
+                {error, Reason} ->
+                    rollback_after_start_error(
+                        Name,
+                        NodeStates,
+                        {plugin_start_enable_failed, Reason}
+                    )
+            end;
+        false ->
+            rollback_after_start_error(
+                Name,
+                NodeStates,
+                {plugin_start_membership_changed, ValidatedNodes, CurrentNodes}
+            )
+    end.
+
+rollback_after_start_error(Name, NodeStates, Cause) ->
+    case rollback_starts(Name, NodeStates) of
+        ok ->
+            {error, Cause};
+        {error, RollbackErrors} ->
+            {error, {plugin_start_rollback_failed, Cause, RollbackErrors}}
+    end.
+
+rollback_starts(Name, NodeStates) ->
+    Nodes = [Node || {Node, not_running} <- NodeStates],
+    {Responses, BadNodes} = emqx_mgmt_api_plugins_proto_v5:ensure_stopped(Nodes, Name),
+    GoodNodes = Nodes -- BadNodes,
+    Errors =
+        [
+            {Node, Response}
+         || {Node, Response} <- lists:zip(GoodNodes, Responses),
+            Response =/= ok
+        ] ++
+            [{Node, {badnode, Node}} || Node <- BadNodes],
+    case Errors of
+        [] -> ok;
+        [_ | _] -> {error, Errors}
+    end.
+
+is_start_validation_result({ok, RunningStatus}) when
+    RunningStatus =:= running; RunningStatus =:= not_running
+->
+    true;
+is_start_validation_result(_) ->
+    false.
+
+is_node_rpc_error({_Node, {badrpc, _}}) -> true;
+is_node_rpc_error({_Node, _}) -> false.
+
 %% for RPC plugin avro encoded config update
 -spec do_update_plugin_config(name_vsn(), map() | binary(), any()) ->
     ok.
@@ -877,13 +1041,107 @@ sync_plugin_cluster(Node, NameVsn) ->
 %% Helper functions
 %%--------------------------------------------------------------------
 
-return(Code, ok) ->
-    {Code};
-return(_, {error, #{msg := Msg, reason := {enoent, Path} = Reason}}) ->
-    ?SLOG(error, #{msg => Msg, reason => Reason}),
-    {404, #{code => 'NOT_FOUND', message => iolist_to_binary([Path, " does not exist"])}};
-return(_, {error, Reason}) ->
-    {400, #{code => 'PARAM_ERROR', message => readable_error_msg(Reason)}}.
+operation_response(_Operation, ok) ->
+    {204};
+operation_response(start, {error, {plugin_start_preflight_failed, NodeErrors}}) ->
+    case classify_start_preflight_errors(NodeErrors) of
+        invalid_config ->
+            {400, #{
+                code => 'BAD_CONFIG',
+                message => format_node_errors(NodeErrors)
+            }};
+        conflicting_version ->
+            {400, #{
+                code => 'PARAM_ERROR',
+                message => format_node_errors(NodeErrors)
+            }};
+        mixed_client_errors ->
+            {400, #{
+                code => 'PARAM_ERROR',
+                message => format_node_errors(NodeErrors)
+            }};
+        internal_error ->
+            internal_error_response(
+                "plugin_start_preflight_failed",
+                #{node_errors => NodeErrors},
+                format_node_errors(NodeErrors)
+            )
+    end;
+operation_response(
+    start,
+    {error, {plugin_start_unavailable, Phase, NodeErrors, BadNodes}}
+) ->
+    internal_error_response(
+        "plugin_start_unavailable",
+        #{phase => Phase, node_errors => NodeErrors, bad_nodes => BadNodes},
+        format_node_errors(NodeErrors ++ [{Node, {badnode, Node}} || Node <- BadNodes])
+    );
+operation_response(
+    start,
+    {error, {plugin_start_membership_changed, ValidatedNodes, CurrentNodes}}
+) ->
+    internal_error_response(
+        "plugin_start_membership_changed",
+        #{validated_nodes => ValidatedNodes, current_nodes => CurrentNodes},
+        <<"Cluster membership changed during plugin start. Retry when the cluster is stable.">>
+    );
+operation_response(start, {error, {plugin_start_rollback_failed, Cause, RollbackErrors}}) ->
+    internal_error_response(
+        "plugin_start_rollback_failed",
+        #{cause => Cause, rollback_errors => RollbackErrors},
+        <<
+            "Plugin start failed and rollback was incomplete. "
+            "Check server logs and plugin status on all nodes."
+        >>
+    );
+operation_response(start, {error, {plugin_start_enable_failed, Reason}}) ->
+    internal_error_response(
+        "plugin_start_enable_failed",
+        #{reason => Reason},
+        <<
+            "Plugin started, but enabling it in the cluster configuration failed. "
+            "Check server logs and plugin status."
+        >>
+    );
+operation_response(start, {error, {plugin_start_failed, NodeErrors}}) ->
+    internal_error_response(
+        "plugin_start_failed",
+        #{node_errors => NodeErrors},
+        format_node_errors(NodeErrors)
+    );
+operation_response(Operation, {error, #{reason := {enoent, Path} = Reason} = Error}) ->
+    ?SLOG(warning, #{
+        msg => "plugin_resource_not_found",
+        operation => Operation,
+        path => Path,
+        reason => Reason,
+        error => Error
+    }),
+    {404, #{
+        code => 'NOT_FOUND',
+        message =>
+            <<
+                "plugin_resource_not_found: A required plugin resource was not found. "
+                "Check server logs for details."
+            >>
+    }};
+operation_response(Operation, {error, Reason}) ->
+    internal_error_response(
+        operation_error_keyword(Operation),
+        #{operation => Operation, reason => Reason},
+        <<"Plugin operation failed. Check server logs for details.">>
+    ).
+
+internal_error_response(Keyword, LogFields, Details) ->
+    ?SLOG(error, LogFields#{msg => Keyword}),
+    {500, #{
+        code => 'INTERNAL_ERROR',
+        message => iolist_to_binary([Keyword, ": ", Details])
+    }}.
+
+operation_error_keyword(start) -> "plugin_start_failed";
+operation_error_keyword(stop) -> "plugin_stop_failed";
+operation_error_keyword(delete) -> "plugin_delete_failed".
 
 return_config_update_result({Responses, BadNodes}) ->
     ResponseErrors = lists:filter(fun(Response) -> Response =/= ok end, Responses),
@@ -894,10 +1152,11 @@ return_config_update_result({Responses, BadNodes}) ->
         {ResponseErrors, []} ->
             {400, #{code => 'BAD_CONFIG', message => format_errors(ResponseErrors)}};
         {ResponseErrors, NodeErrors} ->
-            {500, #{
-                code => 'INTERNAL_ERROR',
-                message => format_errors(ResponseErrors ++ NodeErrors)
-            }}
+            internal_error_response(
+                "plugin_config_update_failed",
+                #{response_errors => ResponseErrors, bad_nodes => BadNodes},
+                format_errors(ResponseErrors ++ NodeErrors)
+            )
     end.
 
 plugin_not_found_msg() ->
@@ -917,6 +1176,181 @@ format_error({badnode, Node}) ->
 format_error(Other) ->
     readable_error_msg(Other).
 
+format_node_errors(NodeErrors) ->
+    iolist_to_binary(
+        lists:join("; ", [format_node_error(Node, Error) || {Node, Error} <- NodeErrors])
+    ).
+
+format_node_error(Node, {badnode, Node}) ->
+    iolist_to_binary(["node ", atom_to_binary(Node), " unavailable"]);
+format_node_error(Node, Error) ->
+    iolist_to_binary([
+        "node ",
+        atom_to_binary(Node),
+        ": ",
+        format_error(Error)
+    ]).
+
+classify_start_preflight_errors(NodeErrors) ->
+    Errors = [Error || {_Node, Error} <- NodeErrors],
+    case lists:all(fun is_invalid_plugin_config_error/1, Errors) of
+        true ->
+            invalid_config;
+        false ->
+            case lists:all(fun is_conflicting_plugin_version_error/1, Errors) of
+                true ->
+                    conflicting_version;
+                false ->
+                    case lists:all(fun is_start_client_error/1, Errors) of
+                        true -> mixed_client_errors;
+                        false -> internal_error
+                    end
+            end
+    end.
+
+is_start_client_error(Error) ->
+    is_invalid_plugin_config_error(Error) orelse
+        is_conflicting_plugin_version_error(Error).
+
+is_invalid_plugin_config_error({error, #{msg := "invalid_plugin_config"}}) -> true;
+is_invalid_plugin_config_error(_) -> false.
+
+is_conflicting_plugin_version_error(
+    {error, #{msg := "conflicting_plugin_version_running"}}
+) ->
+    true;
+is_conflicting_plugin_version_error(_) ->
+    false.
+
+readable_error_msg(#{
+    msg := "invalid_plugin_config",
+    name_vsn := NameVsn,
+    reason := #{
+        reason := invalid_type,
+        path := Path,
+        expected := Expected,
+        actual := Actual
+    }
+}) ->
+    iolist_to_binary([
+        "invalid_plugin_config: Plugin ",
+        NameVsn,
+        " configuration is invalid at '",
+        Path,
+        "': expected ",
+        Expected,
+        ", got ",
+        Actual,
+        ". Fix the plugin configuration on this node and retry."
+    ]);
+readable_error_msg(#{
+    msg := "invalid_plugin_config",
+    name_vsn := NameVsn,
+    reason := _Reason
+}) ->
+    iolist_to_binary([
+        "invalid_plugin_config: Plugin ",
+        NameVsn,
+        " configuration is invalid. Fix the plugin configuration on this node and retry."
+    ]);
+readable_error_msg(#{
+    msg := "invalid_plugin_config_schema",
+    name_vsn := NameVsn,
+    reason := _Reason
+}) ->
+    iolist_to_binary([
+        "invalid_plugin_config_schema: Plugin ",
+        NameVsn,
+        " contains an invalid configuration schema. Rebuild or reinstall a corrected plugin "
+        "package and retry."
+    ]);
+readable_error_msg(#{
+    msg := "bad_plugin_app_file",
+    path := _Path,
+    reason := _Reason
+}) ->
+    <<
+        "bad_plugin_app_file: Plugin package metadata is invalid or unreadable. "
+        "Rebuild or reinstall a corrected plugin package and retry."
+    >>;
+readable_error_msg(#{
+    msg := "plugin_app_version_mismatch",
+    path := _Path,
+    expected_vsn := ExpectedVsn,
+    actual_vsn := ActualVsn
+}) ->
+    iolist_to_binary([
+        "plugin_app_version_mismatch: Plugin package metadata declares application version ",
+        emqx_utils:readable_error_msg(ActualVsn),
+        ", but ",
+        ExpectedVsn,
+        " is required. Rebuild or reinstall the correct plugin package and retry."
+    ]);
+readable_error_msg(#{
+    msg := "plugin_app_loaded_outside_package",
+    name := AppName,
+    expected_ebin := _ExpectedEbin,
+    loaded_ebin := _LoadedEbin
+}) ->
+    iolist_to_binary([
+        "plugin_app_loaded_outside_package: Plugin application ",
+        atom_to_binary(AppName),
+        " is already loaded outside this plugin package. Remove the conflicting code path or "
+        "restart the node, then retry."
+    ]);
+readable_error_msg(#{
+    msg := "bad_default_hocon_file",
+    reason := _Reason
+}) ->
+    <<
+        "bad_default_hocon_file: Plugin package default configuration is invalid or "
+        "unreadable. Rebuild or reinstall a corrected plugin package and retry."
+    >>;
+readable_error_msg(#{
+    reason := bad_schema,
+    details := _Details
+}) ->
+    <<
+        "invalid_plugin_config_schema: Plugin package configuration schema is invalid. "
+        "Rebuild or reinstall a corrected plugin package and retry."
+    >>;
+readable_error_msg(#{
+    msg := "conflicting_plugin_version_running",
+    active_versions := ActiveVersions
+}) ->
+    iolist_to_binary([
+        "conflicting_plugin_version_running: Another version of this plugin is running: ",
+        lists:join(", ", ActiveVersions),
+        ". Stop the active version and retry."
+    ]);
+readable_error_msg(#{
+    reason := invalid_type,
+    path := Path,
+    expected := Expected,
+    actual := Actual
+}) ->
+    iolist_to_binary([
+        "invalid_type: Invalid type for field '",
+        Path,
+        "': expected ",
+        Expected,
+        ", got ",
+        Actual
+    ]);
+readable_error_msg(#{
+    reason := invalid_union_member,
+    path := Path,
+    expected := Expected,
+    actual := Actual
+}) ->
+    iolist_to_binary([
+        "invalid_union_member: Invalid union member for field '",
+        Path,
+        "': expected ",
+        Expected,
+        ", got ",
+        Actual
+    ]);
 readable_error_msg(Msg) ->
     emqx_utils:readable_error_msg(Msg).
 
@@ -1073,10 +1507,6 @@ format_plugin_avsc_and_i18n(NameVsn) ->
 
 or_null({ok, Value}) -> Value;
 or_null(_) -> null.
-
-bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
-bin(L) when is_list(L) -> list_to_binary(L);
-bin(B) when is_binary(B) -> B.
 
 % running_status: running loaded, stopped
 %% config_status: not_configured disable enable

--- a/apps/emqx_management/src/proto/emqx_mgmt_api_plugins_proto_v5.erl
+++ b/apps/emqx_management/src/proto/emqx_mgmt_api_plugins_proto_v5.erl
@@ -1,0 +1,37 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%-------------------------------------------------------------------
+-module(emqx_mgmt_api_plugins_proto_v5).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+    ensure_start_package/2,
+    validate_start/2,
+    ensure_started/2,
+    ensure_stopped/2
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+-define(TIMEOUT, 10000).
+
+introduced_in() ->
+    "6.1.4".
+
+-spec ensure_start_package([node()], binary() | string()) -> emqx_rpc:multicall_result().
+ensure_start_package(Nodes, Name) ->
+    rpc:multicall(Nodes, emqx_plugins, ensure_start_package, [Name], ?TIMEOUT).
+
+-spec validate_start([node()], binary() | string()) -> emqx_rpc:multicall_result().
+validate_start(Nodes, Name) ->
+    rpc:multicall(Nodes, emqx_plugins, validate_start, [Name], ?TIMEOUT).
+
+-spec ensure_started([node()], binary() | string()) -> emqx_rpc:multicall_result().
+ensure_started(Nodes, Name) ->
+    rpc:multicall(Nodes, emqx_plugins, ensure_started, [Name], ?TIMEOUT).
+
+-spec ensure_stopped([node()], binary() | string()) -> emqx_rpc:multicall_result().
+ensure_stopped(Nodes, Name) ->
+    rpc:multicall(Nodes, emqx_plugins, ensure_stopped, [Name], ?TIMEOUT).

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -215,6 +215,24 @@ t_install_plugin_with_bad_app_file_returns_consistent_error(Config) ->
         emqx_utils_json:decode(Body)
     ).
 
+t_start_preflight_package_error_returns_400(Config) ->
+    NameVsn = install_test_plugin(Config),
+    [SchemaPath] = filelib:wildcard(
+        filename:join([
+            emqx_plugins_fs:plugin_dir(NameVsn),
+            "*",
+            "priv",
+            "config_schema.avsc"
+        ])
+    ),
+    ok = file:write_file(SchemaPath, <<"not an avro schema">>),
+    {400, Response} = request_plugin_action(NameVsn, "start"),
+    ?assertEqual(<<"PARAM_ERROR">>, maps:get(<<"code">>, Response)),
+    ?assertNotEqual(
+        nomatch,
+        binary:match(maps:get(<<"message">>, Response), <<"invalid_plugin_config_schema:">>)
+    ).
+
 t_uninstall_conflicting_version_keeps_old_running(Config) ->
     OldPackagePath = make_test_plugin_package(
         Config,
@@ -702,32 +720,33 @@ t_cluster_rolls_back_partial_start_failure(Config) ->
     NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
     ?ON(Initiator, ok = allow_installation(NameVsn)),
     ok = install_plugin_into_cluster(Config, PackagePath),
-    ok = ?ON(FailingNode, meck:new(emqx_plugins, [no_link, passthrough])),
+    FailingAppFile = ?ON(FailingNode, test_plugin_app_file(NameVsn)),
     ok = ?ON(
         FailingNode,
-        meck:expect(
-            emqx_plugins,
-            ensure_started,
-            fun(_Name) -> {error, injected_start_failure} end
+        file:write_file(
+            FailingAppFile,
+            <<
+                "{application, invalid_plugin, ["
+                "{vsn, \"0.1.0\"},"
+                "{applications, [missing_plugin_dependency]}"
+                "]}.\n"
+            >>
         )
     ),
-    try
-        {500, StartResponse} = request_plugin_action_in_cluster(Config, NameVsn, "start"),
-        ?assertEqual(<<"INTERNAL_ERROR">>, maps:get(<<"code">>, StartResponse)),
-        ?assertMatch(
-            <<"plugin_start_failed: ", _/binary>>,
-            maps:get(<<"message">>, StartResponse)
-        ),
-        #{
-            <<"running_status">> := RunningStatus
-        } = describe_plugin_in_cluster(Config, NameVsn),
-        ?assertEqual(
-            [<<"stopped">>, <<"stopped">>],
-            lists:sort([Status || #{<<"status">> := Status} <- RunningStatus])
-        )
-    after
-        ?ON(FailingNode, meck:unload(emqx_plugins))
-    end.
+    ok = ?ON(FailingNode, application:unload(invalid_plugin)),
+    {500, StartResponse} = request_plugin_action_in_cluster(Config, NameVsn, "start"),
+    ?assertEqual(<<"INTERNAL_ERROR">>, maps:get(<<"code">>, StartResponse)),
+    ?assertMatch(
+        <<"plugin_start_failed: ", _/binary>>,
+        maps:get(<<"message">>, StartResponse)
+    ),
+    #{
+        <<"running_status">> := RunningStatus
+    } = describe_plugin_in_cluster(Config, NameVsn),
+    ?assertEqual(
+        [<<"stopped">>, <<"stopped">>],
+        lists:sort([Status || #{<<"status">> := Status} <- RunningStatus])
+    ).
 
 list_plugins_from_cluster(Config) ->
     #{host := Host, auth := Auth} = get_host_and_auth(Config),
@@ -848,6 +867,34 @@ update_boot_order(Name, MoveBody, Config) ->
 uninstall_plugin(Name) ->
     DeletePath = emqx_mgmt_api_test_util:api_path(["plugins", Name]),
     emqx_mgmt_api_test_util:request_api(delete, DeletePath).
+
+install_test_plugin(Config) ->
+    PackagePath = make_test_plugin_package(
+        Config,
+        test_plugin_schema(),
+        <<"foo = \"bar\"\n">>
+    ),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    on_exit(fun() ->
+        _ = emqx_plugins:ensure_stopped(NameVsn),
+        _ = emqx_plugins:ensure_disabled(NameVsn),
+        _ = emqx_plugins:ensure_uninstalled(NameVsn),
+        _ = emqx_plugins:delete_package(NameVsn)
+    end),
+    ok = allow_installation(NameVsn),
+    ok = install_plugin(PackagePath),
+    NameVsn.
+
+test_plugin_app_file(NameVsn) ->
+    [AppFile] = filelib:wildcard(
+        filename:join([
+            emqx_plugins_fs:plugin_dir(NameVsn),
+            "*",
+            "ebin",
+            "invalid_plugin.app"
+        ])
+    ),
+    AppFile.
 
 get_demo_plugin_package() ->
     PkgName = lists:flatten([

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -61,12 +61,34 @@ init_per_testcase(t_cluster_update_order = TestCase, Config0) ->
         {cluster, Cluster}
         | Config
     ];
+init_per_testcase(t_cluster_rejects_invalid_local_config_on_start = TestCase, Config0) ->
+    Config = [{api_port, 28085} | Config0],
+    Cluster = [Node1 | _] = cluster(TestCase, Config),
+    {ok, API} = init_api(Node1),
+    [
+        {api, API},
+        {cluster, Cluster}
+        | Config
+    ];
+init_per_testcase(t_cluster_rolls_back_partial_start_failure = TestCase, Config0) ->
+    Config = [{api_port, 38085} | Config0],
+    Cluster = [Node1 | _] = cluster(TestCase, Config),
+    {ok, API} = init_api(Node1),
+    [
+        {api, API},
+        {cluster, Cluster}
+        | Config
+    ];
 init_per_testcase(TestCase, Config) ->
     ToInstallDir = filename:join(emqx_cth_suite:work_dir(TestCase, Config), "emqx_plugins"),
     emqx_plugins:put_config_internal(install_dir, ToInstallDir),
     Config.
 
-end_per_testcase(t_cluster_update_order, Config) ->
+end_per_testcase(TestCase, Config) when
+    TestCase =:= t_cluster_update_order;
+    TestCase =:= t_cluster_rejects_invalid_local_config_on_start;
+    TestCase =:= t_cluster_rolls_back_partial_start_failure
+->
     Cluster = ?config(cluster, Config),
     emqx_cth_cluster:stop(Cluster),
     end_per_testcase(common, Config);
@@ -147,17 +169,69 @@ t_install_plugin_sha256_mismatch(_Config) ->
     ok = disallow_installation(NameVsn),
     ok.
 
-t_uninstall_conflicting_version_keeps_old_running(_Config) ->
-    #{package := OldPackagePath} = get_demo_plugin_package(#{
-        shdir => "./",
-        vsn => "5.1.0",
-        tag => "5.1.0"
-    }),
-    #{package := NewPackagePath} = get_demo_plugin_package(#{
-        shdir => "./",
-        vsn => "5.9.0-beta.1",
-        tag => "5.9.0-beta.1"
-    }),
+t_install_plugin_with_invalid_schema_returns_bad_plugin_info(Config) ->
+    PackagePath = make_test_plugin_package(
+        Config,
+        <<"not an avro schema">>,
+        <<"foo = \"bar\"\n">>
+    ),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    on_exit(fun() ->
+        _ = disallow_installation(NameVsn),
+        _ = emqx_plugins:delete_package(NameVsn)
+    end),
+    ok = allow_installation(NameVsn),
+    {ok, {{"HTTP/1.1", 400, "Bad Request"}, _, Body}} = install_plugin(PackagePath),
+    #{<<"code">> := <<"BAD_PLUGIN_INFO">>, <<"message">> := Message} =
+        emqx_utils_json:decode(Body),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"invalid_plugin_config_schema">>)),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"Rebuild or reinstall">>)).
+
+t_install_plugin_with_bad_app_file_returns_consistent_error(Config) ->
+    PackagePath = make_test_plugin_package(
+        Config,
+        test_plugin_schema(),
+        <<"foo = \"bar\"\n">>,
+        <<"not an Erlang application resource file">>
+    ),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    on_exit(fun() ->
+        _ = disallow_installation(NameVsn),
+        _ = emqx_plugins:delete_package(NameVsn)
+    end),
+    ok = allow_installation(NameVsn),
+    {ok, {{"HTTP/1.1", 400, "Bad Request"}, _, Body}} = install_plugin(PackagePath),
+    ?assertEqual(
+        #{
+            <<"code">> => <<"BAD_PLUGIN_INFO">>,
+            <<"message">> =>
+                iolist_to_binary([
+                    "node ",
+                    atom_to_binary(node()),
+                    ": bad_plugin_app_file: Plugin package metadata is invalid or unreadable. ",
+                    "Rebuild or reinstall a corrected plugin package and retry."
+                ])
+        },
+        emqx_utils_json:decode(Body)
+    ).
+
+t_uninstall_conflicting_version_keeps_old_running(Config) ->
+    OldPackagePath = make_test_plugin_package(
+        Config,
+        "1.0.0",
+        "invalid_plugin_v1",
+        "0.1.0",
+        test_plugin_schema(),
+        <<"foo = \"old\"\n">>
+    ),
+    NewPackagePath = make_test_plugin_package(
+        Config,
+        "2.0.0",
+        "invalid_plugin_v2",
+        "0.2.0",
+        test_plugin_schema(),
+        <<"foo = \"new\"\n">>
+    ),
     OldNameVsn = filename:basename(OldPackagePath, ?PACKAGE_SUFFIX),
     NewNameVsn = filename:basename(NewPackagePath, ?PACKAGE_SUFFIX),
     on_exit(fun() ->
@@ -174,6 +248,7 @@ t_uninstall_conflicting_version_keeps_old_running(_Config) ->
     ok = allow_installation(OldNameVsn),
     ok = allow_installation(NewNameVsn),
     ok = install_plugin(OldPackagePath),
+    ok = install_plugin(NewPackagePath),
     {ok, []} = update_plugin(OldNameVsn, "start"),
     ?assertMatch(
         #{
@@ -183,10 +258,14 @@ t_uninstall_conflicting_version_keeps_old_running(_Config) ->
         },
         describe_plugin(OldNameVsn)
     ),
-    ok = install_plugin(NewPackagePath),
-    ?assertMatch(
-        {error, {"HTTP/1.1", 400, "Bad Request"}},
-        update_plugin(NewNameVsn, "start")
+    {400, ConflictResponse} = request_plugin_action(NewNameVsn, "start"),
+    ?assertEqual(<<"PARAM_ERROR">>, maps:get(<<"code">>, ConflictResponse)),
+    ?assertNotEqual(
+        nomatch,
+        binary:match(
+            maps:get(<<"message">>, ConflictResponse),
+            <<"conflicting_plugin_version_running:">>
+        )
     ),
     {ok, []} = uninstall_plugin(NewNameVsn),
     ?assertMatch(
@@ -237,6 +316,32 @@ t_update_config(_Config) ->
     ),
     %% Clean up
     {ok, []} = uninstall_plugin(NameVsn).
+
+t_update_config_with_invalid_type_returns_readable_error(Config0) ->
+    PackagePath = make_test_plugin_package(
+        Config0,
+        test_plugin_schema(),
+        <<"foo = \"bar\"\n">>
+    ),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    on_exit(fun() ->
+        _ = emqx_plugins:ensure_stopped(NameVsn),
+        _ = emqx_plugins:ensure_disabled(NameVsn),
+        _ = emqx_plugins:ensure_uninstalled(NameVsn),
+        _ = emqx_plugins:delete_package(NameVsn)
+    end),
+    ok = allow_installation(NameVsn),
+    ok = install_plugin(PackagePath),
+    PluginConfig = emqx_plugins:get_config(NameVsn),
+    {ok, 400, Body} = update_plugin_config(NameVsn, PluginConfig#{<<"foo">> => 42}),
+    ?assertEqual(
+        #{
+            <<"code">> => <<"BAD_CONFIG">>,
+            <<"message">> =>
+                <<"invalid_type: Invalid type for field 'foo': expected string, got integer">>
+        },
+        emqx_utils_json:decode(Body)
+    ).
 
 t_upload_download_config(_Config) ->
     PackagePath = get_demo_plugin_package(),
@@ -552,6 +657,78 @@ t_cluster_update_order(Config) ->
 
     ok.
 
+t_cluster_rejects_invalid_local_config_on_start(Config) ->
+    [Initiator, InvalidNode] = ?config(cluster, Config),
+    PackagePath = make_test_plugin_package(
+        Config,
+        test_plugin_schema(),
+        <<"foo = \"bar\"\n">>
+    ),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    ?ON(Initiator, ok = allow_installation(NameVsn)),
+    ok = install_plugin_into_cluster(Config, PackagePath),
+    InvalidConfigPath = ?ON(InvalidNode, emqx_plugins_fs:config_file_path(NameVsn)),
+    ok = file:write_file(InvalidConfigPath, <<"foo = 42\n">>),
+    {400, StartResponse} = request_plugin_action_in_cluster(Config, NameVsn, "start"),
+    ?assertEqual(<<"BAD_CONFIG">>, maps:get(<<"code">>, StartResponse)),
+    ?assertNotEqual(
+        nomatch,
+        binary:match(maps:get(<<"message">>, StartResponse), <<"invalid_plugin_config:">>)
+    ),
+    ?assertEqual(
+        [{ok, false}, {ok, false}],
+        erpc:multicall(
+            [Initiator, InvalidNode],
+            fun() -> lists:keymember(invalid_plugin, 1, application:which_applications()) end
+        )
+    ),
+    ok = file:write_file(InvalidConfigPath, <<"foo = \"bar\"\n">>),
+    {ok, _} = update_plugin_in_cluster(Config, NameVsn, "start"),
+    ?assertEqual(
+        [{ok, true}, {ok, true}],
+        erpc:multicall(
+            [Initiator, InvalidNode],
+            fun() -> lists:keymember(invalid_plugin, 1, application:which_applications()) end
+        )
+    ).
+
+t_cluster_rolls_back_partial_start_failure(Config) ->
+    [Initiator, FailingNode] = ?config(cluster, Config),
+    PackagePath = make_test_plugin_package(
+        Config,
+        test_plugin_schema(),
+        <<"foo = \"bar\"\n">>
+    ),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    ?ON(Initiator, ok = allow_installation(NameVsn)),
+    ok = install_plugin_into_cluster(Config, PackagePath),
+    ok = ?ON(FailingNode, meck:new(emqx_plugins, [no_link, passthrough])),
+    ok = ?ON(
+        FailingNode,
+        meck:expect(
+            emqx_plugins,
+            ensure_started,
+            fun(_Name) -> {error, injected_start_failure} end
+        )
+    ),
+    try
+        {500, StartResponse} = request_plugin_action_in_cluster(Config, NameVsn, "start"),
+        ?assertEqual(<<"INTERNAL_ERROR">>, maps:get(<<"code">>, StartResponse)),
+        ?assertMatch(
+            <<"plugin_start_failed: ", _/binary>>,
+            maps:get(<<"message">>, StartResponse)
+        ),
+        #{
+            <<"running_status">> := RunningStatus
+        } = describe_plugin_in_cluster(Config, NameVsn),
+        ?assertEqual(
+            [<<"stopped">>, <<"stopped">>],
+            lists:sort([Status || #{<<"status">> := Status} <- RunningStatus])
+        )
+    after
+        ?ON(FailingNode, meck:unload(emqx_plugins))
+    end.
+
 list_plugins_from_cluster(Config) ->
     #{host := Host, auth := Auth} = get_host_and_auth(Config),
     Path = emqx_mgmt_api_test_util:api_path(Host, ["plugins"]),
@@ -570,6 +747,14 @@ list_plugins() ->
 describe_plugin(Name) ->
     Path = emqx_mgmt_api_test_util:api_path(["plugins", Name]),
     case emqx_mgmt_api_test_util:request_api(get, Path) of
+        {ok, Res} -> emqx_utils_json:decode(Res);
+        {error, Reason} -> error(Reason)
+    end.
+
+describe_plugin_in_cluster(Config, Name) ->
+    #{host := Host, auth := Auth} = get_host_and_auth(Config),
+    Path = emqx_mgmt_api_test_util:api_path(Host, ["plugins", Name]),
+    case emqx_mgmt_api_test_util:request_api(get, Path, Auth) of
         {ok, Res} -> emqx_utils_json:decode(Res);
         {error, Reason} -> error(Reason)
     end.
@@ -619,10 +804,29 @@ update_plugin(Name, Action) ->
     Path = emqx_mgmt_api_test_util:api_path(["plugins", Name, Action]),
     emqx_mgmt_api_test_util:request_api(put, Path).
 
+request_plugin_action(Name, Action) ->
+    Path = emqx_mgmt_api_test_util:api_path(["plugins", Name, Action]),
+    request_with_response(put, Path, emqx_mgmt_api_test_util:auth_header_()).
+
 update_plugin_in_cluster(Config, Name, Action) when is_list(Config) ->
     #{host := Host, auth := Auth} = get_host_and_auth(Config),
     Path = emqx_mgmt_api_test_util:api_path(Host, ["plugins", Name, Action]),
     emqx_mgmt_api_test_util:request_api(put, Path, Auth).
+
+request_plugin_action_in_cluster(Config, Name, Action) ->
+    #{host := Host, auth := Auth} = get_host_and_auth(Config),
+    Path = emqx_mgmt_api_test_util:api_path(Host, ["plugins", Name, Action]),
+    request_with_response(put, Path, Auth).
+
+request_with_response(Method, Path, Auth) ->
+    Opts = #{return_all => true, httpc_req_opts => [{body_format, binary}]},
+    Result = emqx_mgmt_api_test_util:request_api(Method, Path, [], Auth, [], Opts),
+    case Result of
+        {ok, {{"HTTP/1.1", StatusCode, _}, _Headers, Body}} ->
+            {StatusCode, emqx_utils_json:decode(Body)};
+        {error, {{"HTTP/1.1", StatusCode, _}, _Headers, Body}} ->
+            {StatusCode, emqx_utils_json:decode(Body)}
+    end.
 
 update_boot_order(Name, MoveBody, Config) ->
     #{host := Host, auth := Auth} = get_host_and_auth(Config),
@@ -695,6 +899,68 @@ create_renamed_package(PackagePath, NewNameVsn) ->
     NewPackagePath = filename:join(filename:dirname(PackagePath), NewNameVsn ++ ?PACKAGE_SUFFIX),
     ok = erl_tar:create(NewPackagePath, Content1, [compressed]),
     NewPackagePath.
+
+make_test_plugin_package(Config, Schema, DefaultConfig) ->
+    make_test_plugin_package(
+        Config,
+        Schema,
+        DefaultConfig,
+        <<"{application, invalid_plugin, [{vsn, \"0.1.0\"}]}.\n">>
+    ).
+
+make_test_plugin_package(Config, Schema, DefaultConfig, AppFile) ->
+    make_test_plugin_package(
+        Config,
+        "1.0.0",
+        "invalid_plugin",
+        "0.1.0",
+        Schema,
+        DefaultConfig,
+        AppFile
+    ).
+
+make_test_plugin_package(Config, RelVsn, AppName, AppVsn, Schema, DefaultConfig) ->
+    AppFile = iolist_to_binary(
+        io_lib:format("{application, ~s, [{vsn, ~p}]}.\n", [AppName, AppVsn])
+    ),
+    make_test_plugin_package(Config, RelVsn, AppName, AppVsn, Schema, DefaultConfig, AppFile).
+
+make_test_plugin_package(Config, RelVsn, AppName, AppVsn, Schema, DefaultConfig, AppFile) ->
+    NameVsn = "invalid_plugin-" ++ RelVsn,
+    PluginApp = AppName ++ "-" ++ AppVsn,
+    PrivDir = filename:join([NameVsn, PluginApp, "priv"]),
+    PackagePath = filename:join(
+        ?config(priv_dir, Config),
+        NameVsn ++ ?PACKAGE_SUFFIX
+    ),
+    ok = filelib:ensure_dir(PackagePath),
+    Info = emqx_utils_json:encode(#{
+        <<"name">> => <<"invalid_plugin">>,
+        <<"rel_vsn">> => list_to_binary(RelVsn),
+        <<"rel_apps">> => [list_to_binary(PluginApp)],
+        <<"description">> => <<"test">>,
+        <<"with_config_schema">> => true
+    }),
+    ok = erl_tar:create(
+        PackagePath,
+        [
+            {filename:join(NameVsn, "release.json"), Info},
+            {
+                filename:join([NameVsn, PluginApp, "ebin", AppName ++ ".app"]),
+                AppFile
+            },
+            {filename:join(PrivDir, "config_schema.avsc"), Schema},
+            {filename:join(PrivDir, "config.hocon"), DefaultConfig}
+        ],
+        [compressed]
+    ),
+    PackagePath.
+
+test_plugin_schema() ->
+    <<
+        "{\"type\":\"record\",\"name\":\"invalid_plugin\","
+        "\"fields\":[{\"name\":\"foo\",\"type\":\"string\"}]}"
+    >>.
 
 update_release_json(["release.json"], FileContent, NewName) ->
     ContentMap = emqx_utils_json:decode(FileContent),

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -819,8 +819,9 @@ do_ensure_started(NameVsn) ->
         ok ?= install(NameVsn, ?normal),
         ok ?= load_config_schema(NameVsn),
         ok ?= maybe_initialize_cached_config(NameVsn),
-        {ok, _} ?= validated_local_config(NameVsn),
         {ok, Plugin} ?= emqx_plugins_info:read(NameVsn),
+        {ok, Schema} ?= read_start_schema(NameVsn, Plugin),
+        {ok, _ConfigSource, _Config} ?= resolve_and_validate_start_config(NameVsn, Schema),
         ok ?= emqx_plugins_apps:start(Plugin)
     else
         {error, Reason} ->
@@ -848,8 +849,7 @@ do_validate_start(NameVsn) ->
             ),
         ok ?= emqx_plugins_apps:validate(Plugin, emqx_plugins_fs:lib_dir(NameVsn)),
         {ok, Schema} ?= read_start_schema(NameVsn, Plugin),
-        {ok, _ConfigSource, Config} ?= read_start_config(NameVsn),
-        ok ?= validate_start_config(NameVsn, Schema, Config),
+        {ok, _ConfigSource, _Config} ?= resolve_and_validate_start_config(NameVsn, Schema),
         {ok, start_validation_status(Plugin)}
     else
         {error, Reason} ->
@@ -895,6 +895,13 @@ read_start_config_without_local_file(NameVsn) ->
             {ok, cached, Config}
     end.
 
+resolve_and_validate_start_config(NameVsn, Schema) ->
+    maybe
+        {ok, ConfigSource, Config} ?= read_start_config(NameVsn),
+        ok ?= validate_start_config(NameVsn, Schema, Config),
+        {ok, ConfigSource, Config}
+    end.
+
 validate_start_config(_NameVsn, no_schema, _Config) ->
     ok;
 validate_start_config(NameVsn, AvscBin, Config) ->
@@ -903,6 +910,7 @@ validate_start_config(NameVsn, AvscBin, Config) ->
             ok;
         {error, #{reason := bad_schema} = Reason} ->
             {error, #{
+                kind => invalid_package,
                 msg => "invalid_plugin_config_schema",
                 name_vsn => bin(NameVsn),
                 reason => Reason,
@@ -914,6 +922,7 @@ validate_start_config(NameVsn, AvscBin, Config) ->
 
 invalid_plugin_config_error(NameVsn, Reason) ->
     #{
+        kind => invalid_config,
         msg => "invalid_plugin_config",
         name_vsn => bin(NameVsn),
         reason => Reason,
@@ -1286,6 +1295,7 @@ validate_no_other_version_running(NameVsn0) ->
             ok;
         [_ | _] ->
             {error, #{
+                kind => conflicting_version,
                 msg => "conflicting_plugin_version_running",
                 active_versions => RunningOtherVersions
             }}
@@ -1343,6 +1353,7 @@ ensure_no_other_version_active(Plugins, NameVsn0) ->
             unload_other_versions(LoadedOtherVersions);
         [_ | _] ->
             {error, #{
+                kind => conflicting_version,
                 msg => "conflicting_plugin_version_running",
                 active_versions => lists:reverse(RunningOtherVersions)
             }}

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -898,13 +898,16 @@ read_start_config_without_local_file(NameVsn) ->
 resolve_and_validate_start_config(NameVsn, Schema) ->
     maybe
         {ok, ConfigSource, Config} ?= read_start_config(NameVsn),
-        ok ?= validate_start_config(NameVsn, Schema, Config),
+        ok ?= validate_start_config(NameVsn, Schema, ConfigSource, Config),
         {ok, ConfigSource, Config}
     end.
 
-validate_start_config(_NameVsn, no_schema, _Config) ->
+validate_start_config(_NameVsn, _Schema, empty, _Config) ->
+    %% A missing config is valid for plugins that intentionally do not ship one.
     ok;
-validate_start_config(NameVsn, AvscBin, Config) ->
+validate_start_config(_NameVsn, no_schema, _ConfigSource, _Config) ->
+    ok;
+validate_start_config(NameVsn, AvscBin, _ConfigSource, Config) ->
     case emqx_plugins_serde:decode(NameVsn, AvscBin, ensure_config_bin(Config)) of
         {ok, _} ->
             ok;

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -56,6 +56,8 @@
 -export([
     ensure_started/0,
     ensure_started/1,
+    ensure_start_package/1,
+    validate_start/1,
     ensure_stopped/0,
     ensure_stopped/1,
     restart/1,
@@ -489,6 +491,19 @@ ensure_started(NameVsn) ->
             {error, Reason}
     end.
 
+%% @doc Ensure that a plugin package is available and extracted locally.
+-spec ensure_start_package(name_vsn()) -> ok | {error, term()}.
+ensure_start_package(NameVsn) ->
+    ?CATCH(do_ensure_start_package(NameVsn)).
+
+%% @doc Validate that a plugin can be started without changing runtime state.
+%% The returned status is a rollback hint only.  Validation and start are not
+%% atomic with concurrent lifecycle or configuration operations, so
+%% `ensure_started/1' must validate the current local configuration again.
+-spec validate_start(name_vsn()) -> {ok, running | not_running} | {error, term()}.
+validate_start(NameVsn) ->
+    ?CATCH(do_validate_start(NameVsn)).
+
 %% @doc Stop all plugins before broker stops.
 -spec ensure_stopped() -> ok.
 ensure_stopped() ->
@@ -542,9 +557,10 @@ update_config(NameVsn, Config) ->
 
 %% @doc Stop and then start the plugin.
 restart(NameVsn) ->
-    case ensure_stopped(NameVsn) of
-        ok -> ensure_started(NameVsn);
-        {error, Reason} -> {error, Reason}
+    maybe
+        {ok, _RunningStatus} ?= validate_start(NameVsn),
+        ok ?= ensure_stopped(NameVsn),
+        ensure_started(NameVsn)
     end.
 
 %% @doc Return Name-Vsn list of currently running plugins.
@@ -810,6 +826,99 @@ do_ensure_started(NameVsn) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+do_ensure_start_package(NameVsn) ->
+    case emqx_plugins_fs:ensure_installed_from_tar(NameVsn, fun() -> ok end) of
+        {error, #{reason := plugin_tarball_not_found}} ->
+            maybe
+                ok ?= get_from_cluster(NameVsn),
+                emqx_plugins_fs:ensure_installed_from_tar(NameVsn, fun() -> ok end)
+            end;
+        Result ->
+            Result
+    end.
+
+do_validate_start(NameVsn) ->
+    maybe
+        ok ?= validate_no_other_version_running(NameVsn),
+        {ok, Plugin} ?=
+            emqx_plugins_info:read(
+                NameVsn,
+                #{fill_readme => false, health_check => false}
+            ),
+        ok ?= emqx_plugins_apps:validate(Plugin, emqx_plugins_fs:lib_dir(NameVsn)),
+        {ok, Schema} ?= read_start_schema(NameVsn, Plugin),
+        {ok, _ConfigSource, Config} ?= read_start_config(NameVsn),
+        ok ?= validate_start_config(NameVsn, Schema, Config),
+        {ok, start_validation_status(Plugin)}
+    else
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+start_validation_status(#{running_status := running}) ->
+    running;
+start_validation_status(_Plugin) ->
+    not_running.
+
+read_start_schema(_NameVsn, #{with_config_schema := false}) ->
+    {ok, no_schema};
+read_start_schema(NameVsn, #{with_config_schema := true}) ->
+    emqx_plugins_fs:read_avsc_bin(NameVsn);
+read_start_schema(_NameVsn, _Plugin) ->
+    {ok, no_schema}.
+
+read_start_config(NameVsn) ->
+    case emqx_plugins_local_config:read(NameVsn) of
+        {ok, Config} ->
+            {ok, local, Config};
+        {error, #{reason := {enoent, _}}} ->
+            read_start_config_without_local_file(NameVsn);
+        {error, #{msg := "bad_hocon_file"} = Reason} ->
+            {error, invalid_plugin_config_error(NameVsn, Reason)};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+read_start_config_without_local_file(NameVsn) ->
+    case get_cached_config(NameVsn, ?plugin_conf_not_found) of
+        ?plugin_conf_not_found ->
+            case emqx_plugins_fs:read_default_hocon(NameVsn) of
+                {ok, Config} ->
+                    {ok, default, Config};
+                {error, #{reason := {enoent, _}}} ->
+                    {ok, empty, #{}};
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        Config ->
+            {ok, cached, Config}
+    end.
+
+validate_start_config(_NameVsn, no_schema, _Config) ->
+    ok;
+validate_start_config(NameVsn, AvscBin, Config) ->
+    case emqx_plugins_serde:decode(NameVsn, AvscBin, ensure_config_bin(Config)) of
+        {ok, _} ->
+            ok;
+        {error, #{reason := bad_schema} = Reason} ->
+            {error, #{
+                msg => "invalid_plugin_config_schema",
+                name_vsn => bin(NameVsn),
+                reason => Reason,
+                hint => "Reinstall a plugin package with a valid config schema and retry"
+            }};
+        {error, Reason} ->
+            {error, invalid_plugin_config_error(NameVsn, Reason)}
+    end.
+
+invalid_plugin_config_error(NameVsn, Reason) ->
+    #{
+        msg => "invalid_plugin_config",
+        name_vsn => bin(NameVsn),
+        reason => Reason,
+        hint => "Fix the plugin configuration on this node and retry"
+    }.
 
 log_start_error(Reason) ->
     ?SLOG(error, #{
@@ -1156,6 +1265,31 @@ latest_enabled_versions(Configured) ->
 
 ensure_no_other_version_active(NameVsn0) ->
     ensure_no_other_version_active(conflicting_versions(NameVsn0), NameVsn0).
+
+validate_no_other_version_running(NameVsn0) ->
+    NameVsn = bin(NameVsn0),
+    RunningOtherVersions = lists:filtermap(
+        fun
+            (#{name := PluginName, rel_vsn := Vsn, running_status := running}) ->
+                OtherNameVsn = name_vsn(PluginName, Vsn),
+                case OtherNameVsn =/= NameVsn of
+                    true -> {true, OtherNameVsn};
+                    false -> false
+                end;
+            (_) ->
+                false
+        end,
+        conflicting_versions(NameVsn)
+    ),
+    case RunningOtherVersions of
+        [] ->
+            ok;
+        [_ | _] ->
+            {error, #{
+                msg => "conflicting_plugin_version_running",
+                active_versions => RunningOtherVersions
+            }}
+    end.
 
 conflicting_versions(NameVsn0) ->
     NameVsn = bin(NameVsn0),

--- a/apps/emqx_plugins/src/emqx_plugins_apps.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_apps.erl
@@ -204,9 +204,19 @@ validate_plugin_app(AppNameVsn, LibDir, ok) ->
         {ok, [{application, AppName, Props}]} ->
             validate_plugin_app(AppName, AppVsn, EbinDir, AppFile, Props);
         {ok, AppSpec} ->
-            {error, #{msg => "bad_plugin_app_file", path => AppFile, reason => AppSpec}};
+            {error, #{
+                kind => invalid_package,
+                msg => "bad_plugin_app_file",
+                path => AppFile,
+                reason => AppSpec
+            }};
         {error, Reason} ->
-            {error, #{msg => "bad_plugin_app_file", path => AppFile, reason => Reason}}
+            {error, #{
+                kind => invalid_package,
+                msg => "bad_plugin_app_file",
+                path => AppFile,
+                reason => Reason
+            }}
     end.
 
 validate_plugin_app(AppName, AppVsn, EbinDir, AppFile, Props) when is_list(Props) ->
@@ -219,6 +229,7 @@ validate_plugin_app(AppName, AppVsn, EbinDir, AppFile, Props) when is_list(Props
             validate_loaded_plugin_app(AppName, EbinDir, Props);
         false ->
             {error, #{
+                kind => invalid_package,
                 msg => "plugin_app_version_mismatch",
                 path => AppFile,
                 expected_vsn => AppVsn,
@@ -226,7 +237,12 @@ validate_plugin_app(AppName, AppVsn, EbinDir, AppFile, Props) when is_list(Props
             }}
     end;
 validate_plugin_app(_AppName, _AppVsn, _EbinDir, AppFile, Props) ->
-    {error, #{msg => "bad_plugin_app_file", path => AppFile, reason => Props}}.
+    {error, #{
+        kind => invalid_package,
+        msg => "bad_plugin_app_file",
+        path => AppFile,
+        reason => Props
+    }}.
 
 validate_loaded_plugin_app(AppName, EbinDir, Props) ->
     case lists:keyfind(AppName, 1, loaded_apps()) of
@@ -246,6 +262,7 @@ validate_loaded_plugin_app(AppName, EbinDir, Props) ->
                             ok;
                         false ->
                             {error, #{
+                                kind => invalid_package,
                                 msg => "plugin_app_loaded_outside_package",
                                 name => AppName,
                                 expected_ebin => ExpectedEbinDir,

--- a/apps/emqx_plugins/src/emqx_plugins_fs.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_fs.erl
@@ -128,7 +128,14 @@ read_hocon(NameVsn) ->
 -spec read_default_hocon(name_vsn()) -> {ok, map()} | {error, term()}.
 read_default_hocon(NameVsn) ->
     HoconFilePath = default_config_file_path(NameVsn),
-    read_file_map(HoconFilePath, "bad_default_hocon_file").
+    case read_file_map(HoconFilePath, "bad_default_hocon_file") of
+        {error, Error} ->
+            {error, Error#{
+                kind => invalid_package
+            }};
+        Result ->
+            Result
+    end.
 
 %% List all installed plugins
 

--- a/apps/emqx_plugins/src/emqx_plugins_serde.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_serde.erl
@@ -6,6 +6,7 @@
 
 -include("emqx_plugins.hrl").
 -include_lib("emqx/include/logger.hrl").
+-include_lib("erlavro/include/erlavro.hrl").
 
 %% API
 -export([
@@ -24,6 +25,7 @@
 
 -export([
     decode/2,
+    decode/3,
     encode/2
 ]).
 
@@ -86,6 +88,17 @@ decode(SerdeName, RawData) ->
         SerdeName,
         [RawData]
     ).
+
+-spec decode(schema_name(), binary(), encoded_data()) ->
+    {ok, decoded_data()} | {error, any()}.
+decode(SerdeName, AvscBin, RawData) ->
+    try
+        Serde = make_serde(SerdeName, AvscBin),
+        with_serde_record(?FUNCTION_NAME, Serde, [RawData])
+    catch
+        _Kind:Error ->
+            {error, #{reason => bad_schema, details => Error}}
+    end.
 
 -spec encode(schema_name(), decoded_data()) -> {ok, encoded_data()} | {error, any()}.
 encode(SerdeName, Data) ->
@@ -158,7 +171,7 @@ do_build_serde({NameVsn, AvscBin}) ->
                     stacktrace => Stacktrace
                 }
             ),
-            {error, Error}
+            {error, #{reason => bad_schema, details => Error}}
     end.
 
 make_serde(NameVsn, AvscBin) when not is_binary(NameVsn) ->
@@ -188,13 +201,25 @@ async_delete_serdes(Names) ->
     gen_server:cast(?MODULE, {delete_serdes, Names}).
 
 with_serde(Op, SerdeName, Args) ->
+    case lookup_serde(SerdeName) of
+        {ok, Serde} ->
+            with_serde_record(Op, Serde, Args);
+        {error, not_found} ->
+            {error, #{
+                error_msg => error_msg(Op),
+                reason => plugin_serde_not_found,
+                serde_name => SerdeName
+            }}
+    end.
+
+with_serde_record(Op, #plugin_schema_serde{} = Serde, Args) ->
     WhichOp = which_op(Op),
-    ErrMsg = error_msg(Op),
     try
-        eval_serde(Op, ErrMsg, SerdeName, Args)
+        eval_serde(Op, Serde, Args)
     catch
         throw:Reason ->
-            ?SLOG(error, Reason#{
+            ?SLOG(error, #{
+                msg => "plugin_schema_op_failed",
                 which_op => WhichOp,
                 reason => emqx_utils:readable_error_msg(Reason)
             }),
@@ -213,21 +238,27 @@ with_serde(Op, SerdeName, Args) ->
             }}
     end.
 
-eval_serde(Op, ErrMsg, SerdeName, Args) ->
-    case lookup_serde(SerdeName) of
-        {ok, Serde} ->
-            eval_serde(Op, Serde, Args);
-        {error, not_found} ->
-            throw(#{
-                error_msg => ErrMsg,
-                reason => plugin_serde_not_found,
-                serde_name => SerdeName
-            })
-    end.
-
 eval_serde(decode, #plugin_schema_serde{name = Name, eval_context = Store}, [Data]) ->
-    Opts = avro:make_decoder_options([{map_type, map}, {record_type, map}, {encoding, avro_json}]),
-    {ok, avro_json_decoder:decode_value(Data, Name, Store, Opts)};
+    Opts = avro:make_decoder_options([
+        {map_type, map},
+        {record_type, map},
+        {encoding, avro_json},
+        {hook, fun decode_hook/4}
+    ]),
+    try avro_json_decoder:decode_value(Data, Name, Store, Opts) of
+        Decoded ->
+            {ok, Decoded}
+    catch
+        error:function_clause:Stacktrace ->
+            case is_avro_decoder_type_mismatch_stack(Stacktrace) of
+                true ->
+                    {ok, RootType} = avro_schema_store:lookup_type(Name, Store),
+                    DecodedData = emqx_utils_json:decode(Data),
+                    throw(invalid_type_error(RootType, DecodedData, <<"$">>));
+                false ->
+                    erlang:raise(error, function_clause, Stacktrace)
+            end
+    end;
 eval_serde(encode, #plugin_schema_serde{name = Name, eval_context = Store}, [Data]) ->
     {ok, avro_json_encoder:encode(Store, Name, Data)};
 eval_serde(_, _, _) ->
@@ -238,6 +269,130 @@ which_op(Op) ->
 
 error_msg(Op) ->
     atom_to_list(Op) ++ "_avro_data".
+
+decode_hook(Type, SubNameOrIndex, Data, DecodeFun) ->
+    Path0 = get(?MODULE),
+    Path = push_path(SubNameOrIndex, Path0),
+    put(?MODULE, Path),
+    try
+        DecodeFun(Data)
+    catch
+        error:{unknown_union_member, Member} ->
+            throw(#{
+                reason => invalid_union_member,
+                path => format_path(lists:reverse(Path)),
+                expected => expected_type(Type, SubNameOrIndex),
+                actual => to_bin(Member)
+            });
+        error:function_clause:Stacktrace ->
+            ExpectedType = expected_avro_type(Type, SubNameOrIndex),
+            case is_avro_type_mismatch(Stacktrace, ExpectedType, Data) of
+                true ->
+                    throw(invalid_type_error(ExpectedType, Data, format_path(lists:reverse(Path))));
+                false ->
+                    erlang:raise(error, function_clause, Stacktrace)
+            end;
+        error:badarg:Stacktrace ->
+            ExpectedType = expected_avro_type(Type, SubNameOrIndex),
+            case is_avro_fixed_type_mismatch(Stacktrace, ExpectedType, Data) of
+                true ->
+                    throw(invalid_type_error(ExpectedType, Data, format_path(lists:reverse(Path))));
+                false ->
+                    erlang:raise(error, badarg, Stacktrace)
+            end
+    after
+        case Path0 of
+            undefined -> erase(?MODULE);
+            _ -> put(?MODULE, Path0)
+        end
+    end.
+
+is_avro_type_mismatch(
+    [{avro_json_decoder, parse, [Data, #avro_enum_type{}, _, _], _} | _],
+    _Type,
+    Data
+) ->
+    true;
+is_avro_type_mismatch(
+    [{avro_json_decoder, parse, [Data, #avro_fixed_type{}, _, _], _} | _],
+    _Type,
+    Data
+) ->
+    true;
+is_avro_type_mismatch([{avro_json_decoder, Function, _, _} | _], _Type, _Data) ->
+    lists:member(Function, [parse_prim, parse_record, parse_array, parse_map, parse_union]);
+is_avro_type_mismatch(_Stacktrace, _Type, _Data) ->
+    false.
+
+is_avro_decoder_type_mismatch_stack([
+    {avro_json_decoder, Function, _, _} | _
+]) ->
+    lists:member(Function, [parse, parse_prim, parse_record, parse_array, parse_map, parse_union]);
+is_avro_decoder_type_mismatch_stack(_) ->
+    false.
+
+is_avro_fixed_type_mismatch(Stacktrace, #avro_fixed_type{}, Data) when not is_binary(Data) ->
+    lists:any(
+        fun
+            ({avro_json_decoder, parse_bytes, _, _}) -> true;
+            (_) -> false
+        end,
+        Stacktrace
+    );
+is_avro_fixed_type_mismatch(_Stacktrace, _ExpectedType, _Data) ->
+    false.
+
+invalid_type_error(ExpectedType, Data, Path) ->
+    #{
+        reason => invalid_type,
+        path => Path,
+        expected => avro:get_type_fullname(ExpectedType),
+        actual => json_type(Data)
+    }.
+
+push_path(<<>>, undefined) ->
+    [];
+push_path(none, undefined) ->
+    [];
+push_path(<<>>, Path) ->
+    Path;
+push_path(none, Path) ->
+    Path;
+push_path(SubNameOrIndex, undefined) ->
+    [SubNameOrIndex];
+push_path(SubNameOrIndex, Path) ->
+    [SubNameOrIndex | Path].
+
+format_path([]) ->
+    <<"$">>;
+format_path(Path) ->
+    iolist_to_binary(lists:join(<<".">>, lists:map(fun format_path_part/1, Path))).
+
+format_path_part(Index) when is_integer(Index) ->
+    integer_to_binary(Index);
+format_path_part(Name) ->
+    to_bin(Name).
+
+expected_type(Type, SubNameOrIndex) ->
+    avro:get_type_fullname(expected_avro_type(Type, SubNameOrIndex)).
+
+expected_avro_type(#avro_record_type{} = Type, FieldName) when is_binary(FieldName) ->
+    avro_record:get_field_type(FieldName, Type);
+expected_avro_type(#avro_array_type{} = Type, Index) when is_integer(Index) ->
+    avro_array:get_items_type(Type);
+expected_avro_type(#avro_map_type{} = Type, Key) when is_binary(Key) ->
+    avro_map:get_items_type(Type);
+expected_avro_type(Type, _SubNameOrIndex) ->
+    Type.
+
+json_type(Value) when is_binary(Value) -> <<"string">>;
+json_type(Value) when is_integer(Value) -> <<"integer">>;
+json_type(Value) when is_float(Value) -> <<"number">>;
+json_type(Value) when is_boolean(Value) -> <<"boolean">>;
+json_type(null) -> <<"null">>;
+json_type(Value) when is_map(Value) -> <<"object">>;
+json_type(Value) when is_list(Value) -> <<"array">>;
+json_type(_) -> <<"unknown">>.
 
 to_bin(A) when is_atom(A) -> atom_to_binary(A);
 to_bin(L) when is_list(L) -> iolist_to_binary(L);

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -626,8 +626,234 @@ t_rejects_invalid_local_config_on_start({'end', Config}) ->
 t_rejects_invalid_local_config_on_start(Config) ->
     NameVsn = ?config(name_vsn, Config),
     ?assertMatch({error, _}, emqx_plugins:ensure_installed(NameVsn)),
+    LoadedApps = lists:sort(application:loaded_applications()),
+    Serdes = lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB)),
+    CachedConfig = emqx_plugins:get_config(NameVsn, not_found),
+    {ok, ConfigBin} = file:read_file(emqx_plugins_fs:config_file_path(NameVsn)),
+    ?assertMatch(
+        {error, #{
+            msg := "invalid_plugin_config",
+            reason := #{
+                reason := invalid_type,
+                path := <<"foo">>,
+                expected := <<"string">>,
+                actual := <<"integer">>
+            }
+        }},
+        emqx_plugins:validate_start(NameVsn)
+    ),
+    ?assertEqual(LoadedApps, lists:sort(application:loaded_applications())),
+    ?assertEqual(Serdes, lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB))),
+    ?assertEqual(CachedConfig, emqx_plugins:get_config(NameVsn, not_found)),
+    ?assertEqual(
+        {ok, ConfigBin},
+        file:read_file(emqx_plugins_fs:config_file_path(NameVsn))
+    ),
     ?assertMatch({error, _}, emqx_plugins:ensure_started(NameVsn)),
     ?assertNot(is_app_running(invalid_plugin)).
+
+t_validate_start_does_not_start({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    [{name_vsn, NameVsn} | Config];
+t_validate_start_does_not_start({'end', Config}) ->
+    cleanup_invalid_plugin(?config(name_vsn, Config));
+t_validate_start_does_not_start(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    LoadedApps = lists:sort(application:loaded_applications()),
+    Serdes = lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB)),
+    CachedConfig = emqx_plugins:get_config(NameVsn, not_found),
+    {ok, ConfigBin} = file:read_file(emqx_plugins_fs:config_file_path(NameVsn)),
+    ?assertEqual({ok, not_running}, emqx_plugins:validate_start(NameVsn)),
+    ?assertNot(is_app_running(invalid_plugin)),
+    ?assertEqual(LoadedApps, lists:sort(application:loaded_applications())),
+    ?assertEqual(Serdes, lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB))),
+    ?assertEqual(CachedConfig, emqx_plugins:get_config(NameVsn, not_found)),
+    ?assertEqual(
+        {ok, ConfigBin},
+        file:read_file(emqx_plugins_fs:config_file_path(NameVsn))
+    ).
+
+t_ensure_start_package_only_materializes_files({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    [{name_vsn, NameVsn} | Config];
+t_ensure_start_package_only_materializes_files({'end', Config}) ->
+    cleanup_invalid_plugin(?config(name_vsn, Config));
+t_ensure_start_package_only_materializes_files(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    LoadedApps = lists:sort(application:loaded_applications()),
+    Serdes = lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB)),
+    CachedConfig = emqx_plugins:get_config(NameVsn, not_found),
+    ?assertNot(filelib:is_dir(emqx_plugins_fs:plugin_dir(NameVsn))),
+    ok = emqx_plugins:ensure_start_package(NameVsn),
+    ?assert(filelib:is_dir(emqx_plugins_fs:plugin_dir(NameVsn))),
+    ?assertNot(is_app_running(invalid_plugin)),
+    ?assertEqual(LoadedApps, lists:sort(application:loaded_applications())),
+    ?assertEqual(Serdes, lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB))),
+    ?assertEqual(CachedConfig, emqx_plugins:get_config(NameVsn, not_found)),
+    ?assertEqual({ok, not_running}, emqx_plugins:validate_start(NameVsn)).
+
+t_restart_rejects_invalid_local_config_without_stopping({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    ok = emqx_plugins:ensure_started(NameVsn),
+    ok = file:write_file(emqx_plugins_fs:config_file_path(NameVsn), <<"foo = 42\n">>),
+    [{name_vsn, NameVsn} | Config];
+t_restart_rejects_invalid_local_config_without_stopping({'end', Config}) ->
+    NameVsn = ?config(name_vsn, Config),
+    _ = emqx_plugins:ensure_stopped(NameVsn),
+    ok = file:delete(emqx_plugins_fs:config_file_path(NameVsn)),
+    cleanup_invalid_plugin(NameVsn);
+t_restart_rejects_invalid_local_config_without_stopping(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    ?assertMatch(
+        {error, #{msg := "invalid_plugin_config", reason := #{reason := invalid_type}}},
+        emqx_plugins:restart(NameVsn)
+    ),
+    ?assert(is_app_running(invalid_plugin)).
+
+t_start_revalidates_after_validation({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    ok = file:write_file(emqx_plugins_fs:config_file_path(NameVsn), <<"foo = \"prepared\"\n">>),
+    [{name_vsn, NameVsn} | Config];
+t_start_revalidates_after_validation({'end', Config}) ->
+    NameVsn = ?config(name_vsn, Config),
+    _ = emqx_plugins:ensure_stopped(NameVsn),
+    ok = file:delete(emqx_plugins_fs:config_file_path(NameVsn)),
+    cleanup_invalid_plugin(NameVsn);
+t_start_revalidates_after_validation(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    {ok, not_running} = emqx_plugins:validate_start(NameVsn),
+    ok = file:write_file(emqx_plugins_fs:config_file_path(NameVsn), <<"foo = 42\n">>),
+    ?assertMatch({error, #{reason := invalid_type}}, emqx_plugins:ensure_started(NameVsn)),
+    ?assertNot(is_app_running(invalid_plugin)).
+
+t_start_is_noop_when_already_running({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    ok = emqx_plugins:ensure_started(NameVsn),
+    ok = file:write_file(
+        emqx_plugins_fs:config_file_path(NameVsn),
+        <<"foo = \"from-file\"\n">>
+    ),
+    [{name_vsn, NameVsn} | Config];
+t_start_is_noop_when_already_running({'end', Config}) ->
+    NameVsn = ?config(name_vsn, Config),
+    _ = emqx_plugins:ensure_stopped(NameVsn),
+    ok = file:delete(emqx_plugins_fs:config_file_path(NameVsn)),
+    cleanup_invalid_plugin(NameVsn);
+t_start_is_noop_when_already_running(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    CachedConfig = emqx_plugins:get_config(NameVsn),
+    {ok, running} = emqx_plugins:validate_start(NameVsn),
+    ok = emqx_plugins:ensure_started(NameVsn),
+    ?assert(is_app_running(invalid_plugin)),
+    ?assertEqual(CachedConfig, emqx_plugins:get_config(NameVsn)).
+
+t_temporary_serde_reports_structured_type_errors({init, Config}) ->
+    Config;
+t_temporary_serde_reports_structured_type_errors({'end', _Config}) ->
+    ok;
+t_temporary_serde_reports_structured_type_errors(_Config) ->
+    Name = <<"validation_plugin-1.0.0">>,
+    NestedSchema = <<
+        "{\"type\":\"record\",\"name\":\"validation_plugin\",\"fields\":["
+        "{\"name\":\"items\",\"type\":{\"type\":\"array\",\"items\":"
+        "{\"type\":\"record\",\"name\":\"item\",\"fields\":["
+        "{\"name\":\"name\",\"type\":\"string\"}]}}}]}"
+    >>,
+    ?assertMatch(
+        {error, #{
+            reason := invalid_type,
+            path := <<"items.0.name">>,
+            expected := <<"string">>,
+            actual := <<"integer">>
+        }},
+        emqx_plugins_serde:decode(
+            Name,
+            NestedSchema,
+            emqx_utils_json:encode(#{<<"items">> => [#{<<"name">> => 42}]})
+        )
+    ),
+    ?assertMatch(
+        {error, #{
+            reason := invalid_type,
+            path := <<"$">>,
+            expected := <<"validation_plugin">>,
+            actual := <<"integer">>
+        }},
+        emqx_plugins_serde:decode(Name, NestedSchema, <<"42">>)
+    ),
+    UnionSchema = <<
+        "{\"type\":\"record\",\"name\":\"validation_plugin\",\"fields\":["
+        "{\"name\":\"value\",\"type\":[\"null\",\"string\"]}]}"
+    >>,
+    ?assertMatch(
+        {error, #{
+            reason := invalid_union_member,
+            path := <<"value.integer">>,
+            actual := <<"integer">>
+        }},
+        emqx_plugins_serde:decode(
+            Name,
+            UnionSchema,
+            emqx_utils_json:encode(#{<<"value">> => #{<<"integer">> => 42}})
+        )
+    ),
+    EnumSchema = <<
+        "{\"type\":\"record\",\"name\":\"validation_plugin\",\"fields\":["
+        "{\"name\":\"mode\",\"type\":{\"type\":\"enum\",\"name\":\"mode_enum\","
+        "\"symbols\":[\"on\",\"off\"]}}]}"
+    >>,
+    ?assertMatch(
+        {error, #{
+            reason := invalid_type,
+            path := <<"mode">>,
+            expected := <<"mode_enum">>,
+            actual := <<"integer">>
+        }},
+        emqx_plugins_serde:decode(
+            Name,
+            EnumSchema,
+            emqx_utils_json:encode(#{<<"mode">> => 42})
+        )
+    ),
+    RootFixedSchema = <<
+        "{\"type\":\"fixed\",\"name\":\"validation_plugin\",\"size\":4}"
+    >>,
+    ?assertMatch(
+        {error, #{
+            reason := invalid_type,
+            path := <<"$">>,
+            expected := <<"validation_plugin">>,
+            actual := <<"integer">>
+        }},
+        emqx_plugins_serde:decode(Name, RootFixedSchema, <<"42">>)
+    ),
+    NestedFixedSchema = <<
+        "{\"type\":\"record\",\"name\":\"validation_plugin\",\"fields\":["
+        "{\"name\":\"token\",\"type\":{\"type\":\"fixed\",\"name\":\"token_fixed\","
+        "\"size\":4}}]}"
+    >>,
+    ?assertMatch(
+        {error, #{
+            reason := invalid_type,
+            path := <<"token">>,
+            expected := <<"token_fixed">>,
+            actual := <<"integer">>
+        }},
+        emqx_plugins_serde:decode(
+            Name,
+            NestedFixedSchema,
+            emqx_utils_json:encode(#{<<"token">> => 42})
+        )
+    ).
 
 assert_invalid_plugin_package(NameVsn) ->
     ?assertMatch({error, _}, emqx_plugins:ensure_installed(NameVsn, ?fresh_install)),

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -730,8 +730,35 @@ t_start_revalidates_after_validation(Config) ->
     NameVsn = ?config(name_vsn, Config),
     {ok, not_running} = emqx_plugins:validate_start(NameVsn),
     ok = file:write_file(emqx_plugins_fs:config_file_path(NameVsn), <<"foo = 42\n">>),
-    ?assertMatch({error, #{reason := invalid_type}}, emqx_plugins:ensure_started(NameVsn)),
+    ?assertMatch(
+        {error, #{msg := "invalid_plugin_config", reason := #{reason := invalid_type}}},
+        emqx_plugins:ensure_started(NameVsn)
+    ),
     ?assertNot(is_app_running(invalid_plugin)).
+
+t_start_revalidates_cached_config_after_validation({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    ValidConfig = emqx_plugins:get_config(NameVsn),
+    ok = file:delete(emqx_plugins_fs:config_file_path(NameVsn)),
+    [{name_vsn, NameVsn}, {valid_config, ValidConfig} | Config];
+t_start_revalidates_cached_config_after_validation({'end', Config}) ->
+    cleanup_invalid_plugin(?config(name_vsn, Config));
+t_start_revalidates_cached_config_after_validation(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    ConfigKey = {emqx_plugins, list_to_binary(NameVsn)},
+    {ok, not_running} = emqx_plugins:validate_start(NameVsn),
+    persistent_term:put(ConfigKey, #{<<"foo">> => 42}),
+    try
+        ?assertMatch(
+            {error, #{msg := "invalid_plugin_config", reason := #{reason := invalid_type}}},
+            emqx_plugins:ensure_started(NameVsn)
+        ),
+        ?assertNot(is_app_running(invalid_plugin))
+    after
+        persistent_term:put(ConfigKey, ?config(valid_config, Config))
+    end.
 
 t_start_is_noop_when_already_running({init, Config}) ->
     NameVsn = "invalid_plugin-1.0.0",


### PR DESCRIPTION
Release version:
- 6.1.4

## Fix #18063

- **Root cause:** `emqx_plugins_serde:do_build_serde/1` returned schema parsing failures as bare terms such as `{error, badarg}`. `emqx_mgmt_api_plugins:install_package_v4/2` assumed the reason was a map, while `do_install_package_on_nodes/2` assumed a limited set of RPC results. These assumptions replaced the validation error with an internal exception.
- **Fix:** Make `emqx_plugins_serde:do_build_serde/1` return a structured `bad_schema` error. Update `emqx_mgmt_api_plugins:install_package_v4/2` and `do_install_package_on_nodes/2` to handle validation errors, RPC failures, and unavailable nodes explicitly. Invalid schemas now return `400 BAD_PLUGIN_INFO`.

## Fix #18064

- **Root cause:** `emqx_plugins_serde:eval_serde/3` delegated type validation to `avro_json_decoder`, which raises `function_clause` or `badarg` for mismatched JSON values. The generic handling in `with_serde_record/3` had no field path or expected-type context.
- **Fix:** Add `emqx_plugins_serde:decode_hook/4` to convert known decoder type mismatches into structured errors containing the field path, expected Avro type, and actual JSON type, while re-raising unrelated decoder failures. Update `emqx_mgmt_api_plugins:readable_error_msg/1` to return actionable `400 BAD_CONFIG` responses for nested fields, root values, unions, enums, and fixed types.

## Fix #18070

- **Root cause:** `emqx_plugins:do_ensure_started/1` validated local configuration inside the effectful start path, so one node could start before another node rejected its configuration. `emqx_plugins:restart/1` also stopped a running plugin before discovering invalid configuration.
- **Fix:** Add side-effect-free `emqx_plugins:validate_start/1`, backed by `do_validate_start/1`, to validate application metadata, schema, and local configuration without loading applications, registering schemas, changing configuration, or starting the plugin. Make `emqx_plugins:restart/1` validate before stopping.

  For cluster starts, `emqx_mgmt_api_plugins:ensure_cluster_action/2` first materializes the package through `emqx_mgmt_api_plugins_proto_v5:ensure_start_package/2`, then validates every node through `validate_start/2`. Only after all nodes pass does it start them in parallel through `ensure_started/2`. `emqx_plugins:ensure_started/1` validates the current configuration again because validation and start are intentionally not atomic. Start failures trigger best-effort parallel rollback through `ensure_stopped/2` only on nodes that were not already running, and cluster membership is checked before globally enabling the plugin. Validation errors return HTTP 400; RPC, rollback, and other internal failures return HTTP 500 with searchable error keywords.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (Not applicable: these fix regressions in unreleased plugin validation changes already covered by `changes/ee/fix-18018.en.md`.)
- [x] Schema changes are backward compatible or intentionally breaking (No schema changes.)
