### PR TITLE
fix(schema_registry): support non-ASCII JSON schemas and resolve Unicode $ref fragments

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -3165,8 +3165,19 @@ to_url(Str) ->
     end.
 
 to_json_binary(Str) ->
-    case emqx_utils_json:safe_decode(Str) of
-        {ok, _} -> {ok, unicode:characters_to_binary(Str)};
+    %% hocon converts the raw binary to a unicode codepoint list before
+    %% calling this; the JSON decoder only accepts binaries and byte lists,
+    %% so re-encode first or any non-ASCII value fails with badarg.
+    case unicode:characters_to_binary(Str) of
+        Bin when is_binary(Bin) ->
+            do_to_json_binary(Bin);
+        _ ->
+            {error, "Invalid UTF-8 in JSON value"}
+    end.
+
+do_to_json_binary(Bin) ->
+    case emqx_utils_json:safe_decode(Bin) of
+        {ok, _} -> {ok, Bin};
         {error, {_Pos, truncated_json}} -> {error, "Truncated JSON value"};
         {error, {_Pos, invalid_literal}} -> {error, "Invalid JSON literal"};
         {error, {_Pos, invalid_number}} -> {error, "Invalid JSON number"};

--- a/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
@@ -57,6 +57,9 @@
         _ = EXPR,
         true
     catch
