### PR TITLE
feat(dashboard): add SCRAM challenge-response login

### DIFF
--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -67,6 +67,23 @@
     extra = #{} :: map()
 }).
 
+-record(emqx_dashboard_scram_challenge, {
+    id :: binary(),
+    username :: dashboard_username(),
+    client_nonce :: binary(),
+    server_nonce :: binary(),
+    salt :: binary(),
+    iterations :: pos_integer(),
+    credential_fingerprint :: binary() | undefined,
+    expires_at :: integer(),
+    extra = #{} :: map()
+}).
+
+-record(emqx_dashboard_scram_meta, {
+    key :: atom(),
+    value :: binary()
+}).
+
 -define(TAB_COLLECT, emqx_collect).
 
 -define(EMPTY_KEY(Key), ((Key == undefined) orelse (Key == <<>>))).

--- a/apps/emqx_dashboard/priv/api-spec-login.html
+++ b/apps/emqx_dashboard/priv/api-spec-login.html
@@ -1,0 +1,252 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="robots" content="noindex,nofollow">
+  <title>EMQX API - Sign in</title>
+  <style>
+    body{font:14px system-ui,sans-serif;background:#0e1116;color:#e6e6e6;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
+    form{background:#161b22;border:1px solid #2a313a;border-radius:8px;padding:24px;width:min(380px,calc(100vw - 32px))}
+    h1{margin:0 0 6px;font-size:16px}
+    p{margin:0 0 16px;color:#9aa4ae;font-size:12px;line-height:1.5}
+    label{display:block;font-size:12px;color:#9aa4ae;margin-bottom:4px}
+    input{width:100%;padding:8px 10px;margin-bottom:12px;border:1px solid #2a313a;border-radius:6px;background:#0e1116;color:#e6e6e6;font-size:13px;box-sizing:border-box}
+    button{width:100%;padding:9px 12px;border:0;border-radius:6px;background:#3b82f6;color:#fff;font-size:13px;cursor:pointer}
+    button:disabled{opacity:.6;cursor:wait}
+    .err{color:#ffb4b4;font-size:12px;margin-bottom:10px;min-height:14px;white-space:pre-wrap}
+    .warning{color:#ffd580}
+    .hidden{display:none}
+  </style>
+</head>
+<body>
+  <form id="login-form" autocomplete="off">
+    <h1>Sign in to view the API specification</h1>
+    <p id="login-hint">The browser login uses SCRAM-SHA-256. Use HTTPS or another secure browser context.</p>
+    <div class="err" id="login-error"></div>
+    <label for="username">Username</label>
+    <input id="username" name="username" autocomplete="username" required>
+    <label for="password">Password</label>
+    <input id="password" name="password" type="password" autocomplete="current-password" required>
+    <div id="mfa-field" class="hidden">
+      <label for="mfa-token">MFA token</label>
+      <input id="mfa-token" name="mfa_token" inputmode="numeric" autocomplete="one-time-code">
+    </div>
+    <button id="submit" type="submit">Sign in</button>
+  </form>
+  <script>
+    const legacyFallbackAllowed = __EMQX_LEGACY_FALLBACK_ALLOWED__;
+    const form = document.getElementById('login-form');
+    const usernameInput = document.getElementById('username');
+    const passwordInput = document.getElementById('password');
+    const mfaField = document.getElementById('mfa-field');
+    const mfaInput = document.getElementById('mfa-token');
+    const errorElement = document.getElementById('login-error');
+    const submitButton = document.getElementById('submit');
+
+    function updateSecureContextHint() {
+      if (!window.isSecureContext || !window.crypto || !window.crypto.subtle) {
+        const message = legacyFallbackAllowed
+          ? 'SCRAM login requires HTTPS or another secure browser context. An older-node compatibility fallback may be available.'
+          : 'SCRAM login requires HTTPS or another secure browser context. Legacy password login is disabled.';
+        document.getElementById('login-hint').textContent = message;
+        document.getElementById('login-hint').classList.add('warning');
+      }
+    }
+
+    updateSecureContextHint();
+
+    function utf8(value) {
+      return new TextEncoder().encode(value);
+    }
+
+    function base64ToBytes(value) {
+      const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+      const padded = normalized + '='.repeat((4 - normalized.length % 4) % 4);
+      const decoded = atob(padded);
+      return Uint8Array.from(decoded, (char) => char.charCodeAt(0));
+    }
+
+    function bytesToBase64(value) {
+      let binary = '';
+      for (const byte of value) binary += String.fromCharCode(byte);
+      return btoa(binary);
+    }
+
+    function bytesToBase64Url(value) {
+      return bytesToBase64(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+    }
+
+    function randomNonce() {
+      return bytesToBase64Url(crypto.getRandomValues(new Uint8Array(24)));
+    }
+
+    function escapeScramUsername(username) {
+      return username.replace(/=/g, '=3D').replace(/,/g, '=2C');
+    }
+
+    async function sha256(value) {
+      return new Uint8Array(await crypto.subtle.digest('SHA-256', value));
+    }
+
+    async function hmac(key, value) {
+      const cryptoKey = await crypto.subtle.importKey(
+        'raw', key, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+      );
+      return new Uint8Array(await crypto.subtle.sign('HMAC', cryptoKey, value));
+    }
+
+    async function saltedPassword(password, salt, iterations) {
+      const cryptoKey = await crypto.subtle.importKey(
+        'raw', utf8(password), 'PBKDF2', false, ['deriveBits']
+      );
+      const bits = await crypto.subtle.deriveBits(
+        { name: 'PBKDF2', salt, iterations, hash: 'SHA-256' }, cryptoKey, 256
+      );
+      return new Uint8Array(bits);
+    }
+
+    function xor(left, right) {
+      if (left.length !== right.length) throw new Error('Invalid SCRAM proof length.');
+      return Uint8Array.from(left, (byte, index) => byte ^ right[index]);
+    }
+
+    function equalBytes(left, right) {
+      if (left.length !== right.length) return false;
+      let difference = 0;
+      for (let index = 0; index < left.length; index++) difference |= left[index] ^ right[index];
+      return difference === 0;
+    }
+
+    async function scramProof(username, password, clientNonce, challenge) {
+      if (challenge.mechanism !== 'SCRAM-SHA-256') throw new Error('Unsupported SCRAM mechanism.');
+      const salt = base64ToBytes(challenge.salt);
+      const serverNonce = challenge.server_nonce;
+      const combinedNonce = clientNonce + serverNonce;
+      const iterations = challenge.iterations;
+      const escapedUsername = escapeScramUsername(username);
+      const authMessage = utf8(
+        'n=' + escapedUsername + ',r=' + clientNonce +
+        ',r=' + combinedNonce + ',s=' + challenge.salt + ',i=' + iterations +
+        ',c=biws,r=' + combinedNonce
+      );
+      const passwordBytes = await saltedPassword(password, salt, iterations);
+      const clientKey = await hmac(passwordBytes, utf8('Client Key'));
+      const storedKey = await sha256(clientKey);
+      const clientSignature = await hmac(storedKey, authMessage);
+      const serverKey = await hmac(passwordBytes, utf8('Server Key'));
+      const serverSignature = await hmac(serverKey, authMessage);
+      return {
+        combinedNonce,
+        clientProof: bytesToBase64(xor(clientKey, clientSignature)),
+        serverSignature,
+      };
+    }
+
+    async function responseBody(response) {
+      try { return await response.json(); } catch (_) { return null; }
+    }
+
+    function responseError(response, body) {
+      const error = new Error((body && body.message) || ('Sign-in failed (HTTP ' + response.status + ').'));
+      error.code = body && body.code;
+      error.status = response.status;
+      return error;
+    }
+
+    async function legacyLogin(username, password, mfaToken) {
+      const body = { username, password };
+      if (mfaToken) body.mfa_token = mfaToken;
+      const response = await fetch('/api/v5/login', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const result = await responseBody(response);
+      if (!response.ok) throw responseError(response, result);
+      return result;
+    }
+
+    async function scramLogin(username, password, mfaToken) {
+      if (!window.crypto || !window.crypto.getRandomValues) {
+        throw new Error('This browser does not provide a secure random source.');
+      }
+      const clientNonce = randomNonce();
+      const challengeResponse = await fetch('/api/v5/login/challenge', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ username, client_nonce: clientNonce }),
+      });
+      const challenge = await responseBody(challengeResponse);
+      if (
+        legacyFallbackAllowed &&
+        challengeResponse.status === 404 &&
+        challenge &&
+        challenge.code === 'NOT_FOUND'
+      ) {
+        return legacyLogin(username, password, mfaToken);
+      }
+      if (!challengeResponse.ok) throw responseError(challengeResponse, challenge);
+      if (!window.isSecureContext || !window.crypto.subtle) {
+        throw new Error('SCRAM login requires HTTPS or another secure browser context.');
+      }
+      const proof = await scramProof(username, password, clientNonce, challenge);
+      const verifyBody = {
+        challenge_id: challenge.challenge_id,
+        combined_nonce: proof.combinedNonce,
+        client_proof: proof.clientProof,
+      };
+      if (mfaToken) verifyBody.mfa_token = mfaToken;
+      const verifyResponse = await fetch('/api/v5/login/verify', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(verifyBody),
+      });
+      const result = await responseBody(verifyResponse);
+      if (!verifyResponse.ok) throw responseError(verifyResponse, result);
+      if (!result || !result.token || !result.server_signature) {
+        throw new Error('SCRAM login succeeded but returned an incomplete response.');
+      }
+      if (!equalBytes(base64ToBytes(result.server_signature), proof.serverSignature)) {
+        throw new Error('SCRAM server verification failed.');
+      }
+      return result;
+    }
+
+    function setSessionCookie(token) {
+      const secure = location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie = 'emqx_auth=' + encodeURIComponent(token) + '; Path=/; SameSite=Strict' + secure;
+    }
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      errorElement.textContent = '';
+      submitButton.disabled = true;
+      try {
+        const username = usernameInput.value.trim();
+        const password = passwordInput.value;
+        const mfaToken = mfaInput.value.trim();
+        const result = await scramLogin(username, password, mfaToken);
+        if (!result || !result.token) throw new Error('Sign-in succeeded but no token was returned.');
+        setSessionCookie(result.token);
+        passwordInput.value = '';
+        mfaInput.value = '';
+        location.reload();
+      } catch (error) {
+        if (error.code === 'BAD_MFA_TOKEN') {
+          mfaField.classList.remove('hidden');
+          mfaInput.required = true;
+          mfaInput.focus();
+          errorElement.textContent = 'Enter the MFA token and submit again.';
+        } else {
+          errorElement.textContent = String(error.message || error);
+        }
+      } finally {
+        submitButton.disabled = false;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/apps/emqx_dashboard/priv/api-spec.html
+++ b/apps/emqx_dashboard/priv/api-spec.html
@@ -958,72 +958,6 @@
       border-color: var(--color-primary);
     }
 
-    .auth-overlay {
-      position: fixed;
-      inset: 0;
-      background: rgba(0, 0, 0, 0.55);
-      display: none;
-      align-items: center;
-      justify-content: center;
-      z-index: 50;
-    }
-
-    .auth-overlay.is-open {
-      display: flex;
-    }
-
-    .auth-dialog {
-      background: var(--color-bg-content);
-      border: 1px solid var(--color-border-primary);
-      border-radius: var(--radius-sm);
-      padding: 20px;
-      width: min(380px, calc(100vw - 32px));
-      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
-    }
-
-    .auth-dialog h3 {
-      margin: 0 0 6px 0;
-      font-size: 16px;
-    }
-
-    .auth-dialog p {
-      margin: 0 0 14px 0;
-      font-size: 12px;
-      color: var(--color-text-secondary);
-    }
-
-    .auth-dialog label {
-      display: block;
-      font-size: 12px;
-      color: var(--color-text-secondary);
-      margin-bottom: 4px;
-    }
-
-    .auth-dialog input {
-      width: 100%;
-      padding: 8px 10px;
-      margin-bottom: 12px;
-      border: 1px solid var(--color-border-primary);
-      border-radius: var(--radius-sm);
-      background: rgba(255, 255, 255, 0.04);
-      color: var(--color-text-primary);
-      font-size: 13px;
-      box-sizing: border-box;
-    }
-
-    .auth-dialog .auth-actions {
-      display: flex;
-      justify-content: flex-end;
-      gap: 8px;
-    }
-
-    .auth-dialog .auth-error {
-      color: #ffc9c9;
-      font-size: 12px;
-      margin-bottom: 10px;
-      min-height: 14px;
-    }
-
     @media (max-width: 1100px) {
       .layout {
         grid-template-columns: 1fr;
@@ -1100,27 +1034,11 @@
         </div>
       </div>
       <div class="actions">
-        <button class="btn" id="btn-logout" title="Sign out of the API spec session" hidden>Sign out</button>
         <button class="btn" id="btn-theme" title="Toggle light/dark theme">Dark</button>
         <span class="pill" id="scope-pill">Scope: index</span>
         <span class="status"><span class="dot"></span><span id="status-text">Ready</span></span>
       </div>
     </header>
-
-    <div class="auth-overlay" id="auth-overlay" role="dialog" aria-modal="true" aria-labelledby="auth-title">
-      <form class="auth-dialog" id="auth-form" autocomplete="off">
-        <h3 id="auth-title">Sign in to view the spec</h3>
-        <p id="auth-hint">Use your dashboard username and password. Credentials are scoped to this browser session.</p>
-        <div class="auth-error" id="auth-error"></div>
-        <label for="auth-username">Username</label>
-        <input id="auth-username" name="username" type="text" autocomplete="username" required />
-        <label for="auth-password">Password</label>
-        <input id="auth-password" name="password" type="password" autocomplete="current-password" required />
-        <div class="auth-actions">
-          <button type="submit" class="btn btn-primary" id="auth-submit">Sign in</button>
-        </div>
-      </form>
-    </div>
 
     <div class="layout">
       <aside class="sidebar">
@@ -1186,19 +1104,7 @@
       btnReload: document.getElementById('btn-reload'),
       btnCopyUrl: document.getElementById('btn-copy-url'),
       btnTheme: document.getElementById('btn-theme'),
-      btnLogout: document.getElementById('btn-logout'),
-      authOverlay: document.getElementById('auth-overlay'),
-      authForm: document.getElementById('auth-form'),
-      authUsername: document.getElementById('auth-username'),
-      authPassword: document.getElementById('auth-password'),
-      authError: document.getElementById('auth-error'),
-      authHint: document.getElementById('auth-hint'),
-      authSubmit: document.getElementById('auth-submit'),
     };
-
-    let signedInUsername = '';
-    let sessionToken = '';
-    let pendingAuthAction = null;
 
     init();
 
@@ -1249,88 +1155,6 @@
         setTheme(next);
       });
 
-      els.authForm.addEventListener('submit', onAuthSubmit);
-      els.btnLogout.addEventListener('click', onLogout);
-    }
-
-    function openAuthDialog(retry) {
-      pendingAuthAction = retry || null;
-      els.authError.textContent = '';
-      els.authOverlay.classList.add('is-open');
-      els.authPassword.value = '';
-      setTimeout(() => els.authUsername.focus(), 0);
-    }
-
-    function closeAuthDialog() {
-      els.authOverlay.classList.remove('is-open');
-    }
-
-    async function onAuthSubmit(e) {
-      e.preventDefault();
-      const username = els.authUsername.value.trim();
-      const password = els.authPassword.value;
-      if (!username || !password) return;
-      els.authError.textContent = '';
-      els.authSubmit.disabled = true;
-      try {
-        const res = await fetch('/api/v5/login', {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-          body: JSON.stringify({ username, password }),
-        });
-        let body = null;
-        try { body = await res.json(); } catch (_err) { body = null; }
-        if (!res.ok) {
-          let msg = `Sign-in failed (HTTP ${res.status}).`;
-          if (body && body.message) msg = body.message;
-          els.authError.textContent = msg;
-          return;
-        }
-        if (!body || !body.token) {
-          els.authError.textContent = 'Sign-in succeeded but no token was returned.';
-          return;
-        }
-        signedInUsername = username;
-        sessionToken = body.token;
-        setSessionCookie(body.token);
-        els.btnLogout.hidden = false;
-        closeAuthDialog();
-        const retry = pendingAuthAction;
-        pendingAuthAction = null;
-        if (retry) {
-          retry();
-        } else {
-          loadIndex();
-        }
-      } catch (err) {
-        els.authError.textContent = String(err.message || err);
-      } finally {
-        els.authSubmit.disabled = false;
-      }
-    }
-
-    async function onLogout() {
-      try {
-        await fetch('/api/v5/logout', {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: 'Bearer ' + sessionToken,
-          },
-          body: JSON.stringify({ username: signedInUsername }),
-        });
-      } catch (_err) {
-        // Even if the call fails, fall through and prompt for credentials again.
-      }
-      clearSessionCookie();
-      signedInUsername = '';
-      sessionToken = '';
-      els.btnLogout.hidden = true;
-      state.indexData = null;
-      state.specData = null;
-      openAuthDialog(() => loadIndex());
     }
 
     function setSessionCookie(token) {
@@ -1416,19 +1240,9 @@
         headers: { Accept: 'application/json' },
       });
       if (res.status === 401) {
-        let hint = 'Authentication required. Sign in to view the spec.';
-        try {
-          const body = await res.json();
-          const desc = body && body.info && body.info.description;
-          if (desc) hint = desc;
-        } catch (_err) {
-          // fall through with the default hint
-        }
-        els.authHint.textContent = hint;
-        signedInUsername = '';
-        els.btnLogout.hidden = true;
-        openAuthDialog(null);
-        const err = new Error(hint);
+        clearSessionCookie();
+        location.reload();
+        const err = new Error('Authentication required. Reloading the SCRAM login page.');
         err.status = 401;
         throw err;
       }

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -52,7 +52,8 @@
     all_users/0,
     admin_users/0,
     check/2,
-    check/3
+    check/3,
+    complete_scram_login/2
 ]).
 
 -export([
@@ -1121,6 +1122,39 @@ check_unchanged_default_credentials(Password) ->
             ok
     end.
 
+%% @doc Apply the same default-password policy after SCRAM has proved
+%% knowledge of the password.  The password itself is intentionally not
+%% available at this seam, so compare the stored verifier with the verifier
+%% for the known insecure default instead.
+check_unchanged_default_credentials_hash(PwdHash) ->
+    case emqx_security_profile:policy(dashboard_unchanged_default_credentials) of
+        allow ->
+            ok;
+        deny ->
+            case is_default_password_hash(PwdHash) of
+                true -> {error, <<"default_credentials_not_changed">>};
+                false -> ok
+            end
+    end.
+
+is_default_password_hash(<<"$1$", _/binary>> = PwdHash) ->
+    case emqx_dashboard_scram:from_pwdhash(PwdHash) of
+        {ok, #{salt := Salt, iterations := Iterations, salted_password := Expected}} ->
+            Actual = crypto:pbkdf2_hmac(
+                sha256, ?INSECURE_DEFAULT_PASSWORD, Salt, Iterations, 32
+            ),
+            crypto:hash_equals(Expected, Actual);
+        _ ->
+            false
+    end;
+is_default_password_hash(<<Salt:4/binary, Expected:32/binary>>) ->
+    crypto:hash_equals(
+        Expected,
+        legacy_sha256(Salt, ?INSECURE_DEFAULT_PASSWORD)
+    );
+is_default_password_hash(_) ->
+    false.
+
 verify_mfa_token(_Username, ?TRUSTED_MFA_TOKEN, _IsPwdOk) ->
     %% e.g. when handing change_pwd request which is authenticated
     %% by bearer token
@@ -1203,6 +1237,20 @@ sign_token(Username, Password, MfaToken) ->
     maybe
         ok ?= emqx_dashboard_login_lock:verify(Username),
         {ok, User} ?= check(Username, Password, MfaToken),
+        {ok, Result} ?= verify_password_expiration(ExpiredTime, User),
+        {ok, Role, Token, Namespace} ?= emqx_dashboard_token:sign(User),
+        {ok, Result#{?role => Role, token => Token, namespace => Namespace}}
+    end.
+
+-spec complete_scram_login(#?ADMIN{}, term()) ->
+    {ok, map()} | {error, term()}.
+complete_scram_login(#?ADMIN{username = Username, pwdhash = PwdHash} = User, MfaToken) ->
+    ExpiredTime = emqx:get_config([dashboard, password_expired_time], 0),
+    maybe
+        ok ?= emqx_dashboard_login_lock:verify(Username),
+        MfaVerifyResult = verify_mfa_token(Username, MfaToken, true),
+        ok ?= check_mfa_pwd(MfaVerifyResult, true),
+        ok ?= check_unchanged_default_credentials_hash(PwdHash),
         {ok, Result} ?= verify_password_expiration(ExpiredTime, User),
         {ok, Role, Token, Namespace} ?= emqx_dashboard_token:sign(User),
         {ok, Result#{?role => Role, token => Token, namespace => Namespace}}

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -24,6 +24,8 @@
 
 -export([
     login/2,
+    scram_challenge/2,
+    scram_verify/2,
     logout/2,
     users/2,
     user_scopes/2,
@@ -43,6 +45,9 @@
 -define(NOT_ALLOWED, 'NOT_ALLOWED').
 -define(BAD_REQUEST, 'BAD_REQUEST').
 -define(LOGIN_LOCKED, 'LOGIN_LOCKED').
+-define(PASSWORD_LOGIN_DISABLED, 'PASSWORD_LOGIN_DISABLED').
+-define(SCRAM_CHALLENGE_INVALID, 'SCRAM_CHALLENGE_INVALID').
+-define(SERVICE_UNAVAILABLE, 'SERVICE_UNAVAILABLE').
 
 namespace() -> "dashboard".
 
@@ -61,6 +66,8 @@ api_spec() ->
 scopes() ->
     #{
         <<"/login">> => ?SCOPE_PUBLIC,
+        <<"/login/challenge">> => ?SCOPE_PUBLIC,
+        <<"/login/verify">> => ?SCOPE_PUBLIC,
         <<"/logout">> => ?SCOPE_PUBLIC,
         <<"/user_scopes">> => ?SCOPE_PUBLIC,
         <<"/users">> => ?SCOPE_USER_MGMT,
@@ -72,6 +79,8 @@ scopes() ->
 paths() ->
     [
         "/login",
+        "/login/challenge",
+        "/login/verify",
         "/logout",
         "/users",
         "/users/:username",
@@ -92,7 +101,51 @@ schema("/login") ->
                 200 => fields([
                     role, token, version, license, password_expire_in_seconds
                 ]),
-                401 => emqx_dashboard_swagger:error_codes(ErrorCodes, ?DESC(login_failed401))
+                401 => emqx_dashboard_swagger:error_codes(ErrorCodes, ?DESC(login_failed401)),
+                403 => emqx_dashboard_swagger:error_codes(
+                    [?PASSWORD_LOGIN_DISABLED], ?DESC(login_failed_response400)
+                )
+            },
+            security => []
+        }
+    };
+schema("/login/challenge") ->
+    #{
+        'operationId' => scram_challenge,
+        post => #{
+            tags => [<<"dashboard">>],
+            desc => ?DESC(login_api),
+            'requestBody' => fields([username, client_nonce]),
+            responses => #{
+                200 => fields([mechanism, challenge_id, salt, iterations, server_nonce]),
+                400 => response_schema(400),
+                503 => response_schema(503)
+            },
+            security => []
+        }
+    };
+schema("/login/verify") ->
+    #{
+        'operationId' => scram_verify,
+        post => #{
+            tags => [<<"dashboard">>],
+            desc => ?DESC(login_api),
+            'requestBody' => fields([challenge_id, combined_nonce, client_proof, mfa_token]),
+            responses => #{
+                200 => fields([
+                    role,
+                    token,
+                    version,
+                    license,
+                    password_expire_in_seconds,
+                    server_signature
+                ]),
+                400 => response_schema(400),
+                401 => emqx_dashboard_swagger:error_codes(
+                    [?BAD_USERNAME_OR_PWD, ?BAD_MFA_TOKEN, ?LOGIN_LOCKED, ?SCRAM_CHALLENGE_INVALID],
+                    ?DESC(login_failed401)
+                ),
+                503 => response_schema(503)
             },
             security => []
         }
@@ -228,6 +281,10 @@ schema("/users/:username/mfa") ->
 
 response_schema(401) ->
     emqx_dashboard_swagger:error_codes([?BAD_USERNAME_OR_PWD], ?DESC(login_failed401));
+response_schema(400) ->
+    emqx_dashboard_swagger:error_codes([?BAD_REQUEST], ?DESC(login_failed_response400));
+response_schema(503) ->
+    emqx_dashboard_swagger:error_codes([?SERVICE_UNAVAILABLE], ?DESC(login_failed_response400));
 response_schema(404) ->
     emqx_dashboard_swagger:error_codes([?USER_NOT_FOUND], ?DESC(users_api404)).
 
@@ -321,12 +378,70 @@ field(backend) ->
     {backend, mk(binary(), #{desc => ?DESC(backend), example => <<"local">>})};
 field(password_expire_in_seconds) ->
     {password_expire_in_seconds,
-        mk(integer(), #{desc => ?DESC(password_expire_in_seconds), example => 3600})}.
+        mk(integer(), #{desc => ?DESC(password_expire_in_seconds), example => 3600})};
+field(mechanism) ->
+    {mechanism, mk(binary(), #{example => <<"SCRAM-SHA-256">>})};
+field(challenge_id) ->
+    {challenge_id,
+        mk(binary(), #{
+            required => true,
+            'maxLength' => 128,
+            example => <<"0123456789abcdefghijklmnopqrstuv">>
+        })};
+field(client_nonce) ->
+    {client_nonce,
+        mk(binary(), #{
+            desc => ?DESC(client_nonce),
+            required => true,
+            'maxLength' => 128,
+            example => <<"clientNonce1234567890">>
+        })};
+field(server_nonce) ->
+    {server_nonce, mk(binary(), #{example => <<"server-nonce">>})};
+field(combined_nonce) ->
+    {combined_nonce,
+        mk(binary(), #{
+            desc => ?DESC(combined_nonce),
+            required => true,
+            'maxLength' => 160,
+            example => <<"clientNonce1234567890serverNonce1234567890">>
+        })};
+field(client_proof) ->
+    {client_proof, mk(binary(), #{required => true, example => <<"base64-proof">>})};
+field(salt) ->
+    {salt, mk(binary(), #{example => <<"base64-salt">>})};
+field(iterations) ->
+    {iterations, mk(pos_integer(), #{example => 600000})};
+field(server_signature) ->
+    {server_signature, mk(binary(), #{example => <<"base64-signature">>})}.
+
+decode_base64(Bin) when is_binary(Bin) ->
+    try
+        {ok, base64:decode(Bin)}
+    catch
+        _:_ -> error
+    end;
+decode_base64(_) ->
+    error.
 
 %% -------------------------------------------------------------------------------------------------
 %% API
 
 login(post, #{body := Params}) ->
+    case emqx_dashboard_login:password_login_enabled() of
+        false ->
+            ?SLOG(error, #{
+                msg => "dashboard_plaintext_password_login_disabled",
+                endpoint => <<"/api/v5/login">>,
+                password_login_mode => scram_only,
+                username => maps:get(<<"username">>, Params, undefined)
+            }),
+            {403, ?PASSWORD_LOGIN_DISABLED, <<"Plaintext password login is disabled.">>};
+        true ->
+            login_enabled(post, Params)
+    end.
+
+login_enabled(post, Params) ->
     Username = maps:get(<<"username">>, Params),
     Password = maps:get(<<"password">>, Params),
     MfaToken = maps:get(<<"mfa_token">>, Params, ?NO_MFA_TOKEN),
@@ -354,6 +469,89 @@ login(post, #{body := Params}) ->
             }),
             format_login_failed_error(R)
     end.
+
+scram_challenge(post, #{body := Params}) ->
+    Username = maps:get(<<"username">>, Params),
+    ClientNonce = maps:get(<<"client_nonce">>, Params),
+    minirest_handler:update_log_meta(#{log_from => dashboard, log_source => Username}),
+    case emqx_dashboard_login:scram_challenge(Username, ClientNonce) of
+        {ok, Result} ->
+            {200, to_json_out(Result)};
+        {error, bad_request} ->
+            ?SLOG(info, #{msg => "dashboard_scram_challenge_failed", username => Username}),
+            {400, ?BAD_REQUEST, <<"Invalid SCRAM challenge request">>};
+        {error, capacity} ->
+            {503, ?SERVICE_UNAVAILABLE, <<"SCRAM challenge capacity exhausted">>};
+        {error, _Reason} ->
+            {503, ?SERVICE_UNAVAILABLE, <<"SCRAM challenge is unavailable">>}
+    end.
+
+scram_verify(post, #{body := Params}) ->
+    ChallengeId = maps:get(<<"challenge_id">>, Params),
+    CombinedNonce = maps:get(<<"combined_nonce">>, Params),
+    Proof0 = maps:get(<<"client_proof">>, Params),
+    MfaToken = maps:get(<<"mfa_token">>, Params, ?NO_MFA_TOKEN),
+    ScramUsername = scram_username(ChallengeId),
+    maybe_update_scram_log_meta(ScramUsername),
+    case decode_base64(Proof0) of
+        {ok, ClientProof} ->
+            case
+                emqx_dashboard_login:scram_verify(
+                    ChallengeId, CombinedNonce, ClientProof, MfaToken
+                )
+            of
+                {ok, Result0} ->
+                    ?SLOG(info, #{
+                        msg => "dashboard_login_successful",
+                        username => ScramUsername
+                    }),
+                    Version = iolist_to_binary(proplists:get_value(version, emqx_sys:info())),
+                    {200,
+                        to_json_out(Result0#{
+                            version => Version,
+                            license => #{edition => emqx_release:edition()}
+                        })};
+                {error, bad_request} ->
+                    log_scram_failure(ScramUsername, bad_request),
+                    {400, ?BAD_REQUEST, <<"Invalid SCRAM verification request">>};
+                {error, invalid_challenge} ->
+                    log_scram_failure(ScramUsername, invalid_challenge),
+                    {401, ?SCRAM_CHALLENGE_INVALID, <<"SCRAM challenge is invalid or expired">>};
+                {error, {storage_unavailable, _Reason}} ->
+                    log_scram_failure(ScramUsername, storage_unavailable),
+                    {503, ?SERVICE_UNAVAILABLE, <<"SCRAM challenge storage is unavailable">>};
+                {error, password_error} ->
+                    log_scram_failure(ScramUsername, password_error),
+                    {401, ?BAD_USERNAME_OR_PWD, <<"Auth failed">>};
+                {error, Reason} ->
+                    log_scram_failure(ScramUsername, Reason),
+                    format_login_failed_error(Reason)
+            end;
+        error ->
+            log_scram_failure(ScramUsername, bad_proof_encoding),
+            {400, ?BAD_REQUEST, <<"Invalid SCRAM proof encoding">>}
+    end.
+
+maybe_update_scram_log_meta(Username) ->
+    case Username of
+        Username0 when is_binary(Username0) ->
+            minirest_handler:update_log_meta(#{log_from => dashboard, log_source => Username0});
+        _ ->
+            ok
+    end.
+
+scram_username(ChallengeId) ->
+    case emqx_dashboard_login:owner(ChallengeId) of
+        {ok, Username} -> Username;
+        _ -> undefined
+    end.
+
+log_scram_failure(Username, Reason) ->
+    ?SLOG(info, #{
+        msg => "dashboard_login_failed",
+        username => Username,
+        reason => emqx_utils:redact(Reason)
+    }).
 
 format_login_failed_error(<<"default_credentials_not_changed">>) ->
     {401, ?BAD_USERNAME_OR_PWD,

--- a/apps/emqx_dashboard/src/emqx_dashboard_api_spec_handler.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api_spec_handler.erl
@@ -8,8 +8,9 @@
 Cowboy REST handler that serves focused, AI-consumable API specs.
 
 All endpoints require authentication (basic with API key/secret, bearer
-JWT from `POST /api/v5/login`, or the dashboard's `emqx_auth` session
-cookie). Unauthenticated requests get a 401 with a minimal but valid
+JWT from the SCRAM challenge/verify flow or legacy `POST /api/v5/login`,
+or the dashboard's `emqx_auth` session cookie). Unauthenticated requests get
+a 401 with a minimal but valid
 OpenAPI document (or its markdown equivalent for `/api-spec.md`) that
 points the caller at how to authenticate. The `WWW-Authenticate` header
 lists the supported schemes per RFC 7235 §4.1.
@@ -69,6 +70,7 @@ Endpoints:
 %% logged-out users see a generic stub. The authenticated spec keeps the
 %% real title and version.
 -define(GENERIC_API_TITLE, <<"EMQX API">>).
+-define(LEGACY_FALLBACK_MARKER, <<"__EMQX_LEGACY_FALLBACK_ALLOWED__">>).
 
 %%--------------------------------------------------------------------
 %% Cowboy REST callbacks
@@ -273,7 +275,11 @@ unauthorized_openapi_doc() ->
                     <<"type">> => <<"http">>,
                     <<"scheme">> => <<"bearer">>,
                     <<"description">> =>
-                        <<"JWT obtained from POST /api/v5/login.">>
+                        <<
+                            "JWT obtained from the SCRAM challenge/verify flow. "
+                            "The legacy POST /api/v5/login endpoint remains available "
+                            "in both mode."
+                        >>
                 }
             }
         },
@@ -282,15 +288,39 @@ unauthorized_openapi_doc() ->
             #{<<"bearerAuth">> => []}
         ],
         <<"paths">> => #{
-            <<"/login">> => #{
+            <<"/login/challenge">> => #{
                 <<"post">> => #{
-                    <<"summary">> => <<"Obtain a bearer token.">>,
+                    <<"summary">> => <<"Start a SCRAM-SHA-256 login.">>,
                     <<"tags">> => [<<"Authentication">>],
                     <<"security">> => [],
                     <<"responses">> => #{
                         <<"200">> => #{
                             <<"description">> =>
-                                <<"Bearer token returned in the response body.">>
+                                <<"SCRAM challenge returned.">>
+                        }
+                    }
+                }
+            },
+            <<"/login/verify">> => #{
+                <<"post">> => #{
+                    <<"summary">> => <<"Complete a SCRAM-SHA-256 login.">>,
+                    <<"tags">> => [<<"Authentication">>],
+                    <<"security">> => [],
+                    <<"responses">> => #{
+                        <<"200">> => #{
+                            <<"description">> => <<"Bearer token returned in the response body.">>
+                        }
+                    }
+                }
+            },
+            <<"/login">> => #{
+                <<"post">> => #{
+                    <<"summary">> => <<"Legacy password login for compatibility.">>,
+                    <<"tags">> => [<<"Authentication">>],
+                    <<"security">> => [],
+                    <<"responses">> => #{
+                        <<"200">> => #{
+                            <<"description">> => <<"Bearer token returned in the response body.">>
                         }
                     }
                 }
@@ -312,52 +342,20 @@ unauthorized_openapi_doc() ->
     }.
 
 unauthorized_html() ->
-    <<
-        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
-        "<title>",
-        ?GENERIC_API_TITLE/binary,
-        " - Sign in</title>"
-        "<meta name=\"robots\" content=\"noindex,nofollow\">"
-        "<style>"
-        "body{font:14px system-ui,sans-serif;background:#0e1116;color:#e6e6e6;"
-        "display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}"
-        "form{background:#161b22;border:1px solid #2a313a;border-radius:8px;"
-        "padding:24px;width:min(360px,calc(100vw - 32px))}"
-        "h1{margin:0 0 6px;font-size:16px}"
-        "p{margin:0 0 16px;color:#9aa4ae;font-size:12px}"
-        "label{display:block;font-size:12px;color:#9aa4ae;margin-bottom:4px}"
-        "input{width:100%;padding:8px 10px;margin-bottom:12px;border:1px solid #2a313a;"
-        "border-radius:6px;background:#0e1116;color:#e6e6e6;font-size:13px;box-sizing:border-box}"
-        "button{width:100%;padding:9px 12px;border:0;border-radius:6px;"
-        "background:#3b82f6;color:#fff;font-size:13px;cursor:pointer}"
-        "button:disabled{opacity:.6;cursor:not-allowed}"
-        ".err{color:#ffb4b4;font-size:12px;margin-bottom:10px;min-height:14px}"
-        "</style></head><body>"
-        "<form id=\"f\" autocomplete=\"off\">"
-        "<h1>Sign in to view the API specification</h1>"
-        "<p>Authenticate to access the in-tree API spec explorer.</p>"
-        "<div class=\"err\" id=\"e\"></div>"
-        "<label for=\"u\">Username</label>"
-        "<input id=\"u\" name=\"username\" autocomplete=\"username\" required>"
-        "<label for=\"p\">Password</label>"
-        "<input id=\"p\" name=\"password\" type=\"password\" autocomplete=\"current-password\" required>"
-        "<button id=\"b\" type=\"submit\">Sign in</button>"
-        "</form>"
-        "<script>"
-        "var f=document.getElementById('f'),e=document.getElementById('e'),b=document.getElementById('b');"
-        "f.addEventListener('submit',async function(ev){ev.preventDefault();e.textContent='';b.disabled=true;"
-        "try{var r=await fetch('/api/v5/login',{method:'POST',credentials:'same-origin',"
-        "headers:{'Content-Type':'application/json',Accept:'application/json'},"
-        "body:JSON.stringify({username:f.username.value.trim(),password:f.password.value})});"
-        "var body=null;try{body=await r.json()}catch(_){body=null}"
-        "if(!r.ok){e.textContent=(body&&body.message)||('Sign-in failed (HTTP '+r.status+').');return}"
-        "if(!body||!body.token){e.textContent='Sign-in succeeded but no token was returned.';return}"
-        "var sec=location.protocol==='https:'?'; Secure':'';"
-        "document.cookie='emqx_auth='+encodeURIComponent(body.token)+'; Path=/; SameSite=Strict'+sec;"
-        "location.reload()}catch(err){e.textContent=String(err.message||err)}finally{b.disabled=false}});"
-        "</script>"
-        "</body></html>"
-    >>.
+    HtmlPath = filename:join(code:priv_dir(emqx_dashboard), "api-spec-login.html"),
+    case file:read_file(HtmlPath) of
+        {ok, Body} ->
+            render_login_html(Body);
+        {error, _Reason} ->
+            <<"<!doctype html><title>EMQX API - Sign in</title>",
+                "<p>API Spec login page unavailable.</p>">>
+    end.
+
+render_login_html(Body) ->
+    LegacyFallbackAllowed = atom_to_binary(
+        emqx_dashboard_login:password_login_enabled(), utf8
+    ),
+    binary:replace(Body, ?LEGACY_FALLBACK_MARKER, LegacyFallbackAllowed, [global]).
 
 unauthorized_markdown() ->
     Lines = [
@@ -368,9 +366,11 @@ unauthorized_markdown() ->
         >>,
         <<"## Authentication\n\n">>,
         <<"- API key: `Authorization: Basic base64(api_key:api_secret)`\n">>,
-        <<"- Bearer token: `POST /api/v5/login`, then `Authorization: Bearer <token>`\n\n">>,
+        <<"- Browser login: use SCRAM `POST /api/v5/login/challenge` followed by `POST /api/v5/login/verify`.\n">>,
+        <<"- Legacy clients: `POST /api/v5/login` remains available when `dashboard.password_login = both`.\n\n">>,
         <<"## Public endpoints\n\n">>,
-        <<"- `POST /api/v5/login` - interactive login (returns a bearer token).\n">>,
+        <<"- `POST /api/v5/login/challenge` and `/api/v5/login/verify` - SCRAM browser login.\n">>,
+        <<"- `POST /api/v5/login` - legacy password login when enabled.\n">>,
         <<"- `GET  /api/v5/status` - broker health check.\n">>
     ],
     unicode:characters_to_binary(Lines).
@@ -460,8 +460,12 @@ auth_help_lines() ->
             "  * Or bootstrap API keys from file by setting, API_KEY__BOOTSTRAP_FILE=/path/to/my-api-keys, "
             "with file lines in '{api_key}:{api_secret}' format."
         >>,
-        <<"- Bearer token: `POST /api/v5/login`, then `Authorization: Bearer <token>`.">>,
-        <<"  * Request body: `{ \"username\": \"admin\", \"password\": \"...\" }`">>,
+        <<
+            "- Browser bearer token: use `POST /api/v5/login/challenge` and "
+            "`POST /api/v5/login/verify` with SCRAM-SHA-256."
+        >>,
+        <<"  * Browser login requires HTTPS or another secure browser context for Web Crypto.">>,
+        <<"- Legacy clients: `POST /api/v5/login` remains available when `dashboard.password_login = both`.">>,
         <<"  * Command to add new user: `emqx ctl admins add <Username> <Password> <Description> <Role>`">>,
         <<
             "The `/api-spec.md`, `/api-spec.json`, `/api-spec/...` and `/api-docs/swagger.json` "

--- a/apps/emqx_dashboard/src/emqx_dashboard_app.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_app.erl
@@ -17,10 +17,14 @@ start(_StartType, _StartArgs) ->
     Tables = lists:append([
         emqx_dashboard_admin:create_tables(),
         emqx_dashboard_token:create_tables(),
+        emqx_dashboard_login:create_tables(),
         emqx_dashboard_monitor:create_tables(),
         emqx_dashboard_login_lock:create_tables()
     ]),
     ok = mria:wait_for_tables(Tables),
+    start_dashboard().
+
+start_dashboard() ->
     {ok, Sup} = emqx_dashboard_sup:start_link(),
     ok = emqx_dashboard_hookcb:register_hooks(),
     case emqx_dashboard:start_listeners() of

--- a/apps/emqx_dashboard/src/emqx_dashboard_login.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_login.erl
@@ -1,0 +1,500 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc Dashboard login protocol orchestration.
+%%
+%% The HTTP module is intentionally a thin adapter.  This module owns the
+%% challenge lifecycle and keeps SCRAM, MFA, lockout, password policy and
+%% token issuance in one login seam.
+
+-module(emqx_dashboard_login).
+
+-behaviour(gen_server).
+
+-include("emqx_dashboard.hrl").
+-include_lib("emqx/include/logger.hrl").
+
+-export([
+    create_tables/0,
+    start_link/0,
+    scram_challenge/2,
+    scram_verify/4,
+    password_login_enabled/0,
+    owner/1
+]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-define(TAB, emqx_dashboard_scram_challenge).
+-define(META_TAB, emqx_dashboard_scram_meta).
+-define(MOCK_SALT_SECRET_KEY, mock_salt_secret).
+-define(MOCK_SALT_CONTEXT, <<"dashboard-scram-mock-salt:">>).
+-define(CHALLENGE_TTL_MS, 60 * 1000).
+-define(SCRAM_ITERATIONS, 600000).
+-define(CLEANUP_MS, 30 * 1000).
+-define(MAX_CHALLENGES, 100000).
+-define(MAX_CHALLENGES_PER_USERNAME, 16).
+-define(MIN_NONCE_BYTES, 20).
+-define(MAX_CLIENT_NONCE_BYTES, 128).
+-define(MAX_COMBINED_NONCE_BYTES, 160).
+
+-type challenge() :: #emqx_dashboard_scram_challenge{}.
+
+-spec create_tables() -> [?TAB | ?META_TAB].
+create_tables() ->
+    ok = mria:create_table(?TAB, [
+        {type, set},
+        {rlog_shard, ?DASHBOARD_SHARD},
+        {storage, ram_copies},
+        {record_name, emqx_dashboard_scram_challenge},
+        {attributes, record_info(fields, emqx_dashboard_scram_challenge)},
+        {storage_properties, [{ets, [{read_concurrency, true}, {write_concurrency, true}]}]}
+    ]),
+    ok = mria:create_table(?META_TAB, [
+        {type, set},
+        {rlog_shard, ?DASHBOARD_SHARD},
+        {storage, disc_copies},
+        {record_name, emqx_dashboard_scram_meta},
+        {attributes, record_info(fields, emqx_dashboard_scram_meta)}
+    ]),
+    [?TAB, ?META_TAB].
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec password_login_enabled() -> boolean().
+password_login_enabled() ->
+    password_login_mode() =:= both.
+
+password_login_mode() ->
+    emqx:get_config([dashboard, password_login], both).
+
+-spec scram_challenge(binary(), binary()) ->
+    {ok, map()}
+    | {error,
+        bad_request
+        | capacity
+        | challenge_id_collision
+        | {storage_unavailable, term()}}.
+scram_challenge(Username, ClientNonce) ->
+    case is_binary(Username) andalso valid_client_nonce(ClientNonce) of
+        false ->
+            {error, bad_request};
+        true ->
+            do_scram_challenge(Username, ClientNonce)
+    end.
+
+do_scram_challenge(Username, ClientNonce) ->
+    ServerNonce = nonce(),
+    case lookup_credential(Username) of
+        {ok, User, Verifier} ->
+            create_challenge(
+                Username,
+                ClientNonce,
+                ServerNonce,
+                maps:get(salt, Verifier),
+                maps:get(iterations, Verifier),
+                credential_fingerprint(User)
+            );
+        {error, unsupported} ->
+            log_password_migration_required(Username),
+            create_fake_challenge(Username, ClientNonce, ServerNonce);
+        {error, not_found} ->
+            create_fake_challenge(Username, ClientNonce, ServerNonce)
+    end.
+
+-spec scram_verify(binary(), binary(), binary(), term()) -> {ok, map()} | {error, term()}.
+scram_verify(ChallengeId, CombinedNonce, ClientProof, MfaToken) ->
+    case {valid_id(ChallengeId), valid_combined_nonce(CombinedNonce), is_binary(ClientProof)} of
+        {true, true, true} when byte_size(ClientProof) =:= 32 ->
+            do_scram_verify(ChallengeId, CombinedNonce, ClientProof, MfaToken);
+        _ ->
+            {error, bad_request}
+    end.
+
+do_scram_verify(ChallengeId, CombinedNonce, ClientProof, MfaToken) ->
+    Now = erlang:system_time(millisecond),
+    case take(ChallengeId) of
+        {error, not_found} ->
+            %% Unknown, replayed, and stateless fake challenges all fail as
+            %% authentication failures.  The client does not need to know
+            %% which kind of challenge was missing.
+            {error, password_error};
+        {error, {storage_unavailable, _Reason} = Error} ->
+            {error, Error};
+        {ok, #emqx_dashboard_scram_challenge{expires_at = ExpiresAt} = Challenge} ->
+            case ExpiresAt =< Now of
+                true -> {error, invalid_challenge};
+                false -> verify_challenge(Challenge, CombinedNonce, ClientProof, MfaToken)
+            end
+    end.
+
+verify_challenge(
+    #emqx_dashboard_scram_challenge{
+        username = Username,
+        client_nonce = ClientNonce,
+        server_nonce = ServerNonce,
+        credential_fingerprint = Fingerprint
+    },
+    CombinedNonce,
+    ClientProof,
+    MfaToken
+) ->
+    case CombinedNonce =:= <<ClientNonce/binary, ServerNonce/binary>> of
+        false ->
+            register_password_failure(Username),
+            {error, password_error};
+        true ->
+            verify_challenge_credential(
+                Username,
+                Fingerprint,
+                ClientNonce,
+                ServerNonce,
+                ClientProof,
+                MfaToken
+            )
+    end.
+
+verify_challenge_credential(Username, Fingerprint, ClientNonce, ServerNonce, ClientProof, MfaToken) ->
+    case lookup_credential(Username) of
+        {ok, User, Verifier} ->
+            verify_challenge_credential(
+                User,
+                Verifier,
+                Fingerprint,
+                ClientNonce,
+                ServerNonce,
+                ClientProof,
+                MfaToken
+            );
+        _ ->
+            password_error(Username)
+    end.
+
+verify_challenge_credential(
+    User,
+    Verifier,
+    Fingerprint,
+    ClientNonce,
+    ServerNonce,
+    ClientProof,
+    MfaToken
+) ->
+    case Fingerprint =:= credential_fingerprint(User) of
+        true -> verify_proof(User, Verifier, ClientNonce, ServerNonce, ClientProof, MfaToken);
+        false -> password_error(User#?ADMIN.username)
+    end.
+
+verify_proof(User, Verifier, ClientNonce, ServerNonce, ClientProof, MfaToken) ->
+    case
+        emqx_dashboard_scram:verify(
+            Verifier, User#?ADMIN.username, ClientNonce, ServerNonce, ClientProof
+        )
+    of
+        {ok, ServerSignature} -> complete_login(User, MfaToken, ServerSignature);
+        {error, invalid_proof} -> password_error(User#?ADMIN.username)
+    end.
+
+password_error(Username) ->
+    register_password_failure(Username),
+    {error, password_error}.
+complete_login(User, MfaToken, ServerSignature) ->
+    case emqx_dashboard_admin:complete_scram_login(User, MfaToken) of
+        {ok, Result} ->
+            ok = emqx_dashboard_login_lock:reset(User#?ADMIN.username),
+            {ok, Result#{server_signature => base64:encode(ServerSignature)}};
+        Error ->
+            Error
+    end.
+
+lookup_credential(Username) ->
+    case emqx_dashboard_admin:lookup_user(Username) of
+        [#?ADMIN{pwdhash = PwdHash} = User] ->
+            case emqx_dashboard_scram:from_pwdhash(PwdHash) of
+                {ok, Verifier} -> {ok, User, Verifier};
+                {error, unsupported} -> {error, unsupported};
+                {error, malformed} -> {error, unsupported}
+            end;
+        [] ->
+            {error, not_found}
+    end.
+
+create_fake_challenge(Username, _ClientNonce, ServerNonce) ->
+    %% Keep unknown and legacy users on the same stateless challenge path so
+    %% the server does not disclose credential state. Fake challenges never
+    %% issue a token and therefore must not consume challenge-table capacity.
+    Salt = mock_salt(Username),
+    {ok, #{
+        mechanism => <<"SCRAM-SHA-256">>,
+        challenge_id => id(),
+        salt => base64:encode(Salt),
+        iterations => ?SCRAM_ITERATIONS,
+        server_nonce => ServerNonce
+    }}.
+
+create_challenge(Username, ClientNonce, ServerNonce, Salt, Iterations, Fingerprint) ->
+    Id = id(),
+    Challenge = #emqx_dashboard_scram_challenge{
+        id = Id,
+        username = Username,
+        client_nonce = ClientNonce,
+        server_nonce = ServerNonce,
+        salt = Salt,
+        iterations = Iterations,
+        credential_fingerprint = Fingerprint,
+        expires_at = erlang:system_time(millisecond) + ?CHALLENGE_TTL_MS
+    },
+    case put(Challenge) of
+        ok ->
+            {ok, #{
+                mechanism => <<"SCRAM-SHA-256">>,
+                challenge_id => Id,
+                salt => base64:encode(Salt),
+                iterations => Iterations,
+                server_nonce => ServerNonce
+            }};
+        {error, capacity} ->
+            {error, capacity};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+register_password_failure(Username) when is_binary(Username) ->
+    emqx_dashboard_login_lock:register_unsuccessful_login(Username);
+register_password_failure(_) ->
+    ok.
+
+credential_fingerprint(#?ADMIN{pwdhash = PwdHash}) ->
+    crypto:hash(sha256, PwdHash).
+
+mock_salt(Username) ->
+    Secret = mock_salt_secret(),
+    Digest = crypto:mac(hmac, sha256, Secret, <<?MOCK_SALT_CONTEXT/binary, Username/binary>>),
+    binary:part(Digest, 0, 16).
+
+mock_salt_secret() ->
+    case ets:lookup(?META_TAB, ?MOCK_SALT_SECRET_KEY) of
+        [#emqx_dashboard_scram_meta{value = Secret}] ->
+            Secret;
+        [] ->
+            error({scram_meta_not_found, ?MOCK_SALT_SECRET_KEY})
+    end.
+
+log_password_migration_required(Username) ->
+    Event = #{
+        msg => "dashboard_scram_password_migration_required",
+        username => Username,
+        migration_command => iolist_to_binary([
+            <<"emqx ctl admins passwd ">>,
+            Username,
+            <<" <new-password>">>
+        ])
+    },
+    case password_login_mode() of
+        scram_only ->
+            ?SLOG(error, Event#{password_login_mode => scram_only});
+        both ->
+            ?SLOG(warning, Event#{password_login_mode => both});
+        Mode ->
+            ?SLOG(warning, Event#{password_login_mode => Mode})
+    end.
+
+nonce() ->
+    base64:encode(crypto:strong_rand_bytes(24), #{mode => urlsafe, padding => false}).
+
+id() ->
+    base64:encode(crypto:strong_rand_bytes(24), #{mode => urlsafe, padding => false}).
+
+valid_id(Id) ->
+    valid_nonce(Id, ?MIN_NONCE_BYTES, ?MAX_CLIENT_NONCE_BYTES).
+
+valid_client_nonce(Nonce) ->
+    valid_nonce(Nonce, ?MIN_NONCE_BYTES, ?MAX_CLIENT_NONCE_BYTES).
+
+valid_combined_nonce(Nonce) ->
+    valid_nonce(Nonce, ?MIN_NONCE_BYTES, ?MAX_COMBINED_NONCE_BYTES).
+
+valid_nonce(Bin, MinBytes, MaxBytes) when is_binary(Bin) ->
+    byte_size(Bin) >= MinBytes andalso byte_size(Bin) =< MaxBytes andalso
+        lists:all(fun valid_nonce_char/1, binary_to_list(Bin));
+valid_nonce(_, _, _) ->
+    false.
+
+valid_nonce_char(C) when C >= $A, C =< $Z -> true;
+valid_nonce_char(C) when C >= $a, C =< $z -> true;
+valid_nonce_char(C) when C >= $0, C =< $9 -> true;
+valid_nonce_char($_) -> true;
+valid_nonce_char($-) -> true;
+valid_nonce_char(_) -> false.
+
+%%--------------------------------------------------------------------
+%% Challenge state implementation
+%%--------------------------------------------------------------------
+
+-spec put(challenge()) ->
+    ok | {error, capacity | challenge_id_collision | {storage_unavailable, term()}}.
+put(#emqx_dashboard_scram_challenge{username = Username} = Challenge) ->
+    case ets:info(?TAB, size) of
+        Size when is_integer(Size), Size >= ?MAX_CHALLENGES ->
+            {error, capacity};
+        Size when is_integer(Size) ->
+            case local_username_challenge_count(Username) >= ?MAX_CHALLENGES_PER_USERNAME of
+                true -> {error, capacity};
+                false -> put_if_available(Challenge)
+            end;
+        undefined ->
+            {error, {storage_unavailable, table_not_found}}
+    end.
+
+local_username_challenge_count(Username) ->
+    ets:select_count(?TAB, [
+        {
+            {emqx_dashboard_scram_challenge, '_', Username, '_', '_', '_', '_', '_', '_', '_'},
+            [],
+            [true]
+        }
+    ]).
+
+put_if_available(#emqx_dashboard_scram_challenge{id = Id} = Challenge) ->
+    Result = mria:sync_transaction(?DASHBOARD_SHARD, fun() -> put_transaction(Id, Challenge) end),
+    format_put_result(Result).
+
+put_transaction(Id, Challenge) ->
+    case mnesia:read(?TAB, Id, write) of
+        [] ->
+            mnesia:write(Challenge),
+            ok;
+        _ ->
+            mnesia:abort(challenge_id_collision)
+    end.
+
+format_put_result({atomic, ok}) ->
+    ok;
+format_put_result({aborted, challenge_id_collision}) ->
+    {error, challenge_id_collision};
+format_put_result({aborted, Reason}) ->
+    {error, {storage_unavailable, Reason}};
+format_put_result({timeout, {atomic, ok}}) ->
+    ok;
+format_put_result({timeout, {aborted, challenge_id_collision}}) ->
+    {error, challenge_id_collision};
+format_put_result({timeout, {aborted, Reason}}) ->
+    {error, {storage_unavailable, Reason}};
+format_put_result({timeout, {error, Reason}}) ->
+    {error, {storage_unavailable, Reason}}.
+
+-spec take(binary()) ->
+    {ok, challenge()}
+    | {error, not_found | {storage_unavailable, term()}}.
+take(Id) ->
+    TransactionResult = mria:sync_transaction(
+        ?DASHBOARD_SHARD,
+        fun() -> take_transaction(Id) end
+    ),
+    case TransactionResult of
+        {atomic, Value} -> Value;
+        {aborted, Reason} -> {error, {storage_unavailable, Reason}};
+        {timeout, {atomic, Value}} -> Value;
+        {timeout, {aborted, Reason}} -> {error, {storage_unavailable, Reason}};
+        {timeout, {error, Reason}} -> {error, {storage_unavailable, Reason}}
+    end.
+
+take_transaction(Id) ->
+    case mnesia:read(?TAB, Id, write) of
+        [Challenge] ->
+            ok = mnesia:delete({?TAB, Id}),
+            {ok, Challenge};
+        [] ->
+            {error, not_found}
+    end.
+
+-spec owner(binary()) -> {ok, binary()} | {error, not_found}.
+owner(Id) ->
+    case mria:ro_transaction(?DASHBOARD_SHARD, fun() -> mnesia:read(?TAB, Id) end) of
+        {atomic, [#emqx_dashboard_scram_challenge{username = Username}]} ->
+            {ok, Username};
+        _ ->
+            {error, not_found}
+    end.
+
+init([]) ->
+    case ensure_mock_salt_secret() of
+        ok ->
+            schedule_cleanup(),
+            {ok, state};
+        {error, Reason} ->
+            {stop, Reason}
+    end.
+
+ensure_mock_salt_secret() ->
+    Result = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        case mnesia:read(?META_TAB, ?MOCK_SALT_SECRET_KEY, write) of
+            [#emqx_dashboard_scram_meta{value = _Secret}] ->
+                ok;
+            [] ->
+                Secret = crypto:strong_rand_bytes(32),
+                ok = mnesia:write(#emqx_dashboard_scram_meta{
+                    key = ?MOCK_SALT_SECRET_KEY,
+                    value = Secret
+                }),
+                ok
+        end
+    end),
+    case Result of
+        {atomic, ok} -> ok;
+        {timeout, {atomic, ok}} -> ok;
+        {aborted, Reason} -> {error, {storage_unavailable, Reason}};
+        {timeout, {aborted, Reason}} -> {error, {storage_unavailable, Reason}};
+        {timeout, {error, Reason}} -> {error, {storage_unavailable, Reason}}
+    end.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(cleanup, State) ->
+    cleanup_expired(erlang:system_time(millisecond)),
+    schedule_cleanup(),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+schedule_cleanup() ->
+    _ = erlang:send_after(?CLEANUP_MS, self(), cleanup),
+    ok.
+
+cleanup_expired(Now) ->
+    Spec = [
+        {
+            {emqx_dashboard_scram_challenge, '_', '_', '_', '_', '_', '_', '_', '$1', '_'},
+            [{'<', '$1', Now}],
+            ['$_']
+        }
+    ],
+    case
+        mria:ro_transaction(?DASHBOARD_SHARD, fun() ->
+            mnesia:select(?TAB, Spec)
+        end)
+    of
+        {atomic, []} ->
+            ok;
+        {atomic, Challenges} ->
+            _ = mria:async_dirty(?DASHBOARD_SHARD, fun() ->
+                lists:foreach(
+                    fun(#emqx_dashboard_scram_challenge{id = Id}) ->
+                        mria:dirty_delete(?TAB, Id)
+                    end,
+                    Challenges
+                )
+            end),
+            ok;
+        _ ->
+            ok
+    end.

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
@@ -67,6 +67,15 @@ fields("dashboard") ->
                     desc => ?DESC(password_expired_time)
                 }
             )},
+        {password_login,
+            ?HOCON(
+                hoconsc:enum([both, scram_only]),
+                #{
+                    default => both,
+                    desc => ?DESC(password_login),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
         {cors, fun cors/1},
         {swagger_support, fun swagger_support/1},
         {i18n_lang, fun i18n_lang/1},

--- a/apps/emqx_dashboard/src/emqx_dashboard_scram.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_scram.erl
@@ -1,0 +1,139 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc The fixed SCRAM-SHA-256 profile used by Dashboard login.
+%%
+%% The HTTP layer transports the fields as JSON, but the values below are
+%% deliberately constructed as the canonical SCRAM message fragments.  JSON
+%% serialization must never become part of AuthMessage.
+
+-module(emqx_dashboard_scram).
+
+-export([
+    from_pwdhash/1,
+    client_proof/6,
+    verify/5,
+    server_first/4
+]).
+
+-define(SHA256_BYTES, 32).
+-define(MIN_ITERATIONS, 4096).
+-define(MAX_ITERATIONS, 10000000).
+
+-type verifier() :: #{
+    iterations := pos_integer(),
+    salt := binary(),
+    salted_password := binary(),
+    stored_key := binary(),
+    server_key := binary()
+}.
+
+-spec from_pwdhash(binary()) -> {ok, verifier()} | {error, unsupported | malformed}.
+from_pwdhash(<<"$1$", Rest/binary>>) ->
+    case binary:split(Rest, <<"$">>, [global]) of
+        [IterationBin, SaltBin, SaltedPasswordBin] ->
+            try
+                Iterations = binary_to_integer(IterationBin),
+                Salt = base64:decode(SaltBin, #{padding => false}),
+                SaltedPassword = base64:decode(SaltedPasswordBin, #{padding => false}),
+                true = valid_iterations(Iterations),
+                true = byte_size(Salt) =:= 16,
+                true = byte_size(SaltedPassword) =:= ?SHA256_BYTES,
+                {ok, verifier_from_salted_password(Iterations, Salt, SaltedPassword)}
+            catch
+                _:_ -> {error, malformed}
+            end;
+        _ ->
+            {error, malformed}
+    end;
+from_pwdhash(<<_:36/binary>>) ->
+    %% The pre-6.4 Dashboard hash cannot be used as SCRAM SaltedPassword.
+    {error, unsupported};
+from_pwdhash(_) ->
+    {error, malformed}.
+
+-spec server_first(binary(), binary(), binary(), pos_integer()) -> binary().
+server_first(ClientNonce, ServerNonce, Salt, Iterations) ->
+    CombinedNonce = <<ClientNonce/binary, ServerNonce/binary>>,
+    iolist_to_binary([
+        <<"r=">>,
+        CombinedNonce,
+        <<",s=">>,
+        base64:encode(Salt),
+        <<",i=">>,
+        integer_to_binary(Iterations)
+    ]).
+
+-spec client_proof(binary(), binary(), binary(), binary(), pos_integer(), binary()) -> binary().
+client_proof(Username, ClientNonce, ServerNonce, Salt, Iterations, Password) ->
+    SaltedPassword = crypto:pbkdf2_hmac(sha256, Password, Salt, Iterations, ?SHA256_BYTES),
+    ClientKey = hmac(SaltedPassword, <<"Client Key">>),
+    StoredKey = crypto:hash(sha256, ClientKey),
+    AuthMessage = auth_message(Username, ClientNonce, ServerNonce, Salt, Iterations),
+    ClientSignature = hmac(StoredKey, AuthMessage),
+    crypto:exor(ClientKey, ClientSignature).
+
+-spec verify(verifier(), binary(), binary(), binary(), binary()) ->
+    {ok, binary()} | {error, invalid_proof}.
+verify(
+    #{
+        stored_key := StoredKey,
+        server_key := ServerKey,
+        salt := Salt,
+        iterations := Iterations
+    },
+    Username,
+    ClientNonce,
+    ServerNonce,
+    ClientProof
+) when byte_size(ClientProof) =:= ?SHA256_BYTES ->
+    AuthMessage = auth_message(Username, ClientNonce, ServerNonce, Salt, Iterations),
+    ClientSignature = hmac(StoredKey, AuthMessage),
+    RecoveredClientKey = crypto:exor(ClientProof, ClientSignature),
+    case crypto:hash_equals(StoredKey, crypto:hash(sha256, RecoveredClientKey)) of
+        true ->
+            {ok, hmac(ServerKey, AuthMessage)};
+        false ->
+            {error, invalid_proof}
+    end;
+verify(_, _, _, _, _) ->
+    {error, invalid_proof}.
+
+verifier_from_salted_password(Iterations, Salt, SaltedPassword) ->
+    ClientKey = hmac(SaltedPassword, <<"Client Key">>),
+    #{
+        iterations => Iterations,
+        salt => Salt,
+        salted_password => SaltedPassword,
+        stored_key => crypto:hash(sha256, ClientKey),
+        server_key => hmac(SaltedPassword, <<"Server Key">>)
+    }.
+
+auth_message(Username, ClientNonce, ServerNonce, Salt, Iterations) ->
+    %% The username is escaped only for the SCRAM client-first-message-bare.
+    %% Credential lookup and the username stored in the challenge remain raw.
+    EscapedUsername = escape_username(Username),
+    CombinedNonce = <<ClientNonce/binary, ServerNonce/binary>>,
+    ClientFirstBare = <<"n=", EscapedUsername/binary, ",r=", ClientNonce/binary>>,
+    ServerFirst = server_first(ClientNonce, ServerNonce, Salt, Iterations),
+    ClientFinalWithoutProof = <<"c=biws,r=", CombinedNonce/binary>>,
+    iolist_to_binary([
+        ClientFirstBare,
+        <<",">>,
+        ServerFirst,
+        <<",">>,
+        ClientFinalWithoutProof
+    ]).
+
+escape_username(Username) ->
+    %% RFC 5802 saslname escaping.  Replace '=' before ',' so the '='
+    %% introduced by comma escaping is not escaped again.
+    EscapedEquals = binary:replace(Username, <<"=">>, <<"=3D">>, [global]),
+    binary:replace(EscapedEquals, <<",">>, <<"=2C">>, [global]).
+
+hmac(Key, Data) ->
+    crypto:mac(hmac, sha256, Key, Data).
+
+valid_iterations(Iterations) ->
+    Iterations >= ?MIN_ITERATIONS andalso Iterations =< ?MAX_ITERATIONS.

--- a/apps/emqx_dashboard/src/emqx_dashboard_sup.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_sup.erl
@@ -23,6 +23,7 @@ init([]) ->
             ?CHILD(emqx_dashboard_dispatch, 5000),
             ?CHILD(emqx_dashboard_listener_config, 5000),
             ?CHILD(emqx_dashboard_token, 5000),
+            ?CHILD(emqx_dashboard_login, 5000),
             ?CHILD(emqx_dashboard_monitor, 5000),
             ?CHILD(emqx_dashboard_login_lock, 5000)
         ]}}.

--- a/apps/emqx_dashboard/test/emqx_dashboard_api_spec_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_api_spec_SUITE.erl
@@ -165,6 +165,8 @@ t_api_spec_html(_Config) ->
     ?assert(string:find(list_to_binary(ContentType), <<"text/html">>) =/= nomatch),
     BodyBin = list_to_binary(Body),
     ?assert(string:find(BodyBin, <<"EMQX API Spec Explorer">>) =/= nomatch),
+    ?assertEqual(nomatch, string:find(BodyBin, <<"fetch('/api/v5/login'">>)),
+    ?assert(string:find(BodyBin, <<"location.reload()">>) =/= nomatch),
     {401, StubHeaders, StubBody} = do_get_raw("/api-spec.html", []),
     StubContentType = proplists:get_value("content-type", StubHeaders, ""),
     ?assert(string:find(list_to_binary(StubContentType), <<"text/html">>) =/= nomatch),
@@ -182,8 +184,44 @@ t_api_spec_html(_Config) ->
     ),
     StubBin = list_to_binary(StubBody),
     ?assert(string:find(StubBin, <<"Sign in">>) =/= nomatch),
+    ?assert(string:find(StubBin, <<"const legacyFallbackAllowed = true;">>) =/= nomatch),
+    ?assert(string:find(StubBin, <<"/api/v5/login/challenge">>) =/= nomatch),
+    ?assert(string:find(StubBin, <<"/api/v5/login/verify">>) =/= nomatch),
+    ?assert(string:find(StubBin, <<"function escapeScramUsername(username)">>) =/= nomatch),
+    ?assert(
+        string:find(
+            StubBin,
+            <<"return username.replace(/=/g, '=3D').replace(/,/g, '=2C');">>
+        ) =/= nomatch
+    ),
+    ?assert(
+        string:find(StubBin, <<"const escapedUsername = escapeScramUsername(username);">>) =/=
+            nomatch
+    ),
+    ?assert(string:find(StubBin, <<"'n=' + escapedUsername + ',r='">>) =/= nomatch),
+    ?assert(string:find(StubBin, <<"crypto.subtle">>) =/= nomatch),
+    ?assertEqual(
+        nomatch,
+        string:find(
+            StubBin,
+            <<"JSON.stringify({username:f.username.value.trim(),password:f.password.value})">>
+        )
+    ),
     %% Stub must not include the full explorer markup.
     ?assertEqual(nomatch, string:find(StubBin, <<"EMQX API Spec Explorer">>)).
+
+-doc "Verify scram_only disables the embedded page's legacy fallback.".
+t_api_spec_html_scram_only_no_legacy_fallback(_Config) ->
+    ok = emqx_config:put([dashboard, password_login], scram_only),
+    try
+        {401, _Headers, RawBody} = do_get_raw("/api-spec.html", []),
+        Body = list_to_binary(RawBody),
+        ?assert(string:find(Body, <<"const legacyFallbackAllowed = false;">>) =/= nomatch),
+        ?assert(string:find(Body, <<"legacyFallbackAllowed &&">>) =/= nomatch),
+        ?assert(string:find(Body, <<"challengeResponse.status === 404">>) =/= nomatch)
+    after
+        ok = emqx_config:put([dashboard, password_login], both)
+    end.
 
 -doc "Verify /api-spec/:tag returns a valid OpenAPI 3.0.0 doc with correctly tagged paths.".
 t_tag_spec(_Config) ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_login_scram_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_login_scram_SUITE.erl
@@ -1,0 +1,526 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_dashboard_login_scram_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include("emqx_dashboard.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(USERNAME, <<"scram_admin">>).
+-define(PASSWORD, <<"scramP@ss1">>).
+-define(GOOD_TOTP, <<"123456">>).
+
+-record(login_attempts, {key, extra}).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            emqx_conf,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(apps, Config)).
+
+init_per_testcase(_Case, Config) ->
+    mnesia:clear_table(?ADMIN),
+    mnesia:clear_table(?ADMIN_JWT),
+    mnesia:clear_table(emqx_dashboard_scram_challenge),
+    emqx_dashboard_login_lock:cleanup_all(),
+    emqx_config:put([dashboard, password_login], both),
+    {ok, _} = emqx_dashboard_admin:add_user(
+        ?USERNAME, ?PASSWORD, ?ROLE_SUPERUSER, <<"SCRAM test user">>
+    ),
+    Config.
+
+t_scram_login_roundtrip(_) ->
+    ClientNonce = <<"clientNonce1234567890">>,
+    {ok, Challenge} = emqx_dashboard_login:scram_challenge(?USERNAME, ClientNonce),
+    Salt = base64:decode(maps:get(salt, Challenge)),
+    Iterations = maps:get(iterations, Challenge),
+    ServerNonce = maps:get(server_nonce, Challenge),
+    [#?ADMIN{pwdhash = PwdHash}] = emqx_dashboard_admin:lookup_user(?USERNAME),
+    {ok, _Verifier} = emqx_dashboard_scram:from_pwdhash(PwdHash),
+    Proof = emqx_dashboard_scram:client_proof(
+        ?USERNAME,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        Iterations,
+        ?PASSWORD
+    ),
+    CombinedNonce = <<ClientNonce/binary, ServerNonce/binary>>,
+    {ok, Result} = emqx_dashboard_login:scram_verify(
+        maps:get(challenge_id, Challenge),
+        CombinedNonce,
+        Proof,
+        ?NO_MFA_TOKEN
+    ),
+    ?assert(is_binary(maps:get(token, Result))),
+    ?assertEqual(32, byte_size(base64:decode(maps:get(server_signature, Result)))),
+    ?assertEqual(
+        {error, password_error},
+        emqx_dashboard_login:scram_verify(
+            maps:get(challenge_id, Challenge),
+            CombinedNonce,
+            Proof,
+            ?NO_MFA_TOKEN
+        )
+    ).
+
+t_long_client_nonce_roundtrip(_) ->
+    ClientNonce = binary:copy(<<"a">>, 128),
+    {ok, Challenge} = emqx_dashboard_login:scram_challenge(?USERNAME, ClientNonce),
+    Salt = base64:decode(maps:get(salt, Challenge)),
+    ServerNonce = maps:get(server_nonce, Challenge),
+    Proof = emqx_dashboard_scram:client_proof(
+        ?USERNAME,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        maps:get(iterations, Challenge),
+        ?PASSWORD
+    ),
+    ?assertMatch(
+        {ok, _},
+        emqx_dashboard_login:scram_verify(
+            maps:get(challenge_id, Challenge),
+            <<ClientNonce/binary, ServerNonce/binary>>,
+            Proof,
+            ?NO_MFA_TOKEN
+        )
+    ).
+
+t_scram_password_changed_invalidates_challenge(_) ->
+    ClientNonce = <<"clientNonce1234567890">>,
+    {ok, Challenge} = emqx_dashboard_login:scram_challenge(?USERNAME, ClientNonce),
+    Salt = base64:decode(maps:get(salt, Challenge)),
+    ServerNonce = maps:get(server_nonce, Challenge),
+    Proof = emqx_dashboard_scram:client_proof(
+        ?USERNAME,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        maps:get(iterations, Challenge),
+        ?PASSWORD
+    ),
+    {ok, _} = emqx_dashboard_admin:change_password_trusted(?USERNAME, <<"newP@ss2">>),
+    ?assertEqual(
+        {error, password_error},
+        emqx_dashboard_login:scram_verify(
+            maps:get(challenge_id, Challenge),
+            <<ClientNonce/binary, ServerNonce/binary>>,
+            Proof,
+            ?NO_MFA_TOKEN
+        )
+    ).
+
+t_expired_scram_challenge_rejected(_) ->
+    ClientNonce = <<"clientNonce1234567890">>,
+    {ok, Challenge} = emqx_dashboard_login:scram_challenge(?USERNAME, ClientNonce),
+    ChallengeId = maps:get(challenge_id, Challenge),
+    {atomic, ok} = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        [Stored] = mnesia:read(emqx_dashboard_scram_challenge, ChallengeId, write),
+        mnesia:write(Stored#emqx_dashboard_scram_challenge{
+            expires_at = erlang:system_time(millisecond) - 1
+        })
+    end),
+    ?assertEqual(
+        {error, invalid_challenge},
+        emqx_dashboard_login:scram_verify(
+            ChallengeId,
+            <<ClientNonce/binary, (maps:get(server_nonce, Challenge))/binary>>,
+            crypto:strong_rand_bytes(32),
+            ?NO_MFA_TOKEN
+        )
+    ).
+
+t_wrong_proof_counts_as_password_failure(_) ->
+    ClientNonce = <<"clientNonce1234567890">>,
+    {ok, Challenge} = emqx_dashboard_login:scram_challenge(?USERNAME, ClientNonce),
+    Salt = base64:decode(maps:get(salt, Challenge)),
+    ServerNonce = maps:get(server_nonce, Challenge),
+    WrongProof = emqx_dashboard_scram:client_proof(
+        ?USERNAME,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        maps:get(iterations, Challenge),
+        <<"wrongP@ss1">>
+    ),
+    CombinedNonce = <<ClientNonce/binary, ServerNonce/binary>>,
+    ?assertEqual(
+        {error, password_error},
+        emqx_dashboard_login:scram_verify(
+            maps:get(challenge_id, Challenge),
+            CombinedNonce,
+            WrongProof,
+            ?NO_MFA_TOKEN
+        )
+    ),
+    ?assertEqual(ok, emqx_dashboard_login_lock:verify(?USERNAME)).
+
+t_scram_challenge_limit_per_username(_) ->
+    ClientNonce = <<"clientNonce1234567890">>,
+    Challenges = [
+        begin
+            {ok, Challenge} = emqx_dashboard_login:scram_challenge(?USERNAME, ClientNonce),
+            Challenge
+        end
+     || _ <- lists:seq(1, 16)
+    ],
+    ?assertEqual(
+        {error, capacity},
+        emqx_dashboard_login:scram_challenge(?USERNAME, ClientNonce)
+    ),
+    ?assertEqual(
+        16,
+        length(
+            mnesia:dirty_match_object(
+                emqx_dashboard_scram_challenge,
+                #emqx_dashboard_scram_challenge{username = ?USERNAME, _ = '_'}
+            )
+        )
+    ),
+    _ = Challenges,
+    First = hd(Challenges),
+    Salt = base64:decode(maps:get(salt, First)),
+    ServerNonce = maps:get(server_nonce, First),
+    Proof = emqx_dashboard_scram:client_proof(
+        ?USERNAME,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        maps:get(iterations, First),
+        ?PASSWORD
+    ),
+    {ok, _} = emqx_dashboard_login:scram_verify(
+        maps:get(challenge_id, First),
+        <<ClientNonce/binary, ServerNonce/binary>>,
+        Proof,
+        ?NO_MFA_TOKEN
+    ),
+    ?assertMatch({ok, _}, emqx_dashboard_login:scram_challenge(?USERNAME, ClientNonce)).
+
+t_scram_login_locked_after_challenge(_) ->
+    ClientNonce = <<"clientNonce1234567890">>,
+    {ok, Challenge} = emqx_dashboard_login:scram_challenge(?USERNAME, ClientNonce),
+    Salt = base64:decode(maps:get(salt, Challenge)),
+    ServerNonce = maps:get(server_nonce, Challenge),
+    Proof = emqx_dashboard_scram:client_proof(
+        ?USERNAME,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        maps:get(iterations, Challenge),
+        ?PASSWORD
+    ),
+    {ok, _} = emqx_dashboard_admin:set_login_lock(
+        ?USERNAME,
+        erlang:system_time(second) + 60
+    ),
+    ?assertEqual(
+        {error, login_locked},
+        emqx_dashboard_login:scram_verify(
+            maps:get(challenge_id, Challenge),
+            <<ClientNonce/binary, ServerNonce/binary>>,
+            Proof,
+            ?NO_MFA_TOKEN
+        )
+    ).
+
+t_http_password_login_disabled(_) ->
+    emqx_config:put([dashboard, password_login], scram_only),
+    ?assertMatch(
+        {ok, 403, #{
+            <<"code">> := <<"PASSWORD_LOGIN_DISABLED">>,
+            <<"message">> :=
+                <<"Plaintext password login is disabled.">>
+        }},
+        request_api(
+            post,
+            api_path(["login"]),
+            no_auth_header,
+            #{username => ?USERNAME, password => ?PASSWORD}
+        )
+    ).
+
+t_http_scram_login_locked(_) ->
+    ClientNonce = <<"clientNonce1234567890">>,
+    {ok, _} = emqx_dashboard_admin:set_login_lock(
+        ?USERNAME,
+        erlang:system_time(second) + 60
+    ),
+    {ok, 200, Challenge} = request_api(
+        post,
+        api_path(["login", "challenge"]),
+        no_auth_header,
+        #{username => ?USERNAME, client_nonce => ClientNonce}
+    ),
+    Salt = base64:decode(maps:get(<<"salt">>, Challenge)),
+    ServerNonce = maps:get(<<"server_nonce">>, Challenge),
+    Proof = emqx_dashboard_scram:client_proof(
+        ?USERNAME,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        maps:get(<<"iterations">>, Challenge),
+        ?PASSWORD
+    ),
+    ?assertMatch(
+        {ok, 401, #{<<"code">> := <<"LOGIN_LOCKED">>}},
+        request_api(
+            post,
+            api_path(["login", "verify"]),
+            no_auth_header,
+            #{
+                challenge_id => maps:get(<<"challenge_id">>, Challenge),
+                combined_nonce => <<ClientNonce/binary, ServerNonce/binary>>,
+                client_proof => base64:encode(Proof)
+            }
+        )
+    ).
+
+t_http_scram_login_storage_unavailable(_) ->
+    ClientNonce = <<"clientNonce1234567890">>,
+    {ok, 200, Challenge} = request_api(
+        post,
+        api_path(["login", "challenge"]),
+        no_auth_header,
+        #{username => ?USERNAME, client_nonce => ClientNonce}
+    ),
+    ok = meck:new(mria, [passthrough, no_history]),
+    ok = meck:expect(mria, sync_transaction, fun(_, _) ->
+        {timeout, {error, shard_not_ready}}
+    end),
+    try
+        ?assertMatch(
+            {ok, 503, #{<<"code">> := <<"SERVICE_UNAVAILABLE">>}},
+            request_api(
+                post,
+                api_path(["login", "verify"]),
+                no_auth_header,
+                #{
+                    challenge_id => maps:get(<<"challenge_id">>, Challenge),
+                    combined_nonce =>
+                        <<ClientNonce/binary, (maps:get(<<"server_nonce">>, Challenge))/binary>>,
+                    client_proof => base64:encode(crypto:strong_rand_bytes(32))
+                }
+            )
+        )
+    after
+        ok = meck:unload(mria)
+    end.
+
+t_http_scram_login_mfa(_) ->
+    ok = meck:new(pot, [passthrough, no_history]),
+    ok = meck:expect(pot, valid_totp, fun(Token, _) -> Token =:= ?GOOD_TOTP end),
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(
+        ?USERNAME,
+        #{mechanism => totp, secret => <<"JBSWY3DPEHPK3PXP">>}
+    ),
+    try
+        ClientNonce = <<"clientNonce1234567890">>,
+        {ok, 200, Challenge1} = request_api(
+            post,
+            api_path(["login", "challenge"]),
+            no_auth_header,
+            #{username => ?USERNAME, client_nonce => ClientNonce}
+        ),
+        Proof1 = http_proof(ClientNonce, Challenge1),
+        ?assertMatch(
+            {ok, 401, #{<<"code">> := <<"BAD_MFA_TOKEN">>}},
+            request_api(
+                post,
+                api_path(["login", "verify"]),
+                no_auth_header,
+                http_verify_body(ClientNonce, Challenge1, Proof1, #{})
+            )
+        ),
+        {ok, 200, Challenge2} = request_api(
+            post,
+            api_path(["login", "challenge"]),
+            no_auth_header,
+            #{username => ?USERNAME, client_nonce => ClientNonce}
+        ),
+        Proof2 = http_proof(ClientNonce, Challenge2),
+        ?assertMatch(
+            {ok, 200, #{<<"token">> := _}},
+            request_api(
+                post,
+                api_path(["login", "verify"]),
+                no_auth_header,
+                http_verify_body(
+                    ClientNonce,
+                    Challenge2,
+                    Proof2,
+                    #{mfa_token => ?GOOD_TOTP}
+                )
+            )
+        )
+    after
+        _ = emqx_dashboard_admin:clear_mfa_state(?USERNAME),
+        ok = meck:unload(pot)
+    end.
+
+t_scram_only_hides_legacy_password_migration(_) ->
+    ok = emqx_config:put([dashboard, password_login], scram_only),
+    {atomic, ok} = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        [User] = mnesia:wread({?ADMIN, ?USERNAME}),
+        mnesia:write(User#?ADMIN{pwdhash = <<"abcd", 0:256>>})
+    end),
+    try
+        Reports =
+            emqx_cth_log_capture:capture(error, fun() ->
+                {ok, _} = emqx_dashboard_login:scram_challenge(
+                    ?USERNAME, <<"clientNonce1234567890">>
+                )
+            end),
+        {ok, 200, LegacyChallenge} =
+            request_api(
+                post,
+                api_path(["login", "challenge"]),
+                no_auth_header,
+                #{username => ?USERNAME, client_nonce => <<"clientNonce1234567890">>}
+            ),
+        {ok, 200, UnknownChallenge} =
+            request_api(
+                post,
+                api_path(["login", "challenge"]),
+                no_auth_header,
+                #{username => <<"unknown_scram_user">>, client_nonce => <<"clientNonce1234567890">>}
+            ),
+        ?assertEqual(
+            lists:sort(maps:keys(LegacyChallenge)),
+            lists:sort(maps:keys(UnknownChallenge))
+        ),
+        ?assertEqual(
+            nomatch,
+            binary:match(emqx_utils_json:encode(LegacyChallenge), <<"migration">>)
+        ),
+        ?assertMatch(
+            {ok, 401, #{
+                <<"code">> := <<"BAD_USERNAME_OR_PWD">>,
+                <<"message">> := <<"Auth failed">>
+            }},
+            request_api(
+                post,
+                api_path(["login", "verify"]),
+                no_auth_header,
+                #{
+                    challenge_id => maps:get(<<"challenge_id">>, LegacyChallenge),
+                    combined_nonce => <<
+                        "clientNonce1234567890",
+                        (maps:get(<<"server_nonce">>, LegacyChallenge))/binary
+                    >>,
+                    client_proof => base64:encode(crypto:strong_rand_bytes(32))
+                }
+            )
+        ),
+        ?assert(
+            lists:any(
+                fun
+                    (
+                        #{
+                            msg := "dashboard_scram_password_migration_required",
+                            username := ?USERNAME,
+                            migration_command := Command
+                        }
+                    ) ->
+                        Command =:=
+                            <<"emqx ctl admins passwd scram_admin <new-password>">>;
+                    (_) ->
+                        false
+                end,
+                Reports
+            )
+        )
+    after
+        ok = emqx_config:put([dashboard, password_login], both)
+    end.
+
+t_fake_challenge_does_not_record_password_failure(_) ->
+    Username = <<"unknown_scram_user">>,
+    ClientNonce = <<"clientNonce1234567890">>,
+    {ok, Challenge} = emqx_dashboard_login:scram_challenge(Username, ClientNonce),
+    CombinedNonce = <<ClientNonce/binary, (maps:get(server_nonce, Challenge))/binary>>,
+    {error, password_error} = emqx_dashboard_login:scram_verify(
+        maps:get(challenge_id, Challenge),
+        CombinedNonce,
+        crypto:strong_rand_bytes(32),
+        ?NO_MFA_TOKEN
+    ),
+    ?assertEqual(
+        [],
+        mnesia:dirty_read(emqx_dashboard_scram_challenge, maps:get(challenge_id, Challenge))
+    ),
+    ?assertEqual(
+        [],
+        mnesia:dirty_select(login_attempts, [
+            {
+                #login_attempts{key = {Username, '_'}, extra = '_'},
+                [],
+                ['$_']
+            }
+        ])
+    ).
+
+t_fake_challenge_is_stable_per_username(_) ->
+    ClientNonce = <<"clientNonce1234567890">>,
+    {ok, Challenge1} = emqx_dashboard_login:scram_challenge(
+        <<"unknown_scram_user">>, ClientNonce
+    ),
+    {ok, Challenge2} = emqx_dashboard_login:scram_challenge(
+        <<"unknown_scram_user">>, ClientNonce
+    ),
+    {ok, OtherChallenge} = emqx_dashboard_login:scram_challenge(
+        <<"another_unknown_scram_user">>, ClientNonce
+    ),
+    ?assertEqual(maps:get(salt, Challenge1), maps:get(salt, Challenge2)),
+    ?assertNotEqual(maps:get(salt, Challenge1), maps:get(salt, OtherChallenge)).
+
+api_path(Parts) ->
+    binary_to_list(iolist_to_binary(emqx_mgmt_api_test_util:api_path(Parts))).
+
+request_api(Method, Url, Auth, Body) ->
+    case emqx_common_test_http:request_api(Method, Url, [], Auth, Body) of
+        {ok, Code, ResponseBody} ->
+            {ok, Code, emqx_utils_json:decode(ResponseBody)};
+        Error ->
+            Error
+    end.
+
+http_proof(ClientNonce, Challenge) ->
+    Salt = base64:decode(maps:get(<<"salt">>, Challenge)),
+    ServerNonce = maps:get(<<"server_nonce">>, Challenge),
+    emqx_dashboard_scram:client_proof(
+        ?USERNAME,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        maps:get(<<"iterations">>, Challenge),
+        ?PASSWORD
+    ).
+
+http_verify_body(ClientNonce, Challenge, Proof, Extra) ->
+    ServerNonce = maps:get(<<"server_nonce">>, Challenge),
+    maps:merge(
+        #{
+            challenge_id => maps:get(<<"challenge_id">>, Challenge),
+            combined_nonce => <<ClientNonce/binary, ServerNonce/binary>>,
+            client_proof => base64:encode(Proof)
+        },
+        Extra
+    ).

--- a/apps/emqx_dashboard/test/emqx_dashboard_scram_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_scram_SUITE.erl
@@ -1,0 +1,147 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_dashboard_scram_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+t_rfc7677_sha256_vector(_) ->
+    Username = <<"user">>,
+    Password = <<"pencil">>,
+    ClientNonce = <<"rOprNGfwEbeRWgbNEkqO">>,
+    ServerNonce = <<"%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0">>,
+    Salt = base64:decode(<<"W22ZaJ0SNY7soEsUEjb6gQ==">>),
+    Iterations = 4096,
+    ClientProof = emqx_dashboard_scram:client_proof(
+        Username,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        Iterations,
+        Password
+    ),
+    ?assertEqual(
+        <<"dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ=">>,
+        base64:encode(ClientProof)
+    ),
+    %% The RFC server-final verifier is independently specified as a literal.
+    SaltedPassword = crypto:pbkdf2_hmac(sha256, Password, Salt, Iterations, 32),
+    PwdHash = iolist_to_binary([
+        <<"$1$4096$">>,
+        base64:encode(Salt, #{padding => false}),
+        <<"$">>,
+        base64:encode(SaltedPassword, #{padding => false})
+    ]),
+    {ok, Verifier} = emqx_dashboard_scram:from_pwdhash(PwdHash),
+    {ok, ServerSignature} = emqx_dashboard_scram:verify(
+        Verifier,
+        Username,
+        ClientNonce,
+        ServerNonce,
+        ClientProof
+    ),
+    ?assertEqual(
+        <<"6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4=">>,
+        base64:encode(ServerSignature)
+    ).
+
+t_username_escaping_vector(_) ->
+    Username = <<"user,name=example">>,
+    Password = <<"pencil">>,
+    ClientNonce = <<"rOprNGfwEbeRWgbNEkqO">>,
+    ServerNonce = <<"%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0">>,
+    Salt = base64:decode(<<"W22ZaJ0SNY7soEsUEjb6gQ==">>),
+    Iterations = 4096,
+    ClientProof = emqx_dashboard_scram:client_proof(
+        Username,
+        ClientNonce,
+        ServerNonce,
+        Salt,
+        Iterations,
+        Password
+    ),
+    ?assertEqual(
+        <<"jA+s4YTor9rmIHiMCNwLGh3OxJzt5J7AGGIFll+Mlzk=">>,
+        base64:encode(ClientProof)
+    ),
+    SaltedPassword = crypto:pbkdf2_hmac(sha256, Password, Salt, Iterations, 32),
+    PwdHash = iolist_to_binary([
+        <<"$1$4096$">>,
+        base64:encode(Salt, #{padding => false}),
+        <<"$">>,
+        base64:encode(SaltedPassword, #{padding => false})
+    ]),
+    {ok, Verifier} = emqx_dashboard_scram:from_pwdhash(PwdHash),
+    {ok, ServerSignature} = emqx_dashboard_scram:verify(
+        Verifier,
+        Username,
+        ClientNonce,
+        ServerNonce,
+        ClientProof
+    ),
+    ?assertEqual(
+        <<"eYccYlA2rAWZTp6yG/400lb9GthcHhtUB9ffXbzpH8o=">>,
+        base64:encode(ServerSignature)
+    ).
+
+t_v1_pwdhash_roundtrip(_) ->
+    Password = <<"correctP@ss1">>,
+    Salt = crypto:strong_rand_bytes(16),
+    SaltedPassword = crypto:pbkdf2_hmac(sha256, Password, Salt, 600000, 32),
+    PwdHash = iolist_to_binary([
+        <<"$1$600000$">>,
+        base64:encode(Salt, #{padding => false}),
+        <<"$">>,
+        base64:encode(SaltedPassword, #{padding => false})
+    ]),
+    {ok, Verifier} = emqx_dashboard_scram:from_pwdhash(PwdHash),
+    Proof = emqx_dashboard_scram:client_proof(
+        <<"admin">>, <<"client">>, <<"server">>, Salt, 600000, Password
+    ),
+    ?assertMatch(
+        {ok, _},
+        emqx_dashboard_scram:verify(Verifier, <<"admin">>, <<"client">>, <<"server">>, Proof)
+    ).
+
+t_wrong_password_rejected(_) ->
+    Password = <<"correctP@ss1">>,
+    Salt = crypto:strong_rand_bytes(16),
+    SaltedPassword = crypto:pbkdf2_hmac(sha256, Password, Salt, 4096, 32),
+    PwdHash = iolist_to_binary([
+        <<"$1$4096$">>,
+        base64:encode(Salt, #{padding => false}),
+        <<"$">>,
+        base64:encode(SaltedPassword, #{padding => false})
+    ]),
+    {ok, Verifier} = emqx_dashboard_scram:from_pwdhash(PwdHash),
+    WrongProof = emqx_dashboard_scram:client_proof(
+        <<"admin">>, <<"client">>, <<"server">>, Salt, 4096, <<"wrongP@ss1">>
+    ),
+    ?assertEqual(
+        {error, invalid_proof},
+        emqx_dashboard_scram:verify(
+            Verifier, <<"admin">>, <<"client">>, <<"server">>, WrongProof
+        )
+    ).
+
+t_legacy_hash_rejected(_) ->
+    ?assertEqual(
+        {error, unsupported},
+        emqx_dashboard_scram:from_pwdhash(
+            <<"abcd", 0:256>>
+        )
+    ).
+
+t_malformed_v1_hash_rejected(_) ->
+    ?assertEqual(
+        {error, malformed},
+        emqx_dashboard_scram:from_pwdhash(<<"$1$600000$not-valid$not-valid">>)
+    ).

--- a/changes/ee/feat-18387.en.md
+++ b/changes/ee/feat-18387.en.md
@@ -1,0 +1,7 @@
+Added optional SCRAM-SHA-256 challenge-response authentication for Dashboard
+JSON API login and switched the embedded API Spec login page to SCRAM by
+default. The existing password login remains enabled by default.
+
+When `dashboard.password_login = scram_only`, scripts and third-party clients
+using `POST /api/v5/login` with a username and password must migrate to the
+SCRAM challenge-response flow or use API keys.

--- a/rel/config/examples/dashboard-with-http.conf.example
+++ b/rel/config/examples/dashboard-with-http.conf.example
@@ -3,6 +3,9 @@
 ## Configure HTTP for EMQX dashboard
 
 dashboard {
+    ## Keep `both` for compatibility. SCRAM browser login requires HTTPS.
+    password_login = both
+
     ## JWT token expiration time
     token_expired_time = 60m
 

--- a/rel/config/examples/dashboard-with-https.conf.example
+++ b/rel/config/examples/dashboard-with-https.conf.example
@@ -3,6 +3,9 @@
 ## Configure HTTPS for EMQX dashboard
 
 dashboard {
+    ## Set to `scram_only` after all nodes and Dashboard clients are upgraded.
+    password_login = both
+
     ## JWT token expiration time
     token_expired_time = 60m
 

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -42,6 +42,12 @@ login_failed_response400.desc:
 login_success.desc:
 """Dashboard Auth Success"""
 
+client_nonce.desc:
+"""SCRAM client nonce. Use 20 to 128 unpadded Base64URL characters: letters, digits, `_`, or `-`."""
+
+combined_nonce.desc:
+"""The client nonce followed by the server nonce returned by the challenge endpoint."""
+
 logout_api.desc:
 """Dashboard user logout.
 This endpoint is only for the Dashboard, not the `API Key`.

--- a/rel/i18n/emqx_dashboard_schema.hocon
+++ b/rel/i18n/emqx_dashboard_schema.hocon
@@ -148,6 +148,12 @@ token_expired_time.label:
 password_expired_time.desc:
 """The expiration time for the password of users. The default value `0` means the password will never expire."""
 
+password_login.label:
+"""Dashboard password login mode"""
+
+password_login.desc:
+"""Select whether Dashboard local-user login accepts the legacy password request or SCRAM challenge-response."""
+
 ssl_options.desc:
 """SSL/TLS options for the dashboard listener."""
 


### PR DESCRIPTION
Release version: 7.0

Introduced in: N/A

## Summary

Add an optional SCRAM-SHA-256 challenge-response login flow for the Dashboard JSON API.

The server-side policy defaults to `dashboard.password_login = both`, so the existing
`POST /api/v5/login` clients remain compatible. The embedded API Spec login page
uses SCRAM by default:

- `POST /api/v5/login/challenge`
- Browser-side PBKDF2-HMAC-SHA256, HMAC-SHA256, and SHA-256 proof derivation
- `POST /api/v5/login/verify`
- Server-signature verification before accepting the session token

The API specification explorer now uses the same SCRAM login flow. Session expiry
returns the user to the shared SCRAM login page instead of maintaining a second
legacy login implementation. The main Dashboard SPA frontend is not included in
this PR; its SCRAM migration is tracked in issue #344.

Browser-based SCRAM login requires HTTPS or another secure browser context because
the implementation uses Web Crypto. This is an operational requirement for browser
clients; the backend does not require EMQX itself to have an HTTPS listener. TLS may
terminate at a reverse proxy or load balancer. `http://localhost` and
`http://127.0.0.1` are normally treated as secure browser contexts.

During rolling upgrades, the browser falls back to the legacy password endpoint only
when the server-rendered page permits legacy fallback and the SCRAM challenge endpoint
returns a genuine `404 NOT_FOUND`. It does not fallback on authentication errors,
service errors, network errors, or missing Web Crypto. In `scram_only` mode the
legacy endpoint remains disabled, including when challenge returns 404.

Do not enable `scram_only` until all Dashboard clients, including the main SPA, and
all cluster nodes support SCRAM. Legacy password hashes are detected before enabling
`scram_only`, with an actionable migration message:

`emqx ctl admins passwd <username> <new-password>`

This PR covers the backend and embedded API-spec login portions of
[issue #343](https://github.com/emqx/emqx-dev-team-tasks/issues/343). The Dashboard
SPA follow-up is tracked in
[issue #344](https://github.com/emqx/emqx-dev-team-tasks/issues/344).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (default remains `both`)
