### PR TITLE
test(retainer): wait for retained store/clear before asserting in t_store_and_clean

### DIFF
--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -141,7 +141,14 @@ t_store_and_clean(_) ->
         <<"this is a retained message">>,
         [{qos, 0}, {retain, true}]
     ),
-    timer:sleep(100),
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            {ok, [#message{payload = <<"this is a retained message">>}]},
+            emqx_retainer:read_message(<<"retained">>)
+        )
+    ),
 
     {ok, _, List} = emqx_retainer:page_read(<<"retained">>, 1, 10),
     ?assertEqual(1, length(List)),
@@ -160,7 +167,7 @@ t_store_and_clean(_) ->
     {ok, #{}, [0]} = emqtt:unsubscribe(C1, <<"retained">>),
 
     emqtt:publish(C1, <<"retained">>, <<"">>, [{qos, 0}, {retain, true}]),
-    timer:sleep(100),
+    ?retry(100, 20, ?assertMatch({ok, []}, emqx_retainer:read_message(<<"retained">>))),
     {ok, #{}, [0]} = emqtt:subscribe(C1, <<"retained">>, [{qos, 0}, {rh, 0}]),
     ?assertEqual(0, length(receive_messages(1))),
     ?assertMatch(
@@ -225,6 +232,7 @@ t_retain_handling(Config) ->
     ?assertEqual(0, length(receive_messages(1))),
 
     emqtt:publish(C1, <<"retained">>, <<"">>, [{qos, 0}, {retain, true}]),
+    ?retry(100, 20, ?assertMatch({ok, []}, emqx_retainer:read_message(<<"retained">>))),
     ok = emqtt:disconnect(C1).
 
 t_wildcard_subscription(Config) ->


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
N/A

## Summary

Fixes the flaky `emqx_retainer_SUITE:t_store_and_clean` (group `mnesia_with_indices`).

The retainer applies retained-message **stores** and **clears** (empty-payload retain publishes) asynchronously, so `emqtt:publish` returns before the operation commits. The test used fixed `timer:sleep(100)` calls before the subsequent reads/subscribes, which under CI load occasionally race the async operation — the stale (or not-yet-stored) retained message is then observed, e.g. `?assertEqual(0, length(receive_messages(1)))` gets `1`.

Replace the fixed sleeps with `?retry` barriers that wait until `emqx_retainer:read_message/1` reflects the committed state (message present after a store, `{ok, []}` after a clear), and add the same wait after the trailing clear in `t_retain_handling` so it cannot leak into the next test. Test-only, no product change.

Verified with 30 consecutive local runs of the case (all pass) after the fix.

Note: the same test/race exists on v6 (`dev-60`…`dev-63`); v5 and v6 do not cross-sync, so a separate port is needed there.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
