### PR TITLE
fix(greptimedb): bump driver for stale channel recovery

### DIFF
--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
   def project do
     [
       app: :emqx_bridge_greptimedb,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/changes/ee/fix-18270.en.md
+++ b/changes/ee/fix-18270.en.md
@@ -1,0 +1,1 @@
+Fix GreptimeDB connectors that could fail to restart when a stale gRPC channel remained after a worker was force-stopped.

--- a/mix.exs
+++ b/mix.exs
@@ -318,7 +318,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:parquer, github: "emqx/parquer", tag: "0.1.8", manager: :rebar3}
 
   def common_dep(:greptimedb),
-    do: {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1"}
+    do: {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.2"}
 
   def common_dep(:thrift),
     do: {:thrift, github: "emqx/thrift.erl", tag: "0.1.4", override: true}


### PR DESCRIPTION
Release version:

6.0.4, 6.1.5, 6.2.3, 6.3.0

## Summary

Port the GreptimeDB stale gRPC channel recovery from #18251 to `dev-60` by bumping the driver to `v0.2.5-emqx.2`.

The updated driver removes an orphaned grpcbox channel before retrying worker startup. This prevents `{error, {already_started, Pid}}` from leaving a GreptimeDB connector inconsistent across cluster nodes.

Driver fix: https://github.com/emqx/greptimedb-ingester-erl/pull/6

No schema changes.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
