### PR TITLE
fix(greptimedb): bump driver for stale channel recovery

### DIFF
--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -26,7 +26,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
-      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1"}
+      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.2"}
     ]
   end
 end

--- a/apps/emqx_bridge_greptimedb/rebar.config
+++ b/apps/emqx_bridge_greptimedb/rebar.config
@@ -6,7 +6,7 @@
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}},
-    {greptimedb, {git, "https://github.com/emqx/greptimedb-ingester-erl", {tag, "v0.2.5-emqx.1"}}}
+    {greptimedb, {git, "https://github.com/emqx/greptimedb-ingester-erl", {tag, "v0.2.5-emqx.2"}}}
 ]}.
 {plugins, [rebar3_path_deps]}.
 {project_plugins, [erlfmt]}.

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.app.src
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_greptimedb, [
     {description, "EMQX GreptimeDB Bridge"},
-    {vsn, "0.2.6"},
+    {vsn, "0.2.7"},
     {registered, []},
     {applications, [
         kernel,

--- a/changes/ee/fix-18251.en.md
+++ b/changes/ee/fix-18251.en.md
@@ -1,0 +1,1 @@
+Fix GreptimeDB connectors that could fail to restart when a stale gRPC channel remained after a worker was force-stopped.

--- a/mix.exs
+++ b/mix.exs
@@ -436,7 +436,7 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:snappyer),
       common_dep(:crc32cer),
       {:opentsdb, github: "emqx/opentsdb-client-erl", tag: "v0.5.1", override: true},
-      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1", override: true},
+      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.2", override: true},
       {:amqp_client, "4.0.3", override: true}
     ]
   end


### PR DESCRIPTION
Release versions:
- e5.10.5

## Summary

Bump the GreptimeDB Erlang driver to `v0.2.5-emqx.2`.

The updated driver removes an orphaned grpcbox channel before retrying worker startup. This prevents `{error, {already_started, Pid}}` from leaving a GreptimeDB connector inconsistent across cluster nodes.

Driver fix: https://github.com/emqx/greptimedb-ingester-erl/pull/6

No schema changes.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe in summary)
