### PR TITLE
fix(conn): redact packet prefix in frame parse errors

### DIFF
--- a/apps/emqx/src/emqx_packet_data_logger.erl
+++ b/apps/emqx/src/emqx_packet_data_logger.erl
@@ -25,9 +25,16 @@ add_raw_packet_data(Log, Key, Data, hex) ->
     Log#{Key => binary_to_list(binary:encode_hex(Data)), type => "hex"}.
 
 add_redacted_packet_data(Log, Key, raw) ->
-    Log#{Key => ?REDACTED};
+    RedactedLog = redact_received_prefix(Log),
+    RedactedLog#{Key => ?REDACTED};
 add_redacted_packet_data(Log, Key, hex) ->
-    Log#{Key => ?REDACTED, type => "hidden"}.
+    RedactedLog = redact_received_prefix(Log),
+    RedactedLog#{Key => ?REDACTED, type => "hidden"}.
+
+redact_received_prefix(#{reason := #{received_prefix := _} = Reason} = Log) ->
+    Log#{reason := Reason#{received_prefix := ?REDACTED, received_prefix_encoding => hidden}};
+redact_received_prefix(Log) ->
+    Log.
 
 is_allowed(Channel) ->
     ClientInfo = emqx_channel:info(clientinfo, Channel),

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -380,7 +380,8 @@ t_socket_parse_incoming_first_packet_hints(_) ->
     ok = meck:unload(emqx_frame).
 
 t_packet_data_logging(_) ->
-    Data = <<16#10, 0, "secret">>,
+    Secret = <<"PR17974_SECRET_001">>,
+    Data = <<16#10, (byte_size(Secret)), Secret/binary>>,
     Channel = channel(),
     OldIPMasks = emqx_config:get_listener_conf(
         tcp, default, [allow_log_packet_data_from]
@@ -394,12 +395,22 @@ t_packet_data_logging(_) ->
             emqx_packet_data_logger:add_packet_data(#{}, bin, Data, Channel, hex)
         ),
         DeniedReports = emqx_cth_log_capture:capture(info, fun() ->
-            emqx_connection:parse_incoming(Data, st())
+            emqx_connection:parse_incoming(Data, st(#{}, #{conn_state => idle}))
         end),
+        [DeniedReport] = [Report || #{msg := "frame_parse_error"} = Report <- DeniedReports],
         ?assertMatch(
-            [#{input_bytes := <<"******">>}],
-            [Report || #{msg := "frame_parse_error"} = Report <- DeniedReports]
+            #{
+                input_bytes := <<"******">>,
+                reason := #{
+                    received_prefix := <<"******">>,
+                    received_prefix_encoding := hidden
+                }
+            },
+            DeniedReport
         ),
+        DeniedLog = iolist_to_binary(io_lib:format("~p", [DeniedReport])),
+        ?assertEqual(nomatch, binary:match(DeniedLog, Secret)),
+        ?assertEqual(nomatch, binary:match(DeniedLog, binary:encode_hex(Secret))),
 
         ok = emqx_config:put_listener_conf(
             tcp, default, [allow_log_packet_data_from], [esockd_cidr:parse("127.0.0.0/24", true)]
@@ -409,10 +420,19 @@ t_packet_data_logging(_) ->
             emqx_packet_data_logger:add_packet_data(#{}, bin, Data, Channel, hex)
         ),
         AllowedReports = emqx_cth_log_capture:capture(info, fun() ->
-            emqx_connection:parse_incoming(Data, st())
+            emqx_connection:parse_incoming(Data, st(#{}, #{conn_state => idle}))
         end),
+        ExpectedPrefix = binary:encode_hex(Data),
         ?assertMatch(
-            [#{input_bytes := Data}],
+            [
+                #{
+                    input_bytes := Data,
+                    reason := #{
+                        received_prefix := ExpectedPrefix,
+                        received_prefix_encoding := hex
+                    }
+                }
+            ],
             [Report || #{msg := "frame_parse_error"} = Report <- AllowedReports]
         )
     after

--- a/changes/ee/fix-18177.en.md
+++ b/changes/ee/fix-18177.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where `frame_parse_error` logs could expose packet data in `received_prefix` when the client was not allowed by `allow_log_packet_data_from`.


### PR DESCRIPTION
Release version: 6.1.4

Fixes #18136

## Summary

Redact `received_prefix` in `frame_parse_error` logs according to the listener packet data logging allowlist. 

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)