### PR TITLE
fix(api): redact secrets in listeners, exhook and audit read endpoints (5.8)

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -31,7 +31,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.23.4"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.5.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.44.0"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.46.3"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}}

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -123,7 +123,9 @@ do_list_raw() ->
             Key = <<"listeners">>,
             Raw = emqx_config:get_raw([Key], #{}),
             SchemaMod = emqx_config:get_schema_mod(Key),
-            #{Key := RawWithDefault} = emqx_config:fill_defaults(SchemaMod, #{Key => Raw}, #{}),
+            #{Key := RawWithDefault} = emqx_config:fill_defaults(SchemaMod, #{Key => Raw}, #{
+                obfuscate_sensitive_values => true
+            }),
             Listeners = maps:to_list(RawWithDefault),
             lists:flatmap(fun format_raw_listeners/1, Listeners);
         false ->

--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -64,6 +64,7 @@ init_per_suite(Config) ->
                 schema_mod => emqx_enterprise_schema
             }},
             emqx_modules,
+            emqx_license,
             emqx_audit,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
@@ -324,6 +325,61 @@ kickout_clients() ->
     {ok, Clients2} = emqx_mgmt_api_test_util:request_api(get, ClientsPath),
     ClientsResponse2 = emqx_utils_json:decode(Clients2, [return_maps]),
     ?assertMatch(#{<<"data">> := []}, ClientsResponse2).
+
+%% The audit log records the `POST /license` request body as `******`
+%% so the license key does not appear in cleartext in `GET /audit`.
+t_license_key_redacted(_) ->
+    StartAt = erlang:system_time(microsecond),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    LicensePath = emqx_mgmt_api_test_util:api_path(["license"]),
+    {ok, _} = emqx_mgmt_api_test_util:request_api(
+        post, LicensePath, "", AuthHeader, #{<<"key">> => <<"default">>}
+    ),
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    Query =
+        lists:flatten(
+            io_lib:format(
+                "operation_id=/license&gte_created_at=~B&limit=1",
+                [StartAt]
+            )
+        ),
+    Res = wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, 2000),
+    ?assertMatch(
+        #{
+            <<"data">> := [
+                #{
+                    <<"operation_id">> := <<"/license">>,
+                    <<"http_request">> := #{<<"method">> := <<"post">>, <<"body">> := _}
+                }
+            ]
+        },
+        emqx_utils_json:decode(Res, [return_maps])
+    ),
+    #{<<"data">> := [#{<<"http_request">> := #{<<"body">> := AuditBody}}]} =
+        emqx_utils_json:decode(Res, [return_maps]),
+    %% the recorded body is redacted: no license key, only the redaction mark
+    ?assertEqual(nomatch, binary:match(AuditBody, <<"default">>), AuditBody),
+    ?assertNotEqual(nomatch, binary:match(AuditBody, <<"******">>), AuditBody),
+    ok.
+
+wait_for_matching_audit_entry(_AuditPath, _Query, _AuthHeader, RemainMs) when RemainMs =< 0 ->
+    ct:fail(audit_entry_not_found_in_time);
+wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, RemainMs) ->
+    case emqx_mgmt_api_test_util:request_api(get, AuditPath, Query, AuthHeader) of
+        {ok, Res} ->
+            case emqx_utils_json:decode(Res, [return_maps]) of
+                #{<<"data">> := [_ | _]} ->
+                    Res;
+                _ ->
+                    SleepMs = 100,
+                    ct:sleep(SleepMs),
+                    wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, RemainMs - SleepMs)
+            end;
+        _ ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, RemainMs - SleepMs)
+    end.
 
 wait_for_dirty_write_log_done(MaxMs) ->
     Size = mnesia:table_info(emqx_audit, size),

--- a/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
@@ -126,9 +126,19 @@ http_request(Meta) ->
     case maps:with([method, headers, bindings, body], Meta) of
         #{body := Body} = Request when is_binary(Body) ->
             Request#{body => <<"******">>};
+        #{body := _} = Request ->
+            case is_sensitive_body_operation(Meta) of
+                true -> Request#{body => <<"******">>};
+                false -> Request
+            end;
         Request ->
             Request
     end.
