### PR TITLE
feat(rule_engine): add LZ4 compression functions

### DIFF
--- a/apps/emqx_rule_engine/mix.exs
+++ b/apps/emqx_rule_engine/mix.exs
@@ -34,7 +34,8 @@ defmodule EMQXRuleEngine.MixProject do
           {:emqx_bridge, in_umbrella: true},
           :rulesql,
           :emqtt,
-          :uuid
+          :uuid,
+          {:lz4b, "0.0.13"}
         ]
     )
   end

--- a/apps/emqx_rule_engine/mix.exs
+++ b/apps/emqx_rule_engine/mix.exs
@@ -35,7 +35,7 @@ defmodule EMQXRuleEngine.MixProject do
           :rulesql,
           :emqtt,
           :uuid,
-          {:lz4b, "0.0.13"}
+          {:lz4b, "0.1.0"}
         ]
     )
   end

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -226,6 +226,12 @@
     zip_uncompress/1
 ]).
 
+%% LZ4 Funcs
+-export([
+    lz4_compress/1,
+    lz4_uncompress/1
+]).
+
 %% Data encode and decode
 -export([
     base64_encode/1,
@@ -1143,6 +1149,23 @@ zip_compress(S) when is_binary(S) ->
 
 zip_uncompress(S) when is_binary(S) ->
     zlib:uncompress(S).
+
+%%------------------------------------------------------------------------------
+%% LZ4 Frame Funcs
+%%------------------------------------------------------------------------------
+
+-doc "Compresses a binary using the LZ4 Frame format.".
+lz4_compress(S) when is_binary(S) ->
+    unwrap_lz4_result(lz4b_nif:dirty_compress_frame(S, 0)).
+
+-doc "Decompresses a binary in the LZ4 Frame format.".
+lz4_uncompress(S) when is_binary(S) ->
+    unwrap_lz4_result(lz4b_nif:dirty_decompress_frame(S, 0)).
+
+unwrap_lz4_result({ok, Result}) ->
+    Result;
+unwrap_lz4_result({error, Reason}) ->
+    erlang:error(Reason).
 
 %%------------------------------------------------------------------------------
 %% Data encode and decode Funcs

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1236,6 +1236,43 @@ prop_zip_compress_fun() ->
     ).
 
 %%------------------------------------------------------------------------------
+%% Test cases for LZ4 Frame funcs
+%%------------------------------------------------------------------------------
+
+t_lz4_funcs(_) ->
+    ?PROPTEST(prop_lz4_fun).
+
+prop_lz4_fun() ->
+    ?FORALL(
+        S,
+        binary(),
+        begin
+            Compressed = apply_func(lz4_compress, [S]),
+            <<16#04, 16#22, 16#4D, 16#18, _/binary>> = Compressed,
+            S == apply_func(lz4_uncompress, [Compressed])
+        end
+    ).
+
+t_lz4_funcs_sql(_) ->
+    Data = <<"hello LZ4">>,
+    Compressed = apply_func(lz4_compress, [Data]),
+    ?assertMatch(
+        {ok, #{<<"decoded">> := Data}},
+        emqx_rule_sqltester:test(
+            #{
+                sql => <<"SELECT lz4_uncompress(payload) AS decoded FROM \"t/#\"">>,
+                context => #{topic => <<"t/1">>, payload => Compressed}
+            }
+        )
+    ).
+
+t_lz4_invalid_frame(_) ->
+    ?assertError(
+        _,
+        apply_func(lz4_uncompress, [<<0:152>>])
+    ).
+
+%%------------------------------------------------------------------------------
 %% Test cases for base64
 %%------------------------------------------------------------------------------
 

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1272,6 +1272,14 @@ t_lz4_invalid_frame(_) ->
         apply_func(lz4_uncompress, [<<0:152>>])
     ).
 
+t_lz4_truncated_frame(_) ->
+    Compressed = apply_func(lz4_compress, [binary:copy(<<"hello">>, 1000)]),
+    Truncated = binary:part(Compressed, 0, byte_size(Compressed) - 1),
+    ?assertError(
+        incomplete_frame,
+        apply_func(lz4_uncompress, [Truncated])
+    ).
+
 %%------------------------------------------------------------------------------
 %% Test cases for base64
 %%------------------------------------------------------------------------------

--- a/changes/ce/feat-18306.en.md
+++ b/changes/ce/feat-18306.en.md
@@ -1,0 +1,1 @@
+Added the `lz4_compress` and `lz4_uncompress` rule functions for LZ4 Frame compression and decompression.


### PR DESCRIPTION
Release version:
6.2.3, 6.3.0

Introduced in:
N/A

## Summary

- Add `lz4_compress/1` and `lz4_uncompress/1` rule functions using the LZ4 Frame format. Raw blocks are intentionally not supported because they require the caller to provide the decompressed size separately, which does not fit a binary-only rule-function interface.
- Run compression and decompression as dirty CPU NIF jobs to avoid blocking normal schedulers.
- Convert lz4b errors into normal rule-function runtime errors.
- Depend on lz4b 0.1.0, which rejects truncated frames instead of returning partial output.

Fixes #18144

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)