### PR TITLE
fix(dssharesub): target leader node in borrower-initiated casts

### DIFF
--- a/apps/emqx/src/emqx_ds_shared_sub/emqx_ds_shared_sub_proto.erl
+++ b/apps/emqx/src/emqx_ds_shared_sub/emqx_ds_shared_sub_proto.erl
@@ -123,23 +123,23 @@ send_to_leader(ToLeader, Msg) when ?is_local_leader(ToLeader) ->
     ok;
 send_to_leader(ToLeader, ?borrower_connect_match(FromBorrowerId, ShareTopicFilter)) ->
     emqx_ds_shared_sub_proto_v3:borrower_connect(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId, ShareTopicFilter
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId, ShareTopicFilter
     );
 send_to_leader(ToLeader, ?borrower_ping_match(FromBorrowerId)) ->
     emqx_ds_shared_sub_proto_v3:borrower_ping(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId
     );
 send_to_leader(ToLeader, ?borrower_disconnect_match(FromBorrowerId, StreamProgresses)) ->
     emqx_ds_shared_sub_proto_v3:borrower_disconnect(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId, StreamProgresses
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId, StreamProgresses
     );
 send_to_leader(ToLeader, ?borrower_update_progress_match(FromBorrowerId, StreamProgress)) ->
     emqx_ds_shared_sub_proto_v3:borrower_update_progress(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId, StreamProgress
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId, StreamProgress
     );
 send_to_leader(ToLeader, ?borrower_revoke_finished_match(FromBorrowerId, Stream)) ->
     emqx_ds_shared_sub_proto_v3:borrower_revoke_finished(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId, Stream
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId, Stream
     ).
 
 -spec send_to_borrower(borrower_id(), to_borrower_msg()) -> ok.

--- a/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
@@ -795,6 +795,80 @@ t_renew_lease_timeout(_Config) ->
         []
     ).
 
+t_cluster_smoke(groups, _Groups) ->
+    [declare_implicit];
+t_cluster_smoke('init', Config) ->
+    start_cluster(Config);
+t_cluster_smoke('end', Config) ->
+    Config.
+
+t_cluster_smoke(Config) ->
+    [N1, N2, N3] = proplists:get_value(cluster_nodes, Config),
+    Group = <<"smoke">>,
+    TF = <<"smoke/#">>,
+    ShareTopic = <<"$share/", Group/binary, "/", TF/binary>>,
+    CIDSub1 = ~"cluster_smoke:sub1",
+    CIDSub2 = ~"cluster_smoke:sub2",
+    CIDPubs = [emqx_utils:format("cluster_smoke:pub~p", [N]) || N <- lists:seq(1, 10)],
+    ?check_trace(
+        #{timetrap => 30_000},
+        begin
+            C1 = emqtt_connect_sub(CIDSub1, [{port, get_mqtt_port(N1)}]),
+            C2 = emqtt_connect_sub(CIDSub2, [{port, get_mqtt_port(N2)}]),
+            CPubs = [
+                emqtt_connect_pub(CID, [{port, get_mqtt_port(N3)}])
+             || CID <- CIDPubs
+            ],
+            ClientByPid = fun(CPid) ->
+                proplists:get_value(clientid, emqtt:info(CPid))
+            end,
+
+            {ok, _, [1]} = emqtt:subscribe(C1, ShareTopic, 1),
+            ?block_until(#{
+                ?snk_kind := ds_shared_sub_become_leader,
+                group := Group,
+                topic := TF
+            }),
+
+            Topics = [~"smoke/1", ~"smoke/2", ~"smoke/3"],
+            ok = lists:foreach(
+                fun({I, CPub}) ->
+                    Topic = lists:nth(I rem 3 + 1, Topics),
+                    {ok, _} = emqtt:publish(CPub, Topic, ~"warmup", 1),
+                    ?assertReceive({publish, #{payload := ~"warmup", client_pid := C1}}, 5_000)
+                end,
+                lists:enumerate(0, CPubs)
+            ),
+
+            {ok, _, [1]} = emqtt:subscribe(C2, ShareTopic, 1),
+            ?block_until(#{
+                ?snk_kind := ds_shared_sub_borrower_leader_grant,
+                session_id := CIDSub2
+            }),
+
+            NPubs = length(CPubs) * 10,
+            ok = lists:foreach(
+                fun({I, CPub}) ->
+                    ok = publish_n(CPub, Topics, I * 10 + 1, I * 10 + 10)
+                end,
+                lists:enumerate(0, CPubs)
+            ),
+
+            Pubs = drain_until_received(NPubs, 30_000),
+            {Missing, Duplicate} = verify_received_pubs(Pubs, NPubs, ClientByPid),
+            snabbkaffe_diff:assert_lists_eq([], Missing, #{comment => "Missing"}),
+            snabbkaffe_diff:assert_lists_eq([], Duplicate, #{comment => "Duplicates"}),
+
+            ?assertMatch(
+                #{CIDSub1 := [_ | _], CIDSub2 := [_ | _]},
+                maps:groups_from_list(fun(P) -> ClientByPid(maps:get(client_pid, P)) end, Pubs)
+            ),
+
+            lists:foreach(fun emqtt:disconnect/1, [C1, C2 | CPubs])
+        end,
+        []
+    ).
+
 t_leader_election(groups, _Groups) ->
     [declare_implicit];
 t_leader_election('init', Config) ->
@@ -958,11 +1032,16 @@ emqtt_connect_sub(ClientId, Options) ->
     C.
 
 emqtt_connect_pub(ClientId) ->
-    {ok, C} = emqtt:start_link([
-        {clientid, ClientId},
-        {clean_start, true},
-        {proto_ver, v5}
-    ]),
+    emqtt_connect_pub(ClientId, []).
+
+emqtt_connect_pub(ClientId, Options) ->
+    {ok, C} = emqtt:start_link(
+        [
+            {clientid, ClientId},
+            {clean_start, true},
+            {proto_ver, v5}
+        ] ++ Options
+    ),
     {ok, _} = emqtt:connect(C),
     C.
 

--- a/changes/ee/fix-18143.en.md
+++ b/changes/ee/fix-18143.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where durable shared subscriptions could fail to communicate with the shared-subscription leader when subscribers were connected to a different node. This could cause an unexplained spike in CPU usage.


### PR DESCRIPTION
Release version: 6.3.0

## Summary

This PR addresses an issue where shared subscriptions borrowers fail to reach corresponding leaders if they were on a separate node, as part of `emqx_ds_shared_sub_proto` communication.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible