### PR TITLE
fix(config): bump `hocon` to 0.46.1

### DIFF
--- a/changes/ee/fix-18289.en.md
+++ b/changes/ee/fix-18289.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where JSON-compatible Unicode escape sequences in quoted HOCON strings and keys were left escaped instead of being decoded.

--- a/mix.exs
+++ b/mix.exs
@@ -177,7 +177,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.0", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.2", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
-  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.9", override: true}
+  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.0", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}
   # in conflict by ehttpc and emqtt
   def common_dep(:gun), do: {:gun, "2.1.0", override: true}

--- a/mix.exs
+++ b/mix.exs
@@ -177,7 +177,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.0", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.2", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
-  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.0", override: true}
+  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.1", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}
   # in conflict by ehttpc and emqtt
   def common_dep(:gun), do: {:gun, "2.1.0", override: true}


### PR DESCRIPTION
Release version: 6.3.0, 6.4.0

Intoduced In: pre-5.8

## Summary

This PR updates `hocon` dependency to a version that includes the fix for proper processing of Unicode escape sequences.

See also emqx/hocon#317, emqx/hocon#318.

## PR Checklist

- [ ] The changes are covered with new or existing tests
    See referenced PR for details on test coverage.
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking
    Strictly speaking, on-disk HOCON configuration files (e.g. `cluster.hocon`) may now parse _differently_, producing different rawconf.