### PR TITLE
test(quic): de-flake t_quic_takeover_tls takeover-completion race

### DIFF
--- a/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
+++ b/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
@@ -2192,13 +2192,8 @@ t_quic_takeover_tls(Config) ->
     %% THEN: client: session_present is true
     ?assertEqual(1, proplists:get_value(session_present, emqtt:info(C0))),
     %% THEN: server: session matches the TLS session.
-    #{
-        session := Session,
-        conninfo := #{connected_at := QuicConnectedAT},
-        sockinfo := #{socktype := quic}
-    } = ChanQuic = emqx_cm:get_chan_info(ClientId),
+    {Session, QuicConnectedAT, _} = retry_get_chan_info(ClientId, quic),
     ?assert(QuicConnectedAT > TLSConnectedAT),
-    ct:pal("~p~n", [emqx_cm:get_chan_info(ChanQuic)]),
     receive
         {disconnected, ?RC_SESSION_TAKEN_OVER, _} -> ok
     end,
@@ -2226,11 +2221,7 @@ t_quic_takeover_tls_0rtt(Config) ->
     #{nst := NST} = proplists:get_value(extra, emqtt:info(C0)),
     ct:pal("~p", [emqtt:info(C0)]),
     ?assert(is_binary(NST)),
-    #{
-        session := Session,
-        conninfo := #{connected_at := QuicConnectedAT},
-        sockinfo := #{socktype := quic}
-    } = ChanQuic = emqx_cm:get_chan_info(ClientId),
+    {Session, QuicConnectedAT, ChanQuic} = retry_get_chan_info(ClientId, quic),
 
     ?assertEqual(0, proplists:get_value(session_present, emqtt:info(C0))),
     %% WHEN: TLS client took over the session
@@ -2249,11 +2240,7 @@ t_quic_takeover_tls_0rtt(Config) ->
     %% THEN: client: session_present is true
     ?assertEqual(1, proplists:get_value(session_present, emqtt:info(CTLS))),
     %% THEN: server: session matches the TLS session and socktype is ssl
-    #{
-        session := Session,
-        conninfo := #{connected_at := TLSConnectedAT},
-        sockinfo := #{socktype := ssl}
-    } = _ChanTLS = emqx_cm:get_chan_info(ClientId),
+    {Session, TLSConnectedAT, _} = retry_get_chan_info(ClientId, ssl),
     ?assert(QuicConnectedAT < TLSConnectedAT),
     receive
         {disconnected, ?RC_SESSION_TAKEN_OVER, _} -> ok
@@ -2281,11 +2268,7 @@ t_quic_takeover_tls_0rtt(Config) ->
         {disconnected, ?RC_SESSION_TAKEN_OVER, _} -> ok
     end,
     assert_client_die(CTLS),
-    #{
-        session := Session3,
-        conninfo := #{connected_at := QuicConnectedAT2},
-        sockinfo := #{socktype := quic}
-    } = ChanQuic2 = emqx_cm:get_chan_info(ClientId),
+    {Session3, QuicConnectedAT2, ChanQuic2} = retry_get_chan_info(ClientId, quic),
     ?assertEqual(1, proplists:get_value(session_present, emqtt:info(C1))),
     ?assert(ChanQuic2 =/= ChanQuic),
     ?assert(maps:without([subscriptions], Session3) == maps:without([subscriptions], Session)),
@@ -2355,6 +2338,26 @@ t_tls_takeover_quic(Config) ->
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------
+
+-doc """
+Fetch channel info of ClientId, retrying until the registered channel has
+the expected socktype: both the initial channel info registration and the
+registry swap after a takeover are asynchronous.
+""".
+retry_get_chan_info(ClientId, SockType) ->
+    ?retry(
+        _Interval = 100,
+        _NAttempts = 30,
+        begin
+            #{
+                session := Session,
+                conninfo := #{connected_at := ConnectedAt},
+                sockinfo := #{socktype := SockType}
+            } = ChanInfo = emqx_cm:get_chan_info(ClientId),
+            {Session, ConnectedAt, ChanInfo}
+        end
+    ).
+
 send_and_recv_with(Sock) ->
     {ok, {IP, _}} = emqtt_quic:sockname(Sock),
     ?assert(lists:member(tuple_size(IP), [4, 8])),

--- a/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
+++ b/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
@@ -843,7 +843,7 @@ t_conn_change_client_addr(Config) ->
     ?retry(
         _Delay = 50,
         _attempt = 20,
-        fun() ->
+        begin
             {ok, NewAddr} = quicer:sockname(Conn),
             ?assertNotEqual(OldAddr, NewAddr)
         end


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0

Introduced in:
N/A (test-only)

## Summary

De-flakes `emqx_quic_multistreams_SUITE:t_quic_takeover_tls` (seen in PR #18245, run 30924540604, job `run_test_cases/apps/emqx-8_10`), which failed with `{badmatch, #{session => ...}}`.

The CM registry swap after a session takeover is asynchronous, so reading `emqx_cm:get_chan_info/1` right after `emqtt:quic_connect/1` can still return the old TLS channel (`socktype = ssl`), failing the `socktype := quic` match. The `{disconnected, ?RC_SESSION_TAKEN_OVER, _}` message only proves the old client was notified, not that the registry already points at the new channel.

Fix: retry the post-connect/post-takeover channel-info reads via a shared `retry_get_chan_info/2` helper (snabbkaffe `?retry`) until the registered channel has the expected socktype, in both `t_quic_takeover_tls` and the equally fragile `t_quic_takeover_tls_0rtt`. No sleeps; the retry is the barrier.

A separate commit fixes an unrelated `?retry` call in `t_conn_change_client_addr` that passed a `fun() -> ... end` body: the `?retry` macro already wraps its body in a fun, so the assertions inside never executed.

Validated by running the `takeover` group 20 times locally (60/60 pass).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

