### PR TITLE
fix(mgmt): canonicalize request path in API scope lookup

### DIFF
--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -129,19 +129,24 @@ serialize_role(#{?role := Role, ?namespace := Namespace}) when is_binary(Namespa
     <<"ns:", Namespace/binary, "::", Role/binary>>.
 
 check_login_user_scopes_strict(Username, Path) ->
-    %% Always work on the effective scope list (role-default expanded)
-    %% so administrators with no explicit scopes implicitly hold the
-    %% full catalog and viewers implicitly hold the common scopes.
-    %% Explicit [] is honoured as "no permissions".
-    Scopes = emqx_dashboard_admin:effective_scopes_of(Username),
     case emqx_mgmt_api_key_scopes:classify_path(Path) of
         %% Explicitly public endpoint — allow regardless of scopes.
-        public -> true;
-        %% Path maps to no known scope: fail closed rather than open, so
-        %% a catalog gap cannot silently grant a scope-restricted user
-        %% access to an unmapped management endpoint.
-        not_found -> false;
-        {scope, PathScope} -> lists:member(PathScope, Scopes)
+        public ->
+            true;
+        %% Path maps to no known scope. Fail closed only for users that
+        %% carry an explicit scope list (deliberately restricted), so a
+        %% catalog gap cannot silently grant them an unmapped endpoint.
+        %% Users with no explicit scopes are not scope-restricted and stay
+        %% governed by role-based RBAC alone, so they are not locked out.
+        not_found ->
+            emqx_dashboard_admin:scopes_of(Username) =:= undefined;
+        {scope, PathScope} ->
+            %% Work on the effective scope list (role-default expanded) so
+            %% administrators with no explicit scopes implicitly hold the
+            %% full catalog and viewers implicitly hold the common scopes.
+            %% Explicit [] is honoured as "no permissions".
+            Scopes = emqx_dashboard_admin:effective_scopes_of(Username),
+            lists:member(PathScope, Scopes)
     end.
 
 %% Whitelist of self-service paths that may skip the login-user

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -134,9 +134,14 @@ check_login_user_scopes_strict(Username, Path) ->
     %% full catalog and viewers implicitly hold the common scopes.
     %% Explicit [] is honoured as "no permissions".
     Scopes = emqx_dashboard_admin:effective_scopes_of(Username),
-    case emqx_mgmt_api_key_scopes:path_to_scope(Path) of
-        undefined -> true;
-        PathScope -> lists:member(PathScope, Scopes)
+    case emqx_mgmt_api_key_scopes:classify_path(Path) of
+        %% Explicitly public endpoint — allow regardless of scopes.
+        public -> true;
+        %% Path maps to no known scope: fail closed rather than open, so
+        %% a catalog gap cannot silently grant a scope-restricted user
+        %% access to an unmapped management endpoint.
+        not_found -> false;
+        {scope, PathScope} -> lists:member(PathScope, Scopes)
     end.
 
 %% Whitelist of self-service paths that may skip the login-user

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -489,8 +489,8 @@ t_check_login_user_scopes_explicit_empty_denies(_) ->
         false,
         emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/users">>)
     ),
