### PR TITLE
docs(i18n): describe krb5.conf location without an absolute path

### DIFF
--- a/rel/i18n/emqx_authn_kerberos_schema.hocon
+++ b/rel/i18n/emqx_authn_kerberos_schema.hocon
@@ -5,7 +5,7 @@ principal {
     desc: """~
         Server Kerberos principal.
         For example <code>mqtt/emqx-cluster-1.example.com@MY_REALM.EXAMPLE.COM</code>.
-        NOTE: The realm in use has to be configured in /etc/krb5.conf in EMQX nodes.~"""
+        NOTE: The realm in use has to be configured in the default config file krb5.conf, usually located in `/etc`, on EMQX nodes.~"""
 }
 
 }

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -150,7 +150,7 @@ consumer_mqtt_opts.label:
 """MQTT publish"""
 
 auth_kerberos_principal.desc:
-"""SASL GSSAPI authentication Kerberos principal. For example <code>kafka/node1.example.com@EXAMPLE.COM</code>, NOTE: The realm in use has to be configured in /etc/krb5.conf in EMQX nodes."""
+"""SASL GSSAPI authentication Kerberos principal. For example <code>kafka/node1.example.com@EXAMPLE.COM</code>, NOTE: The realm in use has to be configured in the default config file krb5.conf, usually located in `/etc`, on EMQX nodes."""
 
 auth_kerberos_principal.label:
 """Kerberos Principal"""


### PR DESCRIPTION
## Summary

The Kerberos principal descriptions in `rel/i18n/emqx_authn_kerberos_schema.hocon` and `rel/i18n/emqx_bridge_kafka.hocon` named `/etc/krb5.conf`. Refer to the default config file by name and give its usual directory separately:

> NOTE: The realm in use has to be configured in the default config file krb5.conf, usually located in `/etc`, on EMQX nodes.

Documentation text only. No schema, config or behaviour change.

Both files were verified to still parse with `hocon:load/1`, and the rendered descriptions were checked.

Not changed, since they are functional rather than documentation:

- `.ci/docker-compose-file/*.yaml` — real volume mount targets
- `apps/emqx_auth_kerberos/src/emqx_authn_kerberos_schema.erl:54` — internal code comment
- `apps/emqx_auth_kerberos/src/emqx_authn_kerberos_schema.erl:93` — the `bad_keytab_file_path` error message, which is operator-facing but not a config description

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)