### PR TITLE
fix(api): redact secrets in listeners, exhook and audit read endpoints

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -121,7 +121,9 @@ do_list_raw() ->
             Key = <<"listeners">>,
             Raw = emqx_config:get_raw([Key], #{}),
             SchemaMod = emqx_config:get_schema_mod(Key),
-            #{Key := RawWithDefault} = emqx_config:fill_defaults(SchemaMod, #{Key => Raw}, #{}),
+            #{Key := RawWithDefault} = emqx_config:fill_defaults(SchemaMod, #{Key => Raw}, #{
+                obfuscate_sensitive_values => true
+            }),
             Listeners = maps:to_list(RawWithDefault),
             lists:flatmap(fun format_raw_listeners/1, Listeners);
         false ->

--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -52,6 +52,7 @@ init_per_suite(Config) ->
                 schema_mod => emqx_enterprise_schema
             }},
             emqx_modules,
+            emqx_license,
             emqx_audit,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
@@ -309,6 +310,44 @@ t_max_size(_Config) ->
     ExpectSize = emqx:get_config([log, audit, cache_size]),
     Size2 = SizeFun(),
     ?assertEqual(ExpectSize, Size2, {sys:get_state(emqx_audit)}),
+    ok.
+
+-doc """
+The audit log records the `POST /license` request body as `******`
+so the license key does not appear in cleartext in `GET /audit`.
+""".
+t_license_key_redacted(_) ->
+    StartAt = erlang:system_time(microsecond),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    LicensePath = emqx_mgmt_api_test_util:api_path(["license"]),
+    {ok, _} = emqx_mgmt_api_test_util:request_api(
+        post, LicensePath, "", AuthHeader, #{<<"key">> => <<"default">>}
+    ),
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    Query =
+        lists:flatten(
+            io_lib:format(
+                "operation_id=/license&gte_created_at=~B&limit=1",
+                [StartAt]
+            )
+        ),
+    Res = wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, 2000),
+    ?assertMatch(
+        #{
+            <<"data">> := [
+                #{
+                    <<"operation_id">> := <<"/license">>,
+                    <<"http_request">> := #{<<"method">> := <<"post">>, <<"body">> := _}
+                }
+            ]
+        },
+        emqx_utils_json:decode(Res)
+    ),
+    #{<<"data">> := [#{<<"http_request">> := #{<<"body">> := AuditBody}}]} =
+        emqx_utils_json:decode(Res),
+    %% the recorded body is redacted: no license key, only the redaction mark
+    ?assertEqual(nomatch, binary:match(AuditBody, <<"default">>), AuditBody),
+    ?assertNotEqual(nomatch, binary:match(AuditBody, <<"******">>), AuditBody),
     ok.
 
 t_kickout_clients_without_log(_) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
@@ -120,9 +120,19 @@ http_request(Meta) ->
     case maps:with([method, headers, bindings, body], Meta) of
         #{body := Body} = Request when is_binary(Body) ->
             Request#{body => <<"******">>};
+        #{body := _} = Request ->
+            case is_sensitive_body_operation(Meta) of
+                true -> Request#{body => <<"******">>};
+                false -> Request
+            end;
         Request ->
             Request
     end.
