### PR TITLE
chore(rel): point the forward-sync chain at 7.0 instead of 6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ _build/emqx/rel/emqx/bin/emqx console
 Below are the matrices of supported rolling upgrade paths since 5.0.
 Tables are split for readability; the late-v5 versions (5.8 – 5.10) appear in both.
 
-- Version numbers end with `?` e.g. `6.3?` are future releases.
+- Version numbers end with `?` e.g. `7.0?` are future releases.
 - ✅: Supported, or planed to support.
 - ⚠️:  Supported, but with limitations.
 - ❌: Not supported.
@@ -196,19 +196,22 @@ See release notes for detailed information.
       5.8 versions running 5.8.7 or later require a rolling upgrade to version 5.9.1 or 5.10.1.
       Alternatively, remove the header configuration for OpenTelemetry integration during the upgrade.
 
-### Into v6 (5.8 – 6.3?)
+### Into v6 and v7 (5.8 – 7.0?)
 
-| From\To | 5.8  | 5.9   | 5.10  | 6.0   | 6.1   | 6.2  | 6.3?  |
-|---------|------|-------|-------|-------|-------|------|-------|
-| 5.8     | ✅   | ⚠️[3]  | ⚠️[3]  | ⚠️[4]  | ⚠️[4]  | ⚠️[4] | ⚠️[4]  |
-| 5.9     |      | ✅    | ✅    | ⚠️[4]  | ⚠️[4]  | ⚠️[4] | ⚠️[4]  |
-| 5.10    |      |       | ✅    | ⚠️[4]  | ⚠️[4]  | ⚠️[4] | ⚠️[4]  |
-| 6.0     |      |       |       | ✅    | ✅    | ✅   | ✅    |
-| 6.1     |      |       |       |       | ✅    | ✅   | ✅    |
-| 6.2     |      |       |       |       |       | ✅   | ✅    |
-| 6.3?    |      |       |       |       |       |      | ✅    |
+There is no 6.4 release. The 6.x line ends at 6.3, and 7.0 follows it.
 
-- [4] Durable session states will be lost after upgraded from v5 to v6. After clients reconnect, the sessions created in the new nodes will appear to be clean.
+| From\To | 5.8  | 5.9   | 5.10  | 6.0   | 6.1   | 6.2  | 6.3   | 7.0?  |
+|---------|------|-------|-------|-------|-------|------|-------|-------|
+| 5.8     | ✅   | ⚠️[3]  | ⚠️[3]  | ⚠️[4]  | ⚠️[4]  | ⚠️[4] | ⚠️[4]  | 🔄    |
+| 5.9     |      | ✅    | ✅    | ⚠️[4]  | ⚠️[4]  | ⚠️[4] | ⚠️[4]  | 🔄    |
+| 5.10    |      |       | ✅    | ⚠️[4]  | ⚠️[4]  | ⚠️[4] | ⚠️[4]  | 🔄    |
+| 6.0     |      |       |       | ✅    | ✅    | ✅   | ✅    | 🔄    |
+| 6.1     |      |       |       |       | ✅    | ✅   | ✅    | 🔄    |
+| 6.2     |      |       |       |       |       | ✅   | ✅    | 🔄    |
+| 6.3     |      |       |       |       |       |      | ✅    | 🔄    |
+| 7.0?    |      |       |       |       |       |      |       | ✅    |
+
+- [4] Durable session states will be lost after upgraded from v5 to v6 or later. After clients reconnect, the sessions created in the new nodes will appear to be clean.
 
 ## License
 

--- a/scripts/rel-versions
+++ b/scripts/rel-versions
@@ -5,10 +5,10 @@
 # Example: if HEAD is on a v6.0 topic branch (last reachable GA tag is 6.0.3),
 # this prints
 #
-#     6.0.4, 6.1.4, 6.2.3, 6.3.0, 6.4.0
+#     6.0.4, 6.1.4, 6.2.3, 6.3.0, 7.0.0
 #
-# A downstream line that has no GA tag yet (e.g. dev-64 before 6.4.0 ships)
-# contributes its first GA version, M.N.0 (6.4.0 above).
+# A downstream line that has no GA tag yet (e.g. dev-70 before 7.0.0 ships)
+# contributes its first GA version, M.N.0 (7.0.0 above).
 #
 # computed by running `git describe <remote>/dev-XX --tags --match 'X.Y.*'
 # --exclude '*-*'` against the matching dev-XX branch (so the answers reflect
