### PR TITLE
fix(socket): expect socket may be unready after select notify

### DIFF
--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -795,6 +795,10 @@ handle_data_ready(Socket, State) ->
     case sock_async_recv(Socket, 0) of
         {ok, Data} ->
             handle_data(Data, true, State);
+        {select, {_Info, Data}} ->
+            handle_data(Data, true, State);
+        {select, _Info} ->
+            {ok, State};
         {error, {closed, Data}} ->
             {ok, [{recv, Data}, {sock_closed, tcp_closed}], socket_closed(State)};
         {error, closed} ->

--- a/apps/emqx/test/emqx_socket_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_socket_connection_SUITE.erl
@@ -119,6 +119,28 @@ t_repeated_send_congestion_preserves_send_order(_) ->
         ok = meck:unload(esockd_socket)
     end.
 
+t_data_ready_handles_rearmed_select(_) ->
+    ok = meck_esockd_socket([no_history]),
+    ok = meck:new(socket, [unstick, passthrough, no_history]),
+    SelectInfo = {select_info, recv, make_ref()},
+    ok = meck:expect(socket, recv, fun(sock, 0, [], nowait) ->
+        {select, SelectInfo}
+    end),
+    try
+        State0 = emqx_socket_connection:init_state(sock, #{
+            zone => default,
+            limiter => undefined,
+            listener => {tcp, default}
+        }),
+        ?assertMatch(
+            {ok, _},
+            emqx_socket_connection:handle_msg({'$socket', sock, select, make_ref()}, State0)
+        )
+    after
+        ok = meck:unload(socket),
+        ok = meck:unload(esockd_socket)
+    end.
+
 meck_esockd_socket(Opts) ->
     ok = meck:new(esockd_socket, [passthrough | Opts]),
     ok = meck:expect(esockd_socket, type, fun(_) -> tcp end),

--- a/changes/ee/fix-18236.en.md
+++ b/changes/ee/fix-18236.en.md
@@ -1,0 +1,5 @@
+Fixed an issue where clients using socket-backed TCP listeners could be unexpectedly disconnected under high load, due to occasional readiness signals arriving for not-yet-ready sockets.
+
+```
+[error] crasher: initial call: emqx_socket_connection:init/4, ..., error: {{case_clause,{select,{select_info,recv,#Ref<...>}}},[{emqx_socket_connection,handle_msg,2,[{file,"emqx_socket_connection.erl"},{line,827}]}, ...
+```


### PR DESCRIPTION
Release version: 6.0.4, 6.1.5, 6.2.3

## Summary

Backport of #17918.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible