### PR TITLE
test(dashboard): retry monitor delete+empty check against periodic sampler

### DIFF
--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -784,8 +784,12 @@ t_monitor_reset(Config) when is_list(Config) ->
         ),
     {ok, Samplers} = request(["monitor"], "latest=1"),
     ?assertEqual(1, erlang:length(Samplers)),
-    ok = delete(["monitor"]),
-    ?assertMatch({ok, []}, request(["monitor"], "latest=1")),
+    %% Re-delete each attempt: a sample the periodic sampler flushed after the
+    %% delete stays until the next delete, so re-GET alone can't reach empty.
+    ?retry(100, 50, begin
+        ok = delete(["monitor"]),
+        ?assertMatch({ok, []}, request(["monitor"], "latest=1"))
+    end),
     ok.
 
 t_monitor_api_error(Config) when is_list(Config) ->
@@ -924,8 +928,12 @@ t_persistent_session_stats(Config) when is_list(Config) ->
         )
     end),
     ?assertNotMatch({ok, []}, ?ON(N1, request(["monitor"]))),
-    ?assertMatch(ok, ?ON(N1, delete(["monitor"]))),
-    ?assertMatch({ok, []}, ?ON(N1, request(["monitor"]))),
+    %% Re-delete each attempt: a sample the periodic sampler flushed after the
+    %% delete stays until the next delete, so re-GET alone can't reach empty.
+    ?retry(100, 50, begin
+        ?assertMatch(ok, ?ON(N1, delete(["monitor"]))),
+        ?assertMatch({ok, []}, ?ON(N1, request(["monitor"])))
+    end),
     ok.
 
 %% Checks that we get consistent data when changing the requested time window for


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0

Introduced in:
N/A

## Summary

Test-only de-flake of `emqx_dashboard_monitor_SUITE`.

The dashboard monitor sampler flushes a fresh data point every `sample_interval` (1s in this suite). A bare `DELETE /monitor` immediately followed by an assert-empty `GET /monitor` races the next flush: a sample landing in between leaves the time-series non-empty, failing the assertion. A landed sample only clears on the *next* `DELETE`, so retrying the `GET` alone can never recover.

Fix: wrap the delete + empty-check as a unit in `?retry`, so each attempt re-clears and re-checks until it lands in a clean inter-sample window. Applied to both:
- `t_persistent_session_stats` (cluster case)
- `t_monitor_reset` (single-node, `latest=1`)

Validated by running each case 30× — 30/30 pass, 0 failures.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
