### PR TITLE
fix(mqtt): reject connection when clientid_override expression fails

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2485,37 +2485,37 @@ initialize_client_attrs(Inits, #{clientid := ClientId} = ClientInfo) ->
 
 maybe_override_clientid(_ConnPkt, #{zone := Zone} = ClientInfo) ->
     Expression = get_mqtt_conf(Zone, clientid_override, disabled),
-    {ok, override_clientid(Expression, ClientInfo)}.
+    override_clientid(Expression, ClientInfo).
 
 override_clientid(disabled, ClientInfo) ->
-    ClientInfo;
+    {ok, ClientInfo};
 override_clientid(Expression, #{clientid := OrigClientId} = ClientInfo) ->
     case emqx_variform:render(Expression, ClientInfo) of
         {ok, <<>>} ->
             ?SLOG(
-                warning,
+                error,
                 #{
                     msg => "clientid_override_expression_returned_empty_string"
                 },
                 #{clientid => OrigClientId}
             ),
-            ClientInfo;
+            {error, ?RC_CLIENT_IDENTIFIER_NOT_VALID, ClientInfo};
         {ok, ClientId} ->
             % Must add 'clientid' log meta for trace log filter
             ?TRACE("MQTT", "clientid_overridden", #{
                 clientid => ClientId, original_clientid => OrigClientId
             }),
-            ClientInfo#{clientid => ClientId};
+            {ok, ClientInfo#{clientid => ClientId}};
         {error, Reason} ->
             ?SLOG(
-                warning,
+                error,
                 #{
                     msg => "clientid_override_expression_failed",
                     reason => Reason
                 },
                 #{clientid => OrigClientId}
             ),
-            ClientInfo
+            {error, ?RC_CLIENT_IDENTIFIER_NOT_VALID, ClientInfo}
     end.
 
 get_user_property_as_map(#mqtt_packet_connect{properties = #{'User-Property' := UserProperty}}) when

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -92,6 +92,7 @@ groups() ->
             t_clientid_override,
             t_clientid_override_fail_with_empty_render_result,
             t_clientid_override_fail_with_expression_exception,
+            t_clientid_override_fail_with_unbound_var,
             t_namespace_as_mountpoint_enabled,
             t_namespace_as_mountpoint_disabled,
             t_namespace_as_mountpoint_no_tns
@@ -717,9 +718,10 @@ t_clientid_override(_) ->
     emqtt:disconnect(Client).
 
 t_clientid_override_fail_with_empty_render_result(init, Config) ->
-    {ok, Rule} = emqx_variform:compile(<<"undefined_var">>),
+    {ok, Rule} = emqx_variform:compile(<<"coalesce(undefined_var)">>),
     override_conf([mqtt, clientid_override], Rule, Config).
 
+-doc "Reject the connection when the override expression renders an empty string.".
 t_clientid_override_fail_with_empty_render_result(_) ->
     test_clientid_override_fail(<<"original-clientid-1">>).
 
@@ -727,14 +729,39 @@ t_clientid_override_fail_with_expression_exception(init, Config) ->
     {ok, Rule} = emqx_variform:compile(<<"nth(1,undefined_var)">>),
     override_conf([mqtt, clientid_override], Rule, Config).
 
+-doc "Reject the connection when the override expression raises an exception.".
 t_clientid_override_fail_with_expression_exception(_) ->
     test_clientid_override_fail(<<"original-clientid-2">>).
 
+t_clientid_override_fail_with_unbound_var(init, Config) ->
+    {ok, Rule} = emqx_variform:compile(<<"concat([client_attrs.tns, '-', clientid])">>),
+    override_conf([mqtt, clientid_override], Rule, Config).
+
+-doc """
+Reject the connection when the override expression references an unbound variable,
+for example `client_attrs.tns` which is not bound before authentication.
+""".
+t_clientid_override_fail_with_unbound_var(_) ->
+    test_clientid_override_fail(<<"original-clientid-3">>).
+
 test_clientid_override_fail(ClientId) ->
-    {ok, Client} = emqtt:start_link([{clientid, ClientId}, {port, 1883}]),
-    {ok, _} = emqtt:connect(Client),
-    ?assertMatch(#{clientid := ClientId}, maps:get(clientinfo, emqx_cm:get_chan_info(ClientId))),
-    emqtt:disconnect(Client).
+    lists:foreach(
+        fun(ProtoVer) -> test_clientid_override_fail(ProtoVer, ClientId) end,
+        [v3, v4, v5]
+    ).
+
+test_clientid_override_fail(ProtoVer, ClientId) ->
+    process_flag(trap_exit, true),
+    {ok, Client} = emqtt:start_link([{clientid, ClientId}, {port, 1883}, {proto_ver, ProtoVer}]),
+    ?assertMatch({error, {client_identifier_not_valid, _}}, emqtt:connect(Client)),
+    receive
+        {'EXIT', Client, {shutdown, client_identifier_not_valid}} -> ok
+    after 1000 ->
+        ct:fail({expect_client_identifier_not_valid, ProtoVer})
+    end,
+    %% The client-supplied Client ID must not reach the session registry.
+    ?assertEqual(undefined, emqx_cm:get_chan_info(ClientId)),
+    ?assertEqual([], emqx_cm:lookup_channels(ClientId)).
 
 t_namespace_as_mountpoint_enabled(init, Config) ->
     %% Set tns attribute from user property

--- a/changes/ee/breaking-18390.en.md
+++ b/changes/ee/breaking-18390.en.md
@@ -1,0 +1,5 @@
+The `mqtt.clientid_override` expression no longer falls back to the client-supplied Client ID when it fails.
+
+When `mqtt.clientid_override` is configured and the expression raises an error (for example, it references an attribute the client did not provide) or renders an empty string, EMQX now refuses the connection with CONNACK reason code 0x85 (Client Identifier not valid; return code 2 for MQTT 3.1 and 3.1.1 clients). Previously such clients stayed connected under their original Client ID, so the override silently did not apply to them.
+
+Before upgrading, verify that every connecting client can render the configured expression to a non-empty string. Clients that could not render the expression connected with their original Client ID before the upgrade; after the upgrade they are refused until the expression or the client data is fixed.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -2001,6 +2001,7 @@ clientid_override {
     Override the Client ID using a Variform expression.
     Example: `concat(client_attrs.tns, '-', clientid)` adds the namespace as a prefix.
     This allows clients in different namespaces to connect using the same Client ID without conflict.
+    When the expression fails to render, or renders an empty string, the connection is rejected.
     See EMQX documentation for expression syntax.~"""
 }
 


### PR DESCRIPTION
Release version:
6.3.0

Introduced in:
5.8.3

## Summary

Implements proposal 1 of emqx/emqx-dev-team-tasks#354.

When `mqtt.clientid_override` is configured and the expression fails to produce a usable Client ID, EMQX now rejects the connection with reason code 0x85 (Client Identifier not valid; CONNACK return code 2 for MQTT 3.1 and 3.1.1 clients). Both failure modes reject:

- the expression renders an empty string
- the expression raises, for example `var_unbound` when it references an attribute that is not bound at the pre-auth render point (the reported case: `client_attrs.tns` combined with post-auth namespace resolution)

Previously both branches fell back to the client-supplied Client ID. The override silently did not apply, and the raw Client ID reached the session registry while the operator believed the override was in effect. There is deliberately no fallback and no opt-in: an override expression that cannot render for some clients is a configuration error, and it now fails on the first affected client instead of running unnoticed.

Main changes:

- `override_clientid/2` in `apps/emqx/src/emqx_channel.erl` returns `{error, ?RC_CLIENT_IDENTIFIER_NOT_VALID, ClientInfo}` on both failure branches, following the `maybe_username_as_clientid/2` precedent in the same `enrich_client/2` pipeline. The failure logs are raised from `warning` to `error`.
- The global Client ID session registry is unchanged; keying on the effective Client ID is the recorded design decision in #354.
- Tests in `emqx_client_SUITE` now assert the rejection reason code across MQTT v3, v4, and v5, and that the client-supplied Client ID never reaches `emqx_cm`. The empty-render case previously used an expression that raises rather than renders empty; it now uses `coalesce(undefined_var)`, and a new case covers the reported unbound-variable expression.

Follow-ups from #354, not implemented here:

- proposal 2: config-time validation of the incompatible pairing of `mqtt.clientid_override` referencing post-auth attributes with `multi_tenancy.post_auth_tns_expression`
- proposal 3: documentation of the session-registry design and the mutual exclusivity of the two override mechanisms

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
