### PR TITLE
build: retry transient download failures in pre-compile

### DIFF
--- a/scripts/get-dashboard.sh
+++ b/scripts/get-dashboard.sh
@@ -26,7 +26,8 @@ if [ -d "$DASHBOARD_PATH/www" ] && [ "$(version)" = "$VERSION" ]; then
 fi
 
 echo "Downloading dashboard from: $DIRECT_DOWNLOAD_URL"
-curl -L --silent --show-error \
+curl -L --fail --silent --show-error \
+     --retry 3 --retry-delay 2 \
      --header "Accept: application/octet-stream" \
      --output "${RELEASE_ASSET_FILE}" \
      "$DIRECT_DOWNLOAD_URL"

--- a/scripts/pre-compile.sh
+++ b/scripts/pre-compile.sh
@@ -26,6 +26,7 @@ if [ "$DOWNLOAD_I18N_TRANSLATIONS" = "true" ]; then
   echo "Downloading i18n translation from emqx/emqx-i18n..."
   start=$(date +%s%N)
   curl -L --fail --silent --show-error \
+       --retry 3 --retry-delay 2 \
        --output "apps/emqx_dashboard/priv/desc.zh.hocon" \
        "https://raw.githubusercontent.com/emqx/emqx-i18n/${I18N_REPO_BRANCH}/desc.zh.hocon"
   end=$(date +%s%N)


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

## Summary

`make pre-compile` performs two network downloads: the dashboard bundle from github.com (`scripts/get-dashboard.sh`) and the i18n translation from raw.githubusercontent.com (`scripts/pre-compile.sh`). Both fail intermittently in CI:

```
Downloading i18n translation from emqx/emqx-i18n...
curl: (22) The requested URL returned error: 502
make: *** [Makefile:331: pre-compile] Error 22
```

Add `--retry 3 --retry-delay 2` to both. curl retries on timeouts and on 408, 429, 500, 502, 503 and 504, so a 502 is covered without any extra flag.

The dashboard download additionally lacked `--fail`. Verified against a local server returning 502:

| flags | exit | output file |
| --- | --- | --- |
| current (`--silent --show-error`) | 0 | `<html>502 Bad Gateway</html>` |
| with `--fail --retry 3` | 0 | real payload, after retry |

So today a 5xx on the dashboard download writes the error page into the zip and exits 0; the build then fails at `unzip` with nothing pointing at the download. `--fail` makes an exhausted retry stop the build where it happens.

Build-time only, no runtime behaviour change, so no changelog entry.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)