### PR TITLE
refactor(plugins): read plugin config schema on demand

### DIFF
--- a/apps/emqx_plugins/include/emqx_plugins.hrl
+++ b/apps/emqx_plugins/include/emqx_plugins.hrl
@@ -7,8 +7,6 @@
 
 -define(CONF_ROOT, plugins).
 
--define(PLUGIN_SERDE_TAB, emqx_plugins_schema_serde_tab).
-
 -define(CONFIG_FORMAT_BIN, config_format_bin).
 -define(CONFIG_FORMAT_MAP, config_format_map).
 

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -461,7 +461,6 @@ purge_other_versions(NameVsn) ->
 %% @doc Delete the package file.
 -spec delete_package(name_vsn()) -> ok.
 delete_package(NameVsn) ->
-    _ = emqx_plugins_serde:delete_schema(NameVsn),
     emqx_plugins_fs:delete_tar(NameVsn).
 
 %% @doc Safely delete a plugin package.
@@ -738,16 +737,15 @@ normalize_headers(_) ->
 decode_plugin_config_map(NameVsn, AvroJson) ->
     case has_avsc(NameVsn) of
         true ->
-            case emqx_plugins_serde:decode(NameVsn, ensure_config_bin(AvroJson)) of
-                {ok, Config} ->
-                    {ok, Config};
-                {error, #{reason := plugin_serde_not_found}} ->
-                    Reason = "plugin_config_schema_serde_not_found",
+            case emqx_plugins_fs:read_avsc_bin(NameVsn) of
+                {ok, AvscBin} ->
+                    emqx_plugins_serde:decode(NameVsn, AvscBin, ensure_config_bin(AvroJson));
+                {error, Reason} = Error ->
                     ?SLOG(error, #{
-                        msg => Reason, name_vsn => NameVsn, plugin_with_avro_schema => true
+                        msg => "failed_to_read_plugin_config_schema",
+                        name_vsn => NameVsn,
+                        reason => Reason
                     }),
-                    {error, Reason};
-                {error, _} = Error ->
                     Error
             end;
         false ->
@@ -863,7 +861,6 @@ do_ensure_started(NameVsn) ->
     maybe
         ok ?= ensure_no_other_version_active(NameVsn),
         ok ?= install(NameVsn, ?normal),
-        ok ?= load_config_schema(NameVsn),
         ok ?= maybe_initialize_cached_config(NameVsn),
         {ok, Plugin} ?= emqx_plugins_info:read(NameVsn),
         {ok, Schema} ?= read_start_schema(NameVsn, Plugin),
@@ -1074,12 +1071,8 @@ validate_installation(NameVsn) ->
     maybe
         {ok, Plugin} ?= emqx_plugins_info:read(NameVsn),
         ok ?= emqx_plugins_apps:validate(Plugin, emqx_plugins_fs:lib_dir(NameVsn)),
-        ok ?= load_config_schema(NameVsn),
+        ok ?= check_config_schema(NameVsn),
         ok ?= validate_default_config(NameVsn)
-    else
-        {error, _} = Error ->
-            _ = emqx_plugins_serde:delete_schema(NameVsn),
-            Error
     end.
 
 validate_default_config(NameVsn) ->
@@ -1103,7 +1096,7 @@ install_and_configure(NameVsn, Mode, RunningSt) ->
 
 configure(NameVsn, Mode, RunningSt) ->
     maybe
-        ok ?= load_config_schema(NameVsn),
+        ok ?= check_config_schema(NameVsn),
         ok ?= ensure_local_config(NameVsn, Mode),
         ok ?= configure_from_local_config(NameVsn, RunningSt),
         ensure_state(NameVsn)
