### PR TITLE
fix(plugins): start plugin apps after all EMQX apps

### DIFF
--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -102,6 +102,11 @@ stop_one_app(App) ->
 ensure_apps_started() ->
     ?SLOG(notice, #{msg => "(re)starting_emqx_apps"}),
     lists:foreach(fun start_one_app/1, sorted_reboot_apps()),
+    %% Start plugin applications only after all EMQX applications are up,
+    %% so a plugin may depend on any of them.
+    %% Note: this function is also the ekka cluster join/leave callback,
+    %% so plugins restart after a join as well (see `start_autocluster/0').
+    ok = emqx_plugins:ensure_started(),
     ?tp(emqx_machine_boot_apps_started, #{}).
 
 start_one_app(App) ->

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -103,7 +103,9 @@ ensure_apps_started() ->
     ?SLOG(notice, #{msg => "(re)starting_emqx_apps"}),
     lists:foreach(fun start_one_app/1, sorted_reboot_apps()),
     %% Start plugin applications only after all EMQX applications are up,
-    %% so a plugin may depend on any of them.
+    %% so a plugin may depend on any of them.  Plugin apps are not part of
+    %% `sorted_reboot_apps/0'; `stop_apps/0' stops them explicitly via
+    %% `emqx_plugins:ensure_stopped/0'.
     %% Note: this function is also the ekka cluster join/leave callback,
     %% so plugins restart after a join as well (see `start_autocluster/0').
     ok = emqx_plugins:ensure_started(),

--- a/apps/emqx_plugins/src/emqx_plugins_app.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_app.erl
@@ -15,10 +15,11 @@
 ]).
 
 start(_Type, _Args) ->
-    %% load all pre-configured
+    %% Load all pre-configured plugins.
+    %% Plugin applications are started by `emqx_machine_boot:ensure_apps_started/0'
+    %% after all EMQX applications are up.
     {ok, Sup} = emqx_plugins_sup:start_link(),
     ok = emqx_plugins:ensure_installed(),
-    ok = emqx_plugins:ensure_started(),
     emqx_plugins:log_unconfigured_plugins(),
     ok = emqx_config_handler:add_handler([?CONF_ROOT], emqx_plugins),
     ?tp("emqx_plugins_app_started", #{}),

--- a/apps/emqx_plugins/src/emqx_plugins_apps.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_apps.erl
@@ -347,22 +347,20 @@ read_app_spec(AppName, Ebin) ->
             {error, {bad_app_file, AppFile, Reason}}
     end.
 
-%% Plugin apps are started from within the emqx_plugins application's own
-%% start/2. A plugin that declares emqx_plugins in its applications list makes
-%% ensure_all_started/1 wait for emqx_plugins to finish starting, which cannot
-%% happen until the plugin start returns: plugin start times out on every node
-%% boot. The dependency is satisfied by construction (emqx_plugins is running
-%% or starting whenever a plugin is started), so drop it from the app spec.
+%% A declared emqx_plugins dependency is satisfied by construction:
+%% emqx_plugins is always running when a plugin is started. Drop it from the
+%% app spec so packages built for releases where the dependency deadlocked
+%% the boot keep working.
 drop_self_dep({application, AppName, Props} = AppSpec) ->
     Deps = proplists:get_value(applications, Props, []),
     case lists:member(emqx_plugins, Deps) of
         true ->
-            ?SLOG(warning, #{
+            ?SLOG(info, #{
                 msg => "plugin_app_declares_emqx_plugins_dependency",
                 name => AppName,
                 hint =>
-                    "remove emqx_plugins from the applications list"
-                    " in the plugin app's .app.src file"
+                    "remove emqx_plugins from the plugin application's"
+                    " dependencies (mix.exs for mix-built plugins)"
             }),
             Deps1 = {applications, lists:delete(emqx_plugins, Deps)},
             {application, AppName, lists:keyreplace(applications, 1, Props, Deps1)};
@@ -382,10 +380,9 @@ load_modules([BeamFile | Modules]) ->
             {error, #{msg => "failed_to_load_plugin_beam", path => BeamFile, reason => Reason}}
     end.
 
-%% Plugin apps are started while the emqx_plugins application itself is
-%% starting during node boot. Applications a plugin declares in its .app.src
-%% must be running by then; EMQX apps that start after emqx_plugins (for
-%% example emqx_management) cannot be declared as plugin dependencies.
+%% During node boot, plugin apps are started after all EMQX applications
+%% (tail of emqx_machine_boot:ensure_apps_started/0), so a plugin may declare
+%% any EMQX application as a dependency.
 start_app(App) ->
     case run_with_timeout(application, ensure_all_started, [App], 10_000) of
         {ok, {ok, Started}} ->
@@ -406,8 +403,9 @@ start_app(App) ->
                 reason => timeout,
                 not_running_deps => not_running_deps(App),
                 hint =>
-                    "all applications a plugin declares in its .app.src"
-                    " must be running before plugins start during node boot"
+                    "every application the plugin declares as a dependency"
+                    " (mix.exs for mix-built plugins) must be part of the"
+                    " EMQX release or bundled with the plugin package"
             }}
     end.
 

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -218,8 +218,9 @@ t_demo_install_start_stop_uninstall(Config) ->
 (tail of `emqx_machine_boot:ensure_apps_started/0').
 A broken configured plugin must be collected and logged, not raised,
 so it cannot fail the node boot, and the plugins configured after it
