### PR TITLE
Upgrade/william/quicer 0.4

### DIFF
--- a/.github/actions/package-macos/action.yaml
+++ b/.github/actions/package-macos/action.yaml
@@ -39,7 +39,7 @@ runs:
         APPLE_DEVELOPER_IDENTITY: ${{ inputs.apple_developer_identity }}
         APPLE_DEVELOPER_ID_BUNDLE: ${{ inputs.apple_developer_id_bundle }}
         APPLE_DEVELOPER_ID_BUNDLE_PASSWORD: ${{ inputs.apple_developer_id_bundle_password }}
-        QUICER_TLS_VER: openssl3
+        QUICER_TLS_VER: quictls
       run: |
         erl -s init stop
         elixir -e "System.version() |> IO.puts()"

--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -19,7 +19,7 @@ end,
 
 Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.3"}}},
 Quicer =
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.5"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.3"}}}.
 
 Dialyzer = fun(Config) ->
     {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),

--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -19,7 +19,7 @@ end,
 
 Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.3"}}},
 Quicer =
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.3"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.4"}}}.
 
 Dialyzer = fun(Config) ->
     {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),

--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -19,7 +19,7 @@ end,
 
 Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.3"}}},
 Quicer =
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.4"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.8"}}}.
 
 Dialyzer = fun(Config) ->
     {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -1114,6 +1114,7 @@ to_quicer_listener_opts(Name, Opts) ->
     %% Conn Opts
     HibernateAfterMs = maps:get(hibernate_after, ListenOpts),
     ConnectionOpts = #{
+        alpn => ["mqtt"],
         conn_callback => emqx_quic_connection,
         peer_unidi_stream_count => maps:get(peer_unidi_stream_count, Opts, 1),
         peer_bidi_stream_count => maps:get(peer_bidi_stream_count, Opts, 10),

--- a/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
+++ b/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
@@ -1701,7 +1701,7 @@ t_olp_reject(Config) ->
     ?assertEqual(
         {error,
             {transport_down, #{
-                error => 346,
+                error => 11,
                 status =>
                     user_canceled
             }}},

--- a/changes/ee/fix-18626.en.md
+++ b/changes/ee/fix-18626.en.md
@@ -1,0 +1,3 @@
+Upgrade QUIC stack to quicer-0.4.8 (msquic 2.5.7).
+
+Contains a security update for CVE-2026-32179

--- a/mix.exs
+++ b/mix.exs
@@ -1127,7 +1127,7 @@ defmodule EMQXUmbrella.MixProject do
     if enable_quicer?(),
       # in conflict with emqx and emqtt
       do: [
-        {:quicer, github: "emqx/quic", tag: "0.2.5", override: true}
+        {:quicer, github: "emqx/quic", tag: "0.4.3", override: true}
       ],
       else: []
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1127,7 +1127,7 @@ defmodule EMQXUmbrella.MixProject do
     if enable_quicer?(),
       # in conflict with emqx and emqtt
       do: [
-        {:quicer, github: "emqx/quic", tag: "0.4.3", override: true}
+        {:quicer, github: "emqx/quic", tag: "0.4.4", override: true}
       ],
       else: []
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1127,7 +1127,7 @@ defmodule EMQXUmbrella.MixProject do
     if enable_quicer?(),
       # in conflict with emqx and emqtt
       do: [
-        {:quicer, github: "emqx/quic", tag: "0.4.4", override: true}
+        {:quicer, github: "emqx/quic", tag: "0.4.8", override: true}
       ],
       else: []
   end

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -36,7 +36,7 @@ assert_otp() ->
     end.
 
 quicer() ->
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.5"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.3"}}}.
 
 jq() ->
     {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.17"}}}.

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -36,7 +36,7 @@ assert_otp() ->
     end.
 
 quicer() ->
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.3"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.4"}}}.
 
 jq() ->
     {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.17"}}}.

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -36,7 +36,7 @@ assert_otp() ->
     end.
 
 quicer() ->
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.4"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.8"}}}.
 
 jq() ->
     {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.17"}}}.


### PR DESCRIPTION
Upgrade QUIC stack to quicer-0.4.8 (msquic 2.5.7).

- Contains a security update for CVE-2026-32179
- el10 support
- appup file support but not yet used in EMQX hot upgrade


Release version:
5.10.5
<!--
run script ./scripts/rel-versions to get release versions
-->


## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
