### PR TITLE
fix(mgmt): accept unset-equivalent scopes on API key write

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -159,8 +159,10 @@ do_add_user(Username, Password, Role, Desc) ->
 %%   * `[binary(), ...]' (5-arg version) - the listed scopes are written
 %%     into the record atomically inside the same mria transaction as the
 %%     row insertion. This is used by paths that do NOT have a follow-up
-%%     `set_user_scopes' step (SSO auto-provisioning, default-admin bootstrap)
-%%     so a new row never appears with a missing scopes key.
+%%     `set_user_scopes' step (SSO auto-provisioning) so a new row never
+%%     appears with a missing scopes key. The default-admin bootstrap
+%%     deliberately omits it: that account stays on implicit role-default
+%%     scopes.
 do_add_user(Username, Password, Role, Desc, InitialScopes) ->
     Res = mria:sync_transaction(
         ?DASHBOARD_SHARD,
@@ -1005,25 +1007,35 @@ add_default_user(Username, Password) ->
                     do_add_default_user(Username, Password)
             end;
         _ ->
+            ok = ensure_default_admin_scopes_unset(Username),
             {ok, default_user_exists}
     end.
 
+%% The default administrator must hold no explicit scope list — it always
+%% follows the role default implicitly (GET surfaces "unset"), so it keeps
+%% forward-compatible scopes instead of a frozen list; the user API rejects
+%% explicit lists for it on the same grounds.
 do_add_default_user(Username, Password) ->
     maybe
-        %% Seed the default admin with its role-default scopes so the very
-        %% first node bootstrap of a fresh cluster yields a default admin
-        %% that already carries scopes — never the legacy `<<"unset">>'
-        %% sentinel.
         {error, ?USERNAME_ALREADY_EXISTS_ERROR} ?=
-            do_add_user(
-                Username,
-                Password,
-                ?ROLE_SUPERUSER,
-                <<"administrator">>,
-                role_default_scopes(?ROLE_SUPERUSER)
-            ),
+            do_add_user(Username, Password, ?ROLE_SUPERUSER, <<"administrator">>, undefined),
         %% race condition: multiple nodes booting at the same time?
         {ok, default_user_exists}
+    end.
+
+%% Earlier releases seeded the default admin with an explicit role-default
+%% list at bootstrap; clear it on boot so upgraded clusters regain the
+%% implicit (forward-compatible) scope set.
+ensure_default_admin_scopes_unset(Username) ->
+    case scopes_of(Username) of
+        undefined ->
+            ok;
+        _Explicit ->
+            Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+                update_extra(Username, fun(Extra) -> maps:remove(scopes, Extra) end)
+            end),
+            _ = return(Res),
+            ok
     end.
 
 %% ensure the `role` is correct when it is directly read from the table

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -54,23 +54,24 @@
 all() ->
     ?EE_ONLY(emqx_common_test_helpers:all(?MODULE), []).
 
-%% The dashboard's default admin user (created by `do_add_default_user'
-%% at boot) used to land in the legacy "no scopes key" state, which
-%% would surface in API responses as the `<<"unset">>' sentinel.
-%% C3 seeds the administrator role default at row insertion time so a
-%% fresh default-admin is indistinguishable from one created via a POST
-%% that omits the `scopes' field.
-%%
-%% `init_per_testcase' clears the admin table to give every case full
-%% control of `admin_override'.  Re-run the same code path the boot
-%% sequence takes so the assertion exercises the real seeding helper.
-t_default_admin_seeded_with_role_default_scopes(_Config) ->
+%% The default admin bootstrapped at boot holds no explicit scope list: it
+%% follows the role default implicitly and keeps forward-compatible scopes.
+%% Re-runs the same code path the boot sequence takes.
+t_default_admin_bootstrap_unset_scopes(_Config) ->
     {ok, _} = emqx_dashboard_admin:add_default_user(),
     Username = emqx_dashboard_admin:default_username(),
