### PR TITLE
fix(es): url-encode index and id when composing request path

### DIFF
--- a/apps/emqx_bridge_es/src/emqx_bridge_es.app.src
+++ b/apps/emqx_bridge_es/src/emqx_bridge_es.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_es, [
     {description, "EMQX Enterprise Elastic Search Bridge"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {modules, [
         emqx_bridge_es,
         emqx_bridge_es_connector

--- a/apps/emqx_bridge_es/src/emqx_bridge_es_connector.erl
+++ b/apps/emqx_bridge_es/src/emqx_bridge_es_connector.erl
@@ -38,7 +38,7 @@
     connector_example_values/0
 ]).
 
--export([render_template/2]).
+-export([render_template/3]).
 -export([convert_server/2]).
 
 %% emqx_connector_resource behaviour callbacks
@@ -71,13 +71,8 @@
 
 -define(CONNECTOR_TYPE, elasticsearch).
 
-%% Literal prefix tagging the request-path template handed to the HTTP
-%% connector, so `render_template/2' can tell it apart from the body
-%% template and URL-encode the interpolated values.
--define(PATH_TEMPLATE_TAG, "__path_template__:").
-
 -ifdef(TEST).
--export([path_template/1]).
+-export([path/1]).
 -endif.
 
 %%-------------------------------------------------------------------------------------
@@ -314,13 +309,13 @@ on_add_channel(
             {error, already_exists};
         _ ->
             Parameter1 = Parameter#{
-                path => path_template(Parameter),
+                path => path(Parameter),
                 method => method(Parameter),
                 body => get_body_template(Parameter)
             },
             ChannelConfig = #{
                 parameters => Parameter1,
-                render_template_func => fun ?MODULE:render_template/2
+                render_template_func => fun ?MODULE:render_template/3
             },
             {ok, State} = emqx_bridge_http_connector:on_add_channel(
                 InstanceId, State0, ChannelId, ChannelConfig
@@ -346,17 +341,17 @@ on_get_channel_status(_InstanceId, ChannelId, #{channels := Channels}) ->
             {error, not_exists}
     end.
 
-render_template([<<"update_without_doc_template">>], Msg) ->
+render_template(_RenderContext, [<<"update_without_doc_template">>], Msg) ->
     emqx_utils_json:encode(#{<<"doc">> => Msg});
-render_template([<<"create_without_doc_template">>], Msg) ->
+render_template(_RenderContext, [<<"create_without_doc_template">>], Msg) ->
     emqx_utils_json:encode(#{<<"doc">> => Msg, <<"doc_as_upsert">> => true});
-render_template([<<?PATH_TEMPLATE_TAG, First/binary>> | Template], Msg) ->
-    %% Request-path template: URL-encode interpolated values so each one
-    %% stays within its path segment; literal template text is untouched.
+render_template(path, Template, Msg) ->
+    %% URL-encode interpolated values so each one stays within its path
+    %% segment; literal template text is untouched.
     Opts = #{var_trans => fun to_urlencoded_string/2},
-    {String, _Errors} = emqx_template:render([First | Template], {emqx_jsonish, Msg}, Opts),
+    {String, _Errors} = emqx_template:render(Template, {emqx_jsonish, Msg}, Opts),
     String;
-render_template(Template, Msg) ->
+render_template(_RenderContext, Template, Msg) ->
     % Ignoring errors here, undefined bindings will be replaced with empty string.
     Opts = #{var_trans => fun to_string/2},
     {String, _Errors} = emqx_template:render(Template, {emqx_jsonish, Msg}, Opts),
@@ -369,15 +364,17 @@ render_template(Template, Msg) ->
 to_string(Name, Value) ->
     emqx_template:to_string(render_var(Name, Value)).
 to_urlencoded_string(Name, Value) ->
-    uri_string:quote(to_string(Name, Value)).
+    try
+        uri_string:quote(to_string(Name, Value))
+    catch
+        throw:{error, Reason, _} ->
+            error({failed_to_urlencode_path_value, Name, Reason})
+    end.
 render_var(_, undefined) ->
     % NOTE Any allowed but undefined binding will be replaced with empty string
     <<>>;
 render_var(_Name, Value) ->
     Value.
-path_template(Parameter) ->
-    [?PATH_TEMPLATE_TAG, path(Parameter)].
-
 %% delete DELETE /<index>/_doc/<_id>
 path(#{action := delete, id := Id, index := Index} = Action) ->
     BasePath = ["/", Index, "/_doc/", Id],

--- a/apps/emqx_bridge_es/src/emqx_bridge_es_connector.erl
+++ b/apps/emqx_bridge_es/src/emqx_bridge_es_connector.erl
@@ -71,6 +71,15 @@
 
 -define(CONNECTOR_TYPE, elasticsearch).
 
+%% Literal prefix tagging the request-path template handed to the HTTP
+%% connector, so `render_template/2' can tell it apart from the body
+%% template and URL-encode the interpolated values.
+-define(PATH_TEMPLATE_TAG, "__path_template__:").
+
+-ifdef(TEST).
+-export([path_template/1]).
+-endif.
+
 %%-------------------------------------------------------------------------------------
 %% connector examples
 %%-------------------------------------------------------------------------------------
@@ -305,7 +314,7 @@ on_add_channel(
             {error, already_exists};
         _ ->
             Parameter1 = Parameter#{
-                path => path(Parameter),
+                path => path_template(Parameter),
                 method => method(Parameter),
                 body => get_body_template(Parameter)
             },
@@ -341,6 +350,12 @@ render_template([<<"update_without_doc_template">>], Msg) ->
     emqx_utils_json:encode(#{<<"doc">> => Msg});
 render_template([<<"create_without_doc_template">>], Msg) ->
     emqx_utils_json:encode(#{<<"doc">> => Msg, <<"doc_as_upsert">> => true});
+render_template([<<?PATH_TEMPLATE_TAG, First/binary>> | Template], Msg) ->
+    %% Request-path template: URL-encode interpolated values so each one
+    %% stays within its path segment; literal template text is untouched.
+    Opts = #{var_trans => fun to_urlencoded_string/2},
+    {String, _Errors} = emqx_template:render([First | Template], {emqx_jsonish, Msg}, Opts),
+    String;
 render_template(Template, Msg) ->
     % Ignoring errors here, undefined bindings will be replaced with empty string.
     Opts = #{var_trans => fun to_string/2},
@@ -353,11 +368,16 @@ render_template(Template, Msg) ->
 
 to_string(Name, Value) ->
     emqx_template:to_string(render_var(Name, Value)).
+to_urlencoded_string(Name, Value) ->
+    uri_string:quote(to_string(Name, Value)).
 render_var(_, undefined) ->
     % NOTE Any allowed but undefined binding will be replaced with empty string
     <<>>;
 render_var(_Name, Value) ->
     Value.
+path_template(Parameter) ->
+    [?PATH_TEMPLATE_TAG, path(Parameter)].
+
 %% delete DELETE /<index>/_doc/<_id>
 path(#{action := delete, id := Id, index := Index} = Action) ->
     BasePath = ["/", Index, "/_doc/", Id],

--- a/apps/emqx_bridge_es/test/emqx_bridge_es_connector_tests.erl
+++ b/apps/emqx_bridge_es/test/emqx_bridge_es_connector_tests.erl
@@ -96,30 +96,42 @@ path_render_unicode_test() ->
         render_path(#{action => create, index => <<"${payload.index}">>}, Msg)
     ).
 
+%% A value that cannot be URL-encoded (not valid unicode) fails the
+%% render with a descriptive error.
+path_render_invalid_unicode_test() ->
+    Msg = #{<<"payload">> => #{<<"index">> => <<255, 254, 1>>}},
+    ?assertError(
+        {failed_to_urlencode_path_value, "payload.index", _},
+        render_path(#{action => create, index => <<"${payload.index}">>}, Msg)
+    ).
+
 %% The request body is rendered by the same function; it must remain
 %% byte-identical, without URL-encoding.
 body_render_unchanged_test_() ->
     [
         ?_assertEqual(
             <<"{\"a\":\"x#y/z ?\"}">>,
-            render(emqx_template:parse(<<"${payload.doc}">>), ?MSG)
+            render(body, emqx_template:parse(<<"${payload.doc}">>), ?MSG)
         ),
         ?_assertEqual(
             <<"{\"doc\":{\"a\":\"x#y/z ?\"}}">>,
-            render(emqx_template:parse(<<"{\"doc\":${payload.doc}}">>), ?MSG)
+            render(body, emqx_template:parse(<<"{\"doc\":${payload.doc}}">>), ?MSG)
         ),
         ?_assertEqual(
             emqx_utils_json:encode(#{<<"doc">> => ?MSG}),
-            render([<<"update_without_doc_template">>], ?MSG)
+            render(body, [<<"update_without_doc_template">>], ?MSG)
         )
     ].
 
 %% Renders a path exactly as `emqx_bridge_http_connector' does: the
 %% template built at channel creation is parsed with
-%% `emqx_template:parse/1' and rendered with `render_template/2'.
+%% `emqx_template:parse/1' and rendered with `render_template/3' in
+%% the `path' render context.
 render_path(Parameter, Msg) ->
-    PathTemplate = emqx_bridge_es_connector:path_template(Parameter),
-    render(emqx_template:parse(PathTemplate), Msg).
+    PathTemplate = emqx_bridge_es_connector:path(Parameter),
+    render(path, emqx_template:parse(PathTemplate), Msg).
 
-render(Template, Msg) ->
-    unicode:characters_to_binary(emqx_bridge_es_connector:render_template(Template, Msg)).
+render(RenderContext, Template, Msg) ->
+    unicode:characters_to_binary(
+        emqx_bridge_es_connector:render_template(RenderContext, Template, Msg)
+    ).

--- a/apps/emqx_bridge_es/test/emqx_bridge_es_connector_tests.erl
+++ b/apps/emqx_bridge_es/test/emqx_bridge_es_connector_tests.erl
@@ -1,0 +1,125 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_es_connector_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(MSG, #{
+    <<"payload">> => #{
+        <<"index">> => <<"a#b/c d">>,
+        <<"id">> => <<"i#1/2">>,
+        <<"routing">> => <<"r/1">>,
+        <<"doc">> => <<"{\"a\":\"x#y/z ?\"}">>
+    }
+}).
+
+%% Interpolated `index'/`id'/`routing' values are URL-encoded when the
+%% request path is rendered, so URL-significant characters stay within
+%% their path segment.
+path_render_urlencodes_values_test_() ->
+    [
+        ?_assertEqual(
+            <<"/a%23b%2Fc%20d/_doc/i%231%2F2?routing=r%2F1">>,
+            render_path(
+                #{
+                    action => delete,
+                    index => <<"${payload.index}">>,
+                    id => <<"${payload.id}">>,
+                    routing => <<"${payload.routing}">>
+                },
+                ?MSG
+            )
+        ),
+        ?_assertEqual(
+            <<"/a%23b%2Fc%20d/_update/i%231%2F2">>,
+            render_path(
+                #{
+                    action => update,
+                    index => <<"${payload.index}">>,
+                    id => <<"${payload.id}">>
+                },
+                ?MSG
+            )
+        ),
+        ?_assertEqual(
+            <<"/a%23b%2Fc%20d/_doc/i%231%2F2">>,
+            render_path(
+                #{
+                    action => create,
+                    index => <<"${payload.index}">>,
+                    id => <<"${payload.id}">>
+                },
+                ?MSG
+            )
+        ),
+        ?_assertEqual(
+            <<"/a%23b%2Fc%20d/_doc/">>,
+            render_path(
+                #{action => create, index => <<"${payload.index}">>},
+                ?MSG
+            )
+        )
+    ].
+
+%% Ordinary index/id values render exactly as before, whether templated
+%% or configured as literals.
+path_render_plain_values_unchanged_test_() ->
+    Msg = #{<<"payload">> => #{<<"index">> => <<"devices">>, <<"id">> => <<"42">>}},
+    [
+        ?_assertEqual(
+            <<"/devices/_doc/42">>,
+            render_path(
+                #{
+                    action => create,
+                    index => <<"${payload.index}">>,
+                    id => <<"${payload.id}">>
+                },
+                Msg
+            )
+        ),
+        ?_assertEqual(
+            <<"/devices/_doc/42">>,
+            render_path(
+                #{action => create, index => <<"devices">>, id => <<"42">>},
+                Msg
+            )
+        )
+    ].
+
+%% Non-ASCII values are percent-encoded as UTF-8 within the path.
+path_render_unicode_test() ->
+    Msg = #{<<"payload">> => #{<<"index">> => <<"日志"/utf8>>}},
+    ?assertEqual(
+        <<"/%E6%97%A5%E5%BF%97/_doc/">>,
+        render_path(#{action => create, index => <<"${payload.index}">>}, Msg)
+    ).
+
+%% The request body is rendered by the same function; it must remain
+%% byte-identical, without URL-encoding.
+body_render_unchanged_test_() ->
+    [
+        ?_assertEqual(
+            <<"{\"a\":\"x#y/z ?\"}">>,
+            render(emqx_template:parse(<<"${payload.doc}">>), ?MSG)
+        ),
+        ?_assertEqual(
+            <<"{\"doc\":{\"a\":\"x#y/z ?\"}}">>,
+            render(emqx_template:parse(<<"{\"doc\":${payload.doc}}">>), ?MSG)
+        ),
+        ?_assertEqual(
+            emqx_utils_json:encode(#{<<"doc">> => ?MSG}),
+            render([<<"update_without_doc_template">>], ?MSG)
+        )
+    ].
+
+%% Renders a path exactly as `emqx_bridge_http_connector' does: the
+%% template built at channel creation is parsed with
+%% `emqx_template:parse/1' and rendered with `render_template/2'.
+render_path(Parameter, Msg) ->
+    PathTemplate = emqx_bridge_es_connector:path_template(Parameter),
+    render(emqx_template:parse(PathTemplate), Msg).
+
+render(Template, Msg) ->
+    unicode:characters_to_binary(emqx_bridge_es_connector:render_template(Template, Msg)).

--- a/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_http, [
     {description, "EMQX HTTP Bridge and Connector Application"},
-    {vsn, "0.3.11"},
+    {vsn, "0.3.12"},
     {registered, []},
     {applications, [kernel, stdlib, emqx_resource, ehttpc]},
     {env, [

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
@@ -43,7 +43,7 @@
 ]).
 
 -export([reply_delegator/3]).
--export([render_template/2]).
+-export([render_template/2, render_template/3]).
 
 -export([
     roots/0,
@@ -275,7 +275,7 @@ on_add_channel(
 ) ->
     InstalledActions = maps:get(installed_actions, OldState, #{}),
     {ok, ActionState} = do_create_http_action(ActionConfig),
-    RenderTmplFunc = maps:get(render_template_func, ActionConfig, fun ?MODULE:render_template/2),
+    RenderTmplFunc = maps:get(render_template_func, ActionConfig, fun ?MODULE:render_template/3),
     ActionState1 = ActionState#{render_template_func => RenderTmplFunc},
     NewInstalledActions = maps:put(ActionId, ActionState1, InstalledActions),
     NewState = maps:put(installed_actions, NewInstalledActions, OldState),
@@ -709,7 +709,7 @@ drop_ehttpc_worker_down_call_args({ehttpc_worker_down, _}) ->
     ehttpc_worker_down.
 
 render_headers(HeadersTemplate) ->
-    RenderTemplateFn = fun render_template/2,
+    RenderTemplateFn = fun render_template/3,
     render_headers(HeadersTemplate, RenderTemplateFn, _Msg = #{}).
 
 %%--------------------------------------------------------------------
@@ -786,9 +786,9 @@ parse_template(String) ->
 process_request_and_action(Request, ActionState, Msg) ->
     MethodTemplate = maps:get(method, ActionState),
     RenderTmplFunc = maps:get(render_template_func, ActionState),
-    Method = make_method(render_template_string(MethodTemplate, RenderTmplFunc, Msg)),
-    PathPrefix = unicode:characters_to_list(RenderTmplFunc(maps:get(path, Request), Msg)),
-    PathSuffix = unicode:characters_to_list(RenderTmplFunc(maps:get(path, ActionState), Msg)),
+    Method = make_method(render_template_string(method, MethodTemplate, RenderTmplFunc, Msg)),
+    PathPrefix = unicode:characters_to_list(RenderTmplFunc(path, maps:get(path, Request), Msg)),
+    PathSuffix = unicode:characters_to_list(RenderTmplFunc(path, maps:get(path, ActionState), Msg)),
 
     Path =
         case PathSuffix of
@@ -828,10 +828,12 @@ process_request(
     } = Conf,
     Msg
 ) ->
-    RenderTemplateFun = fun render_template/2,
+    RenderTemplateFun = fun render_template/3,
     Conf#{
-        method => make_method(render_template_string(MethodTemplate, RenderTemplateFun, Msg)),
-        path => unicode:characters_to_list(RenderTemplateFun(PathTemplate, Msg)),
+        method => make_method(
+            render_template_string(method, MethodTemplate, RenderTemplateFun, Msg)
+        ),
+        path => unicode:characters_to_list(RenderTemplateFun(path, PathTemplate, Msg)),
         body => render_request_body(BodyTemplate, RenderTemplateFun, Msg),
         headers => render_headers(HeadersTemplate, RenderTemplateFun, Msg),
         request_timeout => ReqTimeout
@@ -840,13 +842,13 @@ process_request(
 render_request_body(undefined, _, Msg) ->
     emqx_utils_json:encode(Msg);
 render_request_body(BodyTks, RenderTmplFunc, Msg) ->
-    RenderTmplFunc(BodyTks, Msg).
+    RenderTmplFunc(body, BodyTks, Msg).
 
 render_headers(HeaderTks, RenderTmplFunc, Msg) ->
     lists:filtermap(
         fun({KTks, VTks}) ->
-            K = render_template_string(KTks, RenderTmplFunc, Msg),
-            V = render_template_string(emqx_secret:unwrap(VTks), RenderTmplFunc, Msg),
+            K = render_template_string(header, KTks, RenderTmplFunc, Msg),
+            V = render_template_string(header, emqx_secret:unwrap(VTks), RenderTmplFunc, Msg),
             case safe_http_header(K, V) of
                 true ->
                     {true, {K, V}};
@@ -882,8 +884,13 @@ render_template(Template, Msg) ->
     {String, _Errors} = emqx_template:render(Template, {emqx_jsonish, Msg}),
     String.
 
-render_template_string(Template, RenderTmplFunc, Msg) ->
-    unicode:characters_to_binary(RenderTmplFunc(Template, Msg)).
+%% The `render_template_func' contract: the first argument tells the render
+%% function which part of the request is being rendered.
+render_template(_RenderContext, Template, Msg) ->
+    render_template(Template, Msg).
+
+render_template_string(RenderContext, Template, RenderTmplFunc, Msg) ->
+    unicode:characters_to_binary(RenderTmplFunc(RenderContext, Template, Msg)).
 
 make_method(M) when M == <<"POST">>; M == <<"post">> -> post;
 make_method(M) when M == <<"PUT">>; M == <<"put">> -> put;
@@ -1104,7 +1111,7 @@ drop_unsafe_headers_test() ->
         <<"good">> => <<"alice">>,
         <<"tns">> => <<"alice\r\nX-Override: allow">>
     },
-    Rendered = render_headers(HeadersTemplate, fun render_template/2, Msg),
+    Rendered = render_headers(HeadersTemplate, fun render_template/3, Msg),
     Names = [K || {K, _} <- Rendered],
     ?assert(lists:member(<<"x-clean">>, Names)),
     ?assertNot(lists:member(<<"x-tns">>, Names)).

--- a/changes/ee/fix-18301.en.md
+++ b/changes/ee/fix-18301.en.md
@@ -1,0 +1,1 @@
+Elasticsearch action `index` and `id` values are now URL-encoded when composing the request path, so characters such as `#` or `/` in a templated value are treated as literal text within a single path segment instead of altering the request target. The JSON request body is not affected.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

The Elasticsearch action composes the outbound request path by concatenating the rendered `index` and `id` values verbatim. When these fields are templated (e.g. `index = "${payload.index}"`), a rendered value containing URL-significant characters such as `#`, `/`, `?` or whitespace reshaped the composed path, so the request could target a different endpoint than the configured action.

The request-path template is now rendered with a variable transform that percent-encodes each interpolated value (`uri_string:quote/1`), mirroring `emqx_auth_template:render_urlencoded_str/2`: literal template text (`/_doc/`, `/_update/`) is untouched and only interpolated values are encoded, so ordinary index names are unchanged on the wire and every currently-working configuration keeps working. Encoding was preferred over rejecting unexpected characters for that reason.

Since the same render function also renders the JSON request body (which must stay byte-identical), the path template is tagged with a literal prefix when handed to the HTTP connector, and the tag selects the URL-encoding transform at render time.

Covered by a new docker-free eunit module exercising the exact parse/render pipeline the HTTP connector uses: all four action variants (delete / update / create with and without id), plain and non-ASCII values, and body-rendering invariance.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)