### PR TITLE
test(ds_shared_sub): contain cover meck-unload crash in t_lease_reconnect

### DIFF
--- a/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
@@ -737,6 +737,15 @@ t_lease_reconnect(_Config) ->
 
             ConnShared = emqtt_connect_sub(<<"client_shared">>),
 
+            %% Create the mock unlinked: under cover, meck:unload can crash the
+            %% mock process in terminate (cover re-instrumentation returning
+            %% {error, Beam}). If the mock is linked to this test process (meck's
+            %% default when the mock is auto-created by meck:expect), that crash
+            %% propagates over the link and kills the test (and its
+            %% emqtt/snabbkaffe children). no_link contains it; safe_meck_unload/1
+            %% still swallows the caller-side error.
+            ok = meck:new(emqx_ds_shared_sub_registry, [passthrough, no_link]),
+
             %% Simulate inability to find leader.
             ok = meck:expect(
                 emqx_ds_shared_sub_registry,


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Test-only de-flake for `emqx_ds_shared_sub_SUITE:t_lease_reconnect` (group
`declare_implicit`) under coverage.

When CT runs with coverage, `meck:unload/1` re-instruments the cover-compiled
original via `cover:compile_beam/1`, which intermittently returns `{error, Beam}`
and crashes `meck_proc:terminate/2` with a `badmatch`. The registry mock was
auto-created by `meck:expect` — meck links such mocks to the calling (test)
process by default — so the mock-process crash propagated over that link and
killed the test process along with its `emqtt`/`snabbkaffe` children. The
existing `safe_meck_unload/1` `try/catch` only guards the caller-side
`gen_server:call` exception; it cannot stop a link-propagated `EXIT`.

Fix: create the mock explicitly with `[passthrough, no_link]` before the first
`meck:expect`, so the crash-in-`terminate` stays contained. `passthrough` is
required because the mock overrides only `leader_wanted`; all other
`emqx_ds_shared_sub_registry` calls must pass through. Cleanup is unchanged
(`safe_meck_unload/1` in the test body and in `t_lease_reconnect('end', _)`).

This completes the partial fix `26afbbf9c4` (which added `safe_meck_unload/1`
and handled only the caller-side exception).

Validation: ran the case under coverage (`ENABLE_COVER_COMPILE=1`) 10× in a
loop — all pass, zero `restore_original`/`badmatch` occurrences, no test-process
cascade.

Note: the v5 branches (`dev-58`/`59`/`510`) do not carry `safe_meck_unload/1` at
all, so this is scoped to v6. If `t_lease_reconnect` flakes on v5, both
`safe_meck_unload/1` and this `no_link` change would need porting there
separately.

Relevant file: `apps/emqx/test/emqx_ds_shared_sub_SUITE.erl`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
