### PR TITLE
build(rpm): disable rpmbuild check-rpaths on el10

### DIFF
--- a/deploy/packages/rpm/emqx.spec
+++ b/deploy/packages/rpm/emqx.spec
@@ -7,6 +7,10 @@
 %define _var_home %{_sharedstatedir}/%{_name}
 %define _build_name_fmt %{_arch}/%{_name}-%{_version}.%{_arch}.rpm
 %define _build_id_links none
+# rpm >= 4.19 (el10) runs check-rpaths by default and fails the build:
+# the bundled Erlang runtime and NIFs (crypto.so, jq, crc32cer) carry
+# build-time rpaths which are harmless under the private /usr/lib/emqx tree.
+%global __brp_check_rpaths %{nil}
 
 Name: %{_package_name}
 Version: %{_version}


### PR DESCRIPTION
## Summary

The el10 package build of 6.1.4-rc.1 failed in `rpmbuild` ([failed job](https://github.com/emqx/emqx/actions/runs/30397914390/job/90405670442)): rpm >= 4.19 (el10) runs `check-rpaths` by default and rejects the rpaths carried by the bundled Erlang runtime and NIF shared objects:

- `crypto.so` / `otp_test_engine.so` — standard openssl search-path rpaths from the OTP build
- `libcrc32cer_nif.so` — leftover build-dir rpath plus an empty entry
- `jq_nif1.so` — empty rpath (unquoted `$ORIGIN` in its Makefile)

These are harmless under the private `/usr/lib/emqx` tree, so opt out with `%global __brp_check_rpaths %{nil}` (a no-op on older el releases where the macro is undefined).

Verified in the `el10` builder image (arm64): a synthetic rpm containing an empty-rpath `.so` reproduces the exact `ERROR 0010` failure without the macro and builds cleanly with it.