### PR TITLE
build(quicer): probe system OpenSSL version for QUICER_TLS_VER default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ print-dashboard-version:
 	@echo $(EMQX_DASHBOARD_VERSION)
 
 export EMQX_REL_FORM ?= tgz
-export QUICER_TLS_VER ?= sys
+# quicer 0.4+ (msquic 2.5+) requires OpenSSL >= 3.0 to link the system
+# libcrypto ('sys'); fall back to quicer's bundled TLS otherwise.
+QUICER_TLS_VER_DEFAULT := $(shell $(SCRIPTS)/quicer-tls-ver.sh)
+export QUICER_TLS_VER ?= $(QUICER_TLS_VER_DEFAULT)
 
 -include default-profile.mk
 PROFILE ?= emqx-enterprise

--- a/scripts/quicer-tls-ver.sh
+++ b/scripts/quicer-tls-ver.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+## Print the default QUICER_TLS_VER for this host.
+##
+## quicer 0.4+ (msquic 2.5+) requires OpenSSL >= 3.0 to link the system
+## libcrypto (QUICER_TLS_VER=sys). Print 'sys' when the host has OpenSSL >= 3.0
+## development files, 'quictls' (quicer's bundled TLS) otherwise.
+##
+## Probe pkg-config first: msquic selects the system OpenSSL with CMake
+## find_package(OpenSSL), which resolves the development package, not the CLI.
+## Fall back to the CLI version when pkg-config cannot resolve libcrypto
+## (the emqx-builder images have no pkg-config; there the CLI and the
+## development headers come from the same distro package).
+
+set -euo pipefail
+
+if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists libcrypto 2>/dev/null; then
+    if pkg-config --atleast-version=3 libcrypto; then
+        echo 'sys'
+    else
+        echo 'quictls'
+    fi
+elif openssl version 2>/dev/null | grep -q '^OpenSSL 3\.'; then
+    echo 'sys'
+else
+    echo 'quictls'
+fi


### PR DESCRIPTION
## Summary

PR #18293 bumped quicer to 0.4.8, whose msquic requires OpenSSL >= 3.0 when linking the system libcrypto. The root `Makefile` set `QUICER_TLS_VER ?= sys` unconditionally, so `make` fails on hosts with an older OpenSSL (e.g. Ubuntu 20.04, OpenSSL 1.1.1):

```
CMake Error at msquic/submodules/CMakeLists.txt:361 (message):
  OpenSSL 3.0 not found, found 1.1.1f
```

This change makes the default depend on the host: `sys` when OpenSSL >= 3.0 development files are present, `quictls` (quicer's bundled TLS) otherwise. An explicit `QUICER_TLS_VER` from the environment still wins.

The probe (`scripts/quicer-tls-ver.sh`) checks pkg-config first, because msquic selects the system OpenSSL with CMake `find_package(OpenSSL)`, which resolves the development package, not the CLI. It falls back to `openssl version` when pkg-config cannot resolve libcrypto: the emqx-builder images ship no pkg-config, and there the CLI and the headers come from the same distro package.

Effect on packaging:
- ubuntu24.04 builder image (OpenSSL 3.0.13): still resolves to `sys`, so the released artifacts keep their current system-libcrypto linkage (verified by running the probe inside the image).
- Builders with OpenSSL <= 1.1.1 (debian11, el7, el8): resolve to `quictls` instead of failing the tag build. These distros cannot satisfy msquic's OpenSSL 3 requirement with their system libcrypto.
- macOS packaging keeps its explicit `QUICER_TLS_VER: quictls` (`.github/actions/package-macos/action.yaml`).

Verified on an OpenSSL 1.1.1 host: plain `make` now succeeds from a clean `deps/quicer/c_build` (NIF links no system libcrypto), `QUICER_TLS_VER=quictls make` succeeds, and `QUICER_TLS_VER=sys make` still fails with the CMake error above, proving the override is honored.
