### PR TITLE
fix(bigtable): apply configured ssl options to outbound gRPC connections

### DIFF
--- a/apps/emqx_bridge_bigtable/src/emqx_bridge_bigtable_client.erl
+++ b/apps/emqx_bridge_bigtable/src/emqx_bridge_bigtable_client.erl
@@ -79,7 +79,7 @@ start(ConnResId, Opts0) ->
     maybe
         {ok, AuthCtx} ?=
             emqx_bridge_gcp_pubsub_client:maybe_initialize_auth_resources(ConnResId, Opts),
-        GRPCOpts = #{pool_size => PoolSize},
+        GRPCOpts = #{pool_size => PoolSize, gun_opts => gun_opts(URL, Opts0)},
         {ok, #{recv_pool := Pool}} ?= ensure_channel_pool(ConnResId, URL, GRPCOpts),
         State = AuthCtx#{recv_pool => Pool},
         {ok, State}
@@ -195,6 +195,20 @@ do_ping_and_warm_impl(Req, Metadata, Opts) ->
         Metadata,
         Opts
     ).
+
+gun_opts(URL, ConnConfig) ->
+    case uri_string:parse(URL) of
+        #{scheme := <<"https">>} ->
+            SSLConfig = maps:get(ssl, ConnConfig, #{}),
+            %% An `https' URL mandates TLS: force it on regardless of `ssl.enable',
+            %% while honouring the rest of the configured `ssl' options.
+            #{
+                transport => ssl,
+                tls_opts => emqx_tls_lib:to_client_opts(SSLConfig#{enable => true})
+            };
+        _ ->
+            #{transport => tcp}
+    end.
 
 ensure_channel_pool(ConnResId, URL, GRPCOpts0) ->
     #{pool_size := PoolSize} = GRPCOpts0,

--- a/apps/emqx_bridge_bigtable/src/emqx_bridge_bigtable_connector_schema.erl
+++ b/apps/emqx_bridge_bigtable/src/emqx_bridge_bigtable_connector_schema.erl
@@ -70,8 +70,11 @@ fields(connector_config) ->
 %% default: connections to the default endpoint are verified against the OS CA bundle.
 ssl_fields() ->
     [
-        {ssl, SC#{default => #{<<"enable">> => true, <<"verify">> => <<"verify_peer">>}}}
-     || {ssl, SC} <- emqx_connector_schema_lib:ssl_fields()
+        {ssl, #{
+            type => hoconsc:ref(emqx_schema, "ssl_client_opts"),
+            default => #{<<"enable">> => true, <<"verify">> => <<"verify_peer">>},
+            desc => ?DESC(emqx_connector_schema_lib, "ssl")
+        }}
     ].
 
 desc("config_connector") ->

--- a/apps/emqx_bridge_bigtable/src/emqx_bridge_bigtable_connector_schema.erl
+++ b/apps/emqx_bridge_bigtable/src/emqx_bridge_bigtable_connector_schema.erl
@@ -63,8 +63,16 @@ fields(connector_config) ->
         {pool_size, mk(pos_integer(), #{default => 8, desc => ?DESC("pool_size")})},
         emqx_bridge_gcp_pubsub_schema_lib:authentication_field()
     ] ++
-        emqx_connector_schema_lib:ssl_fields(#{enable_by_default => true}) ++
+        ssl_fields() ++
         emqx_connector_schema:resource_opts().
+
+%% Same as `emqx_connector_schema_lib:ssl_fields/1', with peer verification on by
+%% default: connections to the default endpoint are verified against the OS CA bundle.
+ssl_fields() ->
+    [
+        {ssl, SC#{default => #{<<"enable">> => true, <<"verify">> => <<"verify_peer">>}}}
+     || {ssl, SC} <- emqx_connector_schema_lib:ssl_fields()
+    ].
 
 desc("config_connector") ->
     ?DESC("config_connector");

--- a/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
+++ b/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
@@ -649,21 +649,20 @@ t_tls_verify_none_without_certfiles(TCConfig) when is_list(TCConfig) ->
     end).
 
 -doc """
-Ensure TLS connector still rejects empty cert file paths when verify is `verify_peer`.
+Blank cert file paths are treated as unset, so the connector is created even with
+`verify_peer`; this driver then refuses to start without `cacertfile`, `certfile`
+and `keyfile`, leaving the connector disconnected with a clear reason.
 """.
-t_tls_verify_peer_with_empty_certfiles_rejected() ->
+t_tls_verify_peer_with_empty_certfiles_disconnected() ->
     [{matrix, true}].
-t_tls_verify_peer_with_empty_certfiles_rejected(matrix) ->
+t_tls_verify_peer_with_empty_certfiles_disconnected(matrix) ->
     [[?tls, ?sync, ?without_batch]];
-t_tls_verify_peer_with_empty_certfiles_rejected(TCConfig) when is_list(TCConfig) ->
+t_tls_verify_peer_with_empty_certfiles_disconnected(TCConfig) when is_list(TCConfig) ->
     maybe_with_forced_sync_query_mode(TCConfig, fun() ->
-        ?assertMatch(
-            {400, #{
-                <<"code">> := <<"BAD_REQUEST">>,
-                <<"message">> := #{
-                    <<"reason">> := <<"bad_ssl_config">>
-                }
-            }},
+        {201, #{
+            <<"status">> := <<"disconnected">>,
+            <<"status_reason">> := Reason
+        }} =
             create_connector_api(TCConfig, #{
                 <<"server">> => <<"toxiproxy:4003">>,
                 <<"ssl">> => #{
@@ -673,7 +672,11 @@ t_tls_verify_peer_with_empty_certfiles_rejected(TCConfig) when is_list(TCConfig)
                     <<"certfile">> => <<>>,
                     <<"keyfile">> => <<>>
                 }
