### PR TITLE
fix: handle RPC transport failures in BPAPI proto callers (dev-58 audit findings 4-13)

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.app.src
+++ b/apps/emqx_bridge/src/emqx_bridge.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge, [
     {description, "EMQX bridges"},
-    {vsn, "0.2.10"},
+    {vsn, "0.2.11"},
     {registered, [emqx_bridge_sup]},
     {mod, {emqx_bridge_app, []}},
     {applications, [

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -1047,6 +1047,10 @@ is_ok(OkResult = {ok, _}) ->
     OkResult;
 is_ok(Error = {error, _}) ->
     Error;
+is_ok({badrpc, _} = Error) ->
+    %% Single-node operations use `rpc:call' which returns `{badrpc, Reason}'
+    %% when the target node is unreachable or the remote call fails.
+    {error, Error};
 is_ok(ResL) ->
     case
         lists:filter(
@@ -1112,6 +1116,9 @@ call_operation(NodeOrAll, OperFunc, Args = [_Nodes, BridgeType, BridgeName]) ->
             ?NOT_FOUND(<<"Node not found: ", (atom_to_binary(Node))/binary>>);
         {error, {unhealthy_target, Message}} ->
             ?BAD_REQUEST(Message);
+        {error, {badrpc, Reason}} ->
+            Msg = bin(io_lib:format("RPC to remote node failed: ~0p", [Reason])),
+            ?SERVICE_UNAVAILABLE(Msg);
         {error, Reason} ->
             ?BAD_REQUEST(redact(Reason))
     end.

--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -1064,6 +1064,10 @@ is_ok(OkResult = {ok, _}) ->
     OkResult;
 is_ok(Error = {error, _}) ->
     Error;
+is_ok({badrpc, _} = Error) ->
+    %% Single-node operations use `rpc:call' which returns `{badrpc, Reason}'
+    %% when the target node is unreachable or the remote call fails.
+    {error, Error};
 is_ok(ResL) ->
     case
         lists:filter(
@@ -1202,6 +1206,16 @@ call_operation(NodeOrAll, OperFunc, Args = [_Nodes, _ConfRootKey, BridgeType, Br
             ?SERVICE_UNAVAILABLE(<<"Bridge not found on remote node: ", BridgeId/binary>>);
         {error, {node_not_found, Node}} ->
             ?NOT_FOUND(<<"Node not found: ", (atom_to_binary(Node))/binary>>);
+        {error, {badrpc, Reason}} ->
+            BridgeId = emqx_bridge_resource:bridge_id(BridgeType, BridgeName),
+            ?SLOG(warning, #{
+                msg => "bridge_bpapi_call_failed",
+                bridge => BridgeId,
+                call => OperFunc,
+                reason => Reason
+            }),
+            Msg = bin(io_lib:format("RPC to remote node failed: ~0p", [Reason])),
+            ?SERVICE_UNAVAILABLE(Msg);
         {error, Reason} ->
             ?BAD_REQUEST(redact(Reason))
     end.

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -101,6 +101,7 @@ groups() ->
     SingleOnlyTests = [
         t_broken_bpapi_vsn,
         t_old_bpapi_vsn,
+        t_start_bridge_node_badrpc,
         t_bridges_probe
     ],
     ClusterLaterJoinOnlyTCs = [t_cluster_later_join_metrics],
@@ -169,11 +170,18 @@ init_per_testcase(t_old_bpapi_vsn, Config) ->
     meck:expect(emqx_bpapi, supported_version, 1, 1),
     meck:expect(emqx_bpapi, supported_version, 2, 1),
     init_per_testcase(common, Config);
+init_per_testcase(t_start_bridge_node_badrpc, Config) ->
+    meck:new(emqx_bridge_proto_v4, [passthrough]),
+    meck:expect(emqx_bridge_proto_v4, start_bridge_to_node, 3, {badrpc, nodedown}),
+    init_per_testcase(common, Config);
 init_per_testcase(_, Config) ->
     {Port, Sock, Acceptor} = start_http_server(fun handle_fun_200_ok/2),
     [{port, Port}, {sock, Sock}, {acceptor, Acceptor} | Config].
 
 end_per_testcase(t_broken_bpapi_vsn, Config) ->
+    meck:unload(),
+    end_per_testcase(common, Config);
+end_per_testcase(t_start_bridge_node_badrpc, Config) ->
     meck:unload(),
     end_per_testcase(common, Config);
 end_per_testcase(t_old_bpapi_vsn, Config) ->
@@ -736,6 +744,24 @@ t_start_bridge_unknown_node(Config) ->
             uri(["nodes", "undefined", "bridges", "webhook:foo", start]),
             Config
         ).
+
+%% Per-node start operation returns 503 (not 500) when the RPC to the target node fails.
+t_start_bridge_node_badrpc(Config) ->
+    Port = ?config(port, Config),
+    URL1 = ?URL(Port, "abc"),
+    Name = ?BRIDGE_NAME,
+    {ok, 201, _} = request(
+        post,
+        uri(["bridges"]),
+        ?HTTP_BRIDGE(URL1, Name),
+        Config
+    ),
+    BridgeID = emqx_bridge_resource:bridge_id(?BRIDGE_TYPE_HTTP, Name),
+    ?assertMatch(
+        {ok, 503, #{<<"message">> := _}},
+        request_json(post, {operation, node, start, BridgeID}, Config)
+    ),
+    ok.
 
 t_start_stop_bridges_node(Config) ->
     do_start_stop_bridges(node, Config).

--- a/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
@@ -1148,6 +1148,40 @@ t_start_bridge_unknown_node(Config) ->
             Config
         ).
 
+%% Per-node start operation returns 503 (not 500) when the RPC to the target node fails.
+t_start_bridge_node_badrpc(matrix) ->
+    [[single, actions]];
+t_start_bridge_node_badrpc(Config) ->
+    [_SingleOrCluster, Kind | _] = group_path(Config),
+    Name = atom_to_binary(?FUNCTION_NAME),
+    #{
+        api_root_key := APIRootKey,
+        type := Type,
+        create_config_fn := CreateConfigFn
+    } = get_common_values(Kind, Name),
+    ?assertMatch(
+        {ok, 201, _},
+        request_json(
+            post,
+            uri([APIRootKey]),
+            CreateConfigFn(#{name => Name}),
+            Config
+        )
+    ),
+    BridgeID = emqx_bridge_resource:bridge_id(Type, Name),
+    ok = meck:new(emqx_bridge_proto_v6, [passthrough, no_link]),
+    ok = meck:expect(emqx_bridge_proto_v6, v2_start_bridge_on_node_v6, 4, {badrpc, nodedown}),
+    Node = ?config(node, Config),
+    ?assertMatch(
+        {ok, 503, _},
+        request(
+            post,
+            uri(["nodes", atom_to_binary(Node), APIRootKey, BridgeID, "start"]),
+            Config
+        )
+    ),
+    ok.
+
 t_start_bridge_node(matrix) ->
     [
         [single, actions],

--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -723,6 +723,10 @@ is_ok(OkResult = {ok, _}) ->
     OkResult;
 is_ok(Error = {error, _}) ->
     Error;
+is_ok({badrpc, _} = Error) ->
+    %% Single-node operations use `rpc:call' which returns `{badrpc, Reason}'
+    %% when the target node is unreachable or the remote call fails.
+    {error, Error};
 is_ok(timeout) ->
     %% Returned by `emqx_resource_manager:start' when the connector fails to reach either
     %% `?status_connected' or `?status_disconnected' within `start_timeout'.
@@ -796,6 +800,9 @@ call_operation(NodeOrAll, OperFunc, Args = [_Nodes, ConnectorType, ConnectorName
             ?NOT_FOUND(<<"Node not found: ", (atom_to_binary(Node))/binary>>);
         {error, {unhealthy_target, Message}} ->
             ?BAD_REQUEST(Message);
+        {error, {badrpc, Reason}} ->
+            Msg = bin(io_lib:format("RPC to remote node failed: ~0p", [Reason])),
+            ?SERVICE_UNAVAILABLE(Msg);
         {error, Reason} when not is_tuple(Reason); element(1, Reason) =/= 'exit' ->
             ?BAD_REQUEST(redact(Reason))
     end.

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -146,7 +146,8 @@ groups() ->
         t_fail_delete_with_action,
         t_actions_field,
         t_update_with_failed_validation,
-        t_create_with_failed_root_validation
+        t_create_with_failed_root_validation,
+        t_start_connector_node_badrpc
     ],
     ClusterOnlyTests = [
         t_inconsistent_state
@@ -467,6 +468,27 @@ t_start_connector_unknown_node(Config) ->
 
 t_start_connector_node(Config) ->
     do_start_connector(node, Config).
+
+%% Per-node start operation returns 503 (not 500) when the RPC to the target node fails.
+t_start_connector_node_badrpc(Config) ->
+    Name = atom_to_binary(?FUNCTION_NAME),
+    ?assertMatch(
+        {ok, 201, _},
+        request_json(
+            post,
+            uri(["connectors"]),
+            ?KAFKA_CONNECTOR(Name),
+            Config
+        )
+    ),
+    ConnectorID = emqx_connector_resource:connector_id(?CONNECTOR_TYPE, Name),
+    ok = meck:new(emqx_connector_proto_v1, [passthrough, no_link]),
+    ok = meck:expect(emqx_connector_proto_v1, start_connector_to_node, 3, {badrpc, nodedown}),
+    ?assertMatch(
+        {ok, 503, _},
+        request(post, {operation, node, start, ConnectorID}, Config)
+    ),
+    ok.
 
 t_start_connector_cluster(Config) ->
     do_start_connector(cluster, Config).

--- a/apps/emqx_ft/src/emqx_ft_assembler.erl
+++ b/apps/emqx_ft/src/emqx_ft_assembler.erl
@@ -184,7 +184,17 @@ terminate(_Reason, _StateName, #{}) ->
 pread(Node, Segment, #{storage := Storage, transfer := Transfer}) when Node =:= node() ->
     emqx_ft_storage_fs:pread(Storage, Transfer, Segment, 0, segsize(Segment));
 pread(Node, Segment, #{transfer := Transfer}) ->
-    emqx_ft_storage_fs_proto_v1:pread(Node, Transfer, Segment, 0, segsize(Segment)).
+    %% `emqx_ft_storage_fs_proto_v1:pread/5' is backed by `erpc:call' which raises
+    %% on node/transport failures and remote crashes; turn a raise into an error
+    %% return so assembly stops cleanly instead of crashing the process.
+    try
+        emqx_ft_storage_fs_proto_v1:pread(Node, Transfer, Segment, 0, segsize(Segment))
+    catch
+        error:{erpc, _} = Reason ->
+            {error, Reason};
+        error:{exception, Reason, _Stack} ->
+            {error, Reason}
+    end.
 
 %%
 

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter_fs_api.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter_fs_api.erl
@@ -132,7 +132,15 @@ fields(file_node) ->
                     'NOT_FOUND',
                     iolist_to_binary(["Invalid query parameter: ", Param])
                 )};
-        error:{erpc, noconnection} ->
+        error:{erpc, _} ->
+            {503, error_msg('SERVICE_UNAVAILABLE', <<"Service unavailable">>)};
+        error:{exception, Reason, Stacktrace} ->
+            %% The remote call crashed on the target node; the stacktrace is remote.
+            ?SLOG(warning, #{
+                msg => "get_ready_transfer_fail",
+                error => Reason,
+                stacktrace => Stacktrace
+            }),
             {503, error_msg('SERVICE_UNAVAILABLE', <<"Service unavailable">>)}
     end.
 

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -204,6 +204,33 @@ t_download_transfer(Config) ->
         Response
     ).
 
+%% Download returns 503 (not 500) when the remote call crashes on the node
+%% holding the exported file (erpc raises `error:{exception, _, _}`).
+t_download_transfer_remote_crash(Config) ->
+    ClientId = client_id(Config),
+    FileId = <<"f1">>,
+    Nodes = [Node | _] = test_nodes(Config),
+    NodeUpload = lists:last(Nodes),
+    ok = emqx_ft_test_helpers:upload_file(sync, ClientId, FileId, "f1", <<"data">>, NodeUpload),
+    {ok, 200, #{<<"files">> := [File]}} =
+        request_json(get, uri(["file_transfer", "files", ClientId, FileId]), Config),
+    ok = erpc:call(Node, fun() ->
+        ok = meck:new(emqx_ft_storage_exporter_fs_proto_v1, [passthrough, no_link]),
+        ok = meck:expect(
+            emqx_ft_storage_exporter_fs_proto_v1,
+            read_export_file,
+            fun(_Node, _Filepath, _CallerPid) -> erlang:error({exception, oops, []}) end
+        )
+    end),
+    try
+        ?assertMatch(
+            {ok, 503, _},
+            request(get, host() ++ maps:get(<<"uri">>, File), Config)
+        )
+    after
+        ok = erpc:call(Node, meck, unload, [emqx_ft_storage_exporter_fs_proto_v1])
+    end.
+
 t_list_files_paging(Config) ->
     ClientId = client_id(Config),
     NFiles = 20,

--- a/apps/emqx_ft/test/emqx_ft_assembler_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_assembler_SUITE.erl
@@ -29,6 +29,7 @@ all() ->
         t_assemble_complete_local_transfer,
         t_assemble_incomplete_transfer,
         t_assemble_no_meta,
+        t_assemble_remote_pread_failure,
 
         % NOTE
         % It depends on the side effects of all previous testcases.
@@ -174,6 +175,47 @@ t_assemble_no_meta(Config) ->
     Status = complete_assemble(Storage, Transfer, 42),
     ?assertMatch({shutdown, {error, {incomplete, _}}}, Status).
 
+%% A remote fragment-node failure during assembly (erpc raise from the proto
+%% `pread`) stops the assembler with a clean shutdown error instead of
+%% crashing the process.
+t_assemble_remote_pread_failure(Config) ->
+    Storage = storage(Config),
+    RemoteStorage = remote_storage(Config),
+    Transfer = {?CLIENTID1, ?config(file_id, Config)},
+    Content = <<"remote data">>,
+    Meta = #{
+        name => "remote.pdf",
+        size => byte_size(Content),
+        expire_at => 42
+    },
+    ok = emqx_ft_storage_fs:store_filemeta(Storage, Transfer, Meta),
+    %% The segment lives in a separate storage root, standing in for a remote node.
+    ok = emqx_ft_storage_fs:store_segment(RemoteStorage, Transfer, {0, Content}),
+    {ok, RemoteFragments} = emqx_ft_storage_fs:list(RemoteStorage, Transfer, fragment),
+    Segments = [F || F = #{fragment := {segment, _}} <- RemoteFragments],
+    ?assertMatch([_ | _], Segments),
+    FakeNode = 'fakeremote@127.0.0.1',
+    ok = meck:new(emqx, [passthrough, no_link]),
+    ok = meck:expect(emqx, running_nodes, fun() -> [node(), FakeNode] end),
+    ok = meck:new(emqx_ft_storage_fs_proto_v1, [passthrough, no_link]),
+    ok = meck:expect(emqx_ft_storage_fs_proto_v1, multilist, fun(_Nodes, _Transfer, fragment) ->
+        [{ok, {ok, Segments}}]
+    end),
+    ok = meck:expect(
+        emqx_ft_storage_fs_proto_v1,
+        pread,
+        fun(_Node, _Transfer, _Frag, _Offset, _Size) ->
+            erlang:error({erpc, noconnection})
+        end
+    ),
+    try
+        Status = complete_assemble(Storage, Transfer, byte_size(Content)),
+        ?assertMatch({shutdown, {error, {read_segment, _}}}, Status)
+    after
+        meck:unload(emqx_ft_storage_fs_proto_v1),
+        meck:unload(emqx)
+    end.
+
 complete_assemble(Storage, Transfer, Size) ->
     complete_assemble(Storage, Transfer, Size, 1000).
 
@@ -246,18 +288,27 @@ exporter(Config) ->
     emqx_ft_storage_exporter:exporter(storage(Config)).
 
 storage(Config) ->
+    mk_storage(?config(storage_root, Config), ?config(exports_root, Config)).
+
+remote_storage(Config) ->
+    mk_storage(
+        <<(?config(storage_root, Config))/binary, "_remote">>,
+        <<(?config(exports_root, Config))/binary, "_remote">>
+    ).
+
+mk_storage(SegmentsRoot, ExportsRoot) ->
     emqx_utils_maps:deep_get(
         [storage, local],
         emqx_ft_schema:translate(#{
             <<"storage">> => #{
                 <<"local">> => #{
                     <<"segments">> => #{
-                        <<"root">> => ?config(storage_root, Config)
+                        <<"root">> => SegmentsRoot
                     },
                     <<"exporter">> => #{
                         <<"local">> => #{
                             <<"enable">> => true,
-                            <<"root">> => ?config(exports_root, Config)
+                            <<"root">> => ExportsRoot
                         }
                     }
                 }

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -432,11 +432,17 @@ get_configs_v2(QueryStr) ->
             {ok, Key} ->
                 emqx_conf_proto_v4:get_hocon_config(Node, atom_to_binary(Key))
         end,
-    {
-        200,
-        #{<<"content-type">> => <<"text/plain">>},
-        iolist_to_binary(hocon_pp:do(Conf, #{}))
-    }.
+    case Conf of
+        {badrpc, R} ->
+            Message = list_to_binary(io_lib:format("Bad node ~p, reason ~p", [Node, R])),
+            {500, #{code => 'BAD_NODE', message => Message}};
+        _ ->
+            {
+                200,
+                #{<<"content-type">> => <<"text/plain">>},
+                iolist_to_binary(hocon_pp:do(Conf, #{}))
+            }
+    end.
 
 limiter(get, _Params, _Req) ->
     {200, format_limiter_config(get_raw_config(limiter))};

--- a/apps/emqx_management/src/emqx_mgmt_api_relup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_relup.erl
@@ -452,7 +452,16 @@ validate_name(Name) ->
 
 '/relup/status'(get, _) ->
     Nodes = emqx:running_nodes(),
-    {[_ | _] = Res, []} = emqx_mgmt_api_relup_proto_v1:get_upgrade_status_from_nodes(Nodes),
+    case emqx_mgmt_api_relup_proto_v1:get_upgrade_status_from_nodes(Nodes) of
+        {[_ | _] = Res, []} ->
+            status_from_nodes(Res);
+        {_, [_ | _] = BadNodes} ->
+            return_internal_error(
+                list_to_binary(io_lib:format("Unreachable nodes: ~0p", [BadNodes]))
+            )
+    end.
+
+status_from_nodes(Res) ->
     case
         lists:filter(
             fun
@@ -480,7 +489,14 @@ validate_name(Name) ->
             (Node) when node() =:= Node ->
                 {200, get_upgrade_status()};
             (Node) when is_atom(Node) ->
-                {200, emqx_mgmt_api_relup_proto_v1:get_upgrade_status(Node)}
+                case emqx_mgmt_api_relup_proto_v1:get_upgrade_status(Node) of
+                    {badrpc, Reason} ->
+                        return_internal_error(
+                            list_to_binary(io_lib:format("RPC failed: ~0p", [Reason]))
+                        );
+                    Status when is_map(Status) ->
+                        {200, Status}
+                end
         end
     ).
 

--- a/apps/emqx_management/src/emqx_mgmt_api_trace.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_trace.erl
@@ -660,7 +660,15 @@ stream_log_file(get, #{bindings := #{name := Name}, query_string := Query}) ->
                     }),
                     ?SERVICE_UNAVAILABLE(<<"Requested chunk size too big">>);
                 {badrpc, nodedown} ->
-                    ?NOT_FOUND_WITH_MSG(<<"Node">>)
+                    ?NOT_FOUND_WITH_MSG(<<"Node">>);
+                {badrpc, Reason} ->
+                    ?SLOG(error, #{
+                        msg => "read_trace_file_rpc_failed",
+                        node => Node,
+                        name => Name,
+                        reason => Reason
+                    }),
+                    ?SERVICE_UNAVAILABLE(<<"RPC to remote node failed, please try again">>)
             end;
         {error, not_found} ->
             ?NOT_FOUND_WITH_MSG(<<"Node">>)

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -343,6 +343,19 @@ t_get_configs_in_different_accept(_Config) ->
     %% returns error if it set to other type
     ?assertMatch({400, "application/json", _}, Request(<<"application/xml">>)).
 
+%% text/plain config fetch from an unreachable node returns a structured error, not a crash.
+t_get_configs_v2_unknown_node(_Config) ->
+    URI = emqx_mgmt_api_test_util:api_path(["configs?node=unknownnode@127.0.0.1"]),
+    Auth = emqx_mgmt_api_test_util:auth_header_(),
+    Headers = [{"accept", "text/plain"}, Auth],
+    {error, {{_, 500, _}, _RespHeaders, Body}} =
+        emqx_mgmt_api_test_util:request_api(get, URI, [], Headers, [], #{return_all => true}),
+    ?assertMatch(
+        #{<<"code">> := <<"BAD_NODE">>},
+        emqx_utils_json:decode(iolist_to_binary(Body))
+    ),
+    ok.
+
 t_create_webhook_v1_bridges_api({'init', Config}) ->
     lists:foreach(
         fun(App) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
@@ -675,6 +675,11 @@ t_stream_log(_Config) ->
     meck:expect(file, read, 2, {error, enomem}),
     {error, {_, 503, _}} = request_api(get, Path),
     meck:unload(file),
+    %% a badrpc other than nodedown (e.g. timeout) is a clean 503, not a case_clause crash
+    meck:new(emqx_mgmt_trace_proto_v2, [passthrough]),
+    meck:expect(emqx_mgmt_trace_proto_v2, read_trace_file, 4, {badrpc, timeout}),
+    {error, {_, 503, _}} = request_api(get, Path),
+    meck:unload(emqx_mgmt_trace_proto_v2),
     {error, {_, 404, _}} =
         request_api(
             get,

--- a/apps/emqx_modules/src/emqx_delayed_api.erl
+++ b/apps/emqx_modules/src/emqx_delayed_api.erl
@@ -252,7 +252,9 @@ delayed_message(delete, #{bindings := #{node := NodeBin, msgid := HexId}}) ->
                 ok ->
                     {204};
                 {error, not_found} ->
-                    {404, generate_http_code_map(not_found, Id)}
+                    {404, generate_http_code_map(not_found, Id)};
+                {badrpc, _} ->
+                    {400, generate_http_code_map(invalid_node, NodeBin)}
             end
         end
     ).

--- a/apps/emqx_modules/src/emqx_modules.app.src
+++ b/apps/emqx_modules/src/emqx_modules.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_modules, [
     {description, "EMQX Modules"},
-    {vsn, "5.0.29"},
+    {vsn, "5.0.30"},
     {modules, []},
     {applications, [kernel, stdlib, emqx, emqx_ctl, observer_cli]},
     {mod, {emqx_modules_app, []}},

--- a/apps/emqx_modules/test/emqx_delayed_api_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_delayed_api_SUITE.erl
@@ -173,6 +173,15 @@ t_messages(_) ->
         )
     ),
 
+    %% deleting on an unreachable node is a clean error, not a case_clause crash
+    ?assertMatch(
+        {ok, 400, _},
+        request(
+            delete,
+            uri(["mqtt", "delayed", "messages", atom_to_list('unknownnode@127.0.0.1'), MsgId])
+        )
+    ),
+
     ?assertMatch(
         {ok, 404, _},
         request(

--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -2,7 +2,7 @@
 {application, emqx_retainer, [
     {description, "EMQX Retainer"},
     % strict semver, bump manually!
-    {vsn, "5.1.0"},
+    {vsn, "5.1.1"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -767,7 +767,12 @@ do_reindex_batch(Stream0, Done) ->
 
 wait_dispatch_complete(Timeout) ->
     Nodes = mria:running_nodes(),
-    {Results, []} = emqx_retainer_proto_v2:wait_dispatch_complete(Nodes, Timeout),
+    {Results, BadNodes} = emqx_retainer_proto_v2:wait_dispatch_complete(Nodes, Timeout),
+    BadNodes =/= [] andalso
+        ?SLOG(warning, #{
+            msg => "wait_dispatch_complete_rpc_failed",
+            bad_nodes => BadNodes
+        }),
     lists:all(
         fun(Result) -> Result =:= ok end,
         Results

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -39,13 +39,14 @@ groups() ->
     [
         {mnesia_without_indices, [sequence], common_tests()},
         {mnesia_with_indices, [sequence], common_tests()},
-        {mnesia_reindex, [sequence], [t_reindex]},
+        {mnesia_reindex, [sequence], [t_reindex, t_reindex_bad_node]},
         {test_disable_then_start, [sequence], [t_disable_then_start]},
         {disabled, [t_disabled]}
     ].
 
 common_tests() ->
-    emqx_common_test_helpers:all(?MODULE) -- [t_reindex, t_disable_then_start, t_disabled].
+    emqx_common_test_helpers:all(?MODULE) --
+        [t_reindex, t_reindex_bad_node, t_disable_then_start, t_disabled].
 
 %% erlfmt-ignore
 -define(BASE_CONF, <<"
@@ -886,6 +887,22 @@ t_reindex(_) ->
             )
         end
     ).
+
+%% Reindex tolerates nodes that are unreachable during the dispatch-complete
+%% RPC instead of crashing with a badmatch.
+t_reindex_bad_node(_) ->
+    ok = emqx_retainer:clean(),
+    ok = meck:new(emqx_retainer_proto_v2, [passthrough, no_link]),
+    ok = meck:expect(
+        emqx_retainer_proto_v2,
+        wait_dispatch_complete,
+        fun(_Nodes, _Timeout) -> {[ok], ['fake@node']} end
+    ),
+    try
+        ?assertEqual(ok, emqx_retainer_mnesia:reindex([[1, 3]], false, fun(_Done) -> ok end))
+    after
+        meck:unload(emqx_retainer_proto_v2)
+    end.
 
 t_get_basic_usage_info(_Config) ->
     ?assertEqual(#{retained_messages => 0}, emqx_retainer:get_basic_usage_info()),

--- a/changes/ee/fix-18139.en.md
+++ b/changes/ee/fix-18139.en.md
@@ -1,0 +1,13 @@
+Improved error handling in several cluster REST APIs when a target node is unreachable or restarting.
+
+Previously, the following requests could return an internal error (HTTP 500), or in one case crash an internal process, when the RPC to the target node failed (for example when the node was stopping, restarting, or temporarily unreachable):
+
+- Per-node start operations for actions, sources, bridges, and connectors.
+- Deleting a delayed message on a specific node.
+- Fetching configuration in HOCON format (`GET /configs`) from a specific node.
+- Downloading a trace log file segment.
+- Reading cluster upgrade status.
+- Downloading an exported file via the file-transfer API.
+- Retained-message reindexing could fail midway if a node became unreachable.
+
+These operations now report a clear per-node error instead.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

## Summary

Caller-side fixes for the open findings (4-13) of the RPC error-handling audit that followed #17747 (fixed by #18107): several BPAPI proto callers did not handle the transport-failure shape their proto can actually produce, so a target node going down (or a remote crash) between the `running_nodes` check and the RPC escaped as an HTTP 500 or crashed a server process.

- `emqx_bridge_api` / `emqx_bridge_v2_api` / `emqx_connector_api`: the shared `is_ok/1` helper had no `{badrpc, _}` clause; per-node start/stop/restart operations now return 503 with a clear message instead of crashing in `lists:filter/2`.
- `emqx_delayed_api`: DELETE of a delayed message on an unreachable node returns 400 (like the GET sibling) instead of a `case_clause` 500.
- `emqx_mgmt_api_configs`: the text/plain `GET /configs` path returns a structured `BAD_NODE` error (like the JSON sibling) instead of crashing in `hocon_pp:do/2`.
- `emqx_mgmt_api_relup`: a `{badrpc, _}` result is no longer serialized into a 200 response body; the cluster-wide status endpoint no longer asserts an empty bad-nodes list.
- `emqx_mgmt_api_trace`: trace log streaming handles all `{badrpc, _}` shapes (previously only `nodedown`), returning 503.
- `emqx_retainer_mnesia`: reindexing tolerates nodes that are unreachable during the wait-dispatch-complete multicall instead of a `badmatch` crash.
- `emqx_ft`: the export-file download endpoint catches all erpc transport errors and remote crashes (503 instead of 500); the assembler converts erpc raises from the fragment `pread` proto into `{error, _}` so it stops cleanly instead of crashing the gen_statem.

No proto modules were touched and no proto versions bumped; erpc-backed protos keep their transport, callers' catches were widened instead.

Audit finding 14 (`emqx_cm_proto_v2/v3:takeover_finish` misleading spec + `wrap_rpc/1` "dead" badrpc clause) is intentionally not included: `emqx_cm:wrap_rpc/1` is shared by rpc:call-backed protos for which the clause is live, and the spec fix would touch a frozen proto module.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
