### PR TITLE
test(username_quota): re-enable listener authn in int suite

### DIFF
--- a/plugins/emqx_username_quota/test/emqx_username_quota_int_SUITE.erl
+++ b/plugins/emqx_username_quota/test/emqx_username_quota_int_SUITE.erl
@@ -13,9 +13,11 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
+    %% The test harness defaults listeners to enable_authn = false, which skips the
+    %% 'client.authenticate' hook chain the plugin enforces quota from.
     EmqxConfig = #{
         listeners => #{
-            tcp => #{default => #{bind => 18884}},
+            tcp => #{default => #{bind => 18884, enable_authn => true}},
             ssl => #{default => #{bind => 0}},
             ws => #{default => #{bind => 0}},
             wss => #{default => #{bind => 0}}


### PR DESCRIPTION
Since the hardened-profile default (#18232), the test harness sets `enable_authn = false` on listeners by default, so the `client.authenticate` hook chain does not run. `emqx_username_quota` enforces its session quota from that hook, so `emqx_username_quota_int_SUITE` no longer exercised enforcement and its two over-quota cases failed. Set `enable_authn = true` on the suite's tcp listener so the quota check runs again.

Checked the other in-tree plugins: no other plugin hooks `client.authenticate`.