### PR TITLE
fix(socket): gate esockd_socket MQTT connections until boot completes

### DIFF
--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -274,6 +274,7 @@ stop(Pid) ->
 %%--------------------------------------------------------------------
 
 init(Parent, esockd_socket, RawSocket, Options) ->
+    ok = assert_node_ready(RawSocket),
     case esockd_socket:wait(RawSocket) of
         {ok, Socket} ->
             ?tp(connection_started, #{
@@ -285,6 +286,32 @@ init(Parent, esockd_socket, RawSocket, Options) ->
         {error, Reason} ->
             ok = esockd_socket:fast_close(RawSocket),
             exit_on_sock_error(Reason)
+    end.
+
+%% Refuse to serve before node boot completes: authn/authz hooks
+%% (e.g. from plugins) may not be installed yet. The exit reason feeds
+%% the listener's shutdown counter. Same gate as `emqx_connection:init/4'.
+%% The socket has not completed wait/1 yet, so the peername lookup must
+%% not crash the refusal path, hence the catch-all.
+assert_node_ready(RawSocket) ->
+    case emqx_node_readiness:is_ready() of
+        true ->
+            ok;
+        false ->
+            Peername =
+                try esockd_socket:peername(RawSocket) of
+                    {ok, Peer} -> esockd:format(Peer);
+                    _ -> unknown
+                catch
+                    _:_ -> unknown
+                end,
+            ?SLOG(info, #{
+                msg => connection_refused_before_boot_complete,
+                transport => esockd_socket,
+                peername => Peername
+            }),
+            _ = esockd_socket:fast_close(RawSocket),
+            erlang:exit({shutdown, node_not_ready})
     end.
 
 init_state(

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -14,6 +14,7 @@
 -define(TCP_PORT, 20831).
 -define(WS_PORT, 20832).
 -define(QUIC_PORT, 20833).
+-define(TCP_SOCKET_PORT, 20834).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -23,6 +24,8 @@ init_per_suite(Config) ->
     _ = emqx_common_test_helpers:gen_host_cert("server", "ca", PrivDir, #{}),
     ListenerConf = io_lib:format(
         "listeners.tcp.default.bind = ~b\n"
+        "listeners.tcp.sock.bind = ~b\n"
+        "listeners.tcp.sock.tcp_backend = socket\n"
         "listeners.ws.default.bind = ~b\n"
         "listeners.quic.default {\n"
         "  enable = true\n"
@@ -35,6 +38,7 @@ init_per_suite(Config) ->
         "}",
         [
             ?TCP_PORT,
+            ?TCP_SOCKET_PORT,
             ?WS_PORT,
             ?QUIC_PORT,
             filename:join(PrivDir, "ca.pem"),
@@ -86,6 +90,28 @@ t_gate_tcp_connection(_Config) ->
     ),
     ok = emqx_node_readiness:mark_ready(),
     ?assertEqual(ok, try_connect(fun emqtt:connect/1, #{port => ?TCP_PORT})).
+
+-doc """
+A TCP MQTT connection on a listener with `tcp_backend = socket` is refused
+while the node is not ready, accepted once ready.  The refusal is recorded
+in the listener's shutdown counter.
+""".
+t_gate_tcp_socket_backend_connection(_Config) ->
+    ok = emqx_node_readiness:mark_not_ready(),
+    ?assertMatch({error, _}, try_connect(fun emqtt:connect/1, #{port => ?TCP_SOCKET_PORT})),
+    Bind = emqx_config:get([listeners, tcp, sock, bind]),
+    ?retry(
+        100,
+        10,
+        ?assertMatch(
+            {node_not_ready, _},
+            lists:keyfind(
+                node_not_ready, 1, emqx_listeners:shutdown_count(<<"tcp:sock">>, Bind)
+            )
+        )
+    ),
+    ok = emqx_node_readiness:mark_ready(),
+    ?assertEqual(ok, try_connect(fun emqtt:connect/1, #{port => ?TCP_SOCKET_PORT})).
 
 -doc "A WebSocket MQTT connection is refused while the node is not ready, accepted once ready.".
 t_gate_ws_connection(_Config) ->

--- a/changes/ee/fix-18357.en.md
+++ b/changes/ee/fix-18357.en.md
@@ -1,4 +1,4 @@
-MQTT connections are now refused until node startup completes, so listeners no longer serve traffic before authentication, authorization, and plugin hooks are active.
+[#18375](https://github.com/emqx/emqx/pull/18375) MQTT connections are now refused until node startup completes, so listeners no longer serve traffic before authentication, authorization, and plugin hooks are active.
 
 The `GET /status` API now returns HTTP 503 until startup completes, so load balancers can route new connections to other nodes in the cluster.
 

--- a/changes/ee/fix-18375.en.md
+++ b/changes/ee/fix-18375.en.md
@@ -1,1 +1,0 @@
-TCP listeners configured with `tcp_backend = socket` now refuse client connections until node boot completes, matching the behavior of the other listener types. This ensures no client is served before all authentication and authorization hooks are installed.

--- a/changes/ee/fix-18375.en.md
+++ b/changes/ee/fix-18375.en.md
@@ -1,0 +1,1 @@
+TCP listeners configured with `tcp_backend = socket` now refuse client connections until node boot completes, matching the behavior of the other listener types. This ensures no client is served before all authentication and authorization hooks are installed.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:
6.0.0

## Summary

#18357 added a node-readiness gate to every connection entry point (`emqx_connection`, `emqx_ws_connection`, `emqx_quic_connection`, `emqx_gateway_conn`) so a client cannot be served before plugin `client.authenticate` / `client.authorize` hooks are installed. It missed `emqx_socket_connection`, the connection module used when a TCP listener sets `tcp_backend = socket`. Such a listener accepted clients during the boot window.

This PR adds the same gate to `emqx_socket_connection:init/4`:

* The check runs before `esockd_socket:wait/1`, matching `emqx_connection`, which gates before the transport handshake.
* The refusal exits with `{shutdown, node_not_ready}`, the reason the per-listener shutdown counter keys on.
* The peername lookup is wrapped in `try`/`catch` because the socket has not completed `wait/1` yet; the lookup must not crash the refusal path.

`emqx_node_readiness_SUITE` gains a case that starts a `tcp_backend = socket` listener, verifies the connection is refused while not ready, checks the `node_not_ready` shutdown count, and verifies the connection succeeds once ready.

Note: the same commit currently also sits on the sync PR #18373 (base `dev-63`). This PR is the correct home because `dev-60` forward-syncs into 6.1–6.4; the copy on #18373 should likely be dropped to avoid a conflict when the sync catches up.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
