### PR TITLE
fix(cluster): allow replicant node to join while booting

### DIFF
--- a/apps/emqx/src/emqx_cluster.erl
+++ b/apps/emqx/src/emqx_cluster.erl
@@ -30,7 +30,7 @@
 -endif.
 
 join(PeerNode) ->
-    case is_booting() of
+    case is_booting() andalso mria_rlog:role() =:= core of
         true ->
             {error,
                 "This node has not fully booted yet. "
@@ -55,9 +55,9 @@ Mark boot as in progress (`true`) or complete (`false`).
 
 Called by `emqx_machine`: set at boot entry and cleared once the boot app list
 has been started and the ekka join callbacks are registered. While the flag is
-set, `join/1` refuses to run: joining makes mria restart, and doing that under
-a boot in progress crashes whichever mria-backed application is starting at
-that moment, taking the node down.
+set, `join/1` on a core node refuses to run: joining makes mria restart, and
+doing that under a boot in progress crashes whichever mria-backed application
+is starting at that moment, taking the node down.
 
 Environments that boot without `emqx_machine` (e.g. common tests) never set
 the flag, so `join/1` is not restricted there.

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -147,6 +147,27 @@ t_cluster_join_refused_while_booting(_Config) ->
     ),
     ok.
 
+-doc """
+Verifies that on a replicant node `cluster join' is NOT refused while boot is
+in progress: a replicant cannot finish booting without a core node, so a
+mid-boot join is what bootstraps it under manual cluster discovery. The
+command must proceed past the boot guard to the peer check.
+""".
+t_cluster_join_allowed_while_booting_on_replicant(_Config) ->
+    ok = meck:new(mria_rlog, [passthrough, no_history]),
+    ok = meck:expect(mria_rlog, role, fun() -> replicant end),
+    ok = emqx_cluster:set_booting(true),
+    try
+        ?assertEqual(
+            {error, {node_down, 'nosuchnode@127.0.0.1'}},
+            emqx_ctl:run_command(["cluster", "join", "nosuchnode@127.0.0.1"])
+        )
+    after
+        ok = emqx_cluster:set_booting(false),
+        ok = meck:unload(mria_rlog)
+    end,
+    ok.
+
 t_clients(_Config) ->
     %% clients list            # List all clients
     emqx_ctl:run_command(["clients", "list"]),


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Fixes #18157 — a regression from #18077.

#18077 made `emqx_cluster:join/1` refuse to join while node boot is in progress, because a join
restarts mria under the boot app-start loop and crashes whichever application is starting. That is
correct for core nodes, which boot standalone. But a replicant node cannot complete boot without a
core node to replicate from: with manual cluster discovery, the operator's `emqx ctl cluster join`
is what provides the core, so refusing it deadlocks the replicant (it can never get a core, so it
can never boot; it can never boot, so it can never join).

This PR scopes the refusal to core nodes (`is_booting() andalso mria_rlog:role() =:= core`),
restoring the pre-#18077 behavior for replicants while keeping the #18077 protection for cores.

Safety of the replicant exemption: mid-boot, the ekka `stop`/`start` callbacks are not yet
registered (`start_autocluster/0` runs later), and `mria_lib:exec_callback/2` is a no-op for
unregistered callbacks — so a replicant's mid-boot join does not stop/restart the emqx application
list (the #18077 crash mechanism). Verified end-to-end on a local 1 core + 1 replicant manual-
discovery cluster built from this branch: the replicant stalled with
`no_available_core_node_at_same_version`, the mid-boot `cluster join` succeeded, the replicant then
completed boot and appeared in `cluster status`, with no crash reports in its log. The peer-side
`can_i_join` license/permission check still applies to replicant joins.

Tests: kept `t_cluster_join_refused_while_booting` (nodes run as core in CT, so it now also
documents that the refusal is core-only) and added
`t_cluster_join_allowed_while_booting_on_replicant` (mocks `mria_rlog:role/0` to `replicant` and
asserts the join proceeds past the boot guard to the peer check).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

