### PR TITLE
fix(mgmt): accept unset-equivalent scopes on API key write

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
@@ -164,9 +164,15 @@ fields(app) ->
             )},
         {enable, hoconsc:mk(boolean(), #{desc => ?DESC("enable_desc"), required => false})},
         {expired, hoconsc:mk(boolean(), #{desc => ?DESC("expired_desc"), required => false})},
+        %% Accept the same shapes the response emits, so a read-modify-write
+        %% can round-trip the value verbatim: an explicit array of scope
+        %% names, or the `unset' sentinel (parsed to the atom `unset', also
+        %% tolerated as the binary <<"unset">>). A list whose set equals the
+        %% role default and the `unset' sentinel are both treated as "no
+        %% explicit scopes" on write.
         {scopes,
             hoconsc:mk(
-                hoconsc:array(binary()),
+                hoconsc:union([unset, hoconsc:array(binary())]),
                 #{
                     desc => ?DESC(api_key_scopes_request),
                     required => false,
@@ -175,11 +181,11 @@ fields(app) ->
             )}
     ] ++ app_extend_fields();
 %% Response shape: `scopes' MAY be the binary sentinel <<"unset">> in addition
-%% to the array-of-binaries form. This sentinel surfaces only for legacy
-%% records that survived an upgrade from a release where the scopes feature
-%% did not exist; the POST / bootstrap / SSO-provisioning paths all
-%% materialize role-default scopes at creation time, so no fresh record will
-%% ever appear with `scopes => <<"unset">>'.
+%% to the array-of-binaries form. The sentinel surfaces for records that hold
+%% no explicit `scopes' field: legacy records that survived an upgrade from a
+%% release where the scopes feature did not exist, and records written with
+%% unset-equivalent scopes (the `unset' sentinel or a list equal to the role
+%% default) — both fall back to role-default behavior at runtime.
 %%
 %% Listed explicitly (rather than overriding via `lists:keystore') so that the
 %% OpenAPI spec reads as a self-contained response schema and reviewers do not
@@ -336,30 +342,56 @@ api_key(post, #{body := App} = Req) ->
     end.
 
 create_api_key(App, Name, Enable, ExpiredAt, Desc, Role) ->
-    %% Materialize role defaults when the client omitted `scopes' entirely.
-    %% Explicit `[]' (deny-all) and explicit lists pass through unchanged.
-    %% After this PR `<<"unset">>' in a GET response is reserved for legacy
-    %% records that survived an upgrade; no creation path stores `undefined'.
     RawScopes = maps:get(<<"scopes">>, App, undefined),
-    Scopes = emqx_mgmt_auth:effective_scopes_on_create(Role, RawScopes),
-    case validate_scopes(Role, RawScopes, Scopes) of
-        ok ->
-            case emqx_mgmt_auth:create(Name, Enable, ExpiredAt, Desc, Role, Scopes) of
-                {ok, NewApp} ->
-                    {200, emqx_mgmt_auth:format(NewApp)};
-                {error, Reason} when is_map(Reason) ->
-                    {400, #{
-                        code => 'BAD_REQUEST',
-                        message => Reason
-                    }};
-                {error, Reason} ->
-                    {400, #{
-                        code => 'BAD_REQUEST',
-                        message => iolist_to_binary(io_lib:format("~p", [Reason]))
-                    }}
-            end;
+    case create_scopes(Role, RawScopes) of
+        {ok, Scopes} ->
+            do_create_api_key(Name, Enable, ExpiredAt, Desc, Role, Scopes);
         {error, Msg} ->
             {400, #{code => 'BAD_REQUEST', message => Msg}}
+    end.
+
+%% Resolve the `scopes' value to persist on POST and run validation.
+%% Returns `{ok, [binary()] | undefined}' or `{error, Msg}'.
+%%
+%%   * field omitted -> materialize the role default and store it;
+%%     validation runs with `RawScopes = undefined' so the privilege-scope
+%%     mutex is not applied to the role-default mix.
+%%   * `unset' sentinel or a list whose set equals the role default ->
+%%     store no `scopes' field at all (GET returns the `unset' sentinel);
+%%     valid by construction, nothing to check.
+%%   * any other list -> validate and store it verbatim (explicit `[]'
+%%     means deny-all).
+create_scopes(Role, undefined) ->
+    Scopes = emqx_mgmt_auth:role_default_scopes(Role),
+    case validate_scopes(Role, undefined, Scopes) of
+        ok -> {ok, Scopes};
+        Error -> Error
+    end;
+create_scopes(Role, RawScopes) ->
+    case emqx_mgmt_auth:write_scope_intent(Role, RawScopes) of
+        unset ->
+            {ok, undefined};
+        {set, Scopes} ->
+            case validate_scopes(Role, Scopes, Scopes) of
+                ok -> {ok, Scopes};
+                Error -> Error
+            end
+    end.
+
+do_create_api_key(Name, Enable, ExpiredAt, Desc, Role, Scopes) ->
+    case emqx_mgmt_auth:create(Name, Enable, ExpiredAt, Desc, Role, Scopes) of
+        {ok, NewApp} ->
+            {200, emqx_mgmt_auth:format(NewApp)};
+        {error, Reason} when is_map(Reason) ->
+            {400, #{
+                code => 'BAD_REQUEST',
+                message => Reason
+            }};
+        {error, Reason} ->
+            {400, #{
+                code => 'BAD_REQUEST',
+                message => iolist_to_binary(io_lib:format("~p", [Reason]))
+            }}
     end.
 
 -define(NOT_FOUND_RESPONSE, #{code => 'NOT_FOUND', message => ?DESC("name_not_found")}).
@@ -405,17 +437,11 @@ update_api_key(Name, Role, Body) ->
     Enable = maps:get(<<"enable">>, Body, undefined),
     ExpiredAt = ensure_expired_at(Body),
     Desc = maps:get(<<"desc">>, Body, undefined),
-    Scopes = maps:get(<<"scopes">>, Body, undefined),
-    %% Validation runs against the effective scope list (request body
-    %% when supplied, otherwise the persisted scopes) so a role change
-    %% to `publisher' on a key that already holds non-`publish' scopes
-    %% via a partial-update PUT is rejected — the runtime RBAC layer
-    %% would catch it at request time, but the stored config and the
-    %% API response must not be allowed to drift from the
-    %% publisher-only-`publish' invariant.
-    EffectiveScopes = effective_request_scopes(Name, Scopes),
-    case validate_scopes(Role, Scopes, EffectiveScopes) of
+    RawScopes = maps:get(<<"scopes">>, Body, undefined),
+    Intent = emqx_mgmt_auth:write_scope_intent(Role, RawScopes),
+    case validate_update_scopes(Role, Name, Intent) of
         ok ->
+            Scopes = scopes_update_arg(Intent),
             case emqx_mgmt_auth:update(Name, Enable, ExpiredAt, Desc, Role, Scopes) of
                 {ok, App} ->
                     {200, emqx_mgmt_auth:format(App)};
@@ -433,14 +459,38 @@ update_api_key(Name, Role, Body) ->
             {400, #{code => 'BAD_REQUEST', message => Msg}}
     end.
 
-%% Fall back to persisted scopes only when the body did not supply a
-%% `scopes' field. An explicit list (including `[]') is taken verbatim.
+%% Validate the effective scope list for a PUT. `Intent' is the
+%% normalized write intent from `emqx_mgmt_auth:write_scope_intent/2'.
+%%
+%%   * `keep'     - validate the *persisted* scopes against the (possibly
+%%                  changed) role, so a role change to `publisher' on a
+%%                  key that already holds non-`publish' scopes via a
+%%                  partial-update PUT is rejected — the runtime RBAC
+%%                  layer would catch it at request time, but the stored
+%%                  config and the API response must not be allowed to
+%%                  drift from the publisher-only-`publish' invariant.
+%%   * `unset'    - clears to role-default behavior, which is valid by
+%%                  construction; nothing to check.
+%%   * `{set, L}' - validate the explicit list `L'; the privilege-scope
+%%                  mutex applies.
+validate_update_scopes(_Role, _Name, unset) ->
+    ok;
+validate_update_scopes(Role, Name, keep) ->
+    validate_scopes(Role, undefined, persisted_scopes(Name));
+validate_update_scopes(Role, _Name, {set, Scopes}) ->
+    validate_scopes(Role, Scopes, Scopes).
+
+%% Map the write intent to the `Scopes' argument of
+%% `emqx_mgmt_auth:update/6': `undefined' leaves the persisted scopes
+%% unchanged, `unset' clears the field, a list is stored verbatim.
+scopes_update_arg(keep) -> undefined;
+scopes_update_arg(unset) -> unset;
+scopes_update_arg({set, Scopes}) -> Scopes.
+
 %% A missing API key surfaces here as `undefined' so validation accepts
 %% the partial update; the downstream `emqx_mgmt_auth:update/6' call
 %% will then return 404 with the proper error.
-effective_request_scopes(_Name, Scopes) when is_list(Scopes) ->
-    Scopes;
-effective_request_scopes(Name, undefined) ->
+persisted_scopes(Name) ->
     case emqx_mgmt_auth:read(Name) of
         {ok, #{scopes := Persisted}} when is_list(Persisted) -> Persisted;
         _ -> undefined

--- a/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
@@ -164,12 +164,8 @@ fields(app) ->
             )},
         {enable, hoconsc:mk(boolean(), #{desc => ?DESC("enable_desc"), required => false})},
         {expired, hoconsc:mk(boolean(), #{desc => ?DESC("expired_desc"), required => false})},
-        %% Accept the same shapes the response emits, so a read-modify-write
-        %% can round-trip the value verbatim: an explicit array of scope
-        %% names, or the `unset' sentinel (parsed to the atom `unset', also
-        %% tolerated as the binary <<"unset">>). A list whose set equals the
-        %% role default and the `unset' sentinel are both treated as "no
-        %% explicit scopes" on write.
+        %% Accepts the same shapes the response emits (array or the `unset'
+        %% sentinel) so a read-modify-write can round-trip the value verbatim.
         {scopes,
             hoconsc:mk(
                 hoconsc:union([unset, hoconsc:array(binary())]),
@@ -181,11 +177,8 @@ fields(app) ->
             )}
     ] ++ app_extend_fields();
 %% Response shape: `scopes' MAY be the binary sentinel <<"unset">> in addition
-%% to the array-of-binaries form. The sentinel surfaces for records that hold
-%% no explicit `scopes' field: legacy records that survived an upgrade from a
-%% release where the scopes feature did not exist, and records written with
-%% unset-equivalent scopes (the `unset' sentinel or a list equal to the role
-%% default) — both fall back to role-default behavior at runtime.
+%% to the array-of-binaries form, surfaced when the record holds no explicit
+%% `scopes' field (legacy record or unset-equivalent write).
 %%
 %% Listed explicitly (rather than overriding via `lists:keystore') so that the
 %% OpenAPI spec reads as a self-contained response schema and reviewers do not
@@ -350,17 +343,10 @@ create_api_key(App, Name, Enable, ExpiredAt, Desc, Role) ->
             {400, #{code => 'BAD_REQUEST', message => Msg}}
     end.
 
-%% Resolve the `scopes' value to persist on POST and run validation.
-%% Returns `{ok, [binary()] | undefined}' or `{error, Msg}'.
-%%
-%%   * field omitted -> materialize the role default and store it;
-%%     validation runs with `RawScopes = undefined' so the privilege-scope
-%%     mutex is not applied to the role-default mix.
-%%   * `unset' sentinel or a list whose set equals the role default ->
-%%     store no `scopes' field at all (GET returns the `unset' sentinel);
-%%     valid by construction, nothing to check.
-%%   * any other list -> validate and store it verbatim (explicit `[]'
-%%     means deny-all).
+%% Resolve the `scopes' value to persist on POST: omitted -> materialize
+%% the role default (privilege mutex not applied to that mix);
+%% unset-equivalent -> store no `scopes' field (valid by construction);
+%% explicit list -> validate and store verbatim.
 create_scopes(Role, undefined) ->
     Scopes = emqx_mgmt_auth:role_default_scopes(Role),
     case validate_scopes(Role, undefined, Scopes) of
@@ -459,20 +445,11 @@ update_api_key(Name, Role, Body) ->
             {400, #{code => 'BAD_REQUEST', message => Msg}}
     end.
 
-%% Validate the effective scope list for a PUT. `Intent' is the
-%% normalized write intent from `emqx_mgmt_auth:write_scope_intent/2'.
-%%
-%%   * `keep'     - validate the *persisted* scopes against the (possibly
-%%                  changed) role, so a role change to `publisher' on a
-%%                  key that already holds non-`publish' scopes via a
-%%                  partial-update PUT is rejected — the runtime RBAC
-%%                  layer would catch it at request time, but the stored
-%%                  config and the API response must not be allowed to
-%%                  drift from the publisher-only-`publish' invariant.
-%%   * `unset'    - clears to role-default behavior, which is valid by
-%%                  construction; nothing to check.
-%%   * `{set, L}' - validate the explicit list `L'; the privilege-scope
-%%                  mutex applies.
+%% Validate the effective scope list for a PUT. `keep' validates the
+%% persisted scopes against the (possibly changed) role, so a role
+%% change to `publisher' cannot keep non-`publish' scopes via a partial
+%% update; `unset' clears to role default (valid by construction);
+%% `{set, L}' validates `L' with the privilege mutex applied.
 validate_update_scopes(_Role, _Name, unset) ->
     ok;
 validate_update_scopes(Role, Name, keep) ->
@@ -480,16 +457,13 @@ validate_update_scopes(Role, Name, keep) ->
 validate_update_scopes(Role, _Name, {set, Scopes}) ->
     validate_scopes(Role, Scopes, Scopes).
 
-%% Map the write intent to the `Scopes' argument of
-%% `emqx_mgmt_auth:update/6': `undefined' leaves the persisted scopes
-%% unchanged, `unset' clears the field, a list is stored verbatim.
+%% Intent -> `Scopes' argument of `emqx_mgmt_auth:update/6'.
 scopes_update_arg(keep) -> undefined;
 scopes_update_arg(unset) -> unset;
 scopes_update_arg({set, Scopes}) -> Scopes.
 
-%% A missing API key surfaces here as `undefined' so validation accepts
-%% the partial update; the downstream `emqx_mgmt_auth:update/6' call
-%% will then return 404 with the proper error.
+%% A missing key surfaces as `undefined' so validation passes and the
+%% downstream `emqx_mgmt_auth:update/6' returns the proper 404.
 persisted_scopes(Name) ->
     case emqx_mgmt_auth:read(Name) of
         {ok, #{scopes := Persisted}} when is_list(Persisted) -> Persisted;

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -58,9 +58,7 @@
     do_force_create_app/1
 ]).
 
-%% Helpers for materializing role-default scopes at record-creation time
-%% and for normalizing a `scopes' request value into a write intent.
-%% Used by the REST handlers and the bootstrap-file loader.
+%% Role-default scopes and `scopes' write-intent normalization.
 -export([role_default_scopes/1, write_scope_intent/2]).
 
 -ifdef(TEST).
@@ -403,8 +401,7 @@ get_scopes(_) ->
     undefined.
 
 %% @doc Set scopes in extra map. `undefined' means "don't change";
-%% `unset' removes the field entirely so the record falls back to
-%% role-default behavior (GET surfaces the `<<"unset">>' sentinel).
+%% `unset' clears the field back to role-default behavior.
 maybe_set_scopes(Extra, undefined) ->
     Extra;
 maybe_set_scopes(Extra, unset) ->
@@ -427,24 +424,13 @@ role_default_scopes(?ROLE_API_PUBLISHER) ->
 role_default_scopes(_Role) ->
     ?GENERIC_SCOPES.
 
-%% @doc Normalize a `scopes' request value to a write intent — the
-%% API-key counterpart of `emqx_dashboard_api:write_scope_intent/2'
-%% (dashboard users); keep the two consistent.
-%%   * `keep'     - field omitted (`undefined'): leave persisted scopes
-%%                  unchanged (partial update); creation paths
-%%                  materialize the role default instead.
-%%   * `unset'    - the `unset' sentinel (atom, also tolerated as the
-%%                  binary `<<"unset">>'), or a list whose set equals
-%%                  the role default: store NO explicit `scopes' field,
-%%                  so GET returns the `unset' sentinel and the runtime
-%%                  falls back to role-default behavior.
-%%   * `{set, L}' - store the explicit list `L' verbatim.
-%%
-%% The role-default comparison is order-insensitive (set equality), so a
-%% dashboard read-modify-write that round-trips the expanded role
-%% default never sediments it into a frozen explicit list. A non-list,
-%% non-sentinel value falls through to `{set, Other}' so downstream
-%% validation rejects it with the appropriate 400.
+%% @doc Normalize a `scopes' request value to a write intent:
+%% `keep' (field omitted), `unset' (the `unset' sentinel or a list
+%% set-equal to the role default: store no explicit scopes so a
+%% read-modify-write never freezes the implicit default), or
+%% `{set, L}' (store `L' verbatim; downstream validation rejects
+%% non-list garbage). Counterpart of
+%% `emqx_dashboard_api:write_scope_intent/2'; keep the two consistent.
 write_scope_intent(_Role, undefined) ->
     keep;
 write_scope_intent(_Role, unset) ->
@@ -488,13 +474,9 @@ to_map(#?APP{
 %% @doc Surface raw scope state to the API consumer with a tri-state contract:
 %%   - `[]`            : explicit deny-all (only `security => []` paths reachable)
 %%   - `[binary(), …]` : explicit allow-list
-%%   - `<<"unset">>`   : the persisted record has no `scopes' field at all —
-%%                       either a legacy record from before #16942 landed, or a
-%%                       record written with unset-equivalent scopes (the `unset'
-%%                       sentinel or a list equal to the role default). The
-%%                       runtime authorization path falls back to role-default
-%%                       behaviour (allow-all-mapped-paths for administrator/
-%%                       viewer, hard-coded `/publish*' for publisher).
+%%   - `<<"unset">>`   : the persisted record has no `scopes' field at all
+%%                       (legacy record or unset-equivalent write); the runtime
+%%                       falls back to role-default behaviour.
 %% This intentionally exposes the persisted shape rather than an effective list so
 %% that the dashboard read-modify-write cycle cannot silently sediment role-default
 %% into an explicit list.  The `<<"unset">>' binary is a stable string sentinel

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -58,11 +58,10 @@
     do_force_create_app/1
 ]).
 