+
+%% Endpoints whose request body carries a secret under a key name that
+%% the generic key-name based redaction does not cover.
+is_sensitive_body_operation(#{operation_id := <<"/license">>}) -> true;
+is_sensitive_body_operation(_) -> false.
 
 operation_result(302, _) -> success;
 operation_result(Code, _) when Code >= 300 -> failure;

--- a/apps/emqx_exhook/src/emqx_exhook.app.src
+++ b/apps/emqx_exhook/src/emqx_exhook.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_exhook, [
     {description, "EMQX Extension for Hook"},
-    {vsn, "5.0.21"},
+    {vsn, "5.0.22"},
     {modules, []},
     {registered, []},
     {mod, {emqx_exhook_app, []}},

--- a/apps/emqx_exhook/src/emqx_exhook_api.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_api.erl
@@ -262,7 +262,8 @@ exhooks(post, #{body := #{<<"name">> := Name} = Body}) ->
 
 action_with_name(get, #{bindings := #{name := Name}}) ->
     get_nodes_server_info(Name);
-action_with_name(put, #{bindings := #{name := Name}, body := Body}) ->
+action_with_name(put, #{bindings := #{name := Name}, body := Body0}) ->
+    Body = deobfuscate(Name, Body0),
     case
         emqx_exhook_mgr:update_config(
             [exhook, servers],
@@ -484,8 +485,21 @@ get_raw_config() ->
     RawConfig = emqx:get_raw_config([exhook, servers], []),
     Schema = #{roots => emqx_exhook_schema:fields(exhook), fields => #{}},
     Conf = #{<<"servers">> => RawConfig},
-    #{<<"servers">> := Servers} = hocon_tconf:make_serializable(Schema, Conf, #{}),
+    #{<<"servers">> := Servers} = hocon_tconf:make_serializable(Schema, Conf, #{
+        obfuscate_sensitive_values => true
+    }),
     Servers.
+
+%% GET returns sensitive values as `******`; restore them from the current
+%% config so a round-tripped body does not overwrite stored secrets.
+deobfuscate(Name, Body) ->
+    Servers = emqx:get_raw_config([exhook, servers], []),
+    case lists:search(fun(#{<<"name">> := N}) -> N =:= Name end, Servers) of
+        {value, OldConf} ->
+            emqx_utils:deobfuscate(Body, OldConf);
+        false ->
+            Body
+    end.
 
 position_example() ->
     #{

--- a/apps/emqx_exhook/test/emqx_exhook_api_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_api_SUITE.erl
@@ -49,6 +49,7 @@ all() ->
         t_move_after,
         t_delete,
         t_hooks,
+        t_ssl_password_obfuscated,
         t_update
     ].
 
@@ -272,6 +273,41 @@ t_hooks(_Cfg) ->
         },
         Hook1
     ).
+
+%% GET /exhooks renders the gRPC client `ssl.password` as `******`,
+%% and a round-tripped `******` value does not overwrite the stored secret.
+t_ssl_password_obfuscated(Cfg) ->
+    Template = proplists:get_value(template, Cfg),
+    Password = <<"exhook-passwd">>,
+    Body = Template#{
+        <<"enable">> => false,
+        <<"ssl">> => #{<<"enable">> => false, <<"password">> => Password}
+    },
+    {ok, _} = request_api(
+        put,
+        api_path(["exhooks", "default"]),
+        "",
+        auth_header_(),
+        Body
+    ),
+    {ok, ListData} = request_api(get, api_path(["exhooks"]), "", auth_header_()),
+    ?assertMatch([#{ssl := #{password := <<"******">>}}], decode_json(ListData)),
+    {ok, GetData} = request_api(get, api_path(["exhooks", "default"]), "", auth_header_()),
+    ?assertMatch(#{ssl := #{password := <<"******">>}}, decode_json(GetData)),
+    %% the stored config keeps the real password
+    [RawConf] = emqx:get_raw_config([exhook, servers]),
+    ?assertEqual(Password, emqx_utils_maps:deep_get([<<"ssl">>, <<"password">>], RawConf)),
+    %% a round-tripped body with the obfuscated value keeps the stored secret
+    Body1 = Body#{<<"ssl">> => #{<<"enable">> => false, <<"password">> => <<"******">>}},
+    {ok, _} = request_api(
+        put,
+        api_path(["exhooks", "default"]),
+        "",
+        auth_header_(),
+        Body1
+    ),
+    [RawConf1] = emqx:get_raw_config([exhook, servers]),
+    ?assertEqual(Password, emqx_utils_maps:deep_get([<<"ssl">>, <<"password">>], RawConf1)).
 
 t_update(Cfg) ->
     Template = proplists:get_value(template, Cfg),

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -410,7 +410,11 @@ crud_listeners_by_id(put, #{bindings := #{id := Id}, body := Body0}) ->
                 undefined ->
                     {404, #{code => 'BAD_LISTENER_ID', message => ?LISTENER_NOT_FOUND}};
                 PrevConf ->
-                    MergeConfT = emqx_utils_maps:deep_merge(PrevConf, Conf),
+                    %% GET returns sensitive values as `******`; restore them
+                    %% from the current config so a round-tripped body does not
+                    %% overwrite stored secrets.
+                    Conf1 = emqx_utils:deobfuscate(Conf, PrevConf),
+                    MergeConfT = emqx_utils_maps:deep_merge(PrevConf, Conf1),
                     MergeConf = emqx_listeners:ensure_override_limiter_conf(MergeConfT, Conf),
                     case update(Type, Name, MergeConf) of
                         {ok, #{raw_config := _RawConf}} ->

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -517,6 +517,35 @@ t_update_validation_error_message({'end', Config}) ->
     ?assertEqual([], delete(NewPath)),
     ok.
 
+%% GET /listeners/:id renders `ssl_options.password` as `******`,
+%% and a round-tripped `******` value does not overwrite the stored secret.
+t_ssl_password_obfuscated(Config) when is_list(Config) ->
+    ListenerId = <<"ssl:default">>,
+    Path = emqx_mgmt_api_test_util:api_path(["listeners", ListenerId]),
+    Listener = request(get, Path, [], []),
+    Password = <<"file-passwd">>,
+    Body = emqx_utils_maps:deep_put([<<"ssl_options">>, <<"password">>], Listener, Password),
+    Updated = request(put, Path, [], Body),
+    ?assertMatch(#{<<"ssl_options">> := #{<<"password">> := <<"******">>}}, Updated),
+    ?assertMatch(
+        #{<<"ssl_options">> := #{<<"password">> := <<"******">>}},
+        request(get, Path, [], [])
+    ),
+    %% the stored config keeps the real password
+    ?assertEqual(
+        Password,
+        emqx:get_raw_config([listeners, ssl, default, ssl_options, password])
+    ),
+    %% a round-tripped body with the obfuscated value keeps the stored secret
+    Roundtrip = request(get, Path, [], []),
+    ?assertMatch(#{<<"ssl_options">> := #{<<"password">> := <<"******">>}}, Roundtrip),
+    _ = request(put, Path, [], Roundtrip),
+    ?assertEqual(
+        Password,
+        emqx:get_raw_config([listeners, ssl, default, ssl_options, password])
+    ),
+    ok.
+
 action_listener(ID, Action, Running) ->
     Path = emqx_mgmt_api_test_util:api_path(["listeners", ID, Action]),
     {ok, _} = emqx_mgmt_api_test_util:request_api(post, Path),

--- a/changes/ee/fix-18336.en.md
+++ b/changes/ee/fix-18336.en.md
@@ -5,3 +5,5 @@ Read-only REST endpoints no longer return secrets in cleartext:
 - Audit log entries for `POST /license` now record the request body as `******`, so the license key does not appear in `GET /audit` results.
 
 Updating a listener or an exhook server with a body that contains the `******` placeholder keeps the stored secret unchanged.
+
+Upgraded HOCON to 0.46.3. This release renders sensitive values inside array-typed config fields as `******` and no longer prints sensitive field values in config validation error logs.

--- a/changes/ee/fix-18336.en.md
+++ b/changes/ee/fix-18336.en.md
@@ -1,0 +1,7 @@
+Read-only REST endpoints no longer return secrets in cleartext:
+
+- `GET /listeners` and `GET /listeners/{id}` now render the listener `ssl_options.password` as `******`.
+- `GET /exhooks` and `GET /exhooks/{name}` now render the gRPC client `ssl.password` as `******`.
+- Audit log entries for `POST /license` now record the request body as `******`, so the license key does not appear in `GET /audit` results.
+
+Updating a listener or an exhook server with a body that contains the `******` placeholder keeps the stored secret unchanged.

--- a/mix.exs
+++ b/mix.exs
@@ -189,7 +189,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.4", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.13.0", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
-  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.44.0", override: true}
+  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.3", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}
   # in conflict by ehttpc and emqtt
   def common_dep(:gun), do: {:gun, "2.1.0", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -97,7 +97,7 @@
     {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.5"}}},
     {getopt, "1.0.2"},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.44.0"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.46.3"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {sasl_auth, "2.3.3"},
     {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}},


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

v5 counterpart of emqx/emqx#18330. Fixes findings A2, A3 and A5 of emqx/emqx-dev-team-tasks#333 for the 5.8 / 5.9 / 5.10 lines.

- `GET /listeners` and `GET /listeners/{id}` now render the listener `ssl_options.password` as `******`.
- `GET /exhooks` and `GET /exhooks/{name}` now render the gRPC client `ssl.password` as `******`.
- Audit log entries for `POST /license` now record the request body as `******`, so the license key does not appear in `GET /audit` results.

The `PUT` handlers for listeners and exhook servers restore `******` placeholders from the stored config, so a body round-tripped from `GET` does not overwrite stored secrets.

A1 and A4 are out of scope; A4 is tracked in emqx/emqx-dev-team-tasks#335.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
