### PR TITLE
test(mgmt clients): de-flake t_subscribe_shared_topic

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1477,12 +1477,18 @@ t_subscribe_shared_topic(Config) ->
     ),
 
     %% assert subscription
-    ?assertMatch(
-        [
-            {_, #share{group = <<"group">>, topic = <<"testtopic">>}},
-            {_, <<"t/#">>}
-        ],
-        ets:tab2list(?SUBSCRIPTION)
+    %% The subscribe API returns before the global subscription tables are
+    %% updated, so retry until the async registration is visible.
+    ?retry(
+        _Interval = 200,
+        _Attempts = 10,
+        ?assertMatch(
+            [
+                {_, #share{group = <<"group">>, topic = <<"testtopic">>}},
+                {_, <<"t/#">>}
+            ],
+            ets:tab2list(?SUBSCRIPTION)
+        )
     ),
 
     ?assertMatch(
@@ -1522,7 +1528,7 @@ t_subscribe_shared_topic(Config) ->
     ),
 
     %% assert subscription
-    ?assertEqual([], ets:tab2list(?SUBSCRIPTION)),
+    ?retry(200, 10, ?assertEqual([], ets:tab2list(?SUBSCRIPTION))),
     ?assertEqual([], ets:tab2list(?SUBOPTION)),
     ?assertEqual([], ets:tab2list(emqx_shared_subscription)),
 


### PR DESCRIPTION
## Summary

De-flake `emqx_mgmt_api_clients_SUITE:t_subscribe_shared_topic`.

The clients subscribe/unsubscribe management API replies before the channel process has updated the global subscription tables (`emqx_mgmt:do_unsubscribe*` is a fire-and-forget `Pid ! {unsubscribe, ...}`), so asserting `ets:tab2list(?SUBSCRIPTION)` right after the HTTP call is a race:

```
Failure/Error: ?assertEqual([], ets : tab2list ( ? SUBSCRIPTION ))
  expected: []
       got: [{<0.247145.0>,<<"t/#">>}]
      line: 1525
```

Seen in: https://github.com/emqx/emqx/actions/runs/31306960949/job/93393402365?pr=18301

Backport of the clients-suite hunks of 00fbace235 and 66a62d0c39 (already on master): wrap the `ets:tab2list` assertions in `?retry` until the async (un)registration is visible. Test-only change.