### PR TITLE
fix(nats): enforce account JWT expiry and revocations

### DIFF
--- a/apps/emqx_gateway_nats/mix.exs
+++ b/apps/emqx_gateway_nats/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayNats.MixProject do
   def project do
     [
       app: :emqx_gateway_nats,
-      version: "6.2.2",
+      version: "6.2.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_nats/src/emqx_nats_authn.erl
+++ b/apps/emqx_gateway_nats/src/emqx_nats_authn.erl
@@ -9,7 +9,8 @@
     is_auth_required/2,
     ensure_nkey_nonce/2,
     maybe_add_nkey_nonce/2,
-    authenticate/4
+    authenticate/4,
+    validate_jwt_config/1
 ]).
 
 -ifdef(TEST).
@@ -193,11 +194,11 @@ jwt_authenticate(JWT, NKey, Sig, ConnInfo, ClientInfo, Method) ->
     maybe
         {ok, JWTToken = #{claims := Claims}} ?= decode_jwt(JWT),
         JWTConfig = maps:get(config, Method, #{}),
-        ok ?= verify_jwt_signature_chain(JWTToken, JWTConfig),
+        {ok, AccountClaims} ?= verify_jwt_signature_chain(JWTToken, JWTConfig),
         ok ?= verify_jwt_claims_time(Claims),
         {ok, Username} ?= verify_jwt_nonce_signature(Claims, NKey, Sig, ConnInfo),
         JWTPerms = extract_jwt_permissions(Claims),
-        AuthExpireAt = jwt_claim_expire_at(Claims),
+        AuthExpireAt = jwt_claims_expire_at([Claims, AccountClaims]),
         {ok, ClientInfo#{
             username => Username,
             password => undefined,
@@ -207,6 +208,52 @@ jwt_authenticate(JWT, NKey, Sig, ConnInfo, ClientInfo, Method) ->
             jwt_permissions => JWTPerms,
             auth_expire_at => AuthExpireAt
         }}
+    end.
+
+-spec validate_jwt_config(map()) -> ok | {error, binary()}.
+validate_jwt_config(Config) ->
+    Resolver = map_get_any(Config, [resolver, <<"resolver">>], #{}),
+    Preload = map_get_any(Resolver, [resolver_preload, <<"resolver_preload">>], []),
+    validate_jwt_resolver_preload(Preload, Config, 1).
+
+validate_jwt_resolver_preload([Entry | Rest], Config, Index) ->
+    case normalize_resolver_preload_entry(Entry) of
+        {ok, {AccountPubKey, AccountJWT}} ->
+            case validate_configured_account_jwt(AccountPubKey, AccountJWT, Config) of
+                ok ->
+                    validate_jwt_resolver_preload(Rest, Config, Index + 1);
+                {error, Reason} ->
+                    {error, account_jwt_config_hint(Index, AccountPubKey, Reason)}
+            end;
+        error ->
+            {error,
+                iolist_to_binary(
+                    io_lib:format("resolver_preload[~B]: invalid account JWT entry", [Index])
+                )}
+    end;
+validate_jwt_resolver_preload([], _Config, _Index) ->
+    ok;
+validate_jwt_resolver_preload(_Preload, _Config, _Index) ->
+    {error, <<"resolver_preload must be a list">>}.
+
+account_jwt_config_hint(Index, AccountPubKey, Reason) ->
+    iolist_to_binary(
+        io_lib:format(
+            "resolver_preload[~B] account ~ts: ~ts",
+            [Index, AccountPubKey, error_hint(Reason)]
+        )
+    ).
+
+error_hint(Hint) when is_binary(Hint) ->
+    Hint;
+error_hint(Reason) ->
+    iolist_to_binary(io_lib:format("~0p", [Reason])).
+
+validate_configured_account_jwt(AccountPubKey, AccountJWT, Config) ->
+    maybe
+        {ok, AccountClaims} ?= verify_jwt_account_token(AccountPubKey, AccountJWT, Config),
+        {ok, _Revocations} ?= normalized_jwt_revocations(AccountClaims),
+        ok
     end.
 
 verify_jwt_nonce_signature(Claims, NKey, Sig, ConnInfo) ->
@@ -300,6 +347,7 @@ verify_jwt_signature_chain(#{claims := Claims} = UserToken, Config) ->
         {ok, AccountJWT} ?= jwt_account_jwt(Config, AccountPubKey),
         verify_jwt_account_chain(
             UserToken,
+            Claims,
             UserIssuer,
             AccountPubKey,
             AccountJWT,
@@ -307,7 +355,17 @@ verify_jwt_signature_chain(#{claims := Claims} = UserToken, Config) ->
         )
     end.
 
-verify_jwt_account_chain(UserToken, UserIssuer, AccountPubKey, AccountJWT, Config) ->
+verify_jwt_account_chain(UserToken, UserClaims, UserIssuer, AccountPubKey, AccountJWT, Config) ->
+    maybe
+        {ok, AccountClaims} ?= verify_jwt_account_token(AccountPubKey, AccountJWT, Config),
+        ok ?= verify_account_jwt_claims_time(AccountClaims),
+        ok ?= verify_jwt_user_revocation(UserClaims, AccountClaims),
+        ok ?= verify_jwt_user_issuer_allowed(UserIssuer, AccountPubKey, AccountClaims),
+        ok ?= verify_jwt_token_signature(UserToken, UserIssuer),
+        {ok, AccountClaims}
+    end.
+
+verify_jwt_account_token(AccountPubKey, AccountJWT, Config) ->
     maybe
         {ok, AccountToken = #{claims := AccountClaims}} ?= decode_jwt_account(AccountJWT),
         ok ?= verify_jwt_account_token_alg(AccountToken),
@@ -315,8 +373,7 @@ verify_jwt_account_chain(UserToken, UserIssuer, AccountPubKey, AccountJWT, Confi
         {ok, OperatorPubKey} ?= jwt_claim_account_issuer(AccountClaims),
         ok ?= verify_jwt_operator_trusted(OperatorPubKey, Config),
         ok ?= verify_jwt_token_signature(AccountToken, OperatorPubKey),
-        ok ?= verify_jwt_user_issuer_allowed(UserIssuer, AccountPubKey, AccountClaims),
-        verify_jwt_token_signature(UserToken, UserIssuer)
+        {ok, AccountClaims}
     end.
 
 ensure_jwt_trusted_operators(Config) ->
@@ -500,6 +557,112 @@ verify_jwt_claims_time(Claims) ->
             Error
     end.
 
+verify_jwt_user_revocation(UserClaims, AccountClaims) ->
+    maybe
+        {ok, UserSubject} ?= jwt_claim_sub(UserClaims),
+        UserIssuedAt = map_get(UserClaims, <<"iat">>, undefined),
+        {ok, Revocations} ?= normalized_jwt_revocations(AccountClaims),
+        RevocationAt = max_revocation_time(
+            map_get_any(Revocations, [UserSubject], undefined),
+            map_get_any(Revocations, [<<"*">>], undefined)
+        ),
+        verify_jwt_revocation_time(UserIssuedAt, RevocationAt)
+    end.
+
+max_revocation_time(UserRevocationAt, AllUsersRevocationAt) ->
+    case {revocation_time(UserRevocationAt), revocation_time(AllUsersRevocationAt)} of
+        {undefined, undefined} ->
+            undefined;
+        {UserAt, undefined} ->
+            UserAt;
+        {undefined, AllAt} ->
+            AllAt;
+        {UserAt, AllAt} ->
+            max(UserAt, AllAt)
+    end.
+
+revocation_time(Value) when is_integer(Value) ->
+    Value;
+revocation_time(_) ->
+    undefined.
+
+verify_jwt_revocation_time(_IssuedAt, undefined) ->
+    ok;
+verify_jwt_revocation_time(IssuedAt, RevocationAt) when is_number(IssuedAt) ->
+    case IssuedAt =< RevocationAt of
+        true -> {error, jwt_revoked};
+        false -> ok
+    end;
+verify_jwt_revocation_time(_IssuedAt, _RevocationAt) ->
+    {error, jwt_revoked}.
+
+normalized_jwt_revocations(AccountClaims) ->
+    case map_get_any(AccountClaims, [<<"nats">>, nats], undefined) of
+        undefined ->
+            {ok, #{}};
+        NATSClaims when is_map(NATSClaims) ->
+            case map_get_any(NATSClaims, [<<"revocations">>, revocations], undefined) of
+                undefined ->
+                    {ok, #{}};
+                Revocations when is_map(Revocations) ->
+                    normalize_revocation_map(Revocations);
+                _ ->
+                    {error, <<"account JWT nats.revocations must be a map">>}
+            end;
+        _ ->
+            {error, <<"account JWT nats must be a map">>}
+    end.
+
+normalize_revocation_map(Revocations) ->
+    maps:fold(
+        fun
+            (Key, Value, {ok, Acc}) ->
+                case normalize_revocation_key(Key) of
+                    {ok, NormalizedKey} when is_integer(Value) ->
+                        {ok, Acc#{NormalizedKey => Value}};
+                    error ->
+                        {error,
+                            iolist_to_binary(
+                                io_lib:format("invalid account JWT revocation key: ~0p", [Key])
+                            )};
+                    {ok, _NormalizedKey} ->
+                        {error,
+                            iolist_to_binary(
+                                io_lib:format(
+                                    "account JWT revocation timestamp for key ~0p must be an integer",
+                                    [Key]
+                                )
+                            )}
+                end;
+            (_Key, _Value, Error) ->
+                Error
+        end,
+        {ok, #{}},
+        Revocations
+    ).
+
+normalize_revocation_key(<<"*">>) ->
+    {ok, <<"*">>};
+normalize_revocation_key(Key) when is_binary(Key) ->
+    case emqx_nats_nkey:decode_public(Key) of
+        {ok, _} ->
+            {ok, emqx_nats_nkey:normalize(Key)};
+        _ ->
+            error
+    end;
+normalize_revocation_key(_Key) ->
+    error.
+
+verify_account_jwt_claims_time(AccountClaims) ->
+    case verify_jwt_claims_time(AccountClaims) of
+        ok ->
+            ok;
+        {error, jwt_expired} ->
+            {error, account_jwt_expired};
+        {error, jwt_not_before} ->
+            {error, account_jwt_not_before}
+    end.
+
 verify_jwt_exp(Claims, Now) ->
     case map_get(Claims, <<"exp">>, undefined) of
         undefined ->
@@ -532,6 +695,18 @@ jwt_claim_expire_at(Claims) ->
             erlang:convert_time_unit(trunc(Exp), second, millisecond);
         _ ->
             undefined
+    end.
+
+jwt_claims_expire_at(ClaimsList) ->
+    case lists:filtermap(fun claim_expire_at/1, ClaimsList) of
+        [] -> undefined;
+        ExpireAts -> lists:min(ExpireAts)
+    end.
+
+claim_expire_at(Claims) ->
+    case jwt_claim_expire_at(Claims) of
+        undefined -> false;
+        ExpireAt -> {true, ExpireAt}
     end.
 
 extract_jwt_permissions(Claims) ->

--- a/apps/emqx_gateway_nats/src/emqx_nats_schema.erl
+++ b/apps/emqx_gateway_nats/src/emqx_nats_schema.erl
@@ -355,9 +355,22 @@ validate_resolver_preload_pubkeys([], _Index) ->
 validate_authn_jwt(Config) ->
     case validate_authn_jwt_required_fields(Config) of
         ok ->
-            validate_authn_jwt_nkey_material(Config);
+            case validate_authn_jwt_nkey_material(Config) of
+                ok ->
+                    validate_authn_jwt_account_tokens(Config);
+                {error, _Reason} = Error ->
+                    Error
+            end;
         {error, _Reason} = Error ->
             Error
+    end.
+
+validate_authn_jwt_account_tokens(Config) ->
+    case emqx_nats_authn:validate_jwt_config(Config) of
+        ok ->
+            ok;
+        {error, Hint} ->
+            {error, Hint}
     end.
 
 validate_authn_jwt_required_fields(Config) ->

--- a/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
@@ -135,6 +135,29 @@ t_load_badconf_partial_authn_jwt(_Config) ->
         emqx_gateway_conf:load_gateway(nats, MissingResolverPreload)
     ),
 
+    BaseConfInvalidAccountJWT = nats_conf(emqx_common_test_helpers:select_free_port(tcp)),
+    InvalidAccountJWT = BaseConfInvalidAccountJWT#{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"trusted_operators">> => [?VALID_OPERATOR_NKEY],
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{
+                            <<"pubkey">> => ?VALID_ACCOUNT_NKEY,
+                            <<"jwt">> => <<"invalid-jwt">>
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:load_gateway(nats, InvalidAccountJWT)
+    ),
+
     BaseConfToken = nats_conf(emqx_common_test_helpers:select_free_port(tcp)),
     EmptyTokenMethod = BaseConfToken#{
         <<"internal_authn">> => [

--- a/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
@@ -275,6 +275,144 @@ t_authenticate_jwt_time_validation(_Config) ->
         emqx_nats_authn:authenticate(#{<<"jwt">> => <<"invalid-jwt">>}, #{}, #{}, Authn)
     ).
 
+t_authenticate_jwt_account_claims_validation(_Config) ->
+    Now = now_seconds(),
+    UserJWT = build_test_jwt(#{}),
+    ExpiredAccountAuthn = jwt_conf_with_account_claims(#{<<"exp">> => Now - 10}),
+    FutureAccountAuthn = jwt_conf_with_account_claims(#{<<"nbf">> => Now + 3600}),
+    RevokedUserAccountAuthn = jwt_conf_with_account_claims(#{
+        <<"nats">> => #{<<"revocations">> => #{nkey_pub() => Now + 1}}
+    }),
+    RevokedAllAccountAuthn = jwt_conf_with_account_claims(#{
+        <<"nats">> => #{<<"revocations">> => #{<<"*">> => Now + 1}}
+    }),
+    UnknownRevocationKeyAccountAuthn = jwt_conf_with_account_claims(#{
+        <<"nats">> => #{<<"revocations">> => #{<<"unknown-key">> => Now}}
+    }),
+    MalformedRevocationTypeAuthn = jwt_conf_with_account_claims(#{
+        <<"nats">> => #{<<"revocations">> => <<"invalid">>}
+    }),
+    MalformedRevocationAuthn = jwt_conf_with_account_claims(#{
+        <<"nats">> => #{<<"revocations">> => #{nkey_pub() => <<"invalid">>}}
+    }),
+    Fixture = jwt_fixture(),
+    EmptyAccountJWTAuthn = jwt_conf(#{
+        resolver => #{
+            type => memory,
+            resolver_preload => [
+                #{pubkey => maps:get(account_nkey, Fixture), jwt => <<>>}
+            ]
+        }
+    }),
+    LowercaseSubjectJWT = build_test_jwt(#{
+        <<"sub">> => string:lowercase(nkey_pub())
+    }),
+    ReissuedUserJWT = build_test_jwt(#{<<"iat">> => Now + 2}),
+    InvalidIssuedAtJWT = build_test_jwt(#{<<"iat">> => <<"invalid">>}),
+    UserExp = Now + 120,
+    AccountExp = Now + 60,
+    ExpiringUserJWT = build_test_jwt(#{<<"exp">> => UserExp}),
+    ExpiringAccountAuthn = jwt_conf_with_account_claims(#{<<"exp">> => AccountExp}),
+
+    ?assertEqual(ok, emqx_nats_authn:validate_jwt_config(ExpiredAccountAuthn)),
+    ?assertEqual(ok, emqx_nats_authn:validate_jwt_config(FutureAccountAuthn)),
+    {error, MalformedRevocationConfigHint} =
+        emqx_nats_authn:validate_jwt_config(MalformedRevocationAuthn),
+    assert_binary_contains(MalformedRevocationConfigHint, maps:get(account_nkey, Fixture)),
+    assert_binary_contains(MalformedRevocationConfigHint, nkey_pub()),
+    assert_binary_contains(MalformedRevocationConfigHint, <<"must be an integer">>),
+    {error, UnknownRevocationKeyConfigHint} =
+        emqx_nats_authn:validate_jwt_config(UnknownRevocationKeyAccountAuthn),
+    assert_binary_contains(UnknownRevocationKeyConfigHint, <<"unknown-key">>),
+    ?assertEqual(
+        {error, <<"resolver_preload[1]: invalid account JWT entry">>},
+        emqx_nats_authn:validate_jwt_config(EmptyAccountJWTAuthn)
+    ),
+
+    ?assertEqual(
+        {error, {jwt, account_jwt_expired}},
+        emqx_nats_authn:authenticate(
+            #{<<"jwt">> => UserJWT},
+            #{},
+            #{},
+            mk_authn_ctx(undefined, [], ExpiredAccountAuthn, false)
+        )
+    ),
+    ?assertEqual(
+        {error, {jwt, account_jwt_not_before}},
+        emqx_nats_authn:authenticate(
+            #{<<"jwt">> => UserJWT},
+            #{},
+            #{},
+            mk_authn_ctx(undefined, [], FutureAccountAuthn, false)
+        )
+    ),
+    ?assertEqual(
+        {error, {jwt, jwt_revoked}},
+        emqx_nats_authn:authenticate(
+            #{<<"jwt">> => UserJWT},
+            #{},
+            #{},
+            mk_authn_ctx(undefined, [], RevokedUserAccountAuthn, false)
+        )
+    ),
+    ?assertEqual(
+        {error, {jwt, jwt_revoked}},
+        emqx_nats_authn:authenticate(
+            #{<<"jwt">> => UserJWT},
+            #{},
+            #{},
+            mk_authn_ctx(undefined, [], RevokedAllAccountAuthn, false)
+        )
+    ),
+    ?assertEqual(
+        {error, {jwt, jwt_revoked}},
+        emqx_nats_authn:authenticate(
+            #{<<"jwt">> => LowercaseSubjectJWT},
+            #{},
+            #{},
+            mk_authn_ctx(undefined, [], RevokedUserAccountAuthn, false)
+        )
+    ),
+    ?assertEqual(
+        {error, {jwt, jwt_revoked}},
+        emqx_nats_authn:authenticate(
+            #{<<"jwt">> => InvalidIssuedAtJWT},
+            #{},
+            #{},
+            mk_authn_ctx(undefined, [], RevokedUserAccountAuthn, false)
+        )
+    ),
+    {error, {jwt, MalformedRevocationHint}} = emqx_nats_authn:authenticate(
+        #{<<"jwt">> => UserJWT},
+        #{},
+        #{},
+        mk_authn_ctx(undefined, [], MalformedRevocationAuthn, false)
+    ),
+    assert_binary_contains(MalformedRevocationHint, nkey_pub()),
+    assert_binary_contains(MalformedRevocationHint, <<"must be an integer">>),
+    ?assertEqual(
+        {error, {jwt, <<"account JWT nats.revocations must be a map">>}},
+        emqx_nats_authn:authenticate(
+            #{<<"jwt">> => UserJWT},
+            #{},
+            #{},
+            mk_authn_ctx(undefined, [], MalformedRevocationTypeAuthn, false)
+        )
+    ),
+    {error, {jwt, UnknownRevocationKeyHint}} =
+        authenticate_test_jwt(UserJWT, UnknownRevocationKeyAccountAuthn),
+    assert_binary_contains(UnknownRevocationKeyHint, <<"unknown-key">>),
+    ?assertMatch(
+        {ok, _},
+        authenticate_test_jwt(ReissuedUserJWT, RevokedUserAccountAuthn)
+    ),
+    {ok, Result} = authenticate_test_jwt(ExpiringUserJWT, ExpiringAccountAuthn),
+    ?assertEqual(
+        erlang:convert_time_unit(AccountExp, second, millisecond),
+        maps:get(auth_expire_at, Result)
+    ).
+
 t_authenticate_jwt_signature_and_trust_chain_validation(_Config) ->
     Authn = mk_authn_ctx(undefined, [], jwt_conf(), false),
     ValidJWT = build_test_jwt(#{}),
@@ -768,6 +906,39 @@ jwt_conf(Overrides) ->
         Overrides
     ).
 
+jwt_conf_with_account_claims(AccountClaims) ->
+    Fixture = jwt_fixture(),
+    jwt_conf(#{
+        resolver => #{
+            type => memory,
+            resolver_preload => [
+                #{
+                    pubkey => maps:get(account_nkey, Fixture),
+                    jwt => build_account_jwt(
+                        maps:get(operator_nkey, Fixture),
+                        maps:get(account_nkey, Fixture),
+                        AccountClaims
+                    )
+                }
+            ]
+        }
+    }).
+
+authenticate_test_jwt(JWT, JWTConf) ->
+    Nonce = <<"nonce-jwt-account-claims">>,
+    emqx_nats_authn:authenticate(
+        #{
+            <<"jwt">> => JWT,
+            <<"sig">> => nkey_sig(Nonce)
+        },
+        #{nkey_nonce => Nonce},
+        #{username => undefined},
+        mk_authn_ctx(undefined, [], JWTConf, false)
+    ).
+
+assert_binary_contains(Haystack, Needle) ->
+    ?assertNotEqual(nomatch, binary:match(Haystack, Needle)).
+
 build_test_jwt(Claims) ->
     Fixture = jwt_fixture(),
     DefaultClaims = #{
@@ -820,6 +991,9 @@ jwt_fixture() ->
     }.
 
 build_account_jwt(OperatorNKey, AccountNKey) ->
+    build_account_jwt(OperatorNKey, AccountNKey, #{}).
+
+build_account_jwt(OperatorNKey, AccountNKey, ExtraClaims) ->
     Claims = #{
         <<"iss">> => OperatorNKey,
         <<"sub">> => AccountNKey,
@@ -829,7 +1003,7 @@ build_account_jwt(OperatorNKey, AccountNKey) ->
             <<"version">> => 2
         }
     },
-    sign_jwt(Claims, jwt_operator_priv()).
+    sign_jwt(emqx_utils_maps:deep_merge(Claims, ExtraClaims), jwt_operator_priv()).
 
 operator_nkey() ->
     public_nkey(?NKEY_OPERATOR_PREFIX, jwt_operator_priv()).

--- a/apps/emqx_gateway_nats/test/emqx_nats_protocol_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_nats_protocol_SUITE.erl
@@ -532,6 +532,7 @@ missing_caps(TestCase, Target, Group) ->
 target_caps(emqx, _Group) ->
     [
         jwt_auth,
+        jwt_account_expiry,
         jwt_acl_intersection,
         mixed_auth_priority,
         security_profile
@@ -571,6 +572,8 @@ required_caps(t_jwt_auth_invalid_format_failure) ->
     [jwt_auth];
 required_caps(t_jwt_auth_invalid_signature_failure) ->
     [jwt_auth];
+required_caps(t_jwt_account_expire_disconnect) ->
+    [jwt_account_expiry];
 required_caps(t_jwt_permissions_intersection_with_acl) ->
     [jwt_auth, jwt_acl_intersection];
 required_caps(t_nkey_auth_priority_over_jwt) ->
@@ -996,18 +999,7 @@ jwt_auth_setup(Config, Overrides) ->
             Existing = normalize_internal_authn(Prev),
             Fixture = jwt_fixture(),
             JWTConf0 = maps:merge(
-                #{
-                    trusted_operators => [maps:get(operator_nkey, Fixture)],
-                    resolver => #{
-                        type => memory,
-                        resolver_preload => [
-                            #{
-                                pubkey => maps:get(account_nkey, Fixture),
-                                jwt => maps:get(account_jwt, Fixture)
-                            }
-                        ]
-                    }
-                },
+                jwt_config(maps:get(account_jwt, Fixture)),
                 Overrides
             ),
             JWTConf = maps:merge(#{type => jwt}, JWTConf0),
@@ -1020,6 +1012,36 @@ jwt_auth_setup(Config, Overrides) ->
         nats ->
             Config
     end.
+
+jwt_config(AccountJWT) ->
+    Fixture = jwt_fixture(),
+    #{
+        trusted_operators => [maps:get(operator_nkey, Fixture)],
+        resolver => #{
+            type => memory,
+            resolver_preload => [
+                #{
+                    pubkey => maps:get(account_nkey, Fixture),
+                    jwt => AccountJWT
+                }
+            ]
+        }
+    }.
+
+update_jwt_account_claims(ExtraClaims) ->
+    Fixture = jwt_fixture(),
+    AccountJWT = build_account_jwt(
+        maps:get(operator_nkey, Fixture),
+        maps:get(account_nkey, Fixture),
+        ExtraClaims
+    ),
+    JWTMethod = maps:merge(#{type => jwt}, jwt_config(AccountJWT)),
+    _ = emqx_conf:update(
+        [gateway, nats, internal_authn],
+        [JWTMethod],
+        #{override_to => cluster}
+    ),
+    ok.
 
 jwt_auth_cleanup(Config) ->
     case target_from(Config) of
@@ -1132,6 +1154,9 @@ jwt_fixture() ->
     }.
 
 build_account_jwt(OperatorNKey, AccountNKey) ->
