### PR TITLE
test(kafka_consumer): retry health check to tolerate group rebalancing

### DIFF
--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
@@ -1444,7 +1444,9 @@ t_failed_creation_then_fixed(Config) ->
         )
     ),
     wait_until_subscribers_are_ready(NPartitions, 120_000),
-    ?assertEqual({ok, connected}, health_check(Config)),
+    %% subscribers being ready does not imply the health check already
+    %% reports `connected'; the consumer group may still be rebalancing.
+    ?retry(500, 20, ?assertEqual({ok, connected}, health_check(Config))),
     ping_until_healthy(Config, _Period = 1_500, _Timeout = 24_000),
 
     {ok, C} = emqtt:start_link(),
@@ -1510,7 +1512,7 @@ t_receive_after_recovery(Config) ->
                 #{<<"kafka">> => #{<<"offset_reset_policy">> => <<"earliest">>}}
             ),
             ping_until_healthy(Config, _Period = 1_500, _Timeout0 = 24_000),
-            {ok, connected} = health_check(Config),
+            ?retry(500, 20, ?assertEqual({ok, connected}, health_check(Config))),
             %% 0) ensure each partition commits its offset so it can
             %% recover later.
             Messages0 = [


### PR DESCRIPTION
Deflakes `emqx_bridge_kafka_impl_consumer_SUITE:t_failed_creation_then_fixed` (seen in CI on #18252: https://github.com/emqx/emqx/actions/runs/31024985506/job/92373679523).

The single-shot `?assertEqual({ok, connected}, health_check(Config))` raced against a transient consumer-group rebalancing window (~70 ms in the failing CI log): `wait_until_subscribers_are_ready/2` does not imply the resource health check already reports `connected`. Wrapped in the `?retry(...)` form already used elsewhere in the suite, and fixed the same latent single-shot pattern in `t_receive_after_recovery`.

Test-only change, no user impact.