### PR TITLE
ci: build macos 26 packages

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -147,8 +147,8 @@ jobs:
         os: ${{ matrix.os }}
         apple_id_password: ${{ secrets.APPLE_ID_PASSWORD }}
         apple_developer_identity: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
-        apple_developer_id_bundle: ${{ matrix.os == 'macos-15' && secrets.APPLE_DEVELOPER_ID_BUNDLE_NEW || secrets.APPLE_DEVELOPER_ID_BUNDLE }}
-        apple_developer_id_bundle_password: ${{ matrix.os == 'macos-15' && secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD_NEW || secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD }}
+        apple_developer_id_bundle: ${{ (matrix.os == 'macos-14') && secrets.APPLE_DEVELOPER_ID_BUNDLE || secrets.APPLE_DEVELOPER_ID_BUNDLE_NEW }}
+        apple_developer_id_bundle_password: ${{ (matrix.os == 'macos-14') && secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD || secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD_NEW }}
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success()
       with:

--- a/.github/workflows/build_packages_cron.yaml
+++ b/.github/workflows/build_packages_cron.yaml
@@ -83,7 +83,7 @@ jobs:
           - release-510
           - release-60
         os:
-          - macos-15
+          - macos-26
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -88,7 +88,7 @@ jobs:
         profile:
         - emqx-enterprise
         os:
-        - macos-15
+        - macos-26
 
     runs-on: ${{ matrix.os }}
     env:

--- a/changes/ee/feat-18127.en.md
+++ b/changes/ee/feat-18127.en.md
@@ -1,0 +1,1 @@
+Start releasing macOS 26 (Tahoe) packages.

--- a/scripts/rel/build_matrix.py
+++ b/scripts/rel/build_matrix.py
@@ -48,7 +48,7 @@ LINUX_ARCH = ["amd64", "arm64"]
 LINUX_EXCLUDE = [{"os": "el7", "arch": "arm64"}]
 
 # macOS: runner labels (workflow matrix). Both hosted runners are arm64 today.
-MAC_OS = ["macos-14", "macos-15"]
+MAC_OS = ["macos-14", "macos-15", "macos-26"]
 MAC_ARCH = "arm64"
 
 


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Start releasing macOS 26 (Tahoe) packages.

This is the `dev-60` equivalent of emqx/emqx#18118 (dev-510) and emqx/emqx#16499 (release-61):

- `scripts/rel/build_matrix.py`: add `macos-26` to `MAC_OS` — this drives both the `mac` and `test-mac` matrices in `build_packages.yaml` via the `prepare-matrix` job. Package filenames (`macos26`) are derived automatically by `mac_rows()`.
- `build_packages.yaml`: invert the Apple signing bundle ternary so the old bundle is the exception pinned to the oldest runner (`macos-14`), and every newer runner (macos-15, macos-26, and future additions) uses the `_NEW` bundle. Same form as requested by review on #18118.
- `build_packages_cron.yaml` / `build_slim_packages.yaml`: bump the single macOS smoke-test runner from `macos-15` to `macos-26`.

Full CI verification of the macos-26 package build requires a manual `build_packages.yaml` dispatch (publish=false) from a branch in emqx/emqx.

If this flows forward via sync PRs, #16499 on release-61 may become redundant.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMMxRGUQqKxi1kyWEvYk2J
