### PR TITLE
fix(plugins): [defense-in-depth] plugin framework against malicious packages

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -799,7 +799,14 @@ install_package(FileName, Bin) ->
     install_package_v4(NameVsn, Bin).
 
 install_package_v4(NameVsn, Bin) ->
-    ok = emqx_plugins:write_package(NameVsn, Bin),
+    case emqx_plugins:write_package(NameVsn, Bin) of
+        ok ->
+            install_written_package_v4(NameVsn);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+install_written_package_v4(NameVsn) ->
     case emqx_plugins:ensure_installed(NameVsn, ?fresh_install) of
         {error, #{reason := ?plugin_not_found}} = NotFound ->
             NotFound;

--- a/apps/emqx_plugins/mix.exs
+++ b/apps/emqx_plugins/mix.exs
@@ -25,6 +25,11 @@ defmodule EMQXPlugins.MixProject do
     UMP.deps([
       {:emqx, in_umbrella: true},
       :erlavro
-    ])
+    ]) ++
+      if UMP.test_env?() do
+        [{:cth_readable, "1.5.1"}]
+      else
+        []
+      end
   end
 end

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -8,40 +8,40 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
 
-%% Browser/security-sensitive response headers that plugin API callbacks
-%% are not allowed to set. All names must be lower-case binary because
+%% Response headers that plugin API callbacks are allowed to set. An
+%% allow-list is used instead of a deny-list because a deny-list is doomed to
+%% be incomplete — every new browser security mechanism adds another header
+%% to deny. Plugins that need a custom header must prefix it with
+%% `x-plugin-'. All names must be lower-case binary because
 %% `normalize_headers/1' lower-cases keys.
--define(PLUGIN_API_FORBIDDEN_HEADERS, [
-    %% auth
-    <<"authorization">>,
-    <<"www-authenticate">>,
-    <<"proxy-authenticate">>,
-    %% cookies
-    <<"cookie">>,
-    <<"cookie2">>,
-    <<"set-cookie">>,
-    <<"set-cookie2">>,
-    %% CORS
-    <<"access-control-allow-origin">>,
-    <<"access-control-allow-credentials">>,
-    <<"access-control-allow-methods">>,
-    <<"access-control-allow-headers">>,
-    <<"access-control-expose-headers">>,
-    <<"access-control-max-age">>,
-    <<"access-control-request-method">>,
-    <<"access-control-request-headers">>,
-    %% redirects
-    <<"location">>,
-    <<"refresh">>,
-    %% security/policy
-    <<"content-security-policy">>,
-    <<"content-security-policy-report-only">>,
-    <<"strict-transport-security">>,
-    <<"x-frame-options">>,
-    <<"x-content-type-options">>,
-    <<"referrer-policy">>,
-    <<"permissions-policy">>
+-define(PLUGIN_API_ALLOWED_HEADERS, [
+    %% content metadata
+    <<"content-type">>,
+    <<"content-language">>,
+    <<"content-disposition">>,
+    <<"content-range">>,
+    <<"accept-ranges">>,
+    %% caching
+    <<"cache-control">>,
+    <<"expires">>,
+    <<"pragma">>,
+    %% entity/validation
+    <<"etag">>,
+    <<"last-modified">>,
+    <<"age">>,
+    <<"vary">>,
+    %% misc safe
+    <<"retry-after">>,
+    %% correlation ids
+    <<"x-request-id">>,
+    <<"x-correlation-id">>,
+    %% rate limiting
+    <<"x-ratelimit-limit">>,
+    <<"x-ratelimit-remaining">>,
+    <<"x-ratelimit-reset">>
 ]).
+
+-define(PLUGIN_API_CUSTOM_HEADER_PREFIX, <<"x-plugin-">>).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -695,19 +695,16 @@ map_plugin_api_result(_Other) ->
     {500, #{code => <<"INTERNAL_ERROR">>, message => <<"Invalid Plugin API Response">>}}.
 
 filter_plugin_api_headers(Headers) ->
-    maps:filter(fun(K, _V) -> not is_forbidden_header(K) end, Headers).
+    maps:filter(fun(K, _V) -> is_allowed_header(K) end, Headers).
 
-is_forbidden_header(Header) when is_binary(Header) ->
-    is_forbidden_header_lower(to_bin(string:lowercase(Header)));
-is_forbidden_header(_) ->
-    true.
+is_allowed_header(Header) when is_binary(Header) ->
+    Lower = to_bin(string:lowercase(Header)),
+    lists:member(Lower, ?PLUGIN_API_ALLOWED_HEADERS) orelse is_custom_header(Lower);
+is_allowed_header(_) ->
+    false.
 
-is_forbidden_header_lower(<<"access-control-", _/binary>>) ->
-    true;
-is_forbidden_header_lower(Lower) when is_binary(Lower) ->
-    lists:member(Lower, ?PLUGIN_API_FORBIDDEN_HEADERS);
-is_forbidden_header_lower(_) ->
-    true.
+is_custom_header(Header) ->
+    nomatch =/= string:prefix(Header, ?PLUGIN_API_CUSTOM_HEADER_PREFIX).
 
 normalize_headers(Headers) when is_map(Headers) ->
     maps:from_list([{to_bin(K), iolist_to_binary(V)} || {K, V} <- maps:to_list(Headers)]);
@@ -1646,63 +1643,5 @@ ensure_no_other_version_active_rejects_running_case() ->
         }},
         ensure_no_other_version_active(Plugins, <<"demo-2.0.0">>)
     ).
