### PR TITLE
fix(dashboard): require authentication for schema APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ include env.sh
 
 # Dashboard version
 # from https://github.com/emqx/emqx-dashboard5
-export EMQX_DASHBOARD_VERSION ?= 2.3.0-beta.3
+export EMQX_DASHBOARD_VERSION ?= 2.3.0-beta.4
 
 .PHONY: print-dashboard-version
 print-dashboard-version:

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema_api.erl
@@ -40,7 +40,11 @@
 api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
-scopes() -> ?SCOPE_DENIED.
+%% The schema is an internal Dashboard resource, but it must be available to
+%% any authenticated Dashboard user so the UI can render its forms.  Keep it
+%% outside the user-visible business scopes; route authentication is inherited
+%% from the Dashboard listener's global Minirest security configuration.
+scopes() -> ?SCOPE_PUBLIC.
 
 paths() ->
     ["/schemas/:name"].
@@ -56,7 +60,6 @@ schema("/schemas/:name") ->
             ],
             desc => ?DESC(get_schema),
             tags => ?TAGS,
-            security => [],
             responses => #{
                 200 => hoconsc:mk(binary(), #{desc => ?DESC("schema_json_response")})
             }

--- a/apps/emqx_dashboard/test/emqx_dashboard_schema_api_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_schema_api_SUITE.erl
@@ -42,9 +42,32 @@ t_actions(_) ->
 t_connectors(_) ->
     assert_schema_response("connectors").
 
+t_dashboard_user_access(_) ->
+    AuthHeader = emqx_common_test_http:default_user_auth_header(),
+    lists:foreach(
+        fun(Name) ->
+            Url = ?SERVER ++ "/schemas/" ++ Name,
+            {ok, {{_, 200, _}, _Headers, Body}} =
+                request_with_headers(get, Url, AuthHeader),
+            _ = emqx_utils_json:decode(Body)
+        end,
+        ["hotconf", "actions", "connectors"]
+    ).
+
+t_schema_requires_auth(_) ->
+    lists:foreach(
+        fun(Name) ->
+            Url = ?SERVER ++ "/schemas/" ++ Name,
+            {ok, {{_, 401, _}, _Headers, _Body}} =
+                httpc:request(get, {Url, []}, [], [{body_format, binary}])
+        end,
+        ["hotconf", "actions", "connectors"]
+    ).
+
 assert_schema_response(Name) ->
     Url = ?SERVER ++ "/schemas/" ++ Name,
-    {ok, {{_, 200, _}, Headers, Body}} = request_with_headers(get, Url),
+    {ok, {{_, 200, _}, Headers, Body}} =
+        request_with_headers(get, Url, emqx_mgmt_api_test_util:auth_header_()),
     %% assert it's a valid json
     _ = emqx_utils_json:decode(Body),
     %% assert minirest reports JSON content-type, not the text/plain fallback
@@ -53,6 +76,8 @@ assert_schema_response(Name) ->
     ok.
 
 request_with_headers(Method, Url) ->
-    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    request_with_headers(Method, Url, emqx_mgmt_api_test_util:auth_header_()).
+
+request_with_headers(Method, Url, AuthHeader) ->
     Opts = #{return_all => true, httpc_req_opts => [{body_format, binary}]},
     emqx_mgmt_api_test_util:request_api(Method, Url, [], AuthHeader, [], Opts).

--- a/changes/ee/breaking-18384.en.md
+++ b/changes/ee/breaking-18384.en.md
@@ -1,0 +1,3 @@
+The Dashboard schema endpoints `/api/v5/schemas/hotconf`, `/api/v5/schemas/actions`, and `/api/v5/schemas/connectors` now require authentication.
+
+This is an intentional breaking change for the bundled Dashboard. The Dashboard schema loader must send the logged-in Bearer token when fetching these endpoints. Update the Dashboard package together with EMQX; older Dashboard bundles will receive HTTP 401 and schema-driven configuration forms will not load.

--- a/scripts/test/emqx-smoke-test.sh
+++ b/scripts/test/emqx-smoke-test.sh
@@ -137,7 +137,7 @@ check_schema_json() {
     local expected_title="$2"
     local url="$BASE_URL/api/v5/schemas/$name"
     local json
-    json="$(curl -s "$url" | jq .)"
+    json="$(auth_curl "$url" | jq .)"
     title="$(echo "$json" | jq -r '.info.title')"
     if [[ "$title" != "$expected_title" ]]; then
         echo "unexpected value from GET $url"


### PR DESCRIPTION
Release version: 7.0.0
Introduced in: pre-5.8
Fix: https://github.com/emqx/emqx-dev-team-tasks/issues/313

Frontend will be included from:
- 6.3.0: #18459
- 6.2.x: ?
- 6.1.x: ?
- 6.0.x: ?
- 5.10.x: ?
- 5.9.x: ?
- 5.8.x: ?

## Summary

Require authentication for the Dashboard schema endpoints `/api/v5/schemas/hotconf`, `/api/v5/schemas/actions`, and `/api/v5/schemas/connectors`. The endpoints remain outside the user-visible business scopes, while authenticated Dashboard users can still retrieve them.

This is an intentional breaking change for the bundled Dashboard: the Dashboard schema loader must be updated to send the logged-in Bearer token when fetching these endpoints. Without the corresponding Dashboard change, existing Dashboard bundles will receive HTTP 401 and their schema-driven forms will not load.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/breaking-18384.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (the authentication requirement is intentional and documented above)
