### PR TITLE
fix(plugins): tolerate emqx_plugins as a declared plugin dependency

### DIFF
--- a/apps/emqx_plugins/src/emqx_plugins_apps.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_apps.erl
@@ -323,7 +323,8 @@ do_load_plugin_app(AppName, Ebin) ->
     Modules = filelib:wildcard(filename:join([Ebin, "*.beam"])),
     maybe
         ok ?= load_modules(Modules),
-        ok ?= application:load(AppName)
+        {ok, AppSpec} ?= read_app_spec(AppName, Ebin),
+        ok ?= application:load(drop_self_dep(AppSpec))
     else
         {error, {already_loaded, _}} ->
             ok;
@@ -333,6 +334,40 @@ do_load_plugin_app(AppName, Ebin) ->
                 name => AppName,
                 reason => Reason
             }}
+    end.
+
+read_app_spec(AppName, Ebin) ->
+    AppFile = filename:join(Ebin, atom_to_list(AppName) ++ ".app"),
+    case file:consult(AppFile) of
+        {ok, [{application, AppName, Props}]} ->
+            {ok, {application, AppName, Props}};
+        {ok, Other} ->
+            {error, {bad_app_file, AppFile, Other}};
+        {error, Reason} ->
+            {error, {bad_app_file, AppFile, Reason}}
+    end.
+
+%% Plugin apps are started from within the emqx_plugins application's own
+%% start/2. A plugin that declares emqx_plugins in its applications list makes
+%% ensure_all_started/1 wait for emqx_plugins to finish starting, which cannot
+%% happen until the plugin start returns: plugin start times out on every node
+%% boot. The dependency is satisfied by construction (emqx_plugins is running
+%% or starting whenever a plugin is started), so drop it from the app spec.
+drop_self_dep({application, AppName, Props} = AppSpec) ->
+    Deps = proplists:get_value(applications, Props, []),
+    case lists:member(emqx_plugins, Deps) of
+        true ->
+            ?SLOG(warning, #{
+                msg => "plugin_app_declares_emqx_plugins_dependency",
+                name => AppName,
+                hint =>
+                    "remove emqx_plugins from the applications list"
+                    " in the plugin app's .app.src file"
+            }),
+            Deps1 = {applications, lists:delete(emqx_plugins, Deps)},
+            {application, AppName, lists:keyreplace(applications, 1, Props, Deps1)};
+        false ->
+            AppSpec
     end.
 
 load_modules([]) ->
@@ -347,6 +382,10 @@ load_modules([BeamFile | Modules]) ->
             {error, #{msg => "failed_to_load_plugin_beam", path => BeamFile, reason => Reason}}
     end.
 
+%% Plugin apps are started while the emqx_plugins application itself is
+%% starting during node boot. Applications a plugin declares in its .app.src
+%% must be running by then; EMQX apps that start after emqx_plugins (for
+%% example emqx_management) cannot be declared as plugin dependencies.
 start_app(App) ->
     case run_with_timeout(application, ensure_all_started, [App], 10_000) of
         {ok, {ok, Started}} ->
@@ -360,12 +399,25 @@ start_app(App) ->
                 app => App,
                 reason => Reason
             }};
-        {error, Reason} ->
+        {error, timeout} ->
             {error, #{
                 msg => "failed_to_start_plugin_app",
                 app => App,
-                reason => Reason
+                reason => timeout,
+                not_running_deps => not_running_deps(App),
+                hint =>
+                    "all applications a plugin declares in its .app.src"
+                    " must be running before plugins start during node boot"
             }}
+    end.
+
+not_running_deps(App) ->
+    case application:get_key(App, applications) of
+        {ok, Deps} ->
+            Running = [N || {N, _} <- running_apps()],
+            [Dep || Dep <- Deps, not lists:member(Dep, Running)];
+        undefined ->
+            []
     end.
 
 %% On one hand, Elixir plugins might include Elixir itself, when targetting a non-Elixir

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -591,6 +591,32 @@ t_allows_missing_default_config(Config) ->
     ?assert(is_app_running(invalid_plugin)),
     ok = emqx_plugins:ensure_stopped(NameVsn).
 
