### PR TITLE
build: tolerate gcc 14.3 maybe-uninitialized in quicer

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1125,9 +1125,25 @@ defmodule EMQXUmbrella.MixProject do
     if enable_quicer?(),
       # in conflict with emqx and emqtt
       do: [
-        {:quicer, github: "emqx/quic", tag: "0.2.15", override: true}
+        {:quicer,
+         github: "emqx/quic", tag: "0.2.15", override: true, system_env: quicer_build_env()}
       ],
       else: []
+  end
+
+  defp quicer_build_env() do
+    case :os.type() do
+      {:unix, :linux} ->
+        # GCC 14.3 (el10 builder) reports a 'maybe-uninitialized' false positive
+        # in the vendored msquic which compiles with -Werror; demote this one
+        # diagnostic back to a warning. Remove when a quicer tag containing
+        # emqx/quic#431 is picked up.
+        [{"CFLAGS", "-Wno-error=maybe-uninitialized"}]
+
+      _ ->
+        # never hand the GCC-only flag to clang (macOS)
+        []
+    end
   end
 
   defp enable_jq?() do


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

**Temporary** build workaround — the v6/mix twin of emqx/emqx#18126 (dev-510, rebar).

GCC 14.3.1 (the el10 builder) raises a `maybe-uninitialized` false positive in the msquic v2.3.8 vendored by quicer 0.2.15 (`src/core/packet.h:342`, `PacketNumber` in `QuicPktNumEncode`), and msquic hardcodes `-Werror` in its CMake `QUIC_WARNING_FLAGS` (CACHE INTERNAL, not overridable via `-D`). GCC 14.2 (debian13) does not warn, and the code is unchanged in msquic v2.5.0, so there is no upstream fix to pick up yet.

The fix passes `CFLAGS=-Wno-error=maybe-uninitialized` to the quicer dependency **only**, using mix's per-dep `system_env` option (same mechanism already used for grpc-erl and emqtt in this file). CMake seeds `CMAKE_C_FLAGS` from env `CFLAGS`, additively, reaching the msquic subdirectory; GCC applies `-Wno-error=X` over `-Werror` regardless of order. Notes:

- Scoped, not global: a global `CFLAGS` clobbers jq's `CFLAGS ?=` defaults and breaks its NIF link with `relocation R_X86_64_32 ... recompile with -fPIC` (confirmed in https://github.com/emqx/emqx/actions/runs/30268171912).
- Linux-only via `:os.type()` guard: clang (macOS) has no `maybe-uninitialized` warning group.
- The el10 effect is proven on the dev-510 run https://github.com/emqx/emqx/actions/runs/30270198112 (msquic diagnostic demoted to a warning). dev-60 does not build el10 packages yet, so on the current matrix this is pre-emptive and harmless (the flag is valid on every GCC in use).
- Verified locally that the override reaches the msquic build: `make QUICER_DOWNLOAD_FROM_RELEASE=0 emqx-enterprise` then `CMAKE_C_FLAGS` in quicer's `CMakeCache.txt` contains `-Wno-error=maybe-uninitialized`.

The proper fix is in flight upstream (emqx/quic#430 for main-0.2, emqx/quic#431 for main). Once a fixed quicer tag (0.2.17 on the 0.2 line) is bumped, this override gets reverted, together with #18126 on dev-510.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMMxRGUQqKxi1kyWEvYk2J
