### PR TITLE
test(bigquery): widen retry budget for emulator dataset setup

### DIFF
--- a/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
+++ b/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
@@ -448,15 +448,10 @@ do_create_table(Dataset, Table, TCConfig) ->
     ct:pal("table ~s created", [Table]),
     ok.
 
-%% The bigquery emulator (goccy/bigquery-emulator) intermittently drops its
-%% internal SQL connection and replies `500 "sql: connection is already
-%% closed"' to the next request. That made dataset/table setup in
-%% init_per_testcase fail (and skip the whole case). Retry such transient
-%% failures; a 409 means a previous retried attempt already succeeded.
 query_sync_with_retry(Request, Client) ->
     ?retry(
-        _Sleep = 300,
-        _Attempts = 10,
+        _Sleep = 1000,
+        _Attempts = 30,
         case emqx_bridge_gcp_pubsub_client:query_sync(Request, Client) of
             {ok, Result} -> {ok, Result};
             {error, #{status_code := 409}} -> {ok, already_exists}


### PR DESCRIPTION
## Summary

De-flake `emqx_bridge_bigquery_SUITE` dataset/table setup:

```
init_per_testcase ... {case_clause,{error,#{body => <<"sql: connection is already closed\n">>, ..., status_code => 500}}}
%%% emqx_bridge_bigquery_SUITE ==> t_start_stop: SKIPPED
```

Seen in: https://github.com/emqx/emqx/actions/runs/32366449842/job/96420273457?pr=18411

The bigquery emulator intermittently replies 500 "sql: connection is already closed". `query_sync_with_retry/2` (added in #17659) retries this fault, but its budget was 10 x 300 ms. In the run above the emulator stayed broken for longer than 3 seconds, all attempts failed, and the case auto-skipped, which fails the CI job.

Widen the budget to 30 x 1000 ms. The retry only spins on failure, so a healthy emulator pays nothing. If the emulator can outlast 30 s, the next step is to restart the emulator container on this error; keep that for a recurrence.