### PR TITLE
fix(otel api): match api root schema to correct root

### DIFF
--- a/apps/emqx_opentelemetry/src/emqx_otel_api.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_api.erl
@@ -85,13 +85,17 @@ get_raw() ->
     Conf.
 
 otel_config_schema() ->
-    emqx_dashboard_swagger:schema_with_example(
-        hoconsc:ref(emqx_otel_schema, "opentelemetry"),
-        otel_config_example()
+    emqx_dashboard_swagger:schema_with_examples(
+        emqx_otel_schema:root_type(),
+        #{
+            ~"generic" => otel_config_example(),
+            ~"dynatrace" => dynatrace_config_example()
+        }
     ).
 
 otel_config_example() ->
     #{
+        type => ~"generic",
         exporter => #{
             endpoint => "http://localhost:4317",
             headers => #{},
@@ -103,6 +107,48 @@ otel_config_example() ->
         },
         metrics => #{
             enable => true
+        },
+        traces => #{
+            enable => true,
+            max_queue_size => 2048,
+            scheduled_delay => "5s",
+            filter => #{
+                trace_all => false,
+                trace_mode => legacy,
+                e2e_tracing_options => #{
+                    cluster_identifier => "emqxcl",
+                    msg_trace_level => 0,
+                    clientid_match_rules_max => 30,
+                    topic_match_rules_max => 30,
+                    sample_ratio => "10%",
+                    client_connect_disconnect => true,
+                    client_subscribe_unsubscribe => true,
+                    client_messaging => true,
+                    follow_traceparent => true
+                }
+            }
+        }
+    }.
+
+dynatrace_config_example() ->
+    #{
+        type => ~"dynatrace",
+        exporter => #{
+            endpoint => "https://xxxx.live.dynatrace.com/api/v2/oltp",
+            auth => #{
+                ~"enable" => true,
+                ~"kind" => ~"dynatrace_oauth2",
+                ~"client_id" => ~"myclientid",
+                ~"client_secret" => ~"******",
+                ~"resource" => ~"someres",
+                ~"token_endpoint" => ~"https://127.0.0.1:9998/sso/oauth2/token"
+            },
+            headers => #{},
+            ssl_options => #{}
+        },
+        logs => #{
+            enable => true,
+            level => warning
         },
         traces => #{
             enable => true,

--- a/apps/emqx_opentelemetry/src/emqx_otel_api.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_api.erl
@@ -88,8 +88,16 @@ otel_config_schema() ->
     emqx_dashboard_swagger:schema_with_examples(
         emqx_otel_schema:root_type(),
         #{
-            ~"generic" => otel_config_example(),
-            ~"dynatrace" => dynatrace_config_example()
+            ~"generic" =>
+                #{
+                    summary => ?DESC("example_generic"),
+                    value => otel_config_example()
+                },
+            ~"dynatrace" =>
+                #{
+                    summary => ?DESC("example_dynatrace"),
+                    value => dynatrace_config_example()
+                }
         }
     ).
 
@@ -134,7 +142,7 @@ dynatrace_config_example() ->
     #{
         type => ~"dynatrace",
         exporter => #{
-            endpoint => "https://xxxx.live.dynatrace.com/api/v2/oltp",
+            endpoint => "https://xxxx.live.dynatrace.com/api/v2/otlp",
             auth => #{
                 ~"enable" => true,
                 ~"kind" => ~"dynatrace_oauth2",

--- a/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
@@ -15,6 +15,7 @@
 ]).
 
 -export([
+    root_type/0,
     validate_sample_ratio/1
 ]).
 
@@ -24,20 +25,23 @@ roots() ->
     [
         {"opentelemetry",
             ?HOCON(
-                emqx_schema:mkunion(
-                    type,
-                    #{
-                        <<"generic">> => ?R_REF("opentelemetry"),
-                        <<"dynatrace">> => ?R_REF("opentelemetry_dynatrace")
-                    },
-                    <<"generic">>
-                ),
+                root_type(),
                 #{
                     required => {false, recursively},
                     converter => fun legacy_metrics_converter/2
                 }
             )}
     ].
