### PR TITLE
fix(authn): avoid global and namespaced user conflicts

### DIFF
--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -60,7 +60,8 @@ Returns policy depending on the current security profile.
     (exhook_message_publish_failure) -> ignore | deny;
     (authn_builtin_default_autogenerate_password) -> boolean();
     (authn_builtin_default_manual_password_hash) -> sha256 | pbkdf2;
-    (authn_builtin_accept_weak_password_hash) -> boolean().
+    (authn_builtin_accept_weak_password_hash) -> boolean();
+    (authn_mnesia_mt_user_conflict_protection) -> boolean().
 policy(mqtt_default_bind) ->
     case profile() of
         legacy -> any;
@@ -145,6 +146,11 @@ policy(authn_builtin_accept_weak_password_hash) ->
     case profile() of
         legacy -> true;
         hardened -> false
+    end;
+policy(authn_mnesia_mt_user_conflict_protection) ->
+    case profile() of
+        legacy -> false;
+        hardened -> true
     end.
 
 -doc """

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -95,7 +95,10 @@ assert_policies(legacy) ->
     ?assertEqual(ignore, emqx_security_profile:policy(exhook_message_publish_failure)),
     ?assertEqual(false, emqx_security_profile:policy(authn_builtin_default_autogenerate_password)),
     ?assertEqual(sha256, emqx_security_profile:policy(authn_builtin_default_manual_password_hash)),
-    ?assertEqual(true, emqx_security_profile:policy(authn_builtin_accept_weak_password_hash));
+    ?assertEqual(true, emqx_security_profile:policy(authn_builtin_accept_weak_password_hash)),
+    ?assertEqual(
+        false, emqx_security_profile:policy(authn_mnesia_mt_user_conflict_protection)
+    );
 assert_policies(hardened) ->
     ?assertEqual(deny, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(deny, emqx_security_profile:policy(authz_backend_failure)),
@@ -108,7 +111,10 @@ assert_policies(hardened) ->
     ?assertEqual(deny, emqx_security_profile:policy(exhook_message_publish_failure)),
     ?assertEqual(true, emqx_security_profile:policy(authn_builtin_default_autogenerate_password)),
     ?assertEqual(pbkdf2, emqx_security_profile:policy(authn_builtin_default_manual_password_hash)),
-    ?assertEqual(false, emqx_security_profile:policy(authn_builtin_accept_weak_password_hash)).
+    ?assertEqual(false, emqx_security_profile:policy(authn_builtin_accept_weak_password_hash)),
+    ?assertEqual(
+        true, emqx_security_profile:policy(authn_mnesia_mt_user_conflict_protection)
+    ).
 
 assert_default_binds(Profile, Source) ->
     ?assertEqual(

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -1059,6 +1059,20 @@ bootstrap_user_from_file(Config, State) ->
 lookup_user_with_fallback(?global_ns, UserGroup, UserId) ->
     do_lookup_user(?global_ns, UserGroup, UserId);
 lookup_user_with_fallback(Namespace, UserGroup, UserId) when is_binary(Namespace) ->
+    lookup_namespaced_user_with_fallback(
+        emqx_security_profile:policy(authn_mnesia_mt_user_conflict_protection),
+        Namespace,
+        UserGroup,
+        UserId
+    ).
+
+lookup_namespaced_user_with_fallback(false, Namespace, UserGroup, UserId) ->
+    maybe
+        error ?= do_lookup_user(Namespace, UserGroup, UserId),
+        true ?= is_namespace_empty(Namespace) orelse error,
+        do_lookup_user(?global_ns, UserGroup, UserId)
+    end;
+lookup_namespaced_user_with_fallback(true, Namespace, UserGroup, UserId) ->
     case do_lookup_user(Namespace, UserGroup, UserId) of
         {ok, _} = NamespacedUser ->
             case do_lookup_user(?global_ns, UserGroup, UserId) of
@@ -1119,15 +1133,20 @@ do_lookup_conflicting_global_txn(#user_info{}) ->
 do_lookup_conflicting_global_txn(#?AUTHN_NS_TAB{
     user_id = ?AUTHN_NS_KEY(_, UserGroup, UserId)
 }) ->
-    case mnesia:read(?TAB, {UserGroup, UserId}, write) of
-        [] ->
-            mnesia:read(
-                ?AUTHN_NS_TAB,
-                ?AUTHN_NS_KEY(?global_ns, UserGroup, UserId),
-                write
-            );
-        Records ->
-            Records
+    case emqx_security_profile:policy(authn_mnesia_mt_user_conflict_protection) of
+        false ->
+            [];
+        true ->
+            case mnesia:read(?TAB, {UserGroup, UserId}, write) of
+                [] ->
+                    mnesia:read(
+                        ?AUTHN_NS_TAB,
+                        ?AUTHN_NS_KEY(?global_ns, UserGroup, UserId),
+                        write
+                    );
+                Records ->
+                    Records
+            end
     end.
 
 is_namespace_empty(Namespace) when is_binary(Namespace) ->

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -328,14 +328,21 @@ add_user_record(UserInfoRecord, Password) ->
 add_user_tx(UserInfoRecord) ->
     case lookup_by_record_tx(UserInfoRecord) of
         [] ->
-            ok = write_user_tx(UserInfoRecord),
-            #{
-                namespace := Namespace,
-                user_id := UserId,
-                is_superuser := IsSuperuser
-            } =
-                rec_to_map(UserInfoRecord),
-            {ok, #{namespace => Namespace, user_id => UserId, is_superuser => IsSuperuser}};
+            case do_lookup_conflicting_global_txn(UserInfoRecord) of
+                [] ->
+                    ok = write_user_tx(UserInfoRecord),
+                    #{
+                        namespace := Namespace,
+                        user_id := UserId,
+                        is_superuser := IsSuperuser
+                    } =
+                        rec_to_map(UserInfoRecord),
+                    {ok, #{
+                        namespace => Namespace, user_id => UserId, is_superuser => IsSuperuser
+                    }};
+                [_] ->
+                    {error, already_exist}
+            end;
         [_] ->
             {error, already_exist}
     end.
@@ -656,22 +663,28 @@ insert_user_tx(User, Opts) ->
 
 insert_imported_user_tx(UserInfoRecord, Namespace, UserGroup, UserId, Opts) ->
     CountRecord = is_new_namespaced_record_tx(UserInfoRecord),
+    LogF = fun(Msg) ->
+        ?SLOG(warning, #{
+            msg => Msg,
+            namespace => Namespace,
+            user_id => UserId,
+            group_id => UserGroup,
+            bootstrap_file => maps:get(filename, Opts)
+        })
+    end,
     case lookup_by_record_tx(UserInfoRecord) of
         [] ->
-            ok = write_user_tx(UserInfoRecord),
-            {success, Namespace, CountRecord};
+            case do_lookup_conflicting_global_txn(UserInfoRecord) of
+                [] ->
+                    ok = write_user_tx(UserInfoRecord),
+                    {success, Namespace, CountRecord};
+                [_] ->
+                    LogF("import_namespaced_userid_conflicts_with_global_user"),
+                    failed
+            end;
         [UserInfoRecord] ->
             skipped;
         [_ExistingRecord] ->
-            LogF = fun(Msg) ->
-                ?SLOG(warning, #{
-                    msg => Msg,
-                    namespace => Namespace,
-                    user_id => UserId,
-                    group_id => UserGroup,
-                    bootstrap_file => maps:get(filename, Opts)
-                })
-            end,
             case maps:get(override, Opts, false) of
                 true ->
                     ok = write_user_tx(UserInfoRecord),
@@ -1046,11 +1059,18 @@ bootstrap_user_from_file(Config, State) ->
 lookup_user_with_fallback(?global_ns, UserGroup, UserId) ->
     do_lookup_user(?global_ns, UserGroup, UserId);
 lookup_user_with_fallback(Namespace, UserGroup, UserId) when is_binary(Namespace) ->
-    maybe
-        error ?= do_lookup_user(Namespace, UserGroup, UserId),
-        %% We only fall back to global if there are no records for the whole namespace.
-        true ?= is_namespace_empty(Namespace) orelse error,
-        do_lookup_user(?global_ns, UserGroup, UserId)
+    case do_lookup_user(Namespace, UserGroup, UserId) of
+        {ok, _} = NamespacedUser ->
+            case do_lookup_user(?global_ns, UserGroup, UserId) of
+                error -> NamespacedUser;
+                {ok, _} -> error
+            end;
+        error ->
+            case is_namespace_empty(Namespace) of
+                %% We only fall back to global if there are no records for the whole namespace.
+                true -> do_lookup_user(?global_ns, UserGroup, UserId);
+                false -> error
+            end
     end.
 
 do_lookup_user(?global_ns, UserGroup, UserId) ->
@@ -1093,6 +1113,22 @@ is_new_namespaced_record_tx(#?AUTHN_NS_TAB{user_id = Key}) ->
     mnesia:read(?AUTHN_NS_TAB, Key, write) =:= [];
 is_new_namespaced_record_tx(#user_info{}) ->
     false.
+
+do_lookup_conflicting_global_txn(#user_info{}) ->
+    [];
+do_lookup_conflicting_global_txn(#?AUTHN_NS_TAB{
+    user_id = ?AUTHN_NS_KEY(_, UserGroup, UserId)
+}) ->
+    case mnesia:read(?TAB, {UserGroup, UserId}, write) of
+        [] ->
+            mnesia:read(
+                ?AUTHN_NS_TAB,
+                ?AUTHN_NS_KEY(?global_ns, UserGroup, UserId),
+                write
+            );
+        Records ->
+            Records
+    end.
 
 is_namespace_empty(Namespace) when is_binary(Namespace) ->
     %% `[]` is `<` than any (binary) user id or group

--- a/apps/emqx_auth_mnesia/test/emqx_auth_mnesia_bookkeeper_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_auth_mnesia_bookkeeper_SUITE.erl
@@ -94,7 +94,7 @@ t_smoke_restart(TCConfig) ->
 
     Users = [
         #{namespace => Ns, user_id => UId, password => <<"p">>}
-     || Ns <- [?global_ns, Ns1, Ns2],
+     || Ns <- [Ns1, Ns2, ?global_ns],
         UId <- [<<"u1">>, <<"u2">>]
     ],
     ?ON(

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -569,9 +569,9 @@ t_authenticator_users(TCConfig) ->
 
     %% Global admin can manage other namespaces.
 
-    %% N.B.: same username as existing user in different namespace
+    %% Global admin can create a distinct user in another namespace.
     OtherNsUser = #{
-        <<"user_id">> => <<"u1">>, <<"password">> => <<"p1">>, <<"namespace">> => ?OTHER_NS
+        <<"user_id">> => <<"u4">>, <<"password">> => <<"p1">>, <<"namespace">> => ?OTHER_NS
     },
     maybe
         true ?= ns_of(TCConfig) == ?global_ns,

--- a/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
@@ -54,6 +54,10 @@ init_per_group(?global, Config) ->
     [{ns, ?global_ns} | Config];
 init_per_group(?ns, Config) ->
     [{ns, ?NS} | Config];
+init_per_group(distinct_users, Config) ->
+    [{user_ids, {<<"u">>, <<"v">>}} | Config];
+init_per_group(same_user, Config) ->
+    [{user_ids, {<<"u">>, <<"u">>}} | Config];
 init_per_group(_Group, Config) ->
     Config.
 
@@ -269,34 +273,35 @@ t_update(_) ->
 t_destroy() ->
     [{matrix, true}].
 t_destroy(matrix) ->
-    [[?global], [?ns]];
+    [[?global, distinct_users], [?ns, same_user]];
 t_destroy(TCConfig) ->
     Namespace = ns(TCConfig),
+    {UserId, OtherUserId} = ?config(user_ids, TCConfig),
     Config = config(),
     OtherConfig = Config#{user_group => <<"stomp:global">>},
     {ok, State0} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
     {ok, StateOther} = emqx_authn_mnesia:create(?AUTHN_ID, OtherConfig),
 
-    User = maybe_add_ns(#{user_id => <<"u">>, password => <<"p">>}, TCConfig),
-    User2 = add_ns(#{user_id => <<"u">>, password => <<"p">>}, ?OTHER_NS),
+    User = maybe_add_ns(#{user_id => UserId, password => <<"p">>}, TCConfig),
+    User2 = add_ns(#{user_id => OtherUserId, password => <<"p">>}, ?OTHER_NS),
 
     {ok, _} = emqx_authn_mnesia:add_user(User, State0),
     {ok, _} = emqx_authn_mnesia:add_user(User2, State0),
     {ok, _} = emqx_authn_mnesia:add_user(User, StateOther),
     {ok, _} = emqx_authn_mnesia:add_user(User2, StateOther),
 
-    {ok, _} = lookup_user(Namespace, <<"u">>, State0),
-    {ok, _} = lookup_user(?OTHER_NS, <<"u">>, State0),
-    {ok, _} = lookup_user(Namespace, <<"u">>, StateOther),
-    {ok, _} = lookup_user(?OTHER_NS, <<"u">>, StateOther),
+    {ok, _} = lookup_user(Namespace, UserId, State0),
+    {ok, _} = lookup_user(?OTHER_NS, OtherUserId, State0),
+    {ok, _} = lookup_user(Namespace, UserId, StateOther),
+    {ok, _} = lookup_user(?OTHER_NS, OtherUserId, StateOther),
 
     ok = emqx_authn_mnesia:destroy(State0),
 
     {ok, State1} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
-    {error, not_found} = lookup_user(Namespace, <<"u">>, State1),
-    {error, not_found} = lookup_user(?OTHER_NS, <<"u">>, State1),
-    {ok, _} = lookup_user(Namespace, <<"u">>, StateOther),
-    {ok, _} = lookup_user(?OTHER_NS, <<"u">>, StateOther),
+    {error, not_found} = lookup_user(Namespace, UserId, State1),
+    {error, not_found} = lookup_user(?OTHER_NS, OtherUserId, State1),
+    {ok, _} = lookup_user(Namespace, UserId, StateOther),
+    {ok, _} = lookup_user(?OTHER_NS, OtherUserId, StateOther),
 
     ok.
 
@@ -310,8 +315,9 @@ t_purge_namespace(_TCConfig) ->
     {ok, State} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
     {ok, StateOtherGroup} = emqx_authn_mnesia:create(?AUTHN_ID, OtherGroupConfig),
 
+    GlobalUser = #{user_id => <<"global">>, password => <<"p">>},
     User = #{user_id => <<"u">>, password => <<"p">>},
-    {ok, _} = emqx_authn_mnesia:add_user(User, State),
+    {ok, _} = emqx_authn_mnesia:add_user(GlobalUser, State),
     {ok, _} = emqx_authn_mnesia:add_user(add_ns(User, ?NS), State),
     {ok, _} = emqx_authn_mnesia:add_user(add_ns(User, ?NS), StateOtherGroup),
     {ok, _} = emqx_authn_mnesia:add_user(add_ns(User, ?OTHER_NS), State),
@@ -320,7 +326,7 @@ t_purge_namespace(_TCConfig) ->
 
     {error, not_found} = lookup_user(?NS, <<"u">>, State),
     {error, not_found} = lookup_user(?NS, <<"u">>, StateOtherGroup),
-    {ok, _} = lookup_user(?global_ns, <<"u">>, State),
+    {ok, _} = lookup_user(?global_ns, <<"global">>, State),
     {ok, _} = lookup_user(?OTHER_NS, <<"u">>, State),
     ?assertEqual(0, emqx_authn_mnesia:record_count(?NS)),
 
@@ -400,7 +406,12 @@ t_add_user(TCConfig) ->
     {error, already_exist} = emqx_authn_mnesia:add_user(User, State),
 
     OtherUser = add_ns(User, ?OTHER_NS),
-    {ok, _} = emqx_authn_mnesia:add_user(OtherUser, State),
+    case ns(TCConfig) of
+        ?global_ns ->
+            {error, already_exist} = emqx_authn_mnesia:add_user(OtherUser, State);
+        _ ->
+            {ok, _} = emqx_authn_mnesia:add_user(OtherUser, State)
+    end,
 
     ok.
 
@@ -669,6 +680,42 @@ t_import_records_algorithm_in_generated_mode(_) ->
         },
         emqx_authn_mnesia:rec_to_map(PrehashedRecord)
     ).
+
+t_global_user_conflict(_TCConfig) ->
+    Config = config(),
+    {ok, State} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
+    Namespace = ?NS,
+    Username = <<"u">>,
+    PasswordNs = <<"pns">>,
+    PasswordGlobal = <<"pglobal">>,
+    UserNs = add_ns(#{user_id => Username, password => PasswordNs}, Namespace),
+    UserGlobal = #{user_id => Username, password => PasswordGlobal},
+
+    {ok, _} = emqx_authn_mnesia:add_user(UserNs, State),
+    {ok, _} = emqx_authn_mnesia:add_user(UserGlobal, State),
+    ignore = emqx_authn_mnesia:authenticate(
+        add_ns_clientinfo(#{username => Username, password => PasswordNs}, Namespace),
+        State
+    ),
+    ignore = emqx_authn_mnesia:authenticate(
+        add_ns_clientinfo(#{username => Username, password => PasswordGlobal}, Namespace),
+        State
+    ),
+    {ok, _} = emqx_authn_mnesia:authenticate(
+        #{username => Username, password => PasswordGlobal}, State
+    ),
+
+    ok = delete_user(?global_ns, Username, State),
+    {ok, _} = emqx_authn_mnesia:authenticate(
+        add_ns_clientinfo(#{username => Username, password => PasswordNs}, Namespace),
+        State
+    ),
+
+    {ok, _} = emqx_authn_mnesia:add_user(UserGlobal, State),
+    {error, already_exist} = emqx_authn_mnesia:add_user(
+        add_ns(#{user_id => Username, password => PasswordNs}, ?OTHER_NS), State
+    ),
+    ok.
 
 t_delete_user() ->
     [{matrix, true}].
@@ -1046,11 +1093,11 @@ t_import_users_duplicated_records(_) ->
         read_tables()
     ),
 
-    %% Namespaced users on different namespaces are independent.
+    %% A global user prevents imports of the same user ID into namespaces.
     ok = emqx_authn_mnesia:destroy(State),
     {ok, State2} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
     ?assertMatch(
-        {ok, _},
+        {ok, #{total := 5, success := 1, override := 1, failed := 3}},
         emqx_authn_mnesia:import_users(
             sample_filename_and_data(plain, <<"user-credentials-plain-dup-ns.json">>),
             State2
@@ -1062,18 +1109,6 @@ t_import_users_duplicated_records(_) ->
                 namespace := ?global,
                 user_id := <<"myuser1">>,
                 password_hash := <<"password5">>,
-                is_superuser := false
-            },
-            #{
-                namespace := <<"ns1">>,
-                user_id := <<"myuser1">>,
-                password_hash := <<"password4">>,
-                is_superuser := false
-            },
-            #{
-                namespace := <<"ns2">>,
-                user_id := <<"myuser1">>,
-                password_hash := <<"password3">>,
                 is_superuser := false
             }
         ],
@@ -1203,20 +1238,19 @@ t_namespace_fallback_to_global(_TCConfig) ->
         )
     ),
 
-    %% Now, we create a namespaced user with the same username and different password.
-    %% Authentication should now return this new user.
+    %% A global user reserves its user ID across all namespaces.
     PasswordNs = <<"pns">>,
     UserNs = add_ns(#{user_id => Username, password => PasswordNs}, Namespace),
-    {ok, _} = emqx_authn_mnesia:add_user(UserNs, State),
+    {error, already_exist} = emqx_authn_mnesia:add_user(UserNs, State),
     ?assertMatch(
-        {error, bad_username_or_password},
+        {ok, _},
         emqx_authn_mnesia:authenticate(
             add_ns_clientinfo(#{username => Username, password => PasswordGlobal}, Namespace),
             State
         )
     ),
     ?assertMatch(
-        {ok, _},
+        {error, bad_username_or_password},
         emqx_authn_mnesia:authenticate(
             add_ns_clientinfo(#{username => Username, password => PasswordNs}, Namespace),
             State

--- a/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
@@ -406,8 +406,8 @@ t_add_user(TCConfig) ->
     {error, already_exist} = emqx_authn_mnesia:add_user(User, State),
 
     OtherUser = add_ns(User, ?OTHER_NS),
-    case ns(TCConfig) of
-        ?global_ns ->
+    case {?config(security_profile, TCConfig), ns(TCConfig)} of
+        {hardened, ?global_ns} ->
             {error, already_exist} = emqx_authn_mnesia:add_user(OtherUser, State);
         _ ->
             {ok, _} = emqx_authn_mnesia:add_user(OtherUser, State)
@@ -681,17 +681,13 @@ t_import_records_algorithm_in_generated_mode(_) ->
         emqx_authn_mnesia:rec_to_map(PrehashedRecord)
     ).
 
-t_global_user_conflict(_TCConfig) ->
+t_global_user_conflict(TCConfig) ->
     Config = config(),
     {ok, State} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
-    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
-        assert_global_user_conflict_hardened(State)
-    end),
-
-    reset_tables(),
-    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
-        assert_global_user_conflict_legacy(State)
-    end),
+    case ?config(security_profile, TCConfig) of
+        legacy -> assert_global_user_conflict_legacy(State);
+        hardened -> assert_global_user_conflict_hardened(State)
+    end,
     ok.
 
 assert_global_user_conflict_hardened(State) ->
@@ -1063,7 +1059,7 @@ t_import_users_prepared_list(_) ->
         )
     ).
 
-t_import_users_duplicated_records(_) ->
+t_import_users_duplicated_records(TCConfig) ->
     Config0 = config(),
     Config = Config0#{password_hash_algorithm => #{name => plain, salt_position => disable}},
     {ok, State} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
@@ -1127,65 +1123,62 @@ t_import_users_duplicated_records(_) ->
         read_tables()
     ),
 
-    %% The legacy profile keeps users in different namespaces independent.
     ok = emqx_authn_mnesia:destroy(State),
     {ok, State2} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
-    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
-        ?assertMatch(
-            {ok, _},
-            emqx_authn_mnesia:import_users(
-                sample_filename_and_data(plain, <<"user-credentials-plain-dup-ns.json">>),
-                State2
+    case ?config(security_profile, TCConfig) of
+        legacy ->
+            %% The legacy profile keeps users in different namespaces independent.
+            ?assertMatch(
+                {ok, _},
+                emqx_authn_mnesia:import_users(
+                    sample_filename_and_data(plain, <<"user-credentials-plain-dup-ns.json">>),
+                    State2
+                )
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        namespace := ?global,
+                        user_id := <<"myuser1">>,
+                        password_hash := <<"password5">>,
+                        is_superuser := false
+                    },
+                    #{
+                        namespace := <<"ns1">>,
+                        user_id := <<"myuser1">>,
+                        password_hash := <<"password4">>,
+                        is_superuser := false
+                    },
+                    #{
+                        namespace := <<"ns2">>,
+                        user_id := <<"myuser1">>,
+                        password_hash := <<"password3">>,
+                        is_superuser := false
+                    }
+                ],
+                read_tables()
+            );
+        hardened ->
+            %% The hardened profile rejects namespaced users that conflict with a global user.
+            ?assertMatch(
+                {ok, #{total := 5, success := 1, override := 1, failed := 3}},
+                emqx_authn_mnesia:import_users(
+                    sample_filename_and_data(plain, <<"user-credentials-plain-dup-ns.json">>),
+                    State2
+                )
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        namespace := ?global,
+                        user_id := <<"myuser1">>,
+                        password_hash := <<"password5">>,
+                        is_superuser := false
+                    }
+                ],
+                read_tables()
             )
-        )
-    end),
-    ?assertMatch(
-        [
-            #{
-                namespace := ?global,
-                user_id := <<"myuser1">>,
-                password_hash := <<"password5">>,
-                is_superuser := false
-            },
-            #{
-                namespace := <<"ns1">>,
-                user_id := <<"myuser1">>,
-                password_hash := <<"password4">>,
-                is_superuser := false
-            },
-            #{
-                namespace := <<"ns2">>,
-                user_id := <<"myuser1">>,
-                password_hash := <<"password3">>,
-                is_superuser := false
-            }
-        ],
-        read_tables()
-    ),
-
-    %% The hardened profile rejects namespaced users that conflict with a global user.
-    ok = emqx_authn_mnesia:destroy(State2),
-    {ok, State3} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
-    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
-        ?assertMatch(
-            {ok, #{total := 5, success := 1, override := 1, failed := 3}},
-            emqx_authn_mnesia:import_users(
-                sample_filename_and_data(plain, <<"user-credentials-plain-dup-ns.json">>),
-                State3
-            )
-        )
-    end),
-    ?assertMatch(
-        [
-            #{
-                namespace := ?global,
-                user_id := <<"myuser1">>,
-                password_hash := <<"password5">>,
-                is_superuser := false
-            }
-        ],
-        read_tables()
-    ),
+    end,
 
     ok.
 
@@ -1289,7 +1282,7 @@ t_bootstrap_file_superuser_in_namespace_rejected(_) ->
 Verifies that, if we don't find an username in the desired namespace, we fallback the
 lookup to the global namespace.
 """.
