### PR TITLE
fix(data_backup): scope import extract and cleanup to the caller namespace

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -495,7 +495,7 @@ upload(Namespace, BackupFilename, BackupFileContent) ->
         {ok, FilePath} ?= backup_path(Namespace, BackupFilename),
         case filelib:is_file(FilePath) of
             true -> {error, {already_exists, BackupFilename}};
-            false -> do_upload(FilePath, BackupFileContent)
+            false -> do_upload(Namespace, FilePath, BackupFileContent)
         end
     end.
 
@@ -550,6 +550,8 @@ format_error(invalid_version) ->
     "invalid backup archive content: wrong EMQX version value in " ?META_FILENAME;
 format_error(bad_archive_dir) ->
     "invalid backup archive content: all files in the archive must be under <backup name> directory";
+format_error(bad_archive_member) ->
+    "invalid backup archive content: only regular files and directories are allowed in the archive";
 format_error(not_found) ->
     "backup file not found";
 format_error(bad_backup_name) ->
@@ -629,12 +631,12 @@ maybe_not_found({error, enoent}) ->
 maybe_not_found(Other) ->
     Other.
 
-do_upload(BackupFilePath, BackupFileContent) ->
+do_upload(Namespace, BackupFilePath, BackupFileContent) ->
     try
         maybe
-            {ok, BackupDir} ?= backup_dir(BackupFilePath),
+            {ok, BackupDir} ?= backup_dir(Namespace, BackupFilePath),
             ok ?= file:write_file(BackupFilePath, BackupFileContent),
-            ok ?= extract_backup(BackupFilePath),
+            ok ?= extract_backup(Namespace, BackupFilePath),
             {ok, _} ?= validate_backup(BackupDir),
             HoconFilename = filename:join(BackupDir, ?CLUSTER_HOCON_FILENAME),
             ok ?=
@@ -673,7 +675,7 @@ do_upload(BackupFilePath, BackupFileContent) ->
             }),
             {error, Reason}
     after
-        cleanup_backup_dir(BackupFilePath)
+        cleanup_backup_dir(Namespace, BackupFilePath)
     end.
 
 prepare_new_backup(Opts) ->
@@ -930,9 +932,9 @@ do_import(BackupFilePath, Opts) ->
     Namespace = maps:get(namespace, Opts, ?global_ns),
     try
         maybe
-            {ok, BackupDir} ?= backup_dir(BackupFilePath),
+            {ok, BackupDir} ?= backup_dir(Namespace, BackupFilePath),
             ok ?= validate_backup_basename(BackupFilePath),
-            ok ?= extract_backup(BackupFilePath),
+            ok ?= extract_backup(Namespace, BackupFilePath),
             {ok, _} ?= validate_backup(BackupDir),
             {ok, #{conf_errors := ConfErrors, mnesia_errors := MnesiaErrors}} ?=
                 do_import_for_namespace(Namespace, BackupDir, Opts),
@@ -959,7 +961,7 @@ do_import(BackupFilePath, Opts) ->
             }),
             {error, Reason}
     after
