### PR TITLE
build(rpm): disable rpmbuild check-rpaths on el10

### DIFF
--- a/deploy/packages/rpm/emqx.spec
+++ b/deploy/packages/rpm/emqx.spec
@@ -7,6 +7,10 @@
 %define _var_home %{_sharedstatedir}/%{_name}
 %define _build_name_fmt %{_arch}/%{_name}-%{_version}.%{_arch}.rpm
 %define _build_id_links none
+# rpm >= 4.19 (el10) runs check-rpaths by default and fails the build:
+# the bundled Erlang runtime and NIFs (crypto.so, jq, crc32cer) carry
+# build-time rpaths which are harmless under the private /usr/lib/emqx tree.
+%global __brp_check_rpaths %{nil}
 
 Name: %{_package_name}
 Version: %{_version}


### PR DESCRIPTION
## Summary

Port of #18150 (merged to `dev-61`, verified green on the 6.1.4-rc.1 re-tag build) — el10 rpm packages are built on this branch too.

rpm >= 4.19 (el10) runs `check-rpaths` by default and fails the package build ([example failure on 6.1.4-rc.1](https://github.com/emqx/emqx/actions/runs/30397914390/job/90405670442)): the bundled Erlang runtime and NIF shared objects (`crypto.so`, `jq_nif1.so`, `libcrc32cer_nif.so`) carry build-time rpaths (standard, build-dir, or empty entries) which are harmless under the private `/usr/lib/emqx` tree. Opt out with `%global __brp_check_rpaths %{nil}` — a no-op on older el releases where the macro is undefined.

Also ported to `dev-60` (#18151) and `dev-510` (#18152).