### PR TITLE
fix(deps): upgrade hocon to 0.46.3

### DIFF
--- a/changes/ee/fix-18344.en.md
+++ b/changes/ee/fix-18344.en.md
@@ -1,0 +1,1 @@
+Upgraded HOCON to 0.46.3. This release renders sensitive values inside array-typed config fields as `******` and no longer prints sensitive field values in config validation error logs.

--- a/mix.exs
+++ b/mix.exs
@@ -178,7 +178,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.2", override: true}
 
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
-  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.9", override: true}
+  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.3", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}
   # in conflict by ehttpc and emqtt
   def common_dep(:gun), do: {:gun, "2.1.0", override: true}


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:

## Summary

Upgrade hocon from 0.45.9 to 0.46.3.

This is the v6 counterpart of the hocon upgrade requested in the review of #18336 (dev-58). The 0.46.x releases extend `obfuscate_sensitive_values` to render sensitive values inside array-typed config fields as `******`, and stop logging sensitive field values in config validation errors. The diff from 0.45.9 also includes unicode escape-sequence handling fixes in the scanner and an atomic config-file write fix in `hocon_cli`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