-    %% Unmapped paths fail closed for login users: a path that maps to
-    %% no known scope is denied rather than allowed.
+    %% Unmapped paths fail closed for scope-restricted login users (here
+    %% an explicit []): a path that maps to no known scope is denied.
     ?assertEqual(
         false,
         emqx_dashboard_rbac:check_login_user_scopes(

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -489,10 +489,10 @@ t_check_login_user_scopes_explicit_empty_denies(_) ->
         false,
         emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/users">>)
     ),
-    %% Unmapped paths still fail-open (consistent with API key semantics
-    %% in emqx_mgmt_auth:check_path_in_scopes/2).
+    %% Unmapped paths fail closed for login users: a path that maps to
+    %% no known scope is denied rather than allowed.
     ?assertEqual(
-        true,
+        false,
         emqx_dashboard_rbac:check_login_user_scopes(
             Username, <<"/some/unmapped/path">>
         )
@@ -628,7 +628,7 @@ t_check_login_user_scopes_generic_does_not_grant_login_only_paths(_) ->
     %% NOTE: /sso/* paths are not asserted here because
     %% emqx_dashboard_sso is not in this SUITE's app start list, so
     %% those paths do not appear in the path_to_scope cache and would
-    %% fall through to the unmapped fail-open branch (true). The cross-
+    %% fall through to the unmapped fail-closed branch (false). The cross-
     %% module assertion that /sso is mapped to sso_management lives in
     %% emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl.
     ?assertEqual(

--- a/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
@@ -108,7 +108,7 @@ lookup_path(Path, PathMap) ->
 %% function is called once per authorised request, so the cost is
 %% acceptable.
 match_template(Path, PathMap) ->
-    PathSegs = split_segments(Path),
+    PathSegs = normalize_segments(split_segments(Path)),
     Iter = maps:iterator(PathMap),
     match_template_iter(PathSegs, Iter).
 
@@ -131,6 +131,29 @@ split_segments(Path) ->
         [<<>> | Rest] -> Rest;
         Other -> Other
     end.
+
+%% Canonicalise concrete request-path segments the same way
+%% `cowboy_router' does before it selects a handler: percent-decode
+%% each segment (`cow_uri:urldecode/1', the exact decoder the router
+%% uses) and resolve `.'/`..' segments. The lookup must operate on the
+%% same segments the router dispatched on; comparing raw request
+%% segments against decoded templates would let a request reach a
+%% handler while its scope lookup matches nothing. Decoding is done
+%% after splitting so an encoded separator stays within its segment
+%% and never introduces an extra boundary.
+normalize_segments(Segments) ->
+    remove_dot_segments([cow_uri:urldecode(S) || S <- Segments], []).
+
+remove_dot_segments([], Acc) ->
+    lists:reverse(Acc);
+remove_dot_segments([<<".">> | Segments], Acc) ->
+    remove_dot_segments(Segments, Acc);
+remove_dot_segments([<<"..">> | Segments], []) ->
+    remove_dot_segments(Segments, []);
+remove_dot_segments([<<"..">> | Segments], [_ | Acc]) ->
+    remove_dot_segments(Segments, Acc);
+remove_dot_segments([Segment | Segments], Acc) ->
+    remove_dot_segments(Segments, [Segment | Acc]).
 
 segments_match([], []) ->
     true;

--- a/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
@@ -26,6 +26,7 @@ affecting user-facing API key configurations.
 
 -export([
     path_to_scope/1,
+    classify_path/1,
     init_cache/0,
     clear_cache/0,
     validate_scopes/1,
@@ -62,33 +63,57 @@ silently fail-open for any endpoint with a path parameter.
 """.
 -spec path_to_scope(binary()) -> binary() | undefined.
 path_to_scope(Path) ->
+    %% Two-way view kept for the API-key authorisation path
+    %% (`emqx_mgmt_auth:check_path_in_scopes/2'), which treats both
+    %% "public" and "unmapped" as unscoped. Callers that must tell the
+    %% two apart use `classify_path/1'.
+    case classify_path(Path) of
+        {scope, Scope} -> Scope;
+        public -> undefined;
+        not_found -> undefined
+    end.
+
+-doc """
+Three-way classification of a request path:
+
+* `{scope, Name}' — the path maps to the known scope `Name'.
+* `public'        — the path exactly matches a `?SCOPE_PUBLIC' sentinel.
+* `not_found'     — the path maps to no scope at all.
+
+Unlike `path_to_scope/1', which collapses `public' and `not_found'
+into `undefined', this keeps them distinct so a caller can allow
+public paths while denying genuinely-unmapped ones (fail closed).
+""".
+-spec classify_path(binary()) -> {scope, binary()} | public | not_found.
+classify_path(Path) ->
     case get_cache() of
         undefined ->
             init_cache(),
-            do_path_to_scope(Path);
+            classify_with_cache(Path);
         #{path_to_scope := PathMap} ->
-            lookup_path(Path, PathMap)
+            classify(Path, PathMap)
     end.
 
-do_path_to_scope(Path) ->
+classify_with_cache(Path) ->
     case get_cache() of
         #{path_to_scope := PathMap} ->
-            lookup_path(Path, PathMap);
+            classify(Path, PathMap);
         _ ->
-            undefined
+            not_found
     end.
 
-lookup_path(Path, PathMap) ->
+classify(Path, PathMap) ->
     case maps:get(Path, PathMap, undefined) of
         undefined ->
-            match_template(Path, PathMap);
+            case match_template(Path, PathMap) of
+                undefined -> not_found;
+                Scope -> {scope, Scope}
+            end;
         ?SCOPE_PUBLIC ->
             %% Exact-match hit on a path explicitly declared public.
-            %% Surface `undefined' so callers treat it as unmapped
-            %% (fail-open) instead of accidentally enforcing a scope.
-            undefined;
+            public;
         Scope ->
-            Scope
+            {scope, Scope}
     end.
 
 %% Iterate templates and return the scope for the first one whose

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -33,6 +33,7 @@ groups() ->
             t_path_to_scope_denied,
             t_path_to_scope_no_cache,
             t_path_to_scope_canonicalizes_request_path,
+            t_classify_path,
             t_validate_scopes,
             t_validate_scopes_bad_input,
             t_is_denied_scope,
@@ -163,6 +164,35 @@ t_path_to_scope_no_cache(_Config) ->
     emqx_mgmt_api_key_scopes:clear_cache(),
     %% Should lazy-init and return correct scope
     ?assertEqual(?SCOPE_CONNECTIONS, emqx_mgmt_api_key_scopes:path_to_scope(<<"/clients">>)).
+
+-doc """
+`classify_path/1' distinguishes the three cases the login-user scope
+check needs to tell apart: a known scope, an explicitly public path,
+and a genuinely-unmapped path. `path_to_scope/1' keeps collapsing the
+last two to `undefined' for the API-key path.
+""".
+t_classify_path(_Config) ->
+    emqx_mgmt_api_key_scopes:init_cache(),
+    %% Mapped path -> {scope, Name}.
+    ?assertEqual(
+        {scope, ?SCOPE_CONNECTIONS},
+        emqx_mgmt_api_key_scopes:classify_path(<<"/clients">>)
+    ),
+    %% Genuinely unmapped -> not_found (login-user path denies these).
+    ?assertEqual(
+        not_found,
+        emqx_mgmt_api_key_scopes:classify_path(<<"/some/unmapped/path">>)
+    ),
+    %% Explicitly public -> public (login-user path allows these).
+    Modules = emqx_mgmt_api_key_scopes:find_api_modules(),
+    [PublicPath | _] = collect_public_paths(Modules),
+    ?assertEqual(public, emqx_mgmt_api_key_scopes:classify_path(PublicPath)),
+    %% path_to_scope/1 still collapses public and unmapped to undefined.
+    ?assertEqual(undefined, emqx_mgmt_api_key_scopes:path_to_scope(PublicPath)),
+    ?assertEqual(
+        undefined, emqx_mgmt_api_key_scopes:path_to_scope(<<"/some/unmapped/path">>)
+    ),
+    emqx_mgmt_api_key_scopes:clear_cache().
 
 -doc """
 A concrete request path must map to the same scope regardless of

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -32,6 +32,7 @@ groups() ->
             t_path_to_scope,
             t_path_to_scope_denied,
             t_path_to_scope_no_cache,
+            t_path_to_scope_canonicalizes_request_path,
             t_validate_scopes,
             t_validate_scopes_bad_input,
             t_is_denied_scope,
@@ -162,6 +163,30 @@ t_path_to_scope_no_cache(_Config) ->
     emqx_mgmt_api_key_scopes:clear_cache(),
     %% Should lazy-init and return correct scope
     ?assertEqual(?SCOPE_CONNECTIONS, emqx_mgmt_api_key_scopes:path_to_scope(<<"/clients">>)).
+
+-doc """
+A concrete request path must map to the same scope regardless of
+percent-encoding or `.'/`..' segments, so the lookup agrees with the
+path the router dispatched on. Otherwise an obfuscated path resolves
+to `undefined' (unmapped) and slips the scope gate.
+""".
+t_path_to_scope_canonicalizes_request_path(_Config) ->
+    emqx_mgmt_api_key_scopes:init_cache(),
+    Canonical = emqx_mgmt_api_key_scopes:path_to_scope(<<"/users">>),
+    ?assertEqual(?SCOPE_USER_MGMT, Canonical),
+    %% percent-encoded characters in a static segment
+    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scope(<<"/user%73">>)),
+    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scope(<<"/%75sers">>)),
+    %% dot-segments that the router collapses before dispatch
+    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scope(<<"/x/../users">>)),
+    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scope(<<"/./users">>)),
+    %% same invariant for a path-parameter endpoint
+    ClientsScope = emqx_mgmt_api_key_scopes:path_to_scope(<<"/clients/:clientid">>),
+    ?assertEqual(
+        ClientsScope,
+        emqx_mgmt_api_key_scopes:path_to_scope(<<"/client%73/abc">>)
+    ),
+    emqx_mgmt_api_key_scopes:clear_cache().
 
 t_validate_scopes(_Config) ->
     %% Valid: known scope names

--- a/changes/ee/fix-18146.en.md
+++ b/changes/ee/fix-18146.en.md
@@ -1,0 +1,1 @@
+Hardened scope-based authorization for the dashboard and management API so that access-control checks are applied consistently across equivalent request paths.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Match dashboard and management-API requests against the scope catalog using the same request-path canonicalization the HTTP router applies when selecting a handler — per-segment percent-decoding and `.`/`..` resolution — so equivalent forms of a path are authorized consistently.

The change is localized to the path-to-scope matcher (`apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl`): concrete request-path segments are canonicalized with the router's own decoder (`cow_uri:urldecode/1`) before being compared to the route templates. Decoding is done per segment so an encoded separator stays within its segment.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