-must still start.  The call must also be idempotent, because a cluster
-join re-runs `ensure_apps_started/0'.
+must still start.  The call must also survive the cluster-join cycle:
+a join runs `stop_apps/0' (`emqx_plugins:ensure_stopped/0') and then
+re-runs `ensure_apps_started/0'.
 """.
 t_boot_start_tolerates_broken_plugin({init, Config}) ->
     #{package := Package} = get_demo_plugin_package(),
@@ -237,7 +238,16 @@ t_boot_start_tolerates_broken_plugin(Config) ->
     ok = emqx_plugins:put_configured([Broken, Good]),
     ?assertEqual(ok, emqx_plugins:ensure_started()),
     ?assert(is_app_running(?EMQX_PLUGIN_APP_NAME)),
-    %% idempotent (cluster join re-runs the boot tail)
+    %% Re-running with plugins already up must be a no-op.
+    ?assertEqual(ok, emqx_plugins:ensure_started()),
+    ?assert(is_app_running(?EMQX_PLUGIN_APP_NAME)),
+    %% A cluster join runs `stop_apps/0' (which calls
+    %% `emqx_plugins:ensure_stopped/0') and then re-runs
+    %% `ensure_apps_started/0'.  Simulate the plugin-relevant part of that
+    %% cycle; calling `stop_apps/0' itself would stop this CT node's apps.
+    %% The real join path is covered by `t_start_node_with_plugin_enabled'.
+    ok = emqx_plugins:ensure_stopped(),
+    ?assertNot(is_app_running(?EMQX_PLUGIN_APP_NAME)),
     ?assertEqual(ok, emqx_plugins:ensure_started()),
     ?assert(is_app_running(?EMQX_PLUGIN_APP_NAME)),
     ok.

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -213,6 +213,35 @@ t_demo_install_start_stop_uninstall(Config) ->
     ?assertMatch([<<"[]">>], emqx_plugins_cli_utils:list(fun(_, L) -> L end)),
     ok.
 
+-doc """
+`ensure_started/0' runs on the boot path
+(tail of `emqx_machine_boot:ensure_apps_started/0').
+A broken configured plugin must be collected and logged, not raised,
+so it cannot fail the node boot, and the plugins configured after it
+must still start.  The call must also be idempotent, because a cluster
+join re-runs `ensure_apps_started/0'.
+""".
+t_boot_start_tolerates_broken_plugin({init, Config}) ->
+    #{package := Package} = get_demo_plugin_package(),
+    NameVsn = filename:basename(Package, ?PACKAGE_SUFFIX),
+    [{name_vsn, NameVsn} | Config];
+t_boot_start_tolerates_broken_plugin({'end', Config}) ->
+    NameVsn = proplists:get_value(name_vsn, Config),
+    _ = emqx_plugins:ensure_stopped(NameVsn),
+    ok;
+t_boot_start_tolerates_broken_plugin(Config) ->
+    NameVsn = proplists:get_value(name_vsn, Config),
+    ok = emqx_plugins:ensure_installed(NameVsn),
+    Broken = #{name_vsn => <<"missing_plugin-1.0.0">>, enable => true},
+    Good = #{name_vsn => bin(NameVsn), enable => true},
+    ok = emqx_plugins:put_configured([Broken, Good]),
+    ?assertEqual(ok, emqx_plugins:ensure_started()),
+    ?assert(is_app_running(?EMQX_PLUGIN_APP_NAME)),
+    %% idempotent (cluster join re-runs the boot tail)
+    ?assertEqual(ok, emqx_plugins:ensure_started()),
+    ?assert(is_app_running(?EMQX_PLUGIN_APP_NAME)),
+    ok.
+
 %% help function to create a info file.
 %% The file is in JSON format when built
 %% but since we are using hocon:load to load it
