### PR TITLE
fix(api): correct metrics aggregate default

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_metrics.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_metrics.erl
@@ -136,6 +136,7 @@ schema("/metrics") ->
                                 #{
                                     in => query,
                                     required => false,
+                                    default => false,
                                     desc => ?DESC("aggregate_parameter")
                                 }
                             )},

--- a/rel/i18n/emqx_mgmt_api_metrics.hocon
+++ b/rel/i18n/emqx_mgmt_api_metrics.hocon
@@ -6,7 +6,7 @@ emqx_metrics.label:
 """EMQX metrics"""
 
 aggregate_parameter.desc:
-"""Whether to aggregate all nodes Metrics. Default value is 'true'."""
+"""Whether to aggregate all nodes Metrics. Default value is 'false'."""
 aggregate_parameter.label:
 """Aggregate Parameter"""
 


### PR DESCRIPTION
Port: https://github.com/emqx/emqx/pull/18426
## Summary

Correct the Swagger description for `GET /api/v5/metrics`: `aggregate` defaults to `false`, matching the runtime behavior. The OpenAPI schema now also declares the default explicitly.

## PR Checklist

- [x] The changes are covered with existing tests
- [x] Schema changes are backward compatible or intentionally breaking (the default declaration matches existing behavior)