-
-map_plugin_api_result_filters_forbidden_headers_test() ->
-    Forbidden = [
-        <<"authorization">>,
-        <<"www-authenticate">>,
-        <<"proxy-authenticate">>,
-        <<"cookie">>,
-        <<"cookie2">>,
-        <<"set-cookie">>,
-        <<"set-cookie2">>,
-        <<"access-control-allow-origin">>,
-        <<"access-control-request-method">>,
-        <<"location">>,
-        <<"refresh">>,
-        <<"content-security-policy">>,
-        <<"strict-transport-security">>,
-        <<"x-frame-options">>,
-        <<"x-content-type-options">>,
-        <<"referrer-policy">>,
-        <<"permissions-policy">>
-    ],
-    Allowed = [
-        <<"content-type">>,
-        <<"content-length">>,
-        <<"cache-control">>,
-        <<"etag">>,
-        <<"x-request-id">>,
-        <<"x-plugin-custom">>
-    ],
-    Headers = maps:from_list([{K, <<"1">>} || K <- Forbidden ++ Allowed]),
-    {200, RespHeaders, #{ok := true}} = map_plugin_api_result(
-        {ok, 200, Headers, #{ok => true}}
-    ),
-    [?assertNot(maps:is_key(K, RespHeaders)) || K <- Forbidden],
-    [?assertEqual(<<"1">>, maps:get(K, RespHeaders)) || K <- Allowed],
-    %% error clause is filtered too
-    {401, ErrHeaders, #{error := true}} = map_plugin_api_result(
-        {error, 401, Headers, #{error => true}}
-    ),
-    [?assertNot(maps:is_key(K, ErrHeaders)) || K <- Forbidden],
-    [?assertEqual(<<"1">>, maps:get(K, ErrHeaders)) || K <- Allowed].
-
-map_plugin_api_result_case_insensitive_test() ->
-    Headers = #{
-        <<"Set-Cookie">> => <<"a">>,
-        <<"LOCATION">> => <<"b">>,
-        <<"Content-Type">> => <<"c">>
-    },
-    {200, RespHeaders, #{}} = map_plugin_api_result({ok, 200, Headers, #{}}),
-    %% Forbidden headers filtered regardless of input case
-    [
-        ?assertNot(maps:is_key(K, RespHeaders))
-     || K <- [<<"set-cookie">>, <<"Set-Cookie">>, <<"location">>, <<"LOCATION">>]
-    ],
-    %% Allowed headers preserved (normalization keeps original case)
-    KEs = maps:keys(RespHeaders),
-    ?assert(lists:any(fun(K) -> string:equal(string:lowercase(K), <<"content-type">>) end, KEs)),
-    ?assertEqual(<<"c">>, iolist_to_binary(maps:get(<<"Content-Type">>, RespHeaders))).
 
 -endif.

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -8,8 +8,44 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
 
+%% Browser/security-sensitive response headers that plugin API callbacks
+%% are not allowed to set. All names must be lower-case binary because
+%% `normalize_headers/1' lower-cases keys.
+-define(PLUGIN_API_FORBIDDEN_HEADERS, [
+    %% auth
+    <<"authorization">>,
+    <<"www-authenticate">>,
+    <<"proxy-authenticate">>,
+    %% cookies
+    <<"cookie">>,
+    <<"cookie2">>,
+    <<"set-cookie">>,
+    <<"set-cookie2">>,
+    %% CORS
+    <<"access-control-allow-origin">>,
+    <<"access-control-allow-credentials">>,
+    <<"access-control-allow-methods">>,
+    <<"access-control-allow-headers">>,
+    <<"access-control-expose-headers">>,
+    <<"access-control-max-age">>,
+    <<"access-control-request-method">>,
+    <<"access-control-request-headers">>,
+    %% redirects
+    <<"location">>,
+    <<"refresh">>,
+    %% security/policy
+    <<"content-security-policy">>,
+    <<"content-security-policy-report-only">>,
+    <<"strict-transport-security">>,
+    <<"x-frame-options">>,
+    <<"x-content-type-options">>,
+    <<"referrer-policy">>,
+    <<"permissions-policy">>
+]).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-export([map_plugin_api_result/1]).
 -endif.
 
 -export([
@@ -374,7 +410,7 @@ delete_state(NameVsn) ->
     ensure_delete_state(NameVsn).
 
 %% @doc Write the package file.
--spec write_package(name_vsn(), binary()) -> ok.
+-spec write_package(name_vsn(), binary()) -> ok | {error, map()}.
 write_package(NameVsn, Bin) ->
     emqx_plugins_fs:write_tar(NameVsn, Bin).
 
@@ -648,15 +684,30 @@ resolve_active_name_vsn(Plugin0, ActiveNameVsns) ->
     end.
 
 map_plugin_api_result({ok, Status, Headers, Body}) when is_integer(Status) ->
-    {Status, normalize_headers(Headers), Body};
+    {Status, filter_plugin_api_headers(normalize_headers(Headers)), Body};
 map_plugin_api_result({error, Code, Msg}) ->
     {400, #{code => to_bin(Code), message => to_bin(Msg)}};
 map_plugin_api_result({error, Status, Headers, Body}) when is_integer(Status) ->
-    {Status, normalize_headers(Headers), Body};
+    {Status, filter_plugin_api_headers(normalize_headers(Headers)), Body};
 map_plugin_api_result({error, not_found}) ->
     {404, #{code => <<"NOT_FOUND">>, message => <<"Plugin API Not Found">>}};
 map_plugin_api_result(_Other) ->
     {500, #{code => <<"INTERNAL_ERROR">>, message => <<"Invalid Plugin API Response">>}}.
+
+filter_plugin_api_headers(Headers) ->
+    maps:filter(fun(K, _V) -> not is_forbidden_header(K) end, Headers).
+
+is_forbidden_header(Header) when is_binary(Header) ->
+    is_forbidden_header_lower(to_bin(string:lowercase(Header)));
+is_forbidden_header(_) ->
+    true.
+
+is_forbidden_header_lower(<<"access-control-", _/binary>>) ->
+    true;
+is_forbidden_header_lower(Lower) when is_binary(Lower) ->
+    lists:member(Lower, ?PLUGIN_API_FORBIDDEN_HEADERS);
+is_forbidden_header_lower(_) ->
+    true.
 
 normalize_headers(Headers) when is_map(Headers) ->
     maps:from_list([{to_bin(K), iolist_to_binary(V)} || {K, V} <- maps:to_list(Headers)]);
@@ -847,15 +898,19 @@ get_tar(NameVsn) ->
 
 -spec install_package(name_vsn(), binary()) -> ok | {error, term()}.
 install_package(NameVsn, Bin) ->
-    ok = write_package(NameVsn, Bin),
-    case ensure_installed(NameVsn, ?fresh_install) of
-        {error, #{reason := plugin_not_found}} = NotFound ->
-            NotFound;
-        {error, _} = Error ->
-            _ = delete_package(NameVsn),
-            Error;
-        Result ->
-            Result
+    case write_package(NameVsn, Bin) of
+        ok ->
+            case ensure_installed(NameVsn, ?fresh_install) of
+                {error, #{reason := plugin_not_found}} = NotFound ->
+                    NotFound;
+                {error, _} = Error ->
+                    _ = delete_package(NameVsn),
+                    Error;
+                Result ->
+                    Result
+            end;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %%--------------------------------------------------------------------
@@ -985,7 +1040,8 @@ get_package_from_node(Node, NameVsn) ->
 get_package_from_any_node([], _NameVsn, Errors) ->
     {error, Errors};
 get_package_from_any_node([Node | T], NameVsn, Errors) ->
-    case emqx_plugins_proto_v2:get_tar(Node, NameVsn, infinity) of
+    Timeout = emqx_plugins_fs:max_extraction_time_ms(),
+    case emqx_plugins_proto_v2:get_tar(Node, NameVsn, Timeout) of
         {ok, _} = Res ->
             ?SLOG(debug, #{
                 msg => "get_plugin_tar_from_cluster_successfully",
@@ -1590,5 +1646,63 @@ ensure_no_other_version_active_rejects_running_case() ->
         }},
         ensure_no_other_version_active(Plugins, <<"demo-2.0.0">>)
     ).
+
+map_plugin_api_result_filters_forbidden_headers_test() ->
+    Forbidden = [
+        <<"authorization">>,
+        <<"www-authenticate">>,
+        <<"proxy-authenticate">>,
+        <<"cookie">>,
+        <<"cookie2">>,
+        <<"set-cookie">>,
+        <<"set-cookie2">>,
+        <<"access-control-allow-origin">>,
+        <<"access-control-request-method">>,
+        <<"location">>,
+        <<"refresh">>,
+        <<"content-security-policy">>,
+        <<"strict-transport-security">>,
+        <<"x-frame-options">>,
+        <<"x-content-type-options">>,
+        <<"referrer-policy">>,
+        <<"permissions-policy">>
+    ],
+    Allowed = [
+        <<"content-type">>,
+        <<"content-length">>,
+        <<"cache-control">>,
+        <<"etag">>,
+        <<"x-request-id">>,
+        <<"x-plugin-custom">>
+    ],
+    Headers = maps:from_list([{K, <<"1">>} || K <- Forbidden ++ Allowed]),
+    {200, RespHeaders, #{ok := true}} = map_plugin_api_result(
+        {ok, 200, Headers, #{ok => true}}
+    ),
+    [?assertNot(maps:is_key(K, RespHeaders)) || K <- Forbidden],
+    [?assertEqual(<<"1">>, maps:get(K, RespHeaders)) || K <- Allowed],
+    %% error clause is filtered too
+    {401, ErrHeaders, #{error := true}} = map_plugin_api_result(
+        {error, 401, Headers, #{error => true}}
+    ),
+    [?assertNot(maps:is_key(K, ErrHeaders)) || K <- Forbidden],
+    [?assertEqual(<<"1">>, maps:get(K, ErrHeaders)) || K <- Allowed].
+
+map_plugin_api_result_case_insensitive_test() ->
+    Headers = #{
+        <<"Set-Cookie">> => <<"a">>,
+        <<"LOCATION">> => <<"b">>,
+        <<"Content-Type">> => <<"c">>
+    },
+    {200, RespHeaders, #{}} = map_plugin_api_result({ok, 200, Headers, #{}}),
+    %% Forbidden headers filtered regardless of input case
+    [
+        ?assertNot(maps:is_key(K, RespHeaders))
+     || K <- [<<"set-cookie">>, <<"Set-Cookie">>, <<"location">>, <<"LOCATION">>]
+    ],
+    %% Allowed headers preserved (normalization keeps original case)
+    KEs = maps:keys(RespHeaders),
+    ?assert(lists:any(fun(K) -> string:equal(string:lowercase(K), <<"content-type">>) end, KEs)),
+    ?assertEqual(<<"c">>, iolist_to_binary(maps:get(<<"Content-Type">>, RespHeaders))).
 
 -endif.

--- a/apps/emqx_plugins/src/emqx_plugins_cli_utils.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_cli_utils.erl
@@ -204,7 +204,8 @@ print_cluster_result(Nodes, Results, NameVsn, LogFun) ->
             [] -> ok;
             _ -> {error, maps:from_list(Errors)}
         end,
-    print(NameVsn, Result, LogFun, ensure_installed_cluster).
+    print(NameVsn, Result, LogFun, ensure_installed_cluster),
+    Result.
 
 disallow_installation(NameVsn, LogFun) ->
     try emqx_plugins_utils:parse_name_vsn(NameVsn) of
@@ -236,19 +237,55 @@ do_disallow_installation(NameVsn, LogFun) ->
     ?PRINT(Result, LogFun).
 
 ensure_installed(NameVsn, LogFun) ->
+    %% The CLI path must enforce the same allow gate as the HTTP upload path:
+    %% a tarball that landed in the install dir (e.g. via cluster replication
+    %% or manual placement) must not be installable without an explicit
+    %% `plugins allow' grant from the admin.
+    case emqx_plugins:is_allowed_installation(NameVsn) of
+        true ->
+            Result = do_ensure_installed(NameVsn),
+            maybe_forget_grant(NameVsn, Result),
+            ?PRINT(Result, LogFun);
+        false ->
+            ?PRINT({error, not_allowed}, LogFun)
+    end.
+
+do_ensure_installed(NameVsn) ->
     case emqx_plugins:describe(NameVsn, #{}) of
         {ok, _} ->
-            ?PRINT(
-                {error, #{
-                    msg => "plugin_already_installed", name_vsn => NameVsn
-                }},
-                LogFun
-            );
+            {error, #{
+                msg => "plugin_already_installed", name_vsn => NameVsn
+            }};
         {error, _} ->
-            ?PRINT(emqx_plugins:ensure_installed(NameVsn, ?fresh_install), LogFun)
+            emqx_plugins:ensure_installed(NameVsn, ?fresh_install)
     end.
 
 ensure_installed_cluster(NameVsn, LogFun) ->
+    %% Same allow gate as the single-node CLI install: the tarball is read
+    %% from the local install dir and pushed to all nodes, so it must not be
+    %% installable without an explicit `plugins allow' grant either.
+    case emqx_plugins:is_allowed_installation(NameVsn) of
+        true ->
+            Result = do_ensure_installed_cluster(NameVsn, LogFun),
+            maybe_forget_grant(NameVsn, Result),
+            Result;
+        false ->
+            ?PRINT({error, not_allowed}, LogFun)
+    end.
+
+%% Consume the grant only on success; retain it on failure so the admin can
+%% retry after fixing the underlying problem. Mirroring the HTTP upload
+%% path, the grant is revoked cluster-wide because `plugins allow' is issued
+%% cluster-wide — a local-only forget would leave the grant reusable on
+%% other nodes until its TTL expires.
+maybe_forget_grant(NameVsn, ok) ->
+    Nodes = emqx:running_nodes(),
+    _ = emqx_plugins_proto_v3:disallow_installation(Nodes, NameVsn),
+    ok;
+maybe_forget_grant(_NameVsn, _Result) ->
+    ok.
+
+do_ensure_installed_cluster(NameVsn, LogFun) ->
     case emqx_plugins_fs:get_tar(NameVsn) of
         {ok, TarBin} ->
             Running = emqx:running_nodes(),
@@ -262,10 +299,12 @@ ensure_installed_cluster(NameVsn, LogFun) ->
                         hint => <<"cluster install requires all nodes to support proto v5">>,
                         nodes_missing_v5 => Missing
                     },
