### PR TITLE
fix(data_backup): skip global-only roots in namespaced imports

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -67,6 +67,7 @@
 -include_lib("kernel/include/file.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_config.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(ROOT_BACKUP_DIR, "backup").
 %% Namespaced backups are isolated under `<root>/ns/<Namespace>/'.
@@ -1383,7 +1384,8 @@ do_import_cluster_hocon(Namespace, BackupDir, Filename, Opts) ->
             maybe
                 {ok, RawConf0} ?= hocon:files([Filename]),
                 RawConf1 = upgrade_raw_conf(emqx_conf:schema_module(), RawConf0),
-                {ok, RawConf} ?= validate_cluster_hocon(RawConf1),
+                RawConf2 = drop_global_only_roots(Namespace, RawConf1, Opts),
+                {ok, RawConf} ?= validate_cluster_hocon(RawConf2),
                 maybe_print(
                     "Importing cluster configuration for namespace ~s...~n", [Namespace], Opts
                 ),
@@ -1399,6 +1401,30 @@ do_import_cluster_hocon(Namespace, BackupDir, Filename, Opts) ->
                 backup => BackupDir
             }),
             {ok, #{}}
+    end.
+
+%% A namespaced import applies only the roots in the namespaced-config
+%% allow-list. Most `emqx_config_backup' importers write the global
+%% configuration regardless of the namespace they are given, so every other
+%% root is dropped before the schema check and the importer dispatch.
+drop_global_only_roots(?global_ns, RawConf, _Opts) ->
+    RawConf;
+drop_global_only_roots(Namespace, RawConf, Opts) when is_binary(Namespace) ->
+    Allowed = emqx_config:namespaced_config_allowed_roots(),
+    case lists:sort([Root || Root <- maps:keys(RawConf), not is_map_key(Root, Allowed)]) of
+        [] ->
+            RawConf;
+        Roots ->
+            maybe_print(
+                "Skipping config roots ~s: not namespace-writable.~n",
+                [lists:join(", ", Roots)],
+                Opts
+            ),
+            ?tp(warning, "data_import_skipped_global_roots", #{
+                namespace => Namespace,
+                root_keys => Roots
+            }),
+            maps:without(Roots, RawConf)
     end.
 
 upgrade_raw_conf(SchemaMod, RawConf) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -769,38 +769,6 @@ t_namespaced_import_foreign_content_forbidden(Config) ->
     ok.
 
 -doc """
-A namespaced administrator must not be able to write global configuration
-through a backup import. When `ns/<NS>/cluster.hocon' carries a root that is
-not namespace-writable (`listeners' here), the import skips that root and the
-global configuration stays untouched, while the namespace-writable roots in
-the same archive are still imported into the namespace.
-""".
-t_namespaced_import_skips_global_roots(Config) ->
-    [Core1 | _] = ?config(cluster, Config),
-    Ns1Auth = ?config(ns_admin_auth, Config),
-    ListenerPath = [<<"listeners">>, <<"tcp">>, <<"ns_escalation">>],
-    ?assertEqual(undefined, ?ON(Core1, emqx:get_raw_config(ListenerPath, undefined))),
-    {LocalPath, Base} = forge_backup(Config, "emqx-export-ns1-global-root", #{
-        <<"ns1">> => <<
-            "listeners.tcp.ns_escalation { bind = \"127.0.0.1:21883\" }\n"
-            "rule_engine.rules.ns_rule { sql = \"SELECT * FROM \\\"t/#\\\"\", actions = [] }\n"
-        >>
-    }),
-    ?assertEqual(ok, upload_backup_ns(?NODE1_PORT, Ns1Auth, LocalPath, #{})),
-    ImportRes = import_backup_ns(?NODE1_PORT, Ns1Auth, Base, #{}),
-    ?assertEqual(
-        undefined,
-        ?ON(Core1, emqx:get_raw_config(ListenerPath, undefined)),
-        #{import_result => ImportRes}
-    ),
-    ?assertMatch({204, _}, ImportRes),
-    ?assertMatch(
-        #{<<"rule_engine">> := #{<<"rules">> := #{<<"ns_rule">> := _}}},
-        ?ON(Core1, emqx_config:get_all_roots_from_namespace(<<"ns1">>))
-    ),
-    ok.
-
--doc """
 The global scope is a full-cluster artifact: importing a global archive
 restores every `ns/<NS>/cluster.hocon' entry into its own namespace, and a
 subsequent global export emits every namespace's configuration back into the
@@ -1460,12 +1428,6 @@ test_case_specific_apps_spec(TestCase) when
 ->
     [
         emqx_exhook
-    ];
-test_case_specific_apps_spec(TestCase) when
-    TestCase =:= t_namespaced_import_skips_global_roots
-->
-    [
-        emqx_rule_engine
     ];
 test_case_specific_apps_spec(_TC) ->
     [].

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -769,6 +769,38 @@ t_namespaced_import_foreign_content_forbidden(Config) ->
     ok.
 
 -doc """
+A namespaced administrator must not be able to write global configuration
+through a backup import. When `ns/<NS>/cluster.hocon' carries a root that is
+not namespace-writable (`listeners' here), the import skips that root and the
+global configuration stays untouched, while the namespace-writable roots in
+the same archive are still imported into the namespace.
+""".
+t_namespaced_import_skips_global_roots(Config) ->
+    [Core1 | _] = ?config(cluster, Config),
+    Ns1Auth = ?config(ns_admin_auth, Config),
+    ListenerPath = [<<"listeners">>, <<"tcp">>, <<"ns_escalation">>],
+    ?assertEqual(undefined, ?ON(Core1, emqx:get_raw_config(ListenerPath, undefined))),
+    {LocalPath, Base} = forge_backup(Config, "emqx-export-ns1-global-root", #{
+        <<"ns1">> => <<
+            "listeners.tcp.ns_escalation { bind = \"127.0.0.1:21883\" }\n"
+            "rule_engine.rules.ns_rule { sql = \"SELECT * FROM \\\"t/#\\\"\", actions = [] }\n"
+        >>
+    }),
+    ?assertEqual(ok, upload_backup_ns(?NODE1_PORT, Ns1Auth, LocalPath, #{})),
+    ImportRes = import_backup_ns(?NODE1_PORT, Ns1Auth, Base, #{}),
+    ?assertEqual(
+        undefined,
+        ?ON(Core1, emqx:get_raw_config(ListenerPath, undefined)),
+        #{import_result => ImportRes}
+    ),
+    ?assertMatch({204, _}, ImportRes),
+    ?assertMatch(
+        #{<<"rule_engine">> := #{<<"rules">> := #{<<"ns_rule">> := _}}},
+        ?ON(Core1, emqx_config:get_all_roots_from_namespace(<<"ns1">>))
+    ),
+    ok.
+
+-doc """
 The global scope is a full-cluster artifact: importing a global archive
 restores every `ns/<NS>/cluster.hocon' entry into its own namespace, and a
 subsequent global export emits every namespace's configuration back into the
@@ -1428,6 +1460,12 @@ test_case_specific_apps_spec(TestCase) when
 ->
     [
         emqx_exhook
+    ];
+test_case_specific_apps_spec(TestCase) when
+    TestCase =:= t_namespaced_import_skips_global_roots
+->
+    [
+        emqx_rule_engine
     ];
 test_case_specific_apps_spec(_TC) ->
     [].

--- a/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
@@ -644,6 +644,57 @@ t_import_cluster_hocon_partial_node(Config) ->
         emqx_mgmt_data_backup:import_local(BackupFileName)
     ).
 
+-doc """
+A namespaced import never applies a root that is not namespace-writable: the
+root is skipped with a warning while the namespace-writable roots in the same
+archive are still imported.
+""".
+t_namespaced_import_skips_global_roots(Config) ->
+    Namespace = <<"ns1">>,
+    BaseName = "export-ns-global-root-backup",
+    BackupFileName = filename:join(?config(priv_dir, Config), BaseName ++ ".tar.gz"),
+    Meta = unicode:characters_to_binary(
+        hocon_pp:do(#{edition => emqx_release:edition(), version => emqx_release:version()}, #{})
+    ),
+    NsConf = <<
+        "listeners.tcp.ns_escalation { bind = \"127.0.0.1:21884\" }\n"
+        "rule_engine.rules.ns_rule { sql = \"SELECT * FROM \\\"t/#\\\"\", actions = [] }\n"
+    >>,
+    ok = erl_tar:create(
+        BackupFileName,
+        [
+            {BaseName ++ "/ns/ns1/cluster.hocon", NsConf},
+            {BaseName ++ "/META.hocon", Meta}
+        ],
+        [compressed]
+    ),
+    ListenerPath = [<<"listeners">>, <<"tcp">>, <<"ns_escalation">>],
+    ?assertEqual(undefined, emqx:get_raw_config(ListenerPath, undefined)),
+    ?check_trace(
+        begin
+            ImportRes = emqx_mgmt_data_backup:import_local(
+                BackupFileName, #{namespace => Namespace}
+            ),
+            ?assertEqual(
+                undefined,
+                emqx:get_raw_config(ListenerPath, undefined),
+                #{import => ImportRes}
+            ),
+            ?assertEqual({ok, #{db_errors => #{}, config_errors => #{}}}, ImportRes),
+            ?assertMatch(
+                #{<<"rule_engine">> := #{<<"rules">> := #{<<"ns_rule">> := _}}},
+                emqx_config:get_all_roots_from_namespace(Namespace)
+            )
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [#{namespace := Namespace, root_keys := [<<"listeners">>]}],
+                ?of_kind("data_import_skipped_global_roots", Trace)
+            )
+        end
+    ),
+    ok.
+
 t_cluster_links(_Config) ->
     Link = #{
         <<"name">> => <<"emqxcl_backup_test">>,

--- a/changes/ee/fix-18423.en.md
+++ b/changes/ee/fix-18423.en.md
@@ -1,0 +1,1 @@
+Data Backup imports performed by a namespaced administrator now apply only that namespace's configuration. Cluster-wide settings found in the namespaced configuration, such as authentication, authorization, ExHook, or listeners, are skipped with a warning instead of being written to the global configuration.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
6.0.0

## Summary

Fixes emqx/emqx-dev-team-tasks#349.

A namespaced import dispatched every root found in `ns/<NS>/cluster.hocon` to the `emqx_config_backup` importers. Most importers ignore the namespace argument and write the global configuration, so a namespaced archive carrying a root outside the namespaced-config allow-list was applied globally.

`emqx_mgmt_data_backup:do_import_cluster_hocon/4` now drops every root that is not in `emqx_config:namespaced_config_allowed_roots/0` from a namespaced import before the schema check and the importer dispatch. The skipped roots are logged as a warning (`data_import_skipped_global_roots`) and printed on the CLI; the namespace-writable roots in the same archive are still imported. The import is not failed, so an archive produced by a node with a different allow-list still imports the roots this node can apply.

Test: `t_namespaced_import_skips_global_roots` in `emqx_mgmt_data_backup_SUITE`. It fails on the unfixed code.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
