### PR TITLE
fix(auth): persist HTTP OAuth2 TLS certificates

### DIFF
--- a/apps/emqx_auth/src/emqx_auth_utils.erl
+++ b/apps/emqx_auth/src/emqx_auth_utils.erl
@@ -5,7 +5,8 @@
 -module(emqx_auth_utils).
 
 -export([
-    cached_simple_sync_query/4
+    cached_simple_sync_query/4,
+    sanitize_oauth2_ssl/1
 ]).
 
 %%--------------------------------------------------------------------
@@ -28,9 +29,29 @@ cached_simple_sync_query(CacheName, CacheKey, ResourceID, Query) ->
         end
     end).
 
+-spec sanitize_oauth2_ssl(map()) -> map().
+sanitize_oauth2_ssl(#{<<"ssl">> := SSL} = OAuth2) ->
+    %% Empty certificate fields are optional when peer verification is disabled.
+    OAuth2#{<<"ssl">> := drop_blank_certs_for_verify_none(SSL)};
+sanitize_oauth2_ssl(OAuth2) ->
+    OAuth2.
+
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
+
+drop_blank_certs_for_verify_none(#{<<"verify">> := Verify} = SSL) when
+    Verify =:= verify_none; Verify =:= <<"verify_none">>
+->
+    maps:filter(
+        fun(Key, Value) ->
+            not (lists:member(Key, [<<"cacertfile">>, <<"certfile">>, <<"keyfile">>]) andalso
+                (Value =:= <<>> orelse Value =:= ""))
+        end,
+        SSL
+    );
+drop_blank_certs_for_verify_none(SSL) ->
+    SSL.
 
 eval_query(Query) when is_function(Query, 0) ->
     Query();

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_config.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_config.erl
@@ -270,7 +270,10 @@ convert_certs(CertsDir, NewConfig0) ->
     NewConfig = convert_ssl_certs(CertsDir, NewConfig0),
     case maps:get(<<"oauth2">>, NewConfig, undefined) of
         OAuth2 when is_map(OAuth2) ->
-            NewOAuth2 = convert_ssl_certs(filename:join(CertsDir, "oauth2"), OAuth2),
+            NewOAuth2 = convert_ssl_certs(
+                filename:join(CertsDir, "oauth2"),
+                emqx_auth_utils:sanitize_oauth2_ssl(OAuth2)
+            ),
             NewConfig#{<<"oauth2">> := NewOAuth2};
         _ ->
             NewConfig

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_config.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_config.erl
@@ -266,7 +266,17 @@ convert_certs_for_conf_path(ConfPath, NewConfig) ->
     ),
     {ok, CovertedConfs}.
 
-convert_certs(CertsDir, NewConfig) ->
+convert_certs(CertsDir, NewConfig0) ->
+    NewConfig = convert_ssl_certs(CertsDir, NewConfig0),
+    case maps:get(<<"oauth2">>, NewConfig, undefined) of
+        OAuth2 when is_map(OAuth2) ->
+            NewOAuth2 = convert_ssl_certs(filename:join(CertsDir, "oauth2"), OAuth2),
+            NewConfig#{<<"oauth2">> := NewOAuth2};
+        _ ->
+            NewConfig
+    end.
+
+convert_ssl_certs(CertsDir, NewConfig) ->
     NewSSL = maps:get(<<"ssl">>, NewConfig, undefined),
     case emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir(CertsDir, NewSSL) of
         {ok, NewSSL1} ->

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
@@ -777,7 +777,10 @@ maybe_write_certs(#{<<"type">> := Type} = Source0) ->
     Source = write_ssl_files(CertsDir, Source0),
     case maps:get(<<"oauth2">>, Source, undefined) of
         OAuth2 when is_map(OAuth2) ->
-            NewOAuth2 = write_ssl_files(filename:join(CertsDir, "oauth2"), OAuth2),
+            NewOAuth2 = write_ssl_files(
+                filename:join(CertsDir, "oauth2"),
+                emqx_auth_utils:sanitize_oauth2_ssl(OAuth2)
+            ),
             Source#{<<"oauth2">> := NewOAuth2};
         _ ->
             Source

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
@@ -772,16 +772,29 @@ maybe_read_source_files(Source) ->
             Source
     end.
 
-maybe_write_certs(#{<<"type">> := Type, <<"ssl">> := SSL = #{}} = Source) ->
-    case emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir(ssl_file_path(Type), SSL) of
+maybe_write_certs(#{<<"type">> := Type} = Source0) ->
+    CertsDir = ssl_file_path(Type),
+    Source = write_ssl_files(CertsDir, Source0),
+    case maps:get(<<"oauth2">>, Source, undefined) of
+        OAuth2 when is_map(OAuth2) ->
+            NewOAuth2 = write_ssl_files(filename:join(CertsDir, "oauth2"), OAuth2),
+            Source#{<<"oauth2">> := NewOAuth2};
+        _ ->
+            Source
+    end;
+maybe_write_certs(#{} = Source) ->
+    Source.
+
+write_ssl_files(CertsDir, #{<<"ssl">> := SSL = #{}} = Config) ->
+    case emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir(CertsDir, SSL) of
         {ok, NSSL} ->
-            Source#{<<"ssl">> => NSSL};
+            Config#{<<"ssl">> => NSSL};
         {error, Reason} ->
             ?SLOG(error, Reason#{msg => "bad_ssl_config"}),
             throw({bad_ssl_config, Reason})
     end;
-maybe_write_certs(#{} = Source) ->
-    Source.
+write_ssl_files(_CertsDir, Config) ->
+    Config.
 
 ssl_file_path(Type) ->
     filename:join(["authz", Type]).

--- a/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
@@ -215,6 +215,18 @@ t_oauth2_client_credentials(TCConfig) ->
         emqx_access_control:authenticate(?CREDENTIALS)
     ).
 
+t_oauth2_ssl_certs_are_saved(TCConfig) ->
+    BaseURL = <<"http://127.0.0.1:", (http_port_bin(TCConfig))/binary>>,
+    ok = set_oauth2_token_handler(<<"/auth/token">>),
+    SSL = inline_ssl_certs(),
+    AuthConfig = (raw_http_auth_config(TCConfig))#{
+        <<"oauth2">> =>
+            (oauth2_config(<<BaseURL/binary, "/auth/token">>))#{<<"ssl">> => SSL}
+    },
+    {ok, _} = emqx:update_config(?PATH, {create_authenticator, ?GLOBAL, AuthConfig}),
+    [#{<<"oauth2">> := #{<<"ssl">> := SavedSSL}}] = emqx:get_raw_config(?PATH),
+    assert_ssl_certs_are_saved(SSL, SavedSSL).
+
 t_oauth2_start_timeout_keeps_authenticator(TCConfig) ->
     ok = block_oauth2_token_endpoint(<<"/auth/token">>),
     BaseURL = <<"http://127.0.0.1:", (http_port_bin(TCConfig))/binary>>,
@@ -1274,6 +1286,46 @@ oauth2_config(TokenEndpoint) ->
         <<"client_id">> => <<"client-id">>,
         <<"client_secret">> => <<"client-secret">>
     }.
+
+set_oauth2_token_handler(Path) ->
+    emqx_utils_http_test_server:set_handler(fun(Req0, State) ->
+        Path = cowboy_req:path(Req0),
+        Req = cowboy_req:reply(
+            200,
+            #{<<"content-type">> => <<"application/json">>},
+            emqx_utils_json:encode(#{
+                access_token => <<"oauth2-token">>,
+                expires_in => 3600,
+                token_type => <<"Bearer">>
+            }),
+            Req0
+        ),
+        {ok, Req, State}
+    end).
+
+inline_ssl_certs() ->
+    #{
+        <<"enable">> => true,
+        <<"verify">> => <<"verify_peer">>,
+        <<"cacertfile">> => pem("cacert.pem"),
+        <<"certfile">> => pem("client-cert.pem"),
+        <<"keyfile">> => pem("client-key.pem")
+    }.
+
+pem(Name) ->
+    Path = filename:join([code:lib_dir(emqx), etc, certs, Name]),
+    {ok, Pem} = file:read_file(Path),
+    Pem.
+
+assert_ssl_certs_are_saved(SSL, SavedSSL) ->
+    lists:foreach(
+        fun(Key) ->
+            SavedPath = maps:get(Key, SavedSSL),
+            ?assertNotEqual(maps:get(Key, SSL), SavedPath),
+            ?assert(filelib:is_regular(SavedPath))
+        end,
+        [<<"cacertfile">>, <<"certfile">>, <<"keyfile">>]
+    ).
 
 samples() ->
     [

--- a/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
@@ -227,6 +227,23 @@ t_oauth2_ssl_certs_are_saved(TCConfig) ->
     [#{<<"oauth2">> := #{<<"ssl">> := SavedSSL}}] = emqx:get_raw_config(?PATH),
     assert_ssl_certs_are_saved(SSL, SavedSSL).
 
+t_oauth2_ssl_verify_none_allows_blank_certs(TCConfig) ->
+    BaseURL = <<"http://127.0.0.1:", (http_port_bin(TCConfig))/binary>>,
+    ok = set_oauth2_token_handler(<<"/auth/token">>),
+    AuthConfig = (raw_http_auth_config(TCConfig))#{
+        <<"oauth2">> =>
+            (oauth2_config(<<BaseURL/binary, "/auth/token">>))#{
+                <<"ssl">> => #{
+                    <<"enable">> => true,
+                    <<"verify">> => <<"verify_none">>,
+                    <<"cacertfile">> => <<>>,
+                    <<"certfile">> => <<>>,
+                    <<"keyfile">> => <<>>
+                }
+            }
+    },
+    {ok, _} = emqx:update_config(?PATH, {create_authenticator, ?GLOBAL, AuthConfig}).
+
 t_oauth2_start_timeout_keeps_authenticator(TCConfig) ->
     ok = block_oauth2_token_endpoint(<<"/auth/token">>),
     BaseURL = <<"http://127.0.0.1:", (http_port_bin(TCConfig))/binary>>,

--- a/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
@@ -933,6 +933,25 @@ t_oauth2_ssl_certs_are_saved(TCConfig) ->
         emqx:get_raw_config([authorization, sources]),
     assert_ssl_certs_are_saved(SSL, SavedSSL).
 
+t_oauth2_ssl_verify_none_allows_blank_certs(TCConfig) ->
+    BaseURL = <<"http://127.0.0.1:", (http_port_bin(TCConfig))/binary>>,
+    ok = set_oauth2_token_handler(<<"/authz/token">>),
+    ok = emqx_authz_test_lib:setup_config(
+        raw_http_authz_config(TCConfig),
+        #{
+            <<"oauth2">> =>
+                (oauth2_config(<<BaseURL/binary, "/authz/token">>))#{
+                    <<"ssl">> => #{
+                        <<"enable">> => true,
+                        <<"verify">> => <<"verify_none">>,
+                        <<"cacertfile">> => <<>>,
+                        <<"certfile">> => <<>>,
+                        <<"keyfile">> => <<>>
+                    }
+                }
+        }
+    ).
+
 t_oauth2_start_timeout_keeps_source(TCConfig) ->
     ok = block_oauth2_token_endpoint(<<"/authz/token">>),
     BaseURL = <<"http://127.0.0.1:", (http_port_bin(TCConfig))/binary>>,

