### PR TITLE
fix(bridge_mqtt): clear error for server scheme vs SSL mismatch

### DIFF
--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -871,7 +871,7 @@ t_not_cached_and_unreachable(Config) ->
     Ref = get_crl_cache_table(),
     ?assertEqual([], ets:tab2list(Ref)),
     unlink(C),
-    ?assertMatch({error, {ssl_error, _Sock, {tls_alert, {bad_certificate, _}}}}, emqtt:connect(C)),
+    ?assertMatch({error, {tls_alert, {bad_certificate, _}}}, emqtt:connect(C)),
     ok.
 
 t_revoked(Config) ->

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -422,9 +422,11 @@ t_ssl_update_opts(Config) ->
             ]),
             ct:fail("l ~b: unexpected success", [?LINE])
         catch
-            error:{ssl_error, _Socket, {tls_alert, {certificate_required, _}}} ->
+            error:{tls_alert, {certificate_required, _}} ->
                 ok;
             error:closed ->
+                ok;
+            error:ssl_closed ->
                 ok;
             error:connack_timeout ->
                 ok;

--- a/apps/emqx/test/emqx_listeners_limits_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_limits_SUITE.erl
@@ -224,7 +224,7 @@ assert_connect_refused(Host, Port, Config) ->
     catch
         error:closed when Type == tcp -> ok;
         error:{closed, _} when Type == tcp -> ok;
-        error:{tcp_closed, _} when Type == tcp -> ok;
+        error:tcp_closed when Type == tcp -> ok;
         error:{ws_upgrade_failed, closed} when Type == ws -> ok;
         error:{ws_upgrade_failed, {error, closed}} when Type == ws -> ok;
         error:timeout when Type == wss -> ok

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -495,11 +495,9 @@ classify_error(ecpool_empty) ->
     {recoverable_error, disconnected};
 classify_error({disconnected, _RC, _} = Reason) ->
     {recoverable_error, Reason};
-classify_error({shutdown, {parse_packets_error, _, _}}) ->
+classify_error({shutdown, {frame_parse_error, _}}) ->
     {unrecoverable_error, non_mqtt_data_explanation()};
-classify_error({parse_packets_error, _, _}) ->
-    {unrecoverable_error, non_mqtt_data_explanation()};
-classify_error({tcp, _Port, _Data}) ->
+classify_error({frame_parse_error, _}) ->
     {unrecoverable_error, non_mqtt_data_explanation()};
 classify_error({shutdown, _} = Reason) ->
     {recoverable_error, Reason};
@@ -865,20 +863,18 @@ log_connect_error_reason(Level, econnrefused = Reason, Name) ->
         name => Name,
         explain => explain_error(Reason)
     });
-log_connect_error_reason(Level, {shutdown, {parse_packets_error, _, _} = Reason}, Name) ->
+log_connect_error_reason(Level, {shutdown, {frame_parse_error, _} = Reason}, Name) ->
     log_connect_error_reason(Level, Reason, Name);
-log_connect_error_reason(Level, {parse_packets_error, ParseError, _Stacktrace} = Reason, Name) ->
+log_connect_error_reason(Level, {frame_parse_error, _} = Reason, Name) ->
     ?tp(emqx_bridge_mqtt_connector_non_mqtt_data, #{}),
-    %% The stacktrace is the emqtt frame parser choking on non-MQTT bytes; it
-    %% carries no information beyond the explanation, so keep it out of the log.
     ?SLOG(Level, #{
         msg => "ingress_client_connect_failed",
-        reason => {parse_packets_error, ParseError},
+        reason => Reason,
         name => Name,
         explain => explain_error(Reason)
     });