-                    ?PRINT({error, Reason}, LogFun)
+                    ?PRINT({error, Reason}, LogFun),
+                    {error, Reason}
             end;
         {error, Reason} ->
-            ?PRINT({error, Reason}, LogFun)
+            ?PRINT({error, Reason}, LogFun),
+            {error, Reason}
     end.
 
 ensure_uninstalled(NameVsn, LogFun) ->

--- a/apps/emqx_plugins/src/emqx_plugins_cli_utils.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_cli_utils.erl
@@ -257,7 +257,24 @@ do_ensure_installed(NameVsn) ->
                 msg => "plugin_already_installed", name_vsn => NameVsn
             }};
         {error, _} ->
-            emqx_plugins:ensure_installed(NameVsn, ?fresh_install)
+            case check_local_tar_sha256(NameVsn) of
+                ok ->
+                    emqx_plugins:ensure_installed(NameVsn, ?fresh_install);
+                {error, _} = Error ->
+                    Error
+            end
+    end.
+
+%% If the allow entry recorded a sha256 for the package, verify that the
+%% tarball already present in the install dir matches before installing.
+%% A tarball fetched from another node (no local copy yet) cannot be
+%% checked here; the download path performs its own validation.
+check_local_tar_sha256(NameVsn) ->
+    case emqx_plugins_fs:get_tar(NameVsn) of
+        {ok, TarBin} ->
+            emqx_plugins:is_allowed_installation(NameVsn, TarBin);
+        {error, _} ->
+            ok
     end.
 
 ensure_installed_cluster(NameVsn, LogFun) ->
@@ -288,17 +305,26 @@ maybe_forget_grant(_NameVsn, _Result) ->
 do_ensure_installed_cluster(NameVsn, LogFun) ->
     case emqx_plugins_fs:get_tar(NameVsn) of
         {ok, TarBin} ->
-            Running = emqx:running_nodes(),
-            V5Nodes = nodes_supporting_bpapi_version(5),
-            case Running -- V5Nodes of
-                [] ->
-                    Results = emqx_plugins_proto_v5:install_package(V5Nodes, NameVsn, TarBin),
-                    print_cluster_result(V5Nodes, Results, NameVsn, LogFun);
-                Missing ->
-                    Reason = #{
-                        hint => <<"cluster install requires all nodes to support proto v5">>,
-                        nodes_missing_v5 => Missing
-                    },
+            case emqx_plugins:is_allowed_installation(NameVsn, TarBin) of
+                ok ->
+                    Running = emqx:running_nodes(),
+                    V5Nodes = nodes_supporting_bpapi_version(5),
+                    case Running -- V5Nodes of
+                        [] ->
+                            Results = emqx_plugins_proto_v5:install_package(
+                                V5Nodes, NameVsn, TarBin
+                            ),
+                            print_cluster_result(V5Nodes, Results, NameVsn, LogFun);
+                        Missing ->
+                            Reason = #{
+                                hint =>
+                                    <<"cluster install requires all nodes to support proto v5">>,
+                                nodes_missing_v5 => Missing
+                            },
+                            ?PRINT({error, Reason}, LogFun),
+                            {error, Reason}
+                    end;
+                {error, Reason} ->
                     ?PRINT({error, Reason}, LogFun),
                     {error, Reason}
             end;

--- a/apps/emqx_plugins/src/emqx_plugins_fs.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_fs.erl
@@ -9,9 +9,11 @@
 -include("emqx_plugins.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
+-include_lib("kernel/include/file.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-export([normalize_dir/1, top_dir/2, is_safe_entry/2]).
 -endif.
 
 %% Tarfile operations
@@ -62,7 +64,8 @@
     install_dir/0,
     tar_file_path/1,
     info_file_path/1,
-    plugin_dir/1
+    plugin_dir/1,
+    max_extraction_time_ms/0
 ]).
 
 %%--------------------------------------------------------------------
@@ -148,16 +151,38 @@ list_name_vsn() ->
 -spec get_tar(name_vsn()) -> {ok, binary()} | {error, any}.
 get_tar(NameVsn) ->
     TarGz = tar_file_path(NameVsn),
-    case file:read_file(TarGz) of
-        {ok, Content} ->
-            {ok, Content};
-        {error, _} ->
+    case read_tar_if_size_ok(TarGz) of
+        {error, enoent} ->
             case create_tar(NameVsn, TarGz) of
                 ok ->
-                    file:read_file(TarGz);
+                    read_tar_if_size_ok(TarGz);
                 Err ->
                     Err
-            end
+            end;
+        Result ->
+            Result
+    end.
+
+%% Read the tarball only after verifying its on-disk size is within
+%% `max_package_size'. Checking after `file:read_file/1' would have already
+%% loaded an oversized package into memory, defeating the limit.
+read_tar_if_size_ok(TarGz) ->
+    case file:read_file_info(TarGz) of
+        {ok, #file_info{size = Size}} ->
+            Limit = max_package_size(),
+            case Size > Limit of
+                true ->
+                    {error, #{
+                        msg => "package_too_large",
+                        reason => package_size_limit_exceeded,
+                        size => Size,
+                        limit => Limit
+                    }};
+                false ->
+                    file:read_file(TarGz)
+            end;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 -spec is_tar_present(name_vsn()) ->
@@ -169,13 +194,23 @@ is_tar_present(NameVsn) ->
         false -> false
     end.
 
--spec write_tar(name_vsn(), iodata()) -> ok.
+-spec write_tar(name_vsn(), iodata()) -> ok | {error, map()}.
 write_tar(NameVsn, Content) ->
-    TarFilePath = tar_file_path(NameVsn),
-    ok = filelib:ensure_dir(TarFilePath),
-    ok = file:write_file(TarFilePath, Content),
-    MD5 = emqx_utils:bin_to_hexstr(crypto:hash(md5, Content), lower),
-    ok = file:write_file(md5sum_file_path(NameVsn), MD5).
+    case iolist_size(Content) > max_package_size() of
+        true ->
+            {error, #{
+                msg => "package_too_large",
+                reason => package_size_limit_exceeded,
+                size => iolist_size(Content),
+                limit => max_package_size()
+            }};
+        false ->
+            TarFilePath = tar_file_path(NameVsn),
+            ok = filelib:ensure_dir(TarFilePath),
+            ok = file:write_file(TarFilePath, Content),
+            MD5 = emqx_utils:bin_to_hexstr(crypto:hash(md5, Content), lower),
+            ok = file:write_file(md5sum_file_path(NameVsn), MD5)
+    end.
 
 %%--------------------------------------------------------------------
 %% Plugin package extraction
@@ -183,24 +218,41 @@ write_tar(NameVsn, Content) ->
 
 install_from_local_tar(NameVsn, InstallValidator) ->
     TarGz = tar_file_path(NameVsn),
-    case erl_tar:extract(TarGz, [compressed, memory]) of
-        {ok, TarContent} ->
-            case write_tar_file_content(install_dir(), TarContent) of
-                ok ->
-                    case InstallValidator() of
-                        ok ->
-                            ok;
-                        {error, Reason} ->
-                            ?SLOG(warning, #{
-                                msg => "failed_to_read_after_install", reason => Reason
-                            }),
-                            ok = delete_tar_file_content(install_dir(), TarContent),
-                            {error, Reason}
-                    end;
-                {error, Reason} ->
-                    {error, Reason}
+    maybe
+        ok ?= validate_package_file_size(TarGz),
+        ok ?= validate_decompressed_storage_limits(TarGz),
+        {ok, TarContent} ?= extract_tarball(TarGz),
+        ok ?= validate_decompressed_size(TarContent),
+        ok ?= write_tar_file_content(install_dir(), TarContent),
+        case InstallValidator() of
+            ok ->
+                ok;
+            {error, Reason} ->
+                ?SLOG(warning, #{
+                    msg => "failed_to_read_after_install", reason => Reason
+                }),
+                ok = delete_tar_file_content(install_dir(), TarContent),
+                {error, Reason}
+        end
+    end.
+
+validate_package_file_size(TarGz) ->
+    case file:read_file_info(TarGz) of
+        {ok, #file_info{size = Size}} ->
+            Limit = max_package_size(),
+            case Size > Limit of
+                true ->
+                    {error, #{
+                        msg => "package_too_large",
+                        path => TarGz,
+                        reason => package_size_limit_exceeded,
+                        size => Size,
+                        limit => Limit
+                    }};
+                false ->
+                    ok
             end;