+
+root_type() ->
+    emqx_schema:mkunion(
+        type,
+        #{
+            <<"generic">> => ?R_REF("opentelemetry"),
+            <<"dynatrace">> => ?R_REF("opentelemetry_dynatrace")
+        },
+        <<"generic">>
+    ).
 
 fields("opentelemetry") ->
     [

--- a/apps/emqx_opentelemetry/test/emqx_otel_api_SUITE.erl
+++ b/apps/emqx_opentelemetry/test/emqx_otel_api_SUITE.erl
@@ -78,6 +78,21 @@ auth_header() ->
     {ok, API} = emqx_common_test_http:create_default_app(),
     emqx_common_test_http:auth_header(API).
 
+update_config(Config) ->
+    URL = emqx_mgmt_api_test_util:uri(["opentelemetry"]),
+    emqx_mgmt_api_test_util:simple_request(#{
+        method => put,
+        url => URL,
+        body => Config
+    }).
+
+get_config() ->
+    URL = emqx_mgmt_api_test_util:uri(["opentelemetry"]),
+    emqx_mgmt_api_test_util:simple_request(#{
+        method => get,
+        url => URL
+    }).
+
 t_get(Config) ->
     Auth = ?config(auth, Config),
     Path = ?OTEL_API_PATH,
@@ -281,3 +296,49 @@ t_put_cert(Config) ->
     ),
     ct:pal("CA certfile1: ~p", [CaFile1]),
     ?assertNot(filelib:is_file(CaFile1)).
+
+-doc """
+Smoke tests that verify that the api matches the root schema, by updating it with a
+dynatrace config.
+""".
+t_dynatrace(_TCConfig) ->
+    Conf = #{
+        ~"type" => ~"dynatrace",
+        ~"exporter" => #{
+            ~"auth" => #{
+                ~"enable" => true,
+                ~"kind" => ~"dynatrace_oauth2",
+                ~"client_id" => ~"myclientid",
+                ~"client_secret" => ~"myclientsecret",
+                ~"resource" => ~"someres",
+                ~"token_endpoint" => ~"https://127.0.0.1:9998/sso/oauth2/token"
+            },
+            ~"endpoint" => ~"https://127.0.0.1:9997/api/v2/otlp"
+        },
+        ~"logs" => #{~"enable" => true},
+        ~"traces" => #{~"enable" => true}
+    },
+    ?assertMatch(
+        {200, _},
+        update_config(Conf)
+    ),
+    ?assertMatch(
+        {200, #{
+            ~"type" := ~"dynatrace",
+            ~"exporter" := #{
+                ~"auth" := #{
+                    ~"enable" := true,
+                    ~"kind" := ~"dynatrace_oauth2",
+                    ~"client_id" := ~"myclientid",
+                    ~"client_secret" := ~"******",
+                    ~"resource" := ~"someres",
+                    ~"token_endpoint" := ~"https://127.0.0.1:9998/sso/oauth2/token"
+                },
+                ~"endpoint" := ~"https://127.0.0.1:9997/api/v2/otlp"
+            },
+            ~"logs" := #{~"enable" := true},
+            ~"traces" := #{~"enable" := true}
+        }},
+        get_config()
+    ),
+    ok.

--- a/rel/i18n/emqx_otel_api.hocon
+++ b/rel/i18n/emqx_otel_api.hocon
@@ -15,4 +15,14 @@ update_config_failed.desc:
 update_config_failed.label:
 """Update Config Failed"""
 
+  example_generic {
+    label: "Generic Opentelemetry Example"
+    desc: "Generic Opentelemetry Example"
+  }
+
+  example_dynatrace {
+    label: "Dynatrace Opentelemetry Example"
+    desc: "Dynatrace Opentelemetry Example"
+  }
+
 }


### PR DESCRIPTION
Release version:
6.3.0, 6.4.0

## Summary

The opentelemetry schema did not match the true configuration root schema type, and hence could not be updated with a dynatrace configuration.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