@@ -1615,6 +1644,11 @@ t_start_node_with_plugin_enabled(Config) when is_list(Config) ->
             %% Hack: we use `restart' here to disable the clean state verification, as we
             %% just created and populated the `plugins' directory...
             [N1, N2 | _] = lists:flatmap(fun emqx_cth_cluster:restart/1, NodeSpecs),
+            %% `emqx_cth_cluster' starts applications individually and never runs
+            %% `emqx_machine_boot:ensure_apps_started/0', which starts plugin apps at
+            %% the end of the real node boot.  Emulate that boot tail here.
+            ok = ?ON(N1, emqx_plugins:ensure_started()),
+            ok = ?ON(N2, emqx_plugins:ensure_started()),
             ct:pal("checking N1 state"),
             ?ON(N1, assert_started_and_hooks_loaded()),
             ct:pal("checking N2 state"),
@@ -1637,10 +1671,13 @@ t_start_node_with_plugin_enabled(Config) when is_list(Config) ->
                 end,
                 ekka:callback(start, StartCallback)
             end),
+            %% `emqx_machine_boot_apps_started' fires after the boot tail has
+            %% started the plugin apps, so the assertions below cannot race
+            %% with the plugin start.
             {ok, {ok, _}} =
                 ?wait_async_action(
                     ?ON(N2, emqx_cluster:join(N1)),
-                    #{?snk_kind := "emqx_plugins_app_started"}
+                    #{?snk_kind := emqx_machine_boot_apps_started}
                 ),
             ct:pal("checking N1 state after join"),
             ?ON(N1, assert_started_and_hooks_loaded()),

--- a/changes/ee/fix-18337.en.md
+++ b/changes/ee/fix-18337.en.md
@@ -1,0 +1,1 @@
+Start plugins after all EMQX applications have started. A plugin may now declare any EMQX application in its `applications` list. Previously, a plugin that declared an application which starts late in the boot sequence (for example `emqx_management`) failed to start after a node restart.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:
pre-5.8

## Summary

Part of emqx/emqx-dev-team-tasks#338 (item 1 only).

Plugin applications used to start from inside `emqx_plugins_app:start/2`, in the middle of the boot sequence. `emqx_plugins_apps:start_app/1` wraps `application:ensure_all_started/1` in a 10-second timeout, so a plugin that declares an application which starts later in the boot sequence (for example `emqx_management`) stalled for 10 seconds and was left enabled but not running after every node restart.

This PR moves the plugin start to the end of the boot sequence:

* `emqx_plugins_app:start/2` no longer calls `emqx_plugins:ensure_started/0`. It still installs (extracts and loads) the configured plugins and registers the config handler.
* `emqx_machine_boot:ensure_apps_started/0` calls `emqx_plugins:ensure_started/0` after all reboot applications have started. This is the same function `stop_apps/0` mirrors with `emqx_plugins:ensure_stopped/0`.

Decisions:

* The plugin start goes into `ensure_apps_started/0`, not `post_boot/0`. The ekka cluster join/leave callback re-runs `ensure_apps_started/0` directly (`start_autocluster/0`), so plugins also come back after a cluster join. `post_boot/0` is not invoked on that path.
* Plugins start before the `emqx_machine_boot_apps_started` trace point, so a test that waits for it sees plugins running.
* A broken plugin cannot fail the boot: `emqx_plugins:ensure_started/0` catches per-plugin errors and aggregates them into an error log (`for_plugins_action_error_occurred`). A new test case covers this and the idempotency of the re-run on cluster join.

Known widening of the hook-registration window (item 2 of the issue): listeners already serve traffic before plugin hooks are registered, and starting plugins later widens that window. This is intentional here; a follow-up PR adds a readiness gate so listeners do not serve MQTT traffic until all enabled plugins are running.

Not reverted: the load-time `emqx_plugins` dependency strip and `not_running_deps` diagnostic from #18333 stay, for already-built plugin packages that declare `emqx_plugins`.

Follow-up: update the plugin development docs (emqx-docs) to state that a plugin may declare any EMQX application in `applications`.

Validation on a real release build (CT cannot catch this; `emqx_cth_cluster:restart` bypasses the real boot path):

* Before: a node with an enabled plugin declaring `emqx_management` stalls 10 seconds at the `emqx_plugins` boot slot; the plugin ends up not running.
* After: the same node starts clean and the plugin is running.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
