### PR TITLE
test(message_transformation): retry connect on transient server_busy

### DIFF
--- a/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
+++ b/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
@@ -295,10 +295,28 @@ connect(ClientId, IsPersistent, Opts) ->
         proto_ver => v5
     },
     Props = emqx_utils_maps:deep_merge(Defaults, StartProps),
-    {ok, Client} = emqtt:start_link(Props),
-    {ok, _} = emqtt:connect(Client),
+    Client = connect_with_retry(Props),
     on_exit(fun() -> catch emqtt:stop(Client) end),
     Client.
+
+%% Reconnect on a transient clientid-registration throttle (CONNACK
+%% server_busy): the broker may still be cleaning up a same-clientid channel
+%% asynchronously. Unlink first so the failed client's exit cannot kill the
+%% test process before we get a chance to retry.
+connect_with_retry(Props) ->
+    {ok, Client} = emqtt:start_link(Props),
+    unlink(Client),
+    case emqtt:connect(Client) of
+        {ok, _} ->
+            Client;
+        {error, {server_busy, _}} ->
+            _ = exit(Client, kill),
+            timer:sleep(10),
+            connect_with_retry(Props);
+        {error, Reason} ->
+            _ = exit(Client, kill),
+            error(Reason)
+    end.
 
 publish(Client, Topic, Payload) ->
     publish(Client, Topic, Payload, _QoS = 0).

--- a/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
+++ b/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
@@ -302,12 +302,14 @@ connect(ClientId, IsPersistent, Opts) ->
 %% Reconnect on a transient clientid-registration throttle (CONNACK
 %% server_busy): the broker may still be cleaning up a same-clientid channel
 %% asynchronously. Unlink first so the failed client's exit cannot kill the
-%% test process before we get a chance to retry.
+%% test process before we get a chance to retry; re-link once connected so a
+%% later client crash still fails the test.
 connect_with_retry(Props) ->
     {ok, Client} = emqtt:start_link(Props),
     unlink(Client),
     case emqtt:connect(Client) of
         {ok, _} ->
+            link(Client),
             Client;
         {error, {server_busy, _}} ->
             _ = exit(Client, kill),


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

## Summary

Fixes the intermittent `{'EXIT',{shutdown,server_busy}}` failure in
`emqx_message_transformation_http_api_SUITE:t_smoke_test_2`.

The shared `connect/3` helper started a **linked** `emqtt` client and connected
with **no retry**. When the broker's clientid-registration throttle transiently
returns `client_id_unavailable` (CONNACK `server_busy`) — because a same-clientid
channel is still being cleaned up asynchronously — the linked client shuts down
and the link kills the test process.

The helper now unlinks the client before `emqtt:connect/1` and retries on
`{error, {server_busy, _}}` after a short sleep, mirroring the established pattern
in `emqx_persistent_session_ds_SUITE`. Test-only change; fixes the whole suite,
not just `t_smoke_test_2`.

Known gap: v6 (`dev-60`..`dev-63`) carries the identical bare-connect helper and
needs a separate port of this fix (v5 and v6 do not cross-sync).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
