### PR TITLE
fix(prometheus): omit namespaced metrics for unknown namespaces

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -836,7 +836,15 @@ metric_data_ns(all, MetricSpecs, Mode) ->
     NsToMetrics = maps:remove(?global_ns, NsToMetrics0),
     do_metric_data_ns(NsToMetrics, MetricSpecs, Mode);
 metric_data_ns(Namespace, MetricSpecs, Mode) when is_binary(Namespace) ->
-    NsToMetrics = #{Namespace => emqx_metrics:all(Namespace)},
+    NsToMetrics =
+        case emqx_metrics:all(Namespace) of
+            [] ->
+                %% No metrics counters for this namespace: omit it, as the `all' clause
+                %% does for namespaces absent from `emqx_metrics:all_ns/0'.
+                #{};
+            Metrics ->
+                #{Namespace => Metrics}
+        end,
     do_metric_data_ns(NsToMetrics, MetricSpecs, Mode).
 
 do_metric_data_ns(NsToMetrics, MetricSpecs, Mode) ->
@@ -872,8 +880,8 @@ gather_session_ns_data(all) ->
             {ok, N} ->
                 Acc#{Namespace => [{emqx_sessions_count, N}]};
             {error, _} ->
-                %% race?
-                Acc#{Namespace => [{emqx_sessions_count, 0}]}
+                %% Namespace deleted concurrently: omit it.
+                Acc
         end
     end,
     InitAcc = #{},
@@ -883,7 +891,8 @@ gather_session_ns_data(Namespace) when is_binary(Namespace) ->
         {ok, N} ->
             #{Namespace => [{emqx_sessions_count, N}]};
         {error, _} ->
-            #{Namespace => [{emqx_sessions_count, 0}]}
+            %% Unknown namespace: omit the metric instead of fabricating a zero.
+            #{}
     end.
 
 authz_metric_ns(Namespace, MetricSpecs, Mode) when is_binary(Namespace); Namespace == all ->
@@ -899,8 +908,13 @@ gather_authz_ns_data(all) ->
         emqx_authz_mnesia:record_count_per_namespace()
     );
 gather_authz_ns_data(Namespace) when is_binary(Namespace) ->
-    N = emqx_authz_mnesia:record_count(Namespace),
-    #{Namespace => [{emqx_authz_builtin_record_count, N}]}.
+    case emqx_mt_state:is_known_ns(Namespace) of
+        true ->
+            N = emqx_authz_mnesia:record_count(Namespace),
+            #{Namespace => [{emqx_authz_builtin_record_count, N}]};
+        false ->
+            #{}
+    end.
 
 authn_metric_ns(Namespace, MetricSpecs, Mode) when is_binary(Namespace); Namespace == all ->
     NsToMetrics = gather_authn_ns_data(Namespace),
@@ -915,8 +929,13 @@ gather_authn_ns_data(all) ->
         emqx_authn_mnesia:record_count_per_namespace()
     );
 gather_authn_ns_data(Namespace) when is_binary(Namespace) ->
