### PR TITLE
build(quicer): bump to 0.4.9, default QUICER_TLS_VER to auto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ print-dashboard-version:
 	@echo $(EMQX_DASHBOARD_VERSION)
 
 export EMQX_REL_FORM ?= tgz
-export QUICER_TLS_VER ?= sys
+# 'auto' resolves to 'sys' (link system libcrypto) when the build host has
+# OpenSSL >= 3.0, and to quicer's bundled quictls otherwise.
+export QUICER_TLS_VER ?= auto
 
 -include default-profile.mk
 PROFILE ?= emqx-enterprise

--- a/mix.exs
+++ b/mix.exs
@@ -1126,7 +1126,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict with emqx and emqtt
       do: [
         {:quicer,
-         github: "emqx/quic", tag: "0.4.8", override: true, system_env: quicer_build_env()}
+         github: "emqx/quic", tag: "0.4.9", override: true, system_env: quicer_build_env()}
       ],
       else: []
   end


### PR DESCRIPTION
## Summary

Bump quicer 0.4.8 -> 0.4.9 and change the `QUICER_TLS_VER` Makefile default from `sys` to `auto`.

PR #18293 bumped quicer to 0.4.8, whose msquic requires OpenSSL >= 3.0 when linking the system libcrypto. With the unconditional `QUICER_TLS_VER ?= sys` default, `make` fails on hosts with an older OpenSSL (e.g. Ubuntu 20.04, OpenSSL 1.1.1):

```
CMake Error at msquic/submodules/CMakeLists.txt:361 (message):
  OpenSSL 3.0 not found, found 1.1.1f
```

quicer 0.4.9 adds `QUICER_TLS_VER=auto` (emqx/quic#439): it resolves to `sys` when the build host has OpenSSL >= 3.0 development files and to the bundled quictls otherwise. The resolution runs before the pre-built package name is computed, so prebuilt downloads fetch the matching variant. An explicit `QUICER_TLS_VER` from the environment still wins. Replaces #18335, which carried an EMQX-side probe script; the resolution now lives in quic.git.

Effect on packaging:
- Builders with OpenSSL >= 3 (ubuntu24.04 etc.): `auto` resolves to `sys`; released artifacts keep their current system-libcrypto linkage.
- Builders with OpenSSL <= 1.1.1 (debian11, el7, el8): `auto` resolves to quictls instead of failing the tag build.
- macOS packaging keeps its explicit `QUICER_TLS_VER: quictls`.

Verified on an Ubuntu 20.04 host (OpenSSL 1.1.1f): `make` from scratch succeeds, the build logs `QUICER_TLS_VER=auto resolved to 'quictls'`, and the built NIF has no dynamic libcrypto/libssl dependency.

Note: the 0.4.9 GitHub release is still a draft, so the prebuilt download 404s and the build falls back to compiling from source (works, just slower). Publishing the release restores the prebuilt fast path.
