### PR TITLE
ci: build plugins via the make step, load beams in the cluster-rpc check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,8 @@ ct: $(REBAR) merge-config render-test-env
 ## only check bpapi for enterprise profile because it's a super-set.
 .PHONY: static_checks
 static_checks: $(ELIXIR_COMMON_DEPS)
+	@# the cluster-rpc check reads plugin beams from the shared build tree
+	@env PROFILE=$(PROFILE:%-test=%) $(SCRIPTS)/build-plugins.sh --compile-only
 	@env BPAPI_BUILD_PROFILE=$(PROFILE:%-test=%) \
 	    $(MIX) do \
 	    emqx.xref + dialyzer --mode classic + \

--- a/apps/emqx_bpapi/test/emqx_bpapi_static_checks.erl
+++ b/apps/emqx_bpapi/test/emqx_bpapi_static_checks.erl
@@ -344,13 +344,25 @@ prepare(#{reldir := RelDir, plt := PLT}) ->
 
 %% erlfmt-ignore
 find_remote_calls(_Opts) ->
+    IgnoredApps = ?IGNORED_APPS ++ plugin_apps(),
     Query =
-        "XC | (A - ["?IGNORED_APPS"]:App - ["?IGNORED_MODULES"]:Mod - ["?EXEMPTIONS"])
+        "XC | (A - [" ++ IgnoredApps ++ "]:App - ["?IGNORED_MODULES"]:Mod - ["?EXEMPTIONS"])
            || ((["?RPC_MODULES"] : Mod + ["?RPC_FUNCTIONS"]) - ["?IGNORED_RPC_CALLS"])",
     {ok, Calls} = xref:q(?XREF, Query),
     logger:info("Calls to RPC modules ~p", [Calls]),
     {Callers, _Callees} = lists:unzip(Calls),
     Callers.
+
+%% In-tree plugins own their static-check policy and may be present in
+%% the analyzed build tree (the static_checks make target compiles them
+%% for the cluster_rpc target check, which covers them separately).
+%% Exclude them from the BPAPI analysis.
+plugin_apps() ->
+    lists:append([
+        ", " ++ filename:basename(Dir)
+     || Dir <- filelib:wildcard("plugins/*"),
+        filelib:is_dir(Dir)
+    ]).
 
 -spec warn_nonbpapi_rpcs([mfa()]) -> ok.
 warn_nonbpapi_rpcs([]) ->

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.check_cluster_rpc.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.check_cluster_rpc.ex
@@ -40,11 +40,12 @@ defmodule Mix.Tasks.Emqx.CheckClusterRpc do
   ## Scope
 
   Umbrella apps and in-tree plugins are checked. Plugins are separate mix
-  projects outside the umbrella build, so this task builds each one with its
-  own build tool (as `scripts/build-plugins.sh --compile-only` does) and adds
-  the resulting beams to the xref graph. A plugin caller must follow the same
-  target rules as an umbrella caller, but plugins cannot host BPAPI proto
-  modules, so an audited plugin caller is exempted by module name via
+  projects outside the umbrella build; their beams are loaded from the shared
+  build tree (plugin mix.exs sets `build_path: "../../_build"`). Run
+  `scripts/build-plugins.sh --compile-only` (as the static_checks make target
+  does) or `make plugins` to produce them. A plugin caller must follow the
+  same target rules as an umbrella caller, but plugins cannot host BPAPI
+  proto modules, so an audited plugin caller is exempted by module name via
   `@exempted_callers` instead. A plugin caller must additionally accept that
   a live node where the plugin app is not running fails the apply and retries
   until the plugin starts — the boot path is unaffected because catch-up
@@ -125,7 +126,7 @@ defmodule Mix.Tasks.Emqx.CheckClusterRpc do
       {:ok, _} = :xref.add_application(@xref, to_charlist(app.opts[:build]))
     end)
 
-    for ebin_dir <- compile_plugins() do
+    for ebin_dir <- plugin_ebin_dirs() do
       # The beams must be loadable to read a plugin proto module's bpapi_meta/0:
       true = Code.append_path(ebin_dir)
       {:ok, _} = :xref.add_directory(@xref, to_charlist(ebin_dir))
@@ -146,26 +147,22 @@ defmodule Mix.Tasks.Emqx.CheckClusterRpc do
     end
   end
 
-  # In-tree plugins are not part of the umbrella build: build each one with
-  # its own build tool (same invocation as scripts/build-plugins.sh
-  # --compile-only) so its compile options are honored and rebuilds are
-  # incremental. Plugin mix.exs sets build_path: "../../_build", so the beams
-  # land in the shared build tree.
-  defp compile_plugins() do
-    mix = Path.absname("mix")
-
+  # In-tree plugins are not part of the umbrella build: load their beams from
+  # the shared build tree, where the plugin build (scripts/build-plugins.sh
+  # --compile-only, run by the static_checks make target) puts them.
+  defp plugin_ebin_dirs() do
     for plugin_dir <- Path.wildcard("plugins/*"),
         plugin_app?(plugin_dir) do
-      case System.cmd(mix, ~w(do deps.get + compile),
-             cd: plugin_dir,
-             env: [{"MIX_ENV", to_string(Mix.env())}],
-             into: IO.stream(:stdio, :line)
-           ) do
-        {_, 0} -> :ok
-        {_, status} -> Mix.raise("compiling plugin #{plugin_dir} failed with status #{status}")
+      ebin_dir = Path.join([Mix.Project.build_path(), "lib", Path.basename(plugin_dir), "ebin"])
+
+      if Path.wildcard(Path.join(ebin_dir, "*.beam")) == [] do
+        Mix.raise(
+          "no beams for plugin #{plugin_dir} in #{ebin_dir}; " <>
+            "run 'scripts/build-plugins.sh --compile-only' first"
+        )
       end
 
-      Path.join([Mix.Project.build_path(), "lib", Path.basename(plugin_dir), "ebin"])
+      ebin_dir
     end
   end
 


### PR DESCRIPTION
## Summary

Follow-up to #18342 (merged).

Run `scripts/build-plugins.sh --compile-only` from the `static_checks` make target and make `emqx.check_cluster_rpc` load the plugin beams from the shared build tree (plugin `mix.exs` sets `build_path: "../../_build"`), instead of building plugins inside the task. The task now only reads build results; a missing plugin build fails with an instruction to run the build step.

Verified: clean tree passes; a plugin module calling `emqx_cluster_rpc:multicall` fails the task with exit 1 after the build step picks it up; clean again after removal.