### PR TITLE
fix(auth_cache): make the cache-key hash input injective

### DIFF
--- a/apps/emqx_auth/src/emqx_auth_template.erl
+++ b/apps/emqx_auth/src/emqx_auth_template.erl
@@ -110,10 +110,13 @@ cache_key(Values, #cache_key_template{id = TemplateId, vars = KeyVars}, ExtraKey
         %% We try to add some identifier to the cache key for better introspection.
         CacheKeyId = cache_template_id(first_present_kv(?POSSIBLE_CACHE_KEY_IDS, Values)),
         Key0 = render_deep_for_raw(KeyVars, Values),
+        %% Length-prefix each rendered value so that distinct value lists
+        %% cannot concatenate to the same byte stream.
+        Key1 = [length_prefix(Value) || Value <- Key0],
         %% We hash the key to avoid storing the passwords or other sensitive data as-is in the cache.
         %% TemplateId is used as some kind of salt.
-        Key1 = crypto:hash(sha256, [TemplateId, Key0]),
-        [CacheKeyId, Key1 | ExtraKeyParts]
+        Key2 = crypto:hash(sha256, [TemplateId, Key1]),
+        [CacheKeyId, Key2 | ExtraKeyParts]
     end.
 
 -spec placeholder_vars_from_str(unicode:chardata()) -> [var()].
@@ -335,6 +338,10 @@ render_var(_Name, Value) ->
 
 render_strict(Topic, ClientInfo) ->
     emqx_template:render_strict(Topic, rename_client_info_vars(ClientInfo)).
+
+length_prefix(Value) ->
+    Bin = iolist_to_binary(Value),
+    <<(byte_size(Bin)):64/unsigned, Bin/binary>>.
 
 first_present_kv([Key | Keys], Map) ->
     case Map of

--- a/apps/emqx_auth/test/emqx_auth_cache_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_auth_cache_SUITE.erl
@@ -276,6 +276,26 @@ t_cache_key_template(_Config) ->
         re:run(Key0(), <<"pass1">>)
     ).
 
+-doc """
+Checks that credentials whose field values concatenate to the same bytes
+produce different cache keys, and that identical credentials still produce
+identical cache keys.
+""".
+t_cache_key_boundary_shift(_Config) ->
+    Vars = ["username", "password"],
+    Template = emqx_auth_template:cache_key_template(Vars),
+    %% The same clientid keeps the introspection prefix of the keys identical,
+    %% so the assertions below compare only the hashed part.
+    MakeKey = fun(Username, Password) ->
+        Values = #{clientid => <<"client1">>, username => Username, password => Password},
+        (emqx_auth_template:cache_key(Values, Template))()
+    end,
+    %% "XX" ++ "X" and "X" ++ "XX" concatenate to the same bytes
+    ?assertNotEqual(MakeKey(<<"XX">>, <<"X">>), MakeKey(<<"X">>, <<"XX">>)),
+    ?assertNotEqual(MakeKey(<<"AB">>, <<"C">>), MakeKey(<<"A">>, <<"BC">>)),
+    ?assertNotEqual(MakeKey(<<"A">>, <<"BC">>), MakeKey(<<"ABC">>, <<>>)),
+    ?assertEqual(MakeKey(<<"user1">>, <<"pass1">>), MakeKey(<<"user1">>, <<"pass1">>)).
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/changes/ee/fix-18391.en.md
+++ b/changes/ee/fix-18391.en.md
@@ -1,0 +1,1 @@
+Fixed an authentication cache key collision. Two different credentials whose fields concatenate to the same bytes could share a cache entry, letting one client receive another client's cached authentication result within the cache TTL.


### PR DESCRIPTION
Release version:

6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

Introduced in:

6.0.0 (356a7ec0245e2047880972ac4a3f576a6c18875a)

## Summary

Fixes emqx/emqx-dev-team-tasks#129.

The auth node-cache key is computed in `emqx_auth_template:cache_key/3` as
`crypto:hash(sha256, [TemplateId, RenderedValues])`. `crypto:hash` flattens the
rendered credential fields into one byte stream with no delimiters, so distinct
credentials whose field values concatenate to the same bytes get the same cache
key. Example: `username="XX", password="X"` and `username="X", password="XX"`.
Within the cache TTL, one client could receive another principal's cached
authentication result.

The fix length-prefixes each rendered value before hashing, so the hash input
is an injective encoding of the value list. The length-prefix form is explicit
and independent of term encoding. `TemplateId` stays as the leading salt;
`CacheKeyId` and `ExtraKeyParts` stay as separate key-list elements. The
builder is shared by the HTTP, database, and LDAP authenticators, so the fix
covers all of them.

Regression test `t_cache_key_boundary_shift` in `emqx_auth_cache_SUITE` checks
that boundary-shifted credentials get different keys and that identical
credentials still get identical keys.

Out of scope, follow-up: binding the cached decision to the authenticated
identity (the `fixby: trustattr` half of the issue) is a separate, larger
change and is not part of this PR.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