-        {error, {_, enoent}} ->
+        {error, enoent} ->
             {error, #{
                 msg => "failed_to_extract_plugin_package",
                 path => TarGz,
@@ -212,6 +264,177 @@ install_from_local_tar(NameVsn, InstallValidator) ->
                 path => TarGz,
                 reason => Reason
             }}
+    end.
+
+%% Read the tar entry table (names and metadata only, no content) and reject
+%% packages with too many entries, too-deep paths, or a total declared size
+%% beyond the limit before extraction. The table read itself runs in a
+%% time-bounded worker because reading a crafted archive can be slow.
+validate_decompressed_storage_limits(TarGz) ->
+    Timeout = max_extraction_time_ms(),
+    %% verbose mode returns {Name, Type, Size, Mtime, Mode, Uid, Gid} tuples,
+    %% giving us the declared sizes for a pre-extraction memory check
+    case run_with_timeout(fun() -> erl_tar:table(TarGz, [compressed, verbose]) end, Timeout) of
+        {ok, {ok, Entries}} ->
+            maybe
+                ok ?= validate_max_file_count(Entries),
+                ok ?= validate_max_path_deps(Entries),
+                ok ?= validate_max_decompressed_size(Entries)
+            end;
+        {ok, {error, Reason}} ->
+            {error, #{
+                msg => "bad_plugin_package",
+                path => TarGz,
+                reason => Reason
+            }};
+        {error, timeout} ->
+            {error, #{
+                msg => "tar_table_timeout",
+                path => TarGz,
+                reason => tar_table_timeout,
+                limit_ms => Timeout
+            }};
+        {error, {worker_down, Reason}} ->
+            {error, #{
+                msg => "bad_plugin_package",
+                path => TarGz,
+                reason => {tar_table_crashed, Reason}
+            }}
+    end.
+
+validate_max_file_count(Entries) ->
+    Count = length(Entries),
+    Limit = max_file_count(),
+    case Count > Limit of
+        true ->
+            {error, #{
+                msg => "too_many_files_in_package",
+                reason => file_count_limit_exceeded,
+                count => Count,
+                limit => Limit
+            }};
+        false ->
+            ok
+    end.
+
+validate_max_path_deps(Entries) ->
+    Limit = max_path_depth(),
+    case lists:any(fun(Entry) -> path_depth(entry_name(Entry)) > Limit end, Entries) of
+        true ->
+            {error, #{
+                msg => "tar_entry_path_too_deep",
+                reason => path_depth_limit_exceeded,
+                limit => Limit
+            }};
+        false ->
+            ok
+    end.
+
+path_depth(Name) ->
+    length(filename:split(Name)).
+
+%% Reject packages whose entries declare (in the tar table) a total
+%% decompressed size beyond the limit, before allocating memory for them.
+%% The post-extraction check remains as a backstop for entries whose actual
+%% size differs from the declared one.
+validate_max_decompressed_size(Entries) ->
+    Limit = max_decompressed_size(),
+    Declared = lists:sum([entry_size(E) || E <- Entries]),
+    case Declared > Limit of
+        true ->
+            {error, #{
+                msg => "decompressed_content_too_large",
+                reason => decompressed_size_limit_exceeded,
+                size => Declared,
+                limit => Limit
+            }};
+        false ->
+            ok
+    end.
+
+entry_name({Name, _, _, _, _, _, _}) ->
+    Name;
+entry_name(Name) ->
+    Name.
+
+entry_size({_, _, Size, _, _, _, _}) ->
+    Size;
+entry_size(_) ->
+    0.
+
+%% Run `Fun' in a monitored worker process so that an over-long operation
+%% can be aborted. Returns {ok, Result} | {error, timeout | {worker_down, Reason}}.
+run_with_timeout(Fun, Timeout) ->
+    Parent = self(),
+    {Pid, MRef} = spawn_monitor(fun() ->
+        Parent ! {run_result, self(), Fun()}
+    end),
+    receive
+        {run_result, Pid, Result} ->
+            erlang:demonitor(MRef, [flush]),
+            {ok, Result};
+        {'DOWN', MRef, process, Pid, Reason} ->
+            {error, {worker_down, Reason}}
+    after Timeout ->
+        exit(Pid, kill),
+        erlang:demonitor(MRef, [flush]),
+        {error, timeout}
+    end.
+
+%% Extract in a monitored worker process so that an over-long extraction can
+%% be aborted. Returns the same error shapes as the previous direct call.
+extract_tarball(TarGz) ->
+    Timeout = max_extraction_time_ms(),
+    case run_with_timeout(fun() -> erl_tar:extract(TarGz, [compressed, memory]) end, Timeout) of
+        {ok, Result} ->
+            map_extract_result(TarGz, Result);
+        {error, timeout} ->
+            {error, #{
+                msg => "package_extraction_timeout",
+                path => TarGz,
+                reason => extraction_time_limit_exceeded,
+                limit_ms => Timeout
+            }};
+        {error, {worker_down, Reason}} ->
+            {error, #{
+                msg => "bad_plugin_package",
+                path => TarGz,
+                reason => {extract_crashed, Reason}
+            }}
+    end.
+
+map_extract_result(_TarGz, {ok, TarContent}) ->
+    {ok, TarContent};
+map_extract_result(TarGz, {error, {_, enoent}}) ->
+    {error, #{
+        msg => "failed_to_extract_plugin_package",
+        path => TarGz,
+        reason => plugin_tarball_not_found
+    }};
+map_extract_result(TarGz, {error, Reason}) ->
+    {error, #{
+        msg => "bad_plugin_package",
+        path => TarGz,
+        reason => Reason
+    }}.
+
+validate_decompressed_size(TarContent) ->
+    Limit = max_decompressed_size(),
+    Total = lists:foldl(
+        fun({_Name, Bin}, Acc) -> Acc + byte_size(Bin) end,
+        0,
+        TarContent
+    ),
+    case Total > Limit of
+        true ->
+            {error, #{
+                msg => "decompressed_content_too_large",
+                reason => decompressed_size_limit_exceeded,
+                size => Total,
+                limit => Limit
+            }};
+        false ->
+            ok
     end.
 
 -spec ensure_installed_from_tar(name_vsn(), fun(() -> ok | {error, term()})) -> ok | {error, map()}.
@@ -275,6 +498,24 @@ lib_dir(NameVsn) ->
 
 install_dir() ->
     emqx_config:get([?CONF_ROOT, install_dir], "").
+
+%% Defaults must mirror emqx_plugins_schema. The two-arg form is used so
+%% that a hot-upgraded node whose config map predates `package_limits'
+%% still gets bounded extraction instead of a config_not_found crash.
+max_package_size() ->
+    emqx_config:get([?CONF_ROOT, package_limits, max_package_size], 10 * 1024 * 1024).
+
+max_decompressed_size() ->
+    emqx_config:get([?CONF_ROOT, package_limits, max_decompressed_size], 50 * 1024 * 1024).
+
+max_file_count() ->
+    emqx_config:get([?CONF_ROOT, package_limits, max_file_count], 10000).
+
+max_path_depth() ->
+    emqx_config:get([?CONF_ROOT, package_limits, max_path_depth], 32).
+
+max_extraction_time_ms() ->
+    emqx_config:get([?CONF_ROOT, package_limits, max_extraction_time_ms], 60_000).
 
 plugin_dir(NameVsn) ->
     wrap_to_list(filename:join([install_dir(), NameVsn])).
@@ -464,40 +705,3 @@ delete_file_if_exists(File) ->
         {error, Reason} ->
             {error, {delete_file_failed, File, Reason}}
     end.
-
--ifdef(TEST).
-normalize_dir_test_() ->
-    [
-        ?_assertEqual("foo", normalize_dir("foo")),
-        ?_assertEqual("foo", normalize_dir("foo/")),
-        ?_assertEqual("/foo", normalize_dir("/foo")),
-        ?_assertEqual("/foo", normalize_dir("/foo/"))
-    ].
-
-top_dir_test_() ->
-    [
-        ?_assertEqual({ok, "base/foo"}, top_dir("base", filename:join(["base", "foo", "bar"]))),
-        ?_assertEqual(
-            {ok, "/base/foo"}, top_dir("/base", filename:join(["/", "base", "foo", "bar"]))
-        ),
-        ?_assertEqual(
-            {ok, "/base/foo"}, top_dir("/base/", filename:join(["/", "base", "foo", "bar"]))
-        ),
-        ?_assertMatch({error, {out_of_bounds, _}}, top_dir("/base", filename:join(["/", "base"]))),
-        ?_assertMatch(
-            {error, {out_of_bounds, _}}, top_dir("/base", filename:join(["/", "foo", "bar"]))
-        )
-    ].
-
-is_safe_entry_test_() ->
-    %% Use cwd as a real existing directory; safe_relative_path/2 needs that.
-    {ok, Cwd} = file:get_cwd(),
-    [
-        ?_assert(is_safe_entry(Cwd, "evil-1.0.0/release.json")),
-        ?_assert(is_safe_entry(Cwd, "deep/nested/path.txt")),
-        ?_assertNot(is_safe_entry(Cwd, "../escape")),
-        ?_assertNot(is_safe_entry(Cwd, "../../../tmp/pwned")),
-        ?_assertNot(is_safe_entry(Cwd, "evil/../../../tmp/pwned")),
-        ?_assertNot(is_safe_entry(Cwd, "/abs/path"))
-    ].
--endif.

--- a/apps/emqx_plugins/src/emqx_plugins_fs.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_fs.erl
@@ -13,7 +13,6 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--export([normalize_dir/1, top_dir/2, is_safe_entry/2]).
 -endif.
 
 %% Tarfile operations
