### PR TITLE
refactor: merge bin/nodetool's emulator flags with packaged releases

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -421,8 +421,8 @@ gen_node_id() {
 }
 
 call_nodetool() {
-    ERL_FLAGS="${ERL_FLAGS:-} +P 65536 +Q 65536 +S 2" \
-        "$ERTS_DIR/bin/escript" "$RUNNER_ROOT_DIR/bin/nodetool" "$@"
+    ## Emulator flags (+P, +Q, +S) come from the %%! line in bin/nodetool.
+    "$ERTS_DIR/bin/escript" "$RUNNER_ROOT_DIR/bin/nodetool" "$@"
 }
 
 # Control a node

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -6,6 +6,10 @@
 %%
 %% nodetool: Helper Script for interacting with live nodes
 %%
+%% The %%! line above sets the emulator flags for every nodetool run.
+%% copy_escript/2 in mix.exs merges the release arguments into that
+%% line when packaging; escript honours only the first %%! line.
+%%
 %% -------------------------------------------------------------------
 -mode(compile).
 

--- a/mix.exs
+++ b/mix.exs
@@ -888,18 +888,32 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   defp copy_escript(release, escript_name) do
-    [shebang, rest] =
+    [shebang | lines] =
       "bin/#{escript_name}"
       |> File.read!()
-      |> String.split("\n", parts: 2)
+      |> String.split("\n")
 
     # the elixir version of escript + start.boot required the boot_var
     # RELEASE_LIB to be defined.
     # enable-feature is not required when 1.6.x
-    boot_var = "%%!-boot_var RELEASE_LIB $RUNNER_ROOT_DIR/lib -enable-feature maybe_expr"
+    rel_args = "-boot_var RELEASE_LIB $RUNNER_ROOT_DIR/lib -enable-feature maybe_expr"
+
+    # escript reads emulator flags from the first %%! line only (line 2,
+    # or line 3 when line 2 is a comment), so merge the release arguments
+    # into the script's own %%! line instead of adding a second one.
+    lines =
+      case Enum.find_index(Enum.take(lines, 2), &String.starts_with?(&1, "%%!")) do
+        nil ->
+          ["%%! " <> rel_args | lines]
+
+        idx ->
+          List.update_at(lines, idx, fn "%%!" <> args ->
+            "%%! " <> rel_args <> " " <> String.trim(args)
+          end)
+      end
 
     path = Path.join([release.path, "bin", escript_name])
-    File.write!(path, [shebang, "\n", boot_var, "\n", rest])
+    File.write!(path, Enum.join([shebang | lines], "\n"))
 
     release
   end


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 6.4.0

<!--
run script ./scripts/rel-versions to get release versions
-->

Introduced in:
5.6.0 (e57c354a6a added the header; it has never been applied by mix-built releases)
<!--
N/A: If this is a pre-release fix (e.g. found in QA phase).
pre-5.8: If it's an old one (5.8 is the earliest minor actively maintained).
VSN: The exact version wihch introduced the bug.
-->

## Summary

`bin/nodetool` sets `%%! +P 65536 +Q 65536 +S 1` in its escript header. In a packaged release that line had no effect: `copy_escript/2` in `mix.exs` inserted its own `%%!-boot_var ...` line at line 2 of the packaged escript, and escript reads emulator flags from the first `%%!` line only. The flags nodetool ran with came from `ERL_FLAGS` in `call_nodetool()` in `bin/emqx` (`+P 65536 +Q 65536 +S 2`). The two places had diverged (`+S 1` vs `+S 2`) without anyone noticing.

Changes:

- `mix.exs` `copy_escript/2`: merge the release arguments into the script's own `%%!` line (line 2, or line 3 when line 2 is a comment) instead of adding a second one. A script without a `%%!` line still gets one inserted at line 2.
- `bin/emqx` `call_nodetool()`: remove the duplicate `ERL_FLAGS`. `ERL_FLAGS` is appended after the `%%!` flags and wins on conflict, so keeping it would have silently overridden the header's `+S 1` with `+S 2`. The header is now the single place for nodetool's emulator flags.
- `bin/nodetool`: comment that explains the merge.

Net effect: the nodetool VM behind `emqx ctl` and the other `bin/emqx` helper commands now runs with 1 scheduler instead of 2; process and port limits are unchanged (65536). No end-user visible change, so no changelog.

### Verification

Packaged `bin/nodetool` header, before (two `%%!` lines, the second is ignored):

```
#!/usr/bin/env escript
%%!-boot_var RELEASE_LIB $RUNNER_ROOT_DIR/lib -enable-feature maybe_expr
%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
%%! +P 65536 +Q 65536 +S 1
%% ex: ft=erlang ts=4 sw=4 et
```

After (one merged line):

```
#!/usr/bin/env escript
%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
%%! -boot_var RELEASE_LIB $RUNNER_ROOT_DIR/lib -enable-feature maybe_expr +P 65536 +Q 65536 +S 1
%% ex: ft=erlang ts=4 sw=4 et
```

`beam.smp` argv for `bin/emqx ctl status` (`strace -f -e trace=execve`):

```
before: bin/nodetool -B -P 65536 -Q 65536 -S 2 -- ... -boot_var RELEASE_LIB $RUNNER_ROOT_DIR/lib -enable-feature maybe_expr -run escript start
after:  bin/nodetool -B -P 65536 -Q 65536 -S 1 -- ... -boot_var RELEASE_LIB $RUNNER_ROOT_DIR/lib -enable-feature maybe_expr -run escript start
```

Note: `emqx eval 'erlang:system_info(...)'` reports the broker node, not nodetool's own VM, so it cannot be used to check these flags.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
