### PR TITLE
perf(mgmt): direct lookup for exact client-id queries in /clients API

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -931,19 +931,11 @@ inflight_msgs(get, #{
 
 list_clients(QString) ->
     Result =
-        case maps:get(<<"node">>, QString, undefined) of
-            undefined ->
-                Options = #{fast_total_counting => true},
-                list_clients_cluster_query(QString, Options);
-            Node0 ->
-                case emqx_utils:safe_to_existing_atom(Node0) of
-                    {ok, Node1} ->
-                        QStringWithoutNode = maps:remove(<<"node">>, QString),
-                        Options = #{},
-                        list_clients_node_query(Node1, QStringWithoutNode, Options);
-                    {error, _} ->
-                        {error, Node0, {badrpc, <<"invalid node">>}}
-                end
+        case exact_clientid_filter(QString) of
+            {ok, ClientIds} ->
+                list_clients_by_id(ClientIds, QString);
+            false ->
+                list_clients_scan(QString)
         end,
     case Result of
         {error, page_limit_invalid} ->
@@ -961,6 +953,68 @@ list_clients(QString) ->
             {500, #{code => <<"NODE_DOWN">>, message => Message}};
         Response ->
             {200, Response}
+    end.
+
+list_clients_scan(QString) ->
+    case maps:get(<<"node">>, QString, undefined) of
+        undefined ->
+            Options = #{fast_total_counting => true},
+            list_clients_cluster_query(QString, Options);
+        Node0 ->
+            case emqx_utils:safe_to_existing_atom(Node0) of
+                {ok, Node1} ->
+                    QStringWithoutNode = maps:remove(<<"node">>, QString),
+                    Options = #{},
+                    list_clients_node_query(Node1, QStringWithoutNode, Options);
+                {error, _} ->
+                    {error, Node0, {badrpc, <<"invalid node">>}}
+            end
+    end.
+
+%% Returns `{ok, ClientIds}' when the only filter in the query is a list of exact
+%% client IDs (`node' counts as a filter; `page'/`limit'/`fields' do not).
+exact_clientid_filter(QString) ->
+    FilterKeys = [K || {K, _} <- ?CLIENT_QSCHEMA],
+    case maps:to_list(maps:with(FilterKeys, QString)) of
+        [{<<"clientid">>, ClientIds}] when is_list(ClientIds), ClientIds =/= [] ->
+            {ok, ClientIds};
+        _ ->
+            false
+    end.
+
+%% Fast path for exact-clientid-only queries: resolve each ID through the channel
+%% registry (with durable-session fallback) instead of scanning the whole channel
+%% table on every node. Results are in query-parameter order.
+list_clients_by_id(ClientIds, QString) ->
+    case emqx_mgmt_api:parse_pager_params(QString) of
+        false ->
+            {error, page_limit_invalid};
+        Meta = #{page := Page, limit := Limit} ->
+            try
+                Rows = lists:flatmap(fun lookup_client_rows/1, lists:uniq(ClientIds)),
+                Total = length(Rows),
+                PageRows = lists:sublist(Rows, (Page - 1) * Limit + 1, Limit),
+                ResultAcc = #{
+                    hasnext => Page * Limit < Total,
+                    rows => [{undefined, PageRows}],
+                    total => Total
+                },
+                Opts = #{fields => maps:get(<<"fields">>, QString, all)},
+                emqx_mgmt_api:format_query_result(
+                    fun ?MODULE:format_channel_info/3, Meta, ResultAcc, Opts
+                )
+            catch
+                throw:{lookup_client_error, Reason} ->
+                    {error, unknown, {badrpc, Reason}}
+            end
+    end.
+
+lookup_client_rows(ClientId) ->
+    case emqx_mgmt:lookup_client({clientid, ClientId}, undefined) of
+        {error, Reason} ->
+            throw({lookup_client_error, Reason});
+        Rows when is_list(Rows) ->
+            Rows
     end.
 
 list_clients_v2(get, #{query_string := QString}) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -68,6 +68,7 @@ persistent_session_testcases() ->
         t_persistent_sessions5,
         t_persistent_sessions6,
         t_persistent_sessions_subscriptions1,
+        t_persistent_sessions_exact_clientid,
         t_list_clients_v2,
         t_list_clients_v2_exact_filters,
         t_list_clients_v2_regular_filters,
@@ -630,6 +631,62 @@ t_persistent_sessions6(Config) ->
     ),
     ok.
 
+%% Verifies that an exact-clientid-only query (the direct-lookup fast path)
+%% finds durable sessions both while connected and after disconnection, and
+%% that the returned row matches the single-client lookup endpoint.
+t_persistent_sessions_exact_clientid(Config) ->
+    [N1, _N2] = ?config(nodes, Config),
+    Port1 = get_mqtt_port(N1, tcp),
+    ClientId = <<"exact_ps">>,
+    C1 = connect_client(#{port => Port1, clientid => ClientId}),
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            {ok,
+                {?HTTP200, _, #{
+                    <<"data">> := [#{<<"clientid">> := ClientId, <<"connected">> := true}],
+                    <<"meta">> := #{<<"count">> := 1, <<"hasnext">> := false}
+                }}},
+            list_request(#{clientid => ClientId}, Config)
+        )
+    ),
+    ok = emqtt:disconnect(C1),
+    %% The disconnected durable session is still resolved by exact-id query.
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            {ok,
+                {?HTTP200, _, #{
+                    <<"data">> := [
+                        #{
+                            <<"clientid">> := ClientId,
+                            <<"connected">> := false,
+                            <<"durable">> := true
+                        }
+                    ],
+                    <<"meta">> := #{<<"count">> := 1, <<"hasnext">> := false}
+                }}},
+            list_request(#{clientid => ClientId}, Config)
+        )
+    ),
+    %% Same row as the single-client lookup endpoint; unknown IDs are tolerated.
+    {ok, {?HTTP200, _, ClientInfo}} = get_client_request(ClientId, Config),
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [ClientInfo],
+                <<"meta">> := #{<<"count">> := 1, <<"hasnext">> := false}
+            }}},
+        list_request(
+            [{<<"clientid">>, <<"no-such-client">>}, {<<"clientid">>, ClientId}], Config
+        )
+    ),
+    C2 = connect_client(#{port => Port1, clientid => ClientId}),
+    disconnect_and_destroy_session(C2),
+    ok.
+
 %% Check that the output of `/clients/:clientid/subscriptions' has the expected keys.
 t_persistent_sessions_subscriptions1(Config) ->
     [N1, _N2] = ?config(nodes, Config),
@@ -1060,6 +1117,84 @@ t_query_clients_with_fields(Config) ->
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=bad_field_name")),
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=all,bad_field_name")),
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=all,username,clientid")).
+
+%% Exercises the direct-lookup fast path taken when exact client IDs are the
+%% only filter: rows identical to the single-client lookup endpoint, input-id
+%% ordering, deduplication, `fields' projection and pagination.
+t_query_exact_clientid(Config) ->
+    ClientId1 = <<"exact_clientid_1">>,
+    ClientId2 = <<"exact_clientid_2">>,
+    Clients = lists:map(
+        fun(ClientId) ->
+            {ok, C} = emqtt:start_link(#{clientid => ClientId}),
+            {ok, _} = emqtt:connect(C),
+            C
+        end,
+        [ClientId1, ClientId2]
+    ),
+    timer:sleep(100),
+
+    %% Exact-id query returns the same client object as GET /clients/:clientid.
+    {ok, {?HTTP200, _, Client1Info}} = get_client_request(ClientId1, Config),
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [Client1Info],
+                <<"meta">> := #{<<"count">> := 1, <<"hasnext">> := false}
+            }}},
+        list_request(#{clientid => ClientId1}, Config)
+    ),
+
+    %% Unknown and duplicate IDs are tolerated; results follow input-id order.
+    MixedQs = [
+        {<<"clientid">>, <<"no-such-client">>},
+        {<<"clientid">>, ClientId1},
+        {<<"clientid">>, ClientId2},
+        {<<"clientid">>, ClientId1}
+    ],
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [#{<<"clientid">> := ClientId1}, #{<<"clientid">> := ClientId2}],
+                <<"meta">> := #{<<"count">> := 2, <<"hasnext">> := false}
+            }}},
+        list_request(MixedQs, Config)
+    ),
+
+    %% Pagination slices the resolved rows.
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [#{<<"clientid">> := ClientId1}],
+                <<"meta">> := #{<<"count">> := 2, <<"hasnext">> := true}
+            }}},
+        list_request(MixedQs ++ [{<<"limit">>, <<"1">>}, {<<"page">>, <<"1">>}], Config)
+    ),
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [#{<<"clientid">> := ClientId2}],
+                <<"meta">> := #{<<"count">> := 2, <<"hasnext">> := false}
+            }}},
+        list_request(MixedQs ++ [{<<"limit">>, <<"1">>}, {<<"page">>, <<"2">>}], Config)
+    ),
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [],
+                <<"meta">> := #{<<"count">> := 2, <<"hasnext">> := false}
+            }}},
+        list_request(MixedQs ++ [{<<"limit">>, <<"1">>}, {<<"page">>, <<"3">>}], Config)
+    ),
+
+    %% `fields' projection applies on the fast path.
+    ?assertMatch(
+        {ok, {?HTTP200, _, #{<<"data">> := [#{<<"clientid">> := ClientId1} = Row]}}} when
+            map_size(Row) =:= 1,
+        list_request([{<<"clientid">>, ClientId1}, {<<"fields">>, <<"clientid">>}], Config)
+    ),
+
+    lists:foreach(fun emqtt:stop/1, Clients).
 
 get_clients_all_fields(Auth, Qs) ->
     get_clients(Auth, Qs, false, false).

--- a/changes/ee/perf-18267.en.md
+++ b/changes/ee/perf-18267.en.md
@@ -1,0 +1,3 @@
+Improved the performance of `GET /clients` when querying by exact client IDs (issue #4502).
+
+Such queries now look up each requested client ID directly instead of scanning the clients table on every node in the cluster. Results are returned in the order the client IDs appear in the query string.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

`GET /clients?clientid=a&clientid=b` (one or more exact client IDs and no other filter) used to run the generic paginated match-spec scan: the client IDs end up in match-spec guards, so ETS walks the whole `emqx_channel_info` table on every node (measured: ~224 ms per node for a 1M-row table vs ~4 µs for a direct lookup).

Such queries are now short-circuited to direct per-ID lookups via the channel registry, with the durable-session fallback so disconnected persistent sessions still resolve. Any other filter (`username`, `conn_state`, `like_*`, `gte_*`/`lte_*`, `node`, ...) keeps the existing scan path unchanged; `page`/`limit`/`fields` work the same on both paths. The response shape (`data` + `meta`) is unchanged.

Behavior notes:
- Results are returned in query-parameter order (previously: table traversal order). Duplicate IDs are deduplicated as before.
- `meta.count` for such queries now equals the number of matched clients; previously, with durable sessions enabled, it could overshoot by including the total disconnected-session count.

Follow-up to #4502 (EMQX-11120): the planned `/clients_bulk` endpoint was dropped in favor of optimizing this existing path. A sibling PR applies the same optimization on `dev-60`. `/clients_v2` is out of scope here.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
