### PR TITLE
fix(data_backup): enforce namespace isolation on upload and import

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
@@ -296,7 +296,27 @@ data_import_checked(?global_ns, FileNode, Filename, Req) ->
             do_data_import(FileNode, Filename, ?global_ns)
     end;
 data_import_checked(Namespace, FileNode, Filename, _Req) when is_binary(Namespace) ->
-    do_data_import(FileNode, Filename, Namespace).
+    %% Defense-in-depth: the same scope check runs at upload time, but stored
+    %% files may predate it or have been placed by other means.
+    case check_import_scope(Namespace, FileNode, Filename) of
+        ok ->
+            do_data_import(FileNode, Filename, Namespace);
+        {forbidden, ForeignScopes} ->
+            {403, #{
+                code => 'FORBIDDEN',
+                message => foreign_scope_msg(Namespace, ForeignScopes)
+            }};
+        {peek_error, Reason} ->
+            {400, #{
+                code => ?BAD_REQUEST,
+                message => emqx_mgmt_data_backup:format_error(Reason)
+            }};
+        {badrpc, Reason} ->
+            {500, #{
+                code => ?SERVICE_UNAVAILABLE(Reason),
+                message => emqx_mgmt_data_backup:format_error(Reason)
+            }}
+    end.
 
 do_data_import(FileNode, Filename, Namespace) ->
     CoreNode = core_node(FileNode),
