### PR TITLE
feat(mt): validate managed namespace names at creation

### DIFF
--- a/apps/emqx_mt/src/emqx_mt_config.erl
+++ b/apps/emqx_mt/src/emqx_mt_config.erl
@@ -75,6 +75,10 @@
 
 -define(disabled, disabled).
 
+%% Maximum byte size of a managed namespace name; it must fit in a single
+%% directory name on common filesystems.
+-define(NS_NAME_MAX_LENGTH, 255).
+
 -type limiter_config() :: #{
     ?tenant => disabled | tenant_config(),
     ?client => disabled | client_config()
@@ -173,7 +177,8 @@ update_managed_ns_config(Ns, Configs) ->
         ]
     }}
     | {error, {duplicated_nss, [emqx_mt:tns()]}}
-    | {error, {aborted, term()}}.
+    | {error, {aborted, term()}}
+    | {error, binary()}.
 bulk_import_configs(Entries) ->
     handle_bulk_import_configs(Entries).
 
@@ -185,9 +190,11 @@ when
         | table_is_full
         | already_exists
         | namespace_being_deleted
-        | [map()].
+        | [map()]
+        | binary().
 create_managed_ns(Ns) ->
     maybe
+        ok ?= validate_ns_name(Ns),
         ok ?= emqx_mt_state:create_managed_ns(Ns),
         SideEffects = create_managed_ns_side_effects(Ns),
         case execute_side_effects(SideEffects) of
@@ -539,10 +546,66 @@ limiter_update_side_effects(Ns, {?changed, OldConfig, NewConfig}) ->
 handle_bulk_import_configs(Entries) ->
     maybe
         ok ?= validate_unique_nss(Entries),
