### PR TITLE
fix(sessds): tolerate concurrent session deletion on clean-start

### DIFF
--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_state_v2.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_state_v2.erl
@@ -330,7 +330,7 @@ delete(
         retries => trans_retries(),
         retry_interval => trans_retry_interval()
     },
-    {atomic, _, _} =
+    Result =
         emqx_ds:trans(
             Opts,
             fun() ->
@@ -339,7 +339,25 @@ delete(
                 emqx_ds_pmap:tx_delete_guard(ClientId)
             end
         ),
-    ok.
+    case Result of
+        {atomic, _, _} ->
+            ok;
+        {error, unrecoverable, {precondition_failed, Conflict}} ->
+            %% The session state was concurrently deleted, or it now
+            %% belongs to a newer incarnation of the client that must
+            %% not be deleted. Either way, there's nothing left to do:
+            ?tp(warning, ?sessds_drop_conflict, #{
+                id => ClientId, conflict => Conflict, channel => self()
+            }),
+            ok;
+        {error, Class, Reason} ->
+            error(
+                {failed_to_delete_session, #{
+                    id => ClientId,
+                    Class => Reason
+                }}
+            )
+    end.
 
 tx_del_session_data(ClientId) ->
     emqx_ds_pmap:tx_destroy(ClientId, ?top_metadata),

--- a/apps/emqx/src/emqx_tracepoints.hrl
+++ b/apps/emqx/src/emqx_tracepoints.hrl
@@ -47,6 +47,7 @@
 -define(sessds_sub_down, sessds_sub_down).
 
 -define(sessds_takeover_conflict, sessds_takeover_conflict).
+-define(sessds_drop_conflict, sessds_drop_conflict).
 
 -define(sessds_expired, sessds_expired).
 

--- a/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
@@ -947,6 +947,38 @@ t_state_commit_conflict(_Config) ->
         end
     ).
 
+%% @doc This testcase verifies that concurrent deletion of the same
+%% session state is idempotent: the actor that loses the race on the
+%% collection guard gets `ok' instead of crashing. This happens e.g.
+%% when a client reconnects with clean start while the previous
+%% channel is terminating and dropping the expired session.
+t_state_drop_conflict(init, Config) ->
+    start_local(?FUNCTION_NAME, Config).
+t_state_drop_conflict(_Config) ->
+    ?check_trace(
+        begin
+            Id = <<"clientid">>,
+            %% Create and commit a session:
+            S0 = emqx_persistent_session_ds_state:create_new(Id),
+            _ = emqx_persistent_session_ds_state:commit(S0, #{lifetime => new, sync => true}),
+            %% Two actors open the same state, as happens when a
+            %% clean-start reconnect and the terminating old channel
+            %% both drop the session:
+            {ok, A} = emqx_persistent_session_ds_state:open(Id),
+            {ok, B} = emqx_persistent_session_ds_state:open(Id),
+            %% A wins the race:
+            ?assertEqual(ok, emqx_persistent_session_ds_state:delete(A)),
+            %% B loses, but the deletion is idempotent:
+            ?assertEqual(ok, emqx_persistent_session_ds_state:delete(B)),
+            %% The session is gone:
+            ?assertEqual(undefined, emqx_persistent_session_ds_state:open(Id)),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([_], ?of_kind(?sessds_drop_conflict, Trace))
+        end
+    ).
+
 t_fuzz(init, Config) ->
     start_local(?FUNCTION_NAME, Config).
 t_fuzz(_Config) ->

--- a/changes/ee/fix-18294.en.md
+++ b/changes/ee/fix-18294.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where a client reconnecting with clean start could get disconnected right after connecting if the broker was still cleaning up the client's previous durable (persistent) session. Concurrent session cleanup is now handled gracefully.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:
6.0.0

## Summary

Fixes a race where a clean-start reconnect could crash the new connection while the previous durable session was being cleaned up concurrently.

`emqx_cm:do_open_session(_CleanStart = true, ...)` discards the old channel and destroys the session under the CM locker lock, but the discarded channel terminates asynchronously outside that lock and (with session expiry interval 0) drops the same DS session. Both drops open the session state and read the same collection guard; the winner's transaction deletes the guard, so the loser's `emqx_ds_pmap:tx_assert_guard/2` precondition fails, and the `{atomic, _, _}` badmatch in `emqx_persistent_session_ds_state_v2:delete/2` crashed the connecting client's connection process (client saw `tcp_closed`). Surfaced in CI as `emqx_takeover_SUITE` `persistence_enabled.mqttv5.t_takeover_willmsg_clean_session` hanging until the 120 s timetrap.

The fix tolerates `{error, unrecoverable, {precondition_failed, _}}` inside `emqx_persistent_session_ds_state_v2:delete/2`: a guard mismatch there means the state was concurrently deleted, or now belongs to a newer incarnation of the client whose data must not be deleted — in both cases not deleting is correct for any caller, so the source of the transaction is the precise place to handle it (rather than catching at the `session_drop/2` call site). This mirrors the existing idiom in `commit/3`, which tolerates `precondition_failed` for `lifetime => terminate` with a warning trace point. The tolerated path emits a new `?sessds_drop_conflict` trace point; other transaction errors now raise a descriptive `failed_to_delete_session` error instead of a bare badmatch.

New test `t_state_drop_conflict` in `emqx_persistent_session_ds_SUITE` reproduces the loser's view deterministically (two actors open the same state, both delete) and asserts idempotency plus the trace point.

Possible follow-up (out of scope here): `emqx_takeover_SUITE`'s `start_client_async_subscribe` helper hangs until the timetrap when the client crashes mid-case; it could fail fast instead.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
