### PR TITLE
fix(prometheus): tolerate absent tables in namespaced metrics collection

### DIFF
--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -380,7 +380,12 @@ record_count(Namespace) when is_binary(Namespace) ->
 
 -spec record_count_per_namespace() -> #{emqx_config:namespace() => non_neg_integer()}.
 record_count_per_namespace() ->
-    maps:from_list(ets:tab2list(?AUTHN_NS_COUNT_TAB)).
+    try
+        maps:from_list(ets:tab2list(?AUTHN_NS_COUNT_TAB))
+    catch
+        %% `emqx_auth_mnesia' is not running: the table does not exist.
+        error:badarg -> #{}
+    end.
 
 %%--------------------------------------------------------------------
 %% QueryString to MatchSpec

--- a/apps/emqx_auth_mnesia/src/emqx_authz_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authz_mnesia.erl
@@ -251,7 +251,12 @@ record_count(Namespace) when is_binary(Namespace) ->
 
 -spec record_count_per_namespace() -> #{emqx_config:namespace() => non_neg_integer()}.
 record_count_per_namespace() ->
-    maps:from_list(ets:tab2list(?AUTHZ_NS_COUNT_TAB)).
+    try
+        maps:from_list(ets:tab2list(?AUTHZ_NS_COUNT_TAB))
+    catch
+        %% `emqx_auth_mnesia' is not running: the table does not exist.
+        error:badarg -> #{}
+    end.
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_mt/src/emqx_mt_state.erl
+++ b/apps/emqx_mt/src/emqx_mt_state.erl
@@ -319,7 +319,13 @@ list_managed_ns_details(LastNs, Limit) ->
     do_list_ns_details(?CONFIG_TAB, LastNs, Limit).
 
 fold_known_nss(Fn, Acc) ->
-    do_fold_known_nss(ets:first(?NS_TAB), Fn, Acc).
+    case ets:whereis(?NS_TAB) of
+        undefined ->
+            %% `emqx_mt' is not running: no namespace exists.
+            Acc;
+        _ ->
+            do_fold_known_nss(ets:first(?NS_TAB), Fn, Acc)
+    end.
 
 do_fold_known_nss('$end_of_table', _Fn, Acc) ->
     Acc;
@@ -421,7 +427,13 @@ do_count_clients(_Ns, _Key, Acc) ->
 %% @doc Returns true if it is a known namespace.
 -spec is_known_ns(tns()) -> boolean().
 is_known_ns(Ns) ->
-    [] =/= ets:lookup(?NS_TAB, Ns).
+    case ets:whereis(?NS_TAB) of
+        undefined ->
+            %% `emqx_mt' is not running: no namespace exists.
+            false;
+        _ ->
+            [] =/= ets:lookup(?NS_TAB, Ns)
+    end.
 
 %% @doc list all clients for a given tns.
 %% The second argument is the last clientid from the previous page.

--- a/apps/emqx_mt/test/emqx_mt_state_tests.erl
+++ b/apps/emqx_mt/test/emqx_mt_state_tests.erl
@@ -1,0 +1,16 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_mt_state_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The `emqx_mt' application is not running in these tests, so its tables do not
+%% exist.  Callers from other applications (e.g. the Prometheus collector) must not
+%% crash in this situation.
+
+fold_known_nss_no_table_test() ->
+    ?assertEqual(acc, emqx_mt_state:fold_known_nss(fun(_Ns, _Acc) -> other end, acc)).
+
+is_known_ns_no_table_test() ->
+    ?assertNot(emqx_mt_state:is_known_ns(<<"some_namespace">>)).

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
@@ -241,6 +241,13 @@ t_namespaced_stats(TCConfig) ->
                 ],
                 GetLabels(<<"emqx_bytes_received">>, GlobalNodeRes1)
             ),
+            ?assertMatch(
+                [
+                    #{<<"namespace">> := Ns1},
+                    #{<<"namespace">> := Ns2}
+                ],
+                GetLabels(<<"emqx_sessions_count">>, GlobalNodeRes1)
+            ),
             %% possible to filter one specific namespace
             {200, GlobalNodeRes2} = get_namespaced_stats(Mode, #{
                 auth_header => GlobalAuthHeader,
@@ -290,6 +297,27 @@ t_namespaced_stats(TCConfig) ->
         ?PROM_DATA_MODES
     ),
 
+    ok.
+
+-doc """
+Checks that the namespaced stats endpoint responds successfully when the `emqx_mt' and
+`emqx_auth_mnesia' applications are not running: their tables do not exist, and the
+namespaced session/authz/authn metrics are simply omitted instead of crashing the
+collector.
+""".
+t_namespaced_stats_mt_not_started(TCConfig) ->
+    start_local(?FUNCTION_NAME, TCConfig, #{}),
+    AuthHeader = global_admin_auth_header(),
+    lists:foreach(
+        fun(Mode) ->
+            ct:pal("mode ~s", [Mode]),
+            {200, Res} = get_namespaced_stats(Mode, #{auth_header => AuthHeader}),
+            ?assertNot(is_map_key(<<"emqx_sessions_count">>, Res), Res),
+            ?assertNot(is_map_key(<<"emqx_authz_builtin_record_count">>, Res), Res),
+            ?assertNot(is_map_key(<<"emqx_authn_builtin_record_count">>, Res), Res)
+        end,
+        ?PROM_DATA_MODES
+    ),
     ok.
 
 -doc """

--- a/changes/ee/fix-18183.en.md
+++ b/changes/ee/fix-18183.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the Prometheus metrics collection could fail repeatedly (logging errors on every scrape) when the multi-tenancy feature is not enabled. Namespaced session, authentication, and authorization metrics are now simply omitted when their corresponding features are not active.


### PR DESCRIPTION
Release version:
6.1.5, 6.2.3, 6.3.0

## Summary

Fixes the product robustness issue flagged as out-of-scope in #18179: the Prometheus collector crash-loops with `{badarg, ets:first(emqx_mt_ns)}` on every scrape of the namespaced stats when the `emqx_mt` application is not running, because `emqx_mt_state:fold_known_nss/2` does not guard against its table being absent and `emqx_mt` is not a dependency of `emqx_prometheus`.

Guard at the source, so any caller is safe and the semantics stay correct (no namespaces / no records exist when the owning feature is not running):

* `emqx_mt_state:fold_known_nss/2` returns the accumulator unchanged when `emqx_mt_ns` does not exist.
* `emqx_mt_state:is_known_ns/1` returns `false` in the same situation (reached via `emqx_mt_state:count_clients/1` on the same collect path when a specific namespace is queried).
* `emqx_authz_mnesia:record_count_per_namespace/0` and `emqx_authn_mnesia:record_count_per_namespace/0` (the sibling authz/authn gatherers on the same collect path) return an empty map when their count tables are absent, i.e. when `emqx_auth_mnesia` is not running — it is not a dependency of `emqx_prometheus` either.

Tests: a new CT case scrapes `/prometheus/namespaced_stats` with `emqx_mt` and `emqx_auth_mnesia` not started and asserts a 200 response with the namespaced session/authz/authn metrics omitted; the existing `t_namespaced_stats` case now also asserts that `emqx_sessions_count` is still emitted per namespace when `emqx_mt` is running; eunit covers `fold_known_nss/2` and `is_known_ns/1` with the table absent.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfQYgWJcuCABsSHMrVK4s9