### PR TITLE
perf(resource): avoid per-message error formatting on non-action channel ids

### DIFF
--- a/apps/emqx_resource/include/emqx_resource_runtime.hrl
+++ b/apps/emqx_resource/include/emqx_resource_runtime.hrl
@@ -28,10 +28,7 @@
     st_err :: st_err(),
     cb :: cb(),
     query_mode :: emqx_resource:resource_query_mode(),
-    channel_status :: ?NO_CHANNEL | channel_status(),
-    %% connector part of the queried id (the id itself when it has no channel part),
-    %% carried here so the query hot path does not need to re-parse the id
-    conn_res_id :: binary()
+    channel_status :: ?NO_CHANNEL | channel_status()
 }).
 
 -type runtime() :: #rt{}.

--- a/apps/emqx_resource/include/emqx_resource_runtime.hrl
+++ b/apps/emqx_resource/include/emqx_resource_runtime.hrl
@@ -28,7 +28,10 @@
     st_err :: st_err(),
     cb :: cb(),
     query_mode :: emqx_resource:resource_query_mode(),
-    channel_status :: ?NO_CHANNEL | channel_status()
+    channel_status :: ?NO_CHANNEL | channel_status(),
+    %% connector part of the queried id (the id itself when it has no channel part),
+    %% carried here so the query hot path does not need to re-parse the id
+    conn_res_id :: binary()
 }).
 
 -type runtime() :: #rt{}.

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -974,8 +974,10 @@ parse_connector_id_from_channel_id(Id) ->
                 end,
             {ok, iolist_to_binary(ConnResId)}
     catch
-        throw:{invalid_id, _} ->
-            {error, iolist_to_binary(io_lib:format("Invalid action/source ID: ~p", [Id]))}
+        %% Non-action/source ids (e.g. cluster-link resource ids) reach this branch on
+        %% every query, so it must stay cheap: no error message formatting here.
+        throw:{invalid_id, _} = Reason ->
+            {error, Reason}
     end.
 
 extract_namespace_from_resource_id(Id) ->

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -1362,7 +1362,7 @@ handle_async_worker_down(Data0, Pid) ->
     end.
 
 -spec call_query(force_sync | async_if_possible, _, _, _, _, _, _) -> _.
-call_query(QM, Id, ChanKey, Index, Ref, Query, QueryOpts) ->
+call_query(QM, Id, {ConnResId, _} = ChanKey, Index, Ref, Query, QueryOpts) ->
     ?tp(call_query_enter, #{id => Id, query => Query, query_mode => QM}),
     case emqx_resource_cache:get_runtime(ChanKey) of
         %% This seems to be the only place where the `rm_status_stopped' state matters,
@@ -1377,8 +1377,7 @@ call_query(QM, Id, ChanKey, Index, Ref, Query, QueryOpts) ->
             st_err = #{status := Status},
             cb = Resource,
             query_mode = QueryMode,
-            channel_status = ChanSt,
-            conn_res_id = ConnResId
+            channel_status = ChanSt
         }} ->
             IsAlwaysSend = is_always_send(QueryMode),
             case Status =:= ?status_connected orelse IsAlwaysSend of

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -1367,12 +1367,13 @@ call_query(QM, Id, Index, Ref, Query, QueryOpts) ->
             st_err = #{status := Status},
             cb = Resource,
             query_mode = QueryMode,
-            channel_status = ChanSt
+            channel_status = ChanSt,
+            conn_res_id = ConnResId
         }} ->
             IsAlwaysSend = is_always_send(QueryMode),
             case Status =:= ?status_connected orelse IsAlwaysSend of
                 true ->
-                    call_query2(QM, Id, Index, Ref, Query, QueryOpts, Resource, ChanSt);
+                    call_query2(QM, Id, ConnResId, Index, Ref, Query, QueryOpts, Resource, ChanSt);
                 false ->
                     Result = ?RESOURCE_ERROR(not_connected, "resource not connected"),
                     maybe_reply_to(Result, QueryOpts)
@@ -1382,11 +1383,11 @@ call_query(QM, Id, Index, Ref, Query, QueryOpts) ->
             maybe_reply_to(Result, QueryOpts)
     end.
 
-call_query2(QM, Id, Index, Ref, Query, QueryOpts, Resource, ChanSt) ->
+call_query2(QM, Id, ConnResId, Index, Ref, Query, QueryOpts, Resource, ChanSt) ->
     PrevLoggerProcessMetadata = logger:get_process_metadata(),
     try
         set_rule_id_trace_meta_data(Query),
-        do_call_query(QM, Id, Index, Ref, Query, QueryOpts, Resource, ChanSt)
+        do_call_query(QM, Id, ConnResId, Index, Ref, Query, QueryOpts, Resource, ChanSt)
     after
         reset_logger_process_metadata(PrevLoggerProcessMetadata)
     end.
@@ -1445,11 +1446,11 @@ collect_rule_trigger_times(?QUERY(_, _, _, _, _, _), Acc) ->
 %% a final result attributable to the connector callback.  Skip when:
 %%   * Decision is `?nack' (recoverable; the same request will be retried and
 %%     finalised later in `retry_inflight_sync').
-%%   * Result indicates `call_query/6' short-circuited before `apply_query_fun/9'
+%%   * Result indicates `call_query/6' short-circuited before `apply_query_fun/10'
 %%     (resource not found / stopped), so no callback ran.
 %% The `pre_query_channel_check/4' failure on a simple query produces a final
 %% `?ack' here even though the callback didn't run; we accept that edge case
-%% rather than thread the channel-check outcome out of `apply_query_fun/9'.
+%% rather than thread the channel-check outcome out of `apply_query_fun/10'.
 delta_with_actions_executed(?nack, _Result, DeltaCounters) ->
     DeltaCounters;
 delta_with_actions_executed(?ack, ?RESOURCE_ERROR_M(Kind, _), DeltaCounters) when
@@ -1458,16 +1459,6 @@ delta_with_actions_executed(?ack, ?RESOURCE_ERROR_M(Kind, _), DeltaCounters) whe
     DeltaCounters;
 delta_with_actions_executed(?ack, _Result, DeltaCounters) ->
     DeltaCounters#{actions_executed => 1}.
-
-%% action:kafka_producer:actionname:connector:kafka_producer:connectorname
-%% ns:ns1:action:kafka_producer:actionname:connector:kafka_producer:connectorname
-extract_connector_id(Id) when is_binary(Id) ->
-    case emqx_resource:parse_connector_id_from_channel_id(Id) of
-        {ok, ConnResId} ->
-            ConnResId;
-        {error, _} ->
-            Id
-    end.
 
 %% Check if channel is installed in the connector state.
 %% There is no need to query the conncector if the channel is not
@@ -1506,10 +1497,10 @@ is_always_send(M) when ?IS_BYPASS(M) ->
 is_always_send(_) ->
     false.
 
-do_call_query(QM, Id, Index, Ref, Query, QueryOpts, Resource, ChanSt) ->
+do_call_query(QM, Id, ConnResId, Index, Ref, Query, QueryOpts, Resource, ChanSt) ->
     #{mod := Mod, state := ResSt, callback_mode := CBM} = Resource,
     CallMode = call_mode(QM, CBM),
-    apply_query_fun(CallMode, Mod, Id, Index, Ref, Query, ResSt, ChanSt, QueryOpts).
+    apply_query_fun(CallMode, Mod, Id, ConnResId, Index, Ref, Query, ResSt, ChanSt, QueryOpts).
 
 -define(APPLY_RESOURCE(NAME, EXPR, REQ),
     try
@@ -1542,6 +1533,7 @@ apply_query_fun(
     sync,
     Mod,
     Id,
+    ConnResId,
     _Index,
     _Ref,
     ?QUERY(_, Request, _, _, _RequestContext, _TraceCtx) = _Query,
@@ -1556,7 +1548,7 @@ apply_query_fun(
             begin
                 case pre_query_channel_check(Id, Request, ChanSt, is_simple_query(QueryOpts)) of
                     ok ->
-                        Mod:on_query(extract_connector_id(Id), Request, ResSt);
+                        Mod:on_query(ConnResId, Request, ResSt);
                     Error ->
                         Error
                 end
@@ -1569,6 +1561,7 @@ apply_query_fun(
     async,
     Mod,
     Id,
+    ConnResId,
     Index,
     Ref,
     ?QUERY(_, Request, _, _, _RequestContext, _TraceCtx) = Query,
@@ -1606,7 +1599,7 @@ apply_query_fun(
                 ok ->
                     case
                         Mod:on_query_async(
-                            extract_connector_id(Id), Request, {ReplyFun, [ReplyContext]}, ResSt
+                            ConnResId, Request, {ReplyFun, [ReplyContext]}, ResSt
                         )
                     of
                         {error, _} = Error when IsSimpleQuery ->
@@ -1627,6 +1620,7 @@ apply_query_fun(
     sync,
     Mod,
     Id,
+    ConnResId,
     _Index,
     _Ref,
     [?QUERY(_, FirstRequest, _, _, _RequestContext, _) | _] = Batch,
@@ -1649,7 +1643,7 @@ apply_query_fun(
                     pre_query_channel_check(Id, FirstRequest, ChanSt, is_simple_query(QueryOpts))
                 of
                     ok ->
-                        Mod:on_batch_query(extract_connector_id(Id), Requests, ResSt);
+                        Mod:on_batch_query(ConnResId, Requests, ResSt);
                     Error ->
                         Error
                 end
@@ -1662,6 +1656,7 @@ apply_query_fun(
     async,
     Mod,
     Id,
+    ConnResId,
     Index,
     Ref,
     [?QUERY(_, FirstRequest, _, _, _RequestContext, _) | _] = Batch,
@@ -1704,7 +1699,7 @@ apply_query_fun(
                 ok ->
                     case
                         Mod:on_batch_query_async(
-                            extract_connector_id(Id), Requests, {ReplyFun, [ReplyContext]}, ResSt
+                            ConnResId, Requests, {ReplyFun, [ReplyContext]}, ResSt
                         )
                     of
                         {error, _} = Error when IsSimpleQuery ->

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -140,6 +140,7 @@
 -type inflight_table() :: ets:tid().
 -type data() :: #{
     id := id(),
+    chan_key := emqx_resource_cache:chan_key(),
     namespace := maybe_namespace(),
     index := index(),
     inflight_tid := inflight_table(),
@@ -221,9 +222,11 @@ simple_sync_query(Id, Request, QueryOpts0) ->
     RequestContext = request_context(QueryOpts0),
     TraceCtx = maps:get(trace_ctx, QueryOpts0, #{}),
     Query = ?SIMPLE_QUERY(ReplyTo, Request, RequestContext, TraceCtx),
+    ChanKey = emqx_resource_cache:split_channel_id(Id),
     Result = call_query(
         force_sync,
         Id,
+        ChanKey,
         ?NO_INDEX,
         ?NO_REQ_REF,
         Query,
@@ -242,7 +245,8 @@ simple_async_query(Id, Request, QueryOpts0) ->
     RequestContext = request_context(QueryOpts0),
     TraceCtx = maps:get(trace_ctx, QueryOpts0, #{}),
     Query = ?SIMPLE_QUERY(ReplyTo, Request, RequestContext, TraceCtx),
-    Result = call_query(async_if_possible, Id, ?NO_INDEX, ?NO_REQ_REF, Query, QueryOpts),
+    ChanKey = emqx_resource_cache:split_channel_id(Id),
+    Result = call_query(async_if_possible, Id, ChanKey, ?NO_INDEX, ?NO_REQ_REF, Query, QueryOpts),
     _ = handle_simple_query_result(Id, Query, Result, _HasBeenSent = false),
     Result.
 
@@ -353,6 +357,9 @@ init({Id, Index, Opts}) ->
     MetricsFlushInterval = maps:get(metrics_flush_interval, Opts, ?DEFAULT_METRICS_FLUSH_INTERVAL),
     Data0 = #{
         id => Id,
+        %% cache key derived from the immutable id; computed once for the
+        %% worker's lifetime so the query hot path never re-parses the id
+        chan_key => emqx_resource_cache:split_channel_id(Id),
         namespace => Namespace,
         index => Index,
         inflight_tid => InflightTID,
@@ -541,6 +548,7 @@ resume_from_blocked(Data) ->
 retry_inflight_sync(Ref, QueryOrBatch, Data0) ->
     #{
         id := Id,
+        chan_key := ChanKey,
         inflight_tid := InflightTID,
         index := Index,
         resume_interval := ResumeT
@@ -548,7 +556,7 @@ retry_inflight_sync(Ref, QueryOrBatch, Data0) ->
     ?tp(buffer_worker_retry_inflight, #{query_or_batch => QueryOrBatch, ref => Ref}),
     IsSimpleQuery = false,
     QueryOpts = #{simple_query => IsSimpleQuery},
-    Result = call_query(force_sync, Id, Index, Ref, QueryOrBatch, QueryOpts),
+    Result = call_query(force_sync, Id, ChanKey, Index, Ref, QueryOrBatch, QueryOpts),
     {Decision, PostFn, DeltaCounters0} =
         case QueryOrBatch of
             ?QUERY(ReplyTo, _, HasBeenSent, _ExpireAt, RequestContext, TraceCtx) ->
@@ -785,13 +793,14 @@ do_flush(
 ) ->
     #{
         id := Id,
+        chan_key := ChanKey,
         index := Index,
         inflight_tid := InflightTID
     } = Data0,
     %% unwrap when not batching (i.e., batch size == 1)
     [?QUERY(ReplyTo, _, HasBeenSent, _ExpireAt, RequestContext, TraceCtx) = Request] = Batch,
     QueryOpts = #{inflight_tid => InflightTID, simple_query => false},
-    Result = call_query(async_if_possible, Id, Index, Ref, Request, QueryOpts),
+    Result = call_query(async_if_possible, Id, ChanKey, Index, Ref, Request, QueryOpts),
     Reply = ?REPLY(ReplyTo, HasBeenSent, Result, RequestContext, TraceCtx),
     {Decision, PostFn, DeltaCounters0} = reply_caller_defer_metrics(Id, Reply, QueryOpts),
     DeltaCounters = delta_with_actions_executed(Decision, Result, DeltaCounters0),
@@ -875,13 +884,14 @@ do_flush(#{queue := Q1} = Data0, #{
 }) ->
     #{
         id := Id,
+        chan_key := ChanKey,
         index := Index,
         batch_size := BatchSize,
         inflight_tid := InflightTID
     } = Data0,
     IsSimpleQuery = false,
     QueryOpts = #{inflight_tid => InflightTID, simple_query => IsSimpleQuery},
-    Result = call_query(async_if_possible, Id, Index, Ref, Batch, QueryOpts),
+    Result = call_query(async_if_possible, Id, ChanKey, Index, Ref, Batch, QueryOpts),
     {Decision, PostFn, DeltaCounters0} =
         batch_reply_caller_defer_metrics(Id, Result, Batch, IsSimpleQuery),
     DeltaCounters = delta_with_actions_executed(Decision, Result, DeltaCounters0),
@@ -1351,10 +1361,10 @@ handle_async_worker_down(Data0, Pid) ->
             {next_state, blocked, Data}
     end.
 
--spec call_query(force_sync | async_if_possible, _, _, _, _, _) -> _.
-call_query(QM, Id, Index, Ref, Query, QueryOpts) ->
+-spec call_query(force_sync | async_if_possible, _, _, _, _, _, _) -> _.
+call_query(QM, Id, ChanKey, Index, Ref, Query, QueryOpts) ->
     ?tp(call_query_enter, #{id => Id, query => Query, query_mode => QM}),
-    case emqx_resource_cache:get_runtime(Id) of
+    case emqx_resource_cache:get_runtime(ChanKey) of
         %% This seems to be the only place where the `rm_status_stopped' state matters,
         %% to distinguish from the `disconnected' state.
         {ok, #rt{st_err = #{status := ?rm_status_stopped}}} ->
@@ -1446,7 +1456,7 @@ collect_rule_trigger_times(?QUERY(_, _, _, _, _, _), Acc) ->
 %% a final result attributable to the connector callback.  Skip when:
 %%   * Decision is `?nack' (recoverable; the same request will be retried and
 %%     finalised later in `retry_inflight_sync').
-%%   * Result indicates `call_query/6' short-circuited before `apply_query_fun/10'
+%%   * Result indicates `call_query/7' short-circuited before `apply_query_fun/10'
 %%     (resource not found / stopped), so no callback ran.
 %% The `pre_query_channel_check/4' failure on a simple query produces a final
 %% `?ack' here even though the callback didn't run; we accept that edge case

--- a/apps/emqx_resource/src/emqx_resource_cache.erl
+++ b/apps/emqx_resource/src/emqx_resource_cache.erl
@@ -196,7 +196,8 @@ get_runtime(Id) ->
             st_err = StErr,
             cb = Cb,
             query_mode = ChannelQueryMode,
-            channel_status = ChannelStatus
+            channel_status = ChannelStatus,
+            conn_res_id = ConnectorId
         }}
     catch
         error:badarg ->

--- a/apps/emqx_resource/src/emqx_resource_cache.erl
+++ b/apps/emqx_resource/src/emqx_resource_cache.erl
@@ -11,7 +11,7 @@
 %% For health checks etc.
 -export([read_status/1, read_mod/1, read_manager_pid/1]).
 %% Hot-path
--export([get_runtime/1]).
+-export([get_runtime/1, split_channel_id/1]).
 
 -include("emqx_resource_runtime.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
@@ -29,7 +29,9 @@
     extra = []
 }).
 
--type chan_key() :: {connector_resource_id(), channel_id()}.
+-type chan_key() :: {connector_resource_id(), channel_id() | ?NO_CHANNEL}.
+
+-export_type([chan_key/0]).
 
 -record(channel, {
     id :: chan_key(),
@@ -184,9 +186,12 @@ all_ids() ->
 
 %% @doc The most performance-critical call.
 %% NOTE: Id is the action Id, but not connector Id.
--spec get_runtime(resource_id()) -> {ok, runtime()} | {error, not_found}.
-get_runtime(Id) ->
-    ChanKey = {ConnectorId, _ChanId} = split_channel_id(Id),
+%% Hot-path callers that query repeatedly for the same id should pre-compute
+%% the key once with `split_channel_id/1' and pass the tuple instead.
+-spec get_runtime(resource_id() | chan_key()) -> {ok, runtime()} | {error, not_found}.
+get_runtime(Id) when is_binary(Id) ->
+    get_runtime(split_channel_id(Id));
+get_runtime({ConnectorId, _ChanId} = ChanKey) ->
     try
         Cb = get_cb(ConnectorId),
         ChannelStatus = get_channel_status(ChanKey),
@@ -227,6 +232,7 @@ to_channel_record({Id0, #{status := Status, error := Error, query_mode := QueryM
         extra = []
     }.
 
+-spec split_channel_id(binary()) -> chan_key().
 split_channel_id(Id) when is_binary(Id) ->
     case emqx_bridge_v2:extract_connector_id_from_bridge_v2_id(Id) of
         {ok, ConnResId} ->

--- a/apps/emqx_resource/src/emqx_resource_cache.erl
+++ b/apps/emqx_resource/src/emqx_resource_cache.erl
@@ -201,8 +201,7 @@ get_runtime({ConnectorId, _ChanId} = ChanKey) ->
             st_err = StErr,
             cb = Cb,
             query_mode = ChannelQueryMode,
-            channel_status = ChannelStatus,
-            conn_res_id = ConnectorId
+            channel_status = ChannelStatus
         }}
     catch
         error:badarg ->

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -5265,10 +5265,15 @@ t_independent_channel_health_check_interval(_Config) ->
                 ?assertMatch(
                     {ok, #rt{
                         st_err = #{status := ?status_connected},
-                        channel_status = ?status_connected
+                        channel_status = ?status_connected,
+                        conn_res_id = ConnResId
                     }},
                     emqx_resource_cache:get_runtime(ChanId)
                 )
+            ),
+            ?assertMatch(
+                {ok, #rt{channel_status = ?NO_CHANNEL, conn_res_id = ConnResId}},
+                emqx_resource_cache:get_runtime(ConnResId)
             ),
             %% Upon entering `?status_connected` for the first time, the connector/resource
             %% will kick off the channel health check.  After that, the channel manages its

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -5265,14 +5265,13 @@ t_independent_channel_health_check_interval(_Config) ->
                 ?assertMatch(
                     {ok, #rt{
                         st_err = #{status := ?status_connected},
-                        channel_status = ?status_connected,
-                        conn_res_id = ConnResId
+                        channel_status = ?status_connected
                     }},
                     emqx_resource_cache:get_runtime(ChanId)
                 )
             ),
             ?assertMatch(
-                {ok, #rt{channel_status = ?NO_CHANNEL, conn_res_id = ConnResId}},
+                {ok, #rt{channel_status = ?NO_CHANNEL}},
                 emqx_resource_cache:get_runtime(ConnResId)
             ),
             %% Upon entering `?status_connected` for the first time, the connector/resource

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -847,6 +847,30 @@ t_check_config(_) ->
     {error, _} = emqx_resource:check_config(?TEST_RESOURCE, <<"not a config">>),
     {error, _} = emqx_resource:check_config(?TEST_RESOURCE, #{invalid => config}).
 
+-doc """
+Channel ids parse to their connector resource id; any other id (e.g. a cluster-link
+resource id, queried per message on the buffer-worker hot path) returns a cheap
+`{error, {invalid_id, Id}}` without formatting an error message.
+""".
+t_parse_connector_id_from_channel_id(_) ->
+    ?assertEqual(
+        {ok, <<"connector:ctype:cname">>},
+        emqx_resource:parse_connector_id_from_channel_id(
+            <<"action:atype:aname:connector:ctype:cname">>
+        )
+    ),
+    ?assertEqual(
+        {ok, <<"ns:ns1:connector:ctype:cname">>},
+        emqx_resource:parse_connector_id_from_channel_id(
+            <<"ns:ns1:source:stype:sname:connector:ctype:cname">>
+        )
+    ),
+    NonChannelId = <<"emqx_cluster_link_mqtt:msg:some_link">>,
+    ?assertEqual(
+        {error, {invalid_id, NonChannelId}},
+        emqx_resource:parse_connector_id_from_channel_id(NonChannelId)
+    ).
+
 t_create_remove(_) ->
     ?check_trace(
         begin

--- a/changes/ee/perf-18229.en.md
+++ b/changes/ee/perf-18229.en.md
@@ -1,0 +1,1 @@
+Reduced CPU overhead on the data-integration send path. The broker no longer builds a formatted error string for every message routed through a resource that is not an action or source (for example, cluster-link message forwarding), which could previously trigger long-scheduler warnings under high message volume.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0

## Summary

Since 6.0.0 (f810fd95989a), `emqx_resource:parse_connector_id_from_channel_id/1` builds an
`io_lib:format("Invalid action/source ID: ~p", [Id])` binary whenever the given id is not an
action/source channel id. On the buffer-worker send path this happened for **every message** of any
non-action resource — notably every cluster-link egress message — and the resulting string is always
discarded by the caller. Under high message volume the `~p` pretty-printing of the id binary shows up
as 240–305 ms `long_schedule` warnings in the buffer workers (`io_lib_pretty:printable_bin0`).

Commits (incremental):

1. **Make the invalid-id branch cheap.** Return the already-thrown `{invalid_id, Id}` term instead of
   formatting a message. Parsing semantics and the `{ok, ConnResId}` happy path are unchanged. The
   error-shape change is safe: all consumers (`emqx_resource_buffer_worker`, `emqx_resource_cache:split_channel_id/1`,
   `emqx_bridge_v2:extract_connector_id_from_bridge_v2_id/1` / `get_resource_ids/4`) only pattern-match
   `{ok, _}` vs `{error, _}`; the old message text appears nowhere else in the code base.

2. **Parse the connector id only once per query.** The parse actually ran *twice* per message: once in
   `emqx_resource_cache:get_runtime/1` (`split_channel_id`, to key the cache lookups) and once in
   `apply_query_fun` (`extract_connector_id`, to hand the connector callback its resource id). The
   connector id is now threaded from `call_query` down to `apply_query_fun`; `extract_connector_id/1`
   is removed.

3. **Split the channel id once per buffer worker, not per query.** A buffer worker serves a single
   immutable id, so the `{ConnResId, ChanId}` cache key is now computed once at worker init and kept in
   the worker state; `get_runtime/1` accepts the pre-split key. The buffer-worker hot path now performs
   no id parsing at all. The simple-query path (authn/authz etc.), which has no state to keep the key
   in, still splits once per call as before.

4. **Cleanup:** the connector id is the first element of the pre-split key `call_query` already holds,
   so it is derived there rather than duplicated in the `#rt{}` record.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
