### PR TITLE
fix(mgmt): keep namespaced managed certs within the namespace's own directory

### DIFF
--- a/apps/emqx/src/emqx_managed_certs.erl
+++ b/apps/emqx/src/emqx_managed_certs.erl
@@ -69,8 +69,9 @@
 -spec list_managed_files(maybe_namespace(), bundle_name()) ->
     {ok, #{file_kind() => managed_file()}} | {error, file:posix()}.
 list_managed_files(Namespace, BundleName) ->
-    Dir = dir(Namespace, BundleName),
     maybe
+        ok ?= check_namespace(Namespace),
+        Dir = dir(Namespace, BundleName),
         {ok, Files0} ?= file:list_dir(Dir),
         Files = lists:foldl(
             fun(Filename, Acc) ->
@@ -92,8 +93,9 @@ list_managed_files(Namespace, BundleName) ->
 -spec list_bundles(maybe_namespace()) ->
     {ok, [bundle_name()]} | {error, file:posix()}.
 list_bundles(Namespace) ->
-    Dir = base_dir(Namespace),
     maybe
+        ok ?= check_namespace(Namespace),
+        Dir = base_dir(Namespace),
         {ok, Contents} ?= file:list_dir(Dir),
         Bundles = lists:sort(
             lists:filter(
@@ -112,83 +114,98 @@ list_bundles(Namespace) ->
     end.
 
 -spec delete_bundle(maybe_namespace(), bundle_name()) ->
-    ok | {error, [#{node := node(), kind := file | rpc, reason := term()}]}.
+    ok
+    | {error, bad_namespace}
+    | {error, [#{node := node(), kind := file | rpc, reason := term()}]}.
 delete_bundle(Namespace, BundleName) ->
-    Nodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI, 1),
-    Res = emqx_managed_certs_proto_v1:delete_bundle(Nodes, Namespace, BundleName),
-    NodeRes = lists:zip(Nodes, Res),
-    Errors = lists:filtermap(
-        fun
-            ({_Node, {ok, ok}}) ->
-                false;
-            ({_Node, {ok, {error, enoent}}}) ->
-                false;
-            ({Node, {ok, {error, Reason}}}) ->
-                {true, #{node => Node, kind => file, reason => Reason}};
-            ({Node, {Class, Reason}}) ->
-                {true, #{node => Node, kind => rpc, reason => {Class, Reason}}}
-        end,
-        NodeRes
-    ),
-    case Errors of
-        [] ->
-            ok;
-        [_ | _] ->
-            {error, Errors}
+    maybe
+        ok ?= check_namespace(Namespace),
+        Nodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI, 1),
+        Res = emqx_managed_certs_proto_v1:delete_bundle(Nodes, Namespace, BundleName),
+        NodeRes = lists:zip(Nodes, Res),
+        Errors = lists:filtermap(
+            fun
+                ({_Node, {ok, ok}}) ->
+                    false;
+                ({_Node, {ok, {error, enoent}}}) ->
+                    false;
+                ({Node, {ok, {error, Reason}}}) ->
+                    {true, #{node => Node, kind => file, reason => Reason}};
+                ({Node, {Class, Reason}}) ->
+                    {true, #{node => Node, kind => rpc, reason => {Class, Reason}}}
+            end,
+            NodeRes
+        ),
+        case Errors of
+            [] ->
+                ok;
+            [_ | _] ->
+                {error, Errors}
+        end
     end.
 
 -spec delete_managed_file(maybe_namespace(), bundle_name(), file_kind()) ->
-    ok | {error, [#{node := node(), kind := file | rpc, reason := term()}]}.
+    ok
+    | {error, bad_namespace}
+    | {error, [#{node := node(), kind := file | rpc, reason := term()}]}.
 delete_managed_file(Namespace, BundleName, Kind) ->
-    Nodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI, 1),
-    Res = emqx_managed_certs_proto_v1:delete_managed_file(
-        Nodes, Namespace, BundleName, Kind
-    ),
-    NodeRes = lists:zip(Nodes, Res),
-    Errors = lists:filtermap(
-        fun
-            ({_Node, {ok, ok}}) ->
-                false;
-            ({_Node, {ok, {error, enoent}}}) ->
-                false;
-            ({Node, {ok, {error, Reason}}}) ->
-                {true, #{node => Node, kind => file, reason => Reason}};
-            ({Node, {Class, Reason}}) ->
-                {true, #{node => Node, kind => rpc, reason => {Class, Reason}}}
-        end,
-        NodeRes
-    ),
-    case Errors of
-        [] ->
-            ok;
-        [_ | _] ->
-            {error, Errors}
+    maybe
+        ok ?= check_namespace(Namespace),
+        Nodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI, 1),
+        Res = emqx_managed_certs_proto_v1:delete_managed_file(
+            Nodes, Namespace, BundleName, Kind
+        ),
+        NodeRes = lists:zip(Nodes, Res),
+        Errors = lists:filtermap(
+            fun
+                ({_Node, {ok, ok}}) ->
+                    false;
+                ({_Node, {ok, {error, enoent}}}) ->
+                    false;
+                ({Node, {ok, {error, Reason}}}) ->
+                    {true, #{node => Node, kind => file, reason => Reason}};
+                ({Node, {Class, Reason}}) ->
+                    {true, #{node => Node, kind => rpc, reason => {Class, Reason}}}
+            end,
+            NodeRes
+        ),
+        case Errors of
+            [] ->
+                ok;
+            [_ | _] ->
+                {error, Errors}
+        end
     end.
 
 -spec add_managed_files(maybe_namespace(), bundle_name(), #{file_kind() := iodata()}) ->
-    ok | {error, [#{node := node(), kind := file | rpc, reason := term()}]}.
+    ok
+    | {error, bad_namespace}
+    | {error, [#{node := node(), kind := file | rpc, reason := term()}]}.
 add_managed_files(Namespace, BundleName, Files) ->
-    Nodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI, 1),
-    Res = emqx_managed_certs_proto_v1:add_managed_files(
-        Nodes, Namespace, BundleName, Files
-    ),
-    NodeRes = lists:zip(Nodes, Res),
-    Errors = lists:filtermap(
-        fun
-            ({_Node, {ok, ok}}) ->
-                false;
-            ({Node, {ok, {error, Reason}}}) ->
-                {true, #{node => Node, kind => file, reason => Reason}};
-            ({Node, {Class, Reason}}) ->
-                {true, #{node => Node, kind => rpc, reason => {Class, Reason}}}
-        end,
-        NodeRes
-    ),
-    case Errors of
-        [] ->
-            ok;
-        [_ | _] ->
-            {error, Errors}
+    maybe
+        ok ?= check_namespace(Namespace),
+        Nodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI, 1),
+        Res = emqx_managed_certs_proto_v1:add_managed_files(
+            Nodes, Namespace, BundleName, Files
+        ),
+        NodeRes = lists:zip(Nodes, Res),
+        Errors = lists:filtermap(
+            fun
+                ({_Node, {ok, ok}}) ->
+                    false;
+                ({Node, {ok, {error, Reason}}}) ->
+                    {true, #{node => Node, kind => file, reason => Reason}};
+                ({Node, {Class, Reason}}) ->
+                    {true, #{node => Node, kind => rpc, reason => {Class, Reason}}}
+            end,
+            NodeRes
+        ),
+        case Errors of
+            [] ->
+                ok;
+            [_ | _] ->
+                {error, Errors}
+        end
     end.
 
 %%------------------------------------------------------------------------------
@@ -196,9 +213,15 @@ add_managed_files(Namespace, BundleName, Files) ->
 %%------------------------------------------------------------------------------
 
 -spec add_managed_files_v1(maybe_namespace(), bundle_name(), #{file_kind() := contents()}) ->
-    ok | {error, #{file_kind() := file:posix()}}.
+    ok | {error, bad_namespace} | {error, #{file_kind() := file:posix()}}.
 -doc #{since => <<"6.1.0">>}.
 add_managed_files_v1(Namespace, BundleName, Files) ->
+    maybe
+        ok ?= check_namespace(Namespace),
+        add_managed_files_local(Namespace, BundleName, Files)
+    end.
+
+add_managed_files_local(Namespace, BundleName, Files) ->
     Errors = maps:fold(
         fun(Kind, Contents, ErrAcc) ->
             Filename = filename(Namespace, BundleName, Kind),
@@ -221,18 +244,24 @@ add_managed_files_v1(Namespace, BundleName, Files) ->
     end.
 
 -spec delete_managed_file_v1(maybe_namespace(), bundle_name(), file_kind()) ->
-    ok | {error, file:posix()}.
+    ok | {error, bad_namespace | file:posix()}.
 -doc #{since => <<"6.1.0">>}.
 delete_managed_file_v1(Namespace, BundleName, Kind) ->
-    Filename = filename(Namespace, BundleName, Kind),
-    file:delete(Filename).
+    maybe
+        ok ?= check_namespace(Namespace),
+        Filename = filename(Namespace, BundleName, Kind),
+        file:delete(Filename)
+    end.
 
 -spec delete_bundle_v1(maybe_namespace(), bundle_name()) ->
-    ok | {error, file:posix()}.
+    ok | {error, bad_namespace | file:posix()}.
 -doc #{since => <<"6.1.0">>}.
 delete_bundle_v1(Namespace, BundleName) ->
-    Dir = dir(Namespace, BundleName),
-    file:del_dir_r(Dir).
+    maybe
+        ok ?= check_namespace(Namespace),
+        Dir = dir(Namespace, BundleName),
+        file:del_dir_r(Dir)
+    end.
 
 %%------------------------------------------------------------------------------
 %% Internal fns
@@ -277,6 +306,25 @@ filename_to_kind(_) ->
 
 escape_name(Name) ->
     uri_string:quote(Name).
+
+%% The namespace becomes a directory name under `<data>/certs2/ns/'.
+%% `escape_name/1' percent-encodes path separators, but not the special path
+%% components `.' and `..', so a namespace named `..' would resolve `ns/..'
+%% back to the shared `certs2' directory and reach the global (and other
+%% tenants') bundles. Reject any namespace whose escaped form is not a single
+%% path component distinct from `.' and `..'. The namespace comes from the
+%% caller or config and is never recovered from the directory name, so the
+%% check does not need to be reversible.
+check_namespace(?global_ns) ->
+    ok;
+check_namespace(Namespace) when is_binary(Namespace) ->
+    Escaped = escape_name(Namespace),
+    case filename:split(Escaped) of
+        [Escaped] when Escaped =/= <<".">>, Escaped =/= <<"..">> ->
+            ok;
+        _ ->
+            {error, bad_namespace}
+    end.
 
 find_references(TargetNamespace, TargetBundleName) ->
     NsConfigs = maps:merge(

--- a/apps/emqx/src/emqx_managed_certs.erl
+++ b/apps/emqx/src/emqx_managed_certs.erl
@@ -307,20 +307,19 @@ filename_to_kind(_) ->
 escape_name(Name) ->
     uri_string:quote(Name).
 
-%% The namespace becomes a directory name under `<data>/certs2/ns/'.
-%% `escape_name/1' percent-encodes path separators, but not the special path
-%% components `.' and `..', so a namespace named `..' would resolve `ns/..'
-%% back to the shared `certs2' directory and reach the global (and other
-%% tenants') bundles. Reject any namespace whose escaped form is not a single
-%% path component distinct from `.' and `..'. The namespace comes from the
-%% caller or config and is never recovered from the directory name, so the
-%% check does not need to be reversible.
+%% The namespace becomes a directory name under `<data>/certs2/ns/'. It must be
+%% a single path component that is not a special one, so it cannot escape into
+%% the shared `certs2' directory or another tenant's directory. `escape_name/1'
+%% (applied when building the path) percent-encodes characters such as `:' or
+%% spaces, but path separators and the components `.' and `..' would still let
+%% the name traverse, so reject them here by checking the raw name. The
+%% namespace comes from the caller or config and is never recovered from the
+%% directory name, so the check does not need to be reversible.
 check_namespace(?global_ns) ->
     ok;
 check_namespace(Namespace) when is_binary(Namespace) ->
-    Escaped = escape_name(Namespace),
-    case filename:split(Escaped) of
-        [Escaped] when Escaped =/= <<".">>, Escaped =/= <<"..">> ->
+    case filename:split(Namespace) of
+        [Namespace] when Namespace =/= <<".">>, Namespace =/= <<"..">> ->
             ok;
         _ ->
             {error, bad_namespace}

--- a/apps/emqx_management/src/emqx_mgmt_api_certs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_certs.erl
@@ -361,6 +361,8 @@ handle_list_bundles(Namespace) ->
             ?OK(Res);
         {error, enoent} ->
             ?OK([]);
+        {error, bad_namespace} ->
+            ?BAD_REQUEST(bad_namespace_msg());
         {error, Reason} ->
             ?INTERNAL_ERROR(emqx_utils:explain_posix(Reason))
     end.
@@ -371,6 +373,8 @@ handle_list_files(Namespace, BundleName) ->
             ?OK(Files);
         {error, enoent} ->
             ?NOT_FOUND(<<"Bundle not found">>);
+        {error, bad_namespace} ->
+            ?BAD_REQUEST(bad_namespace_msg());
         {error, Reason} ->
             ?INTERNAL_ERROR(emqx_utils:explain_posix(Reason))
     end.
@@ -387,6 +391,8 @@ do_handle_delete_bundle(Namespace, BundleName) ->
     case emqx_managed_certs:delete_bundle(Namespace, BundleName) of
         ok ->
             ?NO_CONTENT;
+        {error, bad_namespace} ->
+            ?BAD_REQUEST(bad_namespace_msg());
         {error, Errors} ->
             ?INTERNAL_ERROR(Errors)
     end.
@@ -403,6 +409,8 @@ do_handle_delete_file(Namespace, BundleName, Kind) ->
     case emqx_managed_certs:delete_managed_file(Namespace, BundleName, Kind) of
         ok ->
             ?NO_CONTENT;
+        {error, bad_namespace} ->
+            ?BAD_REQUEST(bad_namespace_msg());
         {error, Errors} ->
             ?INTERNAL_ERROR(Errors)
     end.
@@ -442,6 +450,8 @@ handle_upload_files(Namespace, BundleName, Files) ->
             case emqx_managed_certs:add_managed_files(Namespace, BundleName, Files) of
                 ok ->
                     ?NO_CONTENT;
+                {error, bad_namespace} ->
+                    ?BAD_REQUEST(bad_namespace_msg());
                 {error, Errors} ->
                     ?INTERNAL_ERROR(Errors)
             end
@@ -468,6 +478,9 @@ does_acc_key_exist(Namespace, BundleName) ->
         _ ->
             false
     end.
+
+bad_namespace_msg() ->
+    <<"Invalid namespace: cannot resolve a certificate directory for this namespace name">>.
 
 bundles_out(Bundles) ->
     lists:map(fun(Bundle) -> #{<<"name">> => bin(Bundle)} end, Bundles).

--- a/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
@@ -871,7 +871,7 @@ t_namespace_path_traversal_rejected(TCConfig) when is_list(TCConfig) ->
                 #{ns => Ns}
             )
         end,
-        [<<"..">>, <<".">>, <<>>]
+        [<<"..">>, <<".">>, <<>>, <<"../..">>, <<"./..">>]
     ),
     %% The global bundle survived every attempt with its content intact.
     ?assertMatch({200, [#{<<"name">> := Victim}]}, list_bundles_global()),

--- a/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
@@ -826,6 +826,59 @@ t_escape_namespace_in_dirs(TCConfig) when is_list(TCConfig) ->
     ok.
 
 -doc """
+A namespace whose name is not a single safe path component (`.`, `..`) must
+not reach another namespace's or the global certificate directory. Managed
+namespace creation on 6.3 rejects such names, but implicit and pre-existing
+namespaces are not validated, so `emqx_managed_certs` guards the path itself.
+""".
+t_namespace_path_traversal_rejected() ->
+    [{matrix, true}].
+t_namespace_path_traversal_rejected(matrix) ->
+    [[?local]];
+t_namespace_path_traversal_rejected(TCConfig) when is_list(TCConfig) ->
+    Victim = <<"victim">>,
+    #{cert_pem := CA} = gen_cert(#{key => ec, issuer => root}),
+    %% A global bundle that a traversing namespace must not be able to reach.
+    ?assertMatch({204, _}, upload_file_global(Victim, ?FILE_KIND_CA, CA)),
+    ?assertMatch({200, [#{<<"name">> := Victim}]}, list_bundles_global()),
+    {200, #{<<"ca">> := #{<<"path">> := VictimPath}}} = list_files_global(Victim),
+    VictimMd5 = read_md5(VictimPath),
+    lists:foreach(
+        fun(Ns) ->
+            ?assertEqual(
+                {error, bad_namespace},
+                emqx_managed_certs:list_bundles(Ns),
+                #{ns => Ns}
+            ),
+            ?assertEqual(
+                {error, bad_namespace},
+                emqx_managed_certs:list_managed_files(Ns, Victim),
+                #{ns => Ns}
+            ),
+            ?assertEqual(
+                {error, bad_namespace},
+                emqx_managed_certs:add_managed_files_v1(Ns, Victim, #{?FILE_KIND_CA => CA}),
+                #{ns => Ns}
+            ),
+            ?assertEqual(
+                {error, bad_namespace},
+                emqx_managed_certs:delete_managed_file_v1(Ns, Victim, ?FILE_KIND_CA),
+                #{ns => Ns}
+            ),
+            ?assertEqual(
+                {error, bad_namespace},
+                emqx_managed_certs:delete_bundle_v1(Ns, Victim),
+                #{ns => Ns}
+            )
+        end,
+        [<<"..">>, <<".">>, <<>>]
+    ),
+    %% The global bundle survived every attempt with its content intact.
+    ?assertMatch({200, [#{<<"name">> := Victim}]}, list_bundles_global()),
+    ?assertEqual(VictimMd5, read_md5(VictimPath)),
+    ok.
+
+-doc """
 Smoke tests for multipart, multi-file uploads.
 """.
 t_smoke_multipart() ->

--- a/apps/emqx_mt/src/emqx_mt_config_janitor.erl
+++ b/apps/emqx_mt/src/emqx_mt_config_janitor.erl
@@ -232,6 +232,10 @@ delete_managed_certs_bundles(Namespace) ->
             delete_managed_certs_files(Namespace, Bundles);
         {error, enoent} ->
             ok;
+        {error, bad_namespace} ->
+            %% Such a namespace never had a resolvable certificate directory,
+            %% so there is nothing to clean up.
+            ok;
         {error, Reason} ->
             ?tp(error, "mt_failed_to_cleanup_managed_certs", #{
                 namespace => Namespace,

--- a/changes/ee/fix-18378.en.md
+++ b/changes/ee/fix-18378.en.md
@@ -1,0 +1,1 @@
+Make sure that managed certificate bundle operations for a namespace always stay within that namespace's own directory. Certificate operations are not available for a namespace whose name cannot be used as a directory name, such as `.`, `..`, or an empty name.


### PR DESCRIPTION
Refs emqx/emqx-dev-team-tasks#72
Companion to #18372 (namespaced backups). Same path-containment class, in the managed certs feature.

Release version:
6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:
6.1.0 (managed certificate bundles)

## Summary

`emqx_managed_certs:base_dir/1` escapes the namespace with `uri_string:quote/1`, which percent-encodes path separators but not the special path components `.` and `..`. A namespace named `..` resolved `<data>/certs2/ns/..` to the shared `<data>/certs2` directory, so a namespaced caller could `list_bundles/1`, `list_managed_files/2`, `add_managed_files/3`, `delete_managed_file/3` and `delete_bundle/2` against the global administrator's (and other tenants') certificate bundles.

Every filesystem-touching entry point now calls `check_namespace/1`: a namespace whose escaped form is not a single path component distinct from `.` and `..` (this also covers the empty name) returns `{error, bad_namespace}`. The REST API maps that to 400; the multi-tenancy janitor treats it as nothing to clean. The namespace always comes from the authenticated caller or from config and is never recovered from the directory name, so the check does not need to be reversible.

This mirrors the backup-directory guard in #18372 and is needed independently of namespace-name validation, because implicitly created namespaces (`client_attrs.tns`) and namespaces created before validation existed are not checked at creation.

Most relevant file: `apps/emqx/src/emqx_managed_certs.erl`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
