### PR TITLE
fix(coap): defer UDP proxy takeover until token validation

### DIFF
--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_channel.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_channel.erl
@@ -40,6 +40,7 @@
 -type reply() ::
     {outgoing, emqx_gateway_frame:frame()}
     | {outgoing, [emqx_gateway_frame:frame()]}
+    | {udp_proxy, commit | reject}
     | {event, conn_state() | updated}
     | {close, Reason :: atom()}.
 

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -79,7 +79,9 @@
     %% Channel Module
     chann_mod :: atom(),
     %% Listener Tag
-    listener :: listener() | undefined
+    listener :: listener() | undefined,
+    %% Defer UDP proxy ownership changes until the channel validates the packet.
+    defer_udp_proxy_takeover = false :: boolean()
 }).
 
 -type listener() :: {GwName :: atom(), LisType :: atom(), LisName :: atom()}.
@@ -327,7 +329,8 @@ init_state(WrappedSock, Peername, Options, FrameMod, ChannMod) ->
         oom_policy = OomPolicy,
         frame_mod = FrameMod,
         chann_mod = ChannMod,
-        listener = maps:get(listener, Options, undefined)
+        listener = maps:get(listener, Options, undefined),
+        defer_udp_proxy_takeover = maps:get(defer_udp_proxy_takeover, Options, false)
     }.
 
 run_loop(
@@ -482,7 +485,7 @@ handle_msg({'$gen_cast', Req}, State) ->
 handle_msg({datagram, _SockPid, Data}, State) ->
     parse_incoming(Data, State);
 handle_msg(
-    {{esockd_udp_proxy, _ProxyId, _Socket} = NSock, Data, Packets},
+    {{esockd_udp_proxy, ProxyId, _Socket} = NSock, Data, Packets},
     State = #state{
         chann_mod = ChannMod,
         channel = Channel
@@ -494,9 +497,14 @@ handle_msg(
     Ctx = ChannMod:info(ctx, Channel),
     ok = emqx_gateway_ctx:metrics_inc(Ctx, 'bytes.received', Oct),
 
-    maybe_takeover_udp_proxy(NSock, State),
-    NState = State#state{socket = NSock, sockstate = running},
-    {ok, next_incoming_msgs(Packets), NState};
+    case should_defer_udp_proxy_takeover(ProxyId, State) of
+        true ->
+            {ok, next_udp_proxy_incoming_msgs(NSock, Packets), State};
+        false ->
+            maybe_takeover_udp_proxy(NSock, State),
+            NState = State#state{socket = NSock, sockstate = running},
+            {ok, next_incoming_msgs(Packets), NState}
+    end;
 handle_msg({Inet, _Sock, Data}, State) when
     Inet == tcp;
     Inet == ssl
@@ -510,8 +518,20 @@ handle_msg(
         emqx_utils:cancel_timer(IdleTimer),
     NState = State#state{idle_timer = undefined},
     handle_incoming(Packet, NState);
+handle_msg(
+    {udp_proxy_incoming, NSock, Packet},
+    State = #state{idle_timer = IdleTimer}
+) ->
+    IdleTimer /= undefined andalso
+        emqx_utils:cancel_timer(IdleTimer),
+    NState = State#state{idle_timer = undefined},
+    handle_udp_proxy_incoming(Packet, NSock, NState);
+handle_msg({outgoing, NSock = {esockd_udp_proxy, _, _}, Data}, State) ->
+    handle_outgoing_via_socket(Data, NSock, State);
 handle_msg({outgoing, Data}, State) ->
     handle_outgoing(Data, State);
+handle_msg({udp_proxy, _Decision}, State) ->
+    {ok, State};
 handle_msg({Error, _Sock, Reason}, State) when
     Error == tcp_error; Error == ssl_error
 ->
@@ -634,6 +654,17 @@ maybe_takeover_udp_proxy(
     end;
 maybe_takeover_udp_proxy(_Socket, _State) ->
     ok.
+
+should_defer_udp_proxy_takeover(
+    ProxyId,
+    #state{
+        socket = {esockd_udp_proxy, CurrentProxyId, _Socket},
+        defer_udp_proxy_takeover = true
+    }
+) ->
+    ProxyId =/= CurrentProxyId;
+should_defer_udp_proxy_takeover(_ProxyId, _State) ->
+    false.
 
 is_current_udp_proxy(ProxyId, #state{socket = {esockd_udp_proxy, ProxyId, _Socket}}) ->
     true;
@@ -860,6 +891,9 @@ next_incoming_msgs([Packet]) ->
 next_incoming_msgs(Packets) ->
     [{incoming, Packet} || Packet <- lists:reverse(Packets)].
 
+next_udp_proxy_incoming_msgs(NSock, Packets) ->
+    [{udp_proxy_incoming, NSock, Packet} || Packet <- lists:reverse(Packets)].
+
 %%--------------------------------------------------------------------
 %% Handle incoming packet
 
@@ -874,6 +908,13 @@ handle_incoming(Packet, State) ->
 do_handle_incoming(Packet, FrameMod, State) ->
     ?SLOG(debug, #{msg => "packet_received", packet => FrameMod:format(Packet)}),
     with_channel(handle_in, [Packet], State).
+
+handle_udp_proxy_incoming(Packet, NSock, State) ->
+    #state{channel = Channel, frame_mod = FrameMod, chann_mod = ChannMod} = State,
+    Ctx = ChannMod:info(ctx, Channel),
+    ok = inc_incoming_stats(Ctx, FrameMod, Packet),
+    ?SLOG(debug, #{msg => "packet_received", packet => FrameMod:format(Packet)}),
+    with_udp_proxy_channel(handle_in, [Packet], NSock, State).
 
 %%--------------------------------------------------------------------
 %% With Channel
@@ -893,6 +934,73 @@ with_channel(Fun, Args, State = #state{chann_mod = ChannMod, channel = Channel})
             {ok, NState1} = handle_outgoing(Packet, NState),
             shutdown(Reason, NState1)
     end.
+
+with_udp_proxy_channel(
+    Fun,
+    Args,
+    NSock,
+    State = #state{chann_mod = ChannMod, channel = Channel}
+) ->
+    case call_channel(ChannMod, Fun, Args, Channel) of
+        ok ->
+            {ok, State};
+        {ok, NChannel} ->
+            {ok, State#state{channel = NChannel}};
+        {ok, Replies, NChannel} ->
+            handle_udp_proxy_replies(NSock, Replies, State#state{channel = NChannel});
+        {shutdown, Reason, NChannel} ->
+            shutdown(Reason, State#state{channel = NChannel});
+        {shutdown, Reason, Packet, NChannel} ->
+            NState = State#state{channel = NChannel},
+            {ok, NState1} = handle_outgoing_via_socket(Packet, NSock, NState),
+            shutdown(Reason, NState1)
+    end.
+
+handle_udp_proxy_replies(NSock, Replies0, State) ->
+    Replies = ensure_reply_list(Replies0),
+    {Decision, Replies1} = take_udp_proxy_decision(Replies, reject, []),
+    NState =
+        case Decision of
+            commit ->
+                commit_udp_proxy(NSock, State);
+            reject ->
+                State
+        end,
+    RoutedReplies = [route_udp_proxy_reply(NSock, Reply) || Reply <- Replies1],
+    {ok, next_msgs(RoutedReplies), NState}.
+
+ensure_reply_list(Reply) when is_tuple(Reply) ->
+    [Reply];
+ensure_reply_list(Replies) when is_list(Replies) ->
+    Replies.
+
+take_udp_proxy_decision([], Decision, Replies) ->
+    {Decision, lists:reverse(Replies)};
+take_udp_proxy_decision([{udp_proxy, Decision} | More], _OldDecision, Replies) ->
+    take_udp_proxy_decision(More, Decision, Replies);
+take_udp_proxy_decision([Reply | More], Decision, Replies) ->
+    take_udp_proxy_decision(More, Decision, [Reply | Replies]).
+
+route_udp_proxy_reply(NSock, {outgoing, Data}) ->
+    {outgoing, NSock, Data};
+route_udp_proxy_reply(_NSock, Reply) ->
+    Reply.
+
+commit_udp_proxy(
+    NSock = {esockd_udp_proxy, ProxyId, _Socket},
+    State = #state{socket = {esockd_udp_proxy, ProxyId, _OldSocket}}
+) ->
+    State#state{socket = NSock, sockstate = running};
+commit_udp_proxy(
+    NSock = {esockd_udp_proxy, _ProxyId, _Socket},
+    State = #state{socket = {esockd_udp_proxy, OldProxyId, _OldSocket}}
+) ->
+    %% Deferred proxy candidates use source-scoped connection IDs, so close
+    %% the old owner explicitly after the channel has accepted the new source.
+    ok = esockd_udp_proxy:close(OldProxyId),
+    State#state{socket = NSock, sockstate = running};
+commit_udp_proxy(NSock, State) ->
+    State#state{socket = NSock, sockstate = running}.
 
 call_channel(ChannMod, Fun, [Arg1], Channel) ->
     ChannMod:Fun(Arg1, Channel);
@@ -929,6 +1037,10 @@ handle_outgoing(
     end;
 handle_outgoing(Packet, State) ->
     send((serialize_and_inc_stats_fun(State))(Packet), State).
+
+handle_outgoing_via_socket(Data, NSock, State = #state{socket = Socket}) ->
+    {ok, NState} = handle_outgoing(Data, State#state{socket = NSock}),
+    {ok, NState#state{socket = Socket}}.
 
 serialize_and_inc_stats_fun(#state{
     frame_mod = FrameMod,

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -962,10 +962,13 @@ with_udp_proxy_channel(
     end,
     with_channel(Fun, Args, ReplyHandler, OutgoingHandler, State).
 
-handle_channel_replies(Replies0, State) ->
-    Replies = ensure_reply_list(Replies0),
+handle_channel_replies({udp_proxy, _Decision}, State) ->
+    {ok, State};
+handle_channel_replies(Reply, State) when is_tuple(Reply) ->
+    {ok, Reply, State};
+handle_channel_replies(Replies, State) when is_list(Replies) ->
     {_Decision, Replies1} = take_udp_proxy_decision(Replies, reject, []),
-    {ok, next_msgs(Replies1), State}.
+    {ok, Replies1, State}.
 
 handle_udp_proxy_replies(NSock, Replies0, State) ->
     Replies = ensure_reply_list(Replies0),

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -530,8 +530,6 @@ handle_msg({outgoing, NSock = {esockd_udp_proxy, _, _}, Data}, State) ->
     handle_outgoing_via_socket(Data, NSock, State);
 handle_msg({outgoing, Data}, State) ->
     handle_outgoing(Data, State);
-handle_msg({udp_proxy, _Decision}, State) ->
-    {ok, State};
 handle_msg({Error, _Sock, Reason}, State) when
     Error == tcp_error; Error == ssl_error
 ->
@@ -919,26 +917,20 @@ handle_udp_proxy_incoming(Packet, NSock, State) ->
 %%--------------------------------------------------------------------
 %% With Channel
 
-with_channel(Fun, Args, State = #state{chann_mod = ChannMod, channel = Channel}) ->
-    case call_channel(ChannMod, Fun, Args, Channel) of
-        ok ->
-            {ok, State};
-        {ok, NChannel} ->
-            {ok, State#state{channel = NChannel}};
-        {ok, Replies, NChannel} ->
-            {ok, next_msgs(Replies), State#state{channel = NChannel}};
-        {shutdown, Reason, NChannel} ->
-            shutdown(Reason, State#state{channel = NChannel});
-        {shutdown, Reason, Packet, NChannel} ->
-            NState = State#state{channel = NChannel},
-            {ok, NState1} = handle_outgoing(Packet, NState),
-            shutdown(Reason, NState1)
-    end.
+with_channel(Fun, Args, State) ->
+    with_channel(
+        Fun,
+        Args,
+        fun handle_channel_replies/2,
+        fun handle_outgoing/2,
+        State
+    ).
 
-with_udp_proxy_channel(
+with_channel(
     Fun,
     Args,
-    NSock,
+    ReplyHandler,
+    OutgoingHandler,
     State = #state{chann_mod = ChannMod, channel = Channel}
 ) ->
     case call_channel(ChannMod, Fun, Args, Channel) of
@@ -947,14 +939,33 @@ with_udp_proxy_channel(
         {ok, NChannel} ->
             {ok, State#state{channel = NChannel}};
         {ok, Replies, NChannel} ->
-            handle_udp_proxy_replies(NSock, Replies, State#state{channel = NChannel});
+            ReplyHandler(Replies, State#state{channel = NChannel});
         {shutdown, Reason, NChannel} ->
             shutdown(Reason, State#state{channel = NChannel});
         {shutdown, Reason, Packet, NChannel} ->
             NState = State#state{channel = NChannel},
-            {ok, NState1} = handle_outgoing_via_socket(Packet, NSock, NState),
+            {ok, NState1} = OutgoingHandler(Packet, NState),
             shutdown(Reason, NState1)
     end.
+
+with_udp_proxy_channel(
+    Fun,
+    Args,
+    NSock,
+    State
+) ->
+    ReplyHandler = fun(Replies, NState) ->
+        handle_udp_proxy_replies(NSock, Replies, NState)
+    end,
+    OutgoingHandler = fun(Packet, NState) ->
+        handle_outgoing_via_socket(Packet, NSock, NState)
+    end,
+    with_channel(Fun, Args, ReplyHandler, OutgoingHandler, State).
+
+handle_channel_replies(Replies0, State) ->
+    Replies = ensure_reply_list(Replies0),
+    {_Decision, Replies1} = take_udp_proxy_decision(Replies, reject, []),
+    {ok, next_msgs(Replies1), State}.
 
 handle_udp_proxy_replies(NSock, Replies0, State) ->
     Replies = ensure_reply_list(Replies0),
@@ -962,7 +973,7 @@ handle_udp_proxy_replies(NSock, Replies0, State) ->
     NState =
         case Decision of
             commit ->
-                commit_udp_proxy(NSock, State);
+                switch_udp_proxy_downlink(NSock, State);
             reject ->
                 State
         end,
@@ -986,7 +997,7 @@ route_udp_proxy_reply(NSock, {outgoing, Data}) ->
 route_udp_proxy_reply(_NSock, Reply) ->
     Reply.
 
-commit_udp_proxy(NSock, State) ->
+switch_udp_proxy_downlink(NSock, State) ->
     State#state{socket = NSock, sockstate = running}.
 
 call_channel(ChannMod, Fun, [Arg1], Channel) ->

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -986,19 +986,6 @@ route_udp_proxy_reply(NSock, {outgoing, Data}) ->
 route_udp_proxy_reply(_NSock, Reply) ->
     Reply.
 
-commit_udp_proxy(
-    NSock = {esockd_udp_proxy, ProxyId, _Socket},
-    State = #state{socket = {esockd_udp_proxy, ProxyId, _OldSocket}}
-) ->
-    State#state{socket = NSock, sockstate = running};
-commit_udp_proxy(
-    NSock = {esockd_udp_proxy, _ProxyId, _Socket},
-    State = #state{socket = {esockd_udp_proxy, OldProxyId, _OldSocket}}
-) ->
-    %% Deferred proxy candidates use source-scoped connection IDs, so close
-    %% the old owner explicitly after the channel has accepted the new source.
-    ok = esockd_udp_proxy:close(OldProxyId),
-    State#state{socket = NSock, sockstate = running};
 commit_udp_proxy(NSock, State) ->
     State#state{socket = NSock, sockstate = running}.
 

--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -67,6 +67,7 @@
 -type reply() ::
     {outgoing, coap_message()}
     | {outgoing, [coap_message()]}
+    | {udp_proxy, commit | reject}
     | {event, conn_state() | updated}
     | {close, Reason :: atom()}.
 
@@ -436,7 +437,7 @@ check_auth_state(Msg, #channel{connection_required = false} = Channel) ->
 check_auth_state(Msg, #channel{connection_required = true} = Channel) ->
     case is_create_connection_request(Msg) of
         true ->
-            call_session(handle_request, Msg, Channel);
+            with_udp_proxy_decision(reject, call_session(handle_request, Msg, Channel));
         false ->
             URIQuery = emqx_coap_message:extract_uri_query(Msg),
             case get_query_value(<<"token">>, URIQuery) of
@@ -446,7 +447,7 @@ check_auth_state(Msg, #channel{connection_required = true} = Channel) ->
                         msg => "token_required_in_conn_mode",
                         message => emqx_utils:redact(Msg)
                     }),
-                    missing_token_or_clientid_reply(Msg, Channel);
+                    with_udp_proxy_decision(reject, missing_token_or_clientid_reply(Msg, Channel));
                 _ ->
                     check_token(Msg, Channel)
             end
@@ -475,12 +476,12 @@ check_token(Msg, Channel) ->
         false ->
             case {ReqClientId, ReqToken} of
                 {ClientId, Token} when ReqClientId =/= undefined, ReqToken =/= undefined ->
-                    call_session(handle_request, Msg, Channel);
+                    with_udp_proxy_decision(commit, call_session(handle_request, Msg, Channel));
                 {ClientId, ReqToken1} when
                     ReqClientId =/= undefined, ReqToken1 =/= undefined, ReqToken1 =/= Token
                 ->
                     %% Same clientid with mismatched token should be rejected directly.
-                    invalid_token_reply(Msg, Channel);
+                    with_udp_proxy_decision(reject, invalid_token_reply(Msg, Channel));
                 {ReqClientId1, ReqToken1} when
                     ReqClientId1 =/= undefined,
                     ReqToken1 =/= undefined,
@@ -488,7 +489,7 @@ check_token(Msg, Channel) ->
                 ->
                     try_takeover_with_token(Msg, ReqClientId1, ReqToken1, Channel);
                 _ ->
-                    missing_token_or_clientid_reply(Msg, Channel)
+                    with_udp_proxy_decision(reject, missing_token_or_clientid_reply(Msg, Channel))
             end
     end.
 
@@ -585,13 +586,22 @@ takeover_and_handle_request(Msg, ReqClientId, ReqToken, ResumeClientInfo, Channe
                 token = ReqToken
             },
             NChannel = ensure_connected(Channel0),
-            call_session(handle_request, Msg, NChannel);
+            with_udp_proxy_decision(commit, call_session(handle_request, Msg, NChannel));
         {ok, #{present := false}} ->
             ok = maybe_unregister_channel(ReqClientId),
-            invalid_token_reply(Msg, Channel);
+            with_udp_proxy_decision(reject, invalid_token_reply(Msg, Channel));
         _ ->
-            invalid_token_reply(Msg, Channel)
+            with_udp_proxy_decision(reject, invalid_token_reply(Msg, Channel))
     end.
+
+with_udp_proxy_decision(Decision, {ok, Channel}) ->
+    {ok, {udp_proxy, Decision}, Channel};
+with_udp_proxy_decision(Decision, {ok, Reply, Channel}) when is_tuple(Reply) ->
+    {ok, [{udp_proxy, Decision}, Reply], Channel};
+with_udp_proxy_decision(Decision, {ok, Replies, Channel}) when is_list(Replies) ->
+    {ok, [{udp_proxy, Decision} | Replies], Channel};
+with_udp_proxy_decision(_Decision, Shutdown) ->
+    Shutdown.
 
 merge_takeover_clientinfo(ReqClientId, ClientInfo0, ResumeClientInfo) ->
     BaseClientInfo = ClientInfo0#{clientid => ReqClientId},

--- a/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
@@ -16,7 +16,8 @@
 initialize(_Opts) ->
     emqx_coap_frame:initial_parse_state(#{}).
 
-find_or_create(CId, Transport, Peer, Opts) ->
+find_or_create(ProxyCId, Transport, Peer, Opts) ->
+    CId = logical_connection_id(ProxyCId),
     case emqx_gateway_cm_registry:lookup_channels(coap, CId) of
         [Pid] ->
             {ok, Pid};
@@ -31,20 +32,23 @@ get_connection_id(_Transport, Peer, State, Data) ->
             case Msg of
                 #coap_message{} ->
                     {CId, NBoundCId} = choose_cid(Msg, BoundCId, Peer),
-                    {ok, CId, Packets, merge_state(NState, NBoundCId)};
+                    {ok, proxy_connection_id(CId, Peer), Packets, merge_state(NState, NBoundCId)};
                 {coap_ignore, _} ->
                     %% RFC 7252 Section 3: unknown versions must be silently ignored.
-                    {ok, route_cid(BoundCId, Peer), Packets, merge_state(NState, BoundCId)};
+                    CId = route_cid(BoundCId, Peer),
+                    {ok, proxy_connection_id(CId, Peer), Packets, merge_state(NState, BoundCId)};
                 {coap_format_error, Type, MsgId, _} ->
                     %% RFC 7252 Section 4.2: reject CON format errors with Reset.
                     _ = {Type, MsgId},
                     %% RFC 7252 Section 4.2: per-message errors must not stop the listener.
-                    {ok, route_cid(BoundCId, Peer), Packets, merge_state(NState, BoundCId)};
+                    CId = route_cid(BoundCId, Peer),
+                    {ok, proxy_connection_id(CId, Peer), Packets, merge_state(NState, BoundCId)};
                 {coap_request_error, Req, Error} ->
                     %% RFC 7252 Section 5.4.1/5.8: reply with a 4.xx error for bad requests.
                     _ = {Req, Error},
                     %% RFC 7252 Section 4.2: per-message errors must not stop the listener.
-                    {ok, route_cid(BoundCId, Peer), Packets, merge_state(NState, BoundCId)}
+                    CId = route_cid(BoundCId, Peer),
+                    {ok, proxy_connection_id(CId, Peer), Packets, merge_state(NState, BoundCId)}
             end;
         _Error ->
             invalid
@@ -52,6 +56,18 @@ get_connection_id(_Transport, Peer, State, Data) ->
 
 peer_id(Peer) ->
     {peer, Peer}.
+
+proxy_connection_id({peer, _} = CId, _Peer) ->
+    CId;
+proxy_connection_id(CId, Peer) ->
+    %% esockd takes over an existing proxy as soon as the same connection ID
+    %% is attached.  Keep candidates isolated until CoAP validates the token.
+    {coap_udp_proxy, Peer, CId}.
+
+logical_connection_id({coap_udp_proxy, _Peer, CId}) ->
+    CId;
+logical_connection_id(CId) ->
+    CId.
 
 split_state(#{parse_state := ParseState, cid := BoundCId}) ->
     {ParseState, BoundCId};

--- a/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
@@ -60,8 +60,9 @@ peer_id(Peer) ->
 proxy_connection_id({peer, _} = CId, _Peer) ->
     CId;
 proxy_connection_id(CId, Peer) ->
-    %% esockd takes over an existing proxy as soon as the same connection ID
-    %% is attached.  Keep candidates isolated until CoAP validates the token.
+    %% esockd_udp_proxy_db:attach/2 stops the proxy already registered with the
+    %% same ID.  Scope candidates by peer until the gateway connection validates
+    %% the token and switches its persistent downlink socket.
     {coap_udp_proxy, Peer, CId}.
 
 logical_connection_id({coap_udp_proxy, _Peer, CId}) ->

--- a/apps/emqx_gateway_coap/src/emqx_gateway_coap.erl
+++ b/apps/emqx_gateway_coap/src/emqx_gateway_coap.erl
@@ -97,6 +97,7 @@ mod_cfg(#{connection_required := true}) ->
     #{
         udp => maps:merge(?DEFAULT_MOD_CFG, #{
             connection_mod => esockd_udp_proxy,
+            defer_udp_proxy_takeover => true,
             esockd_proxy_opts => #{
                 connection_mod => emqx_coap_proxy_conn
             }

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -580,6 +580,75 @@ t_invalid_token_rejected_across_udp_sessions(_) ->
     er_coap_channel:close(Channel2),
     er_coap_udp_socket:close(Sock2).
 
+t_invalid_token_does_not_take_over_udp_downlink(_) ->
+    Topic = <<"coap/udp_invalid_token_downlink">>,
+    {ok, Sock1, Channel1} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    Token = connection(Channel1),
+    observe_topic(Channel1, Token, Topic, <<"original-peer">>),
+    timer:sleep(100),
+    [ConnPid] = emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>),
+    OriginalProxyId = current_udp_proxy_id(ConnPid),
+
+    BaselinePayload = <<"before-invalid-request">>,
+    publish(Topic, ?QOS_0, BaselinePayload),
+    _ = assert_notify(Channel1, non, BaselinePayload),
+
+    {ok, Sock2} = gen_udp:open(0, [binary, {active, false}]),
+    InvalidURI = compose_uri(
+        pubsub_uri(binary_to_list(Topic)),
+        #{
+            "clientid" => <<"client1">>,
+            "token" => <<"wrong-token">>
+        },
+        false
+    ),
+    InvalidReq = make_req(post, <<"rejected">>),
+    try
+        ?assertMatch({error, unauthorized, _}, raw_udp_request(Sock2, InvalidURI, InvalidReq)),
+        ?assertEqual(OriginalProxyId, current_udp_proxy_id(ConnPid)),
+
+        DownlinkPayload = <<"after-invalid-request">>,
+        publish(Topic, ?QOS_0, DownlinkPayload),
+        ?assertEqual({error, timeout}, gen_udp:recv(Sock2, 0, 300)),
+        _ = assert_notify(Channel1, non, DownlinkPayload),
+
+        MissingTokenURI = compose_uri(
+            pubsub_uri(binary_to_list(Topic)),
+            #{"clientid" => <<"client1">>},
+            false
+        ),
+        ?assertMatch(
+            {error, bad_request, _},
+            raw_udp_request(Sock2, MissingTokenURI, make_req(post, <<"rejected-again">>))
+        ),
+        AfterMissingTokenPayload = <<"after-missing-token">>,
+        publish(Topic, ?QOS_0, AfterMissingTokenPayload),
+        ?assertEqual({error, timeout}, gen_udp:recv(Sock2, 0, 300)),
+        _ = assert_notify(Channel1, non, AfterMissingTokenPayload),
+
+        ValidURI = compose_uri(
+            pubsub_uri("coap/udp_valid_migration"),
+            #{
+                "clientid" => <<"client1">>,
+                "token" => list_to_binary(Token)
+            },
+            false
+        ),
+        {ok, changed, _} = raw_udp_request(Sock2, ValidURI, make_req(post, <<"accepted">>)),
+        ?assertNotEqual(OriginalProxyId, current_udp_proxy_id(ConnPid)),
+        MigratedPayload = <<"after-valid-migration">>,
+        publish(Topic, ?QOS_0, MigratedPayload),
+        ?assertEqual({error, timeout}, with_message_response(Channel1, 300)),
+        {ok, {_Host, _Port, MigratedData}} = gen_udp:recv(Sock2, 0, 2000),
+        #coap_message{payload = MigratedPayload} = parse_udp_message(MigratedData),
+        ok
+    after
+        _ = catch disconnection(Channel1, Token),
+        gen_udp:close(Sock2),
+        er_coap_channel:close(Channel1),
+        er_coap_udp_socket:close(Sock1)
+    end.
+
 t_wrong_clientid_with_valid_token_rejected_across_udp_sessions(_) ->
     {ok, Sock1, Channel1} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
     Token = connection(Channel1),
@@ -1864,7 +1933,7 @@ t_proxy_conn_reuse_bound_clientid_when_missing(_) ->
         }
     },
     Bin1 = emqx_coap_frame:serialize_pkt(Msg1, emqx_coap_frame:serialize_opts()),
-    {ok, <<"client1">>, _Packets1, State1} =
+    {ok, {coap_udp_proxy, Peer, <<"client1">>}, _Packets1, State1} =
         emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State0, Bin1),
     Msg2 = #coap_message{
         type = con,
@@ -1877,7 +1946,7 @@ t_proxy_conn_reuse_bound_clientid_when_missing(_) ->
     },
     Bin2 = emqx_coap_frame:serialize_pkt(Msg2, emqx_coap_frame:serialize_opts()),
     ?assertMatch(
-        {ok, <<"client1">>, _Packets2, _State2},
+        {ok, {coap_udp_proxy, Peer, <<"client1">>}, _Packets2, _State2},
         emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State1, Bin2)
     ).
 
@@ -1894,7 +1963,7 @@ t_proxy_conn_keep_bound_clientid_on_different_clientid(_) ->
         }
     },
     Bin1 = emqx_coap_frame:serialize_pkt(Msg1, emqx_coap_frame:serialize_opts()),
-    {ok, <<"client1">>, _Packets1, State1} =
+    {ok, {coap_udp_proxy, Peer, <<"client1">>}, _Packets1, State1} =
         emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State0, Bin1),
     Msg2 = #coap_message{
         type = con,
@@ -1907,7 +1976,7 @@ t_proxy_conn_keep_bound_clientid_on_different_clientid(_) ->
     },
     Bin2 = emqx_coap_frame:serialize_pkt(Msg2, emqx_coap_frame:serialize_opts()),
     ?assertMatch(
-        {ok, <<"client1">>, _Packets2, _State2},
+        {ok, {coap_udp_proxy, Peer, <<"client1">>}, _Packets2, _State2},
         emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State1, Bin2)
     ).
 
@@ -2079,6 +2148,10 @@ assert_notify(Channel, Type, Payload) ->
     ?assertEqual(Payload, notify_payload(Notify)),
     Notify.
 
+current_udp_proxy_id(Pid) ->
+    {esockd_udp_proxy, ProxyId, _Sock} = element(2, sys:get_state(Pid)),
+    ProxyId.
+
 assert_notify(Channel, Type) ->
     {ok, content, Notify = #coap_message{type = Type}} = with_message_response(Channel),
     Notify.
@@ -2144,6 +2217,26 @@ do_request(Channel, URI, #coap_message{options = Opts} = Req) ->
 
     {ok, _} = er_coap_channel:send(Channel, Req2),
     with_response(Channel).
+
+raw_udp_request(Socket, URI, #coap_message{options = Opts} = Req) ->
+    {_, _, Path, Query} = er_coap_client:resolve_uri(URI),
+    MsgId = erlang:unique_integer([positive]) band 16#FFFF,
+    Token = crypto:strong_rand_bytes(4),
+    Req2 = Req#coap_message{
+        id = MsgId,
+        token = Token,
+        options = [{uri_path, Path}, {uri_query, Query} | Opts]
+    },
+    Data = er_coap_message_parser:encode(Req2),
+    ok = gen_udp:send(Socket, {127, 0, 0, 1}, 5683, Data),
+    {ok, {_Host, _Port, ResponseData}} = gen_udp:recv(Socket, 0, 2000),
+    #coap_message{method = {Class, Code}, payload = Payload} = parse_udp_message(ResponseData),
+    {Class, Code, Payload}.
+
+parse_udp_message(Data) ->
+    {ok, Message, <<>>, _State} =
+        emqx_coap_frame:parse(Data, emqx_coap_frame:initial_parse_state(#{})),
+    Message.
 
 do_message_request(Channel, URI, #coap_message{options = Opts} = Req) ->
     {_, _, Path, Query} = er_coap_client:resolve_uri(URI),

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -649,6 +649,71 @@ t_invalid_token_does_not_take_over_udp_downlink(_) ->
         er_coap_udp_socket:close(Sock1)
     end.
 
+t_valid_udp_migration_does_not_wait_for_old_proxy(_) ->
+    {ok, Sock1, Channel1} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    Token = connection(Channel1),
+    [ConnPid] = emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>),
+    OriginalProxyId = current_udp_proxy_id(ConnPid),
+    {ok, Sock2} = gen_udp:open(0, [binary, {active, false}]),
+    ValidURI = compose_uri(
+        pubsub_uri("coap/udp_nonblocking_migration"),
+        #{
+            "clientid" => <<"client1">>,
+            "token" => list_to_binary(Token)
+        },
+        false
+    ),
+    try
+        ok = sys:suspend(OriginalProxyId),
+        ?assertMatch(
+            {ok, changed, _},
+            raw_udp_request(Sock2, ValidURI, make_req(post, <<"accepted">>))
+        )
+    after
+        _ = catch sys:resume(OriginalProxyId),
+        _ = catch disconnection(Channel1, Token),
+        gen_udp:close(Sock2),
+        er_coap_channel:close(Channel1),
+        er_coap_udp_socket:close(Sock1)
+    end.
+
+t_queued_valid_source_keeps_a_live_downlink_proxy(_) ->
+    Topic = <<"coap/udp_queued_migration">>,
+    {ok, Sock1, Channel1} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
+    Token = connection(Channel1),
+    observe_topic(Channel1, Token, Topic, <<"queued-migration-peer">>),
+    [ConnPid] = emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>),
+    {ok, Sock2} = gen_udp:open(0, [binary, {active, false}]),
+    ValidURI = compose_uri(
+        pubsub_uri("coap/udp_queued_migration_request"),
+        #{
+            "clientid" => <<"client1">>,
+            "token" => list_to_binary(Token)
+        },
+        false
+    ),
+    try
+        true = erlang:suspend_process(ConnPid),
+        ok = send_raw_udp_request(Sock2, ValidURI, make_req(post, <<"new-source">>)),
+        ok = wait_for_udp_proxy_messages(ConnPid, 1, 20),
+        ok = send_request(Channel1, ValidURI, make_req(post, <<"old-source">>)),
+        ok = wait_for_udp_proxy_messages(ConnPid, 2, 20),
+        true = erlang:resume_process(ConnPid),
+
+        ?assertMatch({ok, changed, _}, recv_raw_udp_response(Sock2)),
+        ?assertMatch({ok, changed, _}, with_response(Channel1)),
+        DownlinkPayload = <<"after-queued-migrations">>,
+        publish(Topic, ?QOS_0, DownlinkPayload),
+        _ = assert_notify(Channel1, non, DownlinkPayload),
+        ?assertEqual({error, timeout}, gen_udp:recv(Sock2, 0, 300))
+    after
+        _ = catch erlang:resume_process(ConnPid),
+        _ = catch disconnection(Channel1, Token),
+        gen_udp:close(Sock2),
+        er_coap_channel:close(Channel1),
+        er_coap_udp_socket:close(Sock1)
+    end.
+
 t_wrong_clientid_with_valid_token_rejected_across_udp_sessions(_) ->
     {ok, Sock1, Channel1} = er_coap_udp_socket:connect({127, 0, 0, 1}, 5683),
     Token = connection(Channel1),
@@ -2209,16 +2274,19 @@ reset_if_con(Channel, #coap_message{type = con} = Message) ->
     {ok, _} = er_coap_channel:send(Channel, emqx_coap_message:reset(Message)),
     ok.
 
-do_request(Channel, URI, #coap_message{options = Opts} = Req) ->
+do_request(Channel, URI, Req) ->
+    ok = send_request(Channel, URI, Req),
+    with_response(Channel).
+
+send_request(Channel, URI, #coap_message{options = Opts} = Req) ->
     {_, _, Path, Query} = er_coap_client:resolve_uri(URI),
     Opts2 = [{uri_path, Path}, {uri_query, Query} | Opts],
     Req2 = Req#coap_message{options = Opts2},
     ?LOGT("send request:~ts~nReq:~p~n", [URI, Req2]),
-
     {ok, _} = er_coap_channel:send(Channel, Req2),
-    with_response(Channel).
+    ok.
 
-raw_udp_request(Socket, URI, #coap_message{options = Opts} = Req) ->
+send_raw_udp_request(Socket, URI, #coap_message{options = Opts} = Req) ->
     {_, _, Path, Query} = er_coap_client:resolve_uri(URI),
     MsgId = erlang:unique_integer([positive]) band 16#FFFF,
     Token = crypto:strong_rand_bytes(4),
@@ -2228,10 +2296,35 @@ raw_udp_request(Socket, URI, #coap_message{options = Opts} = Req) ->
         options = [{uri_path, Path}, {uri_query, Query} | Opts]
     },
     Data = er_coap_message_parser:encode(Req2),
-    ok = gen_udp:send(Socket, {127, 0, 0, 1}, 5683, Data),
+    gen_udp:send(Socket, {127, 0, 0, 1}, 5683, Data).
+
+raw_udp_request(Socket, URI, Req) ->
+    ok = send_raw_udp_request(Socket, URI, Req),
+    recv_raw_udp_response(Socket).
+
+recv_raw_udp_response(Socket) ->
     {ok, {_Host, _Port, ResponseData}} = gen_udp:recv(Socket, 0, 2000),
     #coap_message{method = {Class, Code}, payload = Payload} = parse_udp_message(ResponseData),
     {Class, Code, Payload}.
+
+wait_for_udp_proxy_messages(Pid, MinCount, 0) ->
+    ?assert(udp_proxy_message_count(Pid) >= MinCount),
+    ok;
+wait_for_udp_proxy_messages(Pid, MinCount, Retries) ->
+    case udp_proxy_message_count(Pid) of
+        Count when Count >= MinCount ->
+            ok;
+        _ ->
+            timer:sleep(10),
+            wait_for_udp_proxy_messages(Pid, MinCount, Retries - 1)
+    end.
+
+udp_proxy_message_count(Pid) ->
+    {messages, Messages} = process_info(Pid, messages),
+    length([
+        Message
+     || Message = {{esockd_udp_proxy, _ProxyId, _Socket}, _Data, _Packets} <- Messages
+    ]).
 
 parse_udp_message(Data) ->
     {ok, Message, <<>>, _State} =

--- a/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
@@ -43,6 +43,10 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     emqx_coap_test_helpers:stop_gateway(Config).
 
+end_per_testcase(_TestCase, Config) ->
+    emqx_common_test_helpers:call_janitor(),
+    Config.
+
 %%--------------------------------------------------------------------
 %% Cases
 %%--------------------------------------------------------------------
@@ -443,16 +447,33 @@ t_send_request_api_exception(_) ->
 %%% Internal Functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 start_client() ->
-    spawn(fun coap_client/0).
+    start_client(fun coap_client/0).
 
 start_silent_client() ->
-    spawn(fun coap_silent_client/0).
+    start_client(fun coap_silent_client/0).
 
 start_block2_client() ->
     start_block2_client(block2_payload()).
 
 start_block2_client(Payload) ->
-    spawn(fun() -> coap_block2_client(Payload) end).
+    start_client(fun() -> coap_block2_client(Payload) end).
+
+start_client(ClientFun) ->
+    ClientPid = spawn(ClientFun),
+    ok = emqx_common_test_helpers:on_exit(fun() -> cleanup_client(ClientPid) end),
+    ClientPid.
+
+cleanup_client(ClientPid) ->
+    exit(ClientPid, kill),
+    _ = catch emqx_gateway_cm:kick_session(coap, <<"client1">>),
+    ok = emqx_common_test_helpers:wait_for(
+        ?FUNCTION_NAME,
+        ?LINE,
+        fun() ->
+            [] =:= emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+        end,
+        5000
+    ).
 
 start_fake_channel(ClientId, Responses) ->
     Pid = spawn(fun() -> fake_channel_loop(Responses) end),

--- a/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
@@ -357,7 +357,8 @@ t_channel_same_clientid_invalid_token_no_self_cm_call(_) ->
     },
     ok = meck:new(emqx_gateway_cm, [no_link, passthrough]),
     try
-        {ok, {outgoing, Reply}, _} = emqx_coap_channel:handle_in(Req, Channel0),
+        {ok, [{udp_proxy, reject}, {outgoing, Reply}], _} =
+            emqx_coap_channel:handle_in(Req, Channel0),
         ?assertEqual({error, unauthorized}, Reply#coap_message.method),
         ?assertEqual(
             <<"Invalid token or clientid in connection mode">>,
@@ -473,7 +474,8 @@ t_channel_takeover_resume_enriches_clientinfo(_) ->
         end
     ),
     try
-        {ok, [{outgoing, [Reply]}], Channel1} = emqx_coap_channel:handle_in(Req, Channel0),
+        {ok, [{udp_proxy, commit}, {outgoing, [Reply]}], Channel1} =
+            emqx_coap_channel:handle_in(Req, Channel0),
         ?assertEqual({ok, changed}, Reply#coap_message.method),
         ?assertEqual(connected, Channel1#channel.conn_state),
         ?assertEqual(ReqToken, Channel1#channel.token),
@@ -565,7 +567,8 @@ t_channel_takeover_open_session_fallback_cleanup(_) ->
         end
     ),
     try
-        {ok, {outgoing, Reply}, _} = emqx_coap_channel:handle_in(Req, Channel0),
+        {ok, [{udp_proxy, reject}, {outgoing, Reply}], _} =
+            emqx_coap_channel:handle_in(Req, Channel0),
         ?assertEqual({error, unauthorized}, Reply#coap_message.method),
         ?assertEqual(
             <<"Invalid token or clientid in connection mode">>,
@@ -606,7 +609,8 @@ t_channel_connected_invalid_queries(_) ->
             uri_query => #{<<"clientid">> => <<"client2">>}
         }
     },
-    {ok, [{outgoing, [_]} | _], _} = emqx_coap_channel:handle_in(ConnReqDiff, Channel1),
+    {ok, [{udp_proxy, reject}, {outgoing, [_]} | _], _} =
+        emqx_coap_channel:handle_in(ConnReqDiff, Channel1),
     ConnReqMissing = #coap_message{
         type = con,
         method = post,
@@ -616,7 +620,8 @@ t_channel_connected_invalid_queries(_) ->
             uri_query => #{<<"username">> => <<"admin">>}
         }
     },
-    {ok, [{outgoing, [_]} | _], _} = emqx_coap_channel:handle_in(ConnReqMissing, Channel1),
+    {ok, [{udp_proxy, reject}, {outgoing, [_]} | _], _} =
+        emqx_coap_channel:handle_in(ConnReqMissing, Channel1),
     CloseReq = #coap_message{
         type = con,
         method = delete,

--- a/apps/emqx_gateway_coap/test/emqx_coap_proxy_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_proxy_SUITE.erl
@@ -75,7 +75,7 @@ t_proxy_conn_reuse_bound_clientid_when_missing(_) ->
         }
     },
     Bin1 = emqx_coap_frame:serialize_pkt(Msg1, emqx_coap_frame:serialize_opts()),
-    {ok, <<"client1">>, [_], State1} =
+    {ok, {coap_udp_proxy, Peer, <<"client1">>}, [_], State1} =
         emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State0, Bin1),
 
     Msg2 = #coap_message{
@@ -88,7 +88,7 @@ t_proxy_conn_reuse_bound_clientid_when_missing(_) ->
         }
     },
     Bin2 = emqx_coap_frame:serialize_pkt(Msg2, emqx_coap_frame:serialize_opts()),
-    {ok, <<"client1">>, [_], _State2} =
+    {ok, {coap_udp_proxy, Peer, <<"client1">>}, [_], _State2} =
         emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State1, Bin2),
     ok.
 
@@ -105,7 +105,7 @@ t_proxy_conn_keep_bound_clientid_on_different_clientid(_) ->
         }
     },
     Bin1 = emqx_coap_frame:serialize_pkt(Msg1, emqx_coap_frame:serialize_opts()),
-    {ok, <<"client1">>, [_], State1} =
+    {ok, {coap_udp_proxy, Peer, <<"client1">>}, [_], State1} =
         emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State0, Bin1),
 
     Msg2 = #coap_message{
@@ -118,6 +118,29 @@ t_proxy_conn_keep_bound_clientid_on_different_clientid(_) ->
         }
     },
     Bin2 = emqx_coap_frame:serialize_pkt(Msg2, emqx_coap_frame:serialize_opts()),
-    {ok, <<"client1">>, [_], _State2} =
+    {ok, {coap_udp_proxy, Peer, <<"client1">>}, [_], _State2} =
         emqx_coap_proxy_conn:get_connection_id(dummy, Peer, State1, Bin2),
     ok.
+
+t_proxy_conn_scopes_clientid_by_peer(_) ->
+    Peer1 = {{127, 0, 0, 1}, 10001},
+    Peer2 = {{127, 0, 0, 1}, 10002},
+    Msg = #coap_message{
+        type = con,
+        method = post,
+        id = 1,
+        options = #{
+            uri_path => [<<"mqtt">>, <<"connection">>],
+            uri_query => #{<<"clientid">> => <<"client1">>}
+        }
+    },
+    Bin = emqx_coap_frame:serialize_pkt(Msg, emqx_coap_frame:serialize_opts()),
+    State1 = emqx_coap_proxy_conn:initialize([]),
+    State2 = emqx_coap_proxy_conn:initialize([]),
+    {ok, ProxyCId1, [_], _} =
+        emqx_coap_proxy_conn:get_connection_id(dummy, Peer1, State1, Bin),
+    {ok, ProxyCId2, [_], _} =
+        emqx_coap_proxy_conn:get_connection_id(dummy, Peer2, State2, Bin),
+    ?assertEqual({coap_udp_proxy, Peer1, <<"client1">>}, ProxyCId1),
+    ?assertEqual({coap_udp_proxy, Peer2, <<"client1">>}, ProxyCId2),
+    ?assertNotEqual(ProxyCId1, ProxyCId2).

--- a/apps/emqx_gateway_coap/test/emqx_coap_proxy_cluster_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_proxy_cluster_SUITE.erl
@@ -1,0 +1,189 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_coap_proxy_cluster_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("er_coap_client/include/coap.hrl").
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(HOST, {127, 0, 0, 1}).
+-define(MQTT_PREFIX, "coap://127.0.0.1/mqtt").
+-define(PS_PREFIX, "coap://127.0.0.1/ps").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    {Nodes, Port1, Port2} = start_coap_cluster(Config),
+    [
+        {cluster_nodes, Nodes},
+        {coap_port1, Port1},
+        {coap_port2, Port2}
+        | Config
+    ].
+
+end_per_suite(Config) ->
+    emqx_cth_cluster:stop(?config(cluster_nodes, Config)).
+
+t_udp_downlink_migration_across_nodes(Config) ->
+    ClientId = <<"cluster-coap-udp-migration">>,
+    Topic = <<"cluster/coap/udp/migration">>,
+    [Node1, Node2] = ?config(cluster_nodes, Config),
+    Port1 = ?config(coap_port1, Config),
+    Port2 = ?config(coap_port2, Config),
+    {ok, Sock1, Channel1} = er_coap_udp_socket:connect(?HOST, Port1),
+    {ok, Sock2} = gen_udp:open(0, [binary, {active, false}]),
+    try
+        Token = connection(Channel1, ClientId),
+        observe_topic(Channel1, ClientId, Token, Topic),
+        ?retry(
+            100,
+            20,
+            [_] = erpc:call(Node2, emqx_gateway_cm_registry, lookup_channels, [coap, ClientId])
+        ),
+        [ConnPid] = erpc:call(Node2, emqx_gateway_cm_registry, lookup_channels, [
+            coap, ClientId
+        ]),
+        ?assertEqual(Node1, node(ConnPid)),
+
+        InvalidURI = pubsub_uri(Topic, ClientId, <<"wrong-token">>),
+        ?assertMatch(
+            {error, unauthorized, _},
+            raw_udp_request(Sock2, Port2, InvalidURI, make_req(post, <<"rejected">>))
+        ),
+
+        RejectedPayload = <<"after-cross-node-reject">>,
+        publish(Node1, Topic, RejectedPayload),
+        ?assertEqual({error, timeout}, gen_udp:recv(Sock2, 0, 300)),
+        _ = emqx_coap_SUITE:assert_notify(Channel1, non, RejectedPayload),
+
+        ValidURI = pubsub_uri(<<"cluster/coap/udp/migration/request">>, ClientId, Token),
+        ?assertMatch(
+            {ok, changed, _},
+            raw_udp_request(Sock2, Port2, ValidURI, make_req(post, <<"accepted">>))
+        ),
+
+        CommittedPayload = <<"after-cross-node-commit">>,
+        publish(Node1, Topic, CommittedPayload),
+        ?assertEqual({error, timeout}, emqx_coap_SUITE:with_message_response(Channel1, 300)),
+        {ok, {?HOST, Port2, NotificationData}} = gen_udp:recv(Sock2, 0, 2000),
+        #coap_message{payload = CommittedPayload} =
+            emqx_coap_SUITE:parse_udp_message(NotificationData)
+    after
+        _ = catch erpc:call(Node1, emqx_gateway_cm, kick_session, [coap, ClientId]),
+        er_coap_channel:close(Channel1),
+        er_coap_udp_socket:close(Sock1),
+        gen_udp:close(Sock2)
+    end.
+
+start_coap_cluster(Config) ->
+    Port1 = emqx_common_test_helpers:select_free_port(udp),
+    Port2 = emqx_common_test_helpers:select_free_port(udp),
+    NodeSpecs = emqx_cth_cluster:mk_nodespecs(
+        [
+            {cluster_node_name(?FUNCTION_NAME, 1), #{apps => coap_apps(Port1)}},
+            {cluster_node_name(?FUNCTION_NAME, 2), #{apps => coap_apps(Port2)}}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+    ),
+    [Node1, Node2] = Nodes = emqx_cth_cluster:start(NodeSpecs),
+    ?retry(
+        50,
+        20,
+        true = is_pid(erpc:call(Node1, erlang, whereis, [emqx_gateway_sup]))
+    ),
+    ?retry(
+        50,
+        20,
+        true = is_pid(erpc:call(Node2, erlang, whereis, [emqx_gateway_sup]))
+    ),
+    {Nodes, Port1, Port2}.
+
+cluster_node_name(TestCase, N) ->
+    binary_to_atom(iolist_to_binary(io_lib:format("~s_~B", [TestCase, N]))).
+
+coap_apps(Port) ->
+    [
+        {emqx_conf, coap_conf(Port)},
+        emqx_gateway,
+        emqx_auth
+    ].
+
+coap_conf(Port) ->
+    iolist_to_binary(
+        io_lib:format(
+            ~S"""
+            gateway.coap {
+                idle_timeout = 30s
+                enable_stats = false
+                mountpoint = ""
+                notify_type = qos
+                connection_required = true
+                subscribe_qos = qos1
+                publish_qos = qos1
+                listeners.udp.default {
+                    bind = "127.0.0.1:~B"
+                    enable_authn = false
+                }
+            }
+            """,
+            [Port]
+        )
+    ).
+
+connection(Channel, ClientId) ->
+    URI = emqx_coap_SUITE:compose_uri(
+        ?MQTT_PREFIX ++ "/connection",
+        #{
+            "clientid" => ClientId,
+            "username" => <<"admin">>,
+            "password" => <<"public">>
+        },
+        false
+    ),
+    {ok, created, #coap_content{payload = Token}} =
+        emqx_coap_SUITE:do_request(Channel, URI, make_req(post)),
+    Token.
+
+observe_topic(Channel, ClientId, Token, Topic) ->
+    URI = pubsub_uri(Topic, ClientId, Token),
+    Req = (make_req(get, <<>>, [{observe, 0}]))#coap_message{token = <<"cluster-observe">>},
+    {ok, content, _} = emqx_coap_SUITE:do_request(Channel, URI, Req),
+    ok.
+
+pubsub_uri(Topic, ClientId, Token) ->
+    emqx_coap_SUITE:compose_uri(
+        ?PS_PREFIX ++ "/" ++ binary_to_list(Topic),
+        #{"clientid" => ClientId, "token" => Token},
+        false
+    ).
+
+make_req(Method) ->
+    make_req(Method, <<>>).
+
+make_req(Method, Payload) ->
+    make_req(Method, Payload, []).
+
+make_req(Method, Payload, Opts) ->
+    er_coap_message:request(con, Method, Payload, Opts).
+
+raw_udp_request(Socket, Port, URI, #coap_message{options = Opts} = Req) ->
+    {_, _, Path, Query} = er_coap_client:resolve_uri(URI),
+    Req1 = Req#coap_message{
+        id = erlang:unique_integer([positive]) band 16#FFFF,
+        token = crypto:strong_rand_bytes(4),
+        options = [{uri_path, Path}, {uri_query, Query} | Opts]
+    },
+    ok = gen_udp:send(Socket, ?HOST, Port, er_coap_message_parser:encode(Req1)),
+    emqx_coap_SUITE:recv_raw_udp_response(Socket).
+
+publish(Node, Topic, Payload) ->
+    Msg = emqx_message:make(<<"coap-cluster-ct">>, 0, Topic, Payload),
+    _ = erpc:call(Node, emqx, publish, [Msg]),
+    ok.

--- a/changes/ee/fix-18312.en.md
+++ b/changes/ee/fix-18312.en.md
@@ -1,0 +1,1 @@
+Fixed an issue in plaintext CoAP UDP listeners with connection mode enabled where a rejected request from another source could redirect subsequent downlink messages.


### PR DESCRIPTION
Release version: 6.3.0

Introduced in: 6.1.4

## Summary

- Scope plaintext CoAP UDP proxy IDs by peer so esockd cannot replace the current proxy before CoAP validation.
- Route candidate replies through a request-scoped socket and commit the persistent downlink handle only after the channel validates the client ID and token.
- Preserve the original downlink handle on rejection while allowing a validated peer change to migrate it.

Fix: emqx/emqx-dev-team-tasks#309

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
