### PR TITLE
fix(boot): gate connections until node boot completes (v5)

### DIFF
--- a/apps/emqx/include/emqx_quic.hrl
+++ b/apps/emqx/include/emqx_quic.hrl
@@ -21,6 +21,7 @@
 -define(MQTT_QUIC_CONN_NOERROR, 0).
 -define(MQTT_QUIC_CONN_ERROR_CTRL_STREAM_DOWN, 1).
 -define(MQTT_QUIC_CONN_ERROR_OVERLOADED, 2).
+-define(MQTT_QUIC_CONN_ERROR_NOT_READY, 3).
 
 %% Prod SAFE timeout, better than `infinity` or
 %% 5000 (gen_server default timeout)

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -308,9 +308,19 @@ init(Parent, Transport, RawSocket, Options) ->
         false ->
             %% Refuse to serve before node boot completes: authn/authz
             %% hooks (e.g. from plugins) may not be installed yet.
-            ?SLOG_THROTTLE(warning, #{msg => connection_refused_before_boot_complete}),
+            %% The exit reason feeds the listener's shutdown counter.
+            Peername =
+                case Transport:peername(RawSocket) of
+                    {ok, Peer} -> esockd:format(Peer);
+                    {error, _} -> unknown
+                end,
+            ?SLOG(info, #{
+                msg => connection_refused_before_boot_complete,
+                transport => Transport,
+                peername => Peername
+            }),
             ok = Transport:fast_close(RawSocket),
-            erlang:exit(normal)
+            erlang:exit({shutdown, node_not_ready})
     end.
 
 do_init(Parent, Transport, RawSocket, Options) ->

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -302,6 +302,18 @@ stop(Pid) ->
 %%--------------------------------------------------------------------
 
 init(Parent, Transport, RawSocket, Options) ->