@@ -1541,10 +1534,12 @@ request_config_change(NameVsn, #{running_status := RunningSt}, Config) when
 ->
     emqx_plugins_apps:on_config_changed(NameVsn, get_cached_config(NameVsn), Config).
 
-load_config_schema(NameVsn) ->
+%% Check that the plugin's config schema file, when the plugin declares one, is a valid
+%% Avro schema. The schema itself is read again from disk each time a config is validated.
+check_config_schema(NameVsn) ->
     case emqx_plugins_fs:read_avsc_bin(NameVsn) of
         {ok, AvscBin} ->
-            emqx_plugins_serde:add_schema(bin(NameVsn), AvscBin);
+            emqx_plugins_serde:check_schema(NameVsn, AvscBin);
         {error, #{reason := enoent}} = Error ->
             case has_avsc(NameVsn) of
                 true -> Error;

--- a/apps/emqx_plugins/src/emqx_plugins_fs.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_fs.erl
@@ -36,7 +36,6 @@
     read_md5sum/1,
     read_avsc_map/1,
     read_avsc_bin/1,
-    read_avsc_bin_all/0,
     read_i18n/1,
     read_hocon/1,
     read_default_hocon/1
@@ -103,18 +102,6 @@ read_avsc_map(NameVsn) ->
 read_avsc_bin(NameVsn) ->
     AvscFilePath = avsc_file_path(NameVsn),
     read_file_bin(AvscFilePath, "bad_avsc_file").
-
--spec read_avsc_bin_all() -> [{name_vsn(), binary()}].
-read_avsc_bin_all() ->
-    lists:filtermap(
-        fun(NameVsn) ->
-            case read_avsc_bin(NameVsn) of
-                {ok, AvscBin} -> {true, {NameVsn, AvscBin}};
-                {error, _} -> false
-            end
-        end,
-        list_name_vsn()
-    ).
 
 -spec read_i18n(name_vsn()) -> {ok, map()} | {error, term()}.
 read_i18n(NameVsn) ->

--- a/apps/emqx_plugins/src/emqx_plugins_serde.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_serde.erl
@@ -4,32 +4,23 @@
 
 -module(emqx_plugins_serde).
 
+-moduledoc """
+Validate plugin configuration against the plugin's Avro schema.
+
+The caller passes the schema (`config_schema.avsc` content) together with the
+configuration. The schema is parsed on each call and is not kept in memory.
+""".
+
 -include("emqx_plugins.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("erlavro/include/erlavro.hrl").
 
-%% API
 -export([
-    start_link/0,
-    add_schema/2,
-    delete_schema/1
+    check_schema/2,
+    decode/3
 ]).
 
-%% `gen_server' API
--export([
-    init/1,
-    handle_call/3,
-    handle_cast/2,
-    terminate/2
-]).
-
--export([
-    decode/2,
-    decode/3,
-    encode/2
-]).
-
--define(SERVER, ?MODULE).
+-define(WHICH_OP, "decode_avro_json").
 
 %%-------------------------------------------------------------------------------------------------
 %% records
@@ -41,138 +32,38 @@
 }).
 
 %%-------------------------------------------------------------------------------------------------
-%% messages
-%%-------------------------------------------------------------------------------------------------
-
--record(add_schema, {
-    name_vsn :: name_vsn(),
-    avsc_bin :: binary()
-}).
-
-%%-------------------------------------------------------------------------------------------------
 %% API
 %%-------------------------------------------------------------------------------------------------
 
-start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
-
--spec add_schema(schema_name(), binary()) -> ok | {error, term()}.
-add_schema(NameVsn, AvscBin) ->
-    case gen_server:call(?SERVER, #add_schema{name_vsn = NameVsn, avsc_bin = AvscBin}, infinity) of
-        ok ->
-            ?SLOG(debug, #{msg => "plugin_schema_added", plugin => NameVsn}),
-            ok;
-        {error, Reason} = Error ->
-            ?SLOG(error, #{
-                msg => "plugin_schema_add_failed",
-                plugin => NameVsn,
-                reason => emqx_utils:readable_error_msg(Reason)
-            }),
-            Error
+-doc "Check that the schema binary is a valid Avro schema.".
+-spec check_schema(name_vsn(), binary()) -> ok | {error, #{reason := bad_schema, _ => _}}.
+check_schema(NameVsn, AvscBin) ->
+    try
+        _ = make_serde(NameVsn, AvscBin),
+        ok
+    catch
+        _Kind:Error ->
+            {error, bad_schema_error(Error)}
     end.
 
--spec delete_schema(schema_name()) -> ok | {error, term()}.
-delete_schema(NameVsn) ->
-    case lookup_serde(NameVsn) of
-        {ok, _Serde} ->
-            async_delete_serdes([NameVsn]),
-            ok;
-        {error, not_found} ->
-            {error, not_found}
-    end.
-
--spec decode(schema_name(), encoded_data()) -> {ok, decoded_data()} | {error, any()}.
-decode(SerdeName, RawData) ->
-    with_serde(
-        ?FUNCTION_NAME,
-        SerdeName,
-        [RawData]
-    ).
-
--spec decode(schema_name(), binary(), encoded_data()) ->
+-doc "Decode (validate) the JSON configuration against the schema binary.".
+-spec decode(name_vsn(), binary(), encoded_data()) ->
     {ok, decoded_data()} | {error, any()}.
 decode(SerdeName, AvscBin, RawData) ->
     try
         Serde = make_serde(SerdeName, AvscBin),
-        with_serde_record(?FUNCTION_NAME, Serde, [RawData])
+        decode_with_serde(Serde, RawData)
     catch
         _Kind:Error ->
-            {error, #{reason => bad_schema, details => Error}}
+            {error, bad_schema_error(Error)}
     end.
-
--spec encode(schema_name(), decoded_data()) -> {ok, encoded_data()} | {error, any()}.
-encode(SerdeName, Data) ->
-    with_serde(
-        ?FUNCTION_NAME,
-        SerdeName,
-        [Data]
-    ).
-
-%%-------------------------------------------------------------------------------------------------
-%% `gen_server' API
-%%-------------------------------------------------------------------------------------------------
-
-init(_) ->
-    process_flag(trap_exit, true),
-    ok = emqx_utils_ets:new(?PLUGIN_SERDE_TAB, [
-        public, ordered_set, {keypos, #plugin_schema_serde.name}
-    ]),
-    State = #{},
-    Avscs = emqx_plugins_fs:read_avsc_bin_all(),
-    %% force build all schemas at startup
-    %% otherwise plugin schema may not be available when needed
-    _ = build_serdes(Avscs),
-    {ok, State}.
-
-handle_call(#add_schema{name_vsn = NameVsn, avsc_bin = AvscBin}, _From, State) ->
-    BuildRes = do_build_serde({NameVsn, AvscBin}),
-    {reply, BuildRes, State};
-handle_call(_Call, _From, State) ->
-    {reply, {error, unknown_call}, State}.
-
-handle_cast({delete_serdes, Names}, State) ->
-    lists:foreach(fun ensure_serde_absent/1, Names),
-    {noreply, State};
-handle_cast(_Cast, State) ->
-    {noreply, State}.
-
-terminate(_Reason, _State) ->
-    ok.
 
 %%-------------------------------------------------------------------------------------------------
 %% Internal fns
 %%-------------------------------------------------------------------------------------------------
 
-lookup_serde(SchemaName) ->
-    case ets:lookup(?PLUGIN_SERDE_TAB, to_bin(SchemaName)) of
-        [] ->
-            {error, not_found};
-        [Serde] ->
-            {ok, Serde}
-    end.
-
-build_serdes(Avscs) ->
-    ok = lists:foreach(fun do_build_serde/1, Avscs).
-
-do_build_serde({NameVsn, AvscBin}) ->
-    try
-        Serde = make_serde(NameVsn, AvscBin),
-        true = ets:insert(?PLUGIN_SERDE_TAB, Serde),
-        ok
-    catch
-        Kind:Error:Stacktrace ->
-            ?SLOG(
-                error,
-                #{
-                    msg => "error_building_plugin_schema_serde",
-                    name => NameVsn,
-                    kind => Kind,
-                    error => Error,
-                    stacktrace => Stacktrace
-                }
-            ),
-            {error, #{reason => bad_schema, details => Error}}
-    end.
+bad_schema_error(Error) ->
+    #{reason => bad_schema, details => Error}.
 
 make_serde(NameVsn, AvscBin) when not is_binary(NameVsn) ->
     make_serde(to_bin(NameVsn), AvscBin);
@@ -186,41 +77,14 @@ make_serde(NameVsn, AvscBin) ->
         eval_context = Store
     }.
 
-ensure_serde_absent(Name) when not is_binary(Name) ->
-    ensure_serde_absent(to_bin(Name));
-ensure_serde_absent(Name) ->
-    case lookup_serde(Name) of
-        {ok, _Serde} ->
-            _ = ets:delete(?PLUGIN_SERDE_TAB, Name),
-            ok;
-        {error, not_found} ->
-            ok
-    end.
-
-async_delete_serdes(Names) ->
-    gen_server:cast(?MODULE, {delete_serdes, Names}).
-
-with_serde(Op, SerdeName, Args) ->
-    case lookup_serde(SerdeName) of
-        {ok, Serde} ->
-            with_serde_record(Op, Serde, Args);
-        {error, not_found} ->
-            {error, #{
-                error_msg => error_msg(Op),
-                reason => plugin_serde_not_found,
-                serde_name => SerdeName
-            }}
-    end.
-
-with_serde_record(Op, #plugin_schema_serde{} = Serde, Args) ->
-    WhichOp = which_op(Op),
+decode_with_serde(#plugin_schema_serde{} = Serde, Data) ->
     try
-        eval_serde(Op, Serde, Args)
+        decode_value(Serde, Data)
     catch
         throw:Reason ->
             ?SLOG(error, #{
                 msg => "plugin_schema_op_failed",
-                which_op => WhichOp,
+                which_op => ?WHICH_OP,
                 reason => emqx_utils:readable_error_msg(Reason)
             }),
             {error, Reason};
@@ -228,17 +92,17 @@ with_serde_record(Op, #plugin_schema_serde{} = Serde, Args) ->
             %% unexpected errors, log stacktrace
             ?SLOG(warning, #{
                 msg => "plugin_schema_op_failed",
-                which_op => WhichOp,
+                which_op => ?WHICH_OP,
                 exception => Reason,
                 stacktrace => Stacktrace
             }),
             {error, #{
-                which_op => WhichOp,
+                which_op => ?WHICH_OP,
                 reason => Reason
             }}
     end.
 
-eval_serde(decode, #plugin_schema_serde{name = Name, eval_context = Store}, [Data]) ->
+decode_value(#plugin_schema_serde{name = Name, eval_context = Store}, Data) ->
     Opts = avro:make_decoder_options([
         {map_type, map},
         {record_type, map},
@@ -258,17 +122,7 @@ eval_serde(decode, #plugin_schema_serde{name = Name, eval_context = Store}, [Dat
                 false ->
                     erlang:raise(error, function_clause, Stacktrace)
             end
-    end;
-eval_serde(encode, #plugin_schema_serde{name = Name, eval_context = Store}, [Data]) ->
-    {ok, avro_json_encoder:encode(Store, Name, Data)};
-eval_serde(_, _, _) ->
-    throw(#{error_msg => "unexpected_plugin_avro_op"}).
-
-which_op(Op) ->
-    atom_to_list(Op) ++ "_avro_json".
-
-error_msg(Op) ->
-    atom_to_list(Op) ++ "_avro_data".
+    end.
 
 decode_hook(Type, SubNameOrIndex, Data, DecodeFun) ->
     Path0 = get(?MODULE),

--- a/apps/emqx_plugins/src/emqx_plugins_sup.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_sup.erl
@@ -20,14 +20,5 @@ init([]) ->
             intensity => 100,
             period => 10
         },
-    ChildSpecs = [child_spec(emqx_plugins_serde)],
+    ChildSpecs = [],
     {ok, {SupFlags, ChildSpecs}}.
-
-child_spec(Mod) ->
-    #{
-        id => Mod,
-        start => {Mod, start_link, []},
-        restart => permanent,
-        shutdown => 5_000,
-        type => worker
-    }.

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -665,16 +665,117 @@ t_rejects_invalid_schema_on_reconfigure({init, Config}) ->
     ok = make_plugin_tar(NameVsn),
     ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
     ok = emqx_plugins:ensure_started(NameVsn),
-    ok = file:write_file(
-        filename:join([filename:dirname(plugin_ebin_dir(NameVsn)), "priv", "config_schema.avsc"]),
-        <<"not an avro schema">>
-    ),
+    ok = file:write_file(plugin_avsc_path(NameVsn), <<"not an avro schema">>),
     [{name_vsn, NameVsn} | Config];
 t_rejects_invalid_schema_on_reconfigure({'end', Config}) ->
     _ = emqx_plugins:ensure_stopped(?config(name_vsn, Config)),
     cleanup_invalid_plugin(?config(name_vsn, Config));
 t_rejects_invalid_schema_on_reconfigure(Config) ->
     ?assertMatch({error, _}, emqx_plugins:ensure_installed(?config(name_vsn, Config))).
+
+-doc "A plugin with a config schema: a valid config decodes, an invalid one is rejected.".
+t_decode_config_with_schema({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    [{name_vsn, NameVsn} | Config];
+t_decode_config_with_schema({'end', Config}) ->
+    cleanup_invalid_plugin(?config(name_vsn, Config));
+t_decode_config_with_schema(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    ?assertMatch(
+        {ok, _},
+        emqx_plugins:decode_plugin_config_map(NameVsn, #{<<"foo">> => <<"bar">>})
+    ),
+    ?assertMatch(
+        {error, #{
+            reason := invalid_type,
+            path := <<"foo">>,
+            expected := <<"string">>,
+            actual := <<"integer">>
+        }},
+        emqx_plugins:decode_plugin_config_map(NameVsn, #{<<"foo">> => 42})
+    ).
+
+-doc "A plugin that declares no config schema accepts any config without validation.".
+t_decode_config_without_schema({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    Info = <<
+        "{\"name\":\"invalid_plugin\",\"rel_vsn\":\"1.0.0\","
+        "\"rel_apps\":[\"invalid_plugin-0.1.0\"],\"description\":\"test\","
+        "\"with_config_schema\":false}"
+    >>,
+    ok = replace_tar_entry(NameVsn, "release.json", Info),
+    ok = remove_tar_entry(NameVsn, "config_schema.avsc"),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    [{name_vsn, NameVsn} | Config];
+t_decode_config_without_schema({'end', Config}) ->
+    cleanup_invalid_plugin(?config(name_vsn, Config));
+t_decode_config_without_schema(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    ?assertEqual(
+        {ok, ?plugin_without_config_schema},
+        emqx_plugins:decode_plugin_config_map(NameVsn, #{<<"foo">> => 42})
+    ).
+
+-doc """
+The schema is read from the plugin's priv dir at validation time: a missing file is a
+read error, a corrupt file is a bad_schema error.
+""".
+t_decode_config_schema_file_missing_or_corrupt({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    [{name_vsn, NameVsn} | Config];
+t_decode_config_schema_file_missing_or_corrupt({'end', Config}) ->
+    cleanup_invalid_plugin(?config(name_vsn, Config));
+t_decode_config_schema_file_missing_or_corrupt(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    AvscPath = plugin_avsc_path(NameVsn),
+    ValidConfig = #{<<"foo">> => <<"bar">>},
+    ?assertMatch({ok, _}, emqx_plugins:decode_plugin_config_map(NameVsn, ValidConfig)),
+    ok = file:delete(AvscPath),
+    ?assertMatch(
+        {error, #{msg := "bad_avsc_file", reason := enoent}},
+        emqx_plugins:decode_plugin_config_map(NameVsn, ValidConfig)
+    ),
+    ok = file:write_file(AvscPath, <<"not an avro schema">>),
+    ?assertMatch(
+        {error, #{reason := bad_schema}},
+        emqx_plugins:decode_plugin_config_map(NameVsn, ValidConfig)
+    ).
+
+-doc """
+A changed schema file takes effect on the next validation without reinstalling the
+plugin: no stale copy of the schema is kept.
+""".
+t_decode_config_uses_current_schema_file({init, Config}) ->
+    NameVsn = "invalid_plugin-1.0.0",
+    ok = make_plugin_tar(NameVsn),
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
+    [{name_vsn, NameVsn} | Config];
+t_decode_config_uses_current_schema_file({'end', Config}) ->
+    cleanup_invalid_plugin(?config(name_vsn, Config));
+t_decode_config_uses_current_schema_file(Config) ->
+    NameVsn = ?config(name_vsn, Config),
+    IntConfig = #{<<"foo">> => 42},
+    StrConfig = #{<<"foo">> => <<"bar">>},
+    ?assertMatch({ok, _}, emqx_plugins:decode_plugin_config_map(NameVsn, StrConfig)),
+    ?assertMatch(
+        {error, #{reason := invalid_type}},
+        emqx_plugins:decode_plugin_config_map(NameVsn, IntConfig)
+    ),
+    IntSchema =
+        <<"{\"type\":\"record\",\"name\":\"invalid_plugin\",\"fields\":[{\"name\":\"foo\",\"type\":\"int\"}]}">>,
+    ok = file:write_file(plugin_avsc_path(NameVsn), IntSchema),
+    ?assertMatch(
+        {ok, _}, emqx_plugins:decode_plugin_config_map(NameVsn, IntConfig)
+    ),
+    ?assertMatch(
+        {error, #{reason := invalid_type, expected := <<"int">>, actual := <<"string">>}},
+        emqx_plugins:decode_plugin_config_map(NameVsn, StrConfig)
+    ).
 
 t_rejects_invalid_local_config_on_start({init, Config}) ->
     NameVsn = "invalid_plugin-1.0.0",
@@ -692,7 +793,6 @@ t_rejects_invalid_local_config_on_start(Config) ->
     NameVsn = ?config(name_vsn, Config),
     ?assertMatch({error, _}, emqx_plugins:ensure_installed(NameVsn)),
     LoadedApps = lists:sort(application:loaded_applications()),
-    Serdes = lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB)),
     CachedConfig = emqx_plugins:get_config(NameVsn, not_found),
     {ok, ConfigBin} = file:read_file(emqx_plugins_fs:config_file_path(NameVsn)),
     ?assertMatch(
@@ -708,7 +808,6 @@ t_rejects_invalid_local_config_on_start(Config) ->
         emqx_plugins:validate_start(NameVsn)
     ),
     ?assertEqual(LoadedApps, lists:sort(application:loaded_applications())),
-    ?assertEqual(Serdes, lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB))),
     ?assertEqual(CachedConfig, emqx_plugins:get_config(NameVsn, not_found)),
     ?assertEqual(
         {ok, ConfigBin},
@@ -727,13 +826,11 @@ t_validate_start_does_not_start({'end', Config}) ->
 t_validate_start_does_not_start(Config) ->
     NameVsn = ?config(name_vsn, Config),
     LoadedApps = lists:sort(application:loaded_applications()),
-    Serdes = lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB)),
     CachedConfig = emqx_plugins:get_config(NameVsn, not_found),
     {ok, ConfigBin} = file:read_file(emqx_plugins_fs:config_file_path(NameVsn)),
     ?assertEqual({ok, not_running}, emqx_plugins:validate_start(NameVsn)),
     ?assertNot(is_app_running(invalid_plugin)),
     ?assertEqual(LoadedApps, lists:sort(application:loaded_applications())),
-    ?assertEqual(Serdes, lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB))),
     ?assertEqual(CachedConfig, emqx_plugins:get_config(NameVsn, not_found)),
     ?assertEqual(
         {ok, ConfigBin},
@@ -749,14 +846,12 @@ t_ensure_start_package_only_materializes_files({'end', Config}) ->
 t_ensure_start_package_only_materializes_files(Config) ->
     NameVsn = ?config(name_vsn, Config),
     LoadedApps = lists:sort(application:loaded_applications()),
-    Serdes = lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB)),
     CachedConfig = emqx_plugins:get_config(NameVsn, not_found),
     ?assertNot(filelib:is_dir(emqx_plugins_fs:plugin_dir(NameVsn))),
     ok = emqx_plugins:ensure_start_package(NameVsn),
     ?assert(filelib:is_dir(emqx_plugins_fs:plugin_dir(NameVsn))),
     ?assertNot(is_app_running(invalid_plugin)),
     ?assertEqual(LoadedApps, lists:sort(application:loaded_applications())),
-    ?assertEqual(Serdes, lists:sort(ets:tab2list(?PLUGIN_SERDE_TAB))),
     ?assertEqual(CachedConfig, emqx_plugins:get_config(NameVsn, not_found)),
     ?assertEqual({ok, not_running}, emqx_plugins:validate_start(NameVsn)).
 
@@ -960,6 +1055,9 @@ cleanup_invalid_plugin(NameVsn) ->
 
 plugin_ebin_dir(NameVsn) ->
     filename:join([emqx_plugins_fs:lib_dir(NameVsn), "invalid_plugin-0.1.0", "ebin"]).
+
+plugin_avsc_path(NameVsn) ->
+    filename:join([filename:dirname(plugin_ebin_dir(NameVsn)), "priv", "config_schema.avsc"]).
 
 make_plugin_tar(NameVsn) ->
     PluginApp = "invalid_plugin-0.1.0",

--- a/apps/emqx_plugins/test/emqx_plugins_tests.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_tests.erl
@@ -187,7 +187,6 @@ purge_test() ->
 
 meck_emqx() ->
     meck:new(emqx, [passthrough]),
-    meck:new(emqx_plugins_serde),
     meck:expect(
         emqx,
         update_config,
@@ -195,16 +194,10 @@ meck_emqx() ->
             emqx_config:put(Path, Values)
         end
     ),
-    meck:expect(
-        emqx_plugins_serde,
-        delete_schema,
-        fun(_NameVsn) -> ok end
-    ),
     ok.
 
 unmeck_emqx() ->
     meck:unload(emqx),
-    meck:unload(emqx_plugins_serde),
     ok.
 
 %%--------------------------------------------------------------------

--- a/changes/ee/perf-18424.en.md
+++ b/changes/ee/perf-18424.en.md
@@ -1,0 +1,3 @@
+Plugin configuration schemas (`config_schema.avsc`) are now read from the installed plugin package each time a plugin configuration is validated, instead of being kept in memory for every installed plugin.
+
+When the schema file of an installed plugin is missing or unreadable, plugin configuration validation now reports the file error.

--- a/plugins/emqx_acme/test/emqx_acme_api_SUITE.erl
+++ b/plugins/emqx_acme/test/emqx_acme_api_SUITE.erl
@@ -14,7 +14,7 @@ all() ->
 "response when a body passes the avsc schema but the plugin's own parser "
 "rejects it. The HTTP layer's two validation hops (see "
 "emqx_mgmt_api_plugins:put_plugin_config/2) are exercised independently: "
-"emqx_plugins_serde:decode/2 runs the avsc validation, and "
+"emqx_plugins_serde:decode/3 runs the avsc validation, and "
 "emqx_acme_config:parse/1 runs the plugin-specific parse. A bad domain "
 "(\"admin@example\") is the canonical case -- the avsc accepts any "
 "string for `domains` but the parser refuses entries that idna would "
@@ -37,7 +37,7 @@ t_put_config_returns_400_when_parser_rejects_avro_valid_input(_Config) ->
     },
     BadJson = emqx_utils_json:encode(BadBody),
 
-    %% Layer 1 (avsc validation): emqx_plugins_serde:decode/2 mirrors the
+    %% Layer 1 (avsc validation): emqx_plugins_serde:decode/3 mirrors the
     %% server-side avsc check that runs before the BPAPI fan-out. It must
     %% accept the body -- only then is the parse-fail case distinguishable
     %% from the avsc-fail case (which would already return 400 with a


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
N/A

## Summary

`emqx_plugins_serde` was a `gen_server` that parsed every installed plugin's `config_schema.avsc` at boot and kept the Avro schema stores in an ETS table. This PR removes the process and the table. The schema is now read from the plugin's priv dir and parsed each time a plugin config is validated.

Why this is safe:

* Every caller of the resident schema was an install, start, or config-update path: `decode_plugin_config_map/2` is called from the `PUT /plugins/:name/config` handler, from `validate_default_config/1` at install, and from `validated_local_config/1` at start. The start-time validation (`validate_start_config/4`) already used the on-demand `decode/3`. No per-message or per-connection path touches the schema.
* Parse cost is small. `avro_schema_store:import_schema_json/3` on the in-tree plugin schemas: 44 µs (`emqx_username_quota`, 1 KB), 164 µs (`emqx_acme`, 4 KB), 732 µs (`emqx_offline_messages`, 18 KB), 2.6 ms (`emqx_agent`, 22 KB). The same validation path already loads `release.json` through hocon for the `with_config_schema` check, at about 270 µs per call, so the parse does not change the cost class of a validation. A lazy cache would add invalidation logic for no measurable gain.
* The eager build at boot (`force build all schemas at startup`) guarded an ordering race between `ensure_started` and the serde process (e8d4e88118). With no resident store there is nothing to race against.

Changes:

* `emqx_plugins_serde`: keep `decode/3`, add `check_schema/2` (parse-only check used at install and configure). Remove `start_link/0`, `add_schema/2`, `delete_schema/1`, `decode/2`, and the unused `encode/2`.
* `emqx_plugins`: `decode_plugin_config_map/2` reads the schema file and calls `decode/3`. `load_config_schema/1` becomes `check_config_schema/1`. The redundant schema check in `do_ensure_started/1` is dropped (`install/2` and `resolve_and_validate_start_config/2` both cover it).
* `emqx_plugins_sup` has no children now; it stays as the application's top supervisor.
* `emqx_plugins_fs:read_avsc_bin_all/0` and `?PLUGIN_SERDE_TAB` are removed.

Error shape: when a plugin declares a schema but the file is missing or unreadable at validation time, the error is now the file error (`#{msg => "bad_avsc_file", reason => enoent}`) instead of `"plugin_config_schema_serde_not_found"`. A corrupt schema file yields `#{reason => bad_schema}` as before. The changelog covers this.

Tests: the `?PLUGIN_SERDE_TAB` assertions in `emqx_plugins_SUITE` are replaced by cases that validate configs through `decode_plugin_config_map/2`: valid and invalid config with a schema, a plugin without a schema, a schema file that goes missing or corrupt after install, and a changed schema file taking effect without reinstalling.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
