### PR TITLE
fix(mt): fail closed after namespace limiter removal

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
@@ -29,6 +29,7 @@
 %% Generic limiter client API
 -export([
     connect/1,
+    connect/2,
     create_group/3,
     update_group/2,
     delete_group/1
@@ -55,6 +56,7 @@
 -type name() :: atom().
 -type id() :: {group(), name()}.
 -type listener_id() :: term().
+-type client_options() :: #{not_found_mode => open | close}.
 
 %% Limiter types
 -type options() :: unlimited() | limited() | limited_with_burst().
@@ -147,6 +149,14 @@ connect({Group, _} = ListenerId) ->
             error({limiter_group_not_found, Group});
         {Module, _} ->
             Module:connect(ListenerId)
+    end.
+
+-spec connect(id(), client_options()) -> emqx_limiter_client:t().
+connect(LimiterId, Options) ->
+    Client = connect(LimiterId),
+    case maps:get(not_found_mode, Options, open) of
+        close -> Client#{not_found_mode => close};
+        open -> Client
     end.
 
 -spec create_group(shared | exclusive | module(), group(), [{name(), options()}]) -> ok.

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_client.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_client.erl
@@ -16,7 +16,8 @@
 
 -type t() :: #{
     module := module(),
-    state := state()
+    state := state(),
+    not_found_mode => close
 }.
 
 -type reason() :: term().
@@ -60,7 +61,7 @@ try_consume(#{module := Module, state := State} = Limiter, Amount) ->
                 },
                 #{tag => "QUOTA"}
             ),
-            {true, Limiter}
+            handle_failure(Limiter, Reason)
     end.
 
 -spec put_back(t(), non_neg_integer()) -> t().
@@ -81,3 +82,8 @@ put_back(#{module := Module, state := State} = Limiter, Amount) ->
             ),
             Limiter
     end.