+
+%% Endpoints whose request body carries a secret under a key name that
+%% the generic key-name based redaction does not cover.
+is_sensitive_body_operation(#{operation_id := <<"/license">>}) -> true;
+is_sensitive_body_operation(_) -> false.
 
 operation_result(302, _) -> success;
 operation_result(Code, _) when Code >= 300 -> failure;

--- a/apps/emqx_exhook/mix.exs
+++ b/apps/emqx_exhook/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXExhook.MixProject do
   def project do
     [
       app: :emqx_exhook,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       compilers: [:elixir, :grpc, :erlang, :app, :copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_exhook/src/emqx_exhook_api.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_api.erl
@@ -254,7 +254,8 @@ exhooks(post, #{body := #{<<"name">> := Name} = Body}) ->
 
 action_with_name(get, #{bindings := #{name := Name}}) ->
     get_nodes_server_info(Name);
-action_with_name(put, #{bindings := #{name := Name}, body := Body}) ->
+action_with_name(put, #{bindings := #{name := Name}, body := Body0}) ->
+    Body = deobfuscate(Name, Body0),
     case
         emqx_exhook_mgr:update_config(
             [exhook, servers],
@@ -476,8 +477,21 @@ get_raw_config() ->
     RawConfig = emqx:get_raw_config([exhook, servers], []),
     Schema = #{roots => emqx_exhook_schema:fields(exhook), fields => #{}},
     Conf = #{<<"servers">> => RawConfig},
-    #{<<"servers">> := Servers} = hocon_tconf:make_serializable(Schema, Conf, #{}),
+    #{<<"servers">> := Servers} = hocon_tconf:make_serializable(Schema, Conf, #{
+        obfuscate_sensitive_values => true
+    }),
     Servers.
+
+%% GET returns sensitive values as `******`; restore them from the current
+%% config so a round-tripped body does not overwrite stored secrets.
+deobfuscate(Name, Body) ->
+    Servers = emqx:get_raw_config([exhook, servers], []),
+    case lists:search(fun(#{<<"name">> := N}) -> N =:= Name end, Servers) of
+        {value, OldConf} ->
+            emqx_utils:deobfuscate(Body, OldConf);
+        false ->
+            Body
+    end.
 
 position_example() ->
     #{

--- a/apps/emqx_exhook/test/emqx_exhook_api_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_api_SUITE.erl
@@ -39,6 +39,7 @@ all() ->
         t_move_after,
         t_delete,
         t_hooks,
+        t_ssl_password_obfuscated,
         t_update
     ].
 
@@ -279,6 +280,43 @@ t_hooks(_Cfg) ->
         },
         Hook1
     ).
+
+-doc """
+GET /exhooks renders the gRPC client `ssl.password` as `******`,
+and a round-tripped `******` value does not overwrite the stored secret.
+""".
+t_ssl_password_obfuscated(Cfg) ->
+    Template = proplists:get_value(template, Cfg),
+    Password = <<"exhook-passwd">>,
+    Body = Template#{
+        <<"enable">> => false,
+        <<"ssl">> => #{<<"enable">> => false, <<"password">> => Password}
+    },
+    {ok, _} = request_api(
+        put,
+        api_path(["exhooks", "default"]),
+        "",
+        auth_header_(),
+        Body
+    ),
+    {ok, ListData} = request_api(get, api_path(["exhooks"]), "", auth_header_()),
+    ?assertMatch([#{ssl := #{password := <<"******">>}}], decode_json(ListData)),
+    {ok, GetData} = request_api(get, api_path(["exhooks", "default"]), "", auth_header_()),
+    ?assertMatch(#{ssl := #{password := <<"******">>}}, decode_json(GetData)),
+    %% the stored config keeps the real password
+    [RawConf] = emqx:get_raw_config([exhook, servers]),
+    ?assertEqual(Password, emqx_utils_maps:deep_get([<<"ssl">>, <<"password">>], RawConf)),
+    %% a round-tripped body with the obfuscated value keeps the stored secret
+    Body1 = Body#{<<"ssl">> => #{<<"enable">> => false, <<"password">> => <<"******">>}},
+    {ok, _} = request_api(
+        put,
+        api_path(["exhooks", "default"]),
+        "",
+        auth_header_(),
+        Body1
+    ),
+    [RawConf1] = emqx:get_raw_config([exhook, servers]),
+    ?assertEqual(Password, emqx_utils_maps:deep_get([<<"ssl">>, <<"password">>], RawConf1)).
 
 t_update(Cfg) ->
     Template = proplists:get_value(template, Cfg),

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -411,7 +411,11 @@ crud_listeners_by_id(put, #{bindings := #{id := Id}, body := Body0}) ->
                 undefined ->
                     {404, #{code => 'BAD_LISTENER_ID', message => ?LISTENER_NOT_FOUND}};
                 PrevConf ->
-                    MergeConf = emqx_utils_maps:deep_merge(PrevConf, Conf),
+                    %% GET returns sensitive values as `******`; restore them
+                    %% from the current config so a round-tripped body does not
+                    %% overwrite stored secrets.
+                    Conf1 = emqx_utils:deobfuscate(Conf, PrevConf),
+                    MergeConf = emqx_utils_maps:deep_merge(PrevConf, Conf1),
                     case update(Type, Name, MergeConf) of
                         {ok, #{raw_config := _RawConf}} ->
                             crud_listeners_by_id(get, #{bindings => #{id => Id}});

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -504,6 +504,37 @@ t_update_validation_error_message({'end', Config}) ->
     ?assertEqual([], delete(NewPath)),
     ok.
 
+-doc """
+GET /listeners/:id renders `ssl_options.password` as `******`,
+and a round-tripped `******` value does not overwrite the stored secret.
+""".
+t_ssl_password_obfuscated(Config) when is_list(Config) ->
+    ListenerId = <<"ssl:default">>,
+    Path = emqx_mgmt_api_test_util:api_path(["listeners", ListenerId]),
+    Listener = request(get, Path, [], []),
+    Password = <<"file-passwd">>,
+    Body = emqx_utils_maps:deep_put([<<"ssl_options">>, <<"password">>], Listener, Password),
+    Updated = request(put, Path, [], Body),
+    ?assertMatch(#{<<"ssl_options">> := #{<<"password">> := <<"******">>}}, Updated),
+    ?assertMatch(
+        #{<<"ssl_options">> := #{<<"password">> := <<"******">>}},
+        request(get, Path, [], [])
+    ),
+    %% the stored config keeps the real password
+    ?assertEqual(
+        Password,
+        emqx:get_raw_config([listeners, ssl, default, ssl_options, password])
+    ),
+    %% a round-tripped body with the obfuscated value keeps the stored secret
+    Roundtrip = request(get, Path, [], []),
+    ?assertMatch(#{<<"ssl_options">> := #{<<"password">> := <<"******">>}}, Roundtrip),
+    _ = request(put, Path, [], Roundtrip),
+    ?assertEqual(
+        Password,
+        emqx:get_raw_config([listeners, ssl, default, ssl_options, password])
+    ),
+    ok.
+
 action_listener(ID, Action, Running) ->
     Path = emqx_mgmt_api_test_util:api_path(["listeners", ID, Action]),
     {ok, _} = emqx_mgmt_api_test_util:request_api(post, Path),

--- a/changes/ee/fix-18330.en.md
+++ b/changes/ee/fix-18330.en.md
@@ -1,0 +1,7 @@
+Read-only REST endpoints no longer return secrets in cleartext:
+
+- `GET /listeners` and `GET /listeners/{id}` now render the listener `ssl_options.password` as `******`.
+- `GET /exhooks` and `GET /exhooks/{name}` now render the gRPC client `ssl.password` as `******`.
+- Audit log entries for `POST /license` now record the request body as `******`, so the license key does not appear in `GET /audit` results.
+
+Updating a listener or an exhook server with a body that contains the `******` placeholder keeps the stored secret unchanged.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:

## Summary

Fixes findings A2, A3 and A5 of emqx/emqx-dev-team-tasks#333. Findings A1 and A4 are tracked separately and are out of scope for this PR.

Read-only REST endpoints returned secrets in cleartext:

- A2: `GET /listeners` and `GET /listeners/{id}` returned `ssl_options.password` in cleartext. `emqx_listeners:do_list_raw/0` now calls `emqx_config:fill_defaults/3` with `obfuscate_sensitive_values => true`. `list_raw/0` is only used by the listeners management API, so the change is display-only.
- A3: `GET /exhooks` and `GET /exhooks/{name}` returned the gRPC client `ssl.password` in cleartext. `emqx_exhook_api:get_raw_config/0` now calls `hocon_tconf:make_serializable/3` with `obfuscate_sensitive_values => true`.
- A5: the audit log recorded the `POST /license` request body with the license key in cleartext, and `GET /audit` returned it. The body is a decoded map, so the existing binary-body redaction did not apply, and `key` is not in the generic sensitive-key list (it is too common a field name to add there). `emqx_dashboard_audit:http_request/1` now redacts the whole map body for the `/license` operation.

The listeners and exhook update handlers now call `emqx_utils:deobfuscate/2` against the stored config, so a `PUT` body that round-trips the `******` placeholder from a `GET` response keeps the stored secret. This follows the same pattern as `PUT /configs/{root}`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
