### PR TITLE
fix(conf): reliably persist cluster.hocon updates

### DIFF
--- a/apps/emqx/src/emqx_config_backup_manager.erl
+++ b/apps/emqx/src/emqx_config_backup_manager.erl
@@ -55,12 +55,29 @@ start_link() ->
 backup_and_write(DestFilename, NewContents) ->
     _ = filelib:ensure_dir(DestFilename),
     TmpFilename = DestFilename ++ ".tmp",
-    case file:write_file(TmpFilename, NewContents) of
+    case write_and_sync(TmpFilename, NewContents) of
         ok ->
             backup_and_replace(DestFilename, TmpFilename);
         {error, Reason} ->
             log_save_error(TmpFilename, Reason),
+            _ = file:delete(TmpFilename),
             {error, #{filename => DestFilename, reason => Reason}}
+    end.
+
+%% Sync the staged file to disk before it is renamed over the destination,
+%% so a power loss right after the rename cannot leave a truncated config file.
+write_and_sync(Filename, Contents) ->
+    case file:open(Filename, [write, binary, raw]) of
+        {ok, Fd} ->
+            Result =
+                maybe
+                    ok ?= file:write(Fd, Contents),
+                    file:sync(Fd)
+                end,
+            _ = file:close(Fd),
+            Result;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 log_save_error(Filename, Reason) ->
@@ -150,12 +167,14 @@ backup_and_replace(DestFilename, TmpFilename) ->
             %% not created yet
             do_rename(TmpFilename, DestFilename);
         {error, Reason} ->
+            %% Backup is best-effort: skip this backup generation,
+            %% but still persist the new config.
             ?SLOG(warning, #{
                 msg => "failed_to_read_current_conf_file",
                 filename => DestFilename,
                 reason => Reason
             }),
-            ok
+            do_rename(TmpFilename, DestFilename)
     end.
 
 do_rename(TmpFilename, DestFilename) ->

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -198,6 +198,61 @@ t_cluster_hocon_save_failure(C) when is_list(C) ->
     ok = file:delete(Blocker),
     ok.
 
+-doc "New config is persisted even when reading the current file for backup fails.".
+t_cluster_hocon_save_unreadable_current({init, C}) ->
+    ok = meck:new(file, [passthrough, unstick]),
+    C;
+t_cluster_hocon_save_unreadable_current({'end', _C}) ->
+    ok = meck:unload(file),
+    File = "backup-test-unreadable.hocon",
+    lists:foreach(fun file:delete/1, [File | filelib:wildcard(File ++ ".*")]),
+    ok;
+t_cluster_hocon_save_unreadable_current(C) when is_list(C) ->
+    Dest = "backup-test-unreadable.hocon",
+    ok = file:write_file(Dest, <<"old">>),
+    %% meck instead of chmod: chmod is ineffective when the test runs as root
+    ok = meck:expect(file, read_file, fun
+        (F) when F =:= Dest -> {error, eacces};
+        (F) -> meck:passthrough([F])
+    end),
+    ?assertEqual(ok, emqx_config:backup_and_write(Dest, <<"new">>)),
+    ok = meck:expect(file, read_file, fun(F) -> meck:passthrough([F]) end),
+    %% the new config is persisted and the staged file is gone
+    ?assertEqual({ok, <<"new">>}, file:read_file(Dest)),
+    ?assertEqual({error, enoent}, file:read_file(Dest ++ ".tmp")),
+    %% only this backup generation is skipped
+    ok = emqx_config_backup_manager:flush(),
+    ?assertEqual([], filelib:wildcard(Dest ++ ".*.bak")),
+    ok.
+
+-doc "Failure to sync the staged file returns an error and leaves the previous config intact.".
+t_cluster_hocon_save_sync_failure({init, C}) ->
+    ok = meck:new(file, [passthrough, unstick]),
+    C;
+t_cluster_hocon_save_sync_failure({'end', _C}) ->
+    ok = meck:unload(file),
+    File = "backup-test-sync.hocon",
+    lists:foreach(fun file:delete/1, [File | filelib:wildcard(File ++ ".*")]),
+    ok;
+t_cluster_hocon_save_sync_failure(C) when is_list(C) ->
+    Dest = "backup-test-sync.hocon",
+    ok = file:write_file(Dest, <<"old">>),
+    TestPid = self(),
+    ok = meck:expect(file, sync, fun(Fd) ->
+        case self() of
+            TestPid -> {error, enospc};
+            _ -> meck:passthrough([Fd])
+        end
+    end),
+    ?assertMatch(
+        {error, #{filename := Dest, reason := enospc}},
+        emqx_config:backup_and_write(Dest, <<"new">>)
+    ),
+    ok = meck:expect(file, sync, fun(Fd) -> meck:passthrough([Fd]) end),
+    ?assertEqual({ok, <<"old">>}, file:read_file(Dest)),
+    ?assertEqual({error, enoent}, file:read_file(Dest ++ ".tmp")),
+    ok.
+
 t_init_load_emqx_schema(Config) when is_list(Config) ->
     emqx_config:erase_all(),
     %% Given empty config file

--- a/changes/ee/fix-18277.en.md
+++ b/changes/ee/fix-18277.en.md
@@ -1,0 +1,1 @@
+Improved reliability of persisting configuration changes to `cluster.hocon`: the update is now written and synced to disk before atomically replacing the file, and a failure to read the previous file for backup no longer prevents the new configuration from being saved.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:
pre-5.8

## Summary

Two robustness fixes in `emqx_config_backup_manager` (the module that persists `cluster.hocon` on every config update):

- When reading the current file for backup fails with a non-`enoent` error, the staged file is now still renamed into place. Previously the rename was skipped while `ok` was still returned, so the update was reported as saved without being persisted. The backup is best-effort (its own write failures are only warnings), so skipping one backup generation is preferable to not saving the new config.
- The staged tmp file is now synced to disk before the atomic rename, so a power loss right after the rename cannot leave an empty or truncated `cluster.hocon`. This mirrors the staging/sync/rename pattern adopted in emqx/hocon#318 for the generated app/vm files.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)