@@ -357,10 +377,15 @@ core_node(FileNode) ->
 data_files(post, #{body := #{<<"filename">> := #{type := _} = File}, query_string := QS} = Req) ->
     Namespace = op_namespace(Req, QS),
     [{Filename, FileContent} | _] = maps:to_list(maps:without([type], File)),
-    case emqx_mgmt_data_backup:upload(Namespace, Filename, FileContent) of
+    case check_upload_scope(Namespace, FileContent) of
         ok ->
-            {204};
-        {error, Reason} ->
+            store_uploaded_file(Namespace, Filename, FileContent);
+        {forbidden, ForeignScopes} ->
+            {403, #{
+                code => 'FORBIDDEN',
+                message => foreign_scope_msg(Namespace, ForeignScopes)
+            }};
+        {peek_error, Reason} ->
             {400, #{code => ?BAD_REQUEST, message => emqx_mgmt_data_backup:format_error(Reason)}}
     end;
 data_files(post, #{body := _}) ->
@@ -522,6 +547,72 @@ check_no_sensitive_tables(Filename, AuthMeta) ->
                 {error, Reason} -> {peek_error, Reason}
             end
     end.
+
+store_uploaded_file(Namespace, Filename, FileContent) ->
+    case emqx_mgmt_data_backup:upload(Namespace, Filename, FileContent) of
+        ok ->
+            {204};
+        {error, Reason} ->
+            {400, #{code => ?BAD_REQUEST, message => emqx_mgmt_data_backup:format_error(Reason)}}
+    end.
+
+%% A namespaced operation -- a namespaced actor, or a global administrator
+%% acting on `?namespace=<ns>' -- may only handle archives whose entire
+%% content belongs to the resolved namespace. Global content (a top-level
+%% cluster configuration or any mnesia table dump) and other namespaces'
+%% content are rejected. Operations resolved to the global namespace keep
+%% their existing guards (sensitive-table checks) and are not restricted here.
+check_upload_scope(?global_ns, _FileContent) ->
+    ok;
+check_upload_scope(Namespace, FileContent) when is_binary(Namespace) ->
+    validate_backup_scope(
+        Namespace, emqx_mgmt_data_backup:peek_backup_scope_of_content(FileContent)
+    ).
+
+%% Only called with a binary (already resolved, non-global) namespace. When the
+%% file lives on another node, fetch its content over the namespace-scoped v3
+%% RPC to peek it; the import itself copies the file with the same RPC.
+check_import_scope(Namespace, FileNode, Filename) when FileNode =:= node() ->
+    validate_backup_scope(
+        Namespace, emqx_mgmt_data_backup:peek_backup_scope(Namespace, Filename)
+    );
+check_import_scope(Namespace, FileNode, Filename) ->
+    case emqx_mgmt_data_backup_proto_v3:read_file(FileNode, Namespace, Filename, infinity) of
+        {ok, FileContent} ->
+            validate_backup_scope(
+                Namespace, emqx_mgmt_data_backup:peek_backup_scope_of_content(FileContent)
+            );
+        {error, Reason} ->
+            {peek_error, Reason};
+        {badrpc, _} = Error ->
+            Error
+    end.
+
+validate_backup_scope(Namespace, {ok, Scope}) ->
+    case foreign_scopes(Namespace, Scope) of
+        [] -> ok;
+        ForeignScopes -> {forbidden, ForeignScopes}
+    end;
+validate_backup_scope(_Namespace, {error, Reason}) ->
+    {peek_error, Reason}.
+
+foreign_scopes(Namespace, #{global := Global, namespaces := Namespaces}) ->
+    ForeignNamespaces = [
+        iolist_to_binary([<<"namespace \"">>, Ns, <<"\"">>])
+     || Ns <- Namespaces, Ns =/= Namespace
+    ],
+    case Global of
+        true -> [<<"the global scope">> | ForeignNamespaces];
+        false -> ForeignNamespaces
+    end.
+
+foreign_scope_msg(Namespace, ForeignScopes) ->
+    iolist_to_binary([
+        <<"Backup contains data that does not belong to namespace \"">>,
+        Namespace,
+        <<"\": ">>,
+        lists:join(<<", ">>, ForeignScopes)
+    ]).
 
 %% Stored backups may contain `dashboard_users' / `api_keys' mnesia tables
 %% (salted password hashes, MFA / TOTP material, API-key records). Global

--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -36,7 +36,9 @@
     format_conf_errors/1,
     format_db_errors/1,
     sensitive_table_set_names/0,
-    peek_sensitive_table_sets/1
+    peek_sensitive_table_sets/1,
+    peek_backup_scope/2,
+    peek_backup_scope_of_content/1
 ]).
 
 -export([default_validate_mnesia_backup/1]).
@@ -135,6 +137,7 @@
 -type raw_config() :: #{binary() => any()}.
 -type mnesia_table_filter() :: fun((atom()) -> boolean()).
 -type maybe_namespace() :: ?global_ns | binary().
+-type backup_scope() :: #{global := boolean(), namespaces := [binary()]}.
 
 %%------------------------------------------------------------------------------
 %% APIs
@@ -279,6 +282,53 @@ match_sensitive_entry(Path, SensitiveTabMap) ->
         _ ->
             false
     end.
+
+-doc """
+Inspect a previously-uploaded backup file owned by `Namespace` and return the
+configuration scopes its entries contain. See `peek_backup_scope_of_content/1`.
+""".
+-spec peek_backup_scope(maybe_namespace(), file:filename_all()) ->
+    {ok, backup_scope()} | {error, _}.
+peek_backup_scope(Namespace, Filename) ->
+    maybe
+        {ok, FilePath} ?= backup_path(Namespace, Filename),
+        ok ?= validate_file_exists(FilePath),
+        {ok, Entries} ?= tar_table(FilePath),
+        {ok, scope_of_entries(Entries)}
+    end.
+
+-doc """
+Classify the configuration scopes present in an in-memory backup archive:
+`global` is true when the archive holds global content (a top-level
+cluster.hocon or any mnesia table dump); `namespaces` lists every namespace
+with a `ns/<NS>/cluster.hocon` entry. The HTTP handlers use this to confine
+namespaced upload/import operations to archives holding only the resolved
+namespace's data.
+""".
+-spec peek_backup_scope_of_content(binary()) -> {ok, backup_scope()} | {error, _}.
+peek_backup_scope_of_content(BackupFileContent) ->
+    maybe
+        {ok, Entries} ?= tar_table({binary, BackupFileContent}),
+        {ok, scope_of_entries(Entries)}
+    end.
+
+scope_of_entries(Entries) ->
+    lists:foldl(
+        fun(Entry, Acc) ->
+            classify_entry_scope(lists:reverse(filename:split(str(Entry))), Acc)
+        end,
+        #{global => false, namespaces => []},
+        Entries
+    ).
+
+classify_entry_scope(?HOCON_NS_INTERNAL_TAR_PATH_REV_PAT(Namespace), #{namespaces := NSs} = Acc) ->
+    Acc#{namespaces := lists:usort([bin(Namespace) | NSs])};
+classify_entry_scope([?CLUSTER_HOCON_FILENAME | _], Acc) ->
+    Acc#{global := true};
+classify_entry_scope([_TabName, ?BACKUP_MNESIA_DIR | _], Acc) ->
+    Acc#{global := true};
+classify_entry_scope(_Entry, Acc) ->
+    Acc.
 
 validate_export_root_keys(Params) ->
     RootKeys0 = maps:get(<<"root_keys">>, Params, []),
@@ -658,7 +708,10 @@ do_export(BackupName, TarDescriptor, Opts) ->
     ok = format_tar_error(erl_tar:add(TarDescriptor, MetaBin, MetaFilename, [])),
     case Namespace of
         ?global_ns ->
+            %% A global export is a full-cluster artifact: global configuration
+            %% and mnesia tables plus every namespace's configuration.
             ok = export_cluster_hocon(TarDescriptor, BackupBaseName, Opts),
+            ok = export_all_namespaced_cluster_hocon(TarDescriptor, BackupBaseName, Opts),
             ok = export_mnesia_tabs(TarDescriptor, BackupName, BackupBaseName, Opts);
         _ when is_binary(Namespace) ->
             ok = export_namespaced_cluster_hocon(TarDescriptor, BackupBaseName, Namespace, Opts)
@@ -690,9 +743,22 @@ export_cluster_hocon(TarDescriptor, BackupBaseName, Opts) ->
     ok = format_tar_error(erl_tar:add(TarDescriptor, RawConfBin, NameInArchive, [])).
 
 export_namespaced_cluster_hocon(TarDescriptor, BackupBaseName, Namespace, Opts) ->
+    RootConfig = emqx_config:get_all_roots_from_namespace(Namespace),
+    add_namespaced_cluster_hocon(TarDescriptor, BackupBaseName, Namespace, RootConfig, Opts).
+
+export_all_namespaced_cluster_hocon(TarDescriptor, BackupBaseName, Opts) ->
+    maps:foreach(
+        fun(Namespace, RootConfig) ->
+            ok = add_namespaced_cluster_hocon(
+                TarDescriptor, BackupBaseName, Namespace, RootConfig, Opts
+            )
+        end,
+        emqx_config:get_all_raw_namespaced_configs()
+    ).
+
+add_namespaced_cluster_hocon(TarDescriptor, BackupBaseName, Namespace, RootConfig0, Opts) ->
     maybe_print("Exporting cluster configuration for namespace ~s...~n", [Namespace], Opts),
     TransformFn = maps:get(raw_conf_transform, Opts, fun(Raw) -> Raw end),
-    RootConfig0 = emqx_config:get_all_roots_from_namespace(Namespace),
     RootConfig = TransformFn(RootConfig0),
     RawConfBin = bin(hocon_pp:do(RootConfig, #{})),
     NameInArchive = str(
@@ -900,12 +966,14 @@ log_import_result(BackupFilePath, #{db_errors := DbErrors, config_errors := Conf
 do_import_for_namespace(?global_ns, BackupDir, Opts) ->
     maybe
         {ok, GlobalConfErrors} ?= import_cluster_hocon(BackupDir, Opts),
+        {ok, NSConfErrors} ?= import_all_namespaced_cluster_hocon(BackupDir, Opts),
         MnesiaErrors = import_mnesia_tabs(BackupDir, Opts),
-        ConfErrors =
+        ConfErrors0 =
             case map_size(GlobalConfErrors) of
                 0 -> #{};
                 _ -> #{?global_ns => GlobalConfErrors}
             end,
+        ConfErrors = maps:merge(ConfErrors0, NSConfErrors),
         {ok, #{
             mnesia_errors => MnesiaErrors,
             conf_errors => ConfErrors
@@ -1242,6 +1310,27 @@ validate_filenames(BackupFilePath) ->
 import_cluster_hocon(BackupDir, Opts) ->
     HoconFilename = filename:join(BackupDir, ?CLUSTER_HOCON_FILENAME),
     do_import_cluster_hocon(?global_ns, BackupDir, HoconFilename, Opts).
+
+%% A global (full-cluster) archive may carry any number of `ns/<NS>/' entries;
+%% restore each one into its own namespace.
+import_all_namespaced_cluster_hocon(BackupDir, Opts) ->
+    Pattern = filename:join(?HOCON_NS_INTERNAL_TAR_PATH(BackupDir, "*")),
+    lists:foldl(
+        fun
+            (NSHoconPath, {ok, Acc}) ->
+                ?HOCON_NS_INTERNAL_TAR_PATH_REV_PAT(Namespace) =
+                    lists:reverse(filename:split(NSHoconPath)),
+                maybe
+                    {ok, Errors} ?=
+                        import_namespaced_cluster_hocon(bin(Namespace), BackupDir, Opts),
+                    {ok, maps:merge(Acc, Errors)}
+                end;
+            (_NSHoconPath, {error, _} = Error) ->
+                Error
+        end,
+        {ok, #{}},
+        filelib:wildcard(Pattern)
+    ).
 
 import_namespaced_cluster_hocon(Namespace, BackupDir, Opts) when is_binary(Namespace) ->
     NSHoconPath = filename:join(?HOCON_NS_INTERNAL_TAR_PATH(BackupDir, Namespace)),

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -552,16 +552,21 @@ t_namespaced_export_import(Config) ->
     ?assertMatch({204, _}, import_backup_full(?NODE1_PORT, Ns1Auth, N1File)),
     ok.
 
-%% A namespaced administrator uploading a backup lands it in its own space; the
-%% global administrator never sees it.
+%% A namespaced administrator uploading its own namespace's backup lands it in
+%% its own space (the global administrator never sees it), and can then import
+%% it back.
 t_namespaced_upload_isolation(Config) ->
+    [Core1 | _] = ?config(cluster, Config),
     Ns1Auth = ?config(ns_admin_auth, Config),
     DashboardAuth = ?config(dashboard_auth, Config),
-    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
-    ?assertEqual(ok, upload_backup(?NODE1_PORT, Ns1Auth, UploadFile)),
-    Base = list_to_binary(?UPLOAD_CE_BACKUP),
+    {LocalPath, Base} = local_ns_backup_copy(Config, Core1, ?NODE1_PORT, Ns1Auth, <<"ns1">>),
+    %% Remove the exported original so the upload is what lands the file.
+    ?assertMatch({204, _}, delete_backup(?NODE1_PORT, Ns1Auth, Base)),
+    ?assertEqual(ok, upload_backup(?NODE1_PORT, Ns1Auth, LocalPath)),
     ?assert(lists:member(Base, list_filenames(?NODE1_PORT, Ns1Auth))),
     ?assertNot(lists:member(Base, list_filenames(?NODE1_PORT, DashboardAuth))),
+    %% Round trip: importing the uploaded own-namespace backup succeeds.
+    ?assertMatch({204, _}, import_backup_full(?NODE1_PORT, Ns1Auth, Base)),
     ok.
 
 %% A global administrator may opt in to a specific namespace's backup space with
@@ -629,13 +634,15 @@ t_global_admin_import_scoped_namespace(Config) ->
 %% namespace's space (not the global one), and can then import it scoped to that
 %% namespace. Uploading without the parameter stays on the global scope.
 t_global_admin_upload_scoped_namespace(Config) ->
+    [Core1 | _] = ?config(cluster, Config),
     DashboardAuth = ?config(dashboard_auth, Config),
+    Ns1Auth = ?config(ns_admin_auth, Config),
     Ns1 = #{<<"namespace">> => <<"ns1">>},
-    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
-    Base = list_to_binary(?UPLOAD_CE_BACKUP),
+    {LocalPath, Base} = local_ns_backup_copy(Config, Core1, ?NODE1_PORT, Ns1Auth, <<"ns1">>),
+    ?assertMatch({204, _}, delete_backup(?NODE1_PORT, Ns1Auth, Base)),
 
     %% Upload into ns1's space.
-    ?assertEqual(ok, upload_backup_ns(?NODE1_PORT, DashboardAuth, UploadFile, Ns1)),
+    ?assertEqual(ok, upload_backup_ns(?NODE1_PORT, DashboardAuth, LocalPath, Ns1)),
     %% The file is visible in ns1's space, but not in the global listing.
     ?assert(lists:member(Base, list_filenames(?NODE1_PORT, DashboardAuth, Ns1))),
     ?assertNot(lists:member(Base, list_filenames(?NODE1_PORT, DashboardAuth))),
@@ -643,8 +650,10 @@ t_global_admin_upload_scoped_namespace(Config) ->
     ?assertMatch({204, _}, import_backup_ns(?NODE1_PORT, DashboardAuth, Base, Ns1)),
 
     %% Uploading without the parameter stays on the global scope (regression).
+    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
+    GlobalBase = list_to_binary(?UPLOAD_CE_BACKUP),
     ?assertEqual(ok, upload_backup(?NODE2_PORT, DashboardAuth, UploadFile)),
-    ?assert(lists:member(Base, list_filenames(?NODE2_PORT, DashboardAuth))),
+    ?assert(lists:member(GlobalBase, list_filenames(?NODE2_PORT, DashboardAuth))),
     ok.
 
 %% A namespaced administrator cannot import or upload into another namespace by
@@ -664,11 +673,131 @@ t_namespaced_admin_import_upload_confined(Config) ->
     ?assertMatch({400, _}, import_backup_ns(?NODE1_PORT, Ns2Auth, N1File, ForceNs1)),
 
     %% Uploading with `namespace=ns1' lands in ns2's own space, never ns1's.
-    UploadFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
-    Base = list_to_binary(?UPLOAD_CE_BACKUP),
-    ?assertEqual(ok, upload_backup_ns(?NODE1_PORT, Ns2Auth, UploadFile, ForceNs1)),
+    {LocalPath, Base} = local_ns_backup_copy(Config, Core1, ?NODE1_PORT, Ns2Auth, <<"ns2">>),
+    ?assertMatch({204, _}, delete_backup(?NODE1_PORT, Ns2Auth, Base)),
+    ?assertEqual(ok, upload_backup_ns(?NODE1_PORT, Ns2Auth, LocalPath, ForceNs1)),
     ?assertNot(lists:member(Base, list_filenames(?NODE1_PORT, Ns1Auth))),
     ?assert(lists:member(Base, list_filenames(?NODE1_PORT, Ns2Auth))),
+    ok.
+
+-doc """
+A namespaced administrator must not be able to upload an archive holding
+another scope's data: both a global backup (top-level cluster.hocon and mnesia
+tables) and another namespace's backup are rejected with 403, no file is left
+behind, and an uninspectable archive yields 400.
+""".
+t_namespaced_upload_foreign_content_forbidden(Config) ->
+    [Core1 | _] = ?config(cluster, Config),
+    Ns1Auth = ?config(ns_admin_auth, Config),
+    Ns2Auth = ns_admin_auth_header(Core1, <<"ns2">>, <<"ns2_admin_for_test">>, ?NS_ADMIN_PASS),
+
+    %% A global archive -> 403.
+    GlobalFile = ?backup_path(Config, ?UPLOAD_CE_BACKUP),
+    ?assertMatch(
+        {403, #{<<"code">> := <<"FORBIDDEN">>}},
+        upload_backup_full(?NODE1_PORT, Ns1Auth, GlobalFile, #{})
+    ),
+
+    %% Another namespace's archive -> 403.
+    {Ns2LocalPath, _Ns2Base} = local_ns_backup_copy(
+        Config, Core1, ?NODE1_PORT, Ns2Auth, <<"ns2">>
+    ),
+    ?assertMatch(
+        {403, #{<<"code">> := <<"FORBIDDEN">>}},
+        upload_backup_full(?NODE1_PORT, Ns1Auth, Ns2LocalPath, #{})
+    ),
+
+    %% Neither rejected upload left a file in ns1's space.
+    ?assertEqual([], list_filenames(?NODE1_PORT, Ns1Auth)),
+
+    %% An archive that cannot be inspected -> 400.
+    GarbagePath = filename:join(?config(priv_dir, Config), "garbage.tar.gz"),
+    ok = file:write_file(GarbagePath, <<"not a tar archive">>),
+    ?assertMatch({400, _}, upload_backup_full(?NODE1_PORT, Ns1Auth, GarbagePath, #{})),
+    ok.
+
+-doc """
+Defense-in-depth at import time: even when a foreign-content archive is
+already present in the namespace's backup space (e.g. stored before the
+upload-time scope check existed), a namespaced import rejects it with 403.
+""".
+t_namespaced_import_foreign_content_forbidden(Config) ->
+    [Core1 | _] = ?config(cluster, Config),
+    Ns1Auth = ?config(ns_admin_auth, Config),
+    Ns2Auth = ns_admin_auth_header(Core1, <<"ns2">>, <<"ns2_admin_for_test">>, ?NS_ADMIN_PASS),
+
+    %% Plant ns2's archive into ns1's space, bypassing the HTTP API.
+    {200, #{<<"filename">> := Ns2File}} = export_backup2(?NODE1_PORT, Ns2Auth, #{}),
+    {ok, Ns2Content} = ?ON(Core1, emqx_mgmt_data_backup:read_file(<<"ns2">>, Ns2File)),
+    ok = plant_ns_backup_file(Core1, <<"ns1">>, Ns2File, Ns2Content),
+    ?assertMatch(
+        {403, #{<<"code">> := <<"FORBIDDEN">>}},
+        import_backup_ns(?NODE1_PORT, Ns1Auth, Ns2File, #{})
+    ),
+
+    %% Same for a planted global archive.
+    GlobalBase = list_to_binary(?UPLOAD_CE_BACKUP),
+    {ok, GlobalContent} = file:read_file(?backup_path(Config, ?UPLOAD_CE_BACKUP)),
+    ok = plant_ns_backup_file(Core1, <<"ns1">>, GlobalBase, GlobalContent),
+    ?assertMatch(
+        {403, #{<<"code">> := <<"FORBIDDEN">>}},
+        import_backup_ns(?NODE1_PORT, Ns1Auth, GlobalBase, #{})
+    ),
+    ok.
+
+-doc """
+The global scope is a full-cluster artifact: importing a global archive
+restores every `ns/<NS>/cluster.hocon' entry into its own namespace, and a
+subsequent global export emits every namespace's configuration back into the
+archive alongside the global content.
+""".
+t_full_cluster_global_export_import(Config) ->
+    [Core1 | _] = Nodes = ?config(cluster, Config),
+    DashboardAuth = ?config(dashboard_auth, Config),
+    %% `mqtt' is not in the default allowed namespaced roots.
+    _ = ?ON_ALL(Nodes, emqx_config:add_allowed_namespaced_config_root(<<"mqtt">>)),
+
+    %% Forge a full-cluster archive carrying two namespaces' configuration.
+    {LocalPath, Base} = forge_backup(Config, "emqx-export-full-cluster", #{
+        <<"ns1">> => <<"mqtt { max_awaiting_rel = 111 }">>,
+        <<"ns2">> => <<"mqtt { max_awaiting_rel = 222 }">>
+    }),
+    ?assertEqual(ok, upload_backup(?NODE1_PORT, DashboardAuth, LocalPath)),
+    ?assertMatch({204, _}, import_backup_full(?NODE1_PORT, DashboardAuth, Base)),
+
+    %% Each namespace's configuration was restored into its own namespace.
+    ?assertMatch(
+        #{<<"mqtt">> := #{<<"max_awaiting_rel">> := 111}},
+        ?ON(Core1, emqx_config:get_all_roots_from_namespace(<<"ns1">>))
+    ),
+    ?assertMatch(
+        #{<<"mqtt">> := #{<<"max_awaiting_rel">> := 222}},
+        ?ON(Core1, emqx_config:get_all_roots_from_namespace(<<"ns2">>))
+    ),
+
+    %% A global export now carries the global scope plus both namespaces.
+    {200, #{<<"filename">> := ExportFile}} = export_backup2(?NODE1_PORT, DashboardAuth, #{}),
+    {ok, ExportContent} = ?ON(Core1, emqx_mgmt_data_backup:read_file(ExportFile)),
+    ?assertMatch(
+        {ok, #{global := true, namespaces := [<<"ns1">>, <<"ns2">>]}},
+        emqx_mgmt_data_backup:peek_backup_scope_of_content(ExportContent)
+    ),
+    ok.
+
+-doc """
+Single-tenant regression: a cluster with no namespaces exports a global
+archive with no `ns/' entries, and importing it back succeeds as before.
+""".
+t_global_export_import_no_namespaces(Config) ->
+    [Core1 | _] = ?config(cluster, Config),
+    DashboardAuth = ?config(dashboard_auth, Config),
+    {200, #{<<"filename">> := File}} = export_backup2(?NODE1_PORT, DashboardAuth, #{}),
+    {ok, Content} = ?ON(Core1, emqx_mgmt_data_backup:read_file(File)),
+    ?assertMatch(
+        {ok, #{global := true, namespaces := []}},
+        emqx_mgmt_data_backup:peek_backup_scope_of_content(Content)
+    ),
+    ?assertMatch({204, _}, import_backup_full(?NODE1_PORT, DashboardAuth, File)),
     ok.
 
 %% Global dashboard administrators must still be able to download a backup
@@ -759,6 +888,72 @@ upload_backup_ns(NodeApiPort, Auth, BackupFilePath, QueryParams) ->
         Err ->
             Err
     end.
+
+%% Export a backup scoped to `Namespace' (using `Auth'), copy the archive from
+%% `Node' to the test-runner's disk, and return `{LocalPath, Basename}'.
+local_ns_backup_copy(Config, Node, Port, Auth, Namespace) ->
+    {200, #{<<"filename">> := File}} = export_backup2(Port, Auth, #{}),
+    {ok, Content} = ?ON(Node, emqx_mgmt_data_backup:read_file(Namespace, File)),
+    LocalPath = filename:join(?config(priv_dir, Config), to_list(File)),
+    ok = file:write_file(LocalPath, Content),
+    {LocalPath, File}.
+
+%% Write an archive straight into `Namespace''s backup directory on `Node',
+%% bypassing the HTTP upload (and thus its content checks).
+plant_ns_backup_file(Node, Namespace, Filename, Content) ->
+    ?ON(Node, begin
+        Path = filename:join([emqx:data_dir(), "backup", "ns", Namespace, Filename]),
+        ok = filelib:ensure_dir(Path),
+        file:write_file(Path, Content)
+    end).
+
+%% Forge a backup archive holding one `ns/<NS>/cluster.hocon' entry per key of
+%% `NsConfigs' (`#{Namespace => HoconBin}') plus a valid META file, mirroring
+%% the layout of a global export of a cluster that has namespaces but no
+%% global configuration. Returns `{LocalPath, Basename}'.
+forge_backup(Config, BaseName, NsConfigs) ->
+    Filename = BaseName ++ ".tar.gz",
+    LocalPath = filename:join(?config(priv_dir, Config), Filename),
+    {ok, Tar} = erl_tar:open(LocalPath, [write, compressed]),
+    Meta = #{version => emqx_release:version(), edition => emqx_release:edition()},
+    MetaBin = iolist_to_binary(hocon_pp:do(Meta, #{})),
+    ok = erl_tar:add(Tar, MetaBin, filename:join(BaseName, "META.hocon"), []),
+    maps:foreach(
+        fun(Namespace, HoconBin) ->
+            NameInArchive = filename:join([BaseName, "ns", to_list(Namespace), "cluster.hocon"]),
+            ok = erl_tar:add(Tar, HoconBin, NameInArchive, [])
+        end,
+        NsConfigs
+    ),
+    ok = erl_tar:close(Tar),
+    {LocalPath, list_to_binary(Filename)}.
+
+%% Upload a backup file and return `{Status, DecodedBody}'.
+upload_backup_full(NodeApiPort, Auth, BackupFilePath, QueryParams) ->
+    Path0 = emqx_mgmt_api_test_util:api_path(?api_base_url(NodeApiPort), ["data", "files"]),
+    Path =
+        case maps:to_list(QueryParams) of
+            [] ->
+                Path0;
+            QueryList ->
+                Query = unicode:characters_to_list(uri_string:compose_query(QueryList)),
+                Path0 ++ "?" ++ Query
+        end,
+    {ok, {{"HTTP/1.1", Status, _}, _Headers, Body}} =
+        emqx_mgmt_api_test_util:upload_request(
+            Path,
+            BackupFilePath,
+            "filename",
+            <<"application/octet-stream">>,
+            [],
+            Auth
+        ),
+    DecodedBody =
+        case iolist_to_binary(Body) of
+            <<>> -> #{};
+            BodyBin -> emqx_utils_json:decode(BodyBin)
+        end,
+    {Status, DecodedBody}.
 
 do_init_per_testcase(TC, Config) ->
     Cluster = [Core1, _Core2, Repl] = cluster(TC, Config),
@@ -1176,9 +1371,7 @@ test_case_specific_apps_spec(TC) when
     TC =:= t_import_dashboard_token_allows_sensitive_tables;
     TC =:= t_import_restricted_dashboard_token_blocks_sensitive_tables;
     TC =:= t_import_dashboard_token_with_credential_scopes_allows_sensitive_tables;
-    TC =:= t_namespaced_upload_isolation;
-    TC =:= t_global_admin_upload_scoped_namespace;
-    TC =:= t_namespaced_admin_import_upload_confined
+    TC =:= t_global_admin_upload_scoped_namespace
 ->
     [
         emqx_auth,

--- a/changes/ee/fix-18164.en.md
+++ b/changes/ee/fix-18164.en.md
@@ -1,0 +1,3 @@
+Improved backup import feedback when working within a namespace. Importing an archive that does not belong to the target namespace -- for example one exported from a different namespace, or a global backup -- now returns a clear error instead of appearing to succeed while importing nothing. A global administrator can still restore a specific namespace's backup using the `namespace` query parameter.
+
+Global backups are now complete cluster snapshots: a global export also includes every namespace's configuration, and a global import restores each namespace's configuration back into its own namespace. A cluster without namespaces produces and reads exactly the same archives as before.


### PR DESCRIPTION
Release version:

6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Related: #18008, #17946.

Backup archives are self-describing: namespaced configuration lives under `ns/<NS>/cluster.hocon`, global content is the top-level `cluster.hocon` plus `mnesia/` table dumps. This PR peeks the tar entry paths to classify an archive's scopes and keys enforcement off the namespace resolved by `op_namespace/2` (not the raw actor role), so a global administrator restoring a namespace's backup via `?namespace=<ns>` (from #18008) keeps working.

* **Namespace isolation (403)**: an operation resolved to a namespace only accepts archives whose entire content belongs to that namespace — any global content or foreign-namespace entry is rejected with `403 Forbidden` at upload time (`POST /data/files`, peeking the in-memory binary, so nothing is stored), and again at import time as defense-in-depth for files stored before this check existed (remote-node files are peeked via the existing v3 `read_file` RPC; no new BPAPI).
* **Global scope is a full-cluster artifact**: a global export now also emits every namespace's configuration (same `ns/<NS>` tar layout as namespaced exports), and a global import restores each `ns/<NS>` entry into its own namespace, aggregating per-namespace errors. A cluster without namespaces produces and consumes identical archives as before; global imports keep only the pre-existing sensitive-table guard.

Main files: `apps/emqx_management/src/emqx_mgmt_data_backup.erl` (scope classifier, full-cluster export/import), `apps/emqx_management/src/emqx_mgmt_api_data_backup.erl` (403 enforcement).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
