### PR TITLE
fix(cluster_link): connect through all addresses listed in server

### DIFF
--- a/apps/emqx_cluster_link/src/emqx_cluster_link_app.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_app.erl
@@ -29,12 +29,27 @@ start_configured_links() ->
             ok;
         false ->
             lists:foreach(
-                fun(LinkConf) ->
-                    {ok, _} = emqx_cluster_link_sup:ensure_actor(LinkConf),
-                    {ok, _} = emqx_cluster_link_mqtt:ensure_msg_fwd_resource(LinkConf)
-                end,
+                fun start_configured_link/1,
                 emqx_cluster_link_config:get_enabled_links()
             )
+    end.
+
+%% One link that fails to start must not stop the application. The config
+%% handler stays registered, so the link can still be fixed or deleted.
+start_configured_link(#{name := Name} = LinkConf) ->
+    try
+        {ok, _} = emqx_cluster_link_sup:ensure_actor(LinkConf),
+        {ok, _} = emqx_cluster_link_mqtt:ensure_msg_fwd_resource(LinkConf),
+        ok
+    catch
+        Class:Reason:Stacktrace ->
+            ?SLOG(error, #{
+                msg => "cluster_link_start_failed",
+                link => Name,
+                exception => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            })
     end.
 
 warn_if_links_configured() ->

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
@@ -37,6 +37,7 @@
     get_link_raw/1,
     %% Connections
     mk_emqtt_options/1,
+    prefer_host/2,
     %% Actor Lifecycle
     actor_ttl/0,
     actor_gc_interval/0,
@@ -144,14 +145,22 @@ actor_heartbeat_interval() ->
 
 %%
 
