### PR TITLE
chore(release): add 6.4 line to release-version tooling

### DIFF
--- a/scripts/rel-versions
+++ b/scripts/rel-versions
@@ -5,10 +5,10 @@
 # Example: if HEAD is on a v6.0 topic branch (last reachable GA tag is 6.0.3),
 # this prints
 #
-#     6.0.4, 6.1.4, 6.2.3, 6.3.0
+#     6.0.4, 6.1.4, 6.2.3, 6.3.0, 6.4.0
 #
-# A downstream line that has no GA tag yet (e.g. dev-63 before 6.3.0 ships)
-# contributes its first GA version, M.N.0 (6.3.0 above).
+# A downstream line that has no GA tag yet (e.g. dev-64 before 6.4.0 ships)
+# contributes its first GA version, M.N.0 (6.4.0 above).
 #
 # computed by running `git describe <remote>/dev-XX --tags --match 'X.Y.*'
 # --exclude '*-*'` against the matching dev-XX branch (so the answers reflect
@@ -18,7 +18,7 @@
 # from the lookup; the script computes "next patch after the most recent GA".
 #
 # Branches in the forward-sync chain (v6 line):
-#   dev-60 -> dev-61 -> dev-62 -> dev-63
+#   dev-60 -> dev-61 -> dev-62 -> dev-63 -> dev-64
 #
 # The script auto-detects the remote pointing at github.com:emqx/emqx from
 # `git remote -v` -- it doesn't assume the remote is called `origin`.
@@ -99,7 +99,7 @@ start_minor="${BASH_REMATCH[2]}"
 # Forward-sync chain per major version.
 # ---------------------------------------------------------------------------
 case "$start_major" in
-    6) chain=(60 61 62 63) ;;
+    6) chain=(60 61 62 63 64) ;;
     *)
         echo "error: unsupported major version $start_major" >&2
         exit 1
@@ -107,7 +107,7 @@ case "$start_major" in
 esac
 
 # Encode the starting minor the same way the chain entries are encoded:
-# chain entries are e.g. 60, 61, 62, 63 (concatenation of major+minor).
+# chain entries are e.g. 60, 61, 62, 63, 64 (concatenation of major+minor).
 start_key="${start_major}${start_minor}"
 
 # ---------------------------------------------------------------------------

--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -22,6 +22,7 @@ options:
                      release-61
                      release-62
                      release-63
+                     release-64
                      NOTE: this option should be used when --dryrun.
 
   --dryrun:          Do not actually create the git tag.
@@ -110,6 +111,9 @@ rel_branch() {
             ;;
         6.3.*)
             echo 'release-63'
+            ;;
+        6.4.*)
+            echo 'release-64'
             ;;
         *)
             logerr "Unsupported version tag $TAG"


### PR DESCRIPTION
Add the 6.4 (`dev-64`/`release-64`) line to the release-version tooling so `scripts/rel-versions` and `scripts/rel/cut.sh` know about it, mirroring how the 6.3 line is handled.

- `scripts/rel-versions`: add `64` to the v6 forward-sync chain (`chain=(60 61 62 63 64)`) and update the header comments/example.
- `scripts/rel/cut.sh`: add `release-64` to the `--base` help list and a `6.4.*) -> release-64` mapping.

Based on `dev-60` so it forward-syncs up the chain (dev-61 -> 62 -> 63 -> 64); every dev branch's `rel-versions` then lists `6.4.0` as a downstream version. No workflow changes needed: the cron/CI matrices track GA'd lines (release-63 not yet listed either) and CI triggers already match `release-6[0-9]` globs.

Verified: `./scripts/rel-versions` on a dev-60 branch now prints `6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0`.