### PR TITLE
ci(cluster_rpc check): support audited direct plugin callers

### DIFF
--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.check_cluster_rpc.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.check_cluster_rpc.ex
@@ -42,10 +42,14 @@ defmodule Mix.Tasks.Emqx.CheckClusterRpc do
   Umbrella apps and in-tree plugins are checked. Plugins are separate mix
   projects outside the umbrella build, so this task builds each one with its
   own build tool (as `scripts/build-plugins.sh --compile-only` does) and adds
-  the resulting beams to the xref graph. Plugins must not use
-  `emqx_cluster_rpc` at all: their MFAs are not replayed on a rebooted node,
-  and their code may not even be loaded when catch-up runs — any plugin caller
-  is reported as a violation.
+  the resulting beams to the xref graph. A plugin caller must follow the same
+  target rules as an umbrella caller, but plugins cannot host BPAPI proto
+  modules, so an audited plugin caller is exempted by module name via
+  `@exempted_callers` instead. A plugin caller must additionally accept that
+  a live node where the plugin app is not running fails the apply and retries
+  until the plugin starts — the boot path is unaffected because catch-up
+  fast-forwards past missed entries and plugin boot rebuilds runtime state
+  from replicated tables.
   """
 
   @requirements ["compile", "loadpaths"]
@@ -83,6 +87,12 @@ defmodule Mix.Tasks.Emqx.CheckClusterRpc do
     {:emqx_rule_engine, :reset_metrics_for_rule}
   ]
 
+  # Audited direct callers. Plugins cannot host BPAPI proto modules, so their
+  # multicall targets cannot be resolved via bpapi_meta/0; the whole caller
+  # module is exempted instead. Each entry needs a reason.
+  # (No entries on this branch; see the emqx_unsgov exemption on dev-61+.)
+  @exempted_callers []
+
   @impl true
   def run(args) do
     if args != [] do
@@ -93,10 +103,12 @@ defmodule Mix.Tasks.Emqx.CheckClusterRpc do
     :xref.stop(@xref)
     {violations, targets} = Enum.reduce(callers, {[], []}, &collect/2)
     stale = @exemptions -- targets
+    stale_callers = @exempted_callers -- Enum.map(callers, &elem(&1, 0))
     Enum.each(Enum.reverse(violations), &report_violation/1)
     Enum.each(stale, &report_stale/1)
+    Enum.each(stale_callers, &report_stale_caller/1)
 
-    if violations == [] and stale == [] do
+    if violations == [] and stale == [] and stale_callers == [] do
       Mix.shell().info("OK")
     else
       Mix.raise(
@@ -187,7 +199,11 @@ defmodule Mix.Tasks.Emqx.CheckClusterRpc do
         end
 
       _ ->
-        {[{:not_a_proto_module, caller} | violations], targets}
+        if Enum.member?(@exempted_callers, m) do
+          {violations, targets}
+        else
+          {[{:not_a_proto_module, caller} | violations], targets}
+        end
     end
   end
 
@@ -223,6 +239,13 @@ defmodule Mix.Tasks.Emqx.CheckClusterRpc do
 
   defp report_stale({m, f}) do
     Mix.shell().error("stale exemption #{m}:#{f} has no call site; remove it from this task")
+  end
+
+  defp report_stale_caller(m) do
+    Mix.shell().error(
+      "stale exempted caller #{m} no longer calls emqx_cluster_rpc:multicall; " <>
+        "remove it from this task"
+    )
   end
 
   defp ensure_xref() do


### PR DESCRIPTION
Backport of the check-task change from the r60→r61 sync PR #18361.

Plugins cannot host BPAPI proto modules, so a plugin module calling `emqx_cluster_rpc:multicall` cannot expose its targets via `bpapi_meta/0`. This adds a module-level `@exempted_callers` list (with stale detection) and updates the moduledoc rule for plugin callers. The list is empty on dev-60; dev-61+ carries an audited exemption for `emqx_unsgov_store` (mria-first durable state, MFAs rebuild runtime state only, cluster_rpc chosen over erpc for replication ordering on replicants).