### PR TITLE
fix(postgresql): reject non-ASCII application names

### DIFF
--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -113,13 +113,20 @@ validate_application_name_binary(ApplicationName) when is_binary(ApplicationName
     case binary:match(ApplicationName, <<0>>) of
         {_, _} ->
             {error, application_name_cannot_contain_null_byte};
-        nomatch when byte_size(ApplicationName) =< ?MAX_APPLICATION_NAME_BYTES ->
-            ok;
+        nomatch when byte_size(ApplicationName) > ?MAX_APPLICATION_NAME_BYTES ->
+            {error, application_name_too_long};
         nomatch ->
-            {error, application_name_too_long}
+            validate_application_name_characters(ApplicationName)
     end;
 validate_application_name_binary(_) ->
     {error, invalid_string}.
+
+validate_application_name_characters(<<>>) ->
+    ok;
+validate_application_name_characters(<<Char, Rest/binary>>) when Char >= 16#20, Char =< 16#7E ->
+    validate_application_name_characters(Rest);
+validate_application_name_characters(_) ->
+    {error, application_name_must_contain_only_printable_ascii_characters}.
 
 %% ===================================================================
 resource_type() -> pgsql.

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -78,7 +78,11 @@ t_bad_application_name_config(_Config) ->
      || Name <- [
             <<>>,
             <<"bad", 0, "name">>,
-            binary:copy(<<"a">>, 64)
+            <<"bad\nname">>,
+            <<"bad", 16#7F, "name">>,
+            binary:copy(<<"a">>, 64),
+            <<"é"/utf8>>,
+            <<"中"/utf8>>
         ]
     ],
     ok.


### PR DESCRIPTION
Release version:
6.3.0

## Summary

Fixes #18254.

Restrict PostgreSQL `application_name` to 1–63 printable ASCII bytes, matching PostgreSQL’s documented constraints. Multibyte UTF-8 and control characters are now rejected during connector configuration validation instead of failing connection startup or being normalized by PostgreSQL.

## PR Checklist

- [x] Added tests for the changes
- [x] Changelog is not required because the feature is unreleased
- [x] Schema changes are backward compatible