### PR TITLE
feat(rule_engine): expose map_to_range and hash_to_range SQL functions

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -203,7 +203,9 @@
     md5/1,
     sha/1,
     sha256/1,
-    hash/2
+    hash/2,
+    hash_to_range/3,
+    map_to_range/3
 ]).
 
 %% zip Funcs
@@ -1107,6 +1109,10 @@ sha256(S) when is_binary(S) ->
 
 hash(Type, Data) ->
     emqx_variform_bif:hash(Type, Data).
+
+hash_to_range(Val, Min, Max) -> emqx_variform_bif:hash_to_range(Val, Min, Max).
+
+map_to_range(Val, Min, Max) -> emqx_variform_bif:map_to_range(Val, Min, Max).
 
 %%------------------------------------------------------------------------------
 %% gzip Funcs

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1131,6 +1131,68 @@ prop_hash_fun() ->
         end
     ).
 
+-doc "Tests map_to_range/3 maps integer, binary and atom values into an inclusive range.".
+t_map_to_range(_) ->
+    ?assertEqual(3, apply_func(map_to_range, [7, 0, 3])),
+    ?assertEqual(0, apply_func(map_to_range, [4, 0, 3])),
+    ?assertEqual(7, apply_func(map_to_range, [7, 7, 7])),
+    %% binary values are converted with binary:decode_unsigned/1
+    ?assertEqual(1, apply_func(map_to_range, [<<1>>, 0, 3])),
+    %% atom values are converted via their utf8 binary representation ('a' -> 97)
+    ?assertEqual(1, apply_func(map_to_range, [a, 0, 3])),
+    ?assertThrow(
+        #{reason := badarg, function := map_to_range},
+        apply_func(map_to_range, [7, 3, 0])
+    ),
+    ?assertThrow(
+        #{reason := badarg, function := map_to_range},
+        apply_func(map_to_range, [undefined, 0, 3])
+    ).
+
+-doc "Tests hash_to_range/3 hashes a value into a stable bucket within an inclusive range.".
+t_hash_to_range(_) ->
+    Shard = apply_func(hash_to_range, [<<"A_C001">>, 0, 3]),
+    ?assert(is_integer(Shard) andalso Shard >= 0 andalso Shard =< 3),
+    %% stable: same input always lands in the same bucket
+    ?assertEqual(Shard, apply_func(hash_to_range, [<<"A_C001">>, 0, 3])),
+    %% different inputs spread across all buckets
+    Buckets = lists:usort([
+        apply_func(hash_to_range, [integer_to_binary(N), 0, 3])
+     || N <- lists:seq(1, 100)
+    ]),
+    ?assertEqual([0, 1, 2, 3], Buckets),
+    ?assertThrow(
+        #{reason := badarg, function := hash_to_range},
+        apply_func(hash_to_range, [<<"x">>, 3, 0])
+    ),
+    ?assertThrow(
+        #{reason := badarg, function := hash_to_range},
+        apply_func(hash_to_range, [<<>>, 0, 3])
+    ).
+
+-doc "Tests map_to_range/3 and hash_to_range/3 are callable from rule SQL statements.".
+t_to_range_sql(_) ->
+    Shard = apply_func(hash_to_range, [<<"A_C001">>, 0, 3]),
+    ?assertMatch(
+        {ok, #{<<"shard">> := Shard}},
+        emqx_rule_sqltester:test(
+            #{
+                sql =>
+                    <<"SELECT hash_to_range(nth(2, tokens(topic, '/')), 0, 3) as shard FROM \"t/#\"">>,
+                context => #{topic => <<"t/A_C001/status">>}
+            }
+        )
+    ),
+    ?assertMatch(
+        {ok, #{<<"idx">> := 3}},
+        emqx_rule_sqltester:test(
+            #{
+                sql => <<"SELECT map_to_range(7, 0, 3) as idx FROM \"t/#\"">>,
+                context => #{topic => <<"t/1">>}
+            }
+        )
+    ).
+
 %%------------------------------------------------------------------------------
 %% Test cases for zip funcs
 %%------------------------------------------------------------------------------

--- a/changes/ee/feat-18253.en.md
+++ b/changes/ee/feat-18253.en.md
@@ -1,0 +1,1 @@
+Added two Rule-Engine SQL functions: `map_to_range(value, min, max)` and `hash_to_range(value, min, max)`. They map a value (or its hash) into an inclusive integer range, which is useful for sharding or bucketing — for example, distributing a large device fleet across several rules by deriving a shard index from a topic segment: `hash_to_range(nth(2, tokens(topic, '/')), 0, 3)`.


### PR DESCRIPTION
Release version:
6.2.3, 6.3.0

Introduced in:

## Summary

Exposes the existing variform bifs `map_to_range/3` and `hash_to_range/3` as Rule-Engine SQL functions.

Both functions already exist and are tested in `emqx_utils/src/emqx_variform_bif.erl`; this PR only adds thin pass-through wrappers (and exports) in `emqx_rule_funcs.erl` so they are callable from rule SQL — no new logic.

- `map_to_range(value, min, max)`: maps an integer (or a binary/atom, via `binary:decode_unsigned/1`) into the inclusive range `[min, max]`.
- `hash_to_range(value, min, max)`: sha256-hashes the value, then maps the hash into `[min, max]` — a stable, well-distributed bucket.

Use case: sharding a large device fleet across N rules/actions by deriving a shard index from a topic segment, e.g. `SELECT hash_to_range(nth(2, tokens(topic, '/')), 0, 3) as shard FROM "t/#"`, instead of enumerating hundreds of topic filters.

Tests cover the wrappers directly and end-to-end SQL evaluation via `emqx_rule_sqltester`.

Docs: the function reference lives in the emqx-docs repo — to be added there separately.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