-    ?assertEqual(
-        ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES,
-        emqx_dashboard_admin:scopes_of(Username)
-    ).
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Username)).
+
+%% A default admin carrying a frozen explicit scope list (seeded by an
+%% earlier release at bootstrap) is healed back to unset on boot.
+t_default_admin_boot_clears_frozen_scopes(_Config) ->
+    {ok, _} = emqx_dashboard_admin:add_default_user(),
+    Username = emqx_dashboard_admin:default_username(),
+    Frozen = emqx_dashboard_admin:role_default_scopes(?ROLE_SUPERUSER),
+    {ok, ok} = emqx_dashboard_admin:set_user_scopes(Username, Frozen),
+    ?assertEqual(Frozen, emqx_dashboard_admin:scopes_of(Username)),
+    ?assertEqual({ok, default_user_exists}, emqx_dashboard_admin:add_default_user()),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Username)).
 
 init_per_suite(Config) ->
     ?EE_ONLY(

--- a/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
@@ -173,9 +173,11 @@ fields(app) ->
             )},
         {enable, hoconsc:mk(boolean(), #{desc => "Enable/Disable", required => false})},
         {expired, hoconsc:mk(boolean(), #{desc => "Expired", required => false})},
+        %% Accepts the same shapes the response emits (array or the `unset'
+        %% sentinel) so a read-modify-write can round-trip the value verbatim.
         {scopes,
             hoconsc:mk(
-                hoconsc:array(binary()),
+                hoconsc:union([unset, hoconsc:array(binary())]),
                 #{
                     desc => ?DESC(api_key_scopes_request),
                     required => false,
@@ -184,11 +186,8 @@ fields(app) ->
             )}
     ] ++ app_extend_fields();
 %% Response shape: `scopes' MAY be the binary sentinel <<"unset">> in addition
-%% to the array-of-binaries form. This sentinel surfaces only for legacy
-%% records that survived an upgrade from a release where the scopes feature
-%% did not exist; the POST / bootstrap / SSO-provisioning paths all
-%% materialize role-default scopes at creation time, so no fresh record will
-%% ever appear with `scopes => <<"unset">>'.
+%% to the array-of-binaries form, surfaced when the record holds no explicit
+%% `scopes' field (legacy record or unset-equivalent write).
 %%
 %% Listed explicitly (rather than overriding via `lists:keystore') so that the
 %% OpenAPI spec reads as a self-contained response schema and reviewers do not
@@ -341,25 +340,44 @@ api_key(post, #{body := App}) ->
     ExpiredAt = ensure_expired_at(App),
     Desc = unicode:characters_to_binary(Desc0, unicode),
     Role = maps:get(<<"role">>, App, ?ROLE_API_DEFAULT),
-    %% Materialize role defaults when the client omitted `scopes' entirely.
-    %% Explicit `[]' (deny-all) and explicit lists pass through unchanged.
-    %% After this PR `<<"unset">>' in a GET response is reserved for legacy
-    %% records that survived an upgrade; no creation path stores `undefined'.
     RawScopes = maps:get(<<"scopes">>, App, undefined),
-    Scopes = emqx_mgmt_auth:effective_scopes_on_create(Role, RawScopes),
-    case validate_scopes(Role, RawScopes, Scopes) of
-        ok ->
-            case emqx_mgmt_auth:create(Name, Enable, ExpiredAt, Desc, Role, Scopes) of
-                {ok, NewApp} ->
-                    {200, emqx_mgmt_auth:format(NewApp)};
-                {error, Reason} ->
-                    {400, #{
-                        code => 'BAD_REQUEST',
-                        message => iolist_to_binary(io_lib:format("~p", [Reason]))
-                    }}
-            end;
+    case create_scopes(Role, RawScopes) of
+        {ok, Scopes} ->
+            do_create_api_key(Name, Enable, ExpiredAt, Desc, Role, Scopes);
         {error, Msg} ->
             {400, #{code => 'BAD_REQUEST', message => Msg}}
+    end.
+
+%% Resolve the `scopes' value to persist on POST: omitted -> materialize
+%% the role default (privilege mutex not applied to that mix);
+%% unset-equivalent -> store no `scopes' field (valid by construction);
+%% explicit list -> validate and store verbatim.
+create_scopes(Role, undefined) ->
+    Scopes = emqx_mgmt_auth:role_default_scopes(Role),
+    case validate_scopes(Role, undefined, Scopes) of
+        ok -> {ok, Scopes};
+        Error -> Error
+    end;
+create_scopes(Role, RawScopes) ->
+    case emqx_mgmt_auth:write_scope_intent(Role, RawScopes) of
+        unset ->
+            {ok, undefined};
+        {set, Scopes} ->
+            case validate_scopes(Role, Scopes, Scopes) of
+                ok -> {ok, Scopes};
+                Error -> Error
+            end
+    end.
+
+do_create_api_key(Name, Enable, ExpiredAt, Desc, Role, Scopes) ->
+    case emqx_mgmt_auth:create(Name, Enable, ExpiredAt, Desc, Role, Scopes) of
+        {ok, NewApp} ->
+            {200, emqx_mgmt_auth:format(NewApp)};
+        {error, Reason} ->
+            {400, #{
+                code => 'BAD_REQUEST',
+                message => iolist_to_binary(io_lib:format("~p", [Reason]))
+            }}
     end.
 
 -define(NOT_FOUND_RESPONSE, #{code => 'NOT_FOUND', message => <<"Name NOT FOUND">>}).
@@ -379,17 +397,11 @@ api_key_by_name(put, #{bindings := #{name := Name}, body := Body}) ->
     ExpiredAt = ensure_expired_at(Body),
     Desc = maps:get(<<"desc">>, Body, undefined),
     Role = maps:get(<<"role">>, Body, ?ROLE_API_DEFAULT),
-    Scopes = maps:get(<<"scopes">>, Body, undefined),
-    %% Validation runs against the effective scope list (request body
-    %% when supplied, otherwise the persisted scopes) so a role change
-    %% to `publisher' on a key that already holds non-`publish' scopes
-    %% via a partial-update PUT is rejected — the runtime RBAC layer
-    %% would catch it at request time, but the stored config and the
-    %% API response must not be allowed to drift from the
-    %% publisher-only-`publish' invariant.
-    EffectiveScopes = effective_request_scopes(Name, Scopes),
-    case validate_scopes(Role, Scopes, EffectiveScopes) of
+    RawScopes = maps:get(<<"scopes">>, Body, undefined),
+    Intent = emqx_mgmt_auth:write_scope_intent(Role, RawScopes),
+    case validate_update_scopes(Role, Name, Intent) of
         ok ->
+            Scopes = scopes_update_arg(Intent),
             case emqx_mgmt_auth:update(Name, Enable, ExpiredAt, Desc, Role, Scopes) of
                 {ok, App} ->
                     {200, emqx_mgmt_auth:format(App)};
@@ -405,14 +417,26 @@ api_key_by_name(put, #{bindings := #{name := Name}, body := Body}) ->
             {400, #{code => 'BAD_REQUEST', message => Msg}}
     end.
 
-%% Fall back to persisted scopes only when the body did not supply a
-%% `scopes' field. An explicit list (including `[]') is taken verbatim.
-%% A missing API key surfaces here as `undefined' so validation accepts
-%% the partial update; the downstream `emqx_mgmt_auth:update/6' call
-%% will then return 404 with the proper error.
-effective_request_scopes(_Name, Scopes) when is_list(Scopes) ->
-    Scopes;
-effective_request_scopes(Name, undefined) ->
+%% Validate the effective scope list for a PUT. `keep' validates the
+%% persisted scopes against the (possibly changed) role, so a role
+%% change to `publisher' cannot keep non-`publish' scopes via a partial
+%% update; `unset' clears to role default (valid by construction);
+%% `{set, L}' validates `L' with the privilege mutex applied.
+validate_update_scopes(_Role, _Name, unset) ->
+    ok;
+validate_update_scopes(Role, Name, keep) ->
+    validate_scopes(Role, undefined, persisted_scopes(Name));
+validate_update_scopes(Role, _Name, {set, Scopes}) ->
+    validate_scopes(Role, Scopes, Scopes).
+
+%% Intent -> `Scopes' argument of `emqx_mgmt_auth:update/6'.
+scopes_update_arg(keep) -> undefined;
+scopes_update_arg(unset) -> unset;
+scopes_update_arg({set, Scopes}) -> Scopes.
+
+%% A missing key surfaces as `undefined' so validation passes and the
+%% downstream `emqx_mgmt_auth:update/6' returns the proper 404.
+persisted_scopes(Name) ->
     case emqx_mgmt_auth:read(Name) of
         {ok, #{scopes := Persisted}} when is_list(Persisted) -> Persisted;
         _ -> undefined

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -42,11 +42,8 @@
     do_force_create_app/1
 ]).
 
-%% Helpers for materializing role-default scopes at record-creation time.
-%% Used by the POST handler, the bootstrap-file loader, and the SSO
-%% user-provisioning path so that `<<"unset">>' in a GET response can be
-%% interpreted unambiguously as "record predates the scopes feature".
--export([role_default_scopes/1, effective_scopes_on_create/2]).
+%% Role-default scopes and `scopes' write-intent normalization.
+-export([role_default_scopes/1, write_scope_intent/2]).
 
 -ifdef(TEST).
 -export([create/8]).
@@ -331,20 +328,18 @@ get_scopes(_) ->
     %% No scopes key in extra = backward compatible, allow all
     undefined.
 
-%% @doc Set scopes in extra map. undefined means "don't change".
+%% @doc Set scopes in extra map. `undefined' means "don't change";
+%% `unset' clears the field back to role-default behavior.
 maybe_set_scopes(Extra, undefined) ->
     Extra;
+maybe_set_scopes(Extra, unset) ->
+    maps:remove(scopes, Extra);
 maybe_set_scopes(Extra, Scopes) when is_list(Scopes) ->
     Extra#{scopes => Scopes}.
 
 %% @doc Resolve the role-default scopes that should be materialized into
 %% the persisted record when the caller did not explicitly supply a scope
 %% list (POST without `scopes', 2-/3-segment bootstrap line).
-%%
-%% After this PR, `undefined' is never written into mnesia by any creation
-%% path; the `<<"unset">>' state in the GET response is only possible for
-%% records that survived an upgrade from a release where the scopes
-%% feature did not exist.
 %%
 %%   * administrator / viewer -> `?GENERIC_SCOPES' (10 management scopes,
 %%     no login-only scopes — those are reserved for dashboard users).
@@ -357,14 +352,28 @@ role_default_scopes(?ROLE_API_PUBLISHER) ->
 role_default_scopes(_Role) ->
     ?GENERIC_SCOPES.
 
-%% @doc Convenience wrapper for the request-handling layer: if the
-%% caller supplied no scopes, materialize the role default; otherwise
-%% pass the explicit value through unchanged (including the empty list
-%% which means explicit deny-all).
-effective_scopes_on_create(Role, undefined) ->
-    role_default_scopes(Role);
-effective_scopes_on_create(_Role, Scopes) when is_list(Scopes) ->
-    Scopes.
+%% @doc Normalize a `scopes' request value to a write intent:
+%% `keep' (field omitted), `unset' (the `unset' sentinel or a list
+%% set-equal to the role default: store no explicit scopes so a
+%% read-modify-write never freezes the implicit default), or
+%% `{set, L}' (store `L' verbatim; downstream validation rejects
+%% non-list garbage).
+write_scope_intent(_Role, undefined) ->
+    keep;
+write_scope_intent(_Role, unset) ->
+    unset;
+write_scope_intent(_Role, <<"unset">>) ->
+    unset;
+write_scope_intent(Role, Scopes) when is_list(Scopes) ->
+    case is_role_default_scopes(Role, Scopes) of
+        true -> unset;
+        false -> {set, Scopes}
+    end;
+write_scope_intent(_Role, Other) ->
+    {set, Other}.
+
+is_role_default_scopes(Role, Scopes) ->
+    lists:usort(Scopes) =:= lists:usort(role_default_scopes(Role)).
 
 ensure_not_undefined(undefined, Old) -> Old;
 ensure_not_undefined(New, _Old) -> New.
@@ -390,14 +399,9 @@ to_map(#?APP{
 %% @doc Surface raw scope state to the API consumer with a tri-state contract:
 %%   - `[]`            : explicit deny-all (only `security => []` paths reachable)
 %%   - `[binary(), …]` : explicit allow-list
-%%   - `<<"unset">>`   : the persisted record has no `scopes' field at all (legacy
-%%                       upgrade artefact from before #16942 landed). The runtime
-%%                       authorization path falls back to role-default behaviour
-%%                       (allow-all-mapped-paths for administrator/viewer,
-%%                       hard-coded `/publish*' for publisher).  Newly created
-%%                       records never end up in this state: the POST / bootstrap
-%%                       / SSO-provisioning paths all materialize role-default
-%%                       scopes at creation time.
+%%   - `<<"unset">>`   : the persisted record has no `scopes' field at all
+%%                       (legacy record or unset-equivalent write); the runtime
+%%                       falls back to role-default behaviour.
 %% This intentionally exposes the persisted shape rather than an effective list so
 %% that the dashboard read-modify-write cycle cannot silently sediment role-default
 %% into an explicit list.  The `<<"unset">>' binary is a stable string sentinel

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -38,6 +38,11 @@
     t_ee_api_key_rejects_mixed_privilege_via_post,
     t_ee_api_key_rejects_mixed_privilege_via_put,
     t_ee_api_key_privilege_mutex_message,
+    %% Unset-equivalent scopes on create/update (#18195)
+    t_ee_scopes_update_unchanged_roundtrip,
+    t_ee_scopes_create_unset_sentinel,
+    t_ee_scopes_update_explicit_list,
+    t_ee_publisher_update_rejects_explicit_non_publish,
     %% Regression: API key auth must not leak into dashboard
     %% login-user scope check when ApiKey name == dashboard username.
     t_ee_api_key_unaffected_by_colliding_username_scopes
@@ -1462,6 +1467,61 @@ t_ee_api_key_privilege_mutex_message(_Config) ->
         {_, _},
         binary:match(Msg, <<"Privilege scopes cannot be combined with other scopes">>)
     ).
+
+%% The #18195 repro: create a key with the scope left blank, then update it
+%% re-submitting exactly what GET returned (the materialized role-default
+%% list, in any order, later the `unset' sentinel) — the update must
+%% succeed and clear the stored scope list.
+t_ee_scopes_update_unchanged_roundtrip(_Config) ->
+    Name = <<"EE-SCOPES-ROUNDTRIP">>,
+    {ok, _} = create_app(Name),
+    {ok, #{<<"scopes">> := Default}} = read_app(Name),
+    ?assert(is_list(Default)),
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => Default})),
+    %% The role-default list is stored as "no explicit scopes".
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    %% Round-trip once more with the `unset` sentinel GET now returns.
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => <<"unset">>})),
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    %% Order-insensitive: a permuted role-default list is also unset-equivalent.
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => lists:reverse(Default)})),
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    delete_app(Name).
+
+%% POST accepts the `unset' sentinel: the key is created without an explicit
+%% scope list and GET surfaces the sentinel.
+t_ee_scopes_create_unset_sentinel(_Config) ->
+    Name = <<"EE-SCOPES-CREATE-UNSET">>,
+    {ok, _} = create_app(Name, #{scopes => <<"unset">>}),
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    delete_app(Name).
+
+%% A genuinely explicit scope list (different from the role default) is
+%% still validated and stored verbatim; GET reflects it.
+t_ee_scopes_update_explicit_list(_Config) ->
+    Name = <<"EE-SCOPES-EXPLICIT">>,
+    {ok, _} = create_app(Name),
+    Scopes = [?SCOPE_CONNECTIONS, ?SCOPE_MONITORING],
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => Scopes})),
+    ?assertMatch({ok, #{<<"scopes">> := Scopes}}, read_app(Name)),
+    delete_app(Name).
+
+%% The publisher-only-`publish' invariant survives the unset-equivalent
+%% handling: an explicit non-publish list on a publisher key is still
+%% rejected on PUT, while the publisher role default (`[publish]') is
+%% accepted as unset-equivalent.
+t_ee_publisher_update_rejects_explicit_non_publish(_Config) ->
+    Name = <<"EE-PUB-UPDATE-REJECT">>,
+    {ok, _} = create_app(Name, #{role => ?ROLE_API_PUBLISHER}),
+    assert_400_publisher_only(
+        update_app(Name, #{role => ?ROLE_API_PUBLISHER, scopes => [?SCOPE_CONNECTIONS]})
+    ),
+    ?assertMatch(
+        {ok, _},
+        update_app(Name, #{role => ?ROLE_API_PUBLISHER, scopes => [?SCOPE_PUBLISH]})
+    ),
+    ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    delete_app(Name).
 
 %% Regression: API key auth must NOT consult dashboard login-user
 %% scopes, even when the API key's generated `api_key' string happens

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -1486,6 +1486,10 @@ t_ee_scopes_update_unchanged_roundtrip(_Config) ->
     %% Order-insensitive: a permuted role-default list is also unset-equivalent.
     ?assertMatch({ok, _}, update_app(Name, #{scopes => lists:reverse(Default)})),
     ?assertMatch({ok, #{<<"scopes">> := <<"unset">>}}, read_app(Name)),
+    %% From the unset state, an explicit non-default list still takes effect.
+    Explicit = [?SCOPE_CONNECTIONS, ?SCOPE_MONITORING],
+    ?assertMatch({ok, _}, update_app(Name, #{scopes => Explicit})),
+    ?assertMatch({ok, #{<<"scopes">> := Explicit}}, read_app(Name)),
     delete_app(Name).
 
 %% POST accepts the `unset' sentinel: the key is created without an explicit

--- a/changes/ee/fix-18200.en.md
+++ b/changes/ee/fix-18200.en.md
@@ -1,3 +1,5 @@
 Fixed an error when updating an API key that was created with the scope left blank.
 
 The API key create and update requests now accept a scope list that matches the role's implicit default (and the `unset` value) as equivalent to "no explicit scopes", so re-submitting the value returned by a read no longer fails. Such keys also keep their forward-compatible implicit scopes instead of a frozen list.
+
+Also fixed the default administrator user being created with an explicit scope list at startup. The default administrator now follows its role's implicit default scopes (shown as `unset`), so it automatically gains scopes introduced in future releases instead of being pinned to a frozen list. Existing default administrator records that carry an explicit list are updated to the implicit form at boot.

--- a/changes/ee/fix-18200.en.md
+++ b/changes/ee/fix-18200.en.md
@@ -1,0 +1,3 @@
+Fixed an error when updating an API key that was created with the scope left blank.
+
+The API key create and update requests now accept a scope list that matches the role's implicit default (and the `unset` value) as equivalent to "no explicit scopes", so re-submitting the value returned by a read no longer fails. Such keys also keep their forward-compatible implicit scopes instead of a frozen list.

--- a/rel/i18n/emqx_mgmt_api_api_keys.hocon
+++ b/rel/i18n/emqx_mgmt_api_api_keys.hocon
@@ -39,12 +39,12 @@ api_key_scopes_list.label:
 """List API key scopes"""
 
 api_key_scopes_request.desc:
-"""List of scope names to grant this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). When omitted on creation, the server materializes the role default — administrator/viewer get all management scopes, publisher gets `publish` only. Send an explicit empty list `[]` to create a deny-all key (only anonymous endpoints such as `/status` remain reachable)."""
+"""List of scope names to grant this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). When omitted on creation, the server materializes the role default: administrator/viewer get all management scopes, publisher gets `publish` only. The literal string `unset`, or a list equal to the role default, means "no explicit scope policy": the key is stored without a scope list and follows the role default (this lets a client re-submit the value a read returned without modification). Send an explicit empty list `[]` to create a deny-all key (only anonymous endpoints such as `/status` remain reachable)."""
 api_key_scopes_request.label:
 """API key scopes (request)"""
 
 api_key_scopes_response.desc:
-"""List of scope names granted to this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). The literal string `unset` is a legacy-only sentinel surfaced for records that survived an upgrade from a release where the scopes feature did not exist; the runtime falls back to role default for such records and a client should treat them as "no explicit scope policy yet". An empty list `[]` means deny-all (only anonymous endpoints such as `/status` remain reachable)."""
+"""List of scope names granted to this API key. Each scope is a stable functional category (e.g., connections, publish, monitoring). The literal string `unset` is a sentinel surfaced for records that hold no explicit scope list (created or updated with unset-equivalent scopes, or records that survived an upgrade from a release where the scopes feature did not exist); the runtime falls back to role default for such records, and a client should treat them as "no explicit scope policy". An empty list `[]` means deny-all (only anonymous endpoints such as `/status` remain reachable)."""
 api_key_scopes_response.label:
 """API key scopes (response)"""
 


### PR DESCRIPTION
Release versions:
5.10.5

## Summary

Port of #18196 (dev-60) to dev-510.

Fixes the #18195 symptom on 5.10: creating an API key with the scope left blank and then updating it (even unchanged) failed with 400, because the dashboard read-modify-write round-trips the materialized role-default scope list (or the `unset` sentinel for legacy records) and the write path rejected it — the privilege-scope mutex was misapplied to the role-default mix and the request schema did not accept the sentinel.

The create and update paths now normalize the `scopes` field to a write intent: the `unset` sentinel and a scope list whose set equals the role default (order-insensitive) are treated as "no explicit scopes" and stored with the field cleared, so such keys keep their forward-compatible implicit scopes instead of a frozen list. A genuinely explicit list is still validated and stored verbatim, and the publisher-only-`publish` invariant is unchanged. The request schema additionally accepts the `unset` value so a read result can be re-submitted verbatim.

Also ports #18221 (dev-60): the default administrator was bootstrapped with an explicit role-default scope list, freezing the break-glass account's privileges — a scope introduced in a later release would not be granted, and the user API rejects explicit scope lists for the default admin, so the record could not be corrected through the API. The bootstrap now creates the default admin without a scopes field (GET surfaces the `unset` sentinel), and records seeded with an explicit list by earlier releases are cleared back to unset at boot.

Origin of the fix pattern: #18009 / #17930 (dashboard users, dev-60). Note: #18009 itself (the dashboard-USER unset-equivalent handling) is intentionally NOT part of this PR — the same class of bug likely exists for dashboard users on 5.10 and would be a separate PR.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
