### PR TITLE
fix(gcp_pubsub): scope consumer worker health optvars by source

### DIFF
--- a/apps/emqx/src/emqx_post_upgrade.erl
+++ b/apps/emqx/src/emqx_post_upgrade.erl
@@ -29,7 +29,8 @@
 
 -export([
     pr_17586_kickoff_registry_keeper/1,
-    pr_17625_gcp_pubsub_consumer_worker_optvars/1
+    pr_17625_gcp_pubsub_consumer_worker_optvars/1,
+    pr_18193_gcp_pubsub_consumer_worker_optvars/1
 ]).
 
 %% Replicants started on the pre-fix beam stored {no_deletes => true} in
@@ -91,6 +92,42 @@ pr_17625_gcp_pubsub_consumer_worker_optvars(_FromVsn) ->
                 optvar:unset(K);
             (_) ->
                 ok
+        end,
+        optvar:list_all()
+    ),
+    ok.
+
+%% Pre-fix beams keyed the consumer worker optvars by the bare ecpool worker index;
+%% current code reads keys scoped by the source resource id, so running workers started
+%% on the old beam would fail every health check until restarted.  Restart the affected
+%% connectors and sweep the leftover index-keyed entries.
+pr_18193_gcp_pubsub_consumer_worker_optvars(_FromVsn) ->
+    %% Same xref workaround as in `pr_17625_gcp_pubsub_consumer_worker_optvars'.
+    EMQXResource = emqx_resource,
+    ConnImpl = emqx_bridge_gcp_pubsub_impl_consumer,
+    IsIndexKeyed = fun
+        (?GCONSU_WORKER_OPT_KEY(Idx)) when is_integer(Idx) -> true;
+        (_) -> false
+    end,
+    HasIndexKeyedOptvars = lists:any(IsIndexKeyed, optvar:list_all()),
+    ConnResIds =
+        [
+            ConnResId
+         || HasIndexKeyedOptvars,
+            ConnResId <- EMQXResource:list_instances_by_type(ConnImpl),
+            case EMQXResource:get_instance(ConnResId) of
+                {ok, _, #{status := stopped}} -> false;
+                {ok, _, _} -> true;
+                _ -> false
+            end
+        ],
+    lists:foreach(fun EMQXResource:restart/1, ConnResIds),
+    lists:foreach(
+        fun(K) ->
+            case IsIndexKeyed(K) of
+                true -> optvar:unset(K);
+                false -> ok
+            end
         end,
         optvar:list_all()
     ),

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
@@ -12,7 +12,7 @@
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 
 %% `ecpool_worker' API
--export([connect/1, health_check/1, clear_optvar/1]).
+-export([connect/1, health_check/2, clear_optvar/2]).
 
 %% `gen_server' API
 -export([
@@ -90,7 +90,11 @@
 -define(patch_subscription, patch_subscription).
 
 -define(HEALTH_CHECK_TIMEOUT, 10_000).
--define(OPTVAR_SUB_OK(PID), {?MODULE, subscription_ok, PID}).
+%% Must be scoped by the source resource id: worker indices repeat across pools, and a
+%% bare-index key would let one pool (e.g. a probe's) clear or overwrite another's flag.
+-define(OPTVAR_SUB_OK(SOURCE_RES_ID, WORKER_ID),
+    {?MODULE, subscription_ok, SOURCE_RES_ID, WORKER_ID}
+).
 
 -record(register_stream_ref, {stream_ref :: reference(), pid :: pid()}).
 
@@ -172,18 +176,18 @@ get_subscription(WorkerPid) ->
 %% `ecpool' health check
 %%-------------------------------------------------------------------------------------------------
 
--spec health_check(integer()) -> subscription_ok | topic_not_found | timeout.
-health_check(WorkerId) ->
-    case optvar:read(?OPTVAR_SUB_OK(WorkerId), ?HEALTH_CHECK_TIMEOUT) of
+-spec health_check(binary(), integer()) -> subscription_ok | topic_not_found | timeout.
+health_check(SourceResId, WorkerId) ->
+    case optvar:read(?OPTVAR_SUB_OK(SourceResId, WorkerId), ?HEALTH_CHECK_TIMEOUT) of
         {ok, Status} ->
             Status;
         timeout ->
             timeout
     end.
 
--spec clear_optvar(integer()) -> ok.
-clear_optvar(WorkerId) ->
-    optvar:unset(?OPTVAR_SUB_OK(WorkerId)),
+-spec clear_optvar(binary(), integer()) -> ok.
+clear_optvar(SourceResId, WorkerId) ->
+    optvar:unset(?OPTVAR_SUB_OK(SourceResId, WorkerId)),
     ok.
 
 %%-------------------------------------------------------------------------------------------------
@@ -262,7 +266,7 @@ handle_continue(?ensure_subscription, State0) ->
                 ecpool_worker_id := WorkerId
             } = State0,
             ?MODULE:pull_async(self()),
