### PR TITLE
perf(mgmt): direct lookup for exact client-id queries in /clients API

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -872,19 +872,11 @@ inflight_msgs(get, #{
 
 list_clients(QString) ->
     Result =
-        case maps:get(<<"node">>, QString, undefined) of
-            undefined ->
-                Options = #{fast_total_counting => true},
-                list_clients_cluster_query(QString, Options);
-            Node0 ->
-                case emqx_utils:safe_to_existing_atom(Node0) of
-                    {ok, Node1} ->
-                        QStringWithoutNode = maps:remove(<<"node">>, QString),
-                        Options = #{},
-                        list_clients_node_query(Node1, QStringWithoutNode, Options);
-                    {error, _} ->
-                        {error, Node0, {badrpc, <<"invalid node">>}}
-                end
+        case exact_clientid_query(QString) of
+            {ok, ClientIds} ->
+                list_clients_by_id(ClientIds, QString);
+            false ->
+                list_clients_query(QString)
         end,
     case Result of
         {error, page_limit_invalid} ->
@@ -902,6 +894,92 @@ list_clients(QString) ->
             {500, #{code => <<"NODE_DOWN">>, message => Message}};
         Response ->
             {200, Response}
+    end.
+
+-doc """
+Returns `{ok, ClientIds}` when the query filters on exact client IDs only
+(`node` is allowed), i.e. when it can be served by direct per-ID lookups
+instead of the generic table scan.
+""".
+exact_clientid_query(#{<<"clientid">> := ClientIds = [_ | _]} = QString) ->
+    HasOtherFilters = lists:any(
+        fun({Key, _Type}) ->
+            Key =/= <<"clientid">> andalso Key =/= <<"node">> andalso maps:is_key(Key, QString)
+        end,
+        ?CLIENT_QSCHEMA
+    ),
+    case HasOtherFilters of
+        true -> false;
+        false -> {ok, ClientIds}
+    end;
+exact_clientid_query(_QString) ->
+    false.
+
+list_clients_query(QString) ->
+    case maps:get(<<"node">>, QString, undefined) of
+        undefined ->
+            Options = #{fast_total_counting => true},
+            list_clients_cluster_query(QString, Options);
+        Node0 ->
+            case emqx_utils:safe_to_existing_atom(Node0) of
+                {ok, Node1} ->
+                    QStringWithoutNode = maps:remove(<<"node">>, QString),
+                    Options = #{},
+                    list_clients_node_query(Node1, QStringWithoutNode, Options);
+                {error, _} ->
+                    {error, Node0, {badrpc, <<"invalid node">>}}
+            end
+    end.
+
+-doc """
+Fast path for exact-client-ID queries: resolves each ID via the channel
+registry (falling back to durable session storage for disconnected
+persistent sessions) and returns a single directly-computed page.
+""".
+list_clients_by_id(ClientIds, QString) ->
+    case maps:get(<<"node">>, QString, undefined) of
+        undefined ->
+            do_list_clients_by_id(undefined, ClientIds, QString);
+        Node0 ->
+            case emqx_utils:safe_to_existing_atom(Node0) of
+                {ok, Node} ->
+                    do_list_clients_by_id(Node, ClientIds, QString);
+                {error, _} ->
+                    {error, Node0, {badrpc, <<"invalid node">>}}
+            end
+    end.
+
+do_list_clients_by_id(Node, ClientIds, QString) ->
+    case emqx_mgmt_api:parse_pager_params(QString) of
+        false ->
+            {error, page_limit_invalid};
+        Meta = #{page := Page, limit := Limit} ->
+            try
+                Rows = lists:append([
+                    lookup_clientid_rows(Node, ClientId)
+                 || ClientId <- lists:uniq(ClientIds)
+                ]),
+                Count = length(Rows),
+                PageRows = lists:sublist(Rows, (Page - 1) * Limit + 1, Limit),
+                Opts = #{fields => maps:get(<<"fields">>, QString, all)},
+                #{
+                    meta => Meta#{count => Count, hasnext => Count > Page * Limit},
+                    data => [format_channel_info(undefined, Row, Opts) || Row <- PageRows]
+                }
+            catch
+                throw:{badrpc, Reason} ->
+                    {error, Node, {badrpc, Reason}}
+            end
+    end.
+
+lookup_clientid_rows(undefined, ClientId) ->
+    emqx_mgmt:lookup_client({clientid, ClientId}, undefined);
+lookup_clientid_rows(Node, ClientId) ->
+    case emqx_mgmt:lookup_client(Node, {clientid, ClientId}, undefined) of
+        {error, Reason} ->
+            throw({badrpc, Reason});
+        Rows ->
+            Rows
     end.
 
 list_clients_v2(get, #{query_string := QString}) ->

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -75,12 +75,17 @@
 
 -define(TAGS, [<<"Clients">>]).
 
--define(CLIENT_QSCHEMA, [
+%% Query-string keys servable by direct per-client-ID lookups (fast path).
+-define(CLIENT_QSCHEMA_DIRECT_LOOKUP, [
     {<<"node">>, atom},
     %% list
-    {<<"username">>, binary},
+    {<<"clientid">>, binary}
+]).
+
+%% Query-string filter keys that require the generic table scan.
+-define(CLIENT_QSCHEMA_NEED_SCAN, [
     %% list
-    {<<"clientid">>, binary},
+    {<<"username">>, binary},
     {<<"ip_address">>, ip},
     {<<"conn_state">>, atom},
     {<<"clean_start">>, atom},
@@ -92,6 +97,8 @@
     {<<"gte_connected_at">>, timestamp},
     {<<"lte_connected_at">>, timestamp}
 ]).
+
+-define(CLIENT_QSCHEMA, ?CLIENT_QSCHEMA_DIRECT_LOOKUP ++ ?CLIENT_QSCHEMA_NEED_SCAN).
 
 -define(FORMAT_FUN, {?MODULE, format_channel_info}).
 
@@ -902,13 +909,11 @@ Returns `{ok, ClientIds}` when the query filters on exact client IDs only
 instead of the generic table scan.
 """.
 exact_clientid_query(#{<<"clientid">> := ClientIds = [_ | _]} = QString) ->
-    HasOtherFilters = lists:any(
-        fun({Key, _Type}) ->
-            Key =/= <<"clientid">> andalso Key =/= <<"node">> andalso maps:is_key(Key, QString)
-        end,
-        ?CLIENT_QSCHEMA
+    NeedScan = lists:any(
+        fun({Key, _Type}) -> maps:is_key(Key, QString) end,
+        ?CLIENT_QSCHEMA_NEED_SCAN
     ),
-    case HasOtherFilters of
+    case NeedScan of
         true -> false;
         false -> {ok, ClientIds}
     end;

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -439,7 +439,7 @@ fields(list_clients_v1_inputs) ->
             hoconsc:mk(binary(), #{
                 in => query,
                 required => false,
-                desc => ?DESC("node_name"),
+                desc => ?DESC("node_filter"),
                 example => <<"emqx@127.0.0.1">>
             })}
         | fields(common_list_clients_input)
@@ -938,8 +938,10 @@ list_clients_query(QString) ->
 
 -doc """
 Fast path for exact-client-ID queries: resolves each ID via the channel
-registry (falling back to durable session storage for disconnected
-persistent sessions) and returns a single directly-computed page.
+registry and returns a single directly-computed page. Cluster-wide lookups
+fall back to durable session storage, so disconnected persistent sessions
+are found too; node-scoped lookups (`node` parameter) only inspect live
+connections on the given node.
 """.
 list_clients_by_id(ClientIds, QString) ->
     case maps:get(<<"node">>, QString, undefined) of

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -566,7 +566,8 @@ t_persistent_sessions5(Config) ->
 -doc """
 Tests that a disconnected durable session is found by an exact-clientid
 query, which resolves it through the direct-lookup fast path's fallback to
-durable session storage.
+durable session storage — and that the node-scoped variant does not return
+it, since a disconnected durable session is not attached to any node.
 """.
 t_persistent_sessions_exact_clientid_query(Config) ->
     [N1, _N2] = ?config(cluster_nodes, Config),
@@ -589,6 +590,13 @@ t_persistent_sessions_exact_clientid_query(Config) ->
                 }}},
             list_request(#{clientid => ClientId}, Config)
         )
+    ),
+    %% Node-scoped exact-ID queries only inspect live connections on the given
+    %% node: the disconnected durable session is not attached to any node and
+    %% is not returned.
+    ?assertMatch(
+        {ok, {?HTTP200, _, #{<<"data">> := [], <<"meta">> := #{<<"count">> := 0}}}},
+        list_request(#{clientid => ClientId, node => N1}, Config)
     ),
     %% Cleanup: reconnect and destroy the session.
     C2 = connect_client(#{port => Port1, clientid => ClientId}),

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -56,6 +56,7 @@ persistent_session_testcases() ->
         t_persistent_sessions3,
         t_persistent_sessions4,
         t_persistent_sessions5,
+        t_persistent_sessions_exact_clientid_query,
         t_persistent_sessions_subscriptions1,
         t_list_clients_v2,
         t_list_clients_v2_limit,
@@ -65,6 +66,7 @@ persistent_session_testcases() ->
     ].
 persistence_disabled_cluster_testcases() ->
     [
+        t_list_clients_exact_lookup_node,
         t_bulk_subscribe
     ].
 client_msgs_testcases() ->
@@ -561,6 +563,37 @@ t_persistent_sessions5(Config) ->
     ),
     ok.
 
+-doc """
+Tests that a disconnected durable session is found by an exact-clientid
+query, which resolves it through the direct-lookup fast path's fallback to
+durable session storage.
+""".
+t_persistent_sessions_exact_clientid_query(Config) ->
+    [N1, _N2] = ?config(cluster_nodes, Config),
+    Port1 = get_mqtt_port(N1, tcp),
+    ClientId = ?CLIENTID(<<"1">>),
+    C1 = connect_client(#{port => Port1, clientid => ClientId}),
+    ?assertMatch(
+        {ok, {?HTTP200, _, #{<<"data">> := [#{<<"connected">> := true}]}}},
+        list_request(#{clientid => ClientId}, Config)
+    ),
+    ok = emqtt:disconnect(C1),
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            {ok,
+                {?HTTP200, _, #{
+                    <<"data">> := [#{<<"clientid">> := ClientId, <<"connected">> := false}],
+                    <<"meta">> := #{<<"count">> := 1, <<"hasnext">> := false}
+                }}},
+            list_request(#{clientid => ClientId}, Config)
+        )
+    ),
+    %% Cleanup: reconnect and destroy the session.
+    C2 = connect_client(#{port => Port1, clientid => ClientId}),
+    disconnect_and_destroy_session(C2).
+
 %% Check that the output of `/clients/:clientid/subscriptions' has the expected keys.
 t_persistent_sessions_subscriptions1(Config) ->
     [N1, _N2] = ?config(cluster_nodes, Config),
@@ -1022,6 +1055,131 @@ t_query_clients_with_fields(Config) ->
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=bad_field_name")),
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=all,bad_field_name")),
     ?assertMatch({error, _}, get_clients_expect_error(Auth, "fields=all,username,clientid")).
+
+-doc """
+Tests that an exact-clientid query (the direct-lookup fast path) renders
+clients identically to `GET /clients/:clientid`, dedupes repeated IDs,
+skips unknown IDs, computes the single-page meta, applies the `fields`
+projection, and that combining exact IDs with another filter still narrows
+the result (generic path).
+""".
+t_list_clients_exact_lookup(Config) ->
+    ClientId1 = ?CLIENTID(<<"1">>),
+    ClientId2 = ?CLIENTID(<<"2">>),
+    Username1 = <<(atom_to_binary(?FUNCTION_NAME))/binary, "_user1">>,
+    {ok, C1} = emqtt:start_link(#{clientid => ClientId1, username => Username1}),
+    {ok, _} = emqtt:connect(C1),
+    {ok, C2} = emqtt:start_link(#{clientid => ClientId2}),
+    {ok, _} = emqtt:connect(C2),
+    timer:sleep(100),
+
+    %% Same rendering as the single-client endpoint (modulo runtime counters).
+    {ok, {?HTTP200, _, SingleBody}} = get_client_request(ClientId1, Config),
+    {ok, {?HTTP200, _, #{<<"data">> := [ListedBody], <<"meta">> := Meta1}}} =
+        list_request(#{clientid => ClientId1}, Config),
+    Volatile = [
+        <<"heap_size">>,
+        <<"mailbox_len">>,
+        <<"recv_cnt">>,
+        <<"recv_oct">>,
+        <<"recv_pkt">>,
+        <<"send_cnt">>,
+        <<"send_oct">>,
+        <<"send_pkt">>
+    ],
+    ?assertEqual(lists:sort(maps:keys(SingleBody)), lists:sort(maps:keys(ListedBody))),
+    ?assertEqual(maps:without(Volatile, SingleBody), maps:without(Volatile, ListedBody)),
+    ?assertMatch(#{<<"count">> := 1, <<"hasnext">> := false}, Meta1),
+
+    %% Duplicate and unknown IDs: deduped, unknowns skipped.
+    Qs = [
+        {<<"clientid">>, ClientId1},
+        {<<"clientid">>, ClientId1},
+        {<<"clientid">>, ClientId2},
+        {<<"clientid">>, <<"no_such_client">>}
+    ],
+    {ok, {?HTTP200, _, #{<<"data">> := Rows, <<"meta">> := Meta2}}} = list_request(Qs, Config),
+    ?assertEqual(
+        lists:sort([ClientId1, ClientId2]),
+        lists:sort([Id || #{<<"clientid">> := Id} <- Rows])
+    ),
+    ?assertMatch(#{<<"count">> := 2, <<"hasnext">> := false}, Meta2),
+
+    %% Only unknown IDs: empty page.
+    ?assertMatch(
+        {ok, {?HTTP200, _, #{<<"data">> := [], <<"meta">> := #{<<"count">> := 0}}}},
+        list_request(#{clientid => <<"no_such_client">>}, Config)
+    ),
+
+    %% Exact IDs combined with another filter must keep narrowing (generic path).
+    QsWithUsername = [
+        {<<"clientid">>, ClientId1},
+        {<<"clientid">>, ClientId2},
+        {<<"username">>, Username1}
+    ],
+    {ok, {?HTTP200, _, #{<<"data">> := NarrowedRows}}} = list_request(QsWithUsername, Config),
+    ?assertEqual([ClientId1], [Id || #{<<"clientid">> := Id} <- NarrowedRows]),
+
+    %% `fields` projection applies on the fast path.
+    QsWithFields = [
+        {<<"clientid">>, ClientId1},
+        {<<"fields">>, <<"clientid,username">>}
+    ],
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [#{<<"clientid">> := ClientId1, <<"username">> := Username1}]
+            }}},
+        list_request(QsWithFields, Config)
+    ),
+    {ok, {?HTTP200, _, #{<<"data">> := [ProjectedRow]}}} = list_request(QsWithFields, Config),
+    ?assertEqual(2, map_size(ProjectedRow)),
+
+    ok = emqtt:disconnect(C1),
+    ok = emqtt:disconnect(C2).
+
+-doc """
+Tests page/limit slicing on the exact-clientid direct-lookup fast path:
+more IDs than `limit` produce correct `count`, `hasnext` and disjoint pages
+covering all clients.
+""".
+t_list_clients_exact_lookup_pagination(Config) ->
+    ClientIds = [?CLIENTID(<<"1">>), ?CLIENTID(<<"2">>), ?CLIENTID(<<"3">>)],
+    Clients = lists:map(
+        fun(ClientId) ->
+            {ok, C} = emqtt:start_link(#{clientid => ClientId}),
+            {ok, _} = emqtt:connect(C),
+            C
+        end,
+        ClientIds
+    ),
+    timer:sleep(100),
+    IdParams = [{<<"clientid">>, Id} || Id <- ClientIds],
+    Page1Qs = IdParams ++ [{<<"page">>, <<"1">>}, {<<"limit">>, <<"2">>}],
+    {ok, {?HTTP200, _, #{<<"data">> := Page1, <<"meta">> := Meta1}}} = list_request(
+        Page1Qs, Config
+    ),
+    ?assertMatch(
+        #{<<"count">> := 3, <<"hasnext">> := true, <<"page">> := 1, <<"limit">> := 2}, Meta1
+    ),
+    ?assertEqual(2, length(Page1)),
+    Page2Qs = IdParams ++ [{<<"page">>, <<"2">>}, {<<"limit">>, <<"2">>}],
+    {ok, {?HTTP200, _, #{<<"data">> := Page2, <<"meta">> := Meta2}}} = list_request(
+        Page2Qs, Config
+    ),
+    ?assertMatch(#{<<"count">> := 3, <<"hasnext">> := false}, Meta2),
+    ?assertEqual(1, length(Page2)),
+    ?assertEqual(
+        lists:sort(ClientIds),
+        lists:sort([Id || #{<<"clientid">> := Id} <- Page1 ++ Page2])
+    ),
+    %% Page past the end: empty.
+    Page3Qs = IdParams ++ [{<<"page">>, <<"3">>}, {<<"limit">>, <<"2">>}],
+    ?assertMatch(
+        {ok, {?HTTP200, _, #{<<"data">> := [], <<"meta">> := #{<<"hasnext">> := false}}}},
+        list_request(Page3Qs, Config)
+    ),
+    lists:foreach(fun emqtt:disconnect/1, Clients).
 
 t_format_old_style_client_stats_defaults_total_payload_bytes(_) ->
     ClientId = <<"old-style-client-stats">>,
@@ -1595,6 +1753,41 @@ t_subscribe_shared_topic_nl(Config) ->
             }}},
         request(post, Path, #{topic => Topic, qos => 1, nl => 1, rh => 1}, Config)
     ).
+
+-doc """
+Tests the node-scoped exact-clientid fast path: `clientid` + `node` finds a
+client connected to that node, misses on another node, and unknown or down
+nodes produce the node-down error.
+""".
+t_list_clients_exact_lookup_node(Config) ->
+    [N1, N2] = ?config(nodes, Config),
+    Port1 = get_mqtt_port(N1, tcp),
+    ClientId = ?CLIENTID(<<"1">>),
+    C = connect_client(#{port => Port1, clientid => ClientId, expiry => 0}),
+    N1Bin = atom_to_binary(N1),
+    ?assertMatch(
+        {ok,
+            {?HTTP200, _, #{
+                <<"data">> := [#{<<"clientid">> := ClientId, <<"node">> := N1Bin}],
+                <<"meta">> := #{<<"count">> := 1, <<"hasnext">> := false}
+            }}},
+        list_request(#{clientid => ClientId, node => N1}, Config)
+    ),
+    ?assertMatch(
+        {ok, {?HTTP200, _, #{<<"data">> := [], <<"meta">> := #{<<"count">> := 0}}}},
+        list_request(#{clientid => ClientId, node => N2}, Config)
+    ),
+    %% Down node (existing atom).
+    ?assertMatch(
+        {error, {{_, 500, _}, _, #{<<"code">> := <<"NODE_DOWN">>}}},
+        list_request(#{clientid => ClientId, node => <<"nonode@nohost">>}, Config)
+    ),
+    %% Unknown node name (atom does not exist).
+    ?assertMatch(
+        {error, {{_, 500, _}, _, #{<<"code">> := <<"NODE_DOWN">>}}},
+        list_request(#{clientid => ClientId, node => <<"no_such_node@no.such.host">>}, Config)
+    ),
+    ok = emqtt:disconnect(C).
 
 %% Checks that we can use the bulk subscribe API on a different node than the one a client
 %% is connected to.

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1059,9 +1059,9 @@ t_query_clients_with_fields(Config) ->
 -doc """
 Tests that an exact-clientid query (the direct-lookup fast path) renders
 clients identically to `GET /clients/:clientid`, dedupes repeated IDs,
-skips unknown IDs, computes the single-page meta, applies the `fields`
-projection, and that combining exact IDs with another filter still narrows
-the result (generic path).
+skips unknown IDs, returns rows in requested-ID order, computes the
+single-page meta, applies the `fields` projection, and that combining
+exact IDs with another filter still narrows the result (generic path).
 """.
 t_list_clients_exact_lookup(Config) ->
     ClientId1 = ?CLIENTID(<<"1">>),
@@ -1104,6 +1104,11 @@ t_list_clients_exact_lookup(Config) ->
         lists:sort([Id || #{<<"clientid">> := Id} <- Rows])
     ),
     ?assertMatch(#{<<"count">> := 2, <<"hasnext">> := false}, Meta2),
+
+    %% Rows are returned in requested-ID order (first occurrence wins).
+    {ok, {?HTTP200, _, #{<<"data">> := OrderedRows}}} =
+        list_request([{<<"clientid">>, ClientId2}, {<<"clientid">>, ClientId1}], Config),
+    ?assertEqual([ClientId2, ClientId1], [Id || #{<<"clientid">> := Id} <- OrderedRows]),
 
     %% Only unknown IDs: empty page.
     ?assertMatch(

--- a/changes/ee/perf-18269.en.md
+++ b/changes/ee/perf-18269.en.md
@@ -1,3 +1,5 @@
 Improved the performance of `GET /clients` when querying by exact client IDs (one or more `clientid` query-string parameters, optionally combined with `node`). Such queries are now resolved with direct per-client lookups instead of scanning the full client table on every node, making them fast even in clusters with a very large number of connected clients. As part of this change, when durable sessions are enabled, such queries now return only the requested clients: previously, disconnected durable sessions could show up in the result even when their client IDs were not queried.
 
+Additionally, repeated query-string parameters (such as multiple `clientid` values) are now processed in the order they appear in the request, and exact-client-ID query results follow that order.
+
 Fixes [#4502](https://github.com/emqx/emqx/issues/4502).

--- a/changes/ee/perf-18269.en.md
+++ b/changes/ee/perf-18269.en.md
@@ -1,0 +1,3 @@
+Improved the performance of `GET /clients` when querying by exact client IDs (one or more `clientid` query-string parameters, optionally combined with `node`). Such queries are now resolved with direct per-client lookups instead of scanning the full client table on every node, making them fast even in clusters with a very large number of connected clients. As part of this change, when durable sessions are enabled, such queries now return only the requested clients: previously, disconnected durable sessions could show up in the result even when their client IDs were not queried.
+
+Fixes [#4502](https://github.com/emqx/emqx/issues/4502).

--- a/mix.exs
+++ b/mix.exs
@@ -230,7 +230,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:bcrypt, github: "emqx/erlang-bcrypt", tag: "0.6.3", override: true}
 
   def common_dep(:minirest),
-    do: {:minirest, github: "emqx/minirest", tag: "1.5.0", override: true}
+    do: {:minirest, github: "emqx/minirest", tag: "1.5.1", override: true}
 
   # maybe forbid to fetch quicer
   def common_dep(:emqtt),

--- a/rel/i18n/emqx_mgmt_api_clients.hocon
+++ b/rel/i18n/emqx_mgmt_api_clients.hocon
@@ -174,6 +174,11 @@ node_name.desc:
 node_name.label:
 """Node name"""
 
+node_filter.desc:
+"""Filter clients by node. When combined with exact client ID lookups (the `clientid` parameter), only clients whose connection is hosted on the given node are returned; disconnected durable sessions are not attached to any node and are excluded."""
+node_filter.label:
+"""Node name"""
+
 conn_state.desc:
 """The current connection status of the client, the possible values are connected,idle,disconnected"""
 conn_state.label:


### PR DESCRIPTION
Release version:
6.4.0

## Summary

`GET /clients` queries that filter on exact client IDs only (one or more `clientid` query-string parameters, optionally combined with `node`) previously went through the generic paginated match-spec scan. Client IDs end up in the match-spec **guards**, never in the match head, so ETS cannot derive a key range and every such query walks the whole `emqx_channel_info` table on every node (measured ~224 ms for 2 IDs on a 1M-row table, vs microseconds for direct lookups).

`list_clients/1` in `emqx_mgmt_api_clients` now detects this query shape up front and resolves each ID with a direct per-ID lookup, returning a single directly-computed page:

- without `node`: `emqx_mgmt:lookup_client/2` — registry-aware lookup with fallback to durable session storage, so disconnected persistent sessions are found too;
- with `node`: `emqx_mgmt:lookup_client/3` (node-scoped RPC), with the same invalid/down-node error responses as before.

Requested IDs are deduplicated and the bounded result set is sliced by `page`/`limit` into the same `data` + `meta` (`count`/`hasnext`) envelope; the `fields` projection is applied via the same `format_channel_info/3`. Any other filter (`username`, `conn_state`, `like_*`, `gte_*`/`lte_*`, ...) takes the generic scan path, which is untouched. `/clients_v2` is not changed.

Behavior notes:

- This PR also bumps minirest to 1.5.1, which fixes repeated query-string parameters arriving in reverse order. With that, result rows follow the order of the requested client IDs (first occurrence wins for duplicates) rather than ETS table order.
- With durable sessions enabled, an exact-ID query now returns only the requested clients, and `meta.count` is exact. Previously the v1 durable-session sweep did not apply query filters, so unrelated disconnected durable sessions could appear in the result, and `count` was inflated by the total disconnected-session count.

Fixes #4502 (EMQX-11120).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