-        cleanup_backup_dir(BackupFilePath)
+        cleanup_backup_dir(Namespace, BackupFilePath)
     end.
 
 log_import_result(_BackupFilePath, #{db_errors := DbErrors, config_errors := ConfErrors}) when
@@ -1304,10 +1306,10 @@ try_traverse_backup(Fun) ->
             {'EXIT', {Reason, Stacktrace}}
     end.
 
-extract_backup(BackupFilePath) ->
+extract_backup(Namespace, BackupFilePath) ->
     ?SLOG(debug, #{msg => "extract_backup", backup_file_path => BackupFilePath}),
-    RootBackupDir = root_backup_dir(),
     maybe
+        {ok, RootBackupDir} ?= backup_root_dir(Namespace),
         ok ?= validate_filenames(BackupFilePath),
         ?SLOG(debug, #{
             msg => "extracting_backup", backup => BackupFilePath, root_backup_dir => RootBackupDir
@@ -1317,20 +1319,40 @@ extract_backup(BackupFilePath) ->
 
 validate_filenames(BackupFilePath) ->
     maybe
-        {ok, Filenames} ?= format_tar_error(erl_tar:table(BackupFilePath, [compressed])),
+        {ok, Members} ?= format_tar_error(erl_tar:table(BackupFilePath, [compressed, verbose])),
         BackupName = filename:basename(BackupFilePath, ?TAR_SUFFIX),
-        IsValid = lists:all(
-            fun(Filename) ->
-                [Root | _] = filename:split(Filename),
-                Root =:= BackupName
-            end,
-            Filenames
-        ),
-        case IsValid of
-            true -> ok;
-            false -> {error, bad_archive_dir}
-        end
+        validate_tar_members(BackupName, Members)
     end.
+
+validate_tar_members(_BackupName, []) ->
+    ok;
+validate_tar_members(BackupName, [Member | Rest]) ->
+    case validate_tar_member(BackupName, Member) of
+        ok -> validate_tar_members(BackupName, Rest);
+        Error -> Error
+    end.
+
+%% Only regular files and directories confined to the `<backup name>/' subtree may be
+%% extracted: link members or path traversal could reach files outside the backup directory.
+validate_tar_member(BackupName, {Filename, Type, _Size, _MTime, _Mode, _Uid, _Gid}) when
+    Type =:= regular; Type =:= directory
+->
+    [Root | _] = Components = filename:split(Filename),
+    IsValid =
+        filename:pathtype(Filename) =:= relative andalso
+            Root =:= BackupName andalso
+            not lists:member("..", Components),
+    case IsValid of
+        true -> ok;
+        false -> {error, bad_archive_dir}
+    end;
+validate_tar_member(_BackupName, {Filename, Type, _Size, _MTime, _Mode, _Uid, _Gid}) ->
+    ?SLOG(warning, #{
+        msg => "bad_backup_archive_member",
+        filename => Filename,
+        type => Type
+    }),
+    {error, bad_archive_member}.
 
 import_cluster_hocon(BackupDir, Opts) ->
     HoconFilename = filename:join(BackupDir, ?CLUSTER_HOCON_FILENAME),
@@ -1687,13 +1709,23 @@ validate_backup_basename(BackupFilePath) ->
         false -> {error, bad_backup_name}
     end.
 
-backup_dir(BackupFilePath) ->
+backup_dir(Namespace, BackupFilePath) ->
     BaseName = filename:basename(BackupFilePath, ?TAR_SUFFIX),
-    RootBackupDir = root_backup_dir(),
-    case filelib:safe_relative_path(BaseName, RootBackupDir) of
-        unsafe -> {error, unsafe_backup_name};
-        _ -> {ok, filename:join(RootBackupDir, BaseName)}
+    maybe
+        ok ?= validate_extract_dir_name(Namespace, BaseName),
+        {ok, RootBackupDir} ?= backup_root_dir(Namespace),
+        case filelib:safe_relative_path(BaseName, RootBackupDir) of
+            unsafe -> {error, unsafe_backup_name};
+            _ -> {ok, filename:join(RootBackupDir, BaseName)}
+        end
     end.
+
+%% In the global root, `ns/' holds the namespaced backups; a backup named `ns' would
+%% extract into it and its cleanup would delete it.
+validate_extract_dir_name(?global_ns, ?NS_BACKUP_SUBDIR) ->
+    {error, unsafe_backup_name};
+validate_extract_dir_name(_Namespace, _BaseName) ->
+    ok.
 
 backup_path(Filename) ->
     backup_path(?global_ns, Filename).
@@ -1734,9 +1766,9 @@ namespaced_backup_dir(Namespace) ->
             {ok, Dir}
     end.
 
-cleanup_backup_dir(BackupFilePath) ->
+cleanup_backup_dir(Namespace, BackupFilePath) ->
     maybe
-        {ok, BackupDir} ?= backup_dir(BackupFilePath),
+        {ok, BackupDir} ?= backup_dir(Namespace, BackupFilePath),
         file:del_dir_r(BackupDir)
     end.
 

--- a/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
@@ -351,22 +351,23 @@ t_cluster_hocon_export_import(Config) ->
     ),
     ok.
 
+-doc """
+Rejects an archive whose member path contains `..' and would extract outside the
+backup directory.
+""".
 t_tar_outside_backup_dir(Config) ->
     BackupFileName = filename:join(?config(priv_dir, Config), "tar_outside_backup_dir.tar.gz"),
-    Meta = unicode:characters_to_binary(
-        hocon_pp:do(#{edition => emqx_release:edition(), version => emqx_release:version()}, #{})
-    ),
     ok = erl_tar:create(
         BackupFileName,
         [
             {"tar_outside_backup_dir/../../cluster.hocon", <<>>},
-            {"tar_outside_backup_dir/META.hocon", Meta}
+            {"tar_outside_backup_dir/META.hocon", backup_meta_bin()}
         ],
         [compressed]
     ),
-    {error, Message} = emqx_mgmt_data_backup:import_local(BackupFileName),
-    ?assert(
-        string:str(Message, "The path points above the current working directory") > 0
+    ?assertEqual(
+        {error, bad_archive_dir},
+        emqx_mgmt_data_backup:import_local(BackupFileName)
     ).
 
 t_unsafe_backup_name(Config) ->
@@ -390,6 +391,81 @@ t_unsafe_backup_name(Config) ->
         emqx_mgmt_data_backup:upload(filename:basename(BackupFileName), BackupFileContent)
     ),
     ?assert(filelib:is_regular(Filename)).
+
+-doc """
+A namespaced import of an archive named `ns.tar.gz' whose members point into another
+namespace extracts and cleans up only within the caller's own backup directory.
+""".
+t_namespaced_import_isolation(Config) ->
+    Victim = <<"victim_ns">>,
+    Attacker = <<"attacker_ns">>,
+    Meta = backup_meta_bin(),
+    VictimContent = tar_bin(Config, [{"victim-backup/META.hocon", Meta}]),
+    ok = emqx_mgmt_data_backup:upload(Victim, <<"victim-backup.tar.gz">>, VictimContent),
+    {ok, VictimDir} = emqx_mgmt_data_backup:backup_root_dir(Victim),
+    VictimFile = filename:join(VictimDir, "victim-backup.tar.gz"),
+    ?assert(filelib:is_regular(VictimFile)),
+    AttackerContent = tar_bin(Config, [
+        {"ns/META.hocon", Meta},
+        {"ns/victim_ns/planted.tar.gz", <<"planted">>}
+    ]),
+    ok = emqx_mgmt_data_backup:upload(Attacker, <<"ns.tar.gz">>, AttackerContent),
+    ?assertMatch(
+        {ok, _},
+        emqx_mgmt_data_backup:import(<<"ns.tar.gz">>, #{namespace => Attacker})
+    ),
+    %% the victim's backup survives and nothing is planted into its directory
+    ?assert(filelib:is_regular(VictimFile)),
+    ?assertEqual({ok, ["victim-backup.tar.gz"]}, file:list_dir(VictimDir)),
+    %% the attacker's extract directory is cleaned up, the uploaded file remains
+    {ok, AttackerDir} = emqx_mgmt_data_backup:backup_root_dir(Attacker),
+    ?assertEqual({ok, ["ns.tar.gz"]}, file:list_dir(AttackerDir)).
+
+-doc """
+A global-namespace backup must not be named `ns.tar.gz': its extract and cleanup
+directory would collide with the namespaced backups directory.
+""".
+t_reserved_ns_backup_name(Config) ->
+    Content = tar_bin(Config, [{"ns/META.hocon", backup_meta_bin()}]),
+    ?assertEqual(
+        {error, unsafe_backup_name},
+        emqx_mgmt_data_backup:upload(<<"ns.tar.gz">>, Content)
+    ),
+    BackupFilePath = filename:join(?config(priv_dir, Config), "ns.tar.gz"),
+    ok = file:write_file(BackupFilePath, Content),
+    ?assertEqual(
+        {error, unsafe_backup_name},
+        emqx_mgmt_data_backup:import_local(BackupFilePath)
+    ).
+
+-doc """
+Rejects an archive that contains a symlink member.
+""".
+t_symlink_member_rejected(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    SrcDir = filename:join(PrivDir, "symlink-backup"),
+    ok = filelib:ensure_path(SrcDir),
+    LinkPath = filename:join(SrcDir, "escape"),
+    ok = file:make_symlink("/etc/passwd", LinkPath),
+    BackupFilePath = filename:join(PrivDir, "symlink-backup.tar.gz"),
+    ok = erl_tar:create(
+        BackupFilePath,
+        [
+            {"symlink-backup/META.hocon", backup_meta_bin()},
+            {"symlink-backup/escape", LinkPath}
+        ],
+        [compressed]
+    ),
+    ?assertEqual(
+        {error, bad_archive_member},
+        emqx_mgmt_data_backup:import_local(BackupFilePath)
+    ),
+    ?assertMatch([_ | _], emqx_mgmt_data_backup:format_error(bad_archive_member)),
+    {ok, Content} = file:read_file(BackupFilePath),
+    ?assertEqual(
+        {error, bad_archive_member},
+        emqx_mgmt_data_backup:upload(<<"symlink-backup.tar.gz">>, Content)
+    ).
 
 t_no_backup_file(_Config) ->
     ?assertMatch([_ | _], emqx_mgmt_data_backup:format_error(not_found)),
@@ -1660,6 +1736,21 @@ do_normalize_checked_config_prometheus(Cfg0) ->
 
 basename(FilePath) ->
     filename:basename(FilePath).
+
+backup_meta_bin() ->
+    unicode:characters_to_binary(
+        hocon_pp:do(#{edition => emqx_release:edition(), version => emqx_release:version()}, #{})
+    ).
+
+tar_bin(Config, Members) ->
+    TmpFile = filename:join(
+        ?config(priv_dir, Config),
+        "tar_bin_" ++ integer_to_list(erlang:unique_integer([positive])) ++ ".tar.gz"
+    ),
+    ok = erl_tar:create(TmpFile, Members, [compressed]),
+    {ok, Bin} = file:read_file(TmpFile),
+    ok = file:delete(TmpFile),
+    Bin.
 
 deep_diff_maps(#{} = ExpectedMap, #{} = ActualMap) ->
     Diff0 = emqx_utils_maps:diff_maps(ExpectedMap, ActualMap),

--- a/changes/ee/fix-18339.en.md
+++ b/changes/ee/fix-18339.en.md
@@ -1,0 +1,1 @@
+Fixed a data backup import isolation issue where an uploaded archive could delete or write backup files that belong to other namespaces. Import now extracts and cleans up within the caller's own namespace directory. Backup archives that contain symlink or hardlink members are now rejected.


### PR DESCRIPTION
Release version:
6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:
6.1.4

## Summary

Fixes B1 and B4 of emqx/emqx-dev-team-tasks#332. Sibling of emqx/emqx-dev-team-tasks#331 (same audit).

Data backup import derived its extract and cleanup directory from the global backup root and the uploaded file basename, ignoring the caller's namespace. A namespaced admin could upload an archive named `ns.tar.gz`: the import's cleanup step then deleted `<root>/ns`, the parent directory of every namespace's stored backups, and archive members such as `ns/<other-ns>/file` extracted into other namespaces' directories. The upload endpoint runs the same extract and cleanup path.

Changes in `emqx_mgmt_data_backup`:

* `backup_dir`, `extract_backup`, and `cleanup_backup_dir` now take the caller namespace and resolve against `backup_root_dir(Namespace)`, the same choke point that upload, list, and download already use. A namespaced caller extracts to and cleans up only `<root>/ns/<Namespace>/<basename>`.
* The basename `ns` is rejected for global-namespace backups, because its extract directory would collide with the namespaced backups directory and its cleanup would delete it.
* `validate_filenames` now checks member types and paths before extraction (B4): members must be regular files or directories, with relative paths under the `<backup name>/` directory and no `..` components. Symlink and hardlink members are rejected with a new `bad_archive_member` error.

Global-namespace import behavior is otherwise unchanged: `backup_root_dir(?global_ns)` is the old global root.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