+        ok ?= validate_new_ns_names(Entries),
         {ok, Changes} ?= emqx_mt_state:bulk_import_configs(Entries),
         SideEffects = compute_bulk_side_effects(Changes),
         Errors = execute_side_effects(SideEffects),
         {ok, #{errors => Errors}}
+    end.
+
+%% A namespace name is used as a URL path segment and, once managed, as a
+%% directory name and a tar entry path segment (namespaced backups), so only
+%% characters safe in all of them are accepted, and the special path
+%% components `.' and `..' are not valid names. Enforced when a managed
+%% namespace is created; names that already exist keep working.
+-spec validate_ns_name(emqx_mt:tns()) -> ok | {error, binary()}.
+validate_ns_name(Ns) when is_binary(Ns) ->
+    Valid =
+        Ns =/= <<".">> andalso
+            Ns =/= <<"..">> andalso
+            byte_size(Ns) =< ?NS_NAME_MAX_LENGTH andalso
+            has_only_safe_ns_chars(Ns),
+    case Valid of
+        true -> ok;
+        false -> {error, invalid_ns_name_msg()}
+    end.
+
+invalid_ns_name_msg() ->
+    ~b"""
+    Invalid namespace name: only ASCII letters, digits and the characters
+    '.', '-' and '_' are allowed, with length from 1 to 255;
+    '.' and '..' are not valid names
+    """.
+
+%% `\z' rather than `$': `$' also matches just before a trailing newline.
+%% `~' is excluded even though URLs allow it: shells expand it to a home
+%% directory, making a directory named after such a namespace hazardous to
+%% manage by hand.
+has_only_safe_ns_chars(Ns) ->
+    match =:= re:run(Ns, <<"^[A-Za-z0-9._-]+\\z">>, [{capture, none}]).
+
+%% Bulk import both creates and updates namespace configs. Only names that
+%% would be created are validated: existing namespaces keep working.
+validate_new_ns_names(Entries) ->
+    Invalid = lists:filtermap(
+        fun(#{ns := Ns}) ->
+            case is_known_managed_ns(Ns) orelse validate_ns_name(Ns) =:= ok of
+                true -> false;
+                false -> {true, Ns}
+            end
+        end,
+        Entries
+    ),
+    case Invalid of
+        [] ->
+            ok;
+        _ ->
+            Msg = iolist_to_binary([
+                invalid_ns_name_msg(),
+                <<"; offending name(s): ">>,
+                lists:join(<<", ">>, Invalid)
+            ]),
+            {error, Msg}
     end.
 
 validate_unique_nss(Entries) ->

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -310,6 +310,18 @@ create_managed_ns(Ns) ->
     ct:pal("create managed ns result:\n  ~p", [Res]),
     Res.
 
+%% Same as `create_managed_ns/1', but with every byte of the name
+%% percent-encoded, so that names containing characters special to URLs
+%% (`/', `#', `%', ...) reach the handler verbatim.
+create_managed_ns_encoded(Ns) ->
+    Path = emqx_mgmt_api_test_util:api_path(["mt", "ns", percent_encode_all(Ns)]),
+    Res = simple_request(post, Path, ""),
+    ct:pal("create managed ns ~p result:\n  ~p", [Ns, Res]),
+    Res.
+
+percent_encode_all(Bin) ->
+    iolist_to_binary([io_lib:format("%~2.16.0B", [C]) || <<C>> <= Bin]).
+
 delete_ns(Ns) ->
     delete_managed_ns(Ns).
 
@@ -691,6 +703,90 @@ t_reserved_namespaces(_Config) ->
     ),
 
     ?assertMatch({204, _}, delete_managed_ns(<<"tns-ok">>)),
+    ok.
+
+%% Managed namespace names accept only URL- and filesystem-safe characters:
+%% ASCII letters, digits, `.', `-' and `_'. Dotted names such as `my.ns'
+%% are legal; the special path components `.' and `..', path separators and
+%% other special characters are rejected with a 400.
+t_managed_ns_name_validation(_Config) ->
+    ValidNames = [<<"my.ns">>, <<"...">>, <<"nS-1_2">>],
+    lists:foreach(
+        fun(Ns) ->
+            ?assertMatch({204, _}, create_managed_ns_encoded(Ns), #{ns => Ns})
+        end,
+        ValidNames
+    ),
+    {200, Listed} = list_managed_nss(#{}),
+    ?assertEqual(lists:sort(ValidNames), lists:sort(Listed)),
+    %% `.' and `..' are not listed here: HTTP path normalization keeps them
+    %% from ever reaching the handler as one path segment (404). Their
+    %% rejection is covered through the body-based bulk import endpoint in
+    %% `t_bulk_import_configs_ns_name_validation'.
+    InvalidNames = [
+        <<"a/b">>,
+        <<"../a">>,
+        <<"a\\b">>,
+        <<"a#b">>,
+        <<"a%b">>,
+        <<"a&b">>,
+        <<"a~b">>,
+        <<"~">>,
+        <<"a b">>,
+        <<"a?b">>,
+        <<"a\nb">>,
+        <<"ns🐣"/utf8>>,
+        binary:copy(<<"a">>, 256)
+    ],
+    lists:foreach(
+        fun(Ns) ->
+            ?assertMatch(
+                {400, #{<<"message">> := <<"Invalid namespace name", _/binary>>}},
+                create_managed_ns_encoded(Ns),
+                #{ns => Ns}
+            )
+        end,
+        InvalidNames
+    ),
+    ?assertMatch({200, Listed}, list_managed_nss(#{})),
+    %% A name that already exists as an implicit namespace is still rejected
+    %% when promoting it to a managed namespace.
+    ImplicitNs = <<"implicit/ns">>,
+    ok = emqx_mt_state:ensure_ns_added(ImplicitNs),
+    ?assertMatch(
+        {400, #{<<"message">> := <<"Invalid namespace name", _/binary>>}},
+        create_managed_ns_encoded(ImplicitNs)
+    ),
+    ok.
+
+%% Bulk import creates namespaces from the request body, so it validates names
+%% the same way; namespaces that already exist are exempt so that names
+%% created before validation existed keep working.
+t_bulk_import_configs_ns_name_validation(_Config) ->
+    GoodNs = <<"good.ns">>,
+    ImportParams1 = bulk_import_configs_params([
+        {GoodNs, session_params()},
+        {<<"bad/ns">>, session_params()},
+        {<<".">>, session_params()},
+        {<<"..">>, session_params()},
+        {<<>>, session_params()}
+    ]),
+    ?assertMatch(
+        {400, #{<<"message">> := <<"Invalid namespace name", _/binary>>}},
+        bulk_import_configs(ImportParams1)
+    ),
+    %% Nothing was created by the rejected request.
+    ?assertMatch({200, []}, list_managed_nss(#{})),
+    %% Valid names import fine.
+    ImportParams2 = bulk_import_configs_params([{GoodNs, session_params()}]),
+    ?assertMatch({204, _}, bulk_import_configs(ImportParams2)),
+    ?assertMatch({200, [GoodNs]}, list_managed_nss(#{})),
+    %% A pre-existing managed namespace with a name that would be rejected
+    %% today can still have its config imported.
+    LegacyNs = <<"legacy/ns">>,
+    ok = emqx_mt_state:create_managed_ns(LegacyNs),
+    ImportParams3 = bulk_import_configs_params([{LegacyNs, session_params()}]),
+    ?assertMatch({204, _}, bulk_import_configs(ImportParams3)),
     ok.
 
 t_bulk_delete_ns(_Config) ->

--- a/changes/ee/breaking-18377.en.md
+++ b/changes/ee/breaking-18377.en.md
@@ -1,0 +1,1 @@
+Managed namespace names are now validated when created. A name may contain only ASCII letters, digits, and the characters `.`, `-`, and `_`, with a length of 1 to 255 bytes; the names `.` and `..` are not accepted. Namespaces that already exist are not affected.


### PR DESCRIPTION
Refs emqx/emqx-dev-team-tasks#72
Follow-up to #18372.

Release version:
6.3.0

Introduced in:
N/A (behavior restriction for 6.3.0)

## Summary

Validate managed namespace names when they are created. A name may contain only ASCII letters, digits, and the characters `.`, `-` and `_`, with a length of 1 to 255 bytes; the names `.` and `..` are not accepted.

A managed namespace name is used as a URL path segment, as a directory name under the backup root, and as a tar entry path segment inside namespaced backup archives (`<base>/ns/<NS>/cluster.hocon`), so it must be a single safe path component in all of them. The allowed set is the URL-unreserved character set minus `~` (shells expand a leading `~` to a home directory, so directories named after such a namespace are hazardous to manage by hand).

Enforced in `emqx_mt_config:create_managed_ns/1` (behind `POST /mt/ns/:ns`, next to the existing deny-list check) and in bulk config import for namespaces the import would create. Validation applies only at creation:

* Bulk import validates only names that do not already exist, so configs of pre-existing namespaces with out-of-policy names can still be imported.
* `POST /mt/bulk_import_ns_configs` needs no validation: it refuses namespaces that are not already managed.
* Backup restore (`on_backup_table_imported`) writes tables directly and is not affected, so restoring a backup that contains legacy names keeps working.
* Names presented by clients at CONNECT (`client_attrs.tns`) are intentionally not validated: rejecting them would break existing deployments on upgrade.

This lands on `dev-63` only (a breaking change for 6.3.0). Released lines 6.0 to 6.2 keep accepting such names; there, #18372 makes backup operations unavailable for names that cannot be used as a directory name.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