@@ -17,8 +17,9 @@
 # The pre-release tag forms (6.2.2-rc.1, 6.0.0-alpha.1, ...) are excluded
 # from the lookup; the script computes "next patch after the most recent GA".
 #
-# Branches in the forward-sync chain (v6 line):
-#   dev-60 -> dev-61 -> dev-62 -> dev-63 -> dev-64
+# Branches in the forward-sync chain. The 6.x line ends at dev-63; there is no
+# 6.4 release, so dev-63 syncs forward into dev-70:
+#   dev-60 -> dev-61 -> dev-62 -> dev-63 -> dev-70
 #
 # The script auto-detects the remote pointing at github.com:emqx/emqx from
 # `git remote -v` -- it doesn't assume the remote is called `origin`.
@@ -96,10 +97,13 @@ start_major="${BASH_REMATCH[1]}"
 start_minor="${BASH_REMATCH[2]}"
 
 # ---------------------------------------------------------------------------
-# Forward-sync chain per major version.
+# Forward-sync chain. It spans major versions: the 6.x line ends at dev-63,
+# which syncs forward into dev-70, because 6.4 is not released.
 # ---------------------------------------------------------------------------
+chain=(60 61 62 63 70)
+
 case "$start_major" in
-    6) chain=(60 61 62 63 64) ;;
+    6 | 7) ;;
     *)
         echo "error: unsupported major version $start_major" >&2
         exit 1
@@ -107,7 +111,7 @@ case "$start_major" in
 esac
 
 # Encode the starting minor the same way the chain entries are encoded:
-# chain entries are e.g. 60, 61, 62, 63, 64 (concatenation of major+minor).
+# chain entries are e.g. 60, 61, 62, 63, 70 (concatenation of major+minor).
 start_key="${start_major}${start_minor}"
 
 # ---------------------------------------------------------------------------

--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -22,7 +22,7 @@ options:
                      release-61
                      release-62
                      release-63
-                     release-64
+                     release-70
                      NOTE: this option should be used when --dryrun.
 
   --dryrun:          Do not actually create the git tag.
@@ -97,7 +97,7 @@ done
 rel_branch() {
     local tag="$1"
     case "$tag" in
-        6.*-patch.*)
+        6.*-patch.* | 7.*-patch.*)
             echo "patch-${tag%-patch.*}"
             ;;
         6.0.*)
@@ -112,8 +112,8 @@ rel_branch() {
         6.3.*)
             echo 'release-63'
             ;;
-        6.4.*)
-            echo 'release-64'
+        7.0.*)
+            echo 'release-70'
             ;;
         *)
             logerr "Unsupported version tag $TAG"


### PR DESCRIPTION
There is no 6.4 release. The 6.x line ends at `dev-63`, which syncs forward into `dev-70`.

### Release scripts

- `scripts/rel-versions`: the forward-sync chain now spans major versions, so it becomes a single flat list instead of one list per major. `7` is accepted as a starting major.
- `scripts/rel/cut.sh`: `7.0.*` tags map to `release-70`, the `6.4.*` mapping is dropped, and `7.x` patch tags are recognised.

No ordering against the branch rename is needed. While `dev-70` does not exist, the tag lookup finds nothing and falls back to `7.0.0`, which is the correct answer both before and after the rename.

Verified on this branch:

```
$ ./scripts/rel-versions
6.0.4, 6.1.5, 6.2.3, 6.3.0, 7.0.0
```

`rel_branch` mapping in `cut.sh`:

```
6.0.5         -> release-60
6.3.1         -> release-63
7.0.0         -> release-70
7.0.0-patch.2 -> patch-7.0.0
6.4.0         -> Unsupported version tag
```

### Upgrade paths

`README.md` gains a `7.0?` column and row in the second matrix. Upgrading from v5 straight to v7 is possible, so the v5 rows need that column and the table is widened rather than split again. Everything into `7.0?` is marked tentative, matching how `5.x -> 6.0?` was marked while 6.0 was unreleased.

`6.3` loses its `?` since it is no longer a future release, and the legend now uses `7.0?` as its example of one. Footnote [4] reads "v6 or later", since the v5 rows now reach a v7 column.