--- a/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
@@ -918,6 +918,21 @@ t_oauth2_client_credentials(TCConfig) ->
     },
     ?assertEqual(allow, emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t">>)).
 
+t_oauth2_ssl_certs_are_saved(TCConfig) ->
+    BaseURL = <<"http://127.0.0.1:", (http_port_bin(TCConfig))/binary>>,
+    ok = set_oauth2_token_handler(<<"/authz/token">>),
+    SSL = inline_ssl_certs(),
+    ok = emqx_authz_test_lib:setup_config(
+        raw_http_authz_config(TCConfig),
+        #{
+            <<"oauth2">> =>
+                (oauth2_config(<<BaseURL/binary, "/authz/token">>))#{<<"ssl">> => SSL}
+        }
+    ),
+    [#{<<"oauth2">> := #{<<"ssl">> := SavedSSL}}] =
+        emqx:get_raw_config([authorization, sources]),
+    assert_ssl_certs_are_saved(SSL, SavedSSL).
+
 t_oauth2_start_timeout_keeps_source(TCConfig) ->
     ok = block_oauth2_token_endpoint(<<"/authz/token">>),
     BaseURL = <<"http://127.0.0.1:", (http_port_bin(TCConfig))/binary>>,
@@ -980,6 +995,46 @@ oauth2_config(TokenEndpoint) ->
         <<"client_id">> => <<"client-id">>,
         <<"client_secret">> => <<"client-secret">>
     }.
