### PR TITLE
fix(agent): enforce path-segment-aware URL prefix check in HTTP tool

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
@@ -167,18 +167,7 @@ split_segments(Path) ->
 %% after splitting so an encoded separator stays within its segment
 %% and never introduces an extra boundary.
 normalize_segments(Segments) ->
-    remove_dot_segments([cow_uri:urldecode(S) || S <- Segments], []).
-
-remove_dot_segments([], Acc) ->
-    lists:reverse(Acc);
-remove_dot_segments([<<".">> | Segments], Acc) ->
-    remove_dot_segments(Segments, Acc);
-remove_dot_segments([<<"..">> | Segments], []) ->
-    remove_dot_segments(Segments, []);
-remove_dot_segments([<<"..">> | Segments], [_ | Acc]) ->
-    remove_dot_segments(Segments, Acc);
-remove_dot_segments([Segment | Segments], Acc) ->
-    remove_dot_segments(Segments, [Segment | Acc]).
+    emqx_utils_uri:remove_dot_segments([cow_uri:urldecode(S) || S <- Segments]).
 
 segments_match([], []) ->
     true;

--- a/apps/emqx_utils/src/emqx_utils_uri.erl
+++ b/apps/emqx_utils/src/emqx_utils_uri.erl
@@ -42,6 +42,11 @@ to parse invalid URIs, like URI templates, i.e URIs of the form `http://example.
     join_path/2
 ]).
 
+-export([
+    canonicalize_path/1,
+    remove_dot_segments/1
+]).
+
 -type scheme() :: binary().
 -type userinfo() :: binary().
 -type host() :: binary().
@@ -215,9 +220,63 @@ join_path(Base, Path) ->
             [without_trailing_slash(Base), $/, without_starting_slash(Path)]
     end.
 
+-doc """
+Canonicalize an absolute URI path for comparison against another path
+and for safe reuse as a request path: split into segments, percent-decode
+each segment, resolve `.'/`..' segments, then percent-encode again.
+
+Decoding happens after splitting, so an encoded separator cannot introduce
+a segment boundary; a segment that decodes to text containing a separator
+is rejected, because a receiving server may decode it into extra
+boundaries. Returns `error' for non-absolute paths, invalid percent
+encoding, and percent-encoded bytes that are not valid UTF-8.
+""".
+-spec canonicalize_path(binary()) -> {ok, binary()} | error.
+canonicalize_path(<<"/", Rest/binary>>) ->
+    try
+        Segments = [decode_segment(S) || S <- binary:split(Rest, <<"/">>, [global])],
+        Quoted = [uri_string:quote(S) || S <- remove_dot_segments(Segments)],
+        case Quoted of
+            [] -> {ok, <<"/">>};
+            _ -> {ok, iolist_to_binary([[$/, S] || S <- Quoted])}
+        end
+    catch
+        throw:_ -> error
+    end;
+canonicalize_path(_) ->
+    error.
+
+-doc """
+Resolve `.'/`..' segments against the preceding segments; a `..' at the
+root is dropped, as in RFC 3986 `remove_dot_segments'.
+""".
+-spec remove_dot_segments([binary()]) -> [binary()].
+remove_dot_segments(Segments) ->
+    remove_dot_segments(Segments, []).
+
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------
+
+%% `uri_string:percent_decode/1' throws on invalid percent encoding
+%% and on percent-encoded bytes that are not valid UTF-8.
+decode_segment(Segment) ->
+    Decoded = uri_string:percent_decode(Segment),
+    case binary:match(Decoded, [<<"/">>, <<"\\">>]) of
+        nomatch -> Decoded;
+        _ -> throw({encoded_separator, Segment})
+    end.
+
+remove_dot_segments([], Acc) ->
+    lists:reverse(Acc);
+remove_dot_segments([<<".">> | Segments], Acc) ->
+    remove_dot_segments(Segments, Acc);
+remove_dot_segments([<<"..">> | Segments], []) ->
+    remove_dot_segments(Segments, []);
+remove_dot_segments([<<"..">> | Segments], [_ | Acc]) ->
+    remove_dot_segments(Segments, Acc);
+remove_dot_segments([Segment | Segments], Acc) ->
+    remove_dot_segments(Segments, [Segment | Acc]).
 
 parse_scheme(<<>>) -> undefined;
 parse_scheme(Scheme) -> Scheme.

--- a/apps/emqx_utils/test/emqx_utils_uri_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_uri_tests.erl
@@ -1,0 +1,76 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_utils_uri_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+canonicalize_path_test_() ->
+    Cases = [
+        {<<"/">>, {ok, <<"/">>}},
+        {<<"/api">>, {ok, <<"/api">>}},
+        {<<"/api/">>, {ok, <<"/api/">>}},
+        {<<"/api/weather">>, {ok, <<"/api/weather">>}},
+        %% Dot segments are resolved.
+        {<<"/api/v1/../../admin/users">>, {ok, <<"/admin/users">>}},
+        {<<"/api/sub/../weather">>, {ok, <<"/api/weather">>}},
+        {<<"/api/x/./y">>, {ok, <<"/api/x/y">>}},
+        {<<"/api/.">>, {ok, <<"/api">>}},
+        %% `..' at the root is dropped.
+        {<<"/..">>, {ok, <<"/">>}},
+        {<<"/../..">>, {ok, <<"/">>}},
+        %% Percent-encoded dot segments are decoded before resolution.
+        {<<"/api/v1/%2e%2e/%2e%2e/admin">>, {ok, <<"/admin">>}},
+        %% Encoded text round-trips through decode + re-encode.
+        {<<"/api/hello%20world">>, {ok, <<"/api/hello%20world">>}},
+        {<<"/api/caf%C3%A9">>, {ok, <<"/api/caf%C3%A9">>}},
+        %% A segment decoding to a separator is rejected.
+        {<<"/api/..%2f..%2fadmin">>, error},
+        {<<"/api/a%5Cb">>, error},
+        %% Invalid percent encoding and non-UTF-8 bytes are rejected.
+        {<<"/api/%zz">>, error},
+        {<<"/api/%ff">>, error},
+        %% Only absolute paths are accepted.
+        {<<"api/relative">>, error},
+        {<<>>, error}
+    ],
+    [
+        {Path, ?_assertEqual(Expected, emqx_utils_uri:canonicalize_path(Path))}
+     || {Path, Expected} <- Cases
+    ].
+
+remove_dot_segments_test_() ->
+    [
+        ?_assertEqual([], emqx_utils_uri:remove_dot_segments([])),
+        ?_assertEqual([<<"a">>, <<"b">>], emqx_utils_uri:remove_dot_segments([<<"a">>, <<"b">>])),
+        ?_assertEqual(
+            [<<"a">>, <<"c">>],
+            emqx_utils_uri:remove_dot_segments([<<"a">>, <<".">>, <<"c">>])
+        ),
+        ?_assertEqual(
+            [<<"c">>],
+            emqx_utils_uri:remove_dot_segments([<<"a">>, <<"..">>, <<"c">>])
+        ),
+        ?_assertEqual(
+            [<<"c">>],
+            emqx_utils_uri:remove_dot_segments([<<"..">>, <<"..">>, <<"c">>])
+        ),
+        %% A segment merely containing dots is kept literally.
+        ?_assertEqual(
+            [<<"..a">>, <<"b.">>],
+            emqx_utils_uri:remove_dot_segments([<<"..a">>, <<"b.">>])
+        )
+    ].

--- a/changes/ee/fix-18259.en.md
+++ b/changes/ee/fix-18259.en.md
@@ -1,0 +1,1 @@
+Agent HTTP tool invocations now stay within the configured URL path prefix. The invocation path is normalized (percent-decoded with `.`/`..` segments resolved) before it is matched against the prefix, and the match is path-segment aware, so paths such as `/api/../other` or `/api-lookalike` no longer resolve to locations outside the configured prefix.

--- a/changes/ee/fix-18259.en.md
+++ b/changes/ee/fix-18259.en.md
@@ -1,1 +1,0 @@
-Agent HTTP tool invocations now stay within the configured URL path prefix. The invocation path is normalized (percent-decoded with `.`/`..` segments resolved) before it is matched against the prefix, and the match is path-segment aware, so paths such as `/api/../other` or `/api-lookalike` no longer resolve to locations outside the configured prefix.

--- a/plugins/emqx_agent/src/tools/emqx_agent_tool_http.erl
+++ b/plugins/emqx_agent/src/tools/emqx_agent_tool_http.erl
@@ -246,12 +246,15 @@ path_schema(Url) ->
     }.
 
 invocation_url(BaseUrl, Args) ->
-    Path0 = maps:get(<<"path">>, Args, undefined),
-    Path = normalize_path(Path0),
+    Path0 = normalize_path(maps:get(<<"path">>, Args, undefined)),
     Prefix = configured_path_prefix(BaseUrl),
-    case is_path_prefix(Prefix, Path) of
-        true -> {ok, <<(origin(BaseUrl))/binary, Path/binary>>};
-        false -> {error, {path_outside_configured_prefix, #{prefix => Prefix, path => Path}}}
+    maybe
+        {ok, Path} ?= canonicalize_path(Path0),
+        {ok, CanonPrefix} ?= canonicalize_path(Prefix),
+        true ?= is_path_prefix(CanonPrefix, Path),
+        {ok, <<(origin(BaseUrl))/binary, Path/binary>>}
+    else
+        _ -> {error, {path_outside_configured_prefix, #{prefix => Prefix, path => Path0}}}
     end.
 
 normalize_path(<<"/", _/binary>> = Path) ->
@@ -263,11 +266,55 @@ normalize_path(Path) when is_binary(Path) ->
 normalize_path(_) ->
     <<"/">>.
 
-is_path_prefix(Prefix, Path) ->
-    case binary:match(Path, Prefix) of
-        {0, _} -> true;
-        _ -> false
+%% Canonicalize an absolute path: split into segments, percent-decode
+%% each one, resolve `.'/`..' segments, then re-encode. The canonical
+%% form is used both for the prefix check and as the request path, so
+%% the checked path and the requested path cannot diverge. Decoding
+%% after splitting keeps an encoded separator inside its segment; a
+%% segment that decodes to text containing a separator is rejected
+%% because the upstream server may decode it into extra boundaries.
+canonicalize_path(<<"/", Rest/binary>>) ->
+    try
+        Segments = [decode_segment(S) || S <- binary:split(Rest, <<"/">>, [global])],
+        Quoted = [uri_string:quote(S) || S <- remove_dot_segments(Segments, [])],
+        case Quoted of
+            [] -> {ok, <<"/">>};
+            _ -> {ok, iolist_to_binary([[$/, S] || S <- Quoted])}
+        end
+    catch
+        throw:_ -> error
+    end;
+canonicalize_path(_) ->
+    error.
+
+%% `uri_string:percent_decode/1' throws on invalid percent encoding
+%% and on percent-encoded bytes that are not valid UTF-8.
+decode_segment(Segment) ->
+    Decoded = uri_string:percent_decode(Segment),
+    case binary:match(Decoded, [<<"/">>, <<"\\">>]) of
+        nomatch -> Decoded;
+        _ -> throw({encoded_separator, Segment})
     end.
+
+remove_dot_segments([], Acc) ->
+    lists:reverse(Acc);
+remove_dot_segments([<<".">> | Segments], Acc) ->
+    remove_dot_segments(Segments, Acc);
+remove_dot_segments([<<"..">> | Segments], []) ->
+    remove_dot_segments(Segments, []);
+remove_dot_segments([<<"..">> | Segments], [_ | Acc]) ->
+    remove_dot_segments(Segments, Acc);
+remove_dot_segments([Segment | Segments], Acc) ->
+    remove_dot_segments(Segments, [Segment | Acc]).
+
+%% Both arguments must be canonical absolute paths. The path is inside
+%% the prefix only when it equals the prefix or extends it at a segment
+%% boundary, so `/api-internal' does not match prefix `/api'.
+is_path_prefix(Prefix0, Path) ->
+    Prefix = string:trim(Prefix0, trailing, "/"),
+    PrefixSlash = <<Prefix/binary, "/">>,
+    Path =:= Prefix orelse
+        binary:part(Path, 0, min(byte_size(Path), byte_size(PrefixSlash))) =:= PrefixSlash.
 
 configured_path_prefix(Url) ->
     normalize_path(maps:get(path, uri_string:parse(Url), <<"/">>)).

--- a/plugins/emqx_agent/src/tools/emqx_agent_tool_http.erl
+++ b/plugins/emqx_agent/src/tools/emqx_agent_tool_http.erl
@@ -245,12 +245,15 @@ path_schema(Url) ->
             >>
     }.
 
+%% The canonical path is used both for the prefix check and as the
+%% outgoing request path, so the checked path and the requested path
+%% cannot diverge.
 invocation_url(BaseUrl, Args) ->
     Path0 = normalize_path(maps:get(<<"path">>, Args, undefined)),
     Prefix = configured_path_prefix(BaseUrl),
     maybe
-        {ok, Path} ?= canonicalize_path(Path0),
-        {ok, CanonPrefix} ?= canonicalize_path(Prefix),
+        {ok, Path} ?= emqx_utils_uri:canonicalize_path(Path0),
+        {ok, CanonPrefix} ?= emqx_utils_uri:canonicalize_path(Prefix),
         true ?= is_path_prefix(CanonPrefix, Path),
         {ok, <<(origin(BaseUrl))/binary, Path/binary>>}
     else
@@ -265,47 +268,6 @@ normalize_path(Path) when is_binary(Path) ->
     <<"/", Path/binary>>;
 normalize_path(_) ->
     <<"/">>.
-
-%% Canonicalize an absolute path: split into segments, percent-decode
-%% each one, resolve `.'/`..' segments, then re-encode. The canonical
-%% form is used both for the prefix check and as the request path, so
-%% the checked path and the requested path cannot diverge. Decoding
-%% after splitting keeps an encoded separator inside its segment; a
-%% segment that decodes to text containing a separator is rejected
-%% because the upstream server may decode it into extra boundaries.
-canonicalize_path(<<"/", Rest/binary>>) ->
-    try
-        Segments = [decode_segment(S) || S <- binary:split(Rest, <<"/">>, [global])],
-        Quoted = [uri_string:quote(S) || S <- remove_dot_segments(Segments, [])],
-        case Quoted of
-            [] -> {ok, <<"/">>};
-            _ -> {ok, iolist_to_binary([[$/, S] || S <- Quoted])}
-        end
-    catch
-        throw:_ -> error
-    end;
-canonicalize_path(_) ->
-    error.
-
-%% `uri_string:percent_decode/1' throws on invalid percent encoding
-%% and on percent-encoded bytes that are not valid UTF-8.
-decode_segment(Segment) ->
-    Decoded = uri_string:percent_decode(Segment),
-    case binary:match(Decoded, [<<"/">>, <<"\\">>]) of
-        nomatch -> Decoded;
-        _ -> throw({encoded_separator, Segment})
-    end.
-
-remove_dot_segments([], Acc) ->
-    lists:reverse(Acc);
-remove_dot_segments([<<".">> | Segments], Acc) ->
-    remove_dot_segments(Segments, Acc);
-remove_dot_segments([<<"..">> | Segments], []) ->
-    remove_dot_segments(Segments, []);
-remove_dot_segments([<<"..">> | Segments], [_ | Acc]) ->
-    remove_dot_segments(Segments, Acc);
-remove_dot_segments([Segment | Segments], Acc) ->
-    remove_dot_segments(Segments, [Segment | Acc]).
 
 %% Both arguments must be canonical absolute paths. The path is inside
 %% the prefix only when it equals the prefix or extends it at a segment

--- a/plugins/emqx_agent/test/emqx_agent_tool_http_SUITE.erl
+++ b/plugins/emqx_agent/test/emqx_agent_tool_http_SUITE.erl
@@ -248,6 +248,33 @@ t_path_outside_configured_prefix_errors(Config) ->
         ok
     end.
 
+-doc "A path with dot segments resolving above the configured prefix is denied.".
+t_dot_segment_traversal_denied(Config) ->
+    assert_path_denied(Config, <<"/api/v1/../../admin/users">>).
+
+-doc "A sibling path sharing the prefix bytes but not a segment boundary is denied.".
+t_sibling_prefix_denied(Config) ->
+    assert_path_denied(Config, <<"/api-internal/secrets">>).
+
+-doc "Percent-encoded dot segments are decoded before the prefix check and denied.".
+t_encoded_traversal_denied(Config) ->
+    assert_path_denied(Config, <<"/api/v1/%2e%2e/%2e%2e/admin">>).
+
+-doc "A segment decoding to a path separator is denied.".
+t_encoded_separator_denied(Config) ->
+    assert_path_denied(Config, <<"/api/..%2f..%2fadmin">>).
+
+-doc "In-prefix paths still reach the server, on their canonical form.".
+t_in_prefix_paths_allowed(Config) ->
+    %% Exact prefix.
+    assert_request_path(Config, <<"/api">>, <<"/api">>),
+    %% Sub-resource at a segment boundary.
+    assert_request_path(Config, <<"/api/sub/resource">>, <<"/api/sub/resource">>),
+    %% Percent-encoded but in-prefix.
+    assert_request_path(Config, <<"/api/hello%20world">>, <<"/api/hello%20world">>),
+    %% Dot segments resolving within the prefix.
+    assert_request_path(Config, <<"/api/sub/../weather">>, <<"/api/weather">>).
+
 t_unregistered_tool_is_silently_ignored(_Config) ->
     ok = emqx_agent_config:delete_tool(?TOOL_TYPE, ?TOOL_ID),
     Msg = emqx_message:make(?TOOL_ID, 0, invoke_topic(<<"dummy-req">>), <<"ignored">>),
@@ -298,6 +325,43 @@ invoke_and_assert_response(_Config, Args, AssertFn) ->
     AssertFn(emqx_agent_tool_helpers:cap_response(Reply)),
 
     ok = emqx:unsubscribe(ReplyTopic).
+
+assert_path_denied(Config, Path) ->
+    Self = self(),
+    emqx_utils_http_test_server:set_handler(fun(Req0, State) ->
+        Self ! {unexpected_request, cowboy_req:path(Req0)},
+        reply_json(200, #{<<"ok">> => true}, Req0, State)
+    end),
+    invoke_and_assert_response(Config, get_args(Path, #{}), fun(Response) ->
+        ?assertMatch(
+            #{<<"status">> := <<"error">>, <<"reason">> := Reason} when is_binary(Reason),
+            Response
+        ),
+        ?assertNotEqual(
+            nomatch,
+            binary:match(maps:get(<<"reason">>, Response), <<"path_outside_configured_prefix">>)
+        )
+    end),
+    receive
+        {unexpected_request, ReqPath} -> ct:fail({unexpected_request, ReqPath})
+    after 100 ->
+        ok
+    end.
+
+assert_request_path(Config, Path, ExpectedPath) ->
+    Self = self(),
+    emqx_utils_http_test_server:set_handler(fun(Req0, State) ->
+        Self ! {request_path, cowboy_req:path(Req0)},
+        reply_json(200, #{<<"ok">> => true}, Req0, State)
+    end),
+    invoke_and_assert(Config, get_args(Path, #{}), fun(Data) ->
+        ?assertMatch(#{<<"ok">> := true}, Data)
+    end),
+    receive
+        {request_path, ReqPath} -> ?assertEqual(ExpectedPath, ReqPath)
+    after 3000 ->
+        ct:fail(no_request_received)
+    end.
 
 get_args(Path, QueryArgs) ->
     #{<<"path">> => Path, <<"query_args">> => QueryArgs}.


### PR DESCRIPTION
Fixes: https://github.com/emqx/emqx/issues/18207

Release version: 6.3.0
Introduced In: N/A (introduced in 9ccc60eb07, which is not released yet)

## Summary

Hardens URL path-prefix validation for the agent HTTP tool.

The invocation path is now canonicalized before it is matched against the configured URL path prefix: it is split into segments, each segment percent-decoded, `.`/`..` segments resolved, and the result re-encoded. The canonical form is used both for the prefix check and as the outgoing request path, so the checked path and the requested path cannot diverge. The prefix match only accepts the prefix itself or an extension at a segment boundary (so `/api-other` no longer matches prefix `/api`), and segments that decode to a path separator are rejected.

The canonicalization is provided by the new `emqx_utils_uri:canonicalize_path/1`, and the dot-segment resolution previously local to `emqx_mgmt_api_key_scopes` is shared as `emqx_utils_uri:remove_dot_segments/1` (the key-scopes module keeps `cow_uri:urldecode/1`, which must mirror `cowboy_router` exactly).

Relevant files: `apps/emqx_utils/src/emqx_utils_uri.erl` (shared canonicalization), `plugins/emqx_agent/src/tools/emqx_agent_tool_http.erl` (prefix check), `plugins/emqx_agent/test/emqx_agent_tool_http_SUITE.erl` (denial cases plus positive controls asserting the resolved path seen by the server).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