-            optvar:set(?OPTVAR_SUB_OK(WorkerId), subscription_ok),
+            optvar:set(?OPTVAR_SUB_OK(SourceResId, WorkerId), subscription_ok),
             clear_unhealthy_status(State0),
             State = clear_backoff(State0),
             ?tp(
@@ -291,7 +295,7 @@ handle_continue(?patch_subscription, State0) ->
                 ecpool_worker_id := WorkerId
             } = State0,
             ?MODULE:pull_async(self()),
-            optvar:set(?OPTVAR_SUB_OK(WorkerId), subscription_ok),
+            optvar:set(?OPTVAR_SUB_OK(SourceResId, WorkerId), subscription_ok),
             clear_unhealthy_status(State0),
             ?tp(
                 debug,
@@ -378,14 +382,15 @@ terminate({shutdown, {error, Reason}}, State) when
         topic := _Topic
     } = State,
     emqx_bridge_gcp_pubsub_impl_consumer:mark_as_unhealthy(SourceResId, Reason),
-    optvar:set(?OPTVAR_SUB_OK(WorkerId), Reason),
+    optvar:set(?OPTVAR_SUB_OK(SourceResId, WorkerId), Reason),
     ?tp(gcp_pubsub_consumer_worker_terminate, #{reason => {error, Reason}, topic => _Topic}),
     ok;
 terminate(_Reason, State) ->
     #{
-        ecpool_worker_id := WorkerId
+        ecpool_worker_id := WorkerId,
+        source_resource_id := SourceResId
     } = State,
-    clear_optvar(WorkerId),
+    clear_optvar(SourceResId, WorkerId),
     ?tp(gcp_pubsub_consumer_worker_terminate, #{reason => _Reason, topic => maps:get(topic, State)}),
     ok.
 

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -319,7 +319,7 @@ stop_consumers1(SourceResId, PoolSize) ->
     ),
     lists:foreach(
         fun(WorkerId) ->
-            emqx_bridge_gcp_pubsub_consumer_worker:clear_optvar(WorkerId)
+            emqx_bridge_gcp_pubsub_consumer_worker:clear_optvar(SourceResId, WorkerId)
         end,
         lists:seq(1, PoolSize)
     ),
@@ -338,7 +338,7 @@ get_client_status(Client) ->
 check_workers(SourceResId, Client) ->
     Opts = #{
         check_fn => fun(#{id := WorkerId}) ->
-            emqx_bridge_gcp_pubsub_consumer_worker:health_check(WorkerId)
+            emqx_bridge_gcp_pubsub_consumer_worker:health_check(SourceResId, WorkerId)
         end,
         run_on => independent,
         is_success_fn => fun

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -2274,6 +2274,51 @@ t_clear_stuck_unhealthy(TCConfig) ->
     ),
     ok.
 
