### PR TITLE
fix(limiter): consistently treat zero-burst capacity limits

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
@@ -250,7 +250,7 @@ do_post_zone_config_update(false, _OldZoneConfig, _NewZoneConfig) ->
 %% means that the limiter `x` has a rate of 10 tokens per 1000ms and a burst of 100 each 5 minutes.
 %%
 %% The `config(x, Config)` function will return limiter config
-%%  `#{capacity => 10, burst_capacity => 110, interval => 1000, burst_interval => 30000}`.
+%%  `#{capacity => 10, burst_capacity => 100, interval => 1000, burst_interval => 30000}`.
 %%
 %% If the limiter `x` is not configured, the function will return unlimited limiter config
 %%  `#{capacity => infinity}`.
@@ -265,7 +265,7 @@ config(Name, Config) ->
                     %% limited_with_burst()
                     #{
                         capacity => Capacity,
-                        burst_capacity => BurstCapacity + Capacity,
+                        burst_capacity => BurstCapacity,
                         interval => Interval,
                         burst_interval => BurstInterval
                     };

--- a/apps/emqx/test/emqx_limiter_exclusive_SUITE.erl
+++ b/apps/emqx/test/emqx_limiter_exclusive_SUITE.erl
@@ -29,12 +29,7 @@ init_per_testcase(_TestCase, Config) ->
 
 end_per_testcase(_TestCase, Config) ->
     Groups = emqx_limiter_registry:list_groups(),
-    lists:foreach(
-        fun(Group) ->
-            emqx_limiter:delete_group(Group)
-        end,
-        Groups
-    ),
+    lists:foreach(fun emqx_limiter:delete_group/1, Groups),
     Config.
 
 %%--------------------------------------------------------------------
@@ -104,6 +99,25 @@ t_try_consume_burst(_) ->
         Client5,
         lists:seq(1, 10)
     ).