+
+set_oauth2_token_handler(Path) ->
+    emqx_utils_http_test_server:set_handler(fun(Req0, State) ->
+        Path = cowboy_req:path(Req0),
+        Req = cowboy_req:reply(
+            200,
+            #{<<"content-type">> => <<"application/json">>},
+            emqx_utils_json:encode(#{
+                access_token => <<"oauth2-token">>,
+                expires_in => 3600,
+                token_type => <<"Bearer">>
+            }),
+            Req0
+        ),
+        {ok, Req, State}
+    end).
+
+inline_ssl_certs() ->
+    #{
+        <<"enable">> => true,
+        <<"verify">> => <<"verify_peer">>,
+        <<"cacertfile">> => pem("cacert.pem"),
+        <<"certfile">> => pem("client-cert.pem"),
+        <<"keyfile">> => pem("client-key.pem")
+    }.
+
+pem(Name) ->
+    Path = filename:join([code:lib_dir(emqx), etc, certs, Name]),
+    {ok, Pem} = file:read_file(Path),
+    Pem.
+
+assert_ssl_certs_are_saved(SSL, SavedSSL) ->
+    lists:foreach(
+        fun(Key) ->
+            SavedPath = maps:get(Key, SavedSSL),
+            ?assertNotEqual(maps:get(Key, SSL), SavedPath),
+            ?assert(filelib:is_regular(SavedPath))
+        end,
+        [<<"cacertfile">>, <<"certfile">>, <<"keyfile">>]
+    ).
 
 setup_handler_and_config(TCConfig, Handler, Config) ->
     ok = emqx_utils_http_test_server:set_handler(Handler),


### PR DESCRIPTION
Release version:

6.1.4

Fix: N/A

Follow-up: #18079

## Summary

Persist inline TLS certificates configured under `oauth2.ssl` for HTTP authentication and authorization as files in their existing mutable certificate directories.

Keep existing top-level TLS handling and error behavior unchanged. Add end-to-end coverage for both configuration paths.

## PR Checklist

- [x] The changes are covered with new tests
- [x] No changelog is required because this fixes the unreleased OAuth2 support before 6.1.4
- [x] No schema changes