### PR TITLE
build: fix el10 package build

### DIFF
--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -51,13 +51,27 @@ deps(Config) ->
 overrides() ->
     [
         {add, [{extra_src_dirs, [{"etc", [{recursive, true}]}]}]}
-    ] ++ snabbkaffe_overrides().
+    ] ++ snabbkaffe_overrides() ++ quicer_overrides().
 
 %% Temporary workaround for a rebar3 erl_opts duplication
 %% bug. Ideally, we want to set this define globally
 snabbkaffe_overrides() ->
     Apps = [snabbkaffe, ekka, mria, gen_rpc],
     [{add, App, [{erl_opts, [{d, snk_kind, msg}]}]} || App <- Apps].
+
+%% GCC 14.3 (el10 builder) reports a 'maybe-uninitialized' false positive
+%% in the vendored msquic, which is compiled with -Werror;
+%% demote this one diagnostic back to a warning (gcc only, keep mac as-is)
+quicer_overrides() ->
+    [
+        {override, quicer, [
+            {pre_hooks, [
+                {"(linux)", compile,
+                    "sh -c 'CFLAGS=\"${CFLAGS} -Wno-error=maybe-uninitialized\" make build-nif'"},
+                {"(darwin|solaris)", compile, "make build-nif"}
+            ]}
+        ]}
+    ].
 
 config() ->
     [


### PR DESCRIPTION
temp fix for el10 package build, broken since el10 was added to the matrix in #18031 (first-ever execution of the el10 legs was in [this run](https://github.com/emqx/emqx/actions/runs/30258610690), dispatched to verify #18118).

## Root cause

- There is no el10 prebuilt asset for quicer 0.2.5, so the build falls back to compiling the vendored msquic (v2.3.8) from source.
- The el10 builder ships GCC 14.3.1, whose inliner raises a `maybe-uninitialized` false positive in msquic's `packet.h` (`PacketNumber` in `QuicPktNumEncode`); msquic compiles with a hardcoded `-Werror`, turning it fatal. The same code is unchanged in msquic v2.5.0 upstream, so there is no upstream fix to backport.
- debian13 legs pass because their GCC is 14.2.0 — the false positive is specific to GCC 14.3.

## Fix

A rebar override in `rebar.config.erl` replaces quicer's compile pre-hook so that, on Linux only, the quicer NIF build runs with `CFLAGS="${CFLAGS} -Wno-error=maybe-uninitialized"`. CMake seeds `CMAKE_C_FLAGS` from that env, reaching the vendored msquic, and `-Wno-error=X` overrides `-Werror` for that one diagnostic regardless of flag order — the warning stays visible but no longer fails the build. macOS keeps the pristine hook (clang has no `maybe-uninitialized` group). No other dep sees the flag.

An earlier revision exported `CFLAGS` globally for el10 in `scripts/buildx.sh`; that fixed msquic but broke the jq NIF link (jq's `CFLAGS ?=` defaults, including `-fPIC`, were clobbered — [failed run](https://github.com/emqx/emqx/actions/runs/30268171912)), hence the per-dep scoping.

## Verification

- Local: full `make emqx-enterprise` with `QUICER_DOWNLOAD_FROM_RELEASE=0` (forcing the msquic source build) passes, and quicer's `CMakeCache.txt` records `CMAKE_C_FLAGS:STRING=-Wno-error=maybe-uninitialized`, proving the override delivers the flag through rebar → make → build.sh → cmake. All other deps (incl. jq) build unaffected.
- Manual `build_packages.yaml` dispatch on this branch (publish=false): https://github.com/emqx/emqx/actions/runs/30270198112
- Local reproduction in the el10 builder image is not possible on typical dev hosts whose CPUs predate x86-64-v3 (RHEL 10 baseline).

Release version: 5.10.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyC5e51AUx2xww3LgDkHXK