### PR TITLE
fix(influxdb): redact password embedded in v1 query-string path

### DIFF
--- a/apps/emqx_bridge_influxdb/mix.exs
+++ b/apps/emqx_bridge_influxdb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeInfluxdb.MixProject do
   def project do
     [
       app: :emqx_bridge_influxdb,
-      version: "6.2.0",
+      version: "6.2.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -545,6 +545,10 @@ ping_with_auth(_) ->
 redact_auth(Term) ->
     emqx_utils:redact(Term, fun is_auth_key/1).
 
+is_auth_key(path) ->
+    true;
+is_auth_key(auth_path) ->
+    true;
 is_auth_key(Key) when is_binary(Key) ->
     string:equal("authorization", Key, true);
 is_auth_key(_) ->
@@ -1004,8 +1008,23 @@ is_unrecoverable_error(_) ->
 is_auth_key_test_() ->
     [
         ?_assert(is_auth_key(<<"Authorization">>)),
+        ?_assert(is_auth_key(path)),
+        ?_assert(is_auth_key(auth_path)),
         ?_assertNot(is_auth_key(<<"Something">>)),
         ?_assertNot(is_auth_key(89))
+    ].
+
+redact_auth_test_() ->
+    Secret = "public123",
+    Client = #{
+        path => "/write?p=" ++ Secret ++ "&u=admin&db=Datalayers",
+        auth_path => "/query?p=" ++ Secret ++ "&u=admin&db=Datalayers"
+    },
+    Redacted = redact_auth(Client),
+    Rendered = iolist_to_binary(io_lib:format("~p", [Redacted])),
+    [
+        ?_assertEqual(#{path => "******", auth_path => "******"}, Redacted),
+        ?_assertEqual(nomatch, binary:match(Rendered, <<"public123">>))
     ].
 
 %% for coverage

--- a/changes/ee/fix-18386.en.md
+++ b/changes/ee/fix-18386.en.md
@@ -1,0 +1,1 @@
+Fix password leak in logs for InfluxDB v1 connectors using query-string authentication (including the Datalayers connector). The password was logged in clear text as part of the client's `path` and `auth_path` fields.


### PR DESCRIPTION
Fix password leak for Datalayers (and any influxdb v1 connector using query-string auth).

When influxdb v1 uses `query_string` auth transport (which the Datalayers connector forces), the `influxdb` library embeds `u=<username>&p=<password>` into the derived `path` and `auth_path` fields of the client state. `redact_auth/1` only masked the `authorization` header and sensitive keys like `password`, so these two plain-string fields were logged raw by `starting_influxdb_connector_success`, leaking the password.

This change treats `path` and `auth_path` as auth keys so `redact_auth/1` masks them too.

Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/340