### PR TITLE
r60: Improve subscription HTTP API performance

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api.erl
@@ -80,7 +80,10 @@
     %% multiple schemas of data, i.e: Built-in Authorization
     %%
     %% Default: false
-    fast_total_counting => boolean()
+    fast_total_counting => boolean(),
+    %% Accumulate rows on the target node to avoid one RPC per ETS batch.
+    %% Default: false
+    accumulate_rows_on_node => boolean()
 }.
 
 -type query_return() :: #{meta := map(), data := [term()]}.
@@ -188,18 +191,15 @@ do_node_query(
     QueryState,
     ResultAcc
 ) ->
-    case do_query(Node, QueryState) of
+    case query_node(Node, QueryState, ResultAcc) of
         {error, Error} ->
             {error, Node, Error};
-        {Rows, NQueryState = #{complete := Complete}} ->
-            case accumulate_query_rows(Node, Rows, NQueryState, ResultAcc) of
-                {enough, NResultAcc} ->
-                    finalize_query(NResultAcc, NQueryState);
-                {_, NResultAcc} when Complete ->
-                    finalize_query(NResultAcc, NQueryState);
-                {more, NResultAcc} ->
-                    do_node_query(Node, NQueryState, NResultAcc)
-            end
+        {enough, NResultAcc, NQueryState} ->
+            finalize_query(NResultAcc, NQueryState);
+        {complete, NResultAcc, NQueryState} ->
+            finalize_query(NResultAcc, NQueryState);
+        {continue, NResultAcc, NQueryState} ->
+            do_node_query(Node, NQueryState, NResultAcc)
     end.
 
 %%--------------------------------------------------------------------
@@ -311,22 +311,94 @@ do_cluster_query(
     QueryState,
     ResultAcc
 ) ->
-    case do_query(Node, QueryState) of
+    case query_node(Node, QueryState, ResultAcc) of
         {error, Error} ->
             {error, Node, Error};
-        {Rows, NQueryState = #{complete := Complete}} ->
-            case accumulate_query_rows(Node, Rows, NQueryState, ResultAcc) of
-                {enough, NResultAcc} ->
-                    FQueryState = maybe_collect_total_from_tail_nodes(Tail, NQueryState),
-                    FComplete = Complete andalso Tail =:= [],
-                    finalize_query(NResultAcc, mark_complete(FQueryState, FComplete));
-                {more, NResultAcc} when not Complete ->
-                    do_cluster_query(Nodes, NQueryState, NResultAcc);
-                {more, NResultAcc} when Tail =/= [] ->
-                    do_cluster_query(Tail, reset_query_state(NQueryState), NResultAcc);
-                {more, NResultAcc} ->
-                    finalize_query(NResultAcc, NQueryState)
-            end
+        {enough, NResultAcc, NQueryState = #{complete := Complete}} ->
+            FQueryState = maybe_collect_total_from_tail_nodes(Tail, NQueryState),
+            FComplete = Complete andalso Tail =:= [],
+            finalize_query(NResultAcc, mark_complete(FQueryState, FComplete));
+        {continue, NResultAcc, NQueryState} ->
+            do_cluster_query(Nodes, NQueryState, NResultAcc);
+        {complete, NResultAcc, NQueryState} when Tail =/= [] ->
+            do_cluster_query(Tail, reset_query_state(NQueryState), NResultAcc);
+        {complete, NResultAcc, NQueryState} ->
+            finalize_query(NResultAcc, NQueryState)
+    end.
+
+query_node(Node, QueryState = #{options := Options}, ResultAcc) ->
+    case maps:get(accumulate_rows_on_node, Options, false) of
+        true ->
+            query_node_accumulated(Node, QueryState, ResultAcc);
+        false ->
+            query_node_once(Node, QueryState, ResultAcc)
+    end.
+
+query_node_accumulated(Node, QueryState, ResultAcc) when Node =:= node() ->
+    accumulate_query_rows_on_node(QueryState, ResultAcc);
+query_node_accumulated(Node, QueryState, ResultAcc) ->
+    %% New nodes recognize `result_acc` and return a tagged accumulated result.
+    %% Old nodes preserve the unknown field and return one batch in the legacy format.
+    RequestState = QueryState#{result_acc => init_node_query_result(ResultAcc)},
+    case do_query(Node, RequestState) of
+        {accumulated, {Status, NodeResultAcc, NQueryState}} ->
+            {Status, merge_node_query_result(ResultAcc, NodeResultAcc), NQueryState};
+        {accumulated, {error, _} = Error} ->
+            Error;
+        {error, _} = Error ->
+            Error;
+        {Rows, NQueryState0} ->
+            NQueryState = maps:remove(result_acc, NQueryState0),
+            accumulate_query_rows_result(Node, Rows, NQueryState, ResultAcc)
+    end.
+
+init_node_query_result(#{
+    cursor := Cursor,
+    count := Count,
+    overflow := Overflow
+}) ->
+    #{
+        cursor => Cursor,
+        count => Count,
+        rows => [],
+        overflow => Overflow
+    }.
+
+merge_node_query_result(ResultAcc = #{rows := PreviousRows}, NodeResultAcc = #{rows := NodeRows}) ->
+    MergedResultAcc = maps:merge(ResultAcc, NodeResultAcc),
+    MergedResultAcc#{rows := NodeRows ++ PreviousRows}.
+
+query_node_once(Node, QueryState, ResultAcc) ->
+    case do_query(Node, QueryState) of
+        {error, _} = Error ->
+            Error;
+        {Rows, NQueryState} ->
+            accumulate_query_rows_result(Node, Rows, NQueryState, ResultAcc)
+    end.
+
+accumulate_query_rows_result(
+    Node,
+    Rows,
+    NQueryState = #{complete := Complete},
+    ResultAcc
+) ->
+    case accumulate_query_rows(Node, Rows, NQueryState, ResultAcc) of
+        {enough, NResultAcc} ->
+            {enough, NResultAcc, NQueryState};
+        {more, NResultAcc} when Complete ->
+            {complete, NResultAcc, NQueryState};
+        {more, NResultAcc} ->
+            {continue, NResultAcc, NQueryState}
+    end.
+
+-spec accumulate_query_rows_on_node(map(), map()) ->
+    {enough | complete, map(), map()} | {error, term()}.
+accumulate_query_rows_on_node(QueryState, ResultAcc) ->
+    case query_node_once(node(), QueryState, ResultAcc) of
+        {continue, NResultAcc, NQueryState} ->
+            accumulate_query_rows_on_node(NQueryState, NResultAcc);
+        Result ->
+            Result
     end.
 
 maybe_collect_total_from_tail_nodes([], QueryState) ->
@@ -425,6 +497,15 @@ mark_complete(QueryState, Complete) ->
     QueryState#{complete => Complete}.
 
 %% @private This function is exempt from BPAPI
+do_query(
+    Node,
+    QueryState = #{
+        options := #{accumulate_rows_on_node := true},
+        result_acc := ResultAcc
+    }
+) when Node =:= node() ->
+    NQueryState = maps:remove(result_acc, QueryState),
+    {accumulated, accumulate_query_rows_on_node(NQueryState, ResultAcc)};
 do_query(Node, QueryState) when Node =:= node() ->
     do_select(Node, QueryState);
 do_query(Node, QueryState) ->

--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -216,14 +216,29 @@ do_subscriptions_query(QString0) ->
     end.
 
 do_subscriptions_query_mem(QString) ->
-    Args = [?SUBOPTION, QString, ?SUBS_QSCHEMA, fun ?MODULE:qs2ms/2, fun ?MODULE:format/2],
+    Options = #{accumulate_rows_on_node => true},
     case maps:get(<<"node">>, QString, undefined) of
         undefined ->
-            erlang:apply(fun emqx_mgmt_api:cluster_query/5, Args);
+            emqx_mgmt_api:cluster_query(
+                ?SUBOPTION,
+                QString,
+                ?SUBS_QSCHEMA,
+                fun ?MODULE:qs2ms/2,
+                fun ?MODULE:format/2,
+                Options
+            );
         Node0 ->
             case emqx_utils:safe_to_existing_atom(Node0) of
                 {ok, Node1} ->
-                    erlang:apply(fun emqx_mgmt_api:node_query/6, [Node1 | Args]);
+                    emqx_mgmt_api:node_query(
+                        Node1,
+                        ?SUBOPTION,
+                        QString,
+                        ?SUBS_QSCHEMA,
+                        fun ?MODULE:qs2ms/2,
+                        fun ?MODULE:format/2,
+                        Options
+                    );
                 {error, _} ->
                     {error, Node0, {badrpc, <<"invalid node">>}}
             end

--- a/apps/emqx_management/test/emqx_mgmt_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_SUITE.erl
@@ -26,29 +26,12 @@ end_per_suite(_) ->
 %%--------------------------------------------------------------------
 
 t_cluster_query(Config) ->
-    net_kernel:start(['master@127.0.0.1', longnames]),
     ct:timetrap({seconds, 120}),
-    ListenerConf = fun(Port) ->
-        io_lib:format(
-            "\n listeners.tcp.default.bind = ~p"
-            "\n listeners.ssl.default.enable = false"
-            "\n listeners.ws.default.enable = false"
-            "\n listeners.wss.default.enable = false",
-            [Port]
-        )
-    end,
-    Nodes =
-        [Node1, Node2] = emqx_cth_cluster:start(
-            [
-                {corenode1, #{role => core, apps => [{emqx, ListenerConf(2883)}, emqx_management]}},
-                {corenode2, #{role => core, apps => [{emqx, ListenerConf(3883)}, emqx_management]}}
-            ],
-            #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
-        ),
+    Nodes = [Node1, Node2] = start_mgmt_cluster(?FUNCTION_NAME, Config),
     try
         process_flag(trap_exit, true),
-        ClientLs1 = [start_emqtt_client(Node1, I, 2883) || I <- lists:seq(1, 10)],
-        ClientLs2 = [start_emqtt_client(Node2, I, 3883) || I <- lists:seq(1, 10)],
+        ClientLs1 = [start_emqtt_client(Node1, I) || I <- lists:seq(1, 10)],
+        ClientLs2 = [start_emqtt_client(Node2, I) || I <- lists:seq(1, 10)],
 
         %% returned list should be the same regardless of which node is requested
         {200, ClientsAll} = query_clients(Node1, #{}),
@@ -172,6 +155,73 @@ t_cluster_query(Config) ->
         emqx_cth_cluster:stop(Nodes)
     end.
 
+t_cluster_query_deep_subscription_page(Config) ->
+    ct:timetrap({seconds, 120}),
+    Nodes = [Coordinator, DataNode] = start_mgmt_cluster(?FUNCTION_NAME, Config),
+    try
+        %% The API only scans this table; a live MQTT client is unnecessary here.
+        ok = erpc:call(DataNode, ?MODULE, insert_subscription_rows, [4]),
+        ok = erpc:call(Coordinator, meck, new, [emqx, [passthrough, no_link]]),
+        ok = erpc:call(Coordinator, meck, expect, [emqx, running_nodes, 0, [DataNode]]),
+        ok = erpc:call(DataNode, meck, new, [emqx_mgmt_api, [passthrough, no_link]]),
+
+        Response =
+            {200, #{data := [_], meta := #{page := 4, limit := 1, count := 4}}} =
+            query_subscriptions(Coordinator, #{<<"page">> => 4, <<"limit">> => 1}),
+        ?assertEqual(1, remote_query_call_count(DataNode)),
+
+        %% Emulate an old node which ignores the new request state and returns one batch.
+        ok = erpc:call(DataNode, meck, unload, [emqx_mgmt_api]),
+        ok = erpc:call(DataNode, meck, new, [emqx_mgmt_api, [passthrough, no_link]]),
+        ok = erpc:call(DataNode, meck, expect, [
+            emqx_mgmt_api,
+            do_query,
+            fun(Node, QueryState) ->
+                ResultAcc = maps:get(result_acc, QueryState),
+                LegacyQueryState = maps:remove(result_acc, QueryState),
+                {Rows, NQueryState} = meck:passthrough([Node, LegacyQueryState]),
+                {Rows, NQueryState#{result_acc => ResultAcc}}
+            end
+        ]),
+        ?assertEqual(
+            Response,
+            query_subscriptions(Coordinator, #{<<"page">> => 4, <<"limit">> => 1})
+        ),
+        ?assertEqual(4, remote_query_call_count(DataNode))
+    after
+        _ = catch erpc:call(DataNode, meck, unload, [emqx_mgmt_api]),
+        _ = catch erpc:call(Coordinator, meck, unload, [emqx]),
+        emqx_cth_cluster:stop(Nodes)
+    end.
+
+t_cluster_query_subscription_page_across_nodes(Config) ->
+    ct:timetrap({seconds, 120}),
+    Nodes = [Coordinator, DataNode] = start_mgmt_cluster(?FUNCTION_NAME, Config),
+    try
+        ok = erpc:call(Coordinator, ?MODULE, insert_subscription_rows, [2]),
+        ok = erpc:call(DataNode, ?MODULE, insert_subscription_rows, [2]),
+        ok = erpc:call(Coordinator, meck, new, [emqx, [passthrough, no_link]]),
+        ok = erpc:call(Coordinator, meck, expect, [
+            emqx,
+            running_nodes,
+            0,
+            [Coordinator, DataNode]
+        ]),
+
+        {200, #{
+            data := Subscriptions,
+            meta := #{page := 1, limit := 3, count := 4, hasnext := true}
+        }} = query_subscriptions(Coordinator, #{<<"page">> => 1, <<"limit">> => 3}),
+        ?assertEqual(3, length(Subscriptions)),
+        ?assertEqual(
+            [Coordinator, Coordinator, DataNode],
+            [maps:get(node, Subscription) || Subscription <- Subscriptions]
+        )
+    after
+        _ = catch erpc:call(Coordinator, meck, unload, [emqx]),
+        emqx_cth_cluster:stop(Nodes)
+    end.
+
 t_bad_rpc(Config) ->
     Apps = emqx_cth_suite:start(
         [
@@ -201,6 +251,19 @@ t_bad_rpc(Config) ->
 %% helpers
 %%--------------------------------------------------------------------
 
+start_mgmt_cluster(Testcase, Config) ->
+    emqx_cth_cluster:start(
+        [
+            {corenode1, #{role => core, apps => [emqx, emqx_management]}},
+            {corenode2, #{role => core, apps => [emqx, emqx_management]}}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Testcase, Config)}
+    ).
+
+start_emqtt_client(Node, N) ->
+    Port = emqx_cth_cluster:get_tcp_mqtt_port(Node),
+    start_emqtt_client(Node, N, Port).
+
 start_emqtt_client(Node0, N, Port) ->
     Node = atom_to_binary(Node0),
     ClientId = iolist_to_binary([Node, "-", integer_to_binary(N)]),
@@ -214,3 +277,25 @@ query_clients(Node, Qs0) ->
         Qs0
     ),
     rpc:call(Node, emqx_mgmt_api_clients, clients, [get, #{query_string => Qs}]).
+
+query_subscriptions(Node, Qs0) ->
+    Qs = maps:merge(
+        #{<<"page">> => 1, <<"limit">> => 100},
+        Qs0
+    ),
+    erpc:call(Node, emqx_mgmt_api_subscriptions, subscriptions, [get, #{query_string => Qs}]).
+
+insert_subscription_rows(N) ->
+    Subscriber = self(),
+    Rows = [
+        {
+            {<<"t/", (integer_to_binary(I))/binary>>, Subscriber},
+            #{subid => <<"client-", (integer_to_binary(I))/binary>>, qos => 0}
+        }
+     || I <- lists:seq(1, N)
+    ],
+    true = ets:insert(emqx_suboption, Rows),
+    ok.
+
+remote_query_call_count(DataNode) ->
+    erpc:call(DataNode, meck, num_calls, [emqx_mgmt_api, do_query, ['_', '_']]).

--- a/changes/ee/perf-18185.en.md
+++ b/changes/ee/perf-18185.en.md
@@ -1,0 +1,1 @@
+Improved deep-page queries in the subscriptions HTTP API by accumulating in-memory subscription rows on each target node, avoiding one RPC per pagination batch.


### PR DESCRIPTION
Release versions:
- 6.0.4
- 6.1.4
- 6.2.3
- 6.3.0

## Summary

Fix: https://github.com/emqx/emqx/issues/17945

Port #18138 to dev-60. Move in-memory subscription page accumulation to each target node, reducing deep-page queries from one RPC per ETS batch to one RPC per target node. Older nodes automatically continue through the legacy per-batch loop.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)