### PR TITLE
fix(lwm2m): remove unused XPath helper

### DIFF
--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_xml_object.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_xml_object.erl
@@ -12,7 +12,6 @@
     get_obj_def_assertive/2,
     get_object_id/1,
     get_object_name/1,
-    get_object_and_resource_id/2,
     get_resource_type/2,
     get_resource_name/2,
     get_resource_operations/2
@@ -38,14 +37,6 @@ get_object_id(ObjDefinition) ->
 get_object_name(ObjDefinition) ->
     [#xmlText{value = ObjectName}] = xmerl_xpath:string("Name/text()", ObjDefinition),
     ObjectName.
-
-get_object_and_resource_id(ResourceNameBinary, ObjDefinition) ->
-    ResourceNameString = binary_to_list(ResourceNameBinary),
-    [#xmlText{value = ObjectId}] = xmerl_xpath:string("ObjectID/text()", ObjDefinition),
-    [#xmlAttribute{value = ResourceId}] = xmerl_xpath:string(
-        "Resources/Item/Name[.=\"" ++ ResourceNameString ++ "\"]/../@ID", ObjDefinition
-    ),
-    {ObjectId, ResourceId}.
 
 get_resource_type(ResourceIdInt, ObjDefinition) ->
     ResourceIdString = integer_to_list(ResourceIdInt),


### PR DESCRIPTION
Release version: 6.0.4

Introduced in: N/A (port of #18209)

## Summary

Port of #18209 to dev-60.

Fix: #18208

Remove the unused `get_object_and_resource_id/2` helper from the LwM2M XML object module. The helper built XPath expressions by concatenating resource names without escaping them, creating a latent injection surface despite having no production callers. Removing the dead API prevents future misuse.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added (internal maintenance change; no changelog required)
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)