### PR TITLE
test(crl_cache): assert per-process trace order in t_cache_overflow

### DIFF
--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -420,17 +420,16 @@ assert_successful_connection(Config, ClientNum) ->
         end
     ).
 
-trace_between(Trace0, Marker1, Marker2) ->
-    {Trace1, [_ | _]} = ?split_trace_at(#{?snk_kind := Marker2}, Trace0),
-    {[_ | _], [_ | Trace2]} = ?split_trace_at(#{?snk_kind := Marker1}, Trace1),
-    Trace2.
-
 of_kinds(Trace0, Kinds0) ->
     Kinds = sets:from_list(Kinds0, [{version, 2}]),
     lists:filter(
         fun(#{?snk_kind := K}) -> sets:is_element(K, Kinds) end,
         Trace0
     ).
+
+%% The cache mutation events, emitted by the single emqx_crl_cache gen_server.
+cache_trace(Trace) ->
+    of_kinds(Trace, [new_crl_url_inserted, crl_cache_overflow, crl_cache_ensure_timer]).
 
 ensure_ssl_manager_alive() ->
     ?retry(
@@ -675,181 +674,54 @@ t_cache_overflow(Config) ->
     ?check_trace(
         begin
             %% First and second connections goes into the cache
-            ?tp(first_connections, #{}),
             assert_successful_connection(Config, 1),
             assert_successful_connection(Config, 2),
             %% These should be cached
-            ?tp(first_reconnections, #{}),
             assert_successful_connection(Config, 1),
             assert_successful_connection(Config, 2),
             %% A third client connects and evicts the oldest URL (1)
-            ?tp(first_eviction, #{}),
             assert_successful_connection(Config, 3),
             assert_successful_connection(Config, 3),
             %% URL (1) connects again and needs to be re-cached; this
             %% time, (2) gets evicted
-            ?tp(second_eviction, #{}),
             assert_successful_connection(Config, 1),
+            %% The final emqtt:connect returns before the server-side
+            %% emqx_crl_cache gen_server has emitted the URL1 re-insert /
+            %% URL2 overflow / URL1 timer events.  Block until the second
+            %% overflow (evicting URL2) lands so ?check_trace snapshots the
+            %% full event sequence rather than a 7-event prefix.
+            URL2 = "http://localhost:9878/intermediate2.crl.pem",
+            {ok, _} = ?block_until(
+                #{?snk_kind := crl_cache_overflow, oldest_url := URL2},
+                5_000
+            ),
             %% TODO: force race condition where the same URL is fetched
             %% at the same time and tries to be registered
-            ?tp(test_end, #{}),
             ok
         end,
         fun(Trace) ->
             URL1 = "http://localhost:9878/intermediate1.crl.pem",
             URL2 = "http://localhost:9878/intermediate2.crl.pem",
             URL3 = "http://localhost:9878/intermediate3.crl.pem",
-            Kinds = [
-                mqtt_client_connection,
-                new_crl_url_inserted,
-                crl_cache_ensure_timer,
-                crl_cache_overflow
-            ],
-            Trace1 = of_kinds(
-                trace_between(Trace, first_connections, first_reconnections),
-                Kinds
-            ),
+            %% The cache mutation events all come from the single
+            %% emqx_crl_cache gen_server, so their global order is
+            %% deterministic: URL1 and URL2 fill the cache, URL3 evicts the
+            %% oldest (URL1), then URL1 re-enters and evicts the new oldest
+            %% (URL2).
             ?assertMatch(
                 [
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := new_crl_url_inserted,
-                        url := URL1
-                    },
-                    #{
-                        ?snk_kind := crl_cache_ensure_timer,
-                        url := URL1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 2
-                    },
-                    #{
-                        ?snk_kind := new_crl_url_inserted,
-                        url := URL2
-                    },
-                    #{
-                        ?snk_kind := crl_cache_ensure_timer,
-                        url := URL2
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 2
-                    }
+                    #{?snk_kind := new_crl_url_inserted, url := URL1},
+                    #{?snk_kind := crl_cache_ensure_timer, url := URL1},
+                    #{?snk_kind := new_crl_url_inserted, url := URL2},
+                    #{?snk_kind := crl_cache_ensure_timer, url := URL2},
+                    #{?snk_kind := new_crl_url_inserted, url := URL3},
+                    #{?snk_kind := crl_cache_overflow, oldest_url := URL1},
+                    #{?snk_kind := crl_cache_ensure_timer, url := URL3},
+                    #{?snk_kind := new_crl_url_inserted, url := URL1},
+                    #{?snk_kind := crl_cache_overflow, oldest_url := URL2},
+                    #{?snk_kind := crl_cache_ensure_timer, url := URL1}
                 ],
-                Trace1
-            ),
-            Trace2 = of_kinds(
-                trace_between(Trace, first_reconnections, first_eviction),
-                Kinds
-            ),
-            ?assertMatch(
-                [
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 2
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 2
-                    }
-                ],
-                Trace2
-            ),
-            Trace3 = of_kinds(
-                trace_between(Trace, first_eviction, second_eviction),
-                Kinds
-            ),
-            ?assertMatch(
-                [
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 3
-                    },
-                    #{
-                        ?snk_kind := new_crl_url_inserted,
-                        url := URL3
-                    },
-                    #{
-                        ?snk_kind := crl_cache_overflow,
-                        oldest_url := URL1
-                    },
-                    #{
-                        ?snk_kind := crl_cache_ensure_timer,
-                        url := URL3
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 3
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 3
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 3
-                    }
-                ],
-                Trace3
-            ),
-            Trace4 = of_kinds(
-                trace_between(Trace, second_eviction, test_end),
-                Kinds
-            ),
-            ?assertMatch(
-                [
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := start,
-                        client_num := 1
-                    },
-                    #{
-                        ?snk_kind := new_crl_url_inserted,
-                        url := URL1
-                    },
-                    #{
-                        ?snk_kind := crl_cache_overflow,
-                        oldest_url := URL2
-                    },
-                    #{
-                        ?snk_kind := crl_cache_ensure_timer,
-                        url := URL1
-                    },
-                    #{
-                        ?snk_kind := mqtt_client_connection,
-                        ?snk_span := {complete, ok},
-                        client_num := 1
-                    }
-                ],
-                Trace4
+                cache_trace(Trace)
             ),
             ok
         end


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

Test-only de-flake of `emqx_crl_cache_SUITE:t_cache_overflow`.

The post-condition asserted a single fixed interleaving of two trace
streams: the `mqtt_client_connection` span events (emitted by the test
client processes) and the cache events (`new_crl_url_inserted`,
`crl_cache_overflow`, `crl_cache_ensure_timer`, emitted by the single
`emqx_crl_cache` gen_server). The two streams interleave
non-deterministically, so the gen_server events sometimes landed after
the connection-complete span and broke the match.

The client-connect spans add little value, so drop them and assert only
the cache-event stream, whose global order is deterministic (single
gen_server). The final `emqtt:connect` returns before the last
re-insert / overflow / timer events are emitted, so block until the
second overflow lands before snapshotting the trace, avoiding a
truncated prefix.

Port of the v6/master fix (#17706 / #17774) back to dev-58/dev-59;
dev-510 already carries the earlier per-stream split (`dd8597582d`).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