-log_connect_error_reason(Level, {tcp, _Port, _Data} = Reason, Name) ->
-    ?tp(emqx_bridge_mqtt_connector_non_mqtt_data, #{}),
+log_connect_error_reason(Level, tcp_closed = Reason, Name) ->
+    ?tp(emqx_bridge_mqtt_connector_tcp_closed, #{}),
     ?SLOG(Level, #{
         msg => "ingress_client_connect_failed",
         reason => Reason,
@@ -902,15 +898,15 @@ explain_error(econnrefused) ->
         "running at all or you might have provided the wrong address "
         "or port number for the server."
     >>;
+explain_error(tcp_closed) ->
+    listener_max_limit_explanation();
 explain_error({tcp_closed, _}) ->
     listener_max_limit_explanation();
 explain_error(closed) ->
     listener_max_limit_explanation();
-explain_error({shutdown, {parse_packets_error, _, _}}) ->
+explain_error({shutdown, {frame_parse_error, _}}) ->
     non_mqtt_data_explanation();
-explain_error({parse_packets_error, _, _}) ->
-    non_mqtt_data_explanation();
-explain_error({tcp, _Port, _Data}) ->
+explain_error({frame_parse_error, _}) ->
     non_mqtt_data_explanation();
 explain_error(_Reason) ->
     undefined.

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -53,6 +53,12 @@
 
 -define(available_clientid_info, available_clientid_info).
 
+-define(SCHEME_SSL_MISMATCH_MSG, <<
+    "Inconsistent server address and SSL settings: "
+    "the server address uses the mqtts:// (TLS) scheme, but SSL is disabled. "
+    "Enable SSL, or use the mqtt:// scheme for a plain TCP connection."
+>>).
+
 %% Allocatable resources
 -define(topic_to_handler_index, topic_to_handler_index).
 -define(subscription_id_to_handler_index, subscription_id_to_handler_index).
@@ -97,7 +103,41 @@ resource_type() -> mqtt.
 callback_mode() -> async_if_possible.
 
 -spec on_start(connector_resource_id(), map()) -> {ok, connector_state()} | {error, term()}.
-on_start(ConnResId, #{server := Server} = Conf) ->
+on_start(ConnResId, Conf) ->
+    case check_server_scheme_ssl_consistency(Conf) of
+        ok ->
+            do_on_start(ConnResId, Conf);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+%% An explicit `mqtts://' scheme with SSL disabled would otherwise surface only at
+%% connect time: the plain-TCP client sends CONNECT to a TLS port and then fails to
+%% parse the TLS alert bytes it gets back as an MQTT frame.
+check_server_scheme_ssl_consistency(#{server := Server, ssl := #{enable := EnableSsl}}) ->
+    case emqx_bridge_mqtt_connector_schema:explicit_server_scheme(Server) of
+        "mqtts" when not EnableSsl ->
+            {error, ?SCHEME_SSL_MISMATCH_MSG};
+        "mqtt" when EnableSsl ->
+            %% Contradictory but harmless: `ssl.enable' wins and TLS is used.
+            %% Existing configs may rely on this, so only warn.
+            ?SLOG(warning, #{
+                msg => "mqtt_connector_scheme_ssl_mismatch",
+                server => Server,
+                explain =>
+                    <<
+                        "The server address uses the mqtt:// (plain TCP) scheme, "
+                        "but SSL is enabled for this connector; connecting with TLS."
+                    >>
+            }),
+            ok;
+        _ ->
+            ok
+    end;
+check_server_scheme_ssl_consistency(_Conf) ->
+    ok.
+
+do_on_start(ConnResId, #{server := Server} = Conf) ->
     ?tp(info, "starting_mqtt_connector", #{
         connector => ConnResId,
         config => emqx_utils:redact(Conf)
@@ -455,6 +495,12 @@ classify_error(ecpool_empty) ->
     {recoverable_error, disconnected};
 classify_error({disconnected, _RC, _} = Reason) ->
     {recoverable_error, Reason};
+classify_error({shutdown, {parse_packets_error, _, _}}) ->
+    {unrecoverable_error, non_mqtt_data_explanation()};
+classify_error({parse_packets_error, _, _}) ->
+    {unrecoverable_error, non_mqtt_data_explanation()};
+classify_error({tcp, _Port, _Data}) ->
+    {unrecoverable_error, non_mqtt_data_explanation()};
 classify_error({shutdown, _} = Reason) ->
     {recoverable_error, Reason};
 classify_error(shutdown = Reason) ->
@@ -819,6 +865,26 @@ log_connect_error_reason(Level, econnrefused = Reason, Name) ->
         name => Name,
         explain => explain_error(Reason)
     });
+log_connect_error_reason(Level, {shutdown, {parse_packets_error, _, _} = Reason}, Name) ->
+    log_connect_error_reason(Level, Reason, Name);
+log_connect_error_reason(Level, {parse_packets_error, ParseError, _Stacktrace} = Reason, Name) ->
+    ?tp(emqx_bridge_mqtt_connector_non_mqtt_data, #{}),
+    %% The stacktrace is the emqtt frame parser choking on non-MQTT bytes; it
+    %% carries no information beyond the explanation, so keep it out of the log.
+    ?SLOG(Level, #{
+        msg => "ingress_client_connect_failed",
+        reason => {parse_packets_error, ParseError},
+        name => Name,
+        explain => explain_error(Reason)
+    });
+log_connect_error_reason(Level, {tcp, _Port, _Data} = Reason, Name) ->
+    ?tp(emqx_bridge_mqtt_connector_non_mqtt_data, #{}),
+    ?SLOG(Level, #{
+        msg => "ingress_client_connect_failed",
+        reason => Reason,
+        name => Name,
+        explain => explain_error(Reason)
+    });
 log_connect_error_reason(Level, Reason, Name) ->
     ?SLOG(Level, #{
         msg => "ingress_client_connect_failed",
@@ -840,8 +906,24 @@ explain_error({tcp_closed, _}) ->
     listener_max_limit_explanation();
 explain_error(closed) ->
     listener_max_limit_explanation();
+explain_error({shutdown, {parse_packets_error, _, _}}) ->
+    non_mqtt_data_explanation();
+explain_error({parse_packets_error, _, _}) ->
+    non_mqtt_data_explanation();
+explain_error({tcp, _Port, _Data}) ->
+    non_mqtt_data_explanation();
 explain_error(_Reason) ->
     undefined.
+
+non_mqtt_data_explanation() ->
+    <<
+        "Received unexpected data from the remote broker: "
+        "it does not look like MQTT protocol data. "
+        "The server may be expecting a TLS connection "
+        "(e.g. an mqtts:// port while SSL is disabled for this connector), "
+        "or the port may not serve MQTT at all. "
+        "Please check the server address and the SSL settings."
+    >>.
 
 listener_max_limit_explanation() ->
     <<

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
@@ -19,7 +19,8 @@
     roots/0,
     fields/1,
     desc/1,
-    parse_server/1
+    parse_server/1,
+    explicit_server_scheme/1
 ]).
 
 -export([
@@ -444,6 +445,25 @@ qos() ->
 parse_server(Str) ->
     #{hostname := Host, port := Port} = emqx_schema:parse_server(Str, ?MQTT_HOST_OPTS),
     {Host, Port}.
+
+-doc """
+Return the URI scheme explicitly present in a `server' value, or `undefined'
+for a scheme-less `host[:port]' address.
+
+The distinction matters: parsing defaults a scheme-less address to `mqtt', but
+only an address the user explicitly wrote as `mqtt://' or `mqtts://' expresses
+an intent about TLS that can be cross-checked against `ssl.enable'.
+""".
+-spec explicit_server_scheme(binary() | string()) -> string() | undefined.
+explicit_server_scheme(Server) ->
+    Bin = iolist_to_binary(Server),
+    case binary:match(Bin, <<"://">>) of
+        nomatch ->
+            undefined;
+        _ ->
+            #{scheme := Scheme} = emqx_schema:parse_server(Bin, ?MQTT_HOST_OPTS),
+            Scheme
+    end.
 
 connector_examples(Method) ->
     [

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_action_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_action_SUITE.erl
@@ -235,6 +235,10 @@ get_tcp_mqtt_port(Node) ->
     {_Host, Port} = ?ON(Node, emqx_config:get([listeners, tcp, default, bind])),
     Port.
 
+get_ssl_mqtt_port() ->
+    {_Host, Port} = emqx_config:get([listeners, ssl, default, bind]),
+    Port.
+
 setup_auth_header(TCConfig) ->
     case get_config(nodes, TCConfig, undefined) of
         [N1 | _] ->
@@ -1627,5 +1631,99 @@ t_connector_server_scheme(TCConfig) ->
             }
         }},
         create_connector_api(TCConfig, #{<<"server">> => <<"mqtt-tcp://[::1]:1883">>})
+    ),
+    ok.
+
+-doc """
+Checks that a server address with an explicit `mqtts://' (TLS) scheme while SSL is
+disabled fails the connector probe (dashboard Test) with a clear message, and that a
+created connector reports the same clear message as its status reason — instead of a
+raw `function_clause' frame-parse crash (the plain TCP client would otherwise try to
+parse the server's TLS handshake reply as an MQTT frame).
+""".
+t_scheme_ssl_mismatch(TCConfig) ->
+    SslPort = integer_to_binary(get_ssl_mqtt_port()),
+    Overrides = #{
+        <<"server">> => <<"mqtts://127.0.0.1:", SslPort/binary>>,
+        <<"ssl">> => #{<<"enable">> => false}
+    },
+    {400, #{<<"message">> := ProbeMsg0}} = probe_connector_api(TCConfig, Overrides),
+    ProbeMsg = emqx_utils_json:encode(ProbeMsg0),
+    ?assertEqual(
+        match,
+        re:run(ProbeMsg, <<"SSL is disabled">>, [{capture, none}]),
+        #{probe_message => ProbeMsg}
+    ),
+    ?assertEqual(
+        nomatch,
+        re:run(ProbeMsg, <<"function_clause">>, [{capture, none}]),
+        #{probe_message => ProbeMsg}
+    ),
+    {201, _} = create_connector_api(TCConfig, Overrides),
+    ?retry(500, 20, begin
+        {200, #{<<"status">> := Status, <<"status_reason">> := Reason}} =
+            get_connector_api(TCConfig),
+        ?assertEqual(<<"disconnected">>, Status),
+        ?assertEqual(
+            match,
+            re:run(Reason, <<"SSL is disabled">>, [{capture, none}]),
+            #{status_reason => Reason}
+        )
+    end),
+    ok.
+
+-doc """
+Checks that connecting plain TCP to a TLS-speaking port fails with a clear
+explanation about receiving non-MQTT data, instead of a raw emqtt frame-parse crash.
+A scheme-less server address is used, so the upfront scheme/SSL consistency check
+does not apply and the failure happens at connect time.
+""".
+t_connect_to_tls_port(TCConfig) ->
+    SslPort = integer_to_binary(get_ssl_mqtt_port()),
+    {201, _} = create_connector_api(TCConfig, #{
+        <<"server">> => <<"127.0.0.1:", SslPort/binary>>
+    }),
+    ?retry(500, 20, begin
+        {200, #{<<"status">> := Status, <<"status_reason">> := Reason}} =
+            get_connector_api(TCConfig),
+        ?assertEqual(<<"disconnected">>, Status),
+        ?assertEqual(
+            match,
+            re:run(Reason, <<"does not look like MQTT">>, [{capture, none}]),
+            #{status_reason => Reason}
+        ),
+        ?assertEqual(
+            nomatch,
+            re:run(Reason, <<"function_clause">>, [{capture, none}]),
+            #{status_reason => Reason}
+        )
+    end),
+    ok.
+
+-doc """
+Checks that consistently configured connectors still connect: an explicit `mqtt://'
+address with SSL disabled, and an explicit `mqtts://' address with SSL enabled — the
+scheme/SSL consistency check must not reject valid configurations.
+""".
+t_scheme_ssl_consistent_connects(TCConfig) ->
+    TcpPort = integer_to_binary(get_tcp_mqtt_port(node())),
+    SslPort = integer_to_binary(get_ssl_mqtt_port()),
+    {201, _} = create_connector_api(TCConfig, #{
+        <<"server">> => <<"mqtt://127.0.0.1:", TcpPort/binary>>
+    }),
+    ?retry(
+        500,
+        20,
+        ?assertMatch({200, #{<<"status">> := <<"connected">>}}, get_connector_api(TCConfig))
+    ),
+    {204, _} = emqx_bridge_v2_testlib:delete_connector_api(TCConfig),
+    {201, _} = create_connector_api(TCConfig, #{
+        <<"server">> => <<"mqtts://127.0.0.1:", SslPort/binary>>,
+        <<"ssl">> => #{<<"enable">> => true, <<"verify">> => <<"verify_none">>}
+    }),
+    ?retry(
+        500,
+        20,
+        ?assertMatch({200, #{<<"status">> := <<"connected">>}}, get_connector_api(TCConfig))
     ),
     ok.

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -376,7 +376,7 @@ mk_disconnect_handler(ResourceId, WorkerId, ClientId, TargetCluster) ->
 
 -spec handle_disconnect(
     {disconnected, emqx_types:reason_code(), emqx_types:properties()}
-    | {parse_packets_error, _Reason, _ParserState}
+    | {frame_parse_error, _Reason}
     | {connack_error, _Reason :: atom()}
     | connack_timeout
     | _SocketError,
@@ -408,7 +408,7 @@ handle_disconnect(Reason, ResourceId, WorkerId, EventCtx) ->
                 reason_code => RC
             },
             report_disconnect(ResourceId, WorkerId, Level, EventCtx, Info);
-        {parse_packets_error, ParserReason, _ParserState} ->
+        {frame_parse_error, ParserReason} ->
             Info = #{cause => malformed_packet, reason => ParserReason},
             report_disconnect(ResourceId, WorkerId, warning, EventCtx, Info);
         {connack_error, RCName} ->

--- a/changes/ee/fix-18174.en.md
+++ b/changes/ee/fix-18174.en.md
@@ -1,0 +1,3 @@
+The MQTT connector now reports a clear error message when the server address scheme is inconsistent with the SSL settings, for example an `mqtts://` (TLS) address while SSL is disabled.
+
+Previously, such a configuration failed with an internal error and a noisy log, because the connector attempted a plain TCP connection to a TLS port and could not interpret the server's reply. Connection attempts that receive non-MQTT data from the server (for example, when the port expects TLS) now also produce a clear explanation instead of an internal error.

--- a/mix.exs
+++ b/mix.exs
@@ -240,7 +240,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:emqtt),
     do:
       {:emqtt,
-       github: "emqx/emqtt", tag: "1.15.3", override: true, system_env: maybe_no_quic_env()}
+       github: "emqx/emqtt", tag: "1.15.4", override: true, system_env: maybe_no_quic_env()}
 
   def common_dep(:typerefl),
     do: {:typerefl, github: "ieQu1/typerefl", tag: "0.9.6", override: true}


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0

## Summary

Fixes #18173.

An MQTT connector configured with an explicit `mqtts://` (TLS) server address while SSL is disabled used to open a plain TCP connection to the TLS port. The server replies with TLS handshake/alert bytes, which the `emqtt` client tries to parse as an MQTT frame, ending in a raw `function_clause` term on the dashboard and a noisy stacktrace in the logs.

Changes in `apps/emqx_bridge_mqtt`:

* **Proactive validation** (`emqx_bridge_mqtt_connector:on_start/2`): the server scheme is now reconciled with `ssl.enable` before connecting. An explicit `mqtts://` scheme with SSL disabled fails connector start/probe (dashboard Test) with a clear, actionable message. The inverse (`mqtt://` with SSL enabled) only logs a warning, since `ssl.enable` wins there and the TLS connection may be working for existing configs. Scheme-less addresses are unaffected: they default to `mqtt` during parsing but carry no user intent about TLS (`emqx_bridge_mqtt_connector_schema:explicit_server_scheme/1` makes that distinction).
* **Runtime classification** (defense in depth, for scheme-less addresses or servers that unexpectedly speak TLS): connect failures caused by non-MQTT data from the server — the raw `{tcp, _Port, _Data}` reason observed in practice, and `parse_packets_error` — are now classified as unrecoverable and explained with a friendly message in the connector status and API responses, instead of surfacing the raw term.
* **Log hygiene**: the same failures log the explanation and keep the `emqtt` frame-parser stacktrace out of the logs.

The underlying `emqtt_frame` parser raising `function_clause` on non-MQTT input (rather than returning an error tuple) is an upstream `emqtt` matter and a possible follow-up; the changes here address the user-visible symptom on the EMQX side.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
