### PR TITLE
fix(api): correct metrics aggregate default

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_metrics.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_metrics.erl
@@ -137,9 +137,10 @@ schema("/metrics") ->
                                 #{
                                     in => query,
                                     required => false,
+                                    default => false,
                                     desc => <<
                                         "Whether to aggregate all nodes Metrics. "
-                                        "Default value is 'true'."
+                                        "Default value is 'false'."
                                     >>
                                 }
                             )},


### PR DESCRIPTION
Release versions: 5.10.5

Introduced in: 5.8.2

## Summary

Correct the Swagger description for `GET /api/v5/metrics`: `aggregate` defaults to `false`, matching the runtime behavior. The OpenAPI schema now also declares the default explicitly.

## PR Checklist

- [x] The changes are covered with existing tests
- [x] Schema changes are backward compatible or intentionally breaking (the default declaration matches existing behavior)