-t_namespace_fallback_to_global(_TCConfig) ->
+t_namespace_fallback_to_global(TCConfig) ->
     Config = config(),
     {ok, State} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
 
@@ -1310,24 +1303,37 @@ t_namespace_fallback_to_global(_TCConfig) ->
         )
     ),
 
-    %% A global user reserves its user ID across all namespaces.
     PasswordNs = <<"pns">>,
     UserNs = add_ns(#{user_id => Username, password => PasswordNs}, Namespace),
-    {error, already_exist} = emqx_authn_mnesia:add_user(UserNs, State),
-    ?assertMatch(
-        {ok, _},
-        emqx_authn_mnesia:authenticate(
-            add_ns_clientinfo(#{username => Username, password => PasswordGlobal}, Namespace),
-            State
-        )
-    ),
-    ?assertMatch(
-        {error, bad_username_or_password},
-        emqx_authn_mnesia:authenticate(
-            add_ns_clientinfo(#{username => Username, password => PasswordNs}, Namespace),
-            State
-        )
-    ),
+    case ?config(security_profile, TCConfig) of
+        legacy ->
+            {ok, _} = emqx_authn_mnesia:add_user(UserNs, State),
+            ?assertMatch(
+                {ok, _},
+                emqx_authn_mnesia:authenticate(
+                    add_ns_clientinfo(#{username => Username, password => PasswordNs}, Namespace),
+                    State
+                )
+            );
+        hardened ->
+            {error, already_exist} = emqx_authn_mnesia:add_user(UserNs, State),
+            ?assertMatch(
+                {ok, _},
+                emqx_authn_mnesia:authenticate(
+                    add_ns_clientinfo(
+                        #{username => Username, password => PasswordGlobal}, Namespace
+                    ),
+                    State
+                )
+            ),
+            ?assertMatch(
+                {error, bad_username_or_password},
+                emqx_authn_mnesia:authenticate(
+                    add_ns_clientinfo(#{username => Username, password => PasswordNs}, Namespace),
+                    State
+                )
+            )
+    end,
 
     ok.
 

--- a/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
@@ -684,6 +684,17 @@ t_import_records_algorithm_in_generated_mode(_) ->
 t_global_user_conflict(_TCConfig) ->
     Config = config(),
     {ok, State} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        assert_global_user_conflict_hardened(State)
+    end),
+
+    reset_tables(),
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        assert_global_user_conflict_legacy(State)
+    end),
+    ok.
+
+assert_global_user_conflict_hardened(State) ->
     Namespace = ?NS,
     Username = <<"u">>,
     PasswordNs = <<"pns">>,
@@ -713,6 +724,29 @@ t_global_user_conflict(_TCConfig) ->
 
     {ok, _} = emqx_authn_mnesia:add_user(UserGlobal, State),
     {error, already_exist} = emqx_authn_mnesia:add_user(
+        add_ns(#{user_id => Username, password => PasswordNs}, ?OTHER_NS), State
+    ),
+    ok.
+
+assert_global_user_conflict_legacy(State) ->
+    Namespace = ?NS,
+    Username = <<"u">>,
+    PasswordNs = <<"pns">>,
+    PasswordGlobal = <<"pglobal">>,
+    UserNs = add_ns(#{user_id => Username, password => PasswordNs}, Namespace),
+    UserGlobal = #{user_id => Username, password => PasswordGlobal},
+
+    {ok, _} = emqx_authn_mnesia:add_user(UserNs, State),
+    {ok, _} = emqx_authn_mnesia:add_user(UserGlobal, State),
+    {ok, _} = emqx_authn_mnesia:authenticate(
+        add_ns_clientinfo(#{username => Username, password => PasswordNs}, Namespace),
+        State
+    ),
+    {error, bad_username_or_password} = emqx_authn_mnesia:authenticate(
+        add_ns_clientinfo(#{username => Username, password => PasswordGlobal}, Namespace),
+        State
+    ),
+    {ok, _} = emqx_authn_mnesia:add_user(
         add_ns(#{user_id => Username, password => PasswordNs}, ?OTHER_NS), State
     ),
     ok.
@@ -1093,16 +1127,54 @@ t_import_users_duplicated_records(_) ->
         read_tables()
     ),
 
-    %% A global user prevents imports of the same user ID into namespaces.
+    %% The legacy profile keeps users in different namespaces independent.
     ok = emqx_authn_mnesia:destroy(State),
     {ok, State2} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
-    ?assertMatch(
-        {ok, #{total := 5, success := 1, override := 1, failed := 3}},
-        emqx_authn_mnesia:import_users(
-            sample_filename_and_data(plain, <<"user-credentials-plain-dup-ns.json">>),
-            State2
+    emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+        ?assertMatch(
+            {ok, _},
+            emqx_authn_mnesia:import_users(
+                sample_filename_and_data(plain, <<"user-credentials-plain-dup-ns.json">>),
+                State2
+            )
         )
+    end),
+    ?assertMatch(
+        [
+            #{
+                namespace := ?global,
+                user_id := <<"myuser1">>,
+                password_hash := <<"password5">>,
+                is_superuser := false
+            },
+            #{
+                namespace := <<"ns1">>,
+                user_id := <<"myuser1">>,
+                password_hash := <<"password4">>,
+                is_superuser := false
+            },
+            #{
+                namespace := <<"ns2">>,
+                user_id := <<"myuser1">>,
+                password_hash := <<"password3">>,
+                is_superuser := false
+            }
+        ],
+        read_tables()
     ),
+
+    %% The hardened profile rejects namespaced users that conflict with a global user.
+    ok = emqx_authn_mnesia:destroy(State2),
+    {ok, State3} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
+    emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+        ?assertMatch(
+            {ok, #{total := 5, success := 1, override := 1, failed := 3}},
+            emqx_authn_mnesia:import_users(
+                sample_filename_and_data(plain, <<"user-credentials-plain-dup-ns.json">>),
+                State3
+            )
+        )
+    end),
     ?assertMatch(
         [
             #{

--- a/changes/ee/feat-18332.en.md
+++ b/changes/ee/feat-18332.en.md
@@ -1,0 +1,1 @@
+Added built-in database user conflict protection for the hardened security profile. EMQX now rejects namespaced user creation and import when a global user has the same user ID. EMQX also rejects ambiguous namespaced authentication when conflicting records already exist.

--- a/changes/ee/fix-18332.en.md
+++ b/changes/ee/fix-18332.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where a namespaced built-in database user could conflict with a global user with the same user ID. EMQX now rejects conflicting namespaced user creation and import, and refuses ambiguous namespaced authentication when conflicting records already exist.

--- a/changes/ee/fix-18332.en.md
+++ b/changes/ee/fix-18332.en.md
@@ -1,1 +1,0 @@
-Fixed an issue where a namespaced built-in database user could conflict with a global user with the same user ID. EMQX now rejects conflicting namespaced user creation and import, and refuses ambiguous namespaced authentication when conflicting records already exist.


### PR DESCRIPTION
Release version: 6.4.0

Introduced in: N/A

## Summary

Address https://github.com/emqx/emqx-dev-team-tasks/issues/66#issuecomment-4797547228

Built-in database authentication supports global users and namespaced users. A global user and a namespaced user with the same user ID make namespaced authentication ambiguous.

We add two restrictions:
* Forbid to create a namespaced user when a global user exists with the same user id
* Existing global user forbids to login to any namespaced user with the same user id.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)