### PR TITLE
test(prometheus): ignore transient server_busy in t_listener_shutdown_count

### DIFF
--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -402,6 +402,13 @@ t_listener_shutdown_count(_Config) ->
     OnlyDisconnectStats = fun(Stats0) ->
         Stats = lists:filter(
             fun
+                %% `server_busy' is a transient clientid-registration-throttle
+                %% artifact (a rapid same-clientid reconnect racing the previous
+                %% session's async cleanup), not a disconnect reason under test.
+                %% It also carries the `emqx_client_disconnected_reason' key, so
+                %% this clause must come before the catch-all below.
+                (#{<<"reason">> := <<"server_busy">>}) ->
+                    false;
                 (#{<<"emqx_client_disconnected_reason">> := _}) ->
                     true;
                 (_) ->


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Test-only de-flake for `emqx_prometheus_api_SUITE:t_listener_shutdown_count`.

The test drives a fixed sequence of disconnects and asserts the
`emqx_client_disconnected_reason` counter breakdown equals exactly
`[discarded, kicked, tcp_closed]`. It reconnects rapidly with reused clientids,
so occasionally one reconnect hits the broker's clientid-registration throttle
(`open_session` → `client_id_unavailable` → CONNACK `server_busy`), which is
counted as an extra `emqx_client_disconnected_reason{reason="server_busy"}`
entry and breaks the exact-list assertion at line 438.

`server_busy` is a transient artifact of a same-clientid reconnect racing the
previous session's async cleanup — not one of the shutdown reasons under test.
The fix extends the existing `OnlyDisconnectStats` filter to drop
`{reason => "server_busy"}` entries before sorting/asserting. The clause is
placed before the `emqx_client_disconnected_reason` catch-all because a
`server_busy` entry also carries that key. The single filter is used by all
three assertion blocks (node / aggregated / unaggregated), so one change covers
them all. This extends the earlier #17889 de-flake for a new `server_busy`-reason
variant.

Relevant file: `apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl`.

### Out-of-scope observation (not fixed here)

The same failing CI job log shows `emqx_prometheus` crash-looping every 1s with
`{badarg, ets:first(emqx_mt_ns)}` in `emqx_mt_state:fold_known_nss/2` (via
`emqx_prometheus:session_metric_ns/3`). The `emqx_mt_ns` table does not exist
when `emqx_mt` is not started, and `fold_known_nss/2` does not guard against the
absent table. This is a separate product robustness bug present only on dev-61+
(the `session_metric_ns`/`fold_known_nss` code is absent on dev-60); it is not
the cause of the line-438 assertion failure. It should be fixed independently as
a `fix(prometheus)` on dev-61.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
