### PR TITLE
fix(flapping): isolate counters and garbage collection by zone

### DIFF
--- a/apps/emqx/src/emqx_flapping.erl
+++ b/apps/emqx/src/emqx_flapping.erl
@@ -17,7 +17,7 @@
 -export([detect/1]).
 
 -ifdef(TEST).
--export([get_policy/1, dimension_defaults/0]).
+-export([get_policy/1, dimension_defaults/0, gc_interval/1]).
 -endif.
 
 %% gen_server callbacks
@@ -34,9 +34,9 @@
 -define(FLAPPING_TAB, ?MODULE).
 
 -type key() ::
-    {clientid, emqx_types:clientid()}
-    | {username, emqx_types:username()}
-    | {peerhost, emqx_types:peerhost()}.
+    {emqx_types:zone(), clientid, emqx_types:clientid()}
+    | {emqx_types:zone(), username, emqx_types:username()}
+    | {emqx_types:zone(), peerhost, emqx_types:peerhost()}.
 
 %% Must match the field defaults of the `flapping_detect_dimension`
 %% struct in `emqx_schema`: zone overrides may hold partial dimension
@@ -80,13 +80,13 @@ detect(#{clientid := ClientId, peerhost := PeerHost, zone := Zone} = ClientInfo)
     Policy = get_policy(Zone),
     Username = maps:get(username, ClientInfo, undefined),
     Detected = [
-        detect({clientid, ClientId}, PeerHost, dimension_policy(by_clientid, Policy)),
-        detect({username, Username}, PeerHost, dimension_policy(by_username, Policy)),
-        detect({peerhost, PeerHost}, PeerHost, dimension_policy(by_peerhost, Policy))
+        detect({Zone, clientid, ClientId}, PeerHost, dimension_policy(by_clientid, Policy)),
+        detect({Zone, username, Username}, PeerHost, dimension_policy(by_username, Policy)),
+        detect({Zone, peerhost, PeerHost}, PeerHost, dimension_policy(by_peerhost, Policy))
     ],
     lists:member(true, Detected).
 
-detect({username, undefined}, _PeerHost, _Policy) ->
+detect({_Zone, username, undefined}, _PeerHost, _Policy) ->
     false;
 detect(_Key, _PeerHost, none) ->
     false;
@@ -140,27 +140,19 @@ dimension_defaults() -> ?DIMENSION_DEFAULTS.
 
 all_dimensions(Policy) ->
     [
-        dimension_policy(by_clientid, Policy),
-        dimension_policy(by_username, Policy),
-        dimension_policy(by_peerhost, Policy)
+        {clientid, dimension_policy(by_clientid, Policy)},
+        {username, dimension_policy(by_username, Policy)},
+        {peerhost, dimension_policy(by_peerhost, Policy)}
     ].
 
 enabled_window_times(Policy) ->
     lists:filtermap(
         fun
-            (#{window_time := WindowTime}) -> {true, WindowTime};
-            (none) -> false
+            ({_Dimension, #{window_time := WindowTime}}) -> {true, WindowTime};
+            ({_Dimension, none}) -> false
         end,
         all_dimensions(Policy)
     ).
-
-%% Disabled dimensions produce no table entries, so only the enabled
-%% ones are considered when deciding which entries are stale.
-max_window_time(Policy) ->
-    case enabled_window_times(Policy) of
-        [] -> maps:get(window_time, ?DIMENSION_DEFAULTS);
-        WindowTimes -> lists:max(WindowTimes)
-    end.
 
 now_diff(TS) -> erlang:system_time(millisecond) - TS.
 
@@ -186,7 +178,7 @@ handle_call(Req, _From, State) ->
 handle_cast(
     {detected,
         #flapping{
-            key = {Dimension, Value},
+            key = {_Zone, Dimension, Value},
             started_at = StartedAt,
             detect_cnt = DetectCnt
         },
@@ -230,15 +222,16 @@ handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", cast => Msg}),
     {noreply, State}.
 
-handle_info({timeout, _TRef, {garbage_collect, Zone}}, State) ->
-    Policy = get_policy(Zone),
-    Timestamp = erlang:system_time(millisecond) - max_window_time(Policy),
-    MatchSpec = ets:fun2ms(fun(#flapping{started_at = StartedAt}) when StartedAt < Timestamp ->
-        true
-    end),
-    ets:select_delete(?FLAPPING_TAB, MatchSpec),
-    Timer = start_timer(Policy, Zone),
-    {noreply, State#{Zone => Timer}, hibernate};
+handle_info({timeout, TRef, {garbage_collect, Zone}}, State) ->
+    case maps:get(Zone, State, undefined) of
+        TRef ->
+            Policy = get_policy(Zone),
+            garbage_collect_zone(Zone, Policy),
+            Timer = start_timer(Policy, Zone),
+            {noreply, State#{Zone => Timer}, hibernate};
+        _ ->
+            {noreply, State}
+    end;
 handle_info(Info, State) ->
     ?SLOG(error, #{msg => "unexpected_info", info => Info}),
     {noreply, State}.
@@ -261,37 +254,97 @@ log_info(peerhost, _PeerHost) ->
     %% peer_host is always part of the log data.
     {#{}, #{}}.
 
+garbage_collect_zone(Zone, Policy) ->
+    Now = erlang:system_time(millisecond),
+    MatchSpec = lists:append([
+        expired_dimension_match_spec(Zone, Dimension, DimensionPolicy, Now)
+     || {Dimension, DimensionPolicy} <- all_dimensions(Policy),
+        is_map(DimensionPolicy)
+    ]),
+    select_delete(MatchSpec).
+
+garbage_collect_after_config_update(Zones) ->
+    Now = erlang:system_time(millisecond),
+    maps:foreach(
+        fun(Zone, #{flapping_detect := Policy}) ->
+            MatchSpec = lists:append([
+                config_update_dimension_match_spec(Zone, Dimension, DimensionPolicy, Now)
+             || {Dimension, DimensionPolicy} <- all_dimensions(Policy)
+            ]),
+            select_delete(MatchSpec)
+        end,
+        Zones
+    ).
+
+config_update_dimension_match_spec(Zone, Dimension, none, _Now) ->
+    ets:fun2ms(
+        fun(#flapping{key = {EntryZone, EntryDimension, _}}) when
+            EntryZone =:= Zone, EntryDimension =:= Dimension
+        ->
+            true
+        end
+    );
+config_update_dimension_match_spec(Zone, Dimension, DimensionPolicy, Now) ->
+    expired_dimension_match_spec(Zone, Dimension, DimensionPolicy, Now).
+
+expired_dimension_match_spec(Zone, Dimension, #{window_time := WindowTime}, Now) ->
+    Cutoff = Now - WindowTime,
+    ets:fun2ms(
+        fun(#flapping{key = {EntryZone, EntryDimension, _}, started_at = StartedAt}) when
+            EntryZone =:= Zone,
+            EntryDimension =:= Dimension,
+            StartedAt =< Cutoff
+        ->
+            true
+        end
+    ).
+
+select_delete([]) ->
+    0;
+select_delete(MatchSpec) ->
+    ets:select_delete(?FLAPPING_TAB, MatchSpec).
+
+delete_zone(Zone) ->
+    MatchSpec = ets:fun2ms(
+        fun(#flapping{key = {EntryZone, _, _}}) when EntryZone =:= Zone ->
+            true
+        end
+    ),
+    ets:select_delete(?FLAPPING_TAB, MatchSpec).
+
 start_timer(Policy, Zone) ->
-    case enabled_window_times(Policy) of
-        [] ->
+    case gc_interval(Policy) of
+        undefined ->
             undefined;
-        WindowTimes ->
-            emqx_utils:start_timer(lists:max(WindowTimes), {garbage_collect, Zone})
+        Interval ->
+            emqx_utils:start_timer(Interval, {garbage_collect, Zone})
+    end.
+
+gc_interval(Policy) ->
+    case enabled_window_times(Policy) of
+        [] -> undefined;
+        WindowTimes -> lists:min(WindowTimes)
     end.
 
 start_timers() ->
+    start_timers(emqx:get_config([zones], #{})).
+
+start_timers(Zones) ->
     maps:map(
         fun(ZoneName, #{flapping_detect := FlappingDetect}) ->
             start_timer(FlappingDetect, ZoneName)
         end,
-        emqx:get_config([zones], #{})
+        Zones
     ).
 
 update_timer(Timers) ->
-    maps:map(
-        fun(ZoneName, #{flapping_detect := FlappingDetect}) ->
-            Enable = enabled_window_times(FlappingDetect) =/= [],
-            case maps:get(ZoneName, Timers, undefined) of
-                undefined ->
-                    start_timer(FlappingDetect, ZoneName);
-                TRef when Enable -> TRef;
-                TRef ->
-                    _ = erlang:cancel_timer(TRef),
-                    undefined
-            end
-        end,
-        emqx:get_config([zones], #{})
-    ).
+    Zones = emqx:get_config([zones], #{}),
+    OldZones = maps:keys(Timers),
+    NewZones = maps:keys(Zones),
+    lists:foreach(fun delete_zone/1, OldZones -- NewZones),
+    garbage_collect_after_config_update(Zones),
+    maps:foreach(fun(_ZoneName, TRef) -> emqx_utils:cancel_timer(TRef) end, Timers),
+    start_timers(Zones).
 
 fmt_host(PeerHost) ->
     try

--- a/apps/emqx/test/emqx_flapping_SUITE.erl
+++ b/apps/emqx/test/emqx_flapping_SUITE.erl
@@ -129,14 +129,14 @@ t_expired_detecting(_) ->
     false = emqx_flapping:detect(ClientInfo),
     ?assertMatch(
         [_],
-        [X || X = {flapping, {clientid, <<"client008">>}, _, _} <- ets:tab2list(emqx_flapping)]
+        [X || X = {flapping, {_, clientid, <<"client008">>}, _, _} <- ets:tab2list(emqx_flapping)]
     ),
     %% Wait for at least two GC sweeps (window_time = 100ms): the first
     %% sweep may find the record still inside the window.
     timer:sleep(350),
     ?assertMatch(
         [],
-        [X || X = {flapping, {clientid, <<"client008">>}, _, _} <- ets:tab2list(emqx_flapping)]
+        [X || X = {flapping, {_, clientid, <<"client008">>}, _, _} <- ets:tab2list(emqx_flapping)]
     ).
 
 -doc """
@@ -264,6 +264,102 @@ t_independent_dimension_policies(_) ->
     ok = emqx_banned:delete({username, Username}).
 
 -doc """
+Counters for the same dimension value in different zones are independent.
+""".
+t_independent_zone_counters(_) ->
+    ZoneA = ?FUNCTION_NAME,
+    ZoneB = list_to_atom(atom_to_list(ZoneA) ++ "_b"),
+    ClientId = <<"same_client_in_two_zones">>,
+    with_flapping_cleanup([{clientid, ClientId}], fun(_OriginalZones) ->
+        Policy = #{
+            by_clientid => #{max_count => 3, window_time => 10000, ban_time => 2000},
+            by_username => none,
+            by_peerhost => none
+        },
+        ok = emqx_config:put_zone_conf(ZoneA, [flapping_detect], Policy),
+        ok = emqx_config:put_zone_conf(ZoneB, [flapping_detect], Policy),
+        ClientInfo = fun(Zone) ->
+            #{
+                zone => Zone,
+                listener => 'tcp:default',
+                clientid => ClientId,
+                peerhost => {10, 10, 0, 1}
+            }
+        end,
+        false = emqx_flapping:detect(ClientInfo(ZoneA)),
+        false = emqx_flapping:detect(ClientInfo(ZoneA)),
+        false = emqx_flapping:detect(ClientInfo(ZoneB)),
+        false = emqx_flapping:detect(ClientInfo(ZoneB)),
+        true = emqx_flapping:detect(ClientInfo(ZoneB)),
+        timer:sleep(50),
+        ?assertMatch([_], emqx_banned:look_up({clientid, ClientId}))
+    end).
+
+-doc """
+A short-window zone does not collect counters belonging to a long-window zone.
+""".
+t_zone_gc_isolated(_) ->
+    ShortZone = ?FUNCTION_NAME,
+    LongZone = list_to_atom(atom_to_list(ShortZone) ++ "_long"),
+    ClientId = <<"long_window_client">>,
+    with_flapping_cleanup([{clientid, ClientId}], fun(_OriginalZones) ->
+        Policy = fun(WindowTime) ->
+            #{
+                by_clientid => #{max_count => 3, window_time => WindowTime, ban_time => 2000},
+                by_username => none,
+                by_peerhost => none
+            }
+        end,
+        ok = emqx_config:put_zone_conf(ShortZone, [flapping_detect], Policy(100)),
+        ok = emqx_config:put_zone_conf(LongZone, [flapping_detect], Policy(1000)),
+        ok = emqx_cm_sup:restart_flapping(),
+        ClientInfo = fun(Zone) ->
+            #{
+                zone => Zone,
+                listener => 'tcp:default',
+                clientid => ClientId,
+                peerhost => {10, 11, 0, 1}
+            }
+        end,
+        false = emqx_flapping:detect(ClientInfo(LongZone)),
+        timer:sleep(250),
+        false = emqx_flapping:detect(ClientInfo(LongZone)),
+        true = emqx_flapping:detect(ClientInfo(LongZone)),
+        timer:sleep(50),
+        ?assertMatch([_], emqx_banned:look_up({clientid, ClientId}))
+    end).
+
+-doc """
+GC applies each dimension's own window within a zone.
+""".
+t_dimension_gc_isolated(_) ->
+    Zone = ?FUNCTION_NAME,
+    ClientId = <<"short_clientid_long_username">>,
+    Username = <<"long_window_username">>,
+    with_flapping_cleanup([{clientid, ClientId}, {username, Username}], fun(_OriginalZones) ->
+        ok = emqx_config:put_zone_conf(Zone, [flapping_detect], #{
+            by_clientid => #{max_count => 3, window_time => 100, ban_time => 2000},
+            by_username => #{max_count => 3, window_time => 1000, ban_time => 2000},
+            by_peerhost => none
+        }),
+        ok = emqx_cm_sup:restart_flapping(),
+        ClientInfo = #{
+            zone => Zone,
+            listener => 'tcp:default',
+            clientid => ClientId,
+            username => Username,
+            peerhost => {10, 12, 0, 1}
+        },
+        false = emqx_flapping:detect(ClientInfo),
+        timer:sleep(250),
+        false = emqx_flapping:detect(ClientInfo),
+        true = emqx_flapping:detect(ClientInfo),
+        timer:sleep(50),
+        ?assertEqual([], emqx_banned:look_up({clientid, ClientId})),
+        ?assertMatch([_], emqx_banned:look_up({username, Username}))
+    end).
+
+-doc """
 Connections without a username are not counted towards the username
 dimension, so they never produce a username ban entry.
 """.
@@ -286,7 +382,7 @@ t_no_username_no_detect(_) ->
     false = emqx_flapping:detect(ClientInfo),
     ?assertEqual(
         [],
-        [X || X = {flapping, {username, _}, _, _} <- ets:tab2list(emqx_flapping)]
+        [X || X = {flapping, {_, username, _}, _, _} <- ets:tab2list(emqx_flapping)]
     ).
 
 -doc """
@@ -412,6 +508,68 @@ t_conf_update_timer(_Config) ->
     validate_timer([{timer_1, true}, {timer_2, true}, {timer_3, false}, {default, true}]),
     ok.
 
+t_timer_reconfigured_on_window_change(_) ->
+    Zone = ?FUNCTION_NAME,
+    Policy = fun(WindowTime) ->
+        #{
+            by_clientid => #{max_count => 3, window_time => WindowTime, ban_time => 2000},
+            by_username => #{max_count => 3, window_time => 30000, ban_time => 2000},
+            by_peerhost => none
+        }
+    end,
+    with_flapping_cleanup([], fun(_OriginalZones) ->
+        ?assertEqual(30000, emqx_flapping:gc_interval(Policy(60000))),
+        ?assertEqual(20000, emqx_flapping:gc_interval(Policy(20000))),
+        ok = emqx_config:put_zone_conf(Zone, [flapping_detect], Policy(60000)),
+        ok = emqx_cm_sup:restart_flapping(),
+        TRef0 = maps:get(Zone, sys:get_state(emqx_flapping)),
+        ?assert(is_reference(TRef0)),
+        ok = emqx_config:put_zone_conf(Zone, [flapping_detect], Policy(20000)),
+        ok = emqx_flapping:update_config(),
+        _ = sys:get_state(emqx_flapping),
+        TRef1 = maps:get(Zone, sys:get_state(emqx_flapping)),
+        ?assert(is_reference(TRef1)),
+        ?assertNotEqual(TRef0, TRef1),
+        ?assertEqual(false, erlang:read_timer(TRef0)),
+        ?assert(is_integer(erlang:read_timer(TRef1)))
+    end).
+
+t_config_update_cleans_counters(_) ->
+    Zone = ?FUNCTION_NAME,
+    ClientId = <<"config_update_client">>,
+    Username = <<"config_update_username">>,
+    ClientInfo = #{
+        zone => Zone,
+        listener => 'tcp:default',
+        clientid => ClientId,
+        username => Username,
+        peerhost => {10, 13, 0, 1}
+    },
+    with_flapping_cleanup([], fun(OriginalZones) ->
+        EnabledPolicy = #{
+            by_clientid => #{max_count => 3, window_time => 10000, ban_time => 2000},
+            by_username => #{max_count => 3, window_time => 10000, ban_time => 2000},
+            by_peerhost => none
+        },
+        ok = emqx_config:put_zone_conf(Zone, [flapping_detect], EnabledPolicy),
+        ok = emqx_cm_sup:restart_flapping(),
+        false = emqx_flapping:detect(ClientInfo),
+        ?assertMatch([_], flapping_rows(Zone, clientid, ClientId)),
+        ?assertMatch([_], flapping_rows(Zone, username, Username)),
+        ok = emqx_config:put_zone_conf(
+            Zone,
+            [flapping_detect],
+            EnabledPolicy#{by_username := none}
+        ),
+        ok = emqx_flapping:update_config(),
+        _ = sys:get_state(emqx_flapping),
+        ?assertMatch([_], flapping_rows(Zone, clientid, ClientId)),
+        ?assertMatch([], flapping_rows(Zone, username, Username)),
+        {ok, _} = emqx:update_config([zones], OriginalZones),
+        _ = sys:get_state(emqx_flapping),
+        ?assertMatch([], zone_flapping_rows(Zone))
+    end).
+
 validate_timer(Lists) ->
     {Names, _} = lists:unzip(Lists),
     Zones = emqx:get_config([zones]),
@@ -520,3 +678,30 @@ t_dimension_defaults_match_schema(_Conf) ->
 
 get_policy(Zone) ->
     emqx_config:get_zone_conf(Zone, [flapping_detect]).
+
+with_flapping_cleanup(Bans, Fun) ->
+    OriginalZones = emqx:get_raw_config([zones]),
+    try
+        Fun(OriginalZones)
+    after
+        lists:foreach(fun(Who) -> _ = emqx_banned:delete(Who) end, Bans),
+        {ok, _} = emqx:update_config([zones], OriginalZones),
+        ok = emqx_cm_sup:restart_flapping()
+    end.
+
+flapping_rows(Zone, Dimension, Value) ->
+    [
+        X
+     || X = {flapping, {EntryZone, EntryDimension, EntryValue}, _, _} <-
+            ets:tab2list(emqx_flapping),
+        EntryZone =:= Zone,
+        EntryDimension =:= Dimension,
+        EntryValue =:= Value
+    ].
+
+zone_flapping_rows(Zone) ->
+    [
+        X
+     || X = {flapping, {EntryZone, _, _}, _, _} <- ets:tab2list(emqx_flapping),
+        EntryZone =:= Zone
+    ].

--- a/changes/ee/fix-18371.en.md
+++ b/changes/ee/fix-18371.en.md
@@ -1,0 +1,1 @@
+Fixed flapping detection in deployments where zones or detection dimensions use different time windows. Counters are now isolated by zone and dimension, so garbage collection in one zone cannot discard another zone's still-active counters.


### PR DESCRIPTION
Release version: 6.3.0

## Summary

- Isolate flapping counters by zone as well as detection dimension, so activity in one zone cannot contribute to or remove another zone's counters.
- Expire each enabled dimension with its own `window_time`, while scheduling collection at the shortest enabled window.
- Rebuild garbage-collection timers on configuration changes and remove counters belonging to disabled dimensions or deleted zones.
- Add Common Test coverage for cross-zone isolation, per-dimension expiry, timer reconfiguration, and configuration cleanup.

There are no schema changes.

Fixes #18241

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