+    build_account_jwt(OperatorNKey, AccountNKey, #{}).
+
+build_account_jwt(OperatorNKey, AccountNKey, ExtraClaims) ->
     Claims = #{
         <<"iss">> => OperatorNKey,
         <<"sub">> => AccountNKey,
@@ -1141,7 +1166,7 @@ build_account_jwt(OperatorNKey, AccountNKey) ->
             <<"version">> => 2
         }
     },
-    sign_jwt(Claims, jwt_operator_priv()).
+    sign_jwt(emqx_utils_maps:deep_merge(Claims, ExtraClaims), jwt_operator_priv()).
 
 operator_nkey() ->
     public_nkey(?NKEY_OPERATOR_PREFIX, jwt_operator_priv()).
@@ -2048,6 +2073,23 @@ t_jwt_auth_invalid_signature_failure(Config) ->
     assert_auth_failed(Msgs),
     emqx_nats_client:stop(Client).
 
+t_jwt_account_expire_disconnect(init, Config) ->
+    jwt_auth_setup(Config);
+t_jwt_account_expire_disconnect('end', Config) ->
+    jwt_auth_cleanup(Config).
+
+t_jwt_account_expire_disconnect(Config) ->
+    AccountExp = now_seconds() + 5,
+    ok = update_jwt_account_claims(#{<<"exp">> => AccountExp}),
+    JWT = build_test_jwt(#{}),
+    ClientOpts = maps:merge(jwt_client_opts(Config), #{verbose => true}),
+    {ok, Client} = emqx_nats_client:start_link(ClientOpts),
+    InfoMsg = recv_info_frame(Client),
+    ok = emqx_nats_client:connect(Client, jwt_connect_opts(Config, InfoMsg, JWT)),
+    recv_ok_frame(Client),
+    assert_auth_failed(recv_disconnect_frames(Client, 10000)),
+    emqx_nats_client:stop(Client).
+
 t_token_auth_priority_over_jwt(init, Config) ->
     jwt_auth_setup(token_auth_setup(Config, plain, token_plain()));
 t_token_auth_priority_over_jwt('end', Config) ->
@@ -2531,6 +2573,30 @@ assert_auth_failed(Msgs) ->
             ok;
         _ ->
             ?assertMatch([#nats_frame{operation = ?OP_ERR}], Msgs)
+    end.
+
+recv_disconnect_frames(Client, Timeout) ->
+    Deadline = erlang:monotonic_time(millisecond) + Timeout,
+    recv_disconnect_frames_until(Client, Deadline).
+
+recv_disconnect_frames_until(Client, Deadline) ->
+    Remaining = max(0, Deadline - erlang:monotonic_time(millisecond)),
+    recv_disconnect_frames_until(Client, Deadline, Remaining).
+
+recv_disconnect_frames_until(_Client, _Deadline, 0) ->
+    [];
+recv_disconnect_frames_until(Client, Deadline, Remaining) ->
+    case emqx_nats_client:receive_message(Client, 1, Remaining) of
+        {ok, []} ->
+            [];
+        {ok, [#nats_frame{operation = ?OP_PING}]} ->
+            recv_disconnect_frames_until(Client, Deadline);
+        {ok, [Frame = #nats_frame{operation = ?OP_ERR}]} ->
+            [Frame];
+        {ok, [tcp_closed]} ->
+            [tcp_closed];
+        {ok, _Frames} ->
+            recv_disconnect_frames_until(Client, Deadline)
     end.
 
 assert_protocol_error(Msgs) ->

--- a/changes/ee/fix-18436.en.md
+++ b/changes/ee/fix-18436.en.md
@@ -1,0 +1,3 @@
+Fixed an issue where NATS Gateway internal JWT authentication did not enforce account JWT `exp`/`nbf` claims or account-level user revocations.
+
+Expired or not-yet-valid account JWTs and user JWTs revoked by the account are now rejected during authentication. Existing connections are disconnected when the earlier of the user JWT or account JWT expiration is reached. Malformed resolver-preloaded account JWTs are rejected during gateway configuration validation.


### PR DESCRIPTION
Release version: 6.2.4

Introduced in: 6.2.0

Fixes: emqx/emqx-dev-team-tasks#358

## Summary

Validate NATS account JWT lifecycle claims during JWT authentication.

- Enforce account JWT exp and nbf claims during connection authentication.
- Apply account-level nats.revocations to new user JWT authentication, including wildcard and normalized user NKeys.
- Validate resolver-preloaded account JWT structure, signatures, trust, and revocation data when gateway configuration is loaded or updated.
- Return account-specific expiry and revocation errors with the offending public revocation key for actionable diagnostics.
- Set the connection authentication deadline to the earliest user/account JWT expiration so existing connections are closed by the existing connection_expire_timer.
- Revocation updates do not cancel existing connections; existing sessions follow the expiration captured at authentication time.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to changes/ee/fix-18436.en.md
- [x] Schema validation is intentionally stricter for malformed resolver-preloaded account JWT data; valid configurations are unchanged