@@ -705,3 +704,40 @@ delete_file_if_exists(File) ->
         {error, Reason} ->
             {error, {delete_file_failed, File, Reason}}
     end.
+
+-ifdef(TEST).
+normalize_dir_test_() ->
+    [
+        ?_assertEqual("foo", normalize_dir("foo")),
+        ?_assertEqual("foo", normalize_dir("foo/")),
+        ?_assertEqual("/foo", normalize_dir("/foo")),
+        ?_assertEqual("/foo", normalize_dir("/foo/"))
+    ].
+
+top_dir_test_() ->
+    [
+        ?_assertEqual({ok, "base/foo"}, top_dir("base", filename:join(["base", "foo", "bar"]))),
+        ?_assertEqual(
+            {ok, "/base/foo"}, top_dir("/base", filename:join(["/", "base", "foo", "bar"]))
+        ),
+        ?_assertEqual(
+            {ok, "/base/foo"}, top_dir("/base/", filename:join(["/", "base", "foo", "bar"]))
+        ),
+        ?_assertMatch({error, {out_of_bounds, _}}, top_dir("/base", filename:join(["/", "base"]))),
+        ?_assertMatch(
+            {error, {out_of_bounds, _}}, top_dir("/base", filename:join(["/", "foo", "bar"]))
+        )
+    ].
+
+is_safe_entry_test_() ->
+    %% Use cwd as a real existing directory; safe_relative_path/2 needs that.
+    {ok, Cwd} = file:get_cwd(),
+    [
+        ?_assert(is_safe_entry(Cwd, "evil-1.0.0/release.json")),
+        ?_assert(is_safe_entry(Cwd, "deep/nested/path.txt")),
+        ?_assertNot(is_safe_entry(Cwd, "../escape")),
+        ?_assertNot(is_safe_entry(Cwd, "../../../tmp/pwned")),
+        ?_assertNot(is_safe_entry(Cwd, "evil/../../../tmp/pwned")),
+        ?_assertNot(is_safe_entry(Cwd, "/abs/path"))
+    ].
+-endif.

--- a/apps/emqx_plugins/src/emqx_plugins_fs.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_fs.erl
@@ -13,6 +13,7 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-export([normalize_dir/1, top_dir/2, is_safe_entry/2]).
 -endif.
 
 %% Tarfile operations
@@ -704,40 +705,3 @@ delete_file_if_exists(File) ->
         {error, Reason} ->
             {error, {delete_file_failed, File, Reason}}
     end.
-
--ifdef(TEST).
-normalize_dir_test_() ->
-    [
-        ?_assertEqual("foo", normalize_dir("foo")),
-        ?_assertEqual("foo", normalize_dir("foo/")),
-        ?_assertEqual("/foo", normalize_dir("/foo")),
-        ?_assertEqual("/foo", normalize_dir("/foo/"))
-    ].
-
-top_dir_test_() ->
-    [
-        ?_assertEqual({ok, "base/foo"}, top_dir("base", filename:join(["base", "foo", "bar"]))),
-        ?_assertEqual(
-            {ok, "/base/foo"}, top_dir("/base", filename:join(["/", "base", "foo", "bar"]))
-        ),
-        ?_assertEqual(
-            {ok, "/base/foo"}, top_dir("/base/", filename:join(["/", "base", "foo", "bar"]))
-        ),
-        ?_assertMatch({error, {out_of_bounds, _}}, top_dir("/base", filename:join(["/", "base"]))),
-        ?_assertMatch(
-            {error, {out_of_bounds, _}}, top_dir("/base", filename:join(["/", "foo", "bar"]))
-        )
-    ].
-
-is_safe_entry_test_() ->
-    %% Use cwd as a real existing directory; safe_relative_path/2 needs that.
-    {ok, Cwd} = file:get_cwd(),
-    [
-        ?_assert(is_safe_entry(Cwd, "evil-1.0.0/release.json")),
-        ?_assert(is_safe_entry(Cwd, "deep/nested/path.txt")),
-        ?_assertNot(is_safe_entry(Cwd, "../escape")),
-        ?_assertNot(is_safe_entry(Cwd, "../../../tmp/pwned")),
-        ?_assertNot(is_safe_entry(Cwd, "evil/../../../tmp/pwned")),
-        ?_assertNot(is_safe_entry(Cwd, "/abs/path"))
-    ].
--endif.

--- a/apps/emqx_plugins/src/emqx_plugins_schema.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_schema.erl
@@ -29,6 +29,11 @@ fields(api_endpoint) ->
         fields => api_endpoint_fields(),
         desc => ?DESC(api_endpoint)
     };
+fields(package_limits) ->
+    #{
+        fields => package_limits_fields(),
+        desc => ?DESC(package_limits)
+    };
 fields(state) ->
     #{
         fields => state_fields(),
@@ -62,7 +67,21 @@ root_fields() ->
         {states, fun states/1},
         {install_dir, fun install_dir/1},
         {api_endpoint, ?HOCON(?R_REF(api_endpoint), #{desc => ?DESC(api_endpoint)})},
-        {check_interval, fun check_interval/1}
+        {check_interval, fun check_interval/1},
+        {package_limits,
+            ?HOCON(?R_REF(package_limits), #{
+                desc => ?DESC(package_limits),
+                importance => ?IMPORTANCE_LOW
+            })}
+    ].
+
+package_limits_fields() ->
+    [
+        {max_package_size, fun max_package_size/1},
+        {max_decompressed_size, fun max_decompressed_size/1},
+        {max_file_count, fun max_file_count/1},
+        {max_path_depth, fun max_path_depth/1},
+        {max_extraction_time_ms, fun max_extraction_time_ms/1}
     ].
 
 api_endpoint_fields() ->
@@ -95,3 +114,28 @@ api_endpoint_timeout(type) -> emqx_schema:timeout_duration_ms();
 api_endpoint_timeout(default) -> <<"5s">>;
 api_endpoint_timeout(desc) -> ?DESC(api_endpoint_timeout);
 api_endpoint_timeout(_) -> undefined.
+
+max_package_size(type) -> emqx_schema:bytesize();
+max_package_size(default) -> <<"10MB">>;
+max_package_size(desc) -> ?DESC(max_package_size);
+max_package_size(_) -> undefined.
+
+max_decompressed_size(type) -> emqx_schema:bytesize();
+max_decompressed_size(default) -> <<"50MB">>;
+max_decompressed_size(desc) -> ?DESC(max_decompressed_size);
+max_decompressed_size(_) -> undefined.
+
+max_file_count(type) -> range(1, inf);
+max_file_count(default) -> 10000;
+max_file_count(desc) -> ?DESC(max_file_count);
+max_file_count(_) -> undefined.
+
+max_path_depth(type) -> range(1, inf);
+max_path_depth(default) -> 32;
+max_path_depth(desc) -> ?DESC(max_path_depth);
+max_path_depth(_) -> undefined.
+
+max_extraction_time_ms(type) -> emqx_schema:timeout_duration_ms();
+max_extraction_time_ms(default) -> <<"60s">>;
+max_extraction_time_ms(desc) -> ?DESC(max_extraction_time_ms);
+max_extraction_time_ms(_) -> undefined.

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -1471,6 +1471,196 @@ t_allow_sha256_undefined_accepts_any(_Config) ->
     ?assertEqual(ok, emqx_plugins:is_allowed_installation(NameVsn, <<"other bytes">>)),
     ok.
 