-%% Helpers for materializing role-default scopes at record-creation time.
-%% Used by the POST handler, the bootstrap-file loader, and the SSO
-%% user-provisioning path so that `<<"unset">>' in a GET response can be
-%% interpreted unambiguously as "record predates the scopes feature".
--export([role_default_scopes/1, effective_scopes_on_create/2]).
+%% Helpers for materializing role-default scopes at record-creation time
+%% and for normalizing a `scopes' request value into a write intent.
+%% Used by the REST handlers and the bootstrap-file loader.
+-export([role_default_scopes/1, write_scope_intent/2]).
 
 -ifdef(TEST).
 -export([trans/2, force_create_app/1]).
@@ -403,20 +402,19 @@ get_scopes(_) ->
     %% No scopes key in extra = backward compatible, allow all
     undefined.
 
-%% @doc Set scopes in extra map. undefined means "don't change".
+%% @doc Set scopes in extra map. `undefined' means "don't change";
+%% `unset' removes the field entirely so the record falls back to
+%% role-default behavior (GET surfaces the `<<"unset">>' sentinel).
 maybe_set_scopes(Extra, undefined) ->
     Extra;
+maybe_set_scopes(Extra, unset) ->
+    maps:remove(scopes, Extra);
 maybe_set_scopes(Extra, Scopes) when is_list(Scopes) ->
     Extra#{scopes => Scopes}.
 
 %% @doc Resolve the role-default scopes that should be materialized into
 %% the persisted record when the caller did not explicitly supply a scope
 %% list (POST without `scopes', 2-/3-segment bootstrap line).
-%%
-%% After this PR, `undefined' is never written into mnesia by any creation
-%% path; the `<<"unset">>' state in the GET response is only possible for
-%% records that survived an upgrade from a release where the scopes
-%% feature did not exist.
 %%
 %%   * administrator / viewer -> `?GENERIC_SCOPES' (10 management scopes,
 %%     no login-only scopes — those are reserved for dashboard users).
@@ -429,14 +427,40 @@ role_default_scopes(?ROLE_API_PUBLISHER) ->
 role_default_scopes(_Role) ->
     ?GENERIC_SCOPES.
 
-%% @doc Convenience wrapper for the request-handling layer: if the
-%% caller supplied no scopes, materialize the role default; otherwise
-%% pass the explicit value through unchanged (including the empty list
-%% which means explicit deny-all).
-effective_scopes_on_create(Role, undefined) ->
-    role_default_scopes(Role);
-effective_scopes_on_create(_Role, Scopes) when is_list(Scopes) ->
-    Scopes.
+%% @doc Normalize a `scopes' request value to a write intent — the
+%% API-key counterpart of `emqx_dashboard_api:write_scope_intent/2'
+%% (dashboard users); keep the two consistent.
+%%   * `keep'     - field omitted (`undefined'): leave persisted scopes
+%%                  unchanged (partial update); creation paths
+%%                  materialize the role default instead.
+%%   * `unset'    - the `unset' sentinel (atom, also tolerated as the
+%%                  binary `<<"unset">>'), or a list whose set equals
+%%                  the role default: store NO explicit `scopes' field,
+%%                  so GET returns the `unset' sentinel and the runtime
+%%                  falls back to role-default behavior.
+%%   * `{set, L}' - store the explicit list `L' verbatim.
+%%
+%% The role-default comparison is order-insensitive (set equality), so a
+%% dashboard read-modify-write that round-trips the expanded role
+%% default never sediments it into a frozen explicit list. A non-list,
+%% non-sentinel value falls through to `{set, Other}' so downstream
+%% validation rejects it with the appropriate 400.
+write_scope_intent(_Role, undefined) ->
+    keep;
+write_scope_intent(_Role, unset) ->
+    unset;
+write_scope_intent(_Role, <<"unset">>) ->
+    unset;
+write_scope_intent(Role, Scopes) when is_list(Scopes) ->
+    case is_role_default_scopes(Role, Scopes) of
+        true -> unset;
+        false -> {set, Scopes}
+    end;
+write_scope_intent(_Role, Other) ->
+    {set, Other}.
+
+is_role_default_scopes(Role, Scopes) ->
+    lists:usort(Scopes) =:= lists:usort(role_default_scopes(Role)).
 
 ensure_not_undefined(undefined, Old) -> Old;
 ensure_not_undefined(New, _Old) -> New.
@@ -464,14 +488,13 @@ to_map(#?APP{
 %% @doc Surface raw scope state to the API consumer with a tri-state contract:
 %%   - `[]`            : explicit deny-all (only `security => []` paths reachable)
 %%   - `[binary(), …]` : explicit allow-list
-%%   - `<<"unset">>`   : the persisted record has no `scopes' field at all (legacy
-%%                       upgrade artefact from before #16942 landed). The runtime
-%%                       authorization path falls back to role-default behaviour
-%%                       (allow-all-mapped-paths for administrator/viewer,
-%%                       hard-coded `/publish*' for publisher).  Newly created
-%%                       records never end up in this state: the POST / bootstrap
-%%                       / SSO-provisioning paths all materialize role-default
-%%                       scopes at creation time.
+%%   - `<<"unset">>`   : the persisted record has no `scopes' field at all —
+%%                       either a legacy record from before #16942 landed, or a
+%%                       record written with unset-equivalent scopes (the `unset'
+%%                       sentinel or a list equal to the role default). The
+%%                       runtime authorization path falls back to role-default
+%%                       behaviour (allow-all-mapped-paths for administrator/
+%%                       viewer, hard-coded `/publish*' for publisher).
 %% This intentionally exposes the persisted shape rather than an effective list so
 %% that the dashboard read-modify-write cycle cannot silently sediment role-default
 %% into an explicit list.  The `<<"unset">>' binary is a stable string sentinel

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -1460,6 +1460,10 @@ t_ee_scopes_update_unchanged_roundtrip(_Config) ->
     %% Order-insensitive: a permuted role-default list is also unset-equivalent.
     ?assertMatch({ok, _}, update_app(Name, #{scopes => lists:reverse(Default)})),
     ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    %% From the unset state, an explicit non-default list still takes effect.
+    Explicit = [?SCOPE_CONNECTIONS, ?SCOPE_MONITORING],
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => Explicit})),
+    ?assertMatch({ok, #{<<"scopes">> := Explicit}}, read_app(Name)),
     delete_app(Name).
 
 -doc """

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -38,6 +38,11 @@
     t_ee_api_key_rejects_mixed_privilege_via_post,
     t_ee_api_key_rejects_mixed_privilege_via_put,
     t_ee_api_key_privilege_mutex_message,
+    %% Unset-equivalent scopes on create/update (#18195)
+    t_ee_scopes_update_unchanged_roundtrip,
+    t_ee_scopes_create_unset_sentinel,
+    t_ee_scopes_update_explicit_list,
+    t_ee_publisher_update_rejects_explicit_non_publish,
     %% Regression: API key auth must not leak into dashboard
     %% login-user scope check when ApiKey name == dashboard username.
     t_ee_api_key_unaffected_by_colliding_username_scopes
@@ -1434,6 +1439,73 @@ t_ee_api_key_privilege_mutex_message(_Config) ->
         {_, _},
         binary:match(Msg, <<"Privilege scopes cannot be combined with other scopes">>)
     ).
+
+-doc """
+The #18195 repro: create a key with the scope left blank, then update it
+re-submitting exactly what GET returned — the update must succeed.
+
+The blank-scope create materializes the role default, so the first GET
+returns the expanded role-default list; re-submitting that list is an
+unset-equivalent write (order-insensitive) and clears the stored scope
+list, after which GET returns the `unset` sentinel — which must also
+round-trip through a subsequent unchanged update.
+""".
+t_ee_scopes_update_unchanged_roundtrip(_Config) ->
+    Name = <<"EE-SCOPES-ROUNDTRIP">>,
+    {ok, _} = create_app(Name),
+    {ok, #{<<"scopes">> := Default}} = read_app(Name),
+    ?assert(is_list(Default)),
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => Default})),
+    %% The role-default list is stored as "no explicit scopes".
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    %% Round-trip once more with the `unset` sentinel GET now returns.
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => <<"unset">>})),
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    %% Order-insensitive: a permuted role-default list is also unset-equivalent.
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => lists:reverse(Default)})),
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    delete_app(Name).
+
+-doc """
+POST accepts the `unset` sentinel: the key is created without an explicit
+scope list and GET surfaces the sentinel.
+""".
+t_ee_scopes_create_unset_sentinel(_Config) ->
+    Name = <<"EE-SCOPES-CREATE-UNSET">>,
+    {ok, _} = create_app(Name, #{scopes => <<"unset">>}),
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    delete_app(Name).
+
+-doc """
+A genuinely explicit scope list (different from the role default) is
+still validated and stored verbatim; GET reflects it.
+""".
+t_ee_scopes_update_explicit_list(_Config) ->
+    Name = <<"EE-SCOPES-EXPLICIT">>,
+    {ok, _} = create_app(Name),
+    Scopes = [?SCOPE_CONNECTIONS, ?SCOPE_MONITORING],
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => Scopes})),
+    ?assertMatch({ok, #{<<"scopes">> := Scopes}}, read_app(Name)),
+    delete_app(Name).
+
+-doc """
+The publisher-only-`publish` invariant survives the unset-equivalent
+handling: an explicit non-publish list on a publisher key is still
+rejected on PUT, while the publisher role default (`[publish]`) is
+accepted as unset-equivalent.
+""".
+t_ee_publisher_update_rejects_explicit_non_publish(_Config) ->
+    Name = <<"EE-PUB-UPDATE-REJECT">>,
+    {ok, _} = create_app(Name, #{role => ?ROLE_API_PUBLISHER}),
+    assert_400_publisher_only(
+        update_app(Name, #{role => ?ROLE_API_PUBLISHER, scopes => [?SCOPE_CONNECTIONS]})
+    ),
+    ?assertMatch(
+        {ok, _},
+        update_app(Name, #{role => ?ROLE_API_PUBLISHER, scopes => [?SCOPE_PUBLISH]})
+    ),
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    delete_app(Name).
 
 %% Regression: API key auth must NOT consult dashboard login-user
 %% scopes, even when the API key's generated `api_key' string happens

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -1442,13 +1442,9 @@ t_ee_api_key_privilege_mutex_message(_Config) ->
 
 -doc """
 The #18195 repro: create a key with the scope left blank, then update it
-re-submitting exactly what GET returned — the update must succeed.
-
-The blank-scope create materializes the role default, so the first GET
-returns the expanded role-default list; re-submitting that list is an
-unset-equivalent write (order-insensitive) and clears the stored scope
-list, after which GET returns the `unset` sentinel — which must also
-round-trip through a subsequent unchanged update.
+re-submitting exactly what GET returned (the materialized role-default
+list, in any order, later the `unset` sentinel) — the update must
+succeed and clear the stored scope list.
 """.
 t_ee_scopes_update_unchanged_roundtrip(_Config) ->
     Name = <<"EE-SCOPES-ROUNDTRIP">>,

--- a/changes/ee/fix-18196.en.md
+++ b/changes/ee/fix-18196.en.md
@@ -1,0 +1,3 @@
+Fixed an error when updating an API key that was created with the scope left blank.
+
+The API key create and update requests now accept a scope list that matches the role's implicit default (and the `unset` value) as equivalent to "no explicit scopes", so re-submitting the value returned by a read no longer fails. Such keys also keep their forward-compatible implicit scopes instead of a frozen list, consistent with Dashboard users.

--- a/rel/i18n/emqx_mgmt_api_api_keys.hocon
+++ b/rel/i18n/emqx_mgmt_api_api_keys.hocon
@@ -86,12 +86,12 @@ api_key_scopes_list.label:
 """List API key scopes"""
 
 api_key_scopes_request.desc:
-"""List of scope names to grant this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). When omitted on creation, the server materializes the role default: administrator/viewer get all management scopes, publisher gets `publish` only. Send an explicit empty list `[]` to create a deny-all key (only anonymous endpoints such as `/status` remain reachable)."""
+"""List of scope names to grant this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). When omitted on creation, the server materializes the role default: administrator/viewer get all management scopes, publisher gets `publish` only. The literal string `unset`, or a list equal to the role default, means "no explicit scope policy": the key is stored without a scope list and follows the role default (this lets a client re-submit the value a read returned without modification). Send an explicit empty list `[]` to create a deny-all key (only anonymous endpoints such as `/status` remain reachable)."""
 api_key_scopes_request.label:
 """API key scopes (request)"""
 
 api_key_scopes_response.desc:
-"""List of scope names granted to this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). The literal string `unset` is a legacy-only sentinel surfaced for records that survived an upgrade from a release where the scopes feature did not exist; the runtime falls back to role default for such records, and a client should treat them as "no explicit scope policy yet". An empty list `[]` means deny-all (only anonymous endpoints such as `/status` remain reachable)."""
+"""List of scope names granted to this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). The literal string `unset` is a sentinel surfaced for records that hold no explicit scope list (created or updated with unset-equivalent scopes, or records that survived an upgrade from a release where the scopes feature did not exist); the runtime falls back to role default for such records, and a client should treat them as "no explicit scope policy". An empty list `[]` means deny-all (only anonymous endpoints such as `/status` remain reachable)."""
 api_key_scopes_response.label:
 """API key scopes (response)"""
 


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Fixes #18195: creating an API key with the scope left blank and then updating it (even unchanged) failed with 400. This is the API-key counterpart of #18009 (dashboard users, #17930) — the same read-modify-write bug: GET returns the materialized role-default scope list (or the `unset` sentinel for legacy records), and re-submitting that value was rejected because the privilege-scope mutex was misapplied to the role-default mix and the request schema did not accept the sentinel.

* `emqx_mgmt_auth:write_scope_intent/2` (new, mirrors `emqx_dashboard_api:write_scope_intent/2`) normalizes the `scopes` request value to `keep | unset | {set, List}`: the `unset` sentinel and a list whose set equals the role default (order-insensitive) are both "no explicit scopes".
* `emqx_mgmt_api_api_keys` create/update paths run validation per intent: unset-equivalent writes skip the privilege mutex (as omitted scopes already did) and persist with the `scopes` field cleared (`maybe_set_scopes(Extra, unset)` removes the field), so such keys keep forward-compatible implicit scopes instead of a frozen list. Explicit lists are validated and stored verbatim; the publisher-only-`publish` invariant is unchanged.
* The `scopes` request schema is now `hoconsc:union([unset, hoconsc:array(binary())])`, matching the response shape so a GET value round-trips verbatim.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
