### PR TITLE
fix(plugins): start plugin apps after all EMQX apps

### DIFF
--- a/apps/emqx_machine/src/emqx_machine.app.src
+++ b/apps/emqx_machine/src/emqx_machine.app.src
@@ -3,7 +3,7 @@
     {id, "emqx_machine"},
     {description, "The EMQX Machine"},
     % strict semver, bump manually!
-    {vsn, "0.4.3"},
+    {vsn, "0.4.4"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, emqx_ctl, redbug]},

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -89,6 +89,11 @@ stop_one_app(App) ->
 ensure_apps_started() ->
     ?SLOG(notice, #{msg => "(re)starting_emqx_apps"}),
     lists:foreach(fun start_one_app/1, sorted_reboot_apps()),
+    %% Start plugin applications only after all EMQX applications are up,
+    %% so a plugin may depend on any of them.
+    %% Note: this function is also the ekka cluster join/leave callback,
+    %% so plugins restart after a join as well (see `start_autocluster/0').
+    ok = emqx_plugins:ensure_started(),
     ?tp(emqx_machine_boot_apps_started, #{}).
 
 start_one_app(App) ->

--- a/apps/emqx_plugins/src/emqx_plugins_app.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_app.erl
@@ -15,10 +15,11 @@
 ]).
 
 start(_Type, _Args) ->
-    %% load all pre-configured
+    %% Load all pre-configured plugins.
+    %% Plugin applications are started by `emqx_machine_boot:ensure_apps_started/0'
+    %% after all EMQX applications are up.
     {ok, Sup} = emqx_plugins_sup:start_link(),
     ok = emqx_plugins:ensure_installed(),
-    ok = emqx_plugins:ensure_started(),
     emqx_plugins:log_unconfigured_plugins(),
     ok = emqx_config_handler:add_handler([?CONF_ROOT], emqx_plugins),
     ?tp("emqx_plugins_app_started", #{}),

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -213,6 +213,33 @@ t_demo_install_start_stop_uninstall(Config) ->
     ?assertMatch([<<"[]">>], emqx_plugins_cli:list(fun(_, L) -> L end)),
     ok.
 
+%% `ensure_started/0' runs on the boot path
+%% (tail of `emqx_machine_boot:ensure_apps_started/0').
+%% A broken configured plugin must be collected and logged, not raised,
+%% so it cannot fail the node boot, and the plugins configured after it
+%% must still start.  The call must also be idempotent, because a cluster
+%% join re-runs `ensure_apps_started/0'.
+t_boot_start_tolerates_broken_plugin({init, Config}) ->
+    #{package := Package} = get_demo_plugin_package(),
+    NameVsn = filename:basename(Package, ?PACKAGE_SUFFIX),
+    [{name_vsn, NameVsn} | Config];
+t_boot_start_tolerates_broken_plugin({'end', Config}) ->
+    NameVsn = proplists:get_value(name_vsn, Config),
+    _ = emqx_plugins:ensure_stopped(NameVsn),
+    ok;
+t_boot_start_tolerates_broken_plugin(Config) ->
+    NameVsn = proplists:get_value(name_vsn, Config),
+    ok = emqx_plugins:ensure_installed(NameVsn),
+    Broken = #{name_vsn => <<"missing_plugin-1.0.0">>, enable => true},
+    Good = #{name_vsn => bin(NameVsn), enable => true},
+    ok = emqx_plugins:put_configured([Broken, Good]),
+    ?assertEqual(ok, emqx_plugins:ensure_started()),
+    ?assert(is_app_running(?EMQX_PLUGIN_APP_NAME)),
+    %% idempotent (cluster join re-runs the boot tail)
+    ?assertEqual(ok, emqx_plugins:ensure_started()),
+    ?assert(is_app_running(?EMQX_PLUGIN_APP_NAME)),
+    ok.
+
 %% help function to create a info file.
 %% The file is in JSON format when built
 %% but since we are using hocon:load to load it
@@ -1296,6 +1323,11 @@ t_start_node_with_plugin_enabled(Config) when is_list(Config) ->
             %% Hack: we use `restart' here to disable the clean state verification, as we
             %% just created and populated the `plugins' directory...
             [N1, N2 | _] = lists:flatmap(fun emqx_cth_cluster:restart/1, NodeSpecs),
+            %% `emqx_cth_cluster' starts applications individually and never runs
+            %% `emqx_machine_boot:ensure_apps_started/0', which starts plugin apps at
+            %% the end of the real node boot.  Emulate that boot tail here.
+            ok = ?ON(N1, emqx_plugins:ensure_started()),
+            ok = ?ON(N2, emqx_plugins:ensure_started()),
             ct:pal("checking N1 state"),
             ?ON(N1, assert_started_and_hooks_loaded()),
             ct:pal("checking N2 state"),
@@ -1318,10 +1350,13 @@ t_start_node_with_plugin_enabled(Config) when is_list(Config) ->
                 end,
                 ekka:callback(start, StartCallback)
             end),
+            %% `emqx_machine_boot_apps_started' fires after the boot tail has
+            %% started the plugin apps, so the assertions below cannot race
+            %% with the plugin start.
             {ok, {ok, _}} =
                 ?wait_async_action(
                     ?ON(N2, emqx_cluster:join(N1)),
-                    #{?snk_kind := "emqx_plugins_app_started"}
+                    #{?snk_kind := emqx_machine_boot_apps_started}
                 ),
             ct:pal("checking N1 state after join"),
             ?ON(N1, assert_started_and_hooks_loaded()),

--- a/changes/ee/fix-18338.en.md
+++ b/changes/ee/fix-18338.en.md
@@ -1,0 +1,1 @@
+Start plugins after all EMQX applications have started. A plugin may now declare any EMQX application in its `applications` list. Previously, a plugin that declared an application which starts late in the boot sequence (for example `emqx_management`) failed to start after a node restart.


### PR DESCRIPTION
Release versions:
5.10.5

Introduced in:
pre-5.8

## Summary

Port of https://github.com/emqx/emqx/pull/18337 (dev-60) to dev-510.
Item 1 of emqx/emqx-dev-team-tasks#338 only.

Plugin applications used to start from inside `emqx_plugins_app:start/2`, in the middle of the boot sequence. A plugin that declared an application which starts later in the boot sequence (for example `emqx_management`) hit the 10-second start timeout and was left enabled but not running after every node restart.

This PR moves the plugin start to the tail of `emqx_machine_boot:ensure_apps_started/0`:

- `ensure_apps_started/0`, not `post_boot/0`, because the ekka cluster join/leave callback re-runs `ensure_apps_started/0` directly, so plugins also restart after a cluster join.
- Plugins start before the `emqx_machine_boot_apps_started` trace point, so tests that wait for it see plugins running.
- This mirrors `stop_apps/0`, which already calls `emqx_plugins:ensure_stopped/0` before stopping the reboot apps.
- A broken plugin cannot fail the boot: `ensure_started/0` catches per-plugin errors and aggregates them into an error log. A new test case covers this.

Notes:

- This change widens the window where listeners already accept connections before plugin hooks are registered. Item 2 of emqx/emqx-dev-team-tasks#338 (the readiness gate) closes that window in a follow-up PR.
- The load-time dependency strip and `not_running_deps` diagnostic from #18334 are kept; they still help already-built plugin packages.

Validated on a real release build (not only CT, since `emqx_cth_cluster` bypasses the real boot path): before this change a plugin declaring `emqx_management` failed with `failed_to_start_plugin_app, reason: timeout` after `bin/emqx start` and stayed in `running_status: loaded`; with this change the node boots clean, the plugin is `running`, it stays `running` across a `bin/emqx stop`/`start` cycle, and it is `running` on the joining node after a two-node `cluster join`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
