### PR TITLE
test(ws): verify empty proxy_address_header disables forwarded-address lookup

### DIFF
--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -36,7 +36,8 @@ init_per_testcase(TestCase, Config) when
     TestCase =/= t_ws_check_origin,
     TestCase =/= t_ws_pingreq_before_connected,
     TestCase =/= t_ws_non_check_origin,
-    TestCase =/= t_header
+    TestCase =/= t_header,
+    TestCase =/= t_header_proxy_disabled_by_empty_name
 ->
     %% Mock cowboy_req
     ok = meck:new(cowboy_req, [passthrough, no_history, no_link]),
@@ -59,7 +60,8 @@ end_per_testcase(TestCase, _Config) when
     TestCase =/= t_ws_check_origin,
     TestCase =/= t_ws_non_check_origin,
     TestCase =/= t_ws_pingreq_before_connected,
-    TestCase =/= t_header
+    TestCase =/= t_header,
+    TestCase =/= t_header_proxy_disabled_by_empty_name
 ->
     meck:unload([cowboy_req]);
 end_per_testcase(_, Config) ->
@@ -110,6 +112,37 @@ t_header(_) ->
         #{
             socktype := ws,
             peername := {{100, 100, 100, 100}, 1000}
+        },
+        ConnInfo
+    ).
+
+-doc """
+Empty `proxy_address_header`/`proxy_port_header` means forwarded headers are
+never consulted; `peername` is the socket peer.
+""".
+t_header_proxy_disabled_by_empty_name(_) ->
+    set_ws_opts(fail_if_no_subprotocol, false),
+    set_ws_opts(proxy_address_header, <<"">>),
+    set_ws_opts(proxy_port_header, <<"">>),
+    {_Module, _Req, [ConnInfo, _], _ModOpts} = ?ws_conn:init(
+        #{
+            peer => {{127, 0, 0, 1}, 3456},
+            sock => {{127, 0, 0, 1}, 54321},
+            cert => undefined,
+            headers => #{
+                <<"x-forwarded-for">> => <<"100.100.100.100, 99.99.99.99">>,
+                <<"x-forwarded-port">> => <<"1000">>
+            }
+        },
+        #{
+            zone => default,
+            listener => {ws, default}
+        }
+    ),
+    ?assertMatch(
+        #{
+            socktype := ws,
+            peername := {{127, 0, 0, 1}, 3456}
         },
         ConnInfo
     ).

--- a/rel/i18n/emqx_gateway_schema.hocon
+++ b/rel/i18n/emqx_gateway_schema.hocon
@@ -192,14 +192,18 @@ fields_ws_opts_check_origins.desc:
 fields_ws_opts_check_origins.label:
 """Allowed origins"""
 fields_ws_opts_proxy_port_header.desc:
-"""HTTP header used to pass information about the client port. Relevant when the EMQX cluster is deployed behind a load-balancer."""
+"""HTTP header used to pass information about the client port. Relevant when the EMQX cluster is deployed behind a load-balancer.
+
+Set to an empty string (<code>""</code>) to disable it, so the source port of the WebSocket connection is always used."""
 
 fields_ws_opts_proxy_port_header.label:
 """Proxy port header"""
 
 fields_ws_opts_proxy_address_header.desc:
 """HTTP header used to pass information about the client IP address.
-Relevant when the EMQX cluster is deployed behind a load-balancer."""
+Relevant when the EMQX cluster is deployed behind a load-balancer.
+
+Set to an empty string (<code>""</code>) to disable it, so the source IP address of the WebSocket connection is always used."""
 
 fields_ws_opts_proxy_address_header.label:
 """Proxy address header"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -727,7 +727,9 @@ conn_congestion_enable_alarm.label:
 fields_ws_opts_proxy_port_header.desc:
 """The HTTP request header that carries the original client's source port, EMQX will take the leftmost port in the header as the original client's source port.
 
-This option is typically used when EMQX is deployed behind a WebSocket proxy."""
+This option is typically used when EMQX is deployed behind a WebSocket proxy.
+
+Set to an empty string (<code>""</code>) to disable it, so the source port of the WebSocket connection is always used."""
 
 fields_ws_opts_proxy_port_header.label:
 """Proxy port header"""
@@ -837,7 +839,9 @@ fields_mqtt_quic_listener_server_resumption_level.label:
 fields_ws_opts_proxy_address_header.desc:
 """The HTTP request header that carries the original client's IP address, EMQX will take the leftmost IP in the header as the original client's IP.
 
-This option is typically used when EMQX is deployed behind a WebSocket proxy."""
+This option is typically used when EMQX is deployed behind a WebSocket proxy.
+
+Set to an empty string (<code>""</code>) to disable it, so the source IP address of the WebSocket connection is always used."""
 
 fields_ws_opts_proxy_address_header.label:
 """Proxy address header"""


### PR DESCRIPTION
Release version:

6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:

N/A (test and docs only)

## Summary

Adds a test case to `emqx_ws_connection_SUITE` pinning down that setting `proxy_address_header` / `proxy_port_header` to the empty string disables the forwarded-client-address lookup on WebSocket listeners: even when the upgrade request carries `x-forwarded-for` / `x-forwarded-port` headers, `peername` remains the real TCP peer address. This is documented operator guidance, so the behavior is now locked in by a test.

Also updates the `proxy_address_header` / `proxy_port_header` config descriptions (`rel/i18n`, both MQTT WS listeners and gateway WS options) to state that an empty string (`""`) disables the option, so the source address/port of the WebSocket connection is always used.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