+    case emqx_node_readiness:is_ready() of
+        true ->
+            do_init(Parent, Transport, RawSocket, Options);
+        false ->
+            %% Refuse to serve before node boot completes: authn/authz
+            %% hooks (e.g. from plugins) may not be installed yet.
+            ?SLOG_THROTTLE(warning, #{msg => connection_refused_before_boot_complete}),
+            ok = Transport:fast_close(RawSocket),
+            erlang:exit(normal)
+    end.
+
+do_init(Parent, Transport, RawSocket, Options) ->
     case Transport:wait(RawSocket) of
         {ok, Socket} ->
             run_loop(Parent, init_state(Transport, Socket, Options));

--- a/apps/emqx/src/emqx_node_readiness.erl
+++ b/apps/emqx/src/emqx_node_readiness.erl
@@ -1,0 +1,44 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% Node readiness flag.
+%%
+%% Connection processes check this flag at init and refuse to serve
+%% until the node has finished booting, so no client can connect before
+%% authentication, authorization and plugin hooks are installed.
+%%
+%% The flag defaults to `true': only the managed boot sequence
+%% (`emqx_machine_boot:ensure_apps_started/0') clears it and sets it
+%% back once all applications (including plugins) are started.
+%% Contexts that do not boot through `emqx_machine' (test suites) are
+%% therefore always ready.
+-module(emqx_node_readiness).
+
+-export([is_ready/0, mark_ready/0, mark_not_ready/0]).
+
+-define(KEY, {?MODULE, ready}).
+
+-spec is_ready() -> boolean().
+is_ready() ->
+    persistent_term:get(?KEY, true).
+
+-spec mark_ready() -> ok.
+mark_ready() ->
+    persistent_term:put(?KEY, true).
+
+-spec mark_not_ready() -> ok.
+mark_not_ready() ->
+    persistent_term:put(?KEY, false).

--- a/apps/emqx/src/emqx_quic_connection.erl
+++ b/apps/emqx/src/emqx_quic_connection.erl
@@ -107,10 +107,34 @@ closed(_Conn, #{is_peer_acked := _} = Prop, S) ->
 new_conn(
     Conn,
     #{version := _Vsn} = ConnInfo,
-    #{zone := Zone, conn := undefined, ctrl_pid := undefined} = S
+    #{zone := _Zone, conn := undefined, ctrl_pid := undefined} = S
 ) ->
     process_flag(trap_exit, true),
     ?SLOG(debug, ConnInfo#{conn => Conn}),
+    case emqx_node_readiness:is_ready() of
+        true ->
+            do_new_conn(Conn, ConnInfo, S);
+        false ->
+            %% Refuse to serve before node boot completes: authn/authz
+            %% hooks (e.g. from plugins) may not be installed yet.
+            Peername =
+                case quicer:peername(Conn) of
+                    {ok, Peer} -> esockd:format(Peer);
+                    {error, _} -> unknown
+                end,
+            ?SLOG(info, #{
+                msg => quic_connection_refused_before_boot_complete,
+                peername => Peername
+            }),
+            _ = quicer:async_shutdown_connection(
+                Conn,
+                ?QUIC_CONNECTION_SHUTDOWN_FLAG_NONE,
+                ?MQTT_QUIC_CONN_ERROR_NOT_READY
+            ),
+            {stop, normal, S}
+    end.
+
+do_new_conn(Conn, ConnInfo, #{zone := Zone} = S) ->
     case emqx_olp:is_overloaded() andalso is_zone_olp_enabled(Zone) of
         false ->
             %% Start control stream process

--- a/apps/emqx/src/emqx_quic_stream.erl
+++ b/apps/emqx/src/emqx_quic_stream.erl
@@ -101,6 +101,10 @@ wait({ConnOwner, Conn, ConnInfo}) ->
 type(_) ->
     quic.
 
+%% The first clause matches the not-yet-accepted socket passed to
+%% emqx_connection:init/4 (used by the node readiness gate).
+peername({ConnOwner, Conn, _ConnInfo}) when is_pid(ConnOwner) ->
+    quicer:peername(Conn);
 peername({quic, Conn, _Stream, _Info}) ->
     quicer:peername(Conn).
 

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -284,6 +284,17 @@ check_origin_header(Req, #{listener := {Type, Listener}} = Opts) ->
     end.
 
 websocket_init([Req, Opts]) ->
+    case emqx_node_readiness:is_ready() of
+        true ->
+            do_websocket_init(Req, Opts);
+        false ->
+            %% Refuse to serve before node boot completes: authn/authz
+            %% hooks (e.g. from plugins) may not be installed yet.
+            ?SLOG_THROTTLE(warning, #{msg => connection_refused_before_boot_complete}),
+            {stop, node_not_ready}
+    end.
+
+do_websocket_init(Req, Opts) ->
     #{zone := Zone, limiter := LimiterCfg, listener := {Type, Listener} = ListenerCfg} = Opts,
     case check_max_connection(Type, Listener) of
         allow ->

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -290,7 +290,7 @@ websocket_init([Req, Opts]) ->
         false ->
             %% Refuse to serve before node boot completes: authn/authz
             %% hooks (e.g. from plugins) may not be installed yet.
-            ?SLOG_THROTTLE(warning, #{msg => connection_refused_before_boot_complete}),
+            ?SLOG(info, #{msg => ws_connection_refused_before_boot_complete}),
             {stop, node_not_ready}
     end.
 

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -1,0 +1,73 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_node_readiness_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start([emqx], #{work_dir => emqx_cth_suite:work_dir(Config)}),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(apps, Config)).
+
+end_per_testcase(_TestCase, _Config) ->
+    ok = emqx_node_readiness:mark_ready().
+
+%% Checks that the node is ready by default, so contexts that do not
+%% boot through emqx_machine (e.g. test suites) are not gated.
+t_ready_by_default(_Config) ->
+    _ = persistent_term:erase({emqx_node_readiness, ready}),
+    ?assert(emqx_node_readiness:is_ready()).
+
+%% Checks that mark_not_ready/0 and mark_ready/0 toggle the flag.
+t_mark_ready_toggle(_Config) ->
+    ok = emqx_node_readiness:mark_not_ready(),
+    ?assertNot(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:mark_ready(),
+    ?assert(emqx_node_readiness:is_ready()).
+
+%% Checks that a TCP MQTT connection is refused while the node is not
+%% ready, and accepted again once it is ready.
+t_tcp_connection_gated(_Config) ->
+    process_flag(trap_exit, true),
+    ok = emqx_node_readiness:mark_not_ready(),
+    {ok, C1} = emqtt:start_link([{host, "127.0.0.1"}, {port, 1883}]),
+    ?assertMatch({error, _}, emqtt:connect(C1)),
+    ok = emqx_node_readiness:mark_ready(),
+    {ok, C2} = emqtt:start_link([{host, "127.0.0.1"}, {port, 1883}]),
+    ?assertMatch({ok, _}, emqtt:connect(C2)),
+    ok = emqtt:disconnect(C2).
+
+%% Checks that a WebSocket MQTT connection is refused while the node is
+%% not ready, and accepted again once it is ready.
+t_ws_connection_gated(_Config) ->
+    process_flag(trap_exit, true),
+    ok = emqx_node_readiness:mark_not_ready(),
+    {ok, C1} = emqtt:start_link([{host, "127.0.0.1"}, {port, 8083}]),
+    ?assertMatch({error, _}, emqtt:ws_connect(C1)),
+    ok = emqx_node_readiness:mark_ready(),
+    {ok, C2} = emqtt:start_link([{host, "127.0.0.1"}, {port, 8083}]),
+    ?assertMatch({ok, _}, emqtt:ws_connect(C2)),
+    ok = emqtt:disconnect(C2).

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -27,7 +27,10 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx], #{work_dir => emqx_cth_suite:work_dir(Config)}),
+    Apps = emqx_cth_suite:start(
+        [{emqx, "listeners.quic.test { enable = true }"}],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
@@ -71,6 +74,20 @@ t_tcp_connection_gated(_Config) ->
     ok = emqx_node_readiness:mark_ready(),
     {ok, C2} = emqtt:start_link([{host, "127.0.0.1"}, {port, 1883}]),
     ?assertMatch({ok, _}, emqtt:connect(C2)),
+    ok = emqtt:disconnect(C2).
+
+%% Checks that a QUIC MQTT connection is refused while the node is not
+%% ready, and accepted again once it is ready.
+t_quic_connection_gated(_Config) ->
+    process_flag(trap_exit, true),
+    Port = emqx_config:get([listeners, quic, test, bind]),
+    ClientOpts = [{host, "127.0.0.1"}, {port, Port}, {ssl_opts, [{verify, verify_none}]}],
+    ok = emqx_node_readiness:mark_not_ready(),
+    {ok, C1} = emqtt:start_link(ClientOpts),
+    ?assertMatch({error, _}, emqtt:quic_connect(C1)),
+    ok = emqx_node_readiness:mark_ready(),
+    {ok, C2} = emqtt:start_link(ClientOpts),
+    ?assertMatch({ok, _}, emqtt:quic_connect(C2)),
     ok = emqtt:disconnect(C2).
 
 %% Checks that a WebSocket MQTT connection is refused while the node is

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -21,6 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -49,12 +50,24 @@ t_mark_ready_toggle(_Config) ->
     ?assert(emqx_node_readiness:is_ready()).
 
 %% Checks that a TCP MQTT connection is refused while the node is not
-%% ready, and accepted again once it is ready.
+%% ready, and accepted again once it is ready.  Also checks that the
+%% refusal is recorded in the listener's shutdown counter.
 t_tcp_connection_gated(_Config) ->
     process_flag(trap_exit, true),
     ok = emqx_node_readiness:mark_not_ready(),
     {ok, C1} = emqtt:start_link([{host, "127.0.0.1"}, {port, 1883}]),
     ?assertMatch({error, _}, emqtt:connect(C1)),
+    Bind = emqx_config:get([listeners, tcp, default, bind]),
+    ?retry(
+        100,
+        10,
+        ?assertMatch(
+            {node_not_ready, _},
+            lists:keyfind(
+                node_not_ready, 1, emqx_listeners:shutdown_count(<<"tcp:default">>, Bind)
+            )
+        )
+    ),
     ok = emqx_node_readiness:mark_ready(),
     {ok, C2} = emqtt:start_link([{host, "127.0.0.1"}, {port, 1883}]),
     ?assertMatch({ok, _}, emqtt:connect(C2)),

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -85,6 +85,7 @@
     authorization_permission_denied,
     cannot_publish_to_topic_due_to_not_authorized,
     cannot_publish_to_topic_due_to_quota_exceeded,
+    connection_refused_before_boot_complete,
     connection_rejected_due_to_license_limit_reached,
     data_bridge_buffer_overflow,
     dropped_qos0_msg,

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -85,7 +85,6 @@
     authorization_permission_denied,
     cannot_publish_to_topic_due_to_not_authorized,
     cannot_publish_to_topic_due_to_quota_exceeded,
-    connection_refused_before_boot_complete,
     connection_rejected_due_to_license_limit_reached,
     data_bridge_buffer_overflow,
     dropped_qos0_msg,

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -279,6 +279,18 @@ is_datadram_socket({esockd_udp_proxy, _ProxyId, Sock}) -> erlang:is_port(Sock).
 %%--------------------------------------------------------------------
 
 init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod) ->
+    case emqx_node_readiness:is_ready() of
+        true ->
+            do_init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod);
+        false ->
+            %% Refuse to serve before node boot completes: authn/authz
+            %% hooks (e.g. from plugins) may not be installed yet.
+            ?SLOG_THROTTLE(warning, #{msg => connection_refused_before_boot_complete}),
+            ok = esockd_close(WrappedSock),
+            erlang:exit(normal)
+    end.
+
+do_init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod) ->
     case esockd_wait(WrappedSock) of
         {ok, NWrappedSock} ->
             Peername = esockd_peername(NWrappedSock, Peername0),

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -285,10 +285,24 @@ init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod) ->
         false ->
             %% Refuse to serve before node boot completes: authn/authz
             %% hooks (e.g. from plugins) may not be installed yet.
-            ?SLOG_THROTTLE(warning, #{msg => connection_refused_before_boot_complete}),
+            ?SLOG(warning, #{
+                msg => connection_refused_before_boot_complete,
+                peername => gate_peername(WrappedSock, Peername0),
+                channel_module => ChannMod
+            }),
             ok = esockd_close(WrappedSock),
-            erlang:exit(normal)
+            erlang:exit({shutdown, node_not_ready})
     end.
+
+gate_peername({esockd_transport, Sock}, undefined) ->
+    case esockd_transport:peername(Sock) of
+        {ok, Peername} -> esockd:format(Peername);
+        {error, _} -> unknown
+    end;
+gate_peername(_WrappedSock, Peername) when Peername =/= undefined ->
+    esockd:format(Peername);
+gate_peername(_WrappedSock, undefined) ->
+    unknown.
 
 do_init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod) ->
     case esockd_wait(WrappedSock) of

--- a/apps/emqx_gateway/src/emqx_gateway.app.src
+++ b/apps/emqx_gateway/src/emqx_gateway.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway, [
     {description, "The Gateway management application"},
-    {vsn, "0.2.6"},
+    {vsn, "0.2.7"},
     {registered, []},
     {mod, {emqx_gateway_app, []}},
     {applications, [

--- a/apps/emqx_machine/src/emqx_machine.app.src
+++ b/apps/emqx_machine/src/emqx_machine.app.src
@@ -3,7 +3,7 @@
     {id, "emqx_machine"},
     {description, "The EMQX Machine"},
     % strict semver, bump manually!
-    {vsn, "0.3.9"},
+    {vsn, "0.3.10"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, emqx_ctl, redbug]},

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -100,7 +100,10 @@ stop_one_app(App) ->
 
 ensure_apps_started() ->
     ?SLOG(notice, #{msg => "(re)starting_emqx_apps"}),
+    %% Refuse client connections until all apps (including plugins) are started.
+    ok = emqx_node_readiness:mark_not_ready(),
     lists:foreach(fun start_one_app/1, sorted_reboot_apps()),
+    ok = emqx_node_readiness:mark_ready(),
     ?tp(emqx_machine_boot_apps_started, #{}).
 
 start_one_app(App) ->

--- a/apps/emqx_management/src/emqx_mgmt_api_status.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_status.erl
@@ -147,6 +147,13 @@ broker_status() ->
 
 application_status() ->
     case lists:keysearch(emqx, 1, application:which_applications()) of
-        false -> not_running;
-        {value, _Val} -> running
+        false ->
+            not_running;
+        {value, _Val} ->
+            %% Report 503 while the node boot is still in progress
+            %% and MQTT connections are refused.
+            case emqx_node_readiness:is_ready() of
+                true -> running;
+                false -> not_running
+            end
     end.

--- a/changes/ee/fix-18356.en.md
+++ b/changes/ee/fix-18356.en.md
@@ -1,0 +1,1 @@
+MQTT connections are now refused until node startup completes, so listeners no longer serve traffic before authentication, authorization, and plugin security hooks are active. The `GET /status` endpoint reports HTTP 503 during this startup window, so load balancers can route around the node until it is ready.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

Fixes emqx/emqx-dev-team-tasks#341.

MQTT listeners open before all applications have started. Plugins that install `client.authenticate` / `client.authorize` (or other) hooks start late in the boot sequence, so clients connecting in that window bypass the plugin's security checks.

This PR adds a node readiness gate:

- New `emqx_node_readiness` module holds a readiness flag in a `persistent_term`. The flag defaults to ready, so contexts that do not boot through `emqx_machine` (test suites) are unaffected.
- `emqx_machine_boot:ensure_apps_started/0` clears the flag before starting apps and sets it after all apps (including plugins) are up. This function is also the ekka cluster join callback, so the node is re-gated during a rejoin. If boot never completes, the node keeps refusing connections.
- Connection process inits check the flag and close the socket before reading any bytes while the node is not ready: `emqx_connection` (TCP/SSL), `emqx_ws_connection` (WS/WSS), `emqx_quic_connection` (QUIC, refused in the acceptor callback before the TLS handshake), and `emqx_gateway_conn` (gateway connections).
- `GET /status` reports HTTP 503 while the node is not ready, so load balancers and orchestration can route around the node during the startup window.

Refusal observability:

- TCP/SSL refusals exit with `{shutdown, node_not_ready}`, so esockd records them in the per-listener shutdown counter (visible in `emqx ctl listeners`). A test asserts the counter is bumped. The refusal also logs at `info` level with the transport module and peername.
- WS/WSS refusals cannot feed that counter: the cowboy path does not go through esockd's connection supervisor, and `emqx_listeners:shutdown_count/3` returns `[]` for ws/wss listeners. The WS refusal therefore logs a distinct `info` message (`ws_connection_refused_before_boot_complete`).
- QUIC refusals shut down the connection with a dedicated application error code (`MQTT_QUIC_CONN_ERROR_NOT_READY`) and log a distinct `info` message with the peername; QUIC listeners have no shutdown counter either.
- Gateway refusals log at `warning` level with the peername and channel module, since gateway listeners have no shutdown-counter observability.

Notes:

- Gateways without a per-connection process (connectionless UDP paths) are not covered by this gate.
- No schema change.
- The `emqx_access_control:default_authn_result()` = `ignore` behavior is kept as defense in depth.

Sibling dev-60 PR: same design and module names on the v6 line.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
