### PR TITLE
fix(authz): drop default localhost allow-all rule from acl.conf

### DIFF
--- a/apps/emqx_auth/etc/acl.conf
+++ b/apps/emqx_auth/etc/acl.conf
@@ -2,7 +2,9 @@
 
 {allow, {username, {re, "^dashboard$"}}, subscribe, ["$SYS/#"]}.
 
-{allow, {ipaddr, "127.0.0.1"}, all, ["$SYS/#", "#"]}.
+%% Uncomment the rule below to allow clients connecting from localhost
+%% full publish/subscribe access (including `$SYS/#` and `#`).
+%% {allow, {ipaddr, "127.0.0.1"}, all, ["$SYS/#", "#"]}.
 
 {deny, all, subscribe, ["$SYS/#", {eq, "#"}, {eq, "+/#"}]}.
 

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -960,9 +960,7 @@ t_publish_qos0_case3(_) ->
     ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
     gen_udp:close(Socket).
 
-t_publish_qos0_case04(_) ->
-    %% The default acl.conf does not allow wildcard subscriptions,
-    %% so an explicit allow rule is needed for this test.
+t_pub_sub_allowed_by_ipaddr_rule(_) ->
     OldAuthz = emqx:get_raw_config([authorization]),
     ok = emqx_gateway_test_utils:update_authz_file_rule(
         <<"{allow, {ipaddr, \"127.0.0.1\"}, all, [\"$SYS/#\", \"#\"]}.">>

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -961,6 +961,19 @@ t_publish_qos0_case3(_) ->
     gen_udp:close(Socket).
 
 t_publish_qos0_case04(_) ->
+    %% The default acl.conf does not allow wildcard subscriptions,
+    %% so an explicit allow rule is needed for this test.
+    OldAuthz = emqx:get_raw_config([authorization]),
+    ok = emqx_gateway_test_utils:update_authz_file_rule(
+        <<"{allow, {ipaddr, \"127.0.0.1\"}, all, [\"$SYS/#\", \"#\"]}.">>
+    ),
+    try
+        publish_qos0_short_topic_to_wildcard_sub()
+    after
+        {ok, _} = emqx:update_config([authorization], OldAuthz)
+    end.
+
+publish_qos0_short_topic_to_wildcard_sub() ->
     Dup = 0,
     QoS = 0,
     Retain = 0,

--- a/changes/ee/breaking-18228.en.md
+++ b/changes/ee/breaking-18228.en.md
@@ -1,0 +1,11 @@
+The default authorization rules file (`acl.conf`) no longer grants clients connecting from `127.0.0.1` blanket publish/subscribe access to all topics (including `$SYS/#` and `#`).
+
+Clients connecting from localhost are now authorized by the same rules as any other client, and ultimately by the `authorization.no_match` setting. In particular, subscriptions to `$SYS/#` and the wildcard filters `#` and `+/#` are now denied for localhost clients by the default rules, regardless of the security profile.
+
+Deployments that relied on the built-in localhost allowance must add an explicit rule to `acl.conf`. The previous rule is retained in the file as a comment for easy re-enabling:
+
+```erlang
+%% {allow, {ipaddr, "127.0.0.1"}, all, ["$SYS/#", "#"]}.
+```
+
+Note: this applies to new installations and deployments that have not customized `acl.conf`; existing customized `acl.conf` files are not modified by upgrades.


### PR DESCRIPTION
Release version:
6.3.0

## Summary

The shipped default `apps/emqx_auth/etc/acl.conf` contained a rule granting any client connecting from `127.0.0.1` blanket publish/subscribe access to all topics, including `$SYS/#` and `#`:

```erlang
{allow, {ipaddr, "127.0.0.1"}, all, ["$SYS/#", "#"]}.
```

This PR comments out that rule (keeping it in the file as a comment so operators can easily re-enable it). Rationale:

* `acl.conf` is evaluated top-down with first-match-wins. With the `hardened` security profile (default for 6.3+), the trailing `{allow, {security_profile, legacy}}` rule does not apply, so this localhost rule was the remaining implicit grant of full access to localhost clients.
* After this change, localhost clients are authorized by the same rules as any other client: wildcard subscriptions to `$SYS/#`, `#` (exact) and `+/#` (exact) are denied by the default deny rule regardless of security profile, and everything else is decided by the `legacy`-profile allow rule or `authorization.no_match`.

Only the shipped `apps/emqx_auth/etc/acl.conf` is changed. Test fallout was limited to `emqx_sn_protocol_SUITE:t_publish_qos0_case04`, which subscribed to `#` from localhost relying on the removed default; it now installs an explicit allow rule for the duration of the test.

Expected behavior on a fresh 6.3 node (hardened profile): subscribing to `$SYS/#` from `127.0.0.1` is denied (previously allowed); publishing to a normal topic from `127.0.0.1` is decided by `authorization.no_match`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