+-doc """
+Build `emqtt` client options for a link.
+`server` may list several `host[:port]` addresses. They are passed as the
+`hosts` option in the configured order. The client tries them in that order
+until one accepts the connection.
+""".
 mk_emqtt_options(#{server := Server, ssl := #{enable := EnableSsl} = Ssl} = LinkConf) ->
     ClientId = maps:get(clientid, LinkConf, cluster()),
-    #{hostname := Host, port := Port} = emqx_schema:parse_server(Server, ?MQTT_HOST_OPTS),
+    Hosts = [
+        {Host, Port}
+     || #{hostname := Host, port := Port} <- emqx_schema:parse_servers(Server, ?MQTT_HOST_OPTS)
+    ],
     Opts = maps:with([username, retry_interval, max_inflight], LinkConf),
     TcpOpts = emqx_schema:client_tcp_opts_to_proplist(maps:get(tcp_opts, LinkConf, #{})),
     Opts1 = Opts#{
-        host => Host,
-        port => Port,
+        hosts => Hosts,
         clientid => ClientId,
         proto_ver => v5,
         tcp_opts => TcpOpts,
@@ -164,6 +173,16 @@ with_password(Opts, #{password := P} = _LinkConf) ->
     Opts#{password => emqx_secret:unwrap(P)};
 with_password(Opts, _LinkConf) ->
     Opts.
+
+-doc """
+Make the `N`th client of a link prefer the `N`th configured address.
+The clients of one link thereby spread over the addresses, and each of them
+still fails over to the other addresses when its preferred one is down.
+""".
+-spec prefer_host(pos_integer(), map()) -> map().
+prefer_host(N, #{hosts := Hosts} = Opts) ->
+    {Front, Rear} = lists:split((N - 1) rem length(Hosts), Hosts),
+    Opts#{hosts => Rear ++ Front}.
 
 %%
 

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -340,12 +340,13 @@ connect(Options) ->
     ClientOpts0 = #{clientid := ClientId0} = proplists:get_value(client_opts, Options),
     ClientIdBase = emqx_bridge_mqtt_lib:clientid_base([ClientId0, ?MSG_CLIENTID_SUFFIX]),
     ClientId = iolist_to_binary([ClientIdBase, $:, integer_to_binary(WorkerId)]),
-    ClientOpts = ClientOpts0#{
+    ClientOpts1 = ClientOpts0#{
         clientid => ClientId,
         msg_handler => #{
             disconnected => mk_disconnect_handler(ResourceId, WorkerId, ClientId, TargetCluster)
         }
     },
+    ClientOpts = emqx_cluster_link_config:prefer_host(WorkerId, ClientOpts1),
     case emqtt:start_link(ClientOpts) of
         {ok, Pid} ->
             case emqtt:connect(Pid) of

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
@@ -284,6 +284,22 @@ t_put_invalid(Config) ->
         update_link(Name, maps:remove(<<"server">>, link_params()), Config)
     ).
 
+-doc """
+A `server` value with more than one address is accepted on create and update
+and is returned as configured.
+""".
+t_multi_server(Config) ->
+    Name = <<"l1">>,
+    Servers = <<"emqxcl_2.nohost:31883,emqxcl_3.nohost:31883">>,
+    Params = link_params(#{<<"server">> => Servers}),
+    ?assertMatch({201, #{<<"server">> := Servers}}, create_link(Name, Params, Config)),
+    ?assertMatch({200, #{<<"server">> := Servers}}, get_link(Name, Config)),
+    Servers1 = <<"emqxcl_3.nohost:31883, emqxcl_2.nohost:31883">>,
+    ?assertMatch(
+        {200, #{<<"server">> := <<"emqxcl_3.nohost:31883,emqxcl_2.nohost:31883">>}},
+        update_link(Name, Params#{<<"server">> => Servers1}, Config)
+    ).
+
 %% Tests a sequence of CRUD operations and their expected responses, for common use cases
 %% and configuration states.
 t_crud(Config) ->

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_config_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_config_SUITE.erl
@@ -478,6 +478,173 @@ t_misconfigured_links(Config) ->
         10_000
     ).
 
+t_multi_server('init', Config) ->
+    NameA = fmt("~s_~s", [?FUNCTION_NAME, "a"]),
+    NameB = fmt("~s_~s", [?FUNCTION_NAME, "b"]),
+    ClusterA = emqx_cth_cluster:start(mk_cluster(1, NameA, 1, Config)),
+    ClusterB = emqx_cth_cluster:start(mk_cluster(2, NameB, 2, Config)),
+    ok = snabbkaffe:start_trace(),
+    [{cluster_a, ClusterA}, {cluster_b, ClusterB} | Config];
+t_multi_server('end', Config) ->
+    ok = snabbkaffe:stop(),
+    ok = emqx_common_test_helpers:call_janitor(),
+    ok = emqx_cth_cluster:stop(?config(cluster_a, Config)),
+    ok = emqx_cth_cluster:stop(?config(cluster_b, Config)).
+
+-doc """
+A link whose `server` lists several addresses uses all of them: a dead address
+is skipped in favour of a live one (the route replication client and the first
+forwarding client both start with the dead address), and the forwarding clients
+spread over the live addresses (the third forwarding client prefers the second
+node of the remote cluster).
+""".
+t_multi_server(Config) ->
+    ClusterA = [NodeA] = ?config(cluster_a, Config),
+    ClusterB = [NodeB1, NodeB2] = ?config(cluster_b, Config),
+    DeadPort = emqx_common_test_helpers:select_free_port(tcp),
+    PortB1 = emqx_cluster_link_cth:tcp_port(NodeB1, clink),
+    PortB2 = emqx_cluster_link_cth:tcp_port(NodeB2),
+    Server = fmt("localhost:~b,localhost:~b,localhost:~b", [DeadPort, PortB1, PortB2]),
+    LinkConfA = mk_link_conf_to(ClusterB, #{
+        <<"server">> => Server,
+        <<"topics">> => [<<"t/#">>],
+        <<"pool_size">> => 3
+    }),
+    LinkConfB = mk_link_conf_to(ClusterA, #{<<"topics">> => [<<"t/#">>]}),
+    ?assertMatch({ok, _}, update(api, NodeB1, [LinkConfB], Config)),
+    {{ok, _}, {ok, _}} = ?wait_async_action(
+        update(api, NodeA, [LinkConfA], Config),
+        #{?snk_kind := "cluster_link_routerepl_bootstrap_complete", ?snk_meta := #{node := NodeA}},
+        30_000
+    ),
+    #{<<"name">> := NameB} = LinkConfA,
+    ResId = emqx_cluster_link_mqtt:resource_id(NameB),
+    ?retry(
+        500,
+        40,
+        ?assertMatch({ok, _, #{status := connected}}, ?ON(NodeA, emqx_resource:get_instance(ResId)))
+    ),
+    %% Assert both cluster B nodes have at least one connection.
+    ?assertMatch([_ | _], ?ON(NodeB1, emqx_cm:all_client_ids())),
+    ?assertMatch([_ | _], ?ON(NodeB2, emqx_cm:all_client_ids())),
+    %% Cluster B's actors connect back once cluster A knows cluster B.
+    lists:foreach(
+        fun(NodeB) ->
+            ?assertMatch(
+                {ok, _},
+                ?block_until(
+                    #{
+                        ?snk_kind := "cluster_link_routerepl_bootstrap_complete",
+                        ?snk_meta := #{node := NodeB}
+                    },
+                    30_000
+                )
+            )
+        end,
+        ClusterB
+    ),
+    ClientA = start_client("t_multi_server_a", NodeA),
+    ClientB = start_client("t_multi_server_b", NodeB1),
+    on_exit(fun() -> catch emqtt:stop(ClientA) end),
+    on_exit(fun() -> catch emqtt:stop(ClientB) end),
+    {{ok, _, _}, {ok, _}} = ?wait_async_action(
+        emqtt:subscribe(ClientB, <<"t/multi">>, qos1),
+        #{?snk_kind := "cluster_link_route_sync_complete", ?snk_meta := #{node := NodeB1}},
+        10_000
+    ),
+    ok = emqx_cth_cluster:sync_routes(ClusterB),
+    {ok, _} = emqtt:publish(ClientA, <<"t/multi">>, <<"hello-1">>, qos1),
+    ?assertReceive(
+        {publish, #{topic := <<"t/multi">>, payload := <<"hello-1">>, client_pid := ClientB}},
+        5_000
+    ),
+    %% The link keeps working when the addresses are reordered.
+    Server1 = fmt("localhost:~b,localhost:~b", [PortB2, DeadPort]),
+    {{ok, _}, {ok, _}} = ?wait_async_action(
+        update(api, NodeA, [LinkConfA#{<<"server">> => Server1}], Config),
+        #{?snk_kind := "cluster_link_routerepl_bootstrap_complete", ?snk_meta := #{node := NodeA}},
+        30_000
+    ),
+    ?retry(
+        500,
+        40,
+        ?assertMatch({ok, _, #{status := connected}}, ?ON(NodeA, emqx_resource:get_instance(ResId)))
+    ),
+    ClientB2 = start_client("t_multi_server_b2", NodeB2),
+    on_exit(fun() -> catch emqtt:stop(ClientB2) end),
+    {ok, _, _} = emqtt:subscribe(ClientB2, <<"t/multi">>, qos1),
+    %% Wait until the route tables inside cluster B converge, so that one
+    %% publish reaches the subscribers on both nodes.
+    ok = emqx_cth_cluster:sync_routes(ClusterB),
+    {ok, _} = emqtt:publish(ClientA, <<"t/multi">>, <<"hello-2">>, qos1),
+    ?assertReceive(
+        {publish, #{topic := <<"t/multi">>, payload := <<"hello-2">>, client_pid := ClientB}},
+        5_000
+    ),
+    ?assertReceive(
+        {publish, #{topic := <<"t/multi">>, payload := <<"hello-2">>, client_pid := ClientB2}},
+        5_000
+    ).
+
+t_broken_link_crud('init', Config) ->
+    NameA = fmt("~s_~s", [?FUNCTION_NAME, "a"]),
+    %% All addresses are dead: the link can never connect.
+    Server = fmt("localhost:~b,localhost:~b", [
+        emqx_common_test_helpers:select_free_port(tcp),
+        emqx_common_test_helpers:select_free_port(tcp)
+    ]),
+    BrokenLink = #{
+        <<"name">> => <<"broken">>,
+        <<"server">> => Server,
+        <<"topics">> => [<<"t/#">>]
+    },
+    Spec = #{apps => [{emqx_conf, #{config => #{cluster => #{links => [BrokenLink]}}}}]},
+    ok = snabbkaffe:start_trace(),
+    ClusterA = emqx_cth_cluster:start(mk_cluster(1, NameA, [Spec], Config)),
+    [{cluster_a, ClusterA}, {broken_link, BrokenLink} | Config];
+t_broken_link_crud('end', Config) ->
+    ok = snabbkaffe:stop(),
+    ok = emqx_cth_cluster:stop(?config(cluster_a, Config)).
+
+-doc """
+A node starts with a stored link that cannot connect to any of its addresses.
+The application starts, the config handler stays registered, and the broken
+link can coexist with a new link, be updated, and be deleted.
+""".
+t_broken_link_crud(Config) ->
+    [NodeA] = ?config(cluster_a, Config),
+    BrokenLink = #{<<"name">> := Name} = ?config(broken_link, Config),
+    ?assertMatch(
+        {emqx_cluster_link, _, _},
+        lists:keyfind(emqx_cluster_link, 1, ?ON(NodeA, application:which_applications()))
+    ),
+    ?assertMatch(
+        #{handlers := #{cluster := #{links := #{'$mod' := emqx_cluster_link_config}}}},
+        ?ON(NodeA, emqx_config_handler:info())
+    ),
+    %% The route replication actor keeps retrying instead of crashing.
+    ?assertMatch(
+        {ok, _},
+        ?block_until(
+            #{
+                ?snk_kind := "cluster_link_routerepl_connection_failed",
+                ?snk_meta := #{node := NodeA}
+            },
+            10_000
+        )
+    ),
+    %% A new link can be created while the broken one is present.
+    Other = BrokenLink#{<<"name">> => <<"other">>},
+    ?assertMatch({ok, _}, ?ON(NodeA, emqx_cluster_link_config:create_link(Other))),
+    %% The broken link can be updated and deleted.
+    ?assertMatch(
+        {ok, _},
+        ?ON(NodeA, emqx_cluster_link_config:update_link(BrokenLink#{<<"pool_size">> => 2}))
+    ),
+    ?assertEqual(ok, ?ON(NodeA, emqx_cluster_link_config:delete_link(Name))),
+    ?assertEqual(ok, ?ON(NodeA, emqx_cluster_link_config:delete_link(<<"other">>))),
+    ?assertEqual([], ?ON(NodeA, emqx_cluster_link_config:get_links())).
+
 start_client(ClientId, Node) ->
     start_client(ClientId, Node, true).
 

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_config_tests.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_config_tests.erl
@@ -1,0 +1,52 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_cluster_link_config_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+link_conf(Server) ->
+    #{
+        name => <<"remote">>,
+        clientid => <<"linkclientid">>,
+        server => Server,
+        ssl => #{enable => false},
+        retry_interval => 15_000,
+        max_inflight => 32
+    }.
+
+%% `mk_emqtt_options/1` reads the local cluster name from the config.
+with_cluster_name(Tests) ->
+    {
+        setup,
+        fun() -> emqx_config:put([cluster, name], emqxcl) end,
+        fun(_) -> emqx_config:erase(cluster) end,
+        Tests
+    }.
+
+mk_emqtt_options_test_() ->
+    with_cluster_name([
+        ?_assertMatch(
+            #{hosts := [{"h1", 1883}]},
+            emqx_cluster_link_config:mk_emqtt_options(link_conf(<<"h1">>))
+        ),
+        ?_assertMatch(
+            #{hosts := [{"h1", 1883}, {"h2", 1884}, {"h3", 1885}]},
+            emqx_cluster_link_config:mk_emqtt_options(link_conf(<<"h1:1883,h2:1884,h3:1885">>))
+        )
+    ]).
+
+prefer_host_test_() ->
+    with_cluster_name(fun() ->
+        Opts = emqx_cluster_link_config:mk_emqtt_options(link_conf(<<"h1:1883,h2:1884,h3:1885">>)),
+        Preferred = fun(N) ->
+            #{hosts := Hosts} = emqx_cluster_link_config:prefer_host(N, Opts),
+            Hosts
+        end,
+        [
+            ?_assertEqual([{"h1", 1883}, {"h2", 1884}, {"h3", 1885}], Preferred(1)),
+            ?_assertEqual([{"h2", 1884}, {"h3", 1885}, {"h1", 1883}], Preferred(2)),
+            ?_assertEqual([{"h3", 1885}, {"h1", 1883}, {"h2", 1884}], Preferred(3)),
+            ?_assertEqual([{"h1", 1883}, {"h2", 1884}, {"h3", 1885}], Preferred(4))
+        ]
+    end).

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -663,7 +663,9 @@ check_res(_Node, Key, {error, Reason}, Conf, Opts = #{mode := Mode}) ->
         "The effective configurations:~n"
         "```~n"
         "~ts```~n~n",
-    ActiveMsg = io_lib:format(ActiveMsg0, [hocon_pp:do(#{Key => emqx_conf:get_raw([Key])}, #{})]),
+    %% `Key` may be a dotted path such as `cluster.links`.
+    KeyPath = binary:split(Key, <<".">>, [global]),
+    ActiveMsg = io_lib:format(ActiveMsg0, [hocon_pp:do(#{Key => emqx_conf:get_raw(KeyPath)}, #{})]),
     FailedMsg0 =
         "Try to ~ts with:~n"
         "```~n"

--- a/changes/ee/fix-18409.en.md
+++ b/changes/ee/fix-18409.en.md
@@ -1,0 +1,3 @@
+Fixed Cluster Linking for a link whose `server` field lists more than one address.
+
+Such a link now connects through all listed addresses: each connection prefers one of the addresses in turn and fails over to the others when it cannot connect. Before this change the link could not connect, and no link could be created, updated or deleted until the node was restarted.

--- a/mix.exs
+++ b/mix.exs
@@ -236,7 +236,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:emqtt),
     do:
       {:emqtt,
-       github: "emqx/emqtt", tag: "1.15.4", override: true, system_env: maybe_no_quic_env()}
+       github: "emqx/emqtt", tag: "1.16.0", override: true, system_env: maybe_no_quic_env()}
 
   def common_dep(:typerefl),
     do: {:typerefl, github: "ieQu1/typerefl", tag: "0.9.6", override: true}

--- a/rel/i18n/emqx_cluster_link_schema.hocon
+++ b/rel/i18n/emqx_cluster_link_schema.hocon
@@ -17,7 +17,9 @@ link_name.desc:
 link_name.label: "Linked Cluster Name"
 
 server.desc:
-"""MQTT host and port of the remote EMQX broker."""
+"""MQTT host and port of the remote EMQX broker.
+A comma-separated list of `host[:port]` addresses may be given.
+Each connection of the link prefers one of the addresses in turn and fails over to the other addresses when it cannot connect."""
 server.label: "MQTT Server"
 
 username.desc:


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
5.8.0

## Summary

Fixes #18406.

A cluster link `server` value with more than one address (for example `10.42.4.62:1883,10.42.4.61:1883`) passes the schema check but could not be used at runtime. After such a link was saved, no link could be created, updated or deleted.

### Root cause

- `emqx_cluster_link_schema` declares `server` with the plural `emqx_schema:servers_sc/2`, whose validator accepts a comma-separated list.
- `emqx_cluster_link_config:mk_emqtt_options/1` parsed it with the singular `emqx_schema:parse_server/2`, which throws `expecting_one_host_but_got: 2`.
- The throw crashed the route replication actor (`emqx_cluster_link_routerepl`) on every connect attempt. The restart loop escalated through the supervisors until the `emqx_cluster_link` application stopped, and `stop/1` removed the `cluster.links` config handler.
- With no handler, `emqx_config_handler` skips `pre_config_update/3` and hands the raw `{create, _}` / `{update, _}` tuple to the schema check. That is the reported `expected_data_type => array` error.

Reproduced on the unfixed branch: the node logs show 396 `expecting_one_host_but_got: 2` throws and 78 `reached_max_restart_intensity` reports before `create_link/1` returns the reported error.

### Changes

- emqtt is bumped from 1.15.4 to 1.16.0 ([emqx/emqtt#316](https://github.com/emqx/emqtt/pull/316)): it fixes the `hosts` try order (the list used to be tried in reverse) and adds `shuffle_hosts` (not used here).
- `mk_emqtt_options/1` parses every address with `parse_servers/2` and passes them as the emqtt `hosts` option. One connect attempt tries the addresses in the configured order until one accepts.
- `prefer_host/2` rotates the list per forwarding pool worker (`emqx_cluster_link_mqtt:connect/1`), so the connections of one link spread over the remote nodes while each of them can still fail over. The route replication client keeps the configured order.
- `emqx_cluster_link_app:start_configured_links/0` catches per link, so one link that fails to start cannot stop the application or unregister the config handler.
- `emqx_conf_cli:check_res/5` crashed with `config_not_found` when reporting any `cluster.links` load error, because it looked up `[<<"cluster.links">>]` as a config path. It now splits the dotted key.
- The `server` field description documents the list form and the failover behaviour.

A node that already stores a multi-address link (6.2.2, 6.2.3) starts connecting through it after the upgrade; no config change is needed.

### Tests

- `emqx_cluster_link_config_SUITE:t_multi_server`: a link with a dead address first and two live addresses on two remote nodes. The route replication bootstrap completes, the forwarding resource becomes `connected`, both remote nodes receive link connections, messages reach subscribers on both remote nodes, and the link keeps working after the addresses are reordered. Uses `emqx_cth_cluster:sync_routes/1` after subscribing, since route propagation inside the remote cluster is asynchronous.
- `emqx_cluster_link_config_SUITE:t_broken_link_crud`: a node boots with a stored link whose addresses are all unreachable; the application starts, the config handler stays registered, and the broken link can coexist with a new link, be updated, and be deleted.
- `emqx_cluster_link_api_SUITE:t_multi_server`: create and update through the REST API.
- `emqx_cluster_link_config_tests`: `hosts` order and per-worker rotation.

### Scope

The mismatch exists on every maintained branch since cluster linking was introduced (`dev-510` and every v6 line). This PR targets `dev-63` and reaches `dev-70`/`master` through the forward-sync chain.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
