### PR TITLE
fix(aggregated actions): separate different namespaces

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -495,6 +495,7 @@ install_bridge_v2_helper(
         ConnectorId,
         BridgeV2Id,
         augment_channel_config(
+            Namespace,
             RootName,
             BridgeV2Type,
             BridgeName,
@@ -504,12 +505,14 @@ install_bridge_v2_helper(
     ok.
 
 augment_channel_config(
+    Namespace,
     ConfigRoot,
     BridgeV2Type,
     BridgeName,
     Config
 ) ->
     AugmentedConf = Config#{
+        bridge_namespace => Namespace,
         config_root => ConfigRoot,
         bridge_type => bin(BridgeV2Type),
         bridge_name => bin(BridgeName)
@@ -841,6 +844,7 @@ create_dry_run_helper(Namespace, ConfRootKey, BridgeV2Type, ConnectorRawConf, Br
             BridgeV2Conf1 = maps:remove(?COMPUTED, BridgeV2Conf0),
             BridgeV2Conf = emqx_utils_maps:unsafe_atom_key_map(BridgeV2Conf1),
             AugmentedConf = augment_channel_config(
+                Namespace,
                 ConfRootKey,
                 BridgeV2Type,
                 BridgeName,
@@ -928,7 +932,7 @@ get_channels_for_connector(Namespace, SourcesOrActions, ConnectorName, BridgeV2T
             id_with_root_and_connector_names(
                 Namespace, SourcesOrActions, BridgeV2Type, Name, ConnectorName
             ),
-            augment_channel_config(SourcesOrActions, BridgeV2Type, Name, Conf)
+            augment_channel_config(Namespace, SourcesOrActions, BridgeV2Type, Name, Conf)
         }
      || {Name, Conf} <- maps:to_list(BridgeV2s),
         bin(ConnectorName) =:= maps:get(connector, Conf, no_name)

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -2507,6 +2507,48 @@ t_ecpool_workers_crash(TCConfig) ->
     ),
     ok.
 
+-doc """
+For aggregated upload connectors.
+
+Checks that connectors/actions with the same name and different namespaces don't step over
+each other.
+""".
+t_aggreg_different_namespaces(TCConfig, Opts) ->
+    #{
+        aggreg_sup := AggregSup
+    } = Opts,
+
+    Ns = <<"some_ns">>,
+    {ok, APIKey} = emqx_common_test_http:create_default_app(),
+    AuthHeaderGlobal = emqx_common_test_http:auth_header(APIKey),
+    TCConfigGlobal = [{auth_header, AuthHeaderGlobal} | TCConfig],
+    AuthHeaderNs = ensure_namespaced_api_key(#{namespace => Ns}),
+    TCConfigNs = [{auth_header, AuthHeaderNs} | TCConfig],
+
+    {201, #{<<"status">> := <<"connected">>}} = create_connector_api2(TCConfigGlobal, #{}),
+    {201, #{<<"status">> := <<"connected">>}} = create_action_api2(TCConfigGlobal, #{}),
+
+    {201, #{<<"status">> := <<"connected">>}} = create_connector_api2(TCConfigNs, #{}),
+    {201, #{<<"status">> := <<"connected">>}} = create_action_api2(TCConfigNs, #{}),
+
+    %% Should have 2 children, with different work dirs
+    ?assertMatch(
+        [
+            {_, _, #{work_dir := WD1}},
+            {_, _, #{work_dir := WD2}}
+        ] when WD1 /= WD2,
+        [
+            begin
+                {ok, #{
+                    start := {_, _, [_, #{work_dir := WD}, _]}
+                }} = supervisor:get_childspec(AggregSup, Id),
+                {Id, Pid, #{work_dir => WD}}
+            end
+         || {Id, Pid, _, _} <- supervisor:which_children(AggregSup)
+        ]
+    ),
+    ok.
+
 snk_timetrap() ->
     {CTTimetrap, _} = ct:get_timetrap_info(),
     #{timetrap => max(0, CTTimetrap - 1_000)}.

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -2547,6 +2547,28 @@ t_aggreg_different_namespaces(TCConfig, Opts) ->
          || {Id, Pid, _, _} <- supervisor:which_children(AggregSup)
         ]
     ),
+
+    #{kind := Kind, name := Name, type := Type} = get_common_values(TCConfigNs),
+    {204, _} = delete_kind_api(Kind, Type, Name, #{auth_header => AuthHeaderNs}),
+
+    %% Reject creating actions with bad namespaces
+    lists:foreach(
+        fun(BadNs) ->
+            ct:pal("bad ns: ~p", [BadNs]),
+            AuthHeaderBadNs = ensure_namespaced_api_key(#{namespace => BadNs}),
+            TCConfigBadNs = [{auth_header, AuthHeaderBadNs} | TCConfig],
+            {201, #{<<"status">> := <<"connected">>}} =
+                create_connector_api2(TCConfigBadNs, #{}),
+            ?assertMatch(
+                {201, #{
+                    <<"status">> := <<"disconnected">>,
+                    <<"status_reason">> := <<"Action cannot be created in this namespace">>
+                }},
+                create_action_api2(TCConfigBadNs, #{})
+            )
+        end,
+        [<<".">>, <<"..">>, <<"a/b">>]
+    ),
     ok.
 
 snk_timetrap() ->

--- a/apps/emqx_bridge_azure_blob_storage/mix.exs
+++ b/apps/emqx_bridge_azure_blob_storage/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeAzureBlobStorage.MixProject do
   def project do
     [
       app: :emqx_bridge_azure_blob_storage,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
@@ -16,6 +16,7 @@
 -include_lib("emqx_connector_aggregator/include/emqx_connector_aggregator.hrl").
 -include_lib("emqx/include/emqx_trace.hrl").
 -include("emqx_bridge_azure_blob_storage.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 %% `emqx_resource' API
 -export([
@@ -502,6 +503,7 @@ install_action(#{parameters := #{mode := direct}} = ActionConfig, _ConnState) ->
 install_action(#{parameters := #{mode := aggregated}} = ActionConfig, ConnState) ->
     #{driver_state := DriverState} = ConnState,
     #{
+        bridge_namespace := Namespace,
         bridge_name := Name,
         parameters := #{
             mode := Mode = aggregated,
@@ -517,12 +519,12 @@ install_action(#{parameters := #{mode := aggregated}} = ActionConfig, ConnState)
         }
     } = ActionConfig,
     Type = ?ACTION_TYPE_BIN,
-    AggregId = {Type, Name},
+    AggregId = {Namespace, Type, Name},
     Blob = mk_blob_name_template(BlobTemplateStr),
     AggregOpts = #{
         max_records => MaxRecords,
         time_interval => TimeInterval,
-        work_dir => work_dir(Type, Name)
+        work_dir => work_dir(Namespace, Type, Name)
     },
     ContentType = content_type(ContainerType),
     TransferOpts = #{
@@ -608,8 +610,10 @@ run_aggregated_transfer(Records, #{aggreg_id := AggregId}) ->
             {error, {unrecoverable_error, Reason}}
     end.
 
-work_dir(Type, Name) ->
-    filename:join([emqx:data_dir(), bridge, Type, Name]).
+work_dir(?global_ns, Type, Name) ->
+    filename:join([emqx:data_dir(), bridge, Type, Name]);
+work_dir(Ns, Type, Name) when is_binary(Ns) ->
+    filename:join([emqx:data_dir(), bridge, ns, Ns, Type, Name]).
 
 -spec mk_blob_name_template(template_str()) -> emqx_template:str().
 mk_blob_name_template(TemplateStr) ->

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
@@ -524,7 +524,7 @@ install_action(#{parameters := #{mode := aggregated}} = ActionConfig, ConnState)
     AggregOpts = #{
         max_records => MaxRecords,
         time_interval => TimeInterval,
-        work_dir => work_dir(Namespace, Type, Name)
+        work_dir => emqx_connector_aggregator:work_dir(Namespace, Type, Name)
     },
     ContentType = content_type(ContainerType),
     TransferOpts = #{
@@ -609,11 +609,6 @@ run_aggregated_transfer(Records, #{aggreg_id := AggregId}) ->
         {error, Reason} ->
             {error, {unrecoverable_error, Reason}}
     end.
-
-work_dir(?global_ns, Type, Name) ->
-    filename:join([emqx:data_dir(), bridge, Type, Name]);
-work_dir(Ns, Type, Name) when is_binary(Ns) ->
-    filename:join([emqx:data_dir(), bridge, ns, Ns, Type, Name]).
 
 -spec mk_blob_name_template(template_str()) -> emqx_template:str().
 mk_blob_name_template(TemplateStr) ->

--- a/apps/emqx_bridge_azure_blob_storage/test/emqx_bridge_azure_blob_storage_SUITE.erl
+++ b/apps/emqx_bridge_azure_blob_storage/test/emqx_bridge_azure_blob_storage_SUITE.erl
@@ -16,6 +16,7 @@
 -include_lib("erlazure/include/erlazure.hrl").
 -include("../src/emqx_bridge_azure_blob_storage.hrl").
 -include_lib("emqx_utils/include/emqx_message.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -define(ACCOUNT_NAME_BIN, <<"devstoreaccount1">>).
 -define(ACCOUNT_KEY_BIN, <<
@@ -257,7 +258,7 @@ aggreg_action_config(Overrides0) ->
     emqx_utils_maps:deep_merge(CommonConfig, Overrides).
 
 aggreg_id(BridgeName) ->
-    {?ACTION_TYPE_BIN, BridgeName}.
+    {?global_ns, ?ACTION_TYPE_BIN, BridgeName}.
 
 mk_message_event(ClientId, Topic, Payload) ->
     Message = emqx_message:make(bin(ClientId), bin(Topic), Payload),
@@ -858,3 +859,9 @@ t_create_connector_with_obfuscated_key(Config0) ->
         []
     ),
     ok.
+
+t_aggreg_different_namespaces(TCConfig) ->
+    Opts = #{
+        aggreg_sup => ?AGGREG_SUP
+    },
+    emqx_bridge_v2_testlib:t_aggreg_different_namespaces(TCConfig, Opts).

--- a/apps/emqx_bridge_s3/mix.exs
+++ b/apps/emqx_bridge_s3/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeS3.MixProject do
   def project do
     [
       app: :emqx_bridge_s3,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3_connector.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3_connector.erl
@@ -201,7 +201,7 @@ start_channel(State, #{
     AggregOpts = #{
         time_interval => TimeInterval,
         max_records => MaxRecords,
-        work_dir => work_dir(Namespace, Type, Name)
+        work_dir => emqx_connector_aggregator:work_dir(Namespace, Type, Name)
     },
     Template = emqx_bridge_s3_upload:mk_key_template(Key),
     DeliveryOpts = #{
@@ -232,11 +232,6 @@ start_channel(State, #{
 
 upload_options(Parameters) ->
     #{acl => maps:get(acl, Parameters, undefined)}.
-
-work_dir(?global_ns, Type, Name) ->
-    filename:join([emqx:data_dir(), bridge, Type, Name]);
-work_dir(Ns, Type, Name) when is_binary(Ns) ->
-    filename:join([emqx:data_dir(), bridge, ns, Ns, Type, Name]).
 
 stop_channel(#{on_stop := OnStop}) ->
     OnStop();

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3_connector.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3_connector.erl
@@ -90,6 +90,7 @@
 }.
 
 -define(AGGREG_SUP, emqx_bridge_s3_sup).
+-define(AGGREG_ID(NS, TYPE, NAME), {NS, TYPE, NAME}).
 
 %%
 -spec resource_type() -> resource_type().
@@ -182,6 +183,7 @@ start_channel(_State, #{
         upload_options => upload_options(Parameters)
     };
 start_channel(State, #{
+    bridge_namespace := Namespace,
     bridge_type := Type = ?BRIDGE_TYPE_UPLOAD,
     bridge_name := Name,
     parameters := Parameters = #{
@@ -195,11 +197,11 @@ start_channel(State, #{
         key := Key
     }
 }) ->
-    AggregId = {Type, Name},
+    AggregId = ?AGGREG_ID(Namespace, Type, Name),
     AggregOpts = #{
         time_interval => TimeInterval,
         max_records => MaxRecords,
-        work_dir => work_dir(Type, Name)
+        work_dir => work_dir(Namespace, Type, Name)
     },
     Template = emqx_bridge_s3_upload:mk_key_template(Key),
     DeliveryOpts = #{
@@ -231,8 +233,10 @@ start_channel(State, #{
 upload_options(Parameters) ->
     #{acl => maps:get(acl, Parameters, undefined)}.
 
-work_dir(Type, Name) ->
-    filename:join([emqx:data_dir(), bridge, Type, Name]).
+work_dir(?global_ns, Type, Name) ->
+    filename:join([emqx:data_dir(), bridge, Type, Name]);
+work_dir(Ns, Type, Name) when is_binary(Ns) ->
+    filename:join([emqx:data_dir(), bridge, ns, Ns, Type, Name]).
 
 stop_channel(#{on_stop := OnStop}) ->
     OnStop();
@@ -442,9 +446,9 @@ process_terminate(Upload) ->
 
 %% `emqx_template` APIs
 
--spec lookup(emqx_template:accessor(), {_Name, buffer()}) ->
+-spec lookup(emqx_template:accessor(), {?AGGREG_ID(_, _, _), buffer()}) ->
     {ok, integer() | string()} | {error, undefined}.
-lookup([<<"action">>], {_AggregId = {_Type, Name}, _Buffer}) ->
+lookup([<<"action">>], {?AGGREG_ID(_Ns, _Type, Name), _Buffer}) ->
     {ok, mk_fs_safe_string(Name)};
 lookup([<<"node">>], {_AggregId, _Buffer}) ->
     {ok, mk_fs_safe_string(atom_to_binary(erlang:node()))};

--- a/apps/emqx_bridge_s3/test/emqx_bridge_s3_aggreg_upload_SUITE.erl
+++ b/apps/emqx_bridge_s3/test/emqx_bridge_s3_aggreg_upload_SUITE.erl
@@ -85,9 +85,10 @@ init_per_testcase(TestCase, Config) ->
         {connector_type, ?CONNECTOR_TYPE},
         {connector_name, Name},
         {connector_config, ConnectorConfig},
-        {bridge_type, ?BRIDGE_TYPE},
-        {bridge_name, Name},
-        {bridge_config, ActionConfig},
+        {bridge_kind, action},
+        {action_name, Name},
+        {action_config, ActionConfig},
+        {action_type, ?BRIDGE_TYPE},
         {s3_bucket, Bucket}
         | Config
     ].
@@ -225,7 +226,7 @@ t_update_invalid_config(Config) ->
 
 t_aggreg_upload(Config) ->
     Bucket = ?config(s3_bucket, Config),
-    BridgeName = ?config(bridge_name, Config),
+    BridgeName = ?config(action_name, Config),
     AggregId = aggreg_id(BridgeName),
     BridgeNameString = unicode:characters_to_list(BridgeName),
     NodeString = atom_to_list(node()),
@@ -265,11 +266,11 @@ t_aggreg_upload(Config) ->
 %% Smoke test for using JSON Lines container type.
 t_aggreg_upload_json_lines(Config0) ->
     Bucket = ?config(s3_bucket, Config0),
-    BridgeName = ?config(bridge_name, Config0),
+    BridgeName = ?config(action_name, Config0),
     AggregId = aggreg_id(BridgeName),
     BridgeNameString = unicode:characters_to_list(BridgeName),
     NodeString = atom_to_list(node()),
-    Config = emqx_bridge_v2_testlib:proplist_update(Config0, bridge_config, fun(Old) ->
+    Config = emqx_bridge_v2_testlib:proplist_update(Config0, action_config, fun(Old) ->
         Cfg = emqx_utils_maps:deep_put(
             [<<"parameters">>, <<"container">>, <<"type">>],
             Old,
@@ -326,7 +327,7 @@ t_aggreg_upload_json_lines(Config0) ->
 
 t_aggreg_upload_rule(Config) ->
     Bucket = ?config(s3_bucket, Config),
-    BridgeName = ?config(bridge_name, Config),
+    BridgeName = ?config(action_name, Config),
     AggregId = aggreg_id(BridgeName),
     ClientID = emqx_utils_conv:bin(?FUNCTION_NAME),
     %% Create a bridge with the sample configuration and a simple SQL rule.
@@ -380,7 +381,7 @@ t_aggreg_upload_restart(Config) ->
     %% This test verifies that the bridge will reuse existing aggregation buffer
     %% after a restart.
     Bucket = ?config(s3_bucket, Config),
-    BridgeName = ?config(bridge_name, Config),
+    BridgeName = ?config(action_name, Config),
     AggregId = aggreg_id(BridgeName),
     %% Create a bridge with the sample configuration.
     ?assertMatch({ok, _Bridge}, emqx_bridge_v2_testlib:create_bridge_api(Config)),
@@ -421,7 +422,7 @@ t_aggreg_upload_restart(Config) ->
 %% and does so while preserving uncompromised data.
 t_aggreg_upload_restart_corrupted(Config) ->
     Bucket = ?config(s3_bucket, Config),
-    BridgeName = ?config(bridge_name, Config),
+    BridgeName = ?config(action_name, Config),
     BatchSize = ?CONF_MAX_RECORDS div 2,
     Opts = #{
         aggreg_id => aggreg_id(BridgeName),
@@ -476,7 +477,7 @@ t_aggreg_pending_upload_restart(Config) ->
     %% This test verifies that the bridge will finish uploading a buffer file after
     %% a restart.
     Bucket = ?config(s3_bucket, Config),
-    BridgeName = ?config(bridge_name, Config),
+    BridgeName = ?config(action_name, Config),
     AggregId = aggreg_id(BridgeName),
     %% Create a bridge with the sample configuration.
     ?assertMatch({ok, _Bridge}, emqx_bridge_v2_testlib:create_bridge_api(Config)),
@@ -513,7 +514,7 @@ t_aggreg_next_rotate(Config) ->
     %% This is essentially a stress test that tries to verify that buffer rotation
     %% and windowing work correctly under high rate, high concurrency conditions.
     Bucket = ?config(s3_bucket, Config),
-    BridgeName = ?config(bridge_name, Config),
+    BridgeName = ?config(action_name, Config),
     AggregId = aggreg_id(BridgeName),
     NSenders = 4,
     %% Create a bridge with the sample configuration.
@@ -558,6 +559,12 @@ t_aggreg_next_rotate(Config) ->
         NSent,
         lists:sum([NR || {_, NR} <- NRecords])
     ).
+
+t_aggreg_different_namespaces(TCConfig) ->
+    Opts = #{
+        aggreg_sup => ?AGGREG_SUP
+    },
+    emqx_bridge_v2_testlib:t_aggreg_different_namespaces(TCConfig, Opts).
 
 run_message_sender(BridgeName, N) ->
     ClientID = integer_to_binary(N),
@@ -617,4 +624,4 @@ fetch_parse_csv(Bucket, Key) ->
     CSV.
 
 aggreg_id(BridgeName) ->
-    {?BRIDGE_TYPE, BridgeName}.
+    {?global_ns, ?BRIDGE_TYPE, BridgeName}.

--- a/apps/emqx_bridge_s3tables/mix.exs
+++ b/apps/emqx_bridge_s3tables/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeS3Tables.MixProject do
   def project do
     [
       app: :emqx_bridge_s3tables,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_s3tables/src/emqx_bridge_s3tables_impl.erl
+++ b/apps/emqx_bridge_s3tables/src/emqx_bridge_s3tables_impl.erl
@@ -321,7 +321,7 @@ create_channel(ChanResId, ActionConfig, ConnState) ->
     } = ActionConfig,
     Type = ?ACTION_TYPE_BIN,
     AggregId = {ResNamespace, Type, Name},
-    WorkDir = work_dir(ResNamespace, Type, Name),
+    WorkDir = emqx_connector_aggregator:work_dir(ResNamespace, Type, Name),
     AggregOpts = #{
         max_records => MaxRecords,
         time_interval => TimeInterval,
@@ -402,11 +402,6 @@ channel_status(_ConnResId, _ChanResId, ChanState) ->
         ok ?= check_aggreg_upload_errors(AggregId),
         ?status_connected
     end.
-
-work_dir(?global_ns, Type, Name) ->
-    filename:join([emqx:data_dir(), bridge, Type, Name]);
-work_dir(Ns, Type, Name) when is_binary(Ns) ->
-    filename:join([emqx:data_dir(), bridge, ns, Ns, Type, Name]).
 
 check_aggreg_upload_errors(AggregId) ->
     case emqx_connector_aggregator:take_error(AggregId) of

--- a/apps/emqx_bridge_s3tables/src/emqx_bridge_s3tables_impl.erl
+++ b/apps/emqx_bridge_s3tables/src/emqx_bridge_s3tables_impl.erl
@@ -307,6 +307,7 @@ create_channel(ChanResId, ActionConfig, ConnState) ->
         ?location_client := LocClient
     } = ConnState,
     #{
+        bridge_namespace := ResNamespace,
         bridge_name := Name,
         parameters := #{
             aggregation := #{
@@ -319,8 +320,8 @@ create_channel(ChanResId, ActionConfig, ConnState) ->
         }
     } = ActionConfig,
     Type = ?ACTION_TYPE_BIN,
-    AggregId = {Type, Name},
-    WorkDir = work_dir(Type, Name),
+    AggregId = {ResNamespace, Type, Name},
+    WorkDir = work_dir(ResNamespace, Type, Name),
     AggregOpts = #{
         max_records => MaxRecords,
         time_interval => TimeInterval,
@@ -402,8 +403,10 @@ channel_status(_ConnResId, _ChanResId, ChanState) ->
         ?status_connected
     end.
 
-work_dir(Type, Name) ->
-    filename:join([emqx:data_dir(), bridge, Type, Name]).
+work_dir(?global_ns, Type, Name) ->
+    filename:join([emqx:data_dir(), bridge, Type, Name]);
+work_dir(Ns, Type, Name) when is_binary(Ns) ->
+    filename:join([emqx:data_dir(), bridge, ns, Ns, Type, Name]).
 
 check_aggreg_upload_errors(AggregId) ->
     case emqx_connector_aggregator:take_error(AggregId) of

--- a/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
+++ b/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
@@ -39,6 +39,8 @@
 -define(PROXY_HOST, "toxiproxy").
 -define(PROXY_PORT, 8474).
 
+-define(AGGREG_SUP, emqx_bridge_s3tables_sup).
+
 %%------------------------------------------------------------------------------
 %% CT boilerplate
 %%------------------------------------------------------------------------------
@@ -103,7 +105,7 @@ end_per_suite(Config) ->
 init_per_testcase(TestCase, TCConfig0) ->
     reset_proxy(),
     Path = group_path(TCConfig0, no_groups),
-    ct:print(asciiart:visible($%, "~p - ~s", [Path, TestCase])),
+    ct:pal(asciiart:visible($%, "~p - ~s", [Path, TestCase])),
     TCConfig =
         case erlang:function_exported(?MODULE, TestCase, 2) of
             true ->
@@ -664,6 +666,7 @@ create_rule_for_schema1(TCConfig, RuleTopic) ->
     emqx_bridge_v2_testlib:create_rule_and_action_http(?ACTION_TYPE, RuleTopic, TCConfig, Opts).
 
 get_config(K, TCConfig) -> emqx_bridge_v2_testlib:get_value(K, TCConfig).
+get_config(K, TCConfig, Default) -> proplists:get_value(K, TCConfig, Default).
 
 group_path(Config, Default) ->
     case emqx_common_test_helpers:group_path(Config) of
@@ -687,8 +690,9 @@ with_failure(FailureType, Fn) ->
     emqx_common_test_helpers:with_failure(FailureType, ?PROXY_NAME, ?PROXY_HOST, ?PROXY_PORT, Fn).
 
 aggreg_id(Config) ->
+    Namespace = get_config(resource_namespace, Config, ?global_ns),
     ActionName = ?config(action_name, Config),
-    {?ACTION_TYPE_BIN, ActionName}.
+    {Namespace, ?ACTION_TYPE_BIN, ActionName}.
 
 now_s() ->
     erlang:system_time(second).
@@ -2040,6 +2044,12 @@ t_imdsv2_credentials(TCConfig0) when is_list(TCConfig0) ->
         end
     ),
     ok.
+
+t_aggreg_different_namespaces(TCConfig) ->
+    Opts = #{
+        aggreg_sup => ?AGGREG_SUP
+    },
+    emqx_bridge_v2_testlib:t_aggreg_different_namespaces(TCConfig, Opts).
 
 %% More test ideas:
 %%   * Concurrent schema change during upload.

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_impl.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_impl.erl
@@ -750,7 +750,7 @@ start_aggregator(ConnResId, ActionResId, ActionConfig, ActionState0) ->
     #{http := HTTPClientConfig} = ActionState0,
     Type = ?ACTION_TYPE_AGGREG_BIN,
     AggregId = {Namespace, Type, Name},
-    WorkDir = work_dir(Namespace, Type, Name),
+    WorkDir = emqx_connector_aggregator:work_dir(Namespace, Type, Name),
     AggregOpts = #{
         max_records => MaxRecords,
         time_interval => TimeInterval,
@@ -818,11 +818,6 @@ run_aggregated_action(Batch, ActionResId, #{aggreg_id := AggregId}) ->
         {error, Reason} ->
             {error, {unrecoverable_error, Reason}}
     end.
-
-work_dir(?global_ns, Type, Name) ->
-    filename:join([emqx:data_dir(), bridge, Type, Name]);
-work_dir(Ns, Type, Name) when is_binary(Ns) ->
-    filename:join([emqx:data_dir(), bridge, ns, Ns, Type, Name]).
 
 str(X) -> emqx_utils_conv:str(X).
 

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_impl.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_impl.erl
@@ -731,6 +731,7 @@ start_aggregated_http_pool(ConnResId, ActionResId, ActionConfig, ConnState) ->
 
 start_aggregator(ConnResId, ActionResId, ActionConfig, ActionState0) ->
     #{
+        bridge_namespace := Namespace,
         bridge_name := Name,
         parameters := #{
             mode := ?aggregated = Mode,
@@ -748,8 +749,8 @@ start_aggregator(ConnResId, ActionResId, ActionConfig, ActionState0) ->
     } = ActionConfig,
     #{http := HTTPClientConfig} = ActionState0,
     Type = ?ACTION_TYPE_AGGREG_BIN,
-    AggregId = {Type, Name},
-    WorkDir = work_dir(Type, Name),
+    AggregId = {Namespace, Type, Name},
+    WorkDir = work_dir(Namespace, Type, Name),
     AggregOpts = #{
         max_records => MaxRecords,
         time_interval => TimeInterval,
@@ -818,8 +819,10 @@ run_aggregated_action(Batch, ActionResId, #{aggreg_id := AggregId}) ->
             {error, {unrecoverable_error, Reason}}
     end.
 
-work_dir(Type, Name) ->
-    filename:join([emqx:data_dir(), bridge, Type, Name]).
+work_dir(?global_ns, Type, Name) ->
+    filename:join([emqx:data_dir(), bridge, Type, Name]);
+work_dir(Ns, Type, Name) when is_binary(Ns) ->
+    filename:join([emqx:data_dir(), bridge, ns, Ns, Type, Name]).
 
 str(X) -> emqx_utils_conv:str(X).
 

--- a/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_aggregated_SUITE.erl
+++ b/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_aggregated_SUITE.erl
@@ -16,6 +16,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include("../src/emqx_bridge_snowflake.hrl").
 -include_lib("emqx_utils/include/emqx_message.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 %%------------------------------------------------------------------------------
 %% Definitions
@@ -178,6 +179,9 @@ timetrap(Config) ->
         false ->
             {seconds, 150}
     end.
+
+get_config(K, TCConfig) -> emqx_bridge_v2_testlib:get_value(K, TCConfig).
+get_config(K, TCConfig, Default) -> proplists:get_value(K, TCConfig, Default).
 
 group_path(Config, Default) ->
     case emqx_common_test_helpers:group_path(Config) of
@@ -445,8 +449,9 @@ private_key_password() ->
     end.
 
 aggreg_id(Config) ->
+    Namespace = get_config(namespace, Config, ?global_ns),
     ActionName = ?config(action_name, Config),
-    {?ACTION_TYPE_AGGREG_BIN, ActionName}.
+    {Namespace, ?ACTION_TYPE_AGGREG_BIN, ActionName}.
 
 new_odbc_client(Config) when is_list(Config) ->
     new_odbc_client(maps:from_list(Config));
@@ -1405,6 +1410,18 @@ t_optional_username(Config) ->
         create_connector_api(Config, #{})
     ),
     ok.
+
+t_aggreg_different_namespaces(init, TCConfig) when is_list(TCConfig) ->
+    t_aggreg_different_namespaces(init, maps:from_list(TCConfig));
+t_aggreg_different_namespaces(init, #{mock := _} = TCConfig) ->
+    maps:to_list(TCConfig);
+t_aggreg_different_namespaces('end', _TCConfig) ->
+    ok.
+t_aggreg_different_namespaces(TCConfig) ->
+    Opts = #{
+        aggreg_sup => ?AGGREG_SUP
+    },
+    emqx_bridge_v2_testlib:t_aggreg_different_namespaces(TCConfig, Opts).
 
 %% Todo: test scenarios
 %% * User error in rule definition; e.g.:

--- a/apps/emqx_connector_aggregator/src/emqx_connector_aggregator.erl
+++ b/apps/emqx_connector_aggregator/src/emqx_connector_aggregator.erl
@@ -9,6 +9,7 @@
 
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -include("emqx_connector_aggregator.hrl").
 
@@ -20,6 +21,7 @@
     buffer_to_map/1,
     delivery_exit/3
 ]).
+-export([work_dir/3]).
 
 -behaviour(gen_server).
 -export([
@@ -100,6 +102,16 @@ is_empty(Name) ->
             end;
         _ ->
             true
+    end.
+
+work_dir(?global_ns, Type, Name) ->
+    filename:join([emqx:data_dir(), bridge, Type, Name]);
+work_dir(Ns, Type, Name) when is_binary(Ns) ->
+    case filename:split(Ns) of
+        [Ns] when Ns /= <<".">>, Ns /= <<"..">> ->
+            filename:join([emqx:data_dir(), bridge, ns, Ns, Type, Name]);
+        _ ->
+            throw(<<"Action cannot be created in this namespace">>)
     end.
 
 %% testing/debug only

--- a/changes/ee/fix-18392.en.md
+++ b/changes/ee/fix-18392.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where aggregated Actions (S3, S3Tables, Azure Blob Storage, Snowflake Aggregated) with the same name but in different namespaces would share the same working directory for their temporary files.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/352

Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0


## Summary

Makes aggregated actions with same type and name but different namespaces use distinct work dirs.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
