### PR TITLE
fix(plugins): handle root config type errors

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -361,6 +361,18 @@ t_update_config_with_invalid_type_returns_readable_error(Config0) ->
         emqx_utils_json:decode(Body)
     ).
 
+t_update_config_with_invalid_root_type_returns_readable_error(Config) ->
+    NameVsn = install_test_plugin(Config),
+    {ok, 400, Body} = update_plugin_config(NameVsn, 42),
+    ?assertEqual(
+        #{
+            <<"code">> => <<"BAD_CONFIG">>,
+            <<"message">> =>
+                <<"invalid_type: Invalid type for field '$': expected invalid_plugin, got integer">>
+        },
+        emqx_utils_json:decode(Body)
+    ).
+
 t_upload_download_config(_Config) ->
     PackagePath = get_demo_plugin_package(),
     NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -686,13 +686,13 @@ normalize_headers(_) ->
 %%--------------------------------------------------------------------
 %% Package utils
 
--spec decode_plugin_config_map(name_vsn(), map() | binary()) ->
+-spec decode_plugin_config_map(name_vsn(), emqx_utils_json:json_term()) ->
     {ok, map() | ?plugin_without_config_schema}
     | {error, term()}.
-decode_plugin_config_map(NameVsn, AvroJsonMap) ->
+decode_plugin_config_map(NameVsn, AvroJson) ->
     case has_avsc(NameVsn) of
         true ->
-            case emqx_plugins_serde:decode(NameVsn, ensure_config_bin(AvroJsonMap)) of
+            case emqx_plugins_serde:decode(NameVsn, ensure_config_bin(AvroJson)) of
                 {ok, Config} ->
                     {ok, Config};
                 {error, #{reason := plugin_serde_not_found}} ->
@@ -1547,7 +1547,9 @@ delete_cached_config(NameVsn) ->
 ensure_config_bin(AvroJsonMap) when is_map(AvroJsonMap) ->
     emqx_utils_json:encode(AvroJsonMap);
 ensure_config_bin(AvroJsonBin) when is_binary(AvroJsonBin) ->
-    AvroJsonBin.
+    AvroJsonBin;
+ensure_config_bin(AvroJson) ->
+    emqx_utils_json:encode(AvroJson).
 
 bin_key(Map) when is_map(Map) ->
     maps:fold(fun(K, V, Acc) -> Acc#{bin(K) => V} end, #{}, Map);

--- a/changes/ee/fix-18172.en.md
+++ b/changes/ee/fix-18172.en.md
@@ -1,0 +1,1 @@
+Fixed the plugin configuration API to return a readable validation error when the root JSON value has the wrong type, instead of returning `500 INTERNAL_ERROR`.


### PR DESCRIPTION
Release version: 6.1.4

Fixes #18170

## Summary

Return a readable `BAD_CONFIG` response when the plugin configuration API receives a root-level JSON value with the wrong type, instead of exposing an internal `function_clause`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
