### PR TITLE
fix(snowflake): apply configured ssl options to outbound HTTPS connections

### DIFF
--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.app.src
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_snowflake, [
     {description, "EMQX Enterprise Snowflake Bridge"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_connector.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_connector.erl
@@ -62,6 +62,10 @@
 %% Internal exports only for mocking
 -export([do_insert_files_request/4, do_insert_report_request/4]).
 
+-ifdef(TEST).
+-export([http_pool_transport_opts/1]).
+-endif.
+
 %%------------------------------------------------------------------------------
 %% Type declarations
 %%------------------------------------------------------------------------------
@@ -78,11 +82,13 @@
     password := emqx_schema_secret:secret(),
     dsn := binary(),
     pool_size := pos_integer(),
-    proxy := none | proxy_config()
+    proxy := none | proxy_config(),
+    ssl => map()
 }.
 -type connector_state() :: #{
     account := account(),
     server := #{host := binary(), port := emqx_schema:port_number()},
+    ssl := map(),
     installed_actions := #{action_resource_id() => action_state()}
 }.
 
@@ -219,6 +225,7 @@ on_start(ConnResId, ConnConfig) ->
             State = #{
                 account => Account,
                 server => #{host => Host, port => Port},
+                ssl => maps:get(ssl, ConnConfig, #{}),
                 installed_actions => #{}
             },
             {ok, State};
@@ -675,7 +682,7 @@ start_http_pool(ActionResId, ActionConfig, ConnState) ->
         <<"/insertReport">>
     ]),
     JWTConfig = jwt_config(ActionResId, ActionConfig, ConnState),
-    TransportOpts = emqx_tls_lib:to_client_opts(#{enable => true, verify => verify_none}),
+    TransportOpts = http_pool_transport_opts(maps:get(ssl, ConnState, #{})),
     ProxyConfig =
         case ProxyConfig0 of
             none ->
@@ -719,6 +726,11 @@ start_http_pool(ActionResId, ActionConfig, ConnState) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+http_pool_transport_opts(SSLConfig) ->
+    %% Snowflake endpoints are always HTTPS: force TLS on regardless of `ssl.enable`,
+    %% while honouring the rest of the configured `ssl` options.
+    emqx_tls_lib:to_client_opts(SSLConfig#{enable => true}).
 
 start_aggregator(ConnResId, ActionResId, ActionConfig, ActionState0) ->
     maybe

--- a/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_tests.erl
+++ b/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_tests.erl
@@ -51,3 +51,36 @@ validation_test_() ->
                 )
             )}
     ].
+
+ssl_transport_opts_test_() ->
+    TransportOpts = fun(SSL) ->
+        emqx_bridge_snowflake_connector:http_pool_transport_opts(SSL)
+    end,
+    [
+        {"untouched config keeps verify_none",
+            ?_assertEqual(
+                verify_none,
+                proplists:get_value(verify, TransportOpts(#{}))
+            )},
+        {"configured verify is applied",
+            ?_assertEqual(
+                verify_peer,
+                proplists:get_value(verify, TransportOpts(#{verify => verify_peer}))
+            )},
+        {"configured server_name_indication is applied",
+            ?_assertEqual(
+                "custom.sni.host",
+                proplists:get_value(
+                    server_name_indication,
+                    TransportOpts(#{
+                        verify => verify_peer,
+                        server_name_indication => <<"custom.sni.host">>
+                    })
+                )
+            )},
+        {"TLS options are built even when ssl.enable is false",
+            ?_assertMatch(
+                [_ | _],
+                TransportOpts(#{enable => false, verify => verify_none})
+            )}
+    ].

--- a/changes/ee/fix-18328.en.md
+++ b/changes/ee/fix-18328.en.md
@@ -1,0 +1,1 @@
+The Snowflake connector now applies its configured `ssl` options when connecting to Snowflake endpoints. Previously the connector ignored the `ssl` settings and never verified the server certificate.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
5.8.1 (Snowflake connector introduction)

## Summary

v5 counterpart of #18299 (issue emqx/emqx-dev-team-tasks#322). The Snowflake connector schema exposes the standard `ssl` block, but `start_http_pool/3` built the ehttpc transport options from a hardcoded `#{enable => true, verify => verify_none}` literal, so the configured `ssl` settings (`verify`, `cacertfile`, client certificates, SNI, ...) were parsed, stored, displayed, and then silently ignored. An operator who set `ssl.verify = verify_peer` and a `cacertfile` got no error and no verification.

The connector's `ssl` config is now threaded into the transport options of the Snowpipe insert pool. `enable` is forced on (Snowflake endpoints are always HTTPS); the rest of the block is honoured.

The effective default for untouched configs is unchanged (`verify_none`), matching the decision made in #18299: existing connectors keep their current connection behaviour on upgrade.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
