### PR TITLE
fix(boot): gate connections until node boot completes (v6)

### DIFF
--- a/apps/emqx/include/emqx_quic.hrl
+++ b/apps/emqx/include/emqx_quic.hrl
@@ -9,6 +9,7 @@
 -define(MQTT_QUIC_CONN_NOERROR, 0).
 -define(MQTT_QUIC_CONN_ERROR_CTRL_STREAM_DOWN, 1).
 -define(MQTT_QUIC_CONN_ERROR_OVERLOADED, 2).
+-define(MQTT_QUIC_CONN_ERROR_NOT_READY, 3).
 
 %% Prod SAFE timeout, better than `infinity` or
 %% 5000 (gen_server default timeout)

--- a/apps/emqx/src/emqx_cluster.erl
+++ b/apps/emqx/src/emqx_cluster.erl
@@ -30,7 +30,7 @@
 -endif.
 
 join(PeerNode) ->
-    case is_booting() andalso mria_rlog:role() =:= core of
+    case not is_boot_complete() andalso mria_rlog:role() =:= core of
         true ->
             {error,
                 "This node has not fully booted yet. "
@@ -71,6 +71,16 @@ set_booting(Bool) when is_boolean(Bool) ->
 is_booting() ->
     application:get_env(emqx, boot_in_progress, false).
 
+-doc """
+Return `true` once this node's boot is complete.
+
+`is_booting/0` covers the first managed boot up to the point where the
+ekka join callbacks are registered; `emqx_node_readiness` also covers
+the `ensure_apps_started/0` re-run a cluster rejoin triggers.
+""".
+is_boot_complete() ->
+    not is_booting() andalso emqx_node_readiness:is_ready().
+
 leave() ->
     ekka:leave().
 
@@ -92,9 +102,28 @@ check_permission(PeerNode) ->
     end.
 
 %% @doc Check if the requesting node is allowed to join the cluster.
-%% Called by license checker for community license.
+%% Called on the join target node via `emqx_cluster_proto_v1:can_i_join/2'.
 -spec can_i_join(node()) -> ok | {error, string()}.
 can_i_join(_RequestingNode) ->
+    maybe
+        ok ?= check_boot_complete(),
+        ok ?= check_single_node_mode()
+    end.
+
+-doc "Refuse join requests while this node's boot is not complete.".
+check_boot_complete() ->
+    case is_boot_complete() of
+        false ->
+            Msg = io_lib:format(
+                "Node ~s has not fully booted yet. Please retry after it is started.",
+                [node()]
+            ),
+            {error, lists:flatten(Msg)};
+        true ->
+            ok
+    end.
+
+check_single_node_mode() ->
     case is_single_node_mode() of
         true ->
             Msg = lists:flatten(io_lib:format("Node ~s has a single node license", [node()])),

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -308,6 +308,18 @@ stop(Pid) ->
 %%--------------------------------------------------------------------
 
 init(Parent, Transport, RawSocket, Options) ->
+    case emqx_node_readiness:is_ready() of
+        true ->
+            do_init(Parent, Transport, RawSocket, Options);
+        false ->
+            %% Refuse connections until node boot completes,
+            %% i.e. before plugin hooks are registered.
+            ?SLOG_THROTTLE(warning, #{msg => connection_rejected_due_to_node_not_ready}),
+            ok = Transport:fast_close(RawSocket),
+            erlang:exit({shutdown, node_not_ready})
+    end.
+
+do_init(Parent, Transport, RawSocket, Options) ->
     case Transport:wait(RawSocket) of
         {ok, Socket} ->
             ?tp(connection_started, #{

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -312,9 +312,19 @@ init(Parent, Transport, RawSocket, Options) ->
         true ->
             do_init(Parent, Transport, RawSocket, Options);
         false ->
-            %% Refuse connections until node boot completes,
-            %% i.e. before plugin hooks are registered.
-            ?SLOG_THROTTLE(warning, #{msg => connection_rejected_due_to_node_not_ready}),
+            %% Refuse to serve before node boot completes: authn/authz
+            %% hooks (e.g. from plugins) may not be installed yet.
+            %% The exit reason feeds the listener's shutdown counter.
+            Peername =
+                case Transport:peername(RawSocket) of
+                    {ok, Peer} -> esockd:format(Peer);
+                    {error, _} -> unknown
+                end,
+            ?SLOG(info, #{
+                msg => connection_refused_before_boot_complete,
+                transport => Transport,
+                peername => Peername
+            }),
             ok = Transport:fast_close(RawSocket),
             erlang:exit({shutdown, node_not_ready})
     end.

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -315,10 +315,14 @@ init(Parent, Transport, RawSocket, Options) ->
             %% Refuse to serve before node boot completes: authn/authz
             %% hooks (e.g. from plugins) may not be installed yet.
             %% The exit reason feeds the listener's shutdown counter.
+            %% The peername lookup must not crash on the pre-wait QUIC
+            %% socket shape, hence the catch-all.
             Peername =
-                case Transport:peername(RawSocket) of
+                try Transport:peername(RawSocket) of
                     {ok, Peer} -> esockd:format(Peer);
-                    {error, _} -> unknown
+                    _ -> unknown
+                catch
+                    _:_ -> unknown
                 end,
             ?SLOG(info, #{
                 msg => connection_refused_before_boot_complete,

--- a/apps/emqx/src/emqx_node_readiness.erl
+++ b/apps/emqx/src/emqx_node_readiness.erl
@@ -1,0 +1,37 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_node_readiness).
+
+-moduledoc """
+Node readiness flag.
+
+MQTT connection processes check this flag at init and refuse the
+connection while the node is not ready.
+
+The flag defaults to `true`. Only the managed boot sequence
+(`emqx_machine_boot:ensure_apps_started/0`) clears it, then sets it
+back once all applications and plugins are started. Contexts that do
+not boot through `emqx_machine` (for example test suites) never clear
+the flag, so they are not affected.
+""".
+
+-export([is_ready/0, mark_ready/0, mark_not_ready/0]).
+
+-define(KEY, {?MODULE, ready}).
+
+-doc "Return `true` if the node is ready to serve MQTT connections.".
+-spec is_ready() -> boolean().
+is_ready() ->
+    persistent_term:get(?KEY, true).
+
+-doc "Mark the node ready to serve MQTT connections.".
+-spec mark_ready() -> ok.
+mark_ready() ->
+    persistent_term:put(?KEY, true).
+
+-doc "Mark the node not ready. New MQTT connections are refused.".
+-spec mark_not_ready() -> ok.
+mark_not_ready() ->
+    persistent_term:put(?KEY, false).

--- a/apps/emqx/src/emqx_node_readiness.erl
+++ b/apps/emqx/src/emqx_node_readiness.erl
@@ -7,31 +7,34 @@
 -moduledoc """
 Node readiness flag.
 
-MQTT connection processes check this flag at init and refuse the
-connection while the node is not ready.
+Connection processes (MQTT and gateway) check this flag at init and
+refuse to serve until the node has finished booting, so no client can
+connect before authentication, authorization and plugin hooks are
+installed.  The `GET /status` REST API and cluster join checks read it
+too.
 
-The flag defaults to `true`. Only the managed boot sequence
-(`emqx_machine_boot:ensure_apps_started/0`) clears it, then sets it
-back once all applications and plugins are started. Contexts that do
-not boot through `emqx_machine` (for example test suites) never clear
-the flag, so they are not affected.
+The flag defaults to `true`: only the managed boot sequence
+(`emqx_machine_boot:ensure_apps_started/0`) clears it and sets it back
+once all applications (including plugins) are started.  Contexts that
+do not boot through `emqx_machine` (test suites) are therefore always
+ready.
 """.
 
 -export([is_ready/0, mark_ready/0, mark_not_ready/0]).
 
 -define(KEY, {?MODULE, ready}).
 
--doc "Return `true` if the node is ready to serve MQTT connections.".
+-doc "Return `true` once this node has finished booting.".
 -spec is_ready() -> boolean().
 is_ready() ->
     persistent_term:get(?KEY, true).
 
--doc "Mark the node ready to serve MQTT connections.".
+-doc "Mark the node as fully booted.".
 -spec mark_ready() -> ok.
 mark_ready() ->
     persistent_term:put(?KEY, true).
 
--doc "Mark the node not ready. New MQTT connections are refused.".
+-doc "Mark the node as booting. Connection processes refuse to serve.".
 -spec mark_not_ready() -> ok.
 mark_not_ready() ->
     persistent_term:put(?KEY, false).

--- a/apps/emqx/src/emqx_quic_connection.erl
+++ b/apps/emqx/src/emqx_quic_connection.erl
@@ -96,10 +96,26 @@ closed(_Conn, #{is_peer_acked := _} = Prop, S) ->
 new_conn(
     Conn,
     #{version := _Vsn} = ConnInfo,
-    #{zone := Zone, conn := undefined, ctrl_pid := undefined} = S
+    #{zone := _Zone, conn := undefined, ctrl_pid := undefined} = S
 ) ->
     process_flag(trap_exit, true),
     ?SLOG(debug, ConnInfo#{conn => Conn}),
+    case emqx_node_readiness:is_ready() of
+        true ->
+            do_new_conn(Conn, ConnInfo, S);
+        false ->
+            %% Refuse to serve before node boot completes: authn/authz
+            %% hooks (e.g. from plugins) may not be installed yet.
+            ?SLOG(warning, #{msg => quic_connection_refused_before_boot_complete}),
+            _ = quicer:async_shutdown_connection(
+                Conn,
+                ?QUIC_CONNECTION_SHUTDOWN_FLAG_NONE,
+                ?MQTT_QUIC_CONN_ERROR_NOT_READY
+            ),
+            {stop, normal, S}
+    end.
+
+do_new_conn(Conn, ConnInfo, #{zone := Zone} = S) ->
     case emqx_olp:is_overloaded() andalso is_zone_olp_enabled(Zone) of
         false ->
             %% Start control stream process

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -164,9 +164,9 @@ init(Req, Opts) ->
         true ->
             do_init(Req, Opts);
         false ->
-            %% Refuse connections until node boot completes,
-            %% i.e. before plugin hooks are registered.
-            ?SLOG_THROTTLE(warning, #{msg => connection_rejected_due_to_node_not_ready}),
+            %% Refuse to serve before node boot completes: authn/authz
+            %% hooks (e.g. from plugins) may not be installed yet.
+            ?SLOG(info, #{msg => ws_connection_refused_before_boot_complete}),
             {ok, cowboy_req:reply(503, Req), #{}}
     end.
 

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -159,7 +159,18 @@ call(WsPid, Req, Timeout) when is_pid(WsPid) ->
 %% WebSocket callbacks
 %%--------------------------------------------------------------------
 
-init(Req, #{listener := {Type, Listener}} = Opts) ->
+init(Req, Opts) ->
+    case emqx_node_readiness:is_ready() of
+        true ->
+            do_init(Req, Opts);
+        false ->
+            %% Refuse connections until node boot completes,
+            %% i.e. before plugin hooks are registered.
+            ?SLOG_THROTTLE(warning, #{msg => connection_rejected_due_to_node_not_ready}),
+            {ok, cowboy_req:reply(503, Req), #{}}
+    end.
+
+do_init(Req, #{listener := {Type, Listener}} = Opts) ->
     WsOpts = get_ws_opts(Type, Listener),
     case check_request_origin(Req, WsOpts) of
         ok ->

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -59,6 +59,17 @@ t_gate_ws_connection(_Config) ->
     ok = emqx_node_readiness:mark_ready(),
     ?assertEqual(ok, try_connect(fun emqtt:ws_connect/1, #{port => ?WS_PORT})).
 
+-doc "A cluster join is refused on both the joining and the target node while not ready.".
+t_gate_cluster_join(_Config) ->
+    ok = emqx_node_readiness:mark_not_ready(),
+    ?assertMatch({error, _}, emqx_cluster:can_i_join(node())),
+    ?assertMatch(
+        {error, "This node has not fully booted" ++ _},
+        emqx_cluster:join('nosuchnode@127.0.0.1')
+    ),
+    ok = emqx_node_readiness:mark_ready(),
+    ?assertEqual(ok, emqx_cluster:can_i_join(node())).
+
 try_connect(ConnFun, Opts0) ->
     Opts = maps:merge(#{host => "127.0.0.1", connect_timeout => 5}, Opts0),
     {ok, Client} = emqtt:start_link(Opts),

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(TCP_PORT, 20831).
 -define(WS_PORT, 20832).
@@ -45,10 +46,24 @@ t_readiness_flag(_Config) ->
     ok = emqx_node_readiness:mark_ready(),
     ?assert(emqx_node_readiness:is_ready()).
 
--doc "A TCP MQTT connection is refused while the node is not ready, accepted once ready.".
+-doc """
+A TCP MQTT connection is refused while the node is not ready, accepted once
+ready.  The refusal is recorded in the listener's shutdown counter.
+""".
 t_gate_tcp_connection(_Config) ->
     ok = emqx_node_readiness:mark_not_ready(),
     ?assertMatch({error, _}, try_connect(fun emqtt:connect/1, #{port => ?TCP_PORT})),
+    Bind = emqx_config:get([listeners, tcp, default, bind]),
+    ?retry(
+        100,
+        10,
+        ?assertMatch(
+            {node_not_ready, _},
+            lists:keyfind(
+                node_not_ready, 1, emqx_listeners:shutdown_count(<<"tcp:default">>, Bind)
+            )
+        )
+    ),
     ok = emqx_node_readiness:mark_ready(),
     ?assertEqual(ok, try_connect(fun emqtt:connect/1, #{port => ?TCP_PORT})).
 

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -1,0 +1,72 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_node_readiness_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(TCP_PORT, 20831).
+-define(WS_PORT, 20832).
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    ListenerConf = io_lib:format(
+        "listeners.tcp.default.bind = ~b\n"
+        "listeners.ws.default.bind = ~b",
+        [?TCP_PORT, ?WS_PORT]
+    ),
+    Apps = emqx_cth_suite:start(
+        [{emqx, ListenerConf}],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(apps, Config)).
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    ok = emqx_node_readiness:mark_ready().
+
+-doc "The readiness flag defaults to true and toggles with mark_not_ready/mark_ready.".
+t_readiness_flag(_Config) ->
+    _ = persistent_term:erase({emqx_node_readiness, ready}),
+    ?assert(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:mark_not_ready(),
+    ?assertNot(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:mark_ready(),
+    ?assert(emqx_node_readiness:is_ready()).
+
+-doc "A TCP MQTT connection is refused while the node is not ready, accepted once ready.".
+t_gate_tcp_connection(_Config) ->
+    ok = emqx_node_readiness:mark_not_ready(),
+    ?assertMatch({error, _}, try_connect(fun emqtt:connect/1, #{port => ?TCP_PORT})),
+    ok = emqx_node_readiness:mark_ready(),
+    ?assertEqual(ok, try_connect(fun emqtt:connect/1, #{port => ?TCP_PORT})).
+
+-doc "A WebSocket MQTT connection is refused while the node is not ready, accepted once ready.".
+t_gate_ws_connection(_Config) ->
+    ok = emqx_node_readiness:mark_not_ready(),
+    ?assertMatch({error, _}, try_connect(fun emqtt:ws_connect/1, #{port => ?WS_PORT})),
+    ok = emqx_node_readiness:mark_ready(),
+    ?assertEqual(ok, try_connect(fun emqtt:ws_connect/1, #{port => ?WS_PORT})).
+
+try_connect(ConnFun, Opts0) ->
+    Opts = maps:merge(#{host => "127.0.0.1", connect_timeout => 5}, Opts0),
+    {ok, Client} = emqtt:start_link(Opts),
+    true = erlang:unlink(Client),
+    case ConnFun(Client) of
+        {ok, _} ->
+            ok = emqtt:disconnect(Client);
+        {error, Reason} ->
+            catch emqtt:stop(Client),
+            {error, Reason}
+    end.

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -13,17 +13,37 @@
 
 -define(TCP_PORT, 20831).
 -define(WS_PORT, 20832).
+-define(QUIC_PORT, 20833).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    _ = emqx_common_test_helpers:gen_ca(PrivDir, "ca"),
+    _ = emqx_common_test_helpers:gen_host_cert("server", "ca", PrivDir, #{}),
     ListenerConf = io_lib:format(
         "listeners.tcp.default.bind = ~b\n"
-        "listeners.ws.default.bind = ~b",
-        [?TCP_PORT, ?WS_PORT]
+        "listeners.ws.default.bind = ~b\n"
+        "listeners.quic.default {\n"
+        "  enable = true\n"
+        "  bind = ~b\n"
+        "  ssl_options {\n"
+        "    cacertfile = \"~ts\"\n"
+        "    certfile = \"~ts\"\n"
+        "    keyfile = \"~ts\"\n"
+        "  }\n"
+        "}",
+        [
+            ?TCP_PORT,
+            ?WS_PORT,
+            ?QUIC_PORT,
+            filename:join(PrivDir, "ca.pem"),
+            filename:join(PrivDir, "server.pem"),
+            filename:join(PrivDir, "server.key")
+        ]
     ),
     Apps = emqx_cth_suite:start(
-        [{emqx, ListenerConf}],
+        [quicer, {emqx, ListenerConf}],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     [{apps, Apps} | Config].
@@ -73,6 +93,18 @@ t_gate_ws_connection(_Config) ->
     ?assertMatch({error, _}, try_connect(fun emqtt:ws_connect/1, #{port => ?WS_PORT})),
     ok = emqx_node_readiness:mark_ready(),
     ?assertEqual(ok, try_connect(fun emqtt:ws_connect/1, #{port => ?WS_PORT})).
+
+-doc "A QUIC MQTT connection is refused while the node is not ready, accepted once ready.".
+t_gate_quic_connection(_Config) ->
+    QuicOpts = #{
+        port => ?QUIC_PORT,
+        ssl => true,
+        ssl_opts => [{verify, verify_none}]
+    },
+    ok = emqx_node_readiness:mark_not_ready(),
+    ?assertMatch({error, _}, try_connect(fun emqtt:quic_connect/1, QuicOpts)),
+    ok = emqx_node_readiness:mark_ready(),
+    ?assertEqual(ok, try_connect(fun emqtt:quic_connect/1, QuicOpts)).
 
 -doc "A cluster join is refused on both the joining and the target node while not ready.".
 t_gate_cluster_join(_Config) ->

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -84,7 +84,6 @@
     connection_rejected_due_to_license_limit_reached,
     connection_rejected_due_to_trial_license_uptime_limit,
     connection_rejected_due_to_license_expired,
-    connection_rejected_due_to_node_not_ready,
     listener_accept_throttled_due_to_quota_exceeded,
     listener_accept_refused_reached_max_connections,
     failed_to_consume_from_limiter,

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -84,6 +84,7 @@
     connection_rejected_due_to_license_limit_reached,
     connection_rejected_due_to_trial_license_uptime_limit,
     connection_rejected_due_to_license_expired,
+    connection_rejected_due_to_node_not_ready,
     listener_accept_throttled_due_to_quota_exceeded,
     listener_accept_refused_reached_max_connections,
     failed_to_consume_from_limiter,

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -271,12 +271,26 @@ init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod) ->
         true ->
             do_init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod);
         false ->
-            %% Refuse connections until node boot completes,
-            %% i.e. before plugin hooks are registered.
-            ?SLOG_THROTTLE(warning, #{msg => connection_rejected_due_to_node_not_ready}),
+            %% Refuse to serve before node boot completes: authn/authz
+            %% hooks (e.g. from plugins) may not be installed yet.
+            ?SLOG(warning, #{
+                msg => connection_refused_before_boot_complete,
+                peername => gate_peername(WrappedSock, Peername0),
+                channel_module => ChannMod
+            }),
             ok = esockd_close(WrappedSock),
             erlang:exit({shutdown, node_not_ready})
     end.
+
+gate_peername({esockd_transport, Sock}, undefined) ->
+    case esockd_transport:peername(Sock) of
+        {ok, Peername} -> esockd:format(Peername);
+        {error, _} -> unknown
+    end;
+gate_peername(_WrappedSock, Peername) when Peername =/= undefined ->
+    esockd:format(Peername);
+gate_peername(_WrappedSock, undefined) ->
+    unknown.
 
 do_init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod) ->
     case esockd_wait(WrappedSock) of

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -267,6 +267,18 @@ is_datadram_socket({esockd_udp_proxy, _ProxyId, Sock}) -> erlang:is_port(Sock).
 %%--------------------------------------------------------------------
 
 init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod) ->
+    case emqx_node_readiness:is_ready() of
+        true ->
+            do_init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod);
+        false ->
+            %% Refuse connections until node boot completes,
+            %% i.e. before plugin hooks are registered.
+            ?SLOG_THROTTLE(warning, #{msg => connection_rejected_due_to_node_not_ready}),
+            ok = esockd_close(WrappedSock),
+            erlang:exit({shutdown, node_not_ready})
+    end.
+
+do_init(Parent, WrappedSock, Peername0, Options, FrameMod, ChannMod) ->
     case esockd_wait(WrappedSock) of
         {ok, NWrappedSock} ->
             Peername = esockd_peername(NWrappedSock, Peername0),

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -101,6 +101,9 @@ stop_one_app(App) ->
 
 ensure_apps_started() ->
     ?SLOG(notice, #{msg => "(re)starting_emqx_apps"}),
+    %% Refuse MQTT connections until all apps and plugins are started,
+    %% so no client connects before plugin hooks are registered.
+    ok = emqx_node_readiness:mark_not_ready(),
     lists:foreach(fun start_one_app/1, sorted_reboot_apps()),
     %% Start plugin applications only after all EMQX applications are up,
     %% so a plugin may depend on any of them.  Plugin apps are not part of
@@ -109,6 +112,7 @@ ensure_apps_started() ->
     %% Note: this function is also the ekka cluster join/leave callback,
     %% so plugins restart after a join as well (see `start_autocluster/0').
     ok = emqx_plugins:ensure_started(),
+    ok = emqx_node_readiness:mark_ready(),
     ?tp(emqx_machine_boot_apps_started, #{}).
 
 start_one_app(App) ->

--- a/apps/emqx_machine/test/emqx_machine_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_SUITE.erl
@@ -111,6 +111,8 @@ t_shutdown_reboot(Config) ->
             ok = emqx_app:set_config_loader(emqx_cth_suite),
             emqx_machine_boot:ensure_apps_started(),
             true = emqx:is_running(node()),
+            %% managed boot marks the node ready once apps and plugins are started
+            true = emqx_node_readiness:is_ready(),
             ok = emqx_machine_boot:stop_apps(),
             false = emqx:is_running(node()),
             ok

--- a/apps/emqx_management/src/emqx_mgmt_api_status.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_status.erl
@@ -140,8 +140,16 @@ broker_status() ->
 
 application_status() ->
     case lists:keysearch(emqx, 1, application:which_applications()) of
-        false -> not_running;
-        {value, _Val} -> running
+        false ->
+            not_running;
+        {value, _Val} ->
+            %% Report not_running (HTTP 503) until node boot completes,
+            %% so load balancers stop routing MQTT to a node that
+            %% refuses connections.
+            case emqx_node_readiness:is_ready() of
+                true -> running;
+                false -> not_running
+            end
     end.
 
 cluster() ->

--- a/changes/ee/fix-18357.en.md
+++ b/changes/ee/fix-18357.en.md
@@ -1,3 +1,5 @@
 MQTT connections are now refused until node startup completes, so listeners no longer serve traffic before authentication, authorization, and plugin hooks are active.
 
 The `GET /status` API now returns HTTP 503 until startup completes, so load balancers can route new connections to other nodes in the cluster.
+
+A cluster join request toward a node that has not finished starting is now refused with a message that asks to retry later.

--- a/changes/ee/fix-18357.en.md
+++ b/changes/ee/fix-18357.en.md
@@ -1,0 +1,3 @@
+MQTT connections are now refused until node startup completes, so listeners no longer serve traffic before authentication, authorization, and plugin hooks are active.
+
+The `GET /status` API now returns HTTP 503 until startup completes, so load balancers can route new connections to other nodes in the cluster.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0

Introduced in:
pre-5.8

## Summary

Fixes emqx/emqx-dev-team-tasks#341 (part 2 of the closed emqx/emqx-dev-team-tasks#338).

MQTT listeners open before the managed boot sequence finishes. A client that connects in this window is served before plugin hooks (`client.authenticate`, `client.authorize` and others) are registered, so it bypasses a plugin's security logic. The part 1 fix (#18337) moved plugin start to the tail of `ensure_apps_started/0`, which widened this window on v6.

Changes:

* New module `emqx_node_readiness` in the `emqx` app: a `persistent_term` flag with three functions, `is_ready/0`, `mark_ready/0`, `mark_not_ready/0`. The flag defaults to ready. Only `emqx_machine_boot:ensure_apps_started/0` clears it (before starting any app) and sets it (after `emqx_plugins:ensure_started/0`). `ensure_apps_started/0` is also the ekka join/leave callback, so a cluster rejoin re-gates the window. If boot never completes, the node keeps refusing connections.
* Connection process inits check the flag and refuse the connection while the node is not ready:
  * `emqx_connection:init/4` closes the raw socket before the transport handshake and exits with `{shutdown, node_not_ready}`.
  * `emqx_ws_connection:init/2` replies HTTP 503 before the WebSocket upgrade.
  * `emqx_quic_connection:new_conn/3` shuts the incoming QUIC connection down with a dedicated `MQTT_QUIC_CONN_ERROR_NOT_READY` application error code, mirroring the overload-protection branch.
  * `emqx_gateway_conn:init/6` closes the socket and exits (TCP-based gateways). UDP/connectionless gateway paths (CoAP, MQTT-SN) have no per-connection process and are not covered by this gate.
* MQTT TCP and WS refusals log at `info` level; refusal volume is observable through the per-listener shutdown counter, fed by the `{shutdown, node_not_ready}` exit reason. Gateway refusals log at `warning` (with peername and channel module) since gateway listeners have no shutdown-counter observability. No new throttle-log message id.
* `GET /status` returns HTTP 503 while the node is not ready, so load balancers stop routing new connections to a starting node.
* Cluster joins are gated on both sides through a new `emqx_cluster:is_boot_complete/0` predicate that combines `boot_in_progress` (first managed boot, up to ekka callback registration) with `emqx_node_readiness` (also covers the `ensure_apps_started/0` re-run a rejoin triggers):
  * `join/1` on a core node refuses while either flag indicates boot in progress. Replicant joins stay unrestricted (a replicant bootstraps by joining mid-boot).
  * `can_i_join/1`, evaluated on the join target node, refuses join requests while the target's own boot is not complete. Autocluster joins do not go through `can_i_join`, so simultaneous cold-start cluster formation is not affected.

Test suites are unaffected because they start apps through `emqx_cth_suite` / `emqx_cth_cluster`, which never clear the flag. Production boots through `emqx_machine`, so the window is always gated.

The existing `emqx_access_control:default_authn_result() -> ignore` behavior is kept as defense in depth.

A dev-58 port with the same design follows in a separate PR.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
