### PR TITLE
test(management): wait for route removal in t_subscribe_shared_topic

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1479,6 +1479,11 @@ t_subscribe_shared_topic(Config) ->
     ?retry(200, 10, ?assertEqual([], ets:tab2list(?SUBSCRIPTION))),
     ?assertEqual([], ets:tab2list(?SUBOPTION)),
     ?assertEqual([], ets:tab2list(emqx_shared_subscription)),
+    %% Routing is torn down asynchronously by the router syncer, after the local
+    %% subscription tables are cleared. Wait until no route matches the topics,
+    %% otherwise a late-routed publish races the assertNotReceive below.
+    ?retry(200, 10, ?assertEqual([], emqx_router:match_routes(<<"t/1">>))),
+    ?retry(200, 10, ?assertEqual([], emqx_router:match_routes(<<"testtopic">>))),
 
     %% assert subscription virtual
     _ = emqtt:publish(PC, <<"testtopic">>, <<"msg3">>, [{qos, 0}]),


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Fixes an intermittent failure in `emqx_mgmt_api_clients_SUITE:t_subscribe_shared_topic`.

After the REST unsubscribe calls, the test waited only for the client's **local**
per-session subscription ETS tables (`?SUBSCRIPTION` / `?SUBOPTION` /
`emqx_shared_subscription`) to clear before publishing the negative-check
messages. Message routing, however, goes through the broker **router**
(`emqx_router`), which is torn down **asynchronously** by `emqx_router_syncer`
after the local tables are cleared. During that window a publish to `t/1` could
still be routed to the client, making the `?assertNotReceive` for `msg4` flaky.

The fix adds a `?retry` on `emqx_router:match_routes/1` for both `t/1` and
`testtopic` after the local-table wait, so the negative check runs only once the
routes are actually gone. Test-only change in
`apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl`.

Note: v5 (`dev-58` / `dev-510`) carries the same test with the same async-router
pattern; if it flakes there it needs a separate port (v5 and v6 do not
cross-sync).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