-            })
+            }),
+        ?assertMatch(
+            {match, _},
+            re:run(Reason, <<"cacertfile, certfile and keyfile SSL options must be configured">>),
+            #{status_reason => Reason}
         ),
         ok
     end).

--- a/apps/emqx_connector/src/emqx_connector_ssl.erl
+++ b/apps/emqx_connector/src/emqx_connector_ssl.erl
@@ -44,7 +44,7 @@ convert_oauth2_certs(_RltvDir, Config) ->
     {ok, Config}.
 
 new_ssl_config(RltvDir, Config, SSL) ->
-    SanitizedSSL = maybe_drop_blank_certs_for_verify_none(SSL),
+    SanitizedSSL = drop_blank_certs(SSL),
     case emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir(RltvDir, SanitizedSSL) of
         {ok, NewSSL} ->
             {ok, new_ssl_config(Config, NewSSL)};
@@ -63,44 +63,16 @@ new_ssl_config(#{<<"ssl">> := _} = Config, NewSSL) ->
 new_ssl_config(Config, _NewSSL) ->
     Config.
 
-maybe_drop_blank_certs_for_verify_none(SSL) ->
-    case normalize_verify(get_ssl_verify(SSL)) of
-        verify_none ->
-            maps:filter(
-                fun(K, V) ->
-                    not (is_cert_key(K) andalso is_blank_or_undefined(V))
-                end,
-                SSL
-            );
-        _ ->
-            SSL
-    end.
-
-get_ssl_verify(SSL) ->
-    case maps:find(verify, SSL) of
-        {ok, Verify} ->
-            Verify;
-        error ->
-            case maps:find(<<"verify">>, SSL) of
-                {ok, Verify} -> Verify;
-                error -> undefined
-            end
-    end.
-
-normalize_verify(verify_none) ->
-    verify_none;
-normalize_verify(<<"verify_none">>) ->
-    verify_none;
-normalize_verify("verify_none") ->
-    verify_none;
-normalize_verify(verify_peer) ->
-    verify_peer;
-normalize_verify(<<"verify_peer">>) ->
-    verify_peer;
-normalize_verify("verify_peer") ->
-    verify_peer;
-normalize_verify(_) ->
-    undefined.
+%% Blank cert paths mean "not configured": client certificates are optional
+%% regardless of `verify', and a blank `cacertfile' is allowed even with
+%% `verify_peer' (see `ALLOW_EMPTY_PEM' in `emqx_tls_lib').
+drop_blank_certs(SSL) ->
+    maps:filter(
+        fun(K, V) ->
+            not (is_cert_key(K) andalso is_blank_or_undefined(V))
+        end,
+        SSL
+    ).
 
 is_cert_key(cacertfile) ->
     true;
@@ -175,7 +147,7 @@ convert_certs_verify_none_blank_paths_pass_test() ->
         convert_certs("dummy-connector", Config)
     ).
 
-maybe_drop_blank_certs_for_verify_none_with_atom_keys_test() ->
+drop_blank_certs_with_atom_keys_test() ->
     SSL = #{
         enable => true,
         verify => verify_none,
@@ -188,10 +160,10 @@ maybe_drop_blank_certs_for_verify_none_with_atom_keys_test() ->
             enable => true,
             verify => verify_none
         },
-        maybe_drop_blank_certs_for_verify_none(SSL)
+        drop_blank_certs(SSL)
     ).
 