+-doc """
+Checks that probing ("Test Connection") a consumer source does not disturb the health
+status of an already-running source.
+
+Each pool worker publishes its subscription status under an optvar key, and the running
+source's health check reads it back.  Those keys must be scoped by the worker's own pool:
+worker indices restart from 1 in every pool, so an index-only key would be shared with the
+probe's temporary pool, whose teardown then clears the live pool's flags — leaving the
+running source stuck `disconnected` (health check timeout) until manually restarted
+(issue #18190).
+""".
+t_probe_does_not_disturb_running_source(TCConfig) ->
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            {ok, SRef0} =
+                snabbkaffe:subscribe(
+                    ?match_event(#{?snk_kind := "gcp_pubsub_consumer_worker_subscription_ready"}),
+                    40_000
+                ),
+            {201, _} = create_connector_api(TCConfig, #{}),
+            {201, _} = create_source_api(TCConfig, #{}),
+            {ok, _} = snabbkaffe:receive_events(SRef0),
+            ?assertMatch(
+                {200, #{<<"status">> := <<"connected">>}},
+                get_source_api(TCConfig)
+            ),
+            %% "Test Connection": a dry-run probe of the same source config; its
+            %% temporary worker pool is torn down once the probe concludes.
+            ?assertMatch({204, _}, probe_source_api(TCConfig)),
+            %% The running source must not be affected by the probe pool teardown.
+            ?assertMatch(
+                #{status := ?status_connected},
+                emqx_bridge_v2_testlib:health_check_channel(TCConfig)
+            ),
+            ?assertMatch(
+                {200, #{<<"status">> := <<"connected">>}},
+                get_source_api(TCConfig)
+            ),
+            ok
+        end,
+        []
+    ),
+    ok.
+
 %% test for hot upgrade post-upgrade hook.
 -define(OPTVAR_SUB_OK(X), {emqx_bridge_gcp_pubsub_consumer_worker, subscription_ok, X}).
 t_post_upgrade_pr_17625(TCConfig) ->
@@ -2316,6 +2361,54 @@ t_post_upgrade_pr_17625(TCConfig) ->
                     K
                  || ?OPTVAR_SUB_OK(Pid) = K <- optvar:list_all(),
                     is_pid(Pid)
+                ]
+            ),
+            ok
+        end
+    ),
+    ok.
+
+-doc """
+Checks the hot-upgrade hook that handles worker optvars keyed by the bare ecpool worker
+index (left by pre-upgrade beams; current keys are scoped by the source resource id): the
+affected connectors are restarted and the stale index-keyed entries are swept.
+""".
+t_post_upgrade_pr_18193(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_source_api(TCConfig, #{}),
+    ConnNameB = <<"disabled">>,
+    SourceNameB = ConnNameB,
+    TCConfigB = [{connector_name, ConnNameB}, {source_name, SourceNameB} | TCConfig],
+    {201, _} = create_connector_api(TCConfigB, #{}),
+    {201, _} = create_source_api(TCConfigB, #{
+        <<"connector">> => ConnNameB
+    }),
+
+    %% set up old opvars to simulate a worker started by the previous version
+    optvar:set(?OPTVAR_SUB_OK(1), subscription_ok),
+
+    {204, _} = disable_connector_api(TCConfigB),
+
+    ?check_trace(
+        begin
+            emqx_post_upgrade:pr_18193_gcp_pubsub_consumer_worker_optvars("vsn"),
+            ok
+        end,
+        fun(Trace) ->
+            ConnResId = emqx_bridge_v2_testlib:connector_resource_id(TCConfig),
+            ?assertMatch(
+                [
+                    #{?snk_kind := gcp_pubsub_consumer_stop_enter, instance_id := ConnResId},
+                    #{?snk_kind := gcp_pubsub_consumer_start, instance_id := ConnResId}
+                ],
+                ?of_kind([gcp_pubsub_consumer_stop_enter, gcp_pubsub_consumer_start], Trace)
+            ),
+            ?assertEqual(
+                [],
+                [
+                    K
+                 || ?OPTVAR_SUB_OK(Idx) = K <- optvar:list_all(),
+                    is_integer(Idx)
                 ]
             ),
             ok

--- a/changes/ee/fix-18193.en.md
+++ b/changes/ee/fix-18193.en.md
@@ -1,3 +1,5 @@
 Fixed an issue where a running GCP Pub/Sub Consumer source could show as `disconnected` (with reason `timeout`) after "Test Connection" was used on a GCP Pub/Sub Consumer connector or source, and would stay that way until manually disabled and re-enabled.
 
+Affected versions: 6.1.3 and 6.2.2.
+
 The temporary worker pool created for the connection test shared its health-status bookkeeping with the pools of running sources, so cleaning up the test pool also discarded the running source's health status. Each pool now keeps its own bookkeeping, and testing a connection no longer affects running sources. A hot-upgrade hook is included so consumers started by older versions are restarted to pick up the new bookkeeping.

--- a/changes/ee/fix-18193.en.md
+++ b/changes/ee/fix-18193.en.md
@@ -1,0 +1,3 @@
+Fixed an issue where a running GCP Pub/Sub Consumer source could show as `disconnected` (with reason `timeout`) after "Test Connection" was used on a GCP Pub/Sub Consumer connector or source, and would stay that way until manually disabled and re-enabled.
+
+The temporary worker pool created for the connection test shared its health-status bookkeeping with the pools of running sources, so cleaning up the test pool also discarded the running source's health status. Each pool now keeps its own bookkeeping, and testing a connection no longer affects running sources. A hot-upgrade hook is included so consumers started by older versions are restarted to pick up the new bookkeeping.


### PR DESCRIPTION
Release version:
6.1.4, 6.2.3, 6.3.0

## Summary

Fixes #18190.

Since 6.1.3 / 6.2.2 (commit 4d5104f3739a), the GCP Pub/Sub Consumer pool workers publish their subscription status in optvars keyed by the bare ecpool worker index (`1..N`). Those keys are node-global, so the temporary `PROBE_*` pool created by "Test Connection" (a dry-run probe) uses the same keys as the pools of running sources. When the probe tears down, `stop_consumers1/2` and worker `terminate/2` clear those optvars — wiping the live pool's flags. The live workers only set the flag once, during init, so every subsequent health check of the running source blocks on `optvar:read/2` until it times out: the source flips to `disconnected` (`timeout`) and never recovers until it is disabled and re-enabled (which restarts the workers).

Crucial changes:

* `emqx_bridge_gcp_pubsub_consumer_worker` / `emqx_bridge_gcp_pubsub_impl_consumer`: the optvar key is now scoped by the source resource id (which doubles as the pool name), so a pool can only ever touch its own flags. `health_check/2` and `clear_optvar/2` carry the source resource id.
* `emqx_post_upgrade`: new `pr_18193_gcp_pubsub_consumer_worker_optvars/1` hook (mirroring the existing `pr_17625` one for the pid→index transition): workers started by a pre-fix beam hold index-keyed optvars the new code never reads, so the hook restarts the affected consumer connectors and sweeps the stale entries.
* Regression test `t_probe_does_not_disturb_running_source`: connects a source, probes it, and asserts the running source's health check still reports `connected`. Fails on the pre-fix code with `channel_health_check_timed_out` / `disconnected`, passes with the fix. `t_post_upgrade_pr_18193` covers the hook.

Also verified against real GCP with the reporter's configuration shape: probing the connector and the source leaves the running source `connected`; replaying the pre-fix optvar clobber reproduces the permanent `disconnected`/`timeout` and the disable/enable workaround, one-to-one with the report.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
