### PR TITLE
fix(dashboard_rbac): restrict File Transfer file listing/download to non-namespaced users

### DIFF
--- a/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
@@ -574,8 +574,9 @@ Simple assertions about namespaced user permissions.
      are mostly to avoid accidentally mutating the wrong resources rather than hiding
      information.
    - Exception: endpoints whose response would expose MQTT payload content (per-client
-     mqueue/inflight, retained, delayed) are denied for namespaced users by RBAC, because
-     the underlying stores are global and cannot be safely filtered by namespace.  Those
+     mqueue/inflight, retained, delayed) or client-uploaded file content (File Transfer
+     listing and download) are denied for namespaced users by RBAC, because the
+     underlying stores are global and cannot be safely filtered by namespace.  Those
      handlers are kept in a static deny list here so this assertion does not have to
      reach into RBAC internals.
 """.
@@ -632,7 +633,18 @@ namespaced_get_denylist() ->
         #{method => get, module => emqx_retainer_api, function => '/messages'},
         #{method => get, module => emqx_retainer_api, function => with_topic_warp},
         #{method => get, module => emqx_delayed_api, function => delayed_messages},
-        #{method => get, module => emqx_delayed_api, function => delayed_message}
+        #{method => get, module => emqx_delayed_api, function => delayed_message},
+        #{method => get, module => emqx_ft_api, function => '/file_transfer/files'},
+        #{
+            method => get,
+            module => emqx_ft_api,
+            function => '/file_transfer/files/:clientid/:fileid'
+        },
+        #{
+            method => get,
+            module => emqx_ft_storage_exporter_fs_api,
+            function => '/file_transfer/file'
+        }
     ].
 
 -doc """

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -48,6 +48,8 @@
 -define(RETAINER_API(METHOD, FN), ?API(emqx_retainer_api, METHOD, FN)).
 -define(DELAYED_API(METHOD, FN), ?API(emqx_delayed_api, METHOD, FN)).
 -define(API_KEY_API(METHOD, FN), ?API(emqx_mgmt_api_api_keys, METHOD, FN)).
+-define(FT_API(METHOD, FN), ?API(emqx_ft_api, METHOD, FN)).
+-define(FT_FS_API(METHOD, FN), ?API(emqx_ft_storage_exporter_fs_api, METHOD, FN)).
 
 %%=====================================================================
 %% API
@@ -246,6 +248,19 @@ do_check_rbac(#{?namespace := Namespace}, _, ?DELAYED_API(_, Fn)) when
     %% coarse global-only endpoint decision here; filters should resolve or
     %% validate a namespace, not define the static RBAC surface.
     {error, <<"Delayed message endpoints are not available to namespaced users">>};
+do_check_rbac(#{?namespace := Namespace}, _, ?FT_API(get, Fn)) when
+    is_binary(Namespace) andalso
+        (Fn == '/file_transfer/files' orelse
+            Fn == '/file_transfer/files/:clientid/:fileid')
+->
+    %% The File Transfer store is global and holds client-uploaded file content.
+    %% Listing or downloading would expose files uploaded outside the caller's
+    %% namespace.
+    {error, <<"File Transfer endpoints are not available to namespaced users">>};
+do_check_rbac(#{?namespace := Namespace}, _, ?FT_FS_API(get, '/file_transfer/file')) when
+    is_binary(Namespace)
+->
+    {error, <<"File Transfer endpoints are not available to namespaced users">>};
 do_check_rbac(#{?role := ?ROLE_SUPERUSER}, _, #{method := get}) ->
     %% Namespaced administrator; It's fine for such admins to `GET` anything, even outside
     %% their namespace.  Namespaces are mostly to avoid accidentally mutating the wrong

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -744,6 +744,47 @@ t_global_only_message_endpoints_reject_namespaced_actors(_) ->
         global_only_message_endpoint_handlers()
     ).
 
+-doc """
+File Transfer file listing and download endpoints expose client-uploaded file
+content from the global FT store, so they must reject all namespaced actors
+(login users and API keys, any role) while remaining available to global
+principals.  The FT config endpoint (`'/file_transfer'`) is not restricted.
+""".
+t_file_transfer_endpoints_reject_namespaced_actors(_) ->
+    Req = #{},
+    Expected = {error, <<"File Transfer endpoints are not available to namespaced users">>},
+    lists:foreach(
+        fun(HandlerInfo) ->
+            lists:foreach(
+                fun(ActorContext) ->
+                    ?assertEqual(
+                        Expected,
+                        emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, ActorContext)
+                    )
+                end,
+                namespaced_actor_contexts()
+            ),
+            ?assertMatch(
+                {ok, _},
+                emqx_dashboard_rbac:check_rbac(Req, HandlerInfo, global_admin_actor_context())
+            ),
+            assert_global_viewer_rbac(Req, HandlerInfo)
+        end,
+        file_transfer_content_endpoint_handlers()
+    ),
+    %% Sanity: the FT config endpoint stays readable for namespaced actors.
+    ConfigHandlerInfo = #{method => get, module => emqx_ft_api, function => '/file_transfer'},
+    lists:foreach(
+        fun(ActorContext) ->
+            ?assertMatch(
+                {ok, _},
+                emqx_dashboard_rbac:check_rbac(Req, ConfigHandlerInfo, ActorContext)
+            )
+        end,
+        namespaced_actor_contexts() ++
+            [global_admin_actor_context(), global_viewer_actor_context()]
+    ).
+
 t_tracing_config_update_rejects_namespaced_actors(_) ->
     Req = #{},
     HandlerInfo = #{method => put, module => emqx_mgmt_api_trace, function => config},
@@ -778,6 +819,21 @@ global_only_message_endpoint_handlers() ->
         #{method => get, module => emqx_delayed_api, function => delayed_message},
         #{method => delete, module => emqx_delayed_api, function => delayed_message},
         #{method => delete, module => emqx_delayed_api, function => delayed_message_topic}
+    ].
+
+file_transfer_content_endpoint_handlers() ->
+    [
+        #{method => get, module => emqx_ft_api, function => '/file_transfer/files'},
+        #{
+            method => get,
+            module => emqx_ft_api,
+            function => '/file_transfer/files/:clientid/:fileid'
+        },
+        #{
+            method => get,
+            module => emqx_ft_storage_exporter_fs_api,
+            function => '/file_transfer/file'
+        }
     ].
 
 namespaced_actor_contexts() ->

--- a/changes/ee/fix-18315.en.md
+++ b/changes/ee/fix-18315.en.md
@@ -1,0 +1,1 @@
+MQTT File Transfer file listing and download REST endpoints are now available only to global (non-namespaced) Dashboard users and API keys. Namespaced users and API keys can no longer read files uploaded by clients outside their namespace.


### PR DESCRIPTION
Release version:

6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in: 6.0.0

## Summary

The File Transfer store is global and has no Dashboard-namespace awareness. A namespaced Dashboard user or namespaced API key could list and download files uploaded by clients in any namespace.

This PR adds the File Transfer content endpoints to the RBAC restricted set in `emqx_dashboard_rbac:do_check_rbac/3`, before the permissive role fall-through clauses:

* `GET /file_transfer/files` and `GET /file_transfer/files/:clientid/:fileid` (`emqx_ft_api`) — file listing
* `GET /file_transfer/file` (`emqx_ft_storage_exporter_fs_api`) — file download

Namespaced principals of any role now get an error on these endpoints. Global (non-namespaced) principals keep the current behavior. The `/file_transfer` config endpoint is not affected.

This mirrors the existing restrictions for per-client messages, retained messages, and delayed messages.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

