### PR TITLE
ci(kerberos): make CI keytabs readable regardless of chown timing

### DIFF
--- a/.ci/docker-compose-file/kerberos/run.sh
+++ b/.ci/docker-compose-file/kerberos/run.sh
@@ -36,6 +36,13 @@ kadmin.local -w password -q "ktadd  -k /var/lib/secret/rig.keytab -norandkey rig
 kadmin.local -w password -q "ktadd  -k /var/lib/secret/erlang.keytab -norandkey mqtt/erlang.emqx.net@KDC.EMQX.NET "
 kadmin.local -w password -q "ktadd  -k /var/lib/secret/krb_authn_cli.keytab -norandkey krb_authn_cli@KDC.EMQX.NET "
 
+# Test containers read these keytabs as non-root users.
+# ktadd creates the keytabs with mode 0600 and owner root.
+# The chown below runs only when DOCKER_USER is set, and a consumer
+# can open a keytab before the chown runs or with a different uid.
+# chmod keeps the keytabs readable for every consumer.
+chmod a+r /var/lib/secret/*.keytab
+
 echo "===== Dump logs"
 
 for fn in /var/log/kerberos/* ; do


### PR DESCRIPTION
## Summary

dev-60 port of #18291 (dev-58). CI-only change.

`emqx_authn_kerberos_SUITE:init_per_suite` can fail with `krb5_get_init_creds_keytab` errno 13 (Permission denied), which auto-skips all cases. `ktadd` creates the keytabs with mode 0600 and owner root. On dev-60 the KDC bootstrap chowns the keytabs to `DOCKER_USER` only at the end of the script. A test container can open a keytab before the chown runs, or with a uid that differs from `DOCKER_USER`, and gets EACCES.

Fix: `chmod a+r` the keytabs right after the last `ktadd`. The keytabs are throwaway CI-only secrets. This closes the window for every consumer, including the `emqx_bridge_kafka` kerberos groups.