### PR TITLE
fix(dashboard): keep default admin scopes unset at bootstrap

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -177,9 +177,10 @@ parsed_role_to_extra(_) ->
 %%   * `scopes' (binary list) - if present, the listed scopes are written
 %%     into the record atomically inside the same mria transaction as the
 %%     row insertion.  Used by paths that do NOT have a follow-up
-%%     `set_user_scopes' step (SSO auto-provisioning, default-admin
-%%     bootstrap) so a new row never appears in the legacy "no scopes key"
-%%     state.  If the `scopes' key is omitted, no scopes field is written
+%%     `set_user_scopes' step (SSO auto-provisioning) so a new row never
+%%     appears in the legacy "no scopes key" state.  The default-admin
+%%     bootstrap deliberately omits it: that account stays on implicit
+%%     role-default scopes.  If the `scopes' key is omitted, no scopes field is written
 %%     and the caller is expected to materialise scopes afterwards (e.g.
 %%     the API POST handler does `maybe_set_user_scopes/2' with
 %%     role-default scopes).
@@ -1095,20 +1096,32 @@ add_default_user(Username, Password) ->
                     do_add_default_user(Username, Password)
             end;
         _ ->
+            ok = ensure_default_admin_scopes_unset(Username),
             {ok, default_user_exists}
     end.
 
+%% The default administrator must hold no explicit scope list — it always
+%% follows the role default implicitly (GET surfaces "unset"), so it keeps
+%% forward-compatible scopes instead of a frozen list; the user API rejects
+%% explicit lists for it on the same grounds.
 do_add_default_user(Username, Password) ->
-    Extra = #{scopes => role_default_scopes(?ROLE_SUPERUSER)},
     maybe
-        %% Seed the default admin with its role-default scopes so the very
-        %% first node bootstrap of a fresh cluster yields a default admin
-        %% that already carries scopes — never the legacy `<<"unset">>'
-        %% sentinel.
         {error, ?USERNAME_ALREADY_EXISTS_ERROR} ?=
-            do_add_user(Username, Password, ?ROLE_SUPERUSER, <<"administrator">>, Extra),
+            do_add_user(Username, Password, ?ROLE_SUPERUSER, <<"administrator">>, #{}),
         %% race condition: multiple nodes booting at the same time?
         {ok, default_user_exists}
+    end.
+
+%% Earlier releases seeded the default admin with an explicit role-default
+%% list at bootstrap; clear it on boot so upgraded clusters regain the
+%% implicit (forward-compatible) scope set.
+ensure_default_admin_scopes_unset(Username) ->
+    case scopes_of(Username) of
+        undefined ->
+            ok;
+        _Explicit ->
+            _ = clear_user_scopes(Username),
+            ok
     end.
 
 %% ensure the `role` is correct when it is directly read from the table

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -54,23 +54,28 @@
 all() ->
     ?EE_ONLY(emqx_common_test_helpers:all(?MODULE), []).
 
-%% The dashboard's default admin user (created by `do_add_default_user'
-%% at boot) used to land in the legacy "no scopes key" state, which
-%% would surface in API responses as the `<<"unset">>' sentinel.
-%% C3 seeds the administrator role default at row insertion time so a
-%% fresh default-admin is indistinguishable from one created via a POST
-%% that omits the `scopes' field.
-%%
-%% `init_per_testcase' clears the admin table to give every case full
-%% control of `admin_override'.  Re-run the same code path the boot
-%% sequence takes so the assertion exercises the real seeding helper.
-t_default_admin_seeded_with_role_default_scopes(_Config) ->
+-doc """
+The default admin bootstrapped at boot holds no explicit scope list: it
+follows the role default implicitly and keeps forward-compatible scopes.
+Re-runs the same code path the boot sequence takes.
+""".
+t_default_admin_bootstrap_unset_scopes(_Config) ->
     {ok, _} = emqx_dashboard_admin:add_default_user(),
     Username = emqx_dashboard_admin:default_username(),
-    ?assertEqual(
-        ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES,
-        emqx_dashboard_admin:scopes_of(Username)
-    ).
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Username)).
+
+-doc """
+A default admin carrying a frozen explicit scope list (seeded by an
+earlier release at bootstrap) is healed back to unset on boot.
+""".
+t_default_admin_boot_clears_frozen_scopes(_Config) ->
+    {ok, _} = emqx_dashboard_admin:add_default_user(),
+    Username = emqx_dashboard_admin:default_username(),
+    Frozen = emqx_dashboard_admin:role_default_scopes(?ROLE_SUPERUSER),
+    {ok, ok} = emqx_dashboard_admin:set_user_scopes(Username, Frozen),
+    ?assertEqual(Frozen, emqx_dashboard_admin:scopes_of(Username)),
+    ?assertEqual({ok, default_user_exists}, emqx_dashboard_admin:add_default_user()),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Username)).
 
 init_per_suite(Config) ->
     ?EE_ONLY(

--- a/changes/ee/fix-18221.en.md
+++ b/changes/ee/fix-18221.en.md
@@ -1,0 +1,3 @@
+Fixed the default administrator user being created with an explicit scope list at startup.
+
+The default administrator now follows its role's implicit default scopes (shown as `unset`), so it automatically gains scopes introduced in future releases instead of being pinned to a frozen list. Existing default administrator records that carry an explicit list are updated to the implicit form at boot.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.4, 6.2.3, 6.3.0

## Summary

Reported by the frontend team: the default administrator is created at startup with all scopes **explicitly** assigned. Post-#18009 that state is wrong for the break-glass account: the user API rejects explicit scope lists for the default admin ("it always holds the full catalog" implicitly), and a frozen explicit list means the default admin would NOT gain scopes introduced in a future release.

* `emqx_dashboard_admin:do_add_default_user/2` no longer seeds `scopes`; the default admin is created without the field, so it follows the role default implicitly and GET surfaces `unset`.
* `add_default_user/2` heals existing records at boot: if the default admin carries an explicit scope list (seeded by an earlier release), it is cleared back to unset via `clear_user_scopes/1`. Such a list is unreachable through the API (rejected for the default admin), so clearing restores the intended invariant without overriding any operator choice.
* `t_default_admin_seeded_with_role_default_scopes` is replaced by `t_default_admin_bootstrap_unset_scopes` plus a healing test.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