+%% The CLI install path must enforce the same allow gate as the HTTP upload path:
+%% without an `allow_installation' grant the CLI must refuse to install, with a
+%% grant it must install and consume the grant (forget on success, retain on
+%% failure so the admin can retry).
+t_cli_install_requires_allow({init, Config}) ->
+    #{package := Package} = get_demo_plugin_package(),
+    NameVsn = filename:basename(Package, ?PACKAGE_SUFFIX),
+    [{name_vsn, NameVsn} | Config];
+t_cli_install_requires_allow({'end', Config}) ->
+    application:unset_env(emqx_plugins, allowed_installations),
+    _ = emqx_plugins:ensure_uninstalled(?config(name_vsn, Config)),
+    ok;
+t_cli_install_requires_allow(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    LogFun = fun(_F, A) -> A end,
+    %% Without an allow entry the CLI must refuse and install nothing.
+    [DeniedJson] = emqx_plugins_cli_utils:ensure_installed(NameVsn, LogFun),
+    Denied = emqx_utils_json:decode(DeniedJson, [return_maps]),
+    ?assertMatch(
+        #{<<"result">> := <<"not_ok">>, <<"cause">> := <<"not_allowed">>},
+        Denied
+    ),
+    ?assertMatch({error, _}, emqx_plugins:describe(NameVsn)),
+    ?assertNot(is_app_loaded(?EMQX_PLUGIN_APP_NAME)),
+    %% Grant retained when the install itself fails.
+    MissingNameVsn = "missing-plugin-1.0.0",
+    ok = emqx_plugins:allow_installation(MissingNameVsn),
+    ?assert(emqx_plugins:is_allowed_installation(MissingNameVsn)),
+    [FailedJson] = emqx_plugins_cli_utils:ensure_installed(MissingNameVsn, LogFun),
+    Failed = emqx_utils_json:decode(FailedJson, [return_maps]),
+    ?assertMatch(#{<<"result">> := <<"not_ok">>}, Failed),
+    ?assert(emqx_plugins:is_allowed_installation(MissingNameVsn)),
+    %% With a grant the install succeeds and consumes the grant.
+    ok = emqx_plugins:allow_installation(NameVsn),
+    ?assert(emqx_plugins:is_allowed_installation(NameVsn)),
+    [OkJson] = emqx_plugins_cli_utils:ensure_installed(NameVsn, LogFun),
+    Ok = emqx_utils_json:decode(OkJson, [return_maps]),
+    ?assertMatch(#{<<"result">> := <<"ok">>}, Ok),
+    ?assert(is_app_loaded(?EMQX_PLUGIN_APP_NAME)),
+    ?assertNot(emqx_plugins:is_allowed_installation(NameVsn)),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ?assertNot(is_app_loaded(?EMQX_PLUGIN_APP_NAME)),
+    ok.
+
+%% Plugin API callbacks must not be able to set browser-sensitive response headers.
+t_plugin_api_forbidden_headers_filtered({init, Config}) ->
+    Config;
+t_plugin_api_forbidden_headers_filtered({'end', _Config}) ->
+    ok;
+t_plugin_api_forbidden_headers_filtered(_Config) ->
+    Forbidden = [
+        {"set-cookie", "session=evil"},
+        {"location", "https://attacker.com"},
+        {"access-control-allow-origin", "*"},
+        {"content-security-policy", "default-src *"},
+        {"authorization", "Bearer secret"}
+    ],
+    Allowed = [
+        {"content-type", "application/json"},
+        {"x-custom", "keep"}
+    ],
+    {200, Headers, #{ok := true}} = emqx_plugins:map_plugin_api_result(
+        {ok, 200, Forbidden ++ Allowed, #{ok => true}}
+    ),
+    ?assertNot(maps:is_key(<<"set-cookie">>, Headers)),
+    ?assertNot(maps:is_key(<<"location">>, Headers)),
+    ?assertNot(maps:is_key(<<"access-control-allow-origin">>, Headers)),
+    ?assertNot(maps:is_key(<<"content-security-policy">>, Headers)),
+    ?assertNot(maps:is_key(<<"authorization">>, Headers)),
+    ?assert(maps:is_key(<<"content-type">>, Headers)),
+    ?assert(maps:is_key(<<"x-custom">>, Headers)),
+    ok.
+
+%%--------------------------------------------------------------------
+%% package_limits
+%%--------------------------------------------------------------------
+
+-define(LIMITS_PATH, [plugins, package_limits]).
+
+create_test_tar(InstallDir, NameVsn, Entries) ->
+    TarGz = filename:join(InstallDir, NameVsn ++ ".tar.gz"),
+    ok = erl_tar:create(TarGz, Entries, [compressed]),
+    TarGz.
+
+with_package_limit(Key, Value, Fun) ->
+    Path = ?LIMITS_PATH ++ [Key],
+    Old = emqx_config:get(Path),
+    emqx_config:put(Path, Value),
+    try
+        Fun()
+    after
+        emqx_config:put(Path, Old)
+    end.
+
+%% A tarball larger than `max_package_size' must be rejected before any
+%% extraction happens, on both the upload (write_tar) and the install path.
+t_package_size_limit({init, Config}) ->
+    InstallDir = ?config(install_dir, Config),
+    NameVsn = "toobig-1.0.0",
+    create_test_tar(InstallDir, NameVsn, [
+        {filename:join(NameVsn, "release.json"), <<"{}">>}
+    ]),
+    [{name_vsn, NameVsn} | Config];
+t_package_size_limit({'end', Config}) ->
+    ok = emqx_plugins:delete_package(?config(name_vsn, Config));
+t_package_size_limit(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    InstallDir = ?config(install_dir, Config),
+    with_package_limit(max_package_size, 10, fun() ->
+        ?assertMatch(
+            {error, #{reason := package_size_limit_exceeded}},
+            emqx_plugins:ensure_installed(NameVsn)
+        ),
+        ?assertMatch(
+            {error, #{reason := package_size_limit_exceeded}},
+            emqx_plugins_fs:write_tar("upload-1.0.0", binary:copy(<<"a">>, 100))
+        ),
+        ?assertEqual(
+            {error, enoent},
+            file:read_file_info(filename:join(InstallDir, "upload-1.0.0.tar.gz"))
+        )
+    end),
+    ok.
+
+%% A tarball with more entries than `max_file_count' must be rejected.
+t_package_file_count_limit({init, Config}) ->
+    InstallDir = ?config(install_dir, Config),
+    NameVsn = "manyfiles-1.0.0",
+    create_test_tar(InstallDir, NameVsn, [
+        {filename:join([NameVsn, "a"]), <<"a">>},
+        {filename:join([NameVsn, "b"]), <<"b">>},
+        {filename:join([NameVsn, "c"]), <<"c">>}
+    ]),
+    [{name_vsn, NameVsn} | Config];
+t_package_file_count_limit({'end', Config}) ->
+    ok = emqx_plugins:delete_package(?config(name_vsn, Config));
+t_package_file_count_limit(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    with_package_limit(max_file_count, 2, fun() ->
+        ?assertMatch(
+            {error, #{reason := file_count_limit_exceeded}},
+            emqx_plugins:ensure_installed(NameVsn)
+        )
+    end),
+    %% Nothing may be extracted on rejection.
+    ?assertEqual({error, enoent}, file:read_file_info(emqx_plugins_fs:plugin_dir(NameVsn))),
+    ok.
+
+%% A tarball with entries deeper than `max_path_depth' must be rejected.
+t_package_path_depth_limit({init, Config}) ->
+    InstallDir = ?config(install_dir, Config),
+    NameVsn = "deep-1.0.0",
+    DeepEntry = filename:join([NameVsn, "d1", "d2", "d3", "d4", "file.txt"]),
+    create_test_tar(InstallDir, NameVsn, [{DeepEntry, <<"x">>}]),
+    [{name_vsn, NameVsn} | Config];
+t_package_path_depth_limit({'end', Config}) ->
+    ok = emqx_plugins:delete_package(?config(name_vsn, Config));
+t_package_path_depth_limit(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    with_package_limit(max_path_depth, 3, fun() ->
+        ?assertMatch(
+            {error, #{reason := path_depth_limit_exceeded}},
+            emqx_plugins:ensure_installed(NameVsn)
+        )
+    end),
+    ?assertEqual({error, enoent}, file:read_file_info(emqx_plugins_fs:plugin_dir(NameVsn))),
+    ok.
+
+%% A tarball whose decompressed content exceeds `max_decompressed_size' must
+%% be rejected and nothing may be left on disk.
+t_package_decompressed_size_limit({init, Config}) ->
+    InstallDir = ?config(install_dir, Config),
+    NameVsn = "bomb-1.0.0",
+    create_test_tar(InstallDir, NameVsn, [
+        {filename:join([NameVsn, "big.bin"]), binary:copy(<<"0123456789">>, 100)}
+    ]),
+    [{name_vsn, NameVsn} | Config];
+t_package_decompressed_size_limit({'end', Config}) ->
+    ok = emqx_plugins:delete_package(?config(name_vsn, Config));
+t_package_decompressed_size_limit(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    with_package_limit(max_decompressed_size, 100, fun() ->
+        ?assertMatch(
+            {error, #{reason := decompressed_size_limit_exceeded}},
+            emqx_plugins:ensure_installed(NameVsn)
+        )
+    end),
+    ?assertEqual({error, enoent}, file:read_file_info(emqx_plugins_fs:plugin_dir(NameVsn))),
+    ok.
+
 %% A tar entry whose name escapes the install dir (../../../tmp/pwned) must be
 %% rejected, and no part of the tarball may land on disk outside the install dir.
 t_tar_path_traversal({init, Config}) ->

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -1515,35 +1515,6 @@ t_cli_install_requires_allow(Config) ->
     ?assertNot(is_app_loaded(?EMQX_PLUGIN_APP_NAME)),
     ok.
 
-%% Plugin API callbacks must not be able to set browser-sensitive response headers.
-t_plugin_api_forbidden_headers_filtered({init, Config}) ->
-    Config;
-t_plugin_api_forbidden_headers_filtered({'end', _Config}) ->
-    ok;
-t_plugin_api_forbidden_headers_filtered(_Config) ->
-    Forbidden = [
-        {"set-cookie", "session=evil"},
-        {"location", "https://attacker.com"},
-        {"access-control-allow-origin", "*"},
-        {"content-security-policy", "default-src *"},
-        {"authorization", "Bearer secret"}
-    ],
-    Allowed = [
-        {"content-type", "application/json"},
-        {"x-custom", "keep"}
-    ],
-    {200, Headers, #{ok := true}} = emqx_plugins:map_plugin_api_result(
-        {ok, 200, Forbidden ++ Allowed, #{ok => true}}
-    ),
-    ?assertNot(maps:is_key(<<"set-cookie">>, Headers)),
-    ?assertNot(maps:is_key(<<"location">>, Headers)),
-    ?assertNot(maps:is_key(<<"access-control-allow-origin">>, Headers)),
-    ?assertNot(maps:is_key(<<"content-security-policy">>, Headers)),
-    ?assertNot(maps:is_key(<<"authorization">>, Headers)),
-    ?assert(maps:is_key(<<"content-type">>, Headers)),
-    ?assert(maps:is_key(<<"x-custom">>, Headers)),
-    ok.
-
 %%--------------------------------------------------------------------
 %% package_limits
 %%--------------------------------------------------------------------

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -1515,6 +1515,44 @@ t_cli_install_requires_allow(Config) ->
     ?assertNot(is_app_loaded(?EMQX_PLUGIN_APP_NAME)),
     ok.
 
+%% When the allow entry binds a sha256, the CLI install must verify the local
+%% tarball against it before installing anything.
+t_cli_install_sha256_binding({init, Config}) ->
+    #{package := Package} = get_demo_plugin_package(),
+    NameVsn = filename:basename(Package, ?PACKAGE_SUFFIX),
+    [{name_vsn, NameVsn} | Config];
+t_cli_install_sha256_binding({'end', Config}) ->
+    application:unset_env(emqx_plugins, allowed_installations),
+    _ = emqx_plugins:ensure_uninstalled(?config(name_vsn, Config)),
+    ok;
+t_cli_install_sha256_binding(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    LogFun = fun(_F, A) -> A end,
+    TarGz = filename:join(emqx_plugins_fs:install_dir(), NameVsn ++ ".tar.gz"),
+    {ok, TarBin} = file:read_file(TarGz),
+    WrongSha = binary:encode_hex(crypto:hash(sha256, <<"not-the-real-package">>), lowercase),
+    %% A mismatching sha256 must refuse the install and keep the grant.
+    ok = emqx_plugins:allow_installation(NameVsn, WrongSha),
+    [DeniedJson] = emqx_plugins_cli_utils:ensure_installed(NameVsn, LogFun),
+    Denied = emqx_utils_json:decode(DeniedJson, [return_maps]),
+    ?assertMatch(
+        #{<<"result">> := <<"not_ok">>, <<"cause">> := <<"sha256_mismatch">>},
+        Denied
+    ),
+    ?assertMatch({error, _}, emqx_plugins:describe(NameVsn)),
+    ?assert(emqx_plugins:is_allowed_installation(NameVsn)),
+    %% With the matching sha256 the install succeeds and consumes the grant.
+    GoodSha = binary:encode_hex(crypto:hash(sha256, TarBin), lowercase),
+    ok = emqx_plugins:allow_installation(NameVsn, GoodSha),
+    [OkJson] = emqx_plugins_cli_utils:ensure_installed(NameVsn, LogFun),
+    Ok = emqx_utils_json:decode(OkJson, [return_maps]),
+    ?assertMatch(#{<<"result">> := <<"ok">>}, Ok),
+    ?assert(is_app_loaded(?EMQX_PLUGIN_APP_NAME)),
+    ?assertNot(emqx_plugins:is_allowed_installation(NameVsn)),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ?assertNot(is_app_loaded(?EMQX_PLUGIN_APP_NAME)),
+    ok.
+
 %%--------------------------------------------------------------------
 %% package_limits
 %%--------------------------------------------------------------------

--- a/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
@@ -118,6 +118,31 @@ t_plugin_api_sensitive_headers_redacted(_Config) ->
     ?assertEqual(false, maps:get(<<"has_cookie">>, Body)),
     ?assertEqual(true, maps:get(<<"has_x_test">>, Body)).
 
+t_plugin_api_forbidden_headers_filtered(_Config) ->
+    ok = meck:expect(
+        emqx_plugins,
+        handle_api_call,
+        fun(<<"fake">>, _Request, _Timeout) ->
+            Headers = #{
+                <<"content-type">> => <<"application/json">>,
+                <<"set-cookie">> => <<"emqx_auth=evil; Path=/; HttpOnly">>,
+                <<"location">> => <<"https://attacker.com">>,
+                <<"access-control-allow-origin">> => <<"*">>,
+                <<"x-custom">> => <<"keep">>
+            },
+            emqx_plugins:map_plugin_api_result({ok, 200, Headers, #{ok => true}})
+        end
+    ),
+    {200, RespHeaders, Body} = request_with_headers(get, ?SERVER ++ "/plugin_api/fake/ping"),
+    ?assertEqual(#{<<"ok">> => true}, Body),
+    ?assertEqual(
+        <<"application/json">>, iolist_to_binary(maps:get(<<"content-type">>, RespHeaders))
+    ),
+    ?assertEqual(<<"keep">>, iolist_to_binary(maps:get(<<"x-custom">>, RespHeaders))),
+    ?assertNot(maps:is_key(<<"set-cookie">>, RespHeaders)),
+    ?assertNot(maps:is_key(<<"location">>, RespHeaders)),
+    ?assertNot(maps:is_key(<<"access-control-allow-origin">>, RespHeaders)).
+
 t_plugin_api_query_string_passthrough(_Config) ->
     ok = meck:expect(
         emqx_plugins,
@@ -158,6 +183,35 @@ request(Method, Url, AuthOrHeaders) ->
         {error, {{"HTTP/1.1", Code, _}, _Headers, Body}} ->
             {Code, maybe_decode(Body)}
     end.
+
+request_with_headers(Method, Url) ->
+    request_with_headers(Method, Url, emqx_mgmt_api_test_util:auth_header_()).
+
+request_with_headers(Method, Url, AuthOrHeaders) ->
+    Res = emqx_mgmt_api_test_util:request_api(
+        Method,
+        Url,
+        [],
+        AuthOrHeaders,
+        [],
+        #{return_all => true, httpc_req_opts => [{body_format, binary}]}
+    ),
+    case Res of
+        {ok, {{"HTTP/1.1", Code, _}, Headers, Body}} ->
+            {Code, normalize_headers(Headers), maybe_decode(Body)};
+        {error, {{"HTTP/1.1", Code, _}, Headers, Body}} ->
+            {Code, normalize_headers(Headers), maybe_decode(Body)}
+    end.
+
+normalize_headers(Headers) ->
+    maps:from_list([
+        {bin(Key), Value}
+     || {Key, Value} <- Headers
+    ]).
+
+bin(B) when is_binary(B) -> B;
+bin(L) when is_list(L) -> list_to_binary(L);
+bin(A) when is_atom(A) -> atom_to_binary(A, utf8).
 
 maybe_decode(Body) when is_binary(Body) ->
     case emqx_utils_json:safe_decode(Body) of

--- a/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
@@ -128,7 +128,8 @@ t_plugin_api_forbidden_headers_filtered(_Config) ->
                 <<"set-cookie">> => <<"emqx_auth=evil; Path=/; HttpOnly">>,
                 <<"location">> => <<"https://attacker.com">>,
                 <<"access-control-allow-origin">> => <<"*">>,
-                <<"x-custom">> => <<"keep">>
+                <<"x-custom">> => <<"stripped">>,
+                <<"x-plugin-custom">> => <<"keep">>
             },
             emqx_plugins:map_plugin_api_result({ok, 200, Headers, #{ok => true}})
         end
@@ -138,7 +139,8 @@ t_plugin_api_forbidden_headers_filtered(_Config) ->
     ?assertEqual(
         <<"application/json">>, iolist_to_binary(maps:get(<<"content-type">>, RespHeaders))
     ),
-    ?assertEqual(<<"keep">>, iolist_to_binary(maps:get(<<"x-custom">>, RespHeaders))),
+    ?assertEqual(<<"keep">>, iolist_to_binary(maps:get(<<"x-plugin-custom">>, RespHeaders))),
+    ?assertNot(maps:is_key(<<"x-custom">>, RespHeaders)),
     ?assertNot(maps:is_key(<<"set-cookie">>, RespHeaders)),
     ?assertNot(maps:is_key(<<"location">>, RespHeaders)),
     ?assertNot(maps:is_key(<<"access-control-allow-origin">>, RespHeaders)).

--- a/apps/emqx_plugins/test/emqx_plugins_fs_tests.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_fs_tests.erl
@@ -1,0 +1,53 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2019-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_plugins_fs_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+normalize_dir_test_() ->
+    [
+        ?_assertEqual("foo", emqx_plugins_fs:normalize_dir("foo")),
+        ?_assertEqual("foo", emqx_plugins_fs:normalize_dir("foo/")),
+        ?_assertEqual("/foo", emqx_plugins_fs:normalize_dir("/foo")),
+        ?_assertEqual("/foo", emqx_plugins_fs:normalize_dir("/foo/"))
+    ].
+
+top_dir_test_() ->
+    [
+        ?_assertEqual(
+            {ok, "base/foo"}, emqx_plugins_fs:top_dir("base", filename:join(["base", "foo", "bar"]))
+        ),
+        ?_assertEqual(
+            {ok, "/base/foo"},
+            emqx_plugins_fs:top_dir("/base", filename:join(["/", "base", "foo", "bar"]))
+        ),
+        ?_assertEqual(
+            {ok, "/base/foo"},
+            emqx_plugins_fs:top_dir("/base/", filename:join(["/", "base", "foo", "bar"]))
+        ),
+        ?_assertMatch(
+            {error, {out_of_bounds, _}},
+            emqx_plugins_fs:top_dir("/base", filename:join(["/", "base"]))
+        ),
+        ?_assertMatch(
+            {error, {out_of_bounds, _}},
+            emqx_plugins_fs:top_dir("/base", filename:join(["/", "foo", "bar"]))
+        )
+    ].
+
+is_safe_entry_test_() ->
+    %% Use cwd as a real existing directory; safe_relative_path/2 needs that.
+    {ok, Cwd} = file:get_cwd(),
+    [
+        ?_assert(emqx_plugins_fs:is_safe_entry(Cwd, "evil-1.0.0/release.json")),
+        ?_assert(emqx_plugins_fs:is_safe_entry(Cwd, "deep/nested/path.txt")),
+        ?_assertNot(emqx_plugins_fs:is_safe_entry(Cwd, "../escape")),
+        ?_assertNot(emqx_plugins_fs:is_safe_entry(Cwd, "../../../tmp/pwned")),
+        ?_assertNot(emqx_plugins_fs:is_safe_entry(Cwd, "evil/../../../tmp/pwned")),
+        ?_assertNot(emqx_plugins_fs:is_safe_entry(Cwd, "/abs/path"))
+    ].

--- a/apps/emqx_plugins/test/emqx_plugins_tests.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_tests.erl
@@ -206,3 +206,71 @@ unmeck_emqx() ->
     meck:unload(emqx),
     meck:unload(emqx_plugins_serde),
     ok.
+
+%%--------------------------------------------------------------------
+%% plugin API response header filtering (allow-list)
+%%--------------------------------------------------------------------
+
+map_plugin_api_result_filters_forbidden_headers_test() ->
+    Stripped = [
+        %% auth
+        <<"authorization">>,
+        <<"www-authenticate">>,
+        %% cookies
+        <<"set-cookie">>,
+        <<"cookie">>,
+        %% CORS
+        <<"access-control-allow-origin">>,
+        <<"access-control-request-method">>,
+        %% redirects
+        <<"location">>,
+        <<"refresh">>,
+        %% security/policy
+        <<"content-security-policy">>,
+        <<"strict-transport-security">>,
+        <<"x-frame-options">>,
+        <<"x-content-type-options">>,
+        <<"referrer-policy">>,
+        %% custom header without the x-plugin- prefix
+        <<"x-custom">>,
+        %% non-binary key is dropped too
+        content_type
+    ],
+    Allowed = [
+        <<"content-type">>,
+        <<"cache-control">>,
+        <<"etag">>,
+        <<"x-request-id">>,
+        <<"x-plugin-custom">>,
+        <<"x-plugin-set-cookie">>
+    ],
+    Headers = maps:from_list([{K, <<"1">>} || K <- Stripped ++ Allowed]),
+    {200, RespHeaders, #{ok := true}} = emqx_plugins:map_plugin_api_result(
+        {ok, 200, Headers, #{ok => true}}
+    ),
+    [?assertNot(maps:is_key(K, RespHeaders)) || K <- Stripped],
+    [?assertEqual(<<"1">>, maps:get(K, RespHeaders)) || K <- Allowed],
+    %% error clause is filtered too
+    {401, ErrHeaders, #{error := true}} = emqx_plugins:map_plugin_api_result(
+        {error, 401, Headers, #{error => true}}
+    ),
+    [?assertNot(maps:is_key(K, ErrHeaders)) || K <- Stripped],
+    [?assertEqual(<<"1">>, maps:get(K, ErrHeaders)) || K <- Allowed].
+
+map_plugin_api_result_case_insensitive_test() ->
+    Headers = #{
+        <<"Set-Cookie">> => <<"a">>,
+        <<"LOCATION">> => <<"b">>,
+        <<"Content-Type">> => <<"c">>,
+        <<"X-Plugin-Foo">> => <<"d">>
+    },
+    {200, RespHeaders, #{}} = emqx_plugins:map_plugin_api_result({ok, 200, Headers, #{}}),
+    %% Stripped regardless of input case
+    [
+        ?assertNot(maps:is_key(K, RespHeaders))
+     || K <- [<<"set-cookie">>, <<"Set-Cookie">>, <<"location">>, <<"LOCATION">>]
+    ],
+    %% Allowed headers preserved (normalization keeps original case)
+    ?assertEqual(<<"c">>, iolist_to_binary(maps:get(<<"Content-Type">>, RespHeaders))),
+    %% custom header with x-plugin- prefix passes (prefix matched case-insensitively)
+    ?assertEqual(<<"d">>, iolist_to_binary(maps:get(<<"X-Plugin-Foo">>, RespHeaders))).

--- a/changes/ce/fix-18188.en.md
+++ b/changes/ce/fix-18188.en.md
@@ -1,0 +1,5 @@
+Hardened the plugin framework package and runtime integrity checks.
+
+* Now `emqx ctl plugins install` must be done after `emqx ctl plugins allow`, enforcing the same allow gate as the HTTP upload API.
+* Plugin API callback responses are restricted to an allow-list of safe response headers; browser-sensitive headers (such as `set-cookie`, `location`, `access-control-*`, `content-security-policy`, and other authentication or security policy headers) and custom headers without the `x-plugin-` prefix are stripped.
+* Added the `plugins.package_limits` configuration to bound plugin package extraction: `max_package_size` (default `10MB`), `max_decompressed_size` (default `50MB`), `max_file_count` (default `10000`), `max_path_depth` (default `32`), and `max_extraction_time_ms` (default `60s`, also used as the RPC timeout for cluster package copying). Packages violating these limits are rejected before or during extraction. Tar entries escaping the install directory (path traversal) are also rejected.

--- a/rel/i18n/emqx_plugins_schema.hocon
+++ b/rel/i18n/emqx_plugins_schema.hocon
@@ -41,6 +41,49 @@ For example: `my_plugin-0.1.0`."""
 name_vsn.label:
 """Name-Version"""
 
+package_limits.desc:
+"""Resource limits applied when writing and extracting plugin packages.<br/>
+These bounds protect the node from oversized, high-compression-ratio or
+deeply-nested plugin tarballs."""
+
+package_limits.label:
+"""Package Limits"""
+
+max_package_size.desc:
+"""Maximum size of a plugin package file (<code>.tar.gz</code>) in bytes.
+Uploads and cluster copies larger than this are rejected."""
+
+max_package_size.label:
+"""Max Package Size"""
+
+max_decompressed_size.desc:
+"""Maximum total size in bytes of all files contained in a plugin package
+after decompression. Packages extracting to more than this are rejected."""
+
+max_decompressed_size.label:
+"""Max Decompressed Size"""
+
+max_file_count.desc:
+"""Maximum number of file entries allowed in a plugin package."""
+
+max_file_count.label:
+"""Max File Count"""
+
+max_path_depth.desc:
+"""Maximum directory depth of file entries in a plugin package."""
+
+max_path_depth.label:
+"""Max Path Depth"""
+
+max_extraction_time_ms.desc:
+"""Maximum time allowed for extracting a plugin package.
+Extraction taking longer than this is aborted.<br/>
+This value is also used as the RPC timeout when copying a plugin package
+from another node in the cluster."""
+
+max_extraction_time_ms.label:
+"""Max Extraction Time"""
+
 plugins.desc:
 """Manage EMQX plugins.<br/>
 Plugins can be pre-built as a part of EMQX package,


### PR DESCRIPTION
Fixes three plugin framework security issues in a single PR, applying partial restrictions on plugin code execution at the framework level (defense-in-depth).

## 1. CLI install bypasses the allow gate

`emqx ctl plugins install <name-vsn>` did not check `is_allowed_installation/1`, so a tarball that landed in the install dir (cluster replication, manual placement) could be installed without a prior `plugins allow` grant — bypassing the gate enforced by the HTTP upload path.

The CLI path now enforces the same allow gate (both `install` and `install --cluster`): refuses without a grant, verifies the local tarball against the allow entry's sha256 binding when present, consumes the grant cluster-wide on success, retains it on failure so the admin can retry.

## 2. Plugin API responses can set browser-sensitive headers

A plugin callback's returned HTTP headers were passed through to the Dashboard origin unchecked, allowing a malicious plugin to set `set-cookie`, `access-control-allow-origin`, `location`, `content-security-policy`, etc.

Plugin API responses are now restricted to an allow-list of safe headers (content metadata, caching, etag/validation, correlation ids, rate-limit headers); browser-sensitive headers (auth, cookies, CORS, redirects, security policy) and any custom header without the `x-plugin-` prefix are stripped case-insensitively.

## 3. Unbounded plugin package decompression

Package upload and cluster sync accepted tarballs with no limits on size, decompressed size, file count, path depth or extraction time — enabling DoS via oversized / high-compression-ratio / deeply-nested tarballs.

New `plugins.package_limits` configuration bounds the extraction pipeline (package write, tar table scan, timed extraction, cluster sync RPC timeout). Tar entries escaping the install dir (path traversal) are also rejected.

### Default values — open for discussion

| Config | Default | Rationale |
|---|---|---|
| `max_package_size` | `10MB` | Beam plugin packages are small (e.g. a typical plugin tarball is ~400KiB); 10MB only excludes packages with huge static assets |
| `max_decompressed_size` | `50MB` | Still generous vs. real plugin content |
| `max_file_count` | `10000` | |
| `max_path_depth` | `32` | |
| `max_extraction_time_ms` | `60s` | Also used as the RPC timeout for cluster package copying |

The `10MB` / `50MB` defaults in particular are a judgement call — please comment if they should be larger/smaller.

## Test plan

- `t_cli_install_requires_allow`: CLI install denied without grant, succeeds with grant, grant consumed on success / retained on failure
- `t_cli_install_sha256_binding`: CLI install denied on sha256 mismatch, succeeds with the matching sha256
- `t_plugin_api_forbidden_headers_filtered`: unit + HTTP-level tests that headers outside the allow-list are stripped (incl. mixed-case) and allowed / `x-plugin-`-prefixed headers pass through
- `t_package_size_limit` / `t_package_file_count_limit` / `t_package_path_depth_limit` / `t_package_decompressed_size_limit`: each limit rejects offending packages with no partial writes
- `t_tar_path_traversal`: zip-slip entries reject the whole package
- Full `apps/emqx_plugins-ct` (54 cases) and eunit (25) pass; `static_checks`, `elvis` clean