+        throw:Reason ->
+            ?SLOG(debug, #{msg => "schema_check_failed", schema => SerdeName, reason => Reason}),
+            false;
         error:Reason ->
             ?SLOG(debug, #{msg => "schema_check_failed", schema => SerdeName, reason => Reason}),
             false
@@ -263,10 +266,19 @@ make_serde(?protobuf, Name, Source) ->
 make_serde(?json, Name, Source) ->
     case json_decode(Source) of
         SchemaObj when is_map(SchemaObj) ->
-            %% jesse:add_schema adds any map() without further validation
-            %% if it's not a map, then case_clause
-            ok = jesse_add_schema(Name, SchemaObj),
-            #serde{name = Name, type = ?json};
+            Res =
+                try
+                    jesse_add_schema(Name, SchemaObj)
+                catch
+                    _Kind:Reason ->
+                        {error, Reason}
+                end,
+            case Res of
+                ok ->
+                    #serde{name = Name, type = ?json};
+                {error, Reason1} ->
+                    error({invalid_json_schema, Reason1})
+            end;
         _NotMap ->
             error({invalid_json_schema, bad_schema_object})
     end;
@@ -317,8 +329,24 @@ eval_decode(#serde{type = ?protobuf, eval_context = SerdeMod}, [EncodedData, Mes
 eval_decode(#serde{type = ?json, name = Name}, [Data]) ->
     true = is_binary(Data),
     Term = json_decode(Data),
-    {ok, NewTerm} = jesse_validate(Name, Term),
-    NewTerm;
+    case jesse_validate(Name, Term) of
+        {ok, NewTerm} ->
+            NewTerm;
+        {error, Reason} ->
+            throw(
+                {schema_decode_error, #{
+                    error_type => validation_failure,
+                    schema_name => Name,
+                    reason => Reason,
+                    explain =>
+                        <<
+                            "The given data does not conform to the schema,"
+                            " or a schema reference could not be resolved."
+                            " Please check the input data and the schema."
+                        >>
+                }}
+            )
+    end;
 eval_decode(#serde{type = ?external_http, name = Name, eval_context = Context}, [Payload]) ->
     Request = generate_external_http_request(Payload, decode, Name, Context),
     exec_external_http_request(Request, Context).

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
@@ -51,7 +51,9 @@ only_once_testcases() ->
         t_smoke_test_external_registry_confluent,
         t_external_http_serde,
         t_json_schema_2019_09,
-        t_json_schema_2020_12
+        t_json_schema_2020_12,
+        t_json_schema_draft04_unicode_ref,
+        t_json_schema_draft06_unicode_source
     ].
 
 init_per_suite(Config) ->
@@ -1435,6 +1437,101 @@ t_json_schema_2020_12(_TCConfig) ->
     ?assertMatch({200, #{<<"decoded">> := Data1}}, dryrun_rule(SQL1, Context1)),
     %% wrong second element
     Data2 = [1, <<"foo">>],
+    Context2 = publish_context({json, Data2}),
+    ?assertMatch({400, _}, dryrun_rule(SQL1, Context2)),
+    ok.
+
+-doc """
+Registers a Draft-04 schema with a Unicode definition name referenced through a
+percent-encoded `$ref` fragment, and decodes payloads through the Rule Engine:
+a valid payload decodes successfully, an invalid one yields a rule error.
+""".
+t_json_schema_draft04_unicode_ref(_TCConfig) ->
+    Source =
+        #{
+            <<"$schema">> => <<"http://json-schema.org/draft-04/schema#">>,
+            <<"definitions">> => #{
+                <<"姓名类型"/utf8>> => #{
+                    <<"type">> => <<"string">>,
+                    <<"minLength">> => 2
+                }
+            },
+            <<"type">> => <<"object">>,
+            <<"properties">> => #{
+                <<"姓名"/utf8>> => #{
+                    <<"$ref">> => <<"#/definitions/%E5%A7%93%E5%90%8D%E7%B1%BB%E5%9E%8B">>
+                }
+            },
+            <<"required">> => [<<"姓名"/utf8>>]
+        },
+    SourceBin = emqx_utils_json:encode(Source),
+    SchemaName = <<"draft04_unicode_ref">>,
+    Params = #{
+        <<"name">> => SchemaName,
+        <<"type">> => <<"json">>,
+        <<"source">> => SourceBin
+    },
+    ?assertMatch({201, _}, create_schema(Params)),
+
+    SQL1 = sql(
+        <<"select schema_decode('${.name}', payload) as decoded from \"t\" ">>,
+        #{name => SchemaName}
+    ),
+    Data1 = #{<<"姓名"/utf8>> => <<"张三"/utf8>>},
+    Context1 = publish_context({json, Data1}),
+    ?assertMatch({200, #{<<"decoded">> := Data1}}, dryrun_rule(SQL1, Context1)),
+    %% shorter than minLength
+    Data2 = #{<<"姓名"/utf8>> => <<"李"/utf8>>},
+    Context2 = publish_context({json, Data2}),
+    ?assertMatch({400, _}, dryrun_rule(SQL1, Context2)),
+    ok.
+
+-doc """
+Registers a Draft-06 schema containing `$id`, `examples`, a numeric
+`exclusiveMinimum` and non-ASCII strings through the HTTP API, and checks that
+the draft-06 keywords are enforced when decoding through the Rule Engine.
+""".
+t_json_schema_draft06_unicode_source(_TCConfig) ->
+    Source =
+        #{
+            <<"$schema">> => <<"http://json-schema.org/draft-06/schema#">>,
+            <<"$id">> => <<"https://example.com/product.schema.json">>,
+            <<"title">> => <<"Product">>,
+            <<"type">> => <<"object">>,
+            <<"properties">> => #{
+                <<"productId">> => #{
+                    <<"type">> => <<"integer">>,
+                    <<"exclusiveMinimum">> => 0,
+                    <<"examples">> => [1, 100]
+                },
+                <<"productName">> => #{
+                    <<"type">> => <<"string">>,
+                    <<"examples">> => [<<"智能手机"/utf8>>, <<"无线耳机"/utf8>>]
+                }
+            },
+            <<"required">> => [<<"productId">>, <<"productName">>],
+            <<"examples">> => [
+                #{<<"productId">> => 1, <<"productName">> => <<"机械键盘"/utf8>>}
+            ]
+        },
+    SourceBin = emqx_utils_json:encode(Source),
+    SchemaName = <<"draft06_product">>,
+    Params = #{
+        <<"name">> => SchemaName,
+        <<"type">> => <<"json">>,
+        <<"source">> => SourceBin
+    },
+    ?assertMatch({201, _}, create_schema(Params)),
+
+    SQL1 = sql(
+        <<"select schema_decode('${.name}', payload) as decoded from \"t\" ">>,
+        #{name => SchemaName}
+    ),
+    Data1 = #{<<"productId">> => 1, <<"productName">> => <<"机械键盘"/utf8>>},
+    Context1 = publish_context({json, Data1}),
+    ?assertMatch({200, #{<<"decoded">> := Data1}}, dryrun_rule(SQL1, Context1)),
+    %% draft-06 numeric exclusiveMinimum is enforced
+    Data2 = #{<<"productId">> => 0, <<"productName">> => <<"x">>},
     Context2 = publish_context({json, Data2}),
     ?assertMatch({400, _}, dryrun_rule(SQL1, Context2)),
     ok.

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_serde_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_serde_SUITE.erl
@@ -350,6 +350,78 @@ t_json_validation(_Config) ->
     ?assertNot(CheckFn(<<"{\"foo\": \"notinteger\", \"bar\": 2}">>)),
     ok.
 
+-doc """
+Registers a Draft-04 schema whose `$ref` points at a Unicode definition name,
+both percent-encoded (RFC 3986) and as raw UTF-8, and checks that decoding
+resolves the reference: valid payloads decode to the expected map and invalid
+payloads throw a structured `schema_decode_error` instead of crashing.
+""".
+t_json_unicode_ref(_Config) ->
+    PercentEncoded = <<
+        "{\"$schema\":\"http://json-schema.org/draft-04/schema#\","
+        "\"definitions\":{\"姓名类型\":{\"type\":\"string\",\"minLength\":2}},"
+        "\"type\":\"object\","
+        "\"properties\":{\"姓名\":{\"$ref\":\"#/definitions/%E5%A7%93%E5%90%8D%E7%B1%BB%E5%9E%8B\"}},"
+        "\"required\":[\"姓名\"]}"/utf8
+    >>,
+    RawUnicode = <<
+        "{\"$schema\":\"http://json-schema.org/draft-04/schema#\","
+        "\"definitions\":{\"姓名类型\":{\"type\":\"string\",\"minLength\":2}},"
+        "\"type\":\"object\","
+        "\"properties\":{\"姓名\":{\"$ref\":\"#/definitions/姓名类型\"}},"
+        "\"required\":[\"姓名\"]}"/utf8
+    >>,
+    Valid = <<"{\"姓名\":\"张三\"}"/utf8>>,
+    TooShort = <<"{\"姓名\":\"李\"}"/utf8>>,
+    lists:foreach(
+        fun({SerdeName, Source}) ->
+            ok = emqx_schema_registry:add_schema(SerdeName, #{type => json, source => Source}),
+            ?assertEqual(
+                #{<<"姓名"/utf8>> => <<"张三"/utf8>>},
+                emqx_schema_registry_serde:decode(SerdeName, Valid),
+                #{schema => SerdeName}
+            ),
+            ?assertThrow(
+                {schema_decode_error, #{error_type := validation_failure}},
+                emqx_schema_registry_serde:decode(SerdeName, TooShort),
+                #{schema => SerdeName}
+            )
+        end,
+        [
+            {<<"json_percent_encoded_ref">>, PercentEncoded},
+            {<<"json_raw_unicode_ref">>, RawUnicode}
+        ]
+    ),
+    ok.
+
+-doc """
+Registers a Draft-06 schema containing `$id`, `examples`, a numeric
+`exclusiveMinimum` and non-ASCII strings, and checks that registration
+succeeds and the draft-06 keywords are enforced during validation.
+""".
+t_json_draft06_unicode_source(_Config) ->
+    SerdeName = <<"json_draft06_product">>,
+    Source = <<
+        "{\"$schema\":\"http://json-schema.org/draft-06/schema#\","
+        "\"$id\":\"https://example.com/product.schema.json\","
+        "\"title\":\"Product\",\"type\":\"object\","
+        "\"properties\":{"
+        "\"productId\":{\"type\":\"integer\",\"exclusiveMinimum\":0,\"examples\":[1,100]},"
+        "\"productName\":{\"type\":\"string\",\"examples\":[\"智能手机\",\"无线耳机\"]}},"
+        "\"required\":[\"productId\",\"productName\"],"
+        "\"examples\":[{\"productId\":1,\"productName\":\"机械键盘\"}]}"/utf8
+    >>,
+    ok = emqx_schema_registry:add_schema(SerdeName, #{type => json, source => Source}),
+    CheckFn = fun(Data) ->
+        emqx_schema_registry_serde:rsf_schema_check([SerdeName, Data])
+    end,
+    ?assert(CheckFn(<<"{\"productId\":1,\"productName\":\"机械键盘\"}"/utf8>>)),
+    %% draft-06 numeric exclusiveMinimum is enforced
+    ?assertNot(CheckFn(<<"{\"productId\":0,\"productName\":\"x\"}">>)),
+    %% required is enforced
+    ?assertNot(CheckFn(<<"{\"productName\":\"x\"}">>)),
+    ok.
+
 t_is_existing_type(_Config) ->
     JsonName = <<"myjson">>,
     ?assertNot(emqx_schema_registry:is_existing_type(JsonName)),

--- a/changes/ee/fix-18198.en.md
+++ b/changes/ee/fix-18198.en.md
@@ -1,0 +1,6 @@
+Fixed two JSON Schema Registry issues:
+
+- Schemas containing non-ASCII characters (for example Chinese property names or example values) can now be registered through the HTTP API. Previously, registration failed with an internal `badarg` error.
+- `$ref` references pointing at definition names containing non-ASCII characters now resolve correctly during validation and decoding, both in percent-encoded form (for example `#/definitions/%E5%A7%93%E5%90%8D%E7%B1%BB%E5%9E%8B`) and in raw UTF-8 form. Previously, such references failed to resolve, and decoding failed with an internal `badmatch` error.
+
+In addition, a payload that does not conform to its JSON schema now produces a clear schema validation error during Rule Engine decoding instead of an internal error.

--- a/mix.exs
+++ b/mix.exs
@@ -288,7 +288,7 @@ defmodule EMQXUmbrella.MixProject do
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.10", override: true}
   def common_dep(:crc32cer), do: {:crc32cer, "1.1.2", override: true}
-  def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.9.0"}
+  def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.9.1"}
 
   def common_dep(:erlavro),
     do: {:erlavro, github: "emqx/erlavro", tag: "2.10.2-emqx-3", override: true}


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Fixes #18187 and #18189 (both in the JSON Schema Registry serde path, introduced-surface tested against the jesse 1.9.0 bump in #18110).

**#18189 — Draft-06 schema rejected at registration with `badarg`.**
The draft is a red herring: jesse 1.9.0 already handles draft-06 (`$id`, `examples`, numeric `exclusiveMinimum`) correctly. The `badarg` comes from the HTTP request-body typecheck: hocon hands typerefl `from_string` converters a **unicode codepoint list**, and `emqx_schema:to_json_binary/1` passed it straight to the JSON decoder, which only accepts binaries/byte lists — so *any* JSON schema source containing non-ASCII characters (e.g. Chinese example values) was rejected. Fixed by re-encoding to a UTF-8 binary before decoding (`apps/emqx/src/emqx_schema.erl`).

**#18187 — Draft-04 percent-encoded Unicode `$ref` fails to resolve → `badmatch` at decode.**
Root cause fixed in the jesse fork ([emqx/jesse#11](https://github.com/emqx/jesse/pull/11), released as **jesse 1.9.1**, pinned here): `jesse_json_path:parse_json_pointer_token/1` percent-decoded the fragment into raw UTF-8 bytes but then re-encoded each byte as a codepoint, producing a double-encoded key that never matched `definitions` — raw (non-percent-encoded) Unicode `$ref`s were equally broken. The same patch also fixes two RFC 6901 violations (`~1`/`~0` transformed in the wrong order; only the first occurrence replaced).

**Hardening (`emqx_schema_registry_serde`), so jesse errors can never surface as internal crashes:**
- `eval_decode/2` for JSON no longer badmatches on `{error, _}` from jesse; it throws a structured `schema_decode_error` (mirroring the protobuf serde), which the Rule Engine reports as a clean rule error.
- `schema_check/3` treats such throws as a failed check (previously only `error:` class was caught).
- `make_serde/3` for JSON wraps `jesse:add_schema` so any error becomes `{invalid_json_schema, Reason}` → 400 at the API.

Covered by new serde-level tests (percent-encoded + raw Unicode `$ref`, draft-06 Unicode source with `exclusiveMinimum` enforcement, structured decode errors) and HTTP-API-level tests using the exact issue payloads end-to-end (`POST /schema_registry` + `/rule_test` dry-run).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