+%% A plugin declaring emqx_plugins in its applications list must still load
+%% and start: the dependency is dropped from the app spec at load time.
+%% Waiting for it deadlocks plugin start during node boot.
+t_ignores_emqx_plugins_dependency({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    ok = replace_tar_entry(
+        NameVsn,
+        "invalid_plugin.app",
+        <<
+            "{application, invalid_plugin, [{vsn, \"0.1.0\"},"
+            " {applications, [kernel, stdlib, emqx_plugins]}]}.\n"
+        >>
+    ),
+    [{name_vsn, NameVsn} | Config];
+t_ignores_emqx_plugins_dependency({'end', Config}) ->
+    _ = emqx_plugins:ensure_stopped(?config(name_vsn, Config)),
+    cleanup_invalid_plugin(?config(name_vsn, Config));
+t_ignores_emqx_plugins_dependency(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    ok = emqx_plugins:ensure_started(NameVsn),
+    ?assert(is_app_running(invalid_plugin)),
+    ?assertEqual({ok, [kernel, stdlib]}, application:get_key(invalid_plugin, applications)),
+    ok = emqx_plugins:ensure_stopped(NameVsn).
+
 t_rejects_invalid_schema_on_reconfigure({init, Config}) ->
     NameVsn = "invalid_plugin-1.0.0",
     ok = make_plugin_tar(NameVsn),

--- a/changes/ee/fix-18333.en.md
+++ b/changes/ee/fix-18333.en.md
@@ -1,0 +1,5 @@
+Fixed plugin startup after a node restart for plugins that declare `emqx_plugins` in their application dependency list.
+
+Plugins start while the plugin subsystem itself is starting. A plugin that declared `emqx_plugins` as a dependency made its own startup wait for the plugin subsystem, so the plugin start timed out and the plugin was left enabled but not running after every node restart. EMQX now ignores this dependency declaration and logs a warning that asks the plugin author to remove it.
+
+When a plugin fails to start with a timeout, the error log now lists the declared dependency applications that were not running at that moment.

--- a/plugins/emqx_backup_sync/src/emqx_backup_sync.app.src
+++ b/plugins/emqx_backup_sync/src/emqx_backup_sync.app.src
@@ -4,15 +4,16 @@
     {vsn, {file, "VERSION"}},
     {modules, []},
     {registered, [emqx_backup_sync_sup, emqx_backup_sync]},
+    %% Do not declare emqx_plugins or apps started after it (emqx_management):
+    %% plugins start while emqx_plugins itself is starting during node boot,
+    %% and such dependencies make the plugin start time out.
     {applications, [
         kernel,
         stdlib,
         inets,
         ssl,
         emqx,
-        emqx_utils,
-        emqx_plugins,
-        emqx_management
+        emqx_utils
     ]},
     {mod, {emqx_backup_sync_app, []}},
     {env, []},

--- a/plugins/emqx_sync_request/src/emqx_sync_request.app.src
+++ b/plugins/emqx_sync_request/src/emqx_sync_request.app.src
@@ -4,12 +4,14 @@
     {vsn, {file, "VERSION"}},
     {modules, []},
     {registered, [emqx_sync_request_sup, emqx_sync_request]},
+    %% Do not declare emqx_plugins or apps started after it (emqx_management):
+    %% plugins start while emqx_plugins itself is starting during node boot,
+    %% and such dependencies make the plugin start time out.
     {applications, [
         kernel,
         stdlib,
         emqx,
-        emqx_ctl,
-        emqx_plugins
+        emqx_ctl
     ]},
     {mod, {emqx_sync_request_app, []}},
     {env, []},


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:
pre-5.8

## Summary

Plugins are started from inside `emqx_plugins_app:start/2`, and each plugin app start is wrapped in a 10-second kill-timeout (`emqx_plugins_apps:start_app/1`). A plugin whose `.app` file declares `emqx_plugins` in its `applications` list makes `application:ensure_all_started/1` wait for `emqx_plugins` to finish starting, which cannot happen until the plugin start returns. The helper process is killed after 10 seconds and the plugin is left enabled but not running after every node restart. The only signal is one `failed_to_start_plugin_app` log line. The same deadlock applies transitively to any declared dependency that itself depends on `emqx_plugins` (for example `emqx_management`).

Verified on a real node restart (not `emqx_cth_cluster:restart`, which bypasses the boot path): a package declaring `emqx_plugins` fails on every boot with a 10-second stall; the same package without the declaration survives the restart.

Changes:

* `emqx_plugins_apps`: load the plugin app from its parsed spec and drop a declared `emqx_plugins` dependency, with a warning log. The dependency is satisfied by construction: `emqx_plugins` is running or starting whenever a plugin app is started. This also heals already-installed plugin packages without repackaging.
* `emqx_plugins_apps:start_app/1`: on timeout, the error now lists the declared dependencies that were not running and a hint naming the rule.
* In-tree plugins: remove `emqx_plugins` and `emqx_management` from the `.app.src` `applications` lists. Note that the mix-built packages do not carry the `.app.src` list (mix generates the `.app` from `mix.exs`), so the shipped packages of this repo's plugins are not affected; the trim keeps the sources correct for builds that honor `.app.src` (rebar3, as used by third-party plugins).

A dependency that transitively reaches `emqx_plugins` still fails at boot; it now fails with diagnostics naming the not-running dependencies. Dropping such dependencies automatically was considered and rejected: unlike `emqx_plugins`, they are genuinely not running when plugins start at boot. Starting plugins after `emqx_plugins_app:start/2` returns would fix this class at the root; tracked as a follow-up in emqx/emqx-dev-team-tasks#338.

Same fix shape as the dev-510 PR (v5 does not forward-sync into v6).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
