### PR TITLE
test(ws): verify empty proxy_address_header disables forwarded-address lookup

### DIFF
--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -151,6 +151,42 @@ t_header(_) ->
         sockstate := running
     } = SockInfo.
 
+%% An empty proxy_address_header/proxy_port_header disables the
+%% forwarded-address lookup: peername is the real socket peer even when
+%% the request carries x-forwarded-for/x-forwarded-port headers.
+t_header_proxy_disabled_by_empty_name(_) ->
+    ok = meck:expect(
+        cowboy_req,
+        header,
+        fun
+            (<<"x-forwarded-for">>, _, _) -> <<"100.100.100.100, 99.99.99.99">>;
+            (<<"x-forwarded-port">>, _, _) -> <<"1000">>;
+            (_, _, Default) -> Default
+        end
+    ),
+    set_ws_opts(proxy_address_header, <<"">>),
+    set_ws_opts(proxy_port_header, <<"">>),
+    {ok, St, _} = ?ws_conn:websocket_init([
+        #{},
+        #{
+            zone => default,
+            limiter => limiter_cfg(),
+            listener => {ws, default}
+        }
+    ]),
+    WsPid = spawn(fun() ->
+        receive
+            {call, From, info} ->
+                gen_server:reply(From, ?ws_conn:info(St))
+        end
+    end),
+    #{sockinfo := SockInfo} = ?ws_conn:call(WsPid, info),
+    #{
+        socktype := ws,
+        peername := {{127, 0, 0, 1}, 3456},
+        sockstate := running
+    } = SockInfo.
+
 t_info_limiter(_) ->
     Limiter = init_limiter(),
     St = st(#{limiter => Limiter}),

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -664,7 +664,9 @@ conn_congestion_enable_alarm.label:
 fields_ws_opts_proxy_port_header.desc:
 """The HTTP request header that carries the original client's source port, EMQX will take the leftmost port in the header as the original client's source port.
 
-This option is typically used when EMQX is deployed behind a WebSocket proxy."""
+This option is typically used when EMQX is deployed behind a WebSocket proxy.
+
+Set it to an empty string (<code>""</code>) to disable the header lookup, in which case the source port of the TCP connection is always used."""
 
 fields_ws_opts_proxy_port_header.label:
 """Proxy port header"""
@@ -771,7 +773,9 @@ fields_mqtt_quic_listener_server_resumption_level.label:
 fields_ws_opts_proxy_address_header.desc:
 """The HTTP request header that carries the original client's IP address, EMQX will take the leftmost IP in the header as the original client's IP.
 
-This option is typically used when EMQX is deployed behind a WebSocket proxy."""
+This option is typically used when EMQX is deployed behind a WebSocket proxy.
+
+Set it to an empty string (<code>""</code>) to disable the header lookup, in which case the source IP address of the TCP connection is always used."""
 
 fields_ws_opts_proxy_address_header.label:
 """Proxy address header"""


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:

## Summary

Test-only plus a config-description update. Adds a WebSocket connection test case pinning down that setting `proxy_address_header` / `proxy_port_header` to the empty string disables the forwarded-address lookup: the connection's `peername` is always the real TCP peer address, even when the request carries `x-forwarded-for` / `x-forwarded-port` headers. This is documented operator guidance, so the behavior is now locked in by a test.

Also updates the i18n descriptions of both options to state that an empty string disables the header lookup.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)