+
+t_try_consume_zero_burst(_) ->
+    Group = ?FUNCTION_NAME,
+    Conf = #{
+        test_rate => {1, 1000},
+        test_burst => {0, 1000}
+    },
+    ok = emqx_limiter:create_group(exclusive, Group, [
+        {limiter1, emqx_limiter:config(test, Conf)}
+    ]),
+    Client0 = emqx_limiter:connect({Group, limiter1}),
+
+    %% Only regularly refilled tokens are available
+    {true, Client1} = emqx_limiter_client:try_consume(Client0, 1),
+    {false, Client2, _} = emqx_limiter_client:try_consume(Client1, 1),
+
+    ct:sleep(1000),
+    {true, Client3} = emqx_limiter_client:try_consume(Client2, 1),
+    {false, _Client, _} = emqx_limiter_client:try_consume(Client3, 1).
 
 t_try_consume_burst_wide_interval(_) ->
     ok = emqx_limiter:create_group(exclusive, group1, [

--- a/apps/emqx/test/emqx_listeners_limits_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_limits_SUITE.erl
@@ -129,13 +129,10 @@ t_max_conn_rate_update(Config) ->
         Config
     ),
     with_listener(Type, Name, LConf, fun() ->
-        %% Spawn 3 connections:
-        %% NOTE
-        %% All of them should be allowed as burst capacity are currently computed
-        %% as sum of burst _and_ regular rate tokens.
+        %% Spawn connections using the regular capacity plus configured burst capacity.
         Clients1 = emqx_utils:pmap(
             fun(_) -> emqtt_connect("127.0.0.1", Port, Config) end,
-            [1, 2, 3]
+            [1, 2]
         ),
         ?assertEqual([pong], lists:usort([emqtt:ping(C) || C <- Clients1])),
         %% One more client, both rate and burst limits are exhausted:
@@ -185,17 +182,14 @@ t_message_rate(Config) ->
                 fun(_) -> emqtt_connect("127.0.0.1", Port, Config) end,
                 [1, 2, 3]
             ),
-        %% Shoot 6 message per first 2 clients:
-        %% NOTE
-        %% All of them should be allowed as burst capacity are currently computed
-        %% as sum of burst _and_ regular rate tokens.
+        %% Shoot messages using the regular capacity plus configured burst capacity.
         Topic = <<"t/msgrate">>,
         ok = emqx_broker:subscribe(Topic),
         _ = emqx_utils:pmap(
             fun(C) ->
                 [
                     {ok, #{reason_code := ?RC_SUCCESS}} = emqtt:publish(C, Topic, Payload, qos1)
-                 || Payload <- [<<"M1">>, <<"M2">>, <<"M3">>, <<"M4">>, <<"M5">>, <<"M6">>]
+                 || Payload <- [<<"M1">>, <<"M2">>, <<"M3">>, <<"M4">>, <<"M5">>]
                 ]
             end,
             [C1, C2]

--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
 
 -define(STATS_KYES, [
     recv_pkt,
@@ -67,6 +68,54 @@ t_message_expiry_interval(_) ->
 t_message_not_expiry_interval(_) ->
     run_message_expiry_interval(<<"noexp">>, fun message_expiry_interval_not_exipred/4).
 
+-doc """
+A live subscriber skips an expired message that was held in the mqueue by delivery
+rate limiting.
+""".
+t_delivery_limited_queued_messages_expire(_Config) ->
+    Topic = ~"t/delivery_limited_expired",
+    SubscriberId = ~"delivery_limited_expired_sub",
+    PublisherId = ~"delivery_limited_expired_pub",
+    {ok, CPub} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, PublisherId}
+    ]),
+    {ok, CSub} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, SubscriberId},
+        {auto_ack, false}
+    ]),
+    configure_delivery_limiters(tcp, default, ~"1/5s"),
+    try
+        {ok, _} = emqtt:connect(CPub),
+        {ok, _} = emqtt:connect(CSub),
+        {ok, _, [1]} = emqtt:subscribe(CSub, Topic, 1),
+
+        publish_with_expiry(CPub, Topic, ~"1", ?QOS_1, 60),
+        publish_with_expiry(CPub, Topic, ~"2", ?QOS_1, 2),
+        publish_with_expiry(CPub, Topic, ~"3", ?QOS_1, 60),
+
+        ct:sleep(3000),
+
+        configure_delivery_limiters(tcp, default, ~"infinity"),
+
+        {publish, Pub1} = ?assertReceive({publish, #{client_pid := CSub, topic := Topic}}),
+        ok = emqtt:puback(CSub, maps:get(packet_id, Pub1)),
+        {publish, Pub2} = ?assertReceive({publish, #{client_pid := CSub, topic := Topic}}),
+        ?assertMatch(
+            [
+                #{payload := ~"1"},
+                #{payload := ~"3"}
+            ],
+            [Pub1, Pub2]
+        ),
+        ?assertNotReceive({publish, #{client_pid := CSub, topic := Topic}}, 3000)
+    after
+        emqtt:stop(CSub),
+        emqtt:stop(CPub),
+        configure_delivery_limiters(tcp, default, ~"infinity")
+    end.
+
 %% Each QoS iteration uses a fresh set of clientids (tagged with the test name
 %% and the QoS) so that no session/mqueue/subscription state leaks from one
 %% iteration to the next, nor between the two expiry-interval tests. Reusing a
@@ -121,6 +170,21 @@ message_expiry_interval_init(Tag) ->
     %% handshake widens the window).
     ok = wait_until_session_disconnected(<<"Client-Verify-", Tag/binary>>),
     {CPublish, CControl}.
+
+configure_delivery_limiters(Type, Name, MessagesRate) ->
+    {ok, _} = emqx:update_config(
+        [listeners, Type, Name],
+        {update, #{<<"delivery_messages_rate">> => MessagesRate}}
+    ).
+
+publish_with_expiry(Publisher, Topic, Payload, QoS, ExpiryInterval) ->
+    {ok, _} = emqtt:publish(
+        Publisher,
+        Topic,
+        #{'Message-Expiry-Interval' => ExpiryInterval},
+        Payload,
+        [{qos, QoS}]
+    ).
 
 wait_until_session_disconnected(ClientId) ->
     wait_until_session_disconnected(ClientId, 100).

--- a/changes/ee/fix-18181.en.md
+++ b/changes/ee/fix-18181.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where rate limiters configured with a burst value of `0` could still allow an extra burst of traffic. This made limits such as MQTT delivery message rate limits less strict than configured.


### PR DESCRIPTION
Release version: 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced In: 5.9.0

## Summary

This PR fixes handling of zero-burst capacity in a single place where it was still handled according to pre-#15718 logic. See also #14773.

Reproduction attempt for https://github.com/emqx/emqx/issues/18176.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible