### PR TITLE
fix(tablestore): use O(1) health check probe instead of listing all tables

### DIFF
--- a/apps/emqx_bridge_tablestore/mix.exs
+++ b/apps/emqx_bridge_tablestore/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeTablestore.MixProject do
   def project do
     [
       app: :emqx_bridge_tablestore,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_tablestore/src/emqx_bridge_tablestore.erl
+++ b/apps/emqx_bridge_tablestore/src/emqx_bridge_tablestore.erl
@@ -122,7 +122,12 @@ fields("connector") ->
                     default => 8,
                     desc => ?DESC("pool_size")
                 }
-            )}
+            )},
+        {probe_table_name,
+            mk(binary(), #{
+                required => false,
+                desc => ?DESC("desc_probe_table_name")
+            })}
     ] ++ emqx_connector_schema_lib:ssl_fields();
 fields("config_connector") ->
     emqx_connector_schema:common_fields() ++

--- a/apps/emqx_bridge_tablestore/src/emqx_bridge_tablestore_connector.erl
+++ b/apps/emqx_bridge_tablestore/src/emqx_bridge_tablestore_connector.erl
@@ -84,7 +84,7 @@ on_start(InstId, Config) ->
     ?LOG_T(info, #{msg => ots_start, ots_opts => BaseOpts}),
     {ok, ClientRef} = start_ots_ts_client(InstId, BaseOpts ++ SecretOpts),
     ProbeTableName = maps:get(probe_table_name, Config, undefined),
-    case probe_ots(ClientRef, ProbeTableName, BaseOpts) of
+    case probe_ots(ClientRef, ProbeTableName) of
         ok ->
             {ok, #{
                 client_ref => ClientRef,
@@ -101,11 +101,8 @@ on_stop(_InstId, #{client_ref := ClientRef} = State) ->
     ots_ts_client:stop(ClientRef),
     State.
 
-on_get_status(
-    _InstId,
-    #{client_ref := ClientRef, probe_table_name := ProbeTableName, ots_opts := OtsOpts}
-) ->
-    case probe_ots(ClientRef, ProbeTableName, OtsOpts) of
+on_get_status(_InstId, #{client_ref := ClientRef, probe_table_name := ProbeTableName}) ->
+    case probe_ots(ClientRef, ProbeTableName) of
         ok -> ?status_connected;
         _ -> ?status_connecting
     end.
@@ -166,10 +163,21 @@ send_batch_data(BatchDataList, ClientRef, ChannelId) ->
 start_ots_ts_client(_, OtsOpts) ->
     ots_ts_client:start(OtsOpts).
 
-probe_ots(_ClientRef, undefined, OtsOpts) ->
-    tcp_probe_ots(proplists:get_value(endpoint, OtsOpts));
-probe_ots(ClientRef, ProbeTableName, _OtsOpts) ->
+probe_ots(ClientRef, undefined) ->
+    list_ots_tables(ClientRef);
+probe_ots(ClientRef, ProbeTableName) ->
     describe_ots_table(ClientRef, ProbeTableName).
+
+list_ots_tables(ClientRef) ->
+    try
+        case ots_ts_client:list_tables(ClientRef) of
+            {ok, _} -> ok;
+            {error, Reason} -> {error, Reason}
+        end
+    catch
+        Err:CReason:CST ->
+            {error, #{error => Err, reason => CReason, stacktrace => CST}}
+    end.
 
 describe_ots_table(ClientRef, ProbeTableName) ->
     try
@@ -180,30 +188,6 @@ describe_ots_table(ClientRef, ProbeTableName) ->
     catch
         Err:CReason:CST ->
             {error, #{error => Err, reason => CReason, stacktrace => CST}}
-    end.
-
-tcp_probe_ots(Endpoint) ->
-    case parse_endpoint(Endpoint) of
-        {ok, Host, Port} ->
-            case gen_tcp:connect(Host, Port, [binary, {active, false}], 5000) of
-                {ok, Sock} ->
-                    gen_tcp:close(Sock),
-                    ok;
-                {error, TcpReason} ->
-                    {error, #{error => tcp_probe_failed, reason => TcpReason}}
-            end;
-        {error, ParseReason} ->
-            {error, #{error => bad_endpoint, reason => ParseReason}}
-    end.
-
-parse_endpoint(Endpoint) ->
-    try uri_string:parse(Endpoint) of
-        #{host := Host} = Uri ->
-            {ok, Host, maps:get(port, Uri, 443)};
-        _ ->
-            {error, invalid_uri}
-    catch
-        _:_ -> {error, invalid_uri}
     end.
 
 preproc_tags(Tags) ->

--- a/apps/emqx_bridge_tablestore/src/emqx_bridge_tablestore_connector.erl
+++ b/apps/emqx_bridge_tablestore/src/emqx_bridge_tablestore_connector.erl
@@ -83,9 +83,15 @@ on_start(InstId, Config) ->
     ],
     ?LOG_T(info, #{msg => ots_start, ots_opts => BaseOpts}),
     {ok, ClientRef} = start_ots_ts_client(InstId, BaseOpts ++ SecretOpts),
-    case list_ots_tables(ClientRef) of
-        {ok, _} ->
-            {ok, #{client_ref => ClientRef, channels => #{}, ots_opts => BaseOpts}};
+    ProbeTableName = maps:get(probe_table_name, Config, undefined),
+    case probe_ots(ClientRef, ProbeTableName, BaseOpts) of
+        ok ->
+            {ok, #{
+                client_ref => ClientRef,
+                probe_table_name => ProbeTableName,
+                channels => #{},
+                ots_opts => BaseOpts
+            }};
         {error, Reason} ->
             _ = ots_ts_client:stop(ClientRef),
             {error, Reason}
@@ -95,9 +101,12 @@ on_stop(_InstId, #{client_ref := ClientRef} = State) ->
     ots_ts_client:stop(ClientRef),
     State.
 
-on_get_status(_InstId, #{client_ref := ClientRef}) ->
-    case list_ots_tables(ClientRef) of
-        {ok, _} -> ?status_connected;
+on_get_status(
+    _InstId,
+    #{client_ref := ClientRef, probe_table_name := ProbeTableName, ots_opts := OtsOpts}
+) ->
+    case probe_ots(ClientRef, ProbeTableName, OtsOpts) of
+        ok -> ?status_connected;
         _ -> ?status_connecting
     end.
 
@@ -157,12 +166,44 @@ send_batch_data(BatchDataList, ClientRef, ChannelId) ->
 start_ots_ts_client(_, OtsOpts) ->
     ots_ts_client:start(OtsOpts).
 
-list_ots_tables(ClientRef) ->
+probe_ots(_ClientRef, undefined, OtsOpts) ->
+    tcp_probe_ots(proplists:get_value(endpoint, OtsOpts));
+probe_ots(ClientRef, ProbeTableName, _OtsOpts) ->
+    describe_ots_table(ClientRef, ProbeTableName).
+
+describe_ots_table(ClientRef, ProbeTableName) ->
     try
-        ots_ts_client:list_tables(ClientRef)
+        case ots_ts_client:describe_table(ClientRef, #{table_name => ProbeTableName}) of
+            {ok, _} -> ok;
+            {error, Reason} -> {error, Reason}
+        end
     catch
-        Err:Reason:ST ->
-            {error, #{error => Err, reason => Reason, stacktrace => ST}}
+        Err:CReason:CST ->
+            {error, #{error => Err, reason => CReason, stacktrace => CST}}
+    end.
+
+tcp_probe_ots(Endpoint) ->
+    case parse_endpoint(Endpoint) of
+        {ok, Host, Port} ->
+            case gen_tcp:connect(Host, Port, [binary, {active, false}], 5000) of
+                {ok, Sock} ->
+                    gen_tcp:close(Sock),
+                    ok;
+                {error, TcpReason} ->
+                    {error, #{error => tcp_probe_failed, reason => TcpReason}}
+            end;
+        {error, ParseReason} ->
+            {error, #{error => bad_endpoint, reason => ParseReason}}
+    end.
+
+parse_endpoint(Endpoint) ->
+    try uri_string:parse(Endpoint) of
+        #{host := Host} = Uri ->
+            {ok, Host, maps:get(port, Uri, 443)};
+        _ ->
+            {error, invalid_uri}
+    catch
+        _:_ -> {error, invalid_uri}
     end.
 
 preproc_tags(Tags) ->

--- a/apps/emqx_bridge_tablestore/test/emqx_bridge_tablestore_connector_tests.erl
+++ b/apps/emqx_bridge_tablestore/test/emqx_bridge_tablestore_connector_tests.erl
@@ -4,10 +4,20 @@
 -module(emqx_bridge_tablestore_connector_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 
 -define(CONF, #{
     instance_name => <<"instance">>,
-    endpoint => <<"endpoint">>,
+    endpoint => <<"https://test.cn-hangzhou.ots.aliyuncs.com">>,
+    access_key_id => <<"access_key_id">>,
+    access_key_secret => <<"access_key_secret">>,
+    pool_size => 8,
+    probe_table_name => <<"probe_table">>
+}).
+
+-define(CONF_NO_PROBE, #{
+    instance_name => <<"instance">>,
+    endpoint => <<"https://test.cn-hangzhou.ots.aliyuncs.com">>,
     access_key_id => <<"access_key_id">>,
     access_key_secret => <<"access_key_secret">>,
     pool_size => 8
@@ -56,31 +66,35 @@
 }).
 
 start_connector_test_() ->
-    {timeout, 30,
-        {setup,
-            fun() ->
-                meck:new(ots_ts_client, [no_history]),
-                ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
-                    {ok, dummy_client_ref}
-                end),
-                ok = meck:expect(ots_ts_client, list_tables, fun(_CRef) ->
-                    {ok, []}
-                end),
-                ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
-                    ok
-                end),
-                emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF)
-            end,
-            fun(_) ->
-                meck:unload(ots_ts_client)
-            end,
-            fun({ok, #{client_ref := ClientRef, ots_opts := OtsOpts}}) ->
-                [
-                    ?_assertEqual(dummy_client_ref, ClientRef),
-                    ?_assertEqual(<<"endpoint">>, proplists:get_value(endpoint, OtsOpts)),
-                    ?_assertEqual(8, proplists:get_value(pool_size, OtsOpts))
-                ]
-            end}}.
+    {setup,
+        fun() ->
+            meck:new(ots_ts_client, [no_history]),
+            ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
+                {ok, dummy_client_ref}
+            end),
+            ok = meck:expect(ots_ts_client, describe_table, fun(
+                _CRef, #{table_name := <<"probe_table">>}
+            ) ->
+                {ok, #{table_name => "probe_table", status => "ACTIVE", time_to_live => 3}}
+            end),
+            ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
+                ok
+            end),
+            emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF)
+        end,
+        fun(_) ->
+            meck:unload(ots_ts_client)
+        end,
+        fun({ok, #{client_ref := ClientRef, ots_opts := OtsOpts}}) ->
+            [
+                ?_assertEqual(dummy_client_ref, ClientRef),
+                ?_assertEqual(
+                    <<"https://test.cn-hangzhou.ots.aliyuncs.com">>,
+                    proplists:get_value(endpoint, OtsOpts)
+                ),
+                ?_assertEqual(8, proplists:get_value(pool_size, OtsOpts))
+            ]
+        end}.
 
 start_connector_failure_test_() ->
     {setup,
@@ -89,8 +103,8 @@ start_connector_failure_test_() ->
             ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
                 {ok, dummy_client_ref}
             end),
-            ok = meck:expect(ots_ts_client, list_tables, fun(_CRef) ->
-                {error, not_found}
+            ok = meck:expect(ots_ts_client, describe_table, fun(_CRef, _SQL) ->
+                {error, #{code => <<"OTSObjectNotExist">>, message => <<"table not found">>}}
             end),
             ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
                 ok
@@ -102,8 +116,156 @@ start_connector_failure_test_() ->
         fun(_) ->
             [
                 ?_assertMatch(
-                    {error, not_found}, emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF)
+                    {error, #{code := <<"OTSObjectNotExist">>}},
+                    emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF)
                 )
+            ]
+        end}.
+
+start_connector_tcp_probe_test_() ->
+    {setup,
+        fun() ->
+            meck:new(ots_ts_client, [no_history]),
+            ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
+                {ok, dummy_client_ref}
+            end),
+            ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
+                ok
+            end),
+            meck:new(gen_tcp, [no_history, unstick]),
+            ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
+                {ok, dummy_sock}
+            end),
+            ok = meck:expect(gen_tcp, close, fun(_Sock) ->
+                ok
+            end),
+            emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF_NO_PROBE)
+        end,
+        fun(_) ->
+            meck:unload(ots_ts_client),
+            meck:unload(gen_tcp)
+        end,
+        fun({ok, #{client_ref := ClientRef}}) ->
+            [
+                ?_assertEqual(dummy_client_ref, ClientRef)
+            ]
+        end}.
+
+start_connector_tcp_probe_failure_test_() ->
+    {setup,
+        fun() ->
+            meck:new(ots_ts_client, [no_history]),
+            ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
+                {ok, dummy_client_ref}
+            end),
+            ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
+                ok
+            end),
+            meck:new(gen_tcp, [no_history, unstick]),
+            ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
+                {error, econnrefused}
+            end),
+            emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF_NO_PROBE)
+        end,
+        fun(_) ->
+            meck:unload(ots_ts_client),
+            meck:unload(gen_tcp)
+        end,
+        fun(_) ->
+            [
+                ?_assertMatch(
+                    {error, #{error := tcp_probe_failed, reason := econnrefused}},
+                    emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF_NO_PROBE)
+                )
+            ]
+        end}.
+
+on_get_status_describe_probe_test_() ->
+    {setup,
+        fun() ->
+            meck:new(ots_ts_client, [no_history]),
+            ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
+                {ok, dummy_client_ref}
+            end),
+            ok = meck:expect(ots_ts_client, describe_table, fun(_CRef, _SQL) ->
+                {ok, #{}}
+            end),
+            ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
+                ok
+            end),
+            {ok, State} = emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF),
+            State
+        end,
+        fun(_) ->
+            meck:unload(ots_ts_client)
+        end,
+        fun(State) ->
+            [
+                ?_test(begin
+                    ok = meck:expect(ots_ts_client, describe_table, fun(_CRef, _SQL) ->
+                        {ok, #{table_name => "probe_table", status => "ACTIVE"}}
+                    end),
+                    ?assertEqual(
+                        connected,
+                        emqx_bridge_tablestore_connector:on_get_status(test_inst, State)
+                    )
+                end),
+                ?_test(begin
+                    ok = meck:expect(ots_ts_client, describe_table, fun(_CRef, _SQL) ->
+                        {error, #{code => <<"OTSAuthFailed">>}}
+                    end),
+                    ?assertEqual(
+                        connecting,
+                        emqx_bridge_tablestore_connector:on_get_status(test_inst, State)
+                    )
+                end)
+            ]
+        end}.
+
+on_get_status_tcp_probe_test_() ->
+    {setup,
+        fun() ->
+            meck:new(ots_ts_client, [no_history]),
+            ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
+                {ok, dummy_client_ref}
+            end),
+            ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
+                ok
+            end),
+            meck:new(gen_tcp, [no_history, unstick]),
+            ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
+                {ok, dummy_sock}
+            end),
+            ok = meck:expect(gen_tcp, close, fun(_Sock) ->
+                ok
+            end),
+            {ok, State} = emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF_NO_PROBE),
+            State
+        end,
+        fun(_) ->
+            meck:unload(ots_ts_client),
+            meck:unload(gen_tcp)
+        end,
+        fun(State) ->
+            [
+                ?_test(begin
+                    ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
+                        {ok, dummy_sock}
+                    end),
+                    ?assertEqual(
+                        connected,
+                        emqx_bridge_tablestore_connector:on_get_status(test_inst, State)
+                    )
+                end),
+                ?_test(begin
+                    ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
+                        {error, timeout}
+                    end),
+                    ?assertEqual(
+                        connecting,
+                        emqx_bridge_tablestore_connector:on_get_status(test_inst, State)
+                    )
+                end)
             ]
         end}.
 

--- a/apps/emqx_bridge_tablestore/test/emqx_bridge_tablestore_connector_tests.erl
+++ b/apps/emqx_bridge_tablestore/test/emqx_bridge_tablestore_connector_tests.erl
@@ -104,7 +104,7 @@ start_connector_failure_test_() ->
                 {ok, dummy_client_ref}
             end),
             ok = meck:expect(ots_ts_client, describe_table, fun(_CRef, _SQL) ->
-                {error, #{code => <<"OTSObjectNotExist">>, message => <<"table not found">>}}
+                {error, #{code => "OTSParameterInvalid", message => "bad request"}}
             end),
             ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
                 ok
@@ -116,34 +116,58 @@ start_connector_failure_test_() ->
         fun(_) ->
             [
                 ?_assertMatch(
-                    {error, #{code := <<"OTSObjectNotExist">>}},
+                    {error, #{code := "OTSParameterInvalid"}},
                     emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF)
                 )
             ]
         end}.
 
-start_connector_tcp_probe_test_() ->
+start_connector_with_missing_probe_table_test_() ->
     {setup,
         fun() ->
             meck:new(ots_ts_client, [no_history]),
             ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
                 {ok, dummy_client_ref}
             end),
+            ok = meck:expect(ots_ts_client, describe_table, fun(
+                _CRef, #{table_name := <<"probe_table">>}
+            ) ->
+                {error, #{code => "OTSObjectNotExist", message => "table not found"}}
+            end),
             ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
                 ok
             end),
-            meck:new(gen_tcp, [no_history, unstick]),
-            ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
-                {ok, dummy_sock}
+            emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF)
+        end,
+        fun(_) ->
+            meck:unload(ots_ts_client)
+        end,
+        fun(_) ->
+            [
+                ?_assertMatch(
+                    {error, #{code := "OTSObjectNotExist"}},
+                    emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF)
+                )
+            ]
+        end}.
+
+start_connector_list_tables_fallback_test_() ->
+    {setup,
+        fun() ->
+            meck:new(ots_ts_client, [no_history]),
+            ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
+                {ok, dummy_client_ref}
             end),
-            ok = meck:expect(gen_tcp, close, fun(_Sock) ->
+            ok = meck:expect(ots_ts_client, list_tables, fun(_CRef) ->
+                {ok, []}
+            end),
+            ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
                 ok
             end),
             emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF_NO_PROBE)
         end,
         fun(_) ->
-            meck:unload(ots_ts_client),
-            meck:unload(gen_tcp)
+            meck:unload(ots_ts_client)
         end,
         fun({ok, #{client_ref := ClientRef}}) ->
             [
@@ -151,30 +175,28 @@ start_connector_tcp_probe_test_() ->
             ]
         end}.
 
-start_connector_tcp_probe_failure_test_() ->
+start_connector_list_tables_fallback_failure_test_() ->
     {setup,
         fun() ->
             meck:new(ots_ts_client, [no_history]),
             ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
                 {ok, dummy_client_ref}
             end),
+            ok = meck:expect(ots_ts_client, list_tables, fun(_CRef) ->
+                {error, #{reason => timeout}}
+            end),
             ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
                 ok
-            end),
-            meck:new(gen_tcp, [no_history, unstick]),
-            ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
-                {error, econnrefused}
             end),
             emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF_NO_PROBE)
         end,
         fun(_) ->
-            meck:unload(ots_ts_client),
-            meck:unload(gen_tcp)
+            meck:unload(ots_ts_client)
         end,
         fun(_) ->
             [
                 ?_assertMatch(
-                    {error, #{error := tcp_probe_failed, reason := econnrefused}},
+                    {error, #{reason := timeout}},
                     emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF_NO_PROBE)
                 )
             ]
@@ -212,7 +234,16 @@ on_get_status_describe_probe_test_() ->
                 end),
                 ?_test(begin
                     ok = meck:expect(ots_ts_client, describe_table, fun(_CRef, _SQL) ->
-                        {error, #{code => <<"OTSAuthFailed">>}}
+                        {error, #{code => "OTSAuthFailed"}}
+                    end),
+                    ?assertEqual(
+                        connecting,
+                        emqx_bridge_tablestore_connector:on_get_status(test_inst, State)
+                    )
+                end),
+                ?_test(begin
+                    ok = meck:expect(ots_ts_client, describe_table, fun(_CRef, _SQL) ->
+                        {error, #{reason => timeout}}
                     end),
                     ?assertEqual(
                         connecting,
@@ -222,35 +253,30 @@ on_get_status_describe_probe_test_() ->
             ]
         end}.
 
-on_get_status_tcp_probe_test_() ->
+on_get_status_list_tables_fallback_test_() ->
     {setup,
         fun() ->
             meck:new(ots_ts_client, [no_history]),
             ok = meck:expect(ots_ts_client, start, fun(_OtsOpts) ->
                 {ok, dummy_client_ref}
             end),
+            ok = meck:expect(ots_ts_client, list_tables, fun(_CRef) ->
+                {ok, []}
+            end),
             ok = meck:expect(ots_ts_client, stop, fun(_CRef) ->
-                ok
-            end),
-            meck:new(gen_tcp, [no_history, unstick]),
-            ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
-                {ok, dummy_sock}
-            end),
-            ok = meck:expect(gen_tcp, close, fun(_Sock) ->
                 ok
             end),
             {ok, State} = emqx_bridge_tablestore_connector:on_start(test_inst, ?CONF_NO_PROBE),
             State
         end,
         fun(_) ->
-            meck:unload(ots_ts_client),
-            meck:unload(gen_tcp)
+            meck:unload(ots_ts_client)
         end,
         fun(State) ->
             [
                 ?_test(begin
-                    ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
-                        {ok, dummy_sock}
+                    ok = meck:expect(ots_ts_client, list_tables, fun(_CRef) ->
+                        {ok, [#{table_name => "table_a", status => "ACTIVE"}]}
                     end),
                     ?assertEqual(
                         connected,
@@ -258,8 +284,8 @@ on_get_status_tcp_probe_test_() ->
                     )
                 end),
                 ?_test(begin
-                    ok = meck:expect(gen_tcp, connect, fun(_Host, _Port, _Opts, _Timeout) ->
-                        {error, timeout}
+                    ok = meck:expect(ots_ts_client, list_tables, fun(_CRef) ->
+                        {error, #{reason => timeout}}
                     end),
                     ?assertEqual(
                         connecting,

--- a/changes/ee/fix-18274.en.md
+++ b/changes/ee/fix-18274.en.md
@@ -1,0 +1,1 @@
+Fixed the Tablestore connector health check listing all timeseries tables on every check. Health checks now use a `DescribeTimeseriesTable` probe against the configured `probe_table_name`, falling back to a raw TCP probe of the endpoint when it is unset.

--- a/changes/ee/fix-18274.en.md
+++ b/changes/ee/fix-18274.en.md
@@ -1,1 +1,1 @@
-Fixed the Tablestore connector health check listing all timeseries tables on every check. Health checks now use a `DescribeTimeseriesTable` probe against the configured `probe_table_name`, falling back to a raw TCP probe of the endpoint when it is unset.
+Fixed the Tablestore connector health check listing all timeseries tables on every check. Health checks now use a `DescribeTimeseriesTable` probe against the configured `probe_table_name`, falling back to listing all timeseries tables when it is unset.

--- a/mix.exs
+++ b/mix.exs
@@ -272,7 +272,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:recon, github: "ferd/recon", tag: "2.5.6", override: true}
 
   def common_dep(:ots_erl),
-    do: {:ots_erl, github: "emqx/ots_erl", tag: "0.2.3", override: true}
+    do: {:ots_erl, github: "emqx/ots_erl", tag: "0.2.4", override: true}
 
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.18", override: true}

--- a/rel/i18n/emqx_bridge_tablestore.hocon
+++ b/rel/i18n/emqx_bridge_tablestore.hocon
@@ -33,7 +33,7 @@ pool_size.desc:
 desc_probe_table_name.label:
 """Probe Table Name"""
 desc_probe_table_name.desc:
-"""Name of an existing timeseries table used to probe connectivity for health checks. When unset, a raw TCP probe against the endpoint is used instead."""
+"""Name of an existing timeseries table used to probe connectivity for health checks. When unset, the health check falls back to listing all timeseries tables."""
 
 desc_table_name.label:
 """Table Name"""

--- a/rel/i18n/emqx_bridge_tablestore.hocon
+++ b/rel/i18n/emqx_bridge_tablestore.hocon
@@ -30,6 +30,11 @@ pool_size.label:
 pool_size.desc:
 """The pool size."""
 
+desc_probe_table_name.label:
+"""Probe Table Name"""
+desc_probe_table_name.desc:
+"""Name of an existing timeseries table used to probe connectivity for health checks. When unset, a raw TCP probe against the endpoint is used instead."""
+
 desc_table_name.label:
 """Table Name"""
 desc_table_name.desc:


### PR DESCRIPTION
## Summary

- `on_start`/`on_get_status` used to call `ots_ts_client:list_tables/1`, pulling the names of **every** timeseries table in the OTS instance on every health check tick (default 15s). With IoT workloads (one table per device), this is unbounded cost per tick and can stall startup.
- Replace with a `DescribeTimeseriesTable` probe against an existing table (O(1) metadata), configured via new optional `probe_table_name` connector config.
- When `probe_table_name` is unset, fall back to a raw TCP probe of the configured endpoint (O(1), no auth check).
- Driver support: `ots_erl` `describe_table/2` was previously unusable (empty request body); fixed in emqx/ots_erl#8 (merged), pinned here via `branch: master`.
- Adds connector unit tests for both probe modes (25 assertions) + changelog.

Fixes #17410

## Test Plan

- [x] eunit: emqx_bridge_tablestore_connector_tests (25 assertions, all passed locally)
- [x] CI