### PR TITLE
ci(kerberos): make CI keytabs readable regardless of chown timing

### DIFF
--- a/.ci/docker-compose-file/kerberos/run.sh
+++ b/.ci/docker-compose-file/kerberos/run.sh
@@ -34,5 +34,9 @@ kadmin.local -w password -q "ktadd  -k /var/lib/secret/rig.keytab -norandkey rig
 kadmin.local -w password -q "ktadd  -k /var/lib/secret/erlang.keytab -norandkey mqtt/erlang.emqx.net@KDC.EMQX.NET " > /dev/null
 kadmin.local -w password -q "ktadd  -k /var/lib/secret/krb_authn_cli.keytab -norandkey krb_authn_cli@KDC.EMQX.NET " > /dev/null
 
+# The test containers read these keytabs as a non-root user; keep them
+# readable no matter who owns them by the time consumers open them.
+chmod a+r /var/lib/secret/*.keytab
+
 echo STARTING KDC
 /usr/sbin/krb5kdc -n


### PR DESCRIPTION
Fixes a CI flake where `emqx_authn_kerberos_SUITE:init_per_suite` fails with `krb5_get_init_creds_keytab` errno 13 (Permission denied) and all cases auto-skip (seen on https://github.com/emqx/emqx/actions/runs/31034462286/job/92793223427).

`scripts/ct/run.sh` runs `chown -R $DOCKER_USER /var/lib/secret` in the erlang container right after `docker compose up`, racing the KDC container's bootstrap (`kdb5_util create` → `add_principal` → `ktadd`). If the chown wins, keytabs created afterwards by `ktadd` stay `root:root` mode `0600`, and the suite (running as the non-root CT user) gets a permanent EACCES. The same exposure applies to all keytabs in the shared volume, including those used by the `emqx_bridge_kafka` kerberos groups.

Fix: `chmod a+r` the keytabs in the KDC bootstrap script after the last `ktadd`. These are throwaway CI-only secrets; world-readable closes the race for every consumer regardless of ordering.

Validated with the docker CT testbed: `PROFILE=emqx-enterprise ./scripts/ct/run.sh --ci --app apps/emqx_auth_kerberos` — 7 ok, 0 failed, 0 skipped; keytabs in the shared volume come out `-rw-r--r--`.