-maybe_drop_blank_certs_for_verify_none_with_binary_keys_test() ->
+drop_blank_certs_with_binary_keys_test() ->
     SSL = #{
         <<"enable">> => true,
         <<"verify">> => <<"verify_none">>,
@@ -204,10 +176,10 @@ maybe_drop_blank_certs_for_verify_none_with_binary_keys_test() ->
             <<"enable">> => true,
             <<"verify">> => <<"verify_none">>
         },
-        maybe_drop_blank_certs_for_verify_none(SSL)
+        drop_blank_certs(SSL)
     ).
 
-convert_certs_verify_peer_blank_paths_fail_test() ->
+convert_certs_verify_peer_blank_paths_pass_test() ->
     Config = #{
         ssl => #{
             enable => true,
@@ -218,7 +190,12 @@ convert_certs_verify_peer_blank_paths_fail_test() ->
         }
     },
     ?assertMatch(
-        {error, #{reason := <<"bad_ssl_config">>}},
+        {ok, #{
+            ssl := #{verify := verify_peer} = SSL
+        }} when
+            not is_map_key(cacertfile, SSL) andalso
+                not is_map_key(certfile, SSL) andalso
+                not is_map_key(keyfile, SSL),
         convert_certs("dummy-connector", Config)
     ).
 

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -465,8 +465,8 @@ test_configure(Uri, Config) ->
         } when not is_map_key(<<"password">>, SSL),
         GetConfigJson
     ),
-    ?assertMatch(
-        {ok, 400, _},
+    %% A blank keyfile is treated as unset and dropped from the config.
+    {ok, 200, BlankKeyfileConfigJson} =
         request_json(
             put,
             Uri,
@@ -485,7 +485,25 @@ test_configure(Uri, Config) ->
                 }
             },
             Config
-        )
+        ),
+    ?assertMatch(
+        #{
+            <<"storage">> := #{
+                <<"local">> := #{
+                    <<"exporter">> := #{
+                        <<"s3">> := #{
+                            <<"transport_options">> := #{
+                                <<"ssl">> := BlankKeyfileSSL = #{
+                                    <<"enable">> := true,
+                                    <<"certfile">> := <<"/", _/bytes>>
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } when not is_map_key(<<"keyfile">>, BlankKeyfileSSL),
+        BlankKeyfileConfigJson
     ),
     ?assertMatch(
         {ok, 200, #{}},

--- a/changes/ee/fix-18300.en.md
+++ b/changes/ee/fix-18300.en.md
@@ -1,0 +1,1 @@
+Blank certificate file fields in a connector's TLS settings are now treated as not configured regardless of the `verify` mode. Previously, blank client certificate fields were rejected with a validation error when `verify` was set to `verify_peer`, although client certificates are optional for peer verification.


### PR DESCRIPTION
Release version:
6.3.0

Introduced in:
N/A (Bigtable connector has only shipped in 6.3.0 betas)

## Summary

Split out of #18299 (now retargeted at `dev-60` with the Snowflake fix only), from the audit of connectors whose schema exposes an `ssl` block that the implementation ignores.

- **Bigtable**: the connector schema exposes the standard `ssl` block, but the gRPC channel was started without any transport options — gun decided the transport by port and used its own TLS defaults, so every configured `ssl` field was silently ignored. The config is now threaded into gun's `transport`/`tls_opts`, keyed off the (hidden) `url` scheme: `https` forces TLS on and applies `emqx_tls_lib:to_client_opts/1`; `http` (emulator/testing) connects over TCP. The schema default for `verify` becomes `verify_peer`, codifying what the connector effectively did before the fix (gun injects the OS CA bundle; OTP defaults to peer verification); the endpoint is fixed at `bigtable.googleapis.com` (public CAs), so verification works with zero configuration. **Schema change**: default only; all fields remain user-settable.
- **Shared connector cert sanitation** (`emqx_connector_ssl`): blank `certfile`/`keyfile`/`cacertfile` values are now dropped as "not configured" regardless of the `verify` mode. Previously blank client-cert fields were rejected with `pem_file_path_or_string_is_required` when `verify = verify_peer`, although client certificates are orthogonal to peer verification (blank `cacertfile` was already allowed via `ALLOW_EMPTY_PEM`). This also makes the new Bigtable `verify_peer` default safe for dashboard-submitted configs that contain blank cert fields.

Validated with the module eunit tests and the full `emqx_bridge_bigtable_SUITE` docker CT run (34/34, gcp emulator via `http://` exercising the TCP path).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
