### PR TITLE
perf(mgmt): direct lookup for exact client-id queries in /clients API

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -864,19 +864,11 @@ inflight_msgs(get, #{
 
 list_clients(QString) ->
     Result =
-        case maps:get(<<"node">>, QString, undefined) of
-            undefined ->
-                Options = #{fast_total_counting => true},
-                list_clients_cluster_query(QString, Options);
-            Node0 ->
-                case emqx_utils:safe_to_existing_atom(Node0) of
-                    {ok, Node1} ->
-                        QStringWithoutNode = maps:remove(<<"node">>, QString),
-                        Options = #{},
-                        list_clients_node_query(Node1, QStringWithoutNode, Options);
-                    {error, _} ->
-                        {error, Node0, {badrpc, <<"invalid node">>}}
-                end
+        case exact_clientid_only(QString) of
+            {ok, ClientIds} ->
+                list_clients_by_clientid(ClientIds, QString);
+            false ->
+                list_clients_scan(QString)
         end,
     case Result of
         {error, page_limit_invalid} ->
@@ -894,6 +886,64 @@ list_clients(QString) ->
             {500, #{code => <<"NODE_DOWN">>, message => Message}};
         Response ->
             {200, Response}
+    end.
+
+list_clients_scan(QString) ->
+    case maps:get(<<"node">>, QString, undefined) of
+        undefined ->
+            Options = #{fast_total_counting => true},
+            list_clients_cluster_query(QString, Options);
+        Node0 ->
+            case emqx_utils:safe_to_existing_atom(Node0) of
+                {ok, Node1} ->
+                    QStringWithoutNode = maps:remove(<<"node">>, QString),
+                    Options = #{},
+                    list_clients_node_query(Node1, QStringWithoutNode, Options);
+                {error, _} ->
+                    {error, Node0, {badrpc, <<"invalid node">>}}
+            end
+    end.
+
+%% Exact client IDs are the only filter present: such queries are served by direct
+%% per-ID registry lookups instead of a channel-table scan on every node.
+exact_clientid_only(QString) ->
+    FilterKeys = [K || {K, _} <- ?CLIENT_QSCHEMA],
+    case maps:to_list(maps:with(FilterKeys, QString)) of
+        [{<<"clientid">>, [_ | _] = ClientIds}] ->
+            {ok, ClientIds};
+        _ ->
+            false
+    end.
+
+%% Row order is deterministic for a fixed query string (so pagination is consistent),
+%% but no particular order is guaranteed.
+list_clients_by_clientid(ClientIds0, QString) ->
+    case emqx_mgmt_api:parse_pager_params(QString) of
+        false ->
+            {error, page_limit_invalid};
+        #{page := Page, limit := Limit} = Meta ->
+            ClientIds = lists:uniq(ClientIds0),
+            try lists:flatmap(fun lookup_clientid_rows/1, ClientIds) of
+                Rows ->
+                    Count = length(Rows),
+                    PageRows = lists:sublist(Rows, (Page - 1) * Limit + 1, Limit),
+                    Opts = #{fields => maps:get(<<"fields">>, QString, all)},
+                    #{
+                        meta => Meta#{count => Count, hasnext => Page * Limit < Count},
+                        data => [format_channel_info(undefined, Row, Opts) || Row <- PageRows]
+                    }
+            catch
+                throw:{lookup_failed, Reason} ->
+                    {error, unknown, {badrpc, Reason}}
+            end
+    end.
+
+lookup_clientid_rows(ClientId) ->
+    case emqx_mgmt:lookup_client({clientid, ClientId}, undefined) of
+        {error, Reason} ->
+            throw({lookup_failed, Reason});
+        Rows when is_list(Rows) ->
+            Rows
     end.
 
 list_clients_v2(get, #{query_string := QString}) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -57,6 +57,7 @@ persistent_session_testcases() ->
         t_persistent_sessions4,
         t_persistent_sessions5,
         t_persistent_sessions_subscriptions1,
+        t_persistent_session_exact_clientid,
         t_list_clients_v2,
         t_list_clients_v2_limit,
         t_list_clients_v2_exact_filters,
@@ -611,6 +612,44 @@ t_persistent_sessions_subscriptions1(Config) ->
     ),
     ok.
 
+-doc """
+A disconnected durable session is found by an exact client ID query (direct
+lookup path), also when queried together with unknown IDs.
+""".
+t_persistent_session_exact_clientid(Config) ->
+    [N1, _N2] = ?config(cluster_nodes, Config),
+    Port1 = get_mqtt_port(N1, tcp),
+    ClientId = ?CLIENTID(<<"1">>),
+    Qs = binary_to_list(uri_string:compose_query([{<<"clientid">>, ClientId}])),
+    C1 = connect_client(#{port => Port1, clientid => ClientId}),
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            {ok,
+                {?HTTP200, _, #{
+                    <<"data">> := [#{<<"clientid">> := ClientId, <<"connected">> := true}],
+                    <<"meta">> := #{<<"count">> := 1, <<"hasnext">> := false}
+                }}},
+            list_request(Qs, Config)
+        )
+    ),
+    ok = emqtt:disconnect(C1),
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            {ok,
+                {?HTTP200, _, #{
+                    <<"data">> := [#{<<"clientid">> := ClientId, <<"connected">> := false}],
+                    <<"meta">> := #{<<"count">> := 1, <<"hasnext">> := false}
+                }}},
+            list_request(Qs ++ "&clientid=no-such-client", Config)
+        )
+    ),
+    C2 = connect_client(#{port => Port1, clientid => ClientId}),
+    disconnect_and_destroy_session(C2).
+
 t_clients_bad_value_type(Config) ->
     %% get /clients
     ClientsPath = emqx_mgmt_api_test_util:api_path(["clients"]),
@@ -1002,6 +1041,133 @@ t_query_clients_with_fields(Config) ->
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=bad_field_name")),
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=all,bad_field_name")),
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=all,username,clientid")).
+
+-doc """
+Exact client ID query (direct lookup path) returns the same client object as
+`GET /clients/:clientid`.
+""".
+t_query_exact_clientid_same_as_lookup(Config) ->
+    ClientId = ?CLIENTID(<<"1">>),
+    {ok, C} = emqtt:start_link(#{clientid => ClientId, username => <<"exact_lookup_user">>}),
+    {ok, _} = emqtt:connect(C),
+    timer:sleep(100),
+    {ok, {?HTTP200, _, #{<<"data">> := [Listed], <<"meta">> := Meta}}} =
+        list_request(#{clientid => ClientId}, Config),
+    {ok, {?HTTP200, _, Looked}} = get_client_request(ClientId, Config),
+    ?assertMatch(#{<<"count">> := 1, <<"hasnext">> := false}, Meta),
+    ?assertEqual(lists:sort(maps:keys(Looked)), lists:sort(maps:keys(Listed))),
+    %% compare fields that do not change between two consecutive reads
+    StableKeys = [
+        <<"clientid">>,
+        <<"username">>,
+        <<"node">>,
+        <<"connected">>,
+        <<"clean_start">>,
+        <<"proto_name">>,
+        <<"proto_ver">>,
+        <<"ip_address">>,
+        <<"port">>,
+        <<"keepalive">>,
+        <<"is_bridge">>,
+        <<"is_persistent">>,
+        <<"is_expired">>,
+        <<"listener">>,
+        <<"expiry_interval">>,
+        <<"created_at">>,
+        <<"connected_at">>
+    ],
+    ?assertEqual(maps:with(StableKeys, Looked), maps:with(StableKeys, Listed)),
+    ok = emqtt:stop(C).
+
+-doc """
+Pagination on the exact client ID query path: `count`, `hasnext` and page slicing
+are consistent across pages; unknown and duplicate IDs do not affect the count.
+""".
+t_query_exact_clientid_pagination(Config) ->
+    ClientIds = lists:map(
+        fun(N) ->
+            Suffix = integer_to_binary(N),
+            ?CLIENTID(Suffix)
+        end,
+        lists:seq(1, 5)
+    ),
+    Clients = lists:map(
+        fun(ClientId) ->
+            {ok, C} = emqtt:start_link(#{clientid => ClientId}),
+            {ok, _} = emqtt:connect(C),
+            C
+        end,
+        ClientIds
+    ),
+    timer:sleep(100),
+    IdsQs = binary_to_list(
+        uri_string:compose_query(
+            [{<<"clientid">>, Id} || Id <- ClientIds] ++
+                [{<<"clientid">>, <<"no-such-client">>}, {<<"clientid">>, hd(ClientIds)}]
+        )
+    ),
+    Page1 = list_request(IdsQs ++ "&limit=2&page=1", Config),
+    Page2 = list_request(IdsQs ++ "&limit=2&page=2", Config),
+    Page3 = list_request(IdsQs ++ "&limit=2&page=3", Config),
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [_, _],
+                <<"meta">> := #{<<"count">> := 5, <<"hasnext">> := true}
+            }}},
+        Page1
+    ),
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [_, _],
+                <<"meta">> := #{<<"count">> := 5, <<"hasnext">> := true}
+            }}},
+        Page2
+    ),
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [_],
+                <<"meta">> := #{<<"count">> := 5, <<"hasnext">> := false}
+            }}},
+        Page3
+    ),
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [],
+                <<"meta">> := #{<<"count">> := 5, <<"hasnext">> := false}
+            }}},
+        list_request(IdsQs ++ "&limit=2&page=4", Config)
+    ),
+    %% pages are disjoint and together cover exactly the connected clients
+    PagedIds = [
+        Id
+     || {ok, {_, _, #{<<"data">> := Rows}}} <- [Page1, Page2, Page3],
+        #{<<"clientid">> := Id} <- Rows
+    ],
+    ?assertEqual(lists:sort(ClientIds), lists:sort(PagedIds)),
+    lists:foreach(fun emqtt:stop/1, Clients).
+
+-doc "The `fields` projection applies on the exact client ID query path.".
+t_query_exact_clientid_with_fields(Config) ->
+    Auth = ?config(api_auth_header, Config),
+    ClientId = ?CLIENTID(<<"1">>),
+    Username = <<"exact_fields_user">>,
+    {ok, C} = emqtt:start_link(#{clientid => ClientId, username => Username}),
+    {ok, _} = emqtt:connect(C),
+    timer:sleep(100),
+    Qs = binary_to_list(uri_string:compose_query([{<<"clientid">>, ClientId}])),
+    ?assertEqual(
+        [#{<<"clientid">> => ClientId}],
+        get_clients_all_fields(Auth, Qs ++ "&fields=clientid")
+    ),
+    ?assertEqual(
+        [#{<<"clientid">> => ClientId, <<"username">> => Username}],
+        get_clients_all_fields(Auth, Qs ++ "&fields=clientid,username")
+    ),
+    ok = emqtt:stop(C).
 
 get_clients_all_fields(Auth, Qs) ->
     get_clients(Auth, Qs, false, false).

--- a/changes/ee/perf-18268.en.md
+++ b/changes/ee/perf-18268.en.md
@@ -1,0 +1,3 @@
+Improved the performance of `GET /clients` queries that filter by exact client IDs (one or more `clientid` query string parameters and no other filters).
+
+Such queries now look up each requested client ID directly instead of scanning the full client table on every node in the cluster, making them fast even with millions of connected clients. See issue #4502.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:
pre-5.8

## Summary

`GET /clients?clientid=a&clientid=b` (one or more exact client IDs and no other filter) used to run the generic paginated match-spec scan: the client IDs end up in match-spec guards, so ETS walks the whole `emqx_channel_info` table on every node (measured: ~224 ms per node for a 1M-row table vs ~4 µs for a direct lookup).

Such queries are now short-circuited to direct per-ID lookups via the channel registry, with the durable-session fallback so disconnected persistent sessions still resolve. Any other filter (`username`, `conn_state`, `like_*`, `gte_*`/`lte_*`, `node`, ...) keeps the existing scan path unchanged; `page`/`limit`/`fields` work the same on both paths. The response shape (`data` + `meta`) is unchanged.

Behavior notes:
- Result order for such queries may differ from before (previously: table traversal order; now: derived from the query parameters — deterministic for a fixed query string, so pagination stays consistent). Duplicate IDs are deduplicated as before.
- `meta.count` for such queries now equals the number of matched clients; previously, with durable sessions enabled, it could overshoot by including the total disconnected-session count.

Follow-up to #4502 (EMQX-11120): the planned `/clients_bulk` endpoint was dropped in favor of optimizing this existing path. Sibling PR on dev-58: #18267. `/clients_v2` is out of scope here.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)