### PR TITLE
fix(config): return 400 for invalid HOCON escape sequences (5.8)

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -338,9 +338,10 @@ load_config(Bin, Opts) when is_binary(Bin) ->
         {ok, RawConf} ->
             load_config_from_raw(RawConf, Opts);
         %% Type is scan_error, parse_error...
+        %% Reason may be an atom, a binary or a string.
         {error, {Type, Meta = #{reason := Reason}}} ->
             {error, Meta#{
-                reason => unicode:characters_to_binary(Reason),
+                reason => emqx_utils:readable_error_msg(Reason),
                 type => Type
             }};
         {error, Reason} ->

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -478,6 +478,47 @@ t_config_update_parse_error(_Config) ->
         emqx_utils_json:decode(ScanError)
     ).
 
+%% An invalid Unicode escape in the submitted HOCON returns a 400 with a readable
+%% reason, leaks no internal module names, and leaves the configuration unchanged.
+t_config_update_invalid_uescape(_Config) ->
+    Before = read_conf(<<"mqtt">>),
+    BadHoconList = [
+        <<"mqtt { response_information = \"\\uD800\" }">>,
+        <<"mqtt { response_information = \"\\uDC00\" }">>,
+        <<"mqtt { response_information = \"\\uD800A\" }">>,
+        <<"mqtt { response_information = \"\\u123x\" }">>,
+        <<"mqtt { response_information = \"\\u123\" }">>
+    ],
+    lists:foreach(
+        fun(BadHocon) ->
+            %% update_configs_with_binary/1 fails the test on any status
+            %% other than 2xx or 400, so this match asserts the 400.
+            {error, Body} = update_configs_with_binary(BadHocon),
+            ?assertMatch(
+                #{
+                    <<"errors">> := #{
+                        <<"type">> := <<"scan_error">>,
+                        <<"reason">> := <<"invalid_uescape", _/binary>>
+                    }
+                },
+                emqx_utils_json:decode(Body),
+                BadHocon
+            ),
+            lists:foreach(
+                fun(InternalDetail) ->
+                    ?assertEqual(
+                        nomatch,
+                        binary:match(Body, InternalDetail),
+                        {BadHocon, Body}
+                    )
+                end,
+                [<<"emqx_conf_cli">>, <<"unicode">>, <<"minirest">>, <<"cowboy">>]
+            )
+        end,
+        BadHoconList
+    ),
+    ?assertEqual(Before, read_conf(<<"mqtt">>)).
+
 t_config_update_unknown_root(_Config) ->
     ?assertMatch(
         {error, <<"{\"errors\":{\"a\":\"{root_key_not_found,", _/binary>>},

--- a/apps/emqx_utils/test/emqx_utils_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_tests.erl
@@ -64,6 +64,12 @@ to_binary_representation(Bin) when is_binary(Bin) ->
 
 readable_error_msg_test_() ->
     [
+        {"atom reason",
+            ?_assertEqual(<<"invalid_uescape">>, emqx_utils:readable_error_msg(invalid_uescape))},
+        {"binary reason", ?_assertEqual(<<"oops">>, emqx_utils:readable_error_msg(<<"oops">>))},
+        {"string reason", ?_assertEqual(<<"oops">>, emqx_utils:readable_error_msg("oops"))},
+        {"other term reason",
+            ?_assertEqual(<<"{failed,42}">>, emqx_utils:readable_error_msg({failed, 42}))},
         {"binary in nested structure with non-latin1 characters",
             ?_assert(begin
                 %% An unexpected error that could occur and be returned via HTTP API.

--- a/changes/ee/fix-18385.en.md
+++ b/changes/ee/fix-18385.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where submitting a configuration containing an invalid Unicode escape sequence through `PUT /configs` returned an internal error. Such requests now return a validation error that names the invalid escape.


### PR DESCRIPTION
Release version:
5.8.12, 5.9.4, 5.10.5

<!--
run script ./scripts/rel-versions to get release versions
-->

Introduced in:
N/A (the HOCON 0.46.3 upgrade that surfaced this is not in a GA release yet)

## Summary

v5 port of #18383. Fixes #18382 for the 5.8 line.

`hocon:binary/1` reports scan and parse errors with an atom `reason`, for example `invalid_uescape` for a bad `\u` escape sequence. `emqx_conf_cli:load_config/2` passed the reason to `unicode:characters_to_binary/1`, which raises `badarg` on atoms. The exception escaped to minirest, so `PUT /configs` replied 500 and the response body contained internal detail (an Erlang stack trace).

The fix formats the reason with `emqx_utils:readable_error_msg/1`. It accepts atoms, binaries, strings and arbitrary terms, so `load_config/2` always returns `{error, Map}` and the existing handler in `emqx_mgmt_api_configs` maps it to a 400 response. This also removes the latent case where `unicode:characters_to_binary/1` returns an `{error, _, _}` or `{incomplete, _, _}` tuple on malformed chardata and the tuple ends up in the response.

Tests:
- `emqx_mgmt_api_configs_SUITE:t_config_update_invalid_uescape` sends the payloads from the issue and asserts a 400 response, a readable reason, no internal module names in the body, and an unchanged configuration.
- eunit cases in `emqx_utils_tests` cover `readable_error_msg/1` for atom, binary, string and other-term inputs.

Note: `dev-59` and `dev-510` carry hocon 0.45.3; the change is safe there as well and rides the normal forward sync.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
