### PR TITLE
fix(datalayers): handle blank database/credentials without function_clause

### DIFF
--- a/apps/emqx_bridge_datalayers/mix.exs
+++ b/apps/emqx_bridge_datalayers/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeDatalayers.MixProject do
   def project do
     [
       app: :emqx_bridge_datalayers,
-      version: "6.1.1",
+      version: "6.1.2",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       erlc_options: UMP.strict_erlc_options(),

--- a/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
+++ b/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
@@ -83,14 +83,12 @@ on_start(
     InstId,
     Config = #{
         server := Server,
-        parameters := #{
-            username := Username,
-            password := Password,
-            database := Database
-        } = _Parameters,
+        parameters := Parameters = #{database := Database},
         ssl := SSL
     }
 ) ->
+    Username = maps:get(username, Parameters, <<>>),
+    Password = maps:get(password, Parameters, <<>>),
     #{hostname := Host, port := Port} = emqx_schema:parse_server(
         Server, ?DATALAYERS_HOST_ARROW_OPTIONS
     ),

--- a/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
+++ b/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_arrow_flight_connector.erl
@@ -83,12 +83,13 @@ on_start(
     InstId,
     Config = #{
         server := Server,
-        parameters := Parameters = #{database := Database},
+        parameters := Parameters,
         ssl := SSL
     }
 ) ->
     Username = maps:get(username, Parameters, <<>>),
     Password = maps:get(password, Parameters, <<>>),
+    Database = maps:get(database, Parameters, <<>>),
     #{hostname := Host, port := Port} = emqx_schema:parse_server(
         Server, ?DATALAYERS_HOST_ARROW_OPTIONS
     ),

--- a/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_connector.erl
+++ b/apps/emqx_bridge_datalayers/src/emqx_bridge_datalayers_connector.erl
@@ -88,12 +88,24 @@ callback_mode() -> async_if_possible.
     Config :: resource_config()
 ) -> {ok, state()} | {error, term()}.
 on_start(InstId, Config) ->
-    case ?with_driver(Config, [InstId, enrich_config(Config)]) of
-        {ok, State} ->
-            {ok, State#{driver_type => DriverType}};
+    case ensure_database(Config) of
+        ok ->
+            case ?with_driver(Config, [InstId, enrich_config(Config)]) of
+                {ok, State} ->
+                    {ok, State#{driver_type => DriverType}};
+                {error, _} = Err ->
+                    Err
+            end;
         {error, _} = Err ->
             Err
     end.
+
+ensure_database(#{parameters := #{database := Database}}) when
+    is_binary(Database), Database =/= <<>>
+->
+    ok;
+ensure_database(_) ->
+    {error, {bad_config, database_required}}.
 
 enrich_config(Config = #{parameters := Params = #{driver_type := ?DATALAYERS_DRIVER_TYPE_INFLUX}}) ->
     Config#{

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_flight_connector_tests.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_flight_connector_tests.erl
@@ -53,6 +53,18 @@ blank_credentials_test_() ->
                             parameters := (maps:get(parameters, Base))#{password => <<"pass">>}
                         }
                     )
+                ),
+                ?_assertMatch(
+                    {error, _},
+                    emqx_bridge_datalayers_arrow_flight_connector:on_start(
+                        <<"test:blank_database">>,
+                        Base#{
+                            parameters := maps:remove(
+                                database,
+                                maps:get(parameters, Base)
+                            )
+                        }
+                    )
                 )
             ]
         end}.

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_flight_connector_tests.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_arrow_flight_connector_tests.erl
@@ -1,0 +1,58 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_datalayers_arrow_flight_connector_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+blank_credentials_test_() ->
+    {setup,
+        fun() ->
+            meck:new(emqx_resource_pool, [passthrough, no_link]),
+            meck:expect(
+                emqx_resource_pool,
+                start,
+                fun(_, _, _) -> {error, {start_pool_failed, noproc, mocked}} end
+            ),
+            ok
+        end,
+        fun(_) -> meck:unload(emqx_resource_pool) end, fun(_) ->
+            Base = #{
+                server => <<"127.0.0.1:8360">>,
+                pool_size => 8,
+                ssl => #{enable => false},
+                parameters => #{
+                    driver_type => arrow_flight,
+                    database => <<"db">>,
+                    enable_prepared => true
+                }
+            },
+            [
+                ?_assertMatch(
+                    {error, _},
+                    emqx_bridge_datalayers_arrow_flight_connector:on_start(
+                        <<"test:blank_credentials">>,
+                        Base
+                    )
+                ),
+                ?_assertMatch(
+                    {error, _},
+                    emqx_bridge_datalayers_arrow_flight_connector:on_start(
+                        <<"test:blank_credentials">>,
+                        Base#{
+                            parameters := (maps:get(parameters, Base))#{username => <<"user">>}
+                        }
+                    )
+                ),
+                ?_assertMatch(
+                    {error, _},
+                    emqx_bridge_datalayers_arrow_flight_connector:on_start(
+                        <<"test:blank_credentials">>,
+                        Base#{
+                            parameters := (maps:get(parameters, Base))#{password => <<"pass">>}
+                        }
+                    )
+                )
+            ]
+        end}.

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_connector_tests.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_connector_tests.erl
@@ -1,0 +1,67 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_datalayers_connector_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+blank_database_test_() ->
+    Base = #{
+        server => <<"127.0.0.1:8361">>,
+        pool_size => 8,
+        ssl => #{enable => false},
+        parameters => #{
+            driver_type => influxdb_v1,
+            enable_prepared => true
+        }
+    },
+    [
+        ?_assertMatch(
+            {error, {bad_config, _}},
+            emqx_bridge_datalayers_connector:on_start(
+                <<"test:blank_database">>,
+                Base
+            )
+        ),
+        ?_assertMatch(
+            {error, {bad_config, _}},
+            emqx_bridge_datalayers_connector:on_start(
+                <<"test:blank_database">>,
+                Base#{
+                    parameters =>
+                        (maps:get(parameters, Base))#{database => <<>>}
+                }
+            )
+        )
+    ].
+
+blank_database_arrow_flight_driver_test_() ->
+    Base = #{
+        server => <<"127.0.0.1:8360">>,
+        pool_size => 8,
+        ssl => #{enable => false},
+        parameters => #{
+            driver_type => arrow_flight,
+            enable_prepared => true
+        }
+    },
+    [
+        ?_assertMatch(
+            {error, {bad_config, _}},
+            emqx_bridge_datalayers_connector:on_start(
+                <<"test:blank_database_arrow">>,
+                Base
+            )
+        ),
+        ?_assertMatch(
+            {error, {bad_config, _}},
+            emqx_bridge_datalayers_connector:on_start(
+                <<"test:blank_database_arrow">>,
+                Base#{
+                    parameters =>
+                        (maps:get(parameters, Base))#{database => <<>>}
+                }
+            )
+        )
+    ].

--- a/changes/ce/fix-18242.en.md
+++ b/changes/ce/fix-18242.en.md
@@ -1,0 +1,1 @@
+Fix Datalayers connectors failing with `function_clause` when database or credentials are left blank. A clear configuration error is reported instead.


### PR DESCRIPTION
Release version: 6.1.5

Introduced In: 6.0.0 (datalayers schema made `database` optional in PR #15544)

Fixes https://github.com/emqx/emqx/issues/18192

## Summary

When `database`, `username` and `password` are left blank in a Datalayers connector config, starting the connector crashed with `function_clause`:

- `emqx_bridge_datalayers_connector:on_start/2` dispatched to the influxdb driver, where `emqx_bridge_influxdb_connector:protocol_config/1` unconditionally matched `database := DB` in the parameters map, crashing when the key was absent.
- The Arrow Flight driver `emqx_bridge_datalayers_arrow_flight_connector:on_start/2` pattern-matched `username`/`password`/`database` as mandatory keys, so blank credentials crashed the same way.

Changes:

- `emqx_bridge_datalayers_connector.erl`: validate `database` in `on_start/2` before dispatching to a driver; missing or empty database returns `{error, {bad_config, database_required}}` instead of crashing. This covers both the influxdb and the Arrow Flight driver paths.
- `emqx_bridge_datalayers_arrow_flight_connector.erl`: fall back to empty binaries for `username`/`password` when absent, matching the underlying `datalayers` adapter which already uses `unwrap_or_default` on these options. Whether an empty credential is accepted is decided by the server side at connect time.
- Added eunit tests covering blank database (both drivers) and blank username/password (Arrow Flight driver).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ce/fix-18242.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)