-    N = emqx_authn_mnesia:record_count(Namespace),
-    #{Namespace => [{emqx_authn_builtin_record_count, N}]}.
+    case emqx_mt_state:is_known_ns(Namespace) of
+        true ->
+            N = emqx_authn_mnesia:record_count(Namespace),
+            #{Namespace => [{emqx_authn_builtin_record_count, N}]};
+        false ->
+            #{}
+    end.
 
 client_metric_data(Mode) ->
     Acc = listener_shutdown_counts(Mode),

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_2_SUITE.erl
@@ -321,6 +321,89 @@ t_namespaced_stats_mt_not_started(TCConfig) ->
     ok.
 
 -doc """
+Checks that requesting stats for a specific namespace while `emqx_mt' is not running (its
+tables do not exist, so no namespace is known) responds successfully with the namespaced
+metrics omitted, instead of fabricating zero-valued samples for a namespace that does not
+exist.
+""".
+t_namespaced_stats_unknown_ns_mt_not_started(TCConfig) ->
+    start_local(?FUNCTION_NAME, TCConfig, #{}),
+    AuthHeader = global_admin_auth_header(),
+    lists:foreach(
+        fun(Mode) ->
+            ct:pal("mode ~s", [Mode]),
+            {200, Res} = get_namespaced_stats(Mode, #{
+                auth_header => AuthHeader,
+                ns => <<"unknown_ns">>
+            }),
+            ?assertNot(is_map_key(<<"emqx_sessions_count">>, Res), Res),
+            ?assertNot(is_map_key(<<"emqx_authz_builtin_record_count">>, Res), Res),
+            ?assertNot(is_map_key(<<"emqx_authn_builtin_record_count">>, Res), Res),
+            ?assertNot(is_map_key(<<"emqx_bytes_received">>, Res), Res)
+        end,
+        ?PROM_DATA_MODES
+    ),
+    ok.
+
+-doc """
+Checks that requesting stats for a namespace name that was never created responds
+successfully with the namespaced metrics omitted, while metrics for a known namespace are
+still reported.
+""".
+t_namespaced_stats_unknown_ns(TCConfig) ->
+    start_local(?FUNCTION_NAME, TCConfig, #{
+        extra_apps => [
+            emqx_auth_mnesia,
+            emqx_auth,
+            emqx_mt
+        ]
+    }),
+    GetLabels = fun(Key, Res) -> lists:sort(maps:keys(maps:get(Key, Res, #{}))) end,
+    Ns1 = <<"ns1">>,
+    ok = emqx_mt_config:create_managed_ns(Ns1),
+    AuthHeader = global_admin_auth_header(),
+    lists:foreach(
+        fun(Mode) ->
+            ct:pal("mode ~s", [Mode]),
+            {200, UnknownRes} = get_namespaced_stats(Mode, #{
+                auth_header => AuthHeader,
+                ns => <<"unknown_ns">>
+            }),
+            ?assertNot(is_map_key(<<"emqx_sessions_count">>, UnknownRes), UnknownRes),
+            ?assertNot(
+                is_map_key(<<"emqx_authz_builtin_record_count">>, UnknownRes), UnknownRes
+            ),
+            ?assertNot(
+                is_map_key(<<"emqx_authn_builtin_record_count">>, UnknownRes), UnknownRes
+            ),
+            ?assertNot(is_map_key(<<"emqx_bytes_received">>, UnknownRes), UnknownRes),
+            %% The known namespace is still reported.
+            {200, KnownRes} = get_namespaced_stats(Mode, #{
+                auth_header => AuthHeader,
+                ns => Ns1
+            }),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns1}],
+                GetLabels(<<"emqx_sessions_count">>, KnownRes)
+            ),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns1}],
+                GetLabels(<<"emqx_authz_builtin_record_count">>, KnownRes)
+            ),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns1}],
+                GetLabels(<<"emqx_authn_builtin_record_count">>, KnownRes)
+            ),
+            ?assertMatch(
+                [#{<<"namespace">> := Ns1}],
+                GetLabels(<<"emqx_bytes_received">>, KnownRes)
+            )
+        end,
+        ?PROM_DATA_MODES
+    ),
+    ok.
+
+-doc """
 Regression test for the case where there is an action whose connector does not exist.
 
 This may arise if someone manually edits the configuration and starts up the node like that.

--- a/changes/ee/fix-18292.en.md
+++ b/changes/ee/fix-18292.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the `/prometheus/namespaced_stats` endpoint reported zero-valued metrics for a namespace that does not exist. When the requested namespace is not known, its metrics are now omitted from the output, consistent with the collection of metrics for all namespaces.


### PR DESCRIPTION
Release version:
6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:
6.1.0

## Summary

Fixes #18288. Follow-up to #18183.

The specific-namespace path of `/prometheus/namespaced_stats` (`?ns=<ns>`) fabricated zero-valued samples for namespaces that do not exist, while the all-namespaces path correctly omits them. A fabricated `0` is worse than an omitted sample: for a real namespace hitting a transient read error it looks like all sessions vanished (false alerts), and for an unknown namespace it invents a series that never existed. Omission means "no data", which is what Prometheus consumers expect.

Changes in `emqx_prometheus`:

* `gather_session_ns_data/1` (the reported bug): when `emqx_mt_state:count_clients/1` returns an error for the requested namespace, omit the namespace instead of emitting `emqx_sessions_count 0`.
* The `all` clause's `{error, _}` branch (namespace deleted concurrently during the fold) now also skips the namespace instead of reporting `0`, for consistency.
* `gather_authz_ns_data/1` / `gather_authn_ns_data/1` had the same defect: `record_count/1` returns `0` both for an unknown namespace and when the `emqx_auth_mnesia` tables are absent, so the specific-ns path fabricated `..._record_count 0`. They are now gated on `emqx_mt_state:is_known_ns/1`; known namespaces keep reporting their (possibly zero) record count.
* `metric_data_ns/3` specific-ns clause also fabricated `0` for every packet/message/delivery metric (`emqx_metrics:all/1` returns `[]` for a namespace with no counters, and the sample builder defaults missing keys to `0`). It now omits the namespace when no metrics counters exist for it, mirroring the `all` clause which only enumerates namespaces present in `emqx_metrics:all_ns/0`.

The all-namespaces collection path is untouched. Unknown namespaces still respond HTTP 200 with the metrics omitted (matching the all-namespaces path); returning 404 would be a behavior change beyond the issue's scope.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