+
+handle_failure(#{not_found_mode := close} = Limiter, {limiter_not_found, _} = Reason) ->
+    {false, Limiter, Reason};
+handle_failure(Limiter, _Reason) ->
+    {true, Limiter}.

--- a/apps/emqx/test/emqx_limiter_exclusive_SUITE.erl
+++ b/apps/emqx/test/emqx_limiter_exclusive_SUITE.erl
@@ -179,3 +179,27 @@ t_change_options(_) ->
     {true, Client3} = emqx_limiter_client:try_consume(Client2, 1),
     {true, Client4} = emqx_limiter_client:try_consume(Client3, 1),
     {false, _Client5, _} = emqx_limiter_client:try_consume(Client4, 1).
+
+t_not_found_mode(_) ->
+    LimiterId = {group1, limiter1},
+    ok = emqx_limiter:create_group(exclusive, group1, [
+        {limiter1, #{capacity => infinity}}
+    ]),
+    DefaultClient = emqx_limiter:connect(LimiterId),
+    OpenClient = emqx_limiter:connect(LimiterId, #{not_found_mode => open}),
+    CloseClient = emqx_limiter:connect(LimiterId, #{not_found_mode => close}),
+
+    ok = emqx_limiter:delete_group(group1),
+    ?assertMatch({true, _}, emqx_limiter_client:try_consume(DefaultClient, 1)),
+    ?assertMatch({true, _}, emqx_limiter_client:try_consume(OpenClient, 1)),
+    ?assertMatch(
+        {false, _, {limiter_not_found, LimiterId}},
+        emqx_limiter_client:try_consume(CloseClient, 1)
+    ),
+
+    UnexpectedErrorClient0 = emqx_limiter_client:new(?MODULE, unexpected_error),
+    UnexpectedErrorClient = UnexpectedErrorClient0#{not_found_mode => close},
+    ?assertMatch({true, _}, emqx_limiter_client:try_consume(UnexpectedErrorClient, 1)).
+
+try_consume(unexpected_error, _Amount) ->
+    error(unexpected_error).

--- a/apps/emqx_mt/src/emqx_mt_limiter.erl
+++ b/apps/emqx_mt/src/emqx_mt_limiter.erl
@@ -117,10 +117,8 @@ ensure_client_limiter_group_absent(Ns) ->
 %%
 
 cleanup_configs(Ns, _Configs) ->
-    %% Note: we may safely delete the limiter groups here: when clients attempt to consume
-    %% from the now dangling limiters, `emqx_limiter_client' will log the error but don't
-    %% do any limiting when it fails to fetch the missing limiter group configuration.
-    %% The user may choose to later kick all clients from this namespace.
+    %% MT limiter clients fail closed when these groups are removed, so deleted namespace
+    %% clients cannot bypass their quotas while they are being kicked.
     _ = ensure_group_absent(tenant_group(Ns)),
     _ = ensure_group_absent(client_group(Ns)),
     ok.
@@ -191,7 +189,7 @@ create_tenant_limiters(Zone, Ns, Name) ->
     case emqx_mt_config:get_tenant_limiter_config(Ns) of
         {ok, #{}} ->
             TenantLimiterId = {tenant_group(Ns), Name},
-            TenantLimiterClient = emqx_limiter:connect(TenantLimiterId),
+            TenantLimiterClient = emqx_limiter:connect(TenantLimiterId, #{not_found_mode => close}),
             [ZoneLimiterClient, TenantLimiterClient];
         _ ->
             [ZoneLimiterClient]
@@ -201,7 +199,7 @@ create_client_limiters(ListenerId, Ns, Name) ->
     case emqx_mt_config:get_client_limiter_config(Ns) of
         {ok, #{}} ->
             ClientLimiterId = {client_group(Ns), Name},
-            ClientLimiterClient = emqx_limiter:connect(ClientLimiterId),
+            ClientLimiterClient = emqx_limiter:connect(ClientLimiterId, #{not_found_mode => close}),
             [ClientLimiterClient];
         _ ->
             %% TODO: Isolate implementation details in `emqx_limiter` API.

--- a/apps/emqx_mt/src/emqx_mt_state.erl
+++ b/apps/emqx_mt/src/emqx_mt_state.erl
@@ -579,10 +579,6 @@ create_managed_ns(Ns) ->
 -spec delete_managed_ns(emqx_mt:tns()) ->
     {ok, emqx_mt_config:root_config()} | {error, {aborted, _}}.
 delete_managed_ns(Ns) ->
-    %% Note: we may safely delete the limiter groups here: when clients attempt to consume
-    %% from the now dangling limiters, `emqx_limiter_client' will log the error but don't
-    %% do any limiting when it fails to fetch the missing limiter group configuration.
-    %% The user may choose to later kick all clients from this namespace.
     transaction(fun delete_ns_txn/1, [Ns]).
 
 -spec is_known_managed_ns(emqx_mt:tns()) -> boolean().

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -1139,6 +1139,47 @@ t_kick_clients_when_deleting(_Config) ->
 
     ok.
 
+t_fail_closed_while_deleting(_Config) ->
+    Ns = <<"ns1">>,
+    {204, _} = create_managed_ns(Ns),
+    Params = emqx_utils_maps:deep_merge(tenant_limiter_params(), client_limiter_params()),
+    {200, _} = update_managed_ns_config(Ns, Params),
+    Client = connect(?NEW_CLIENTID(1), Ns),
+    MRef = monitor(process, Client),
+    LimiterGroups = [{mt_tenant, Ns}, {mt_client, Ns}],
+    ?assert(lists:all(fun limiter_group_exists/1, LimiterGroups)),
+
+    TestPid = self(),
+    ok = meck:new(emqx_mgmt, [passthrough, no_history]),
+    ok = meck:expect(emqx_mgmt, kickout_clients, fun(ClientIds) ->
+        TestPid ! {kicking, self()},
+        receive
+            continue -> meck:passthrough([ClientIds])
+        end
+    end),
+    on_exit(fun() -> meck:unload(emqx_mgmt) end),
+
+    ?assertMatch({204, _}, delete_managed_ns(Ns)),
+    Kicker =
+        receive
+            {kicking, Pid} -> Pid
+        after 1_000 ->
+            ct:fail("client kicker did not start")
+        end,
+    ?assert(lists:all(fun limiter_group_absent/1, LimiterGroups)),
+    ?assertMatch(
+        {ok, #{reason_code := ?RC_QUOTA_EXCEEDED}},
+        emqtt:publish(Client, <<"topic">>, <<"payload">>, qos1)
+    ),
+
+    Kicker ! continue,
+    receive
+        {'DOWN', MRef, process, Client, _} -> ok
+    after 1_000 ->
+        ct:fail("client was not kicked")
+    end,
+    ok.
+
 %% Smoke test for "kick all NS clients" API.
 t_kick_all_ns_clients(_Config) ->
     Ns = <<"ns1">>,
@@ -1255,6 +1296,12 @@ t_backup_export_and_import(_Config) ->
     ?assertEqual(match, re:run(Msg, <<"mocked_error">>, [global, {capture, none}])),
 
     ok.
+
+limiter_group_exists(Group) ->
+    emqx_limiter_registry:find_group(Group) =/= undefined.
+
+limiter_group_absent(Group) ->
+    emqx_limiter_registry:find_group(Group) =:= undefined.
 
 %% Smoke tests for checking that we assign creation times for namespaces.
 t_creation_date(_Config) ->

--- a/changes/ee/fix-18227.en.md
+++ b/changes/ee/fix-18227.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where clients of a deleted managed namespace could temporarily publish without namespace rate limits while asynchronous client kicking was in progress.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/64

Release version: 6.0.4

## Summary

Deleting a managed namespace removes its limiter groups before the asynchronous client kicker finishes. Existing limiter clients previously treated the missing group configuration as a successful consumption, allowing **dangling connected clients to publish without the deleted namespace quota** until they were kicked.

In the PR, we create mt limiters with new `no_found_mode` option set to `close`, i.e. once a tenant and its limiter configs are deleted, the dangling clients are instantly "out of quota".


## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
