### PR TITLE
chore: cut 6.1.4 release

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -19,4 +19,4 @@
 %% NOTE: Also make sure to follow the instructions in end of
 %% `apps/emqx/src/bpapi/README.md'
 
--define(EMQX_RELEASE_EE, "6.1.4-rc.2").
+-define(EMQX_RELEASE_EE, "6.1.4").

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -177,9 +177,10 @@ parsed_role_to_extra(_) ->
 %%   * `scopes' (binary list) - if present, the listed scopes are written
 %%     into the record atomically inside the same mria transaction as the
 %%     row insertion.  Used by paths that do NOT have a follow-up
-%%     `set_user_scopes' step (SSO auto-provisioning, default-admin
-%%     bootstrap) so a new row never appears in the legacy "no scopes key"
-%%     state.  If the `scopes' key is omitted, no scopes field is written
+%%     `set_user_scopes' step (SSO auto-provisioning) so a new row never
+%%     appears in the legacy "no scopes key" state.  The default-admin
+%%     bootstrap deliberately omits it: that account stays on implicit
+%%     role-default scopes.  If the `scopes' key is omitted, no scopes field is written
 %%     and the caller is expected to materialise scopes afterwards (e.g.
 %%     the API POST handler does `maybe_set_user_scopes/2' with
 %%     role-default scopes).
@@ -1095,20 +1096,32 @@ add_default_user(Username, Password) ->
                     do_add_default_user(Username, Password)
             end;
         _ ->
+            ok = ensure_default_admin_scopes_unset(Username),
             {ok, default_user_exists}
     end.
 
+%% The default administrator must hold no explicit scope list — it always
+%% follows the role default implicitly (GET surfaces "unset"), so it keeps
+%% forward-compatible scopes instead of a frozen list; the user API rejects
+%% explicit lists for it on the same grounds.
 do_add_default_user(Username, Password) ->
-    Extra = #{scopes => role_default_scopes(?ROLE_SUPERUSER)},
     maybe
-        %% Seed the default admin with its role-default scopes so the very
-        %% first node bootstrap of a fresh cluster yields a default admin
-        %% that already carries scopes — never the legacy `<<"unset">>'
-        %% sentinel.
         {error, ?USERNAME_ALREADY_EXISTS_ERROR} ?=
-            do_add_user(Username, Password, ?ROLE_SUPERUSER, <<"administrator">>, Extra),
+            do_add_user(Username, Password, ?ROLE_SUPERUSER, <<"administrator">>, #{}),
         %% race condition: multiple nodes booting at the same time?
         {ok, default_user_exists}
+    end.
+
+%% Earlier releases seeded the default admin with an explicit role-default
+%% list at bootstrap; clear it on boot so upgraded clusters regain the
+%% implicit (forward-compatible) scope set.
+ensure_default_admin_scopes_unset(Username) ->
+    case scopes_of(Username) of
+        undefined ->
+            ok;
+        _Explicit ->
+            _ = clear_user_scopes(Username),
+            ok
     end.
 
 %% ensure the `role` is correct when it is directly read from the table

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -54,23 +54,28 @@
 all() ->
     ?EE_ONLY(emqx_common_test_helpers:all(?MODULE), []).
 
-%% The dashboard's default admin user (created by `do_add_default_user'
-%% at boot) used to land in the legacy "no scopes key" state, which
-%% would surface in API responses as the `<<"unset">>' sentinel.
-%% C3 seeds the administrator role default at row insertion time so a
-%% fresh default-admin is indistinguishable from one created via a POST
-%% that omits the `scopes' field.
-%%
-%% `init_per_testcase' clears the admin table to give every case full
-%% control of `admin_override'.  Re-run the same code path the boot
-%% sequence takes so the assertion exercises the real seeding helper.
-t_default_admin_seeded_with_role_default_scopes(_Config) ->
+-doc """
+The default admin bootstrapped at boot holds no explicit scope list: it
+follows the role default implicitly and keeps forward-compatible scopes.
+Re-runs the same code path the boot sequence takes.
+""".
+t_default_admin_bootstrap_unset_scopes(_Config) ->
     {ok, _} = emqx_dashboard_admin:add_default_user(),
     Username = emqx_dashboard_admin:default_username(),
-    ?assertEqual(
-        ?GENERIC_SCOPES ++ ?LOGIN_ONLY_SCOPES,
-        emqx_dashboard_admin:scopes_of(Username)
-    ).
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Username)).
+
+-doc """
+A default admin carrying a frozen explicit scope list (seeded by an
+earlier release at bootstrap) is healed back to unset on boot.
+""".
+t_default_admin_boot_clears_frozen_scopes(_Config) ->
+    {ok, _} = emqx_dashboard_admin:add_default_user(),
+    Username = emqx_dashboard_admin:default_username(),
+    Frozen = emqx_dashboard_admin:role_default_scopes(?ROLE_SUPERUSER),
+    {ok, ok} = emqx_dashboard_admin:set_user_scopes(Username, Frozen),
+    ?assertEqual(Frozen, emqx_dashboard_admin:scopes_of(Username)),
+    ?assertEqual({ok, default_user_exists}, emqx_dashboard_admin:add_default_user()),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(Username)).
 
 init_per_suite(Config) ->
     ?EE_ONLY(

--- a/changes/6.1.4.en.md
+++ b/changes/6.1.4.en.md
@@ -147,13 +147,11 @@
 
 - [#18005](https://github.com/emqx/emqx/pull/18005) Fixed an issue where CLI audit logs could store sensitive command arguments.
 
-- [#18009](https://github.com/emqx/emqx/pull/18009) Fixed an error when editing only the note (description) of the default administrator via the Dashboard user API.
+- [#18009](https://github.com/emqx/emqx/pull/18009) Made scope handling consistent for administrator and API key records that use their role's implicit default scopes (shown as `unset`). Reads and writes now accept the unset-equivalent scope list, and such records keep their forward-compatible implicit scopes instead of a frozen list, so they automatically gain scopes introduced in future releases.
 
-  The user API now accepts a scope list that matches the role's implicit full set (and the `unset` value) as equivalent to "no explicit scopes", so a read-modify-write of an administrator no longer fails. Such users also keep their forward-compatible implicit scopes instead of a frozen list.
-
-- [#18196](https://github.com/emqx/emqx/pull/18196) Fixed an error when updating an API key that was created with the scope left blank.
-
-  The API key create and update requests now accept a scope list that matches the role's implicit default (and the `unset` value) as equivalent to "no explicit scopes", so re-submitting the value returned by a read no longer fails. Such keys also keep their forward-compatible implicit scopes instead of a frozen list, consistent with Dashboard users.
+  - Editing only the note (description) of the default administrator via the Dashboard user API no longer fails; the user API now treats a scope list that matches the role's implicit full set (and the `unset` value) as "no explicit scopes".
+  - [#18196](https://github.com/emqx/emqx/pull/18196) The API key create and update requests accept the same unset-equivalent scope list, so re-submitting the value returned by a read no longer fails.
+  - [#18221](https://github.com/emqx/emqx/pull/18221) The default administrator is no longer created with an explicit scope list at startup, and existing default administrator records that carry an explicit list are updated to the implicit form at boot.
 
 - [#18204](https://github.com/emqx/emqx/pull/18204) Strengthened validation of data backup archives during import so a backup file's contents are restored only into the table it is meant for.
 

--- a/changes/ee/fix-18221.en.md
+++ b/changes/ee/fix-18221.en.md
@@ -1,0 +1,3 @@
+Fixed the default administrator user being created with an explicit scope list at startup.
+
+The default administrator now follows its role's implicit default scopes (shown as `unset`), so it automatically gains scopes introduced in future releases instead of being pinned to a frozen list. Existing default administrator records that carry an explicit list are updated to the implicit form at boot.

--- a/deploy/charts/emqx-enterprise/Chart.yaml
+++ b/deploy/charts/emqx-enterprise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 6.1.4-rc.2
+version: 6.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 6.1.4-rc.2
+appVersion: 6.1.4


### PR DESCRIPTION
Prepare the 6.1.4 release.

- Bump release version `6.1.4-rc.2` → `6.1.4` (drop rc).
- Consolidate the admin/API-key scope changelog entries in `changes/6.1.4.en.md` into a single entry (headed by #18009) that folds in #18196 and #18221 with reference links.
- Include #18221 (default administrator bootstraps with implicit `unset` scopes) forward-ported from dev-60, so its code matches the 6.1.4 changelog reference.

Release version:
6.1.4, 6.2.3, 6.3.0