### PR TITLE
fix(dssharesub): target leader node in borrower-initiated casts [r60]

### DIFF
--- a/apps/emqx/src/emqx_ds_shared_sub/emqx_ds_shared_sub_proto.erl
+++ b/apps/emqx/src/emqx_ds_shared_sub/emqx_ds_shared_sub_proto.erl
@@ -123,23 +123,23 @@ send_to_leader(ToLeader, Msg) when ?is_local_leader(ToLeader) ->
     ok;
 send_to_leader(ToLeader, ?borrower_connect_match(FromBorrowerId, ShareTopicFilter)) ->
     emqx_ds_shared_sub_proto_v3:borrower_connect(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId, ShareTopicFilter
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId, ShareTopicFilter
     );
 send_to_leader(ToLeader, ?borrower_ping_match(FromBorrowerId)) ->
     emqx_ds_shared_sub_proto_v3:borrower_ping(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId
     );
 send_to_leader(ToLeader, ?borrower_disconnect_match(FromBorrowerId, StreamProgresses)) ->
     emqx_ds_shared_sub_proto_v3:borrower_disconnect(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId, StreamProgresses
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId, StreamProgresses
     );
 send_to_leader(ToLeader, ?borrower_update_progress_match(FromBorrowerId, StreamProgress)) ->
     emqx_ds_shared_sub_proto_v3:borrower_update_progress(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId, StreamProgress
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId, StreamProgress
     );
 send_to_leader(ToLeader, ?borrower_revoke_finished_match(FromBorrowerId, Stream)) ->
     emqx_ds_shared_sub_proto_v3:borrower_revoke_finished(
-        ?borrower_node(FromBorrowerId), ToLeader, FromBorrowerId, Stream
+        ?leader_node(ToLeader), ToLeader, FromBorrowerId, Stream
     ).
 
 -spec send_to_borrower(borrower_id(), to_borrower_msg()) -> ok.

--- a/changes/ee/fix-18143.en.md
+++ b/changes/ee/fix-18143.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where durable shared subscriptions could fail to communicate with the shared-subscription leader when subscribers were connected to a different node. This could cause an unexplained spike in CPU usage.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.4, 6.2.3

## Summary

Backport of #18143.

## PR Checklist

- [ ] The changes are covered with new or existing tests
    Corresponding smoke testcase is not backported, see #18143 for details.
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible