### PR TITLE
test(dsraft): retry membership ops during chaotic rebalance

### DIFF
--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_raft_test_helpers.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_raft_test_helpers.erl
@@ -91,10 +91,13 @@ apply_stream(DB, NodeStream0, Stream0, N) ->
             Operation =:= assign_db_sites
         ->
             ?tp(notice, test_apply_operation, #{node => Node, operation => Operation, arg => Arg}),
-            %% Apply the transition.
-            ?assertMatch(
-                {ok, _},
-                ?ON(Node, emqx_ds_builtin_raft_meta:Operation(DB, Arg))
+            ?retry(
+                _Interval = 500,
+                _Attempts = 30,
+                ?assertMatch(
+                    {ok, _},
+                    ?ON(Node, emqx_ds_builtin_raft_meta:Operation(DB, Arg))
+                )
             ),
             apply_stream(DB, NodeStream0, Stream, N);
         [Fun | Stream] when is_function(Fun) ->


### PR DESCRIPTION
Release version:
6.1.5, 6.2.3, 6.3.0

Introduced in:
N/A (test-only flake fix)

## Summary

De-flakes `emqx_ds_builtin_raft_SUITE:t_rebalance_chaotic_converges`.

The test applies an interleaved stream of `join_db_site`/`leave_db_site`
operations while messages are appended. Under this concurrent churn a membership
transition can transiently fail while the shard set is being reallocated, and the
one-shot `?assertMatch({ok, _}, ...)` in `apply_stream/4` surfaced that as a
spurious `run_stage_failed`.

This completes `68c7a6764f` (which gave the message **append** path a
recoverable-retry budget): the flake had moved to the un-retried **membership**
operation in the same helper. The recoverable errors originate from the
non-blocking cluster-upgrade behaviour introduced in `92a339ff59`.

Fix (test-only): wrap the membership op in a bounded `?retry` (30 × 500 ms,
matching the append budget) so it is re-issued until accepted. Re-issuing is safe
— a failed transition commits nothing, and re-applying an already-applied add/del
yields `{ok, unchanged}`. A permanently-bad transition still fails at the
deadline.

Relevant file: `apps/emqx_ds_builtin_raft/test/emqx_ds_raft_test_helpers.erl`.

Verified by looping the case 20×: 20 passed, 0 failed.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
