### PR TITLE
fix(frame): allow outgoing packets of exactly Maximum Packet Size

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -1368,9 +1368,12 @@ serialize_variable_byte_integer(Acc, N) when N < (1 bsl 28) ->
     >>.
 
 %% Is the frame too large?
+%% A packet whose size equals the limit is allowed: MQTT-3.1.2-24 forbids only
+%% packets *exceeding* Maximum Packet Size. This matches the parser, which also
+%% rejects on `FrameLen > MaxSize'.
 -spec is_too_large(iodata(), pos_integer()) -> boolean().
 is_too_large(IoData, MaxSize) ->
-    iolist_size(IoData) >= MaxSize.
+    iolist_size(IoData) > MaxSize.
 
 get_property(_Key, undefined, Default) ->
     Default;

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -36,6 +36,7 @@ groups() ->
         {parse, [parallel], [
             t_parse_cont,
             t_parse_frame_too_large,
+            t_serialize_frame_at_max_size,
             t_parse_frame_malformed_variable_byte_integer,
             t_parse_malformed_utf8_string,
             t_default_parse_state_is_strict,
@@ -144,6 +145,22 @@ t_parse_frame_too_large(_) ->
     ?ASSERT_FRAME_THROW(#{cause := frame_too_large}, parse_serialize(Packet, #{max_size => 256})),
     ?ASSERT_FRAME_THROW(#{cause := frame_too_large}, parse_serialize(Packet, #{max_size => 512})),
     ?assertEqual(Packet, parse_serialize(Packet, #{max_size => 2048, version => ?MQTT_PROTO_V4})).
+
+%% MQTT-3.1.2-24 forbids only packets *exceeding* Maximum Packet Size, so a
+%% packet whose serialized size is exactly the limit must still be sent.
+t_serialize_frame_at_max_size(_) ->
+    Ver = ?MQTT_PROTO_V5,
+    Packet = ?PUBLISH_PACKET(?QOS_1, <<"t">>, 1, payload(100)),
+    Bin = iolist_to_binary(emqx_frame:serialize(Packet, Ver)),
+    Size = byte_size(Bin),
+    AtLimit = emqx_frame:serialize_opts(Ver, Size),
+    OverLimit = emqx_frame:serialize_opts(Ver, Size - 1),
+    %% exactly at the limit: sent
+    ?assertEqual(Bin, iolist_to_binary(emqx_frame:serialize_pkt(Packet, AtLimit))),
+    ?assertEqual(Bin, iolist_to_binary(emqx_frame:serialize_iovec(Packet, AtLimit))),
+    %% one byte over the limit: dropped
+    ?assertEqual(<<>>, emqx_frame:serialize_pkt(Packet, OverLimit)),
+    ?assertEqual([], emqx_frame:serialize_iovec(Packet, OverLimit)).
 
 t_parse_frame_malformed_variable_byte_integer(_) ->
     %% PUBLISH(QoS 0) fixed header byte followed by a malformed remaining

--- a/changes/ee/fix-18438.en.md
+++ b/changes/ee/fix-18438.en.md
@@ -1,0 +1,3 @@
+Fixed an off-by-one in the size check applied to outgoing packets.
+
+A packet whose serialized size was exactly the client's `Maximum Packet Size` was discarded and logged as `frame_is_too_large`, instead of being delivered. Only packets larger than the limit are now discarded, which is what MQTT 5.0 requires. Packets below the limit are unaffected.


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

Fixes [#18425](https://github.com/emqx/emqx/issues/18425). A packet whose serialized size was exactly the client's `Maximum Packet Size` was discarded and logged as `frame_is_too_large`, instead of being delivered.

`apps/emqx/src/emqx_frame.erl`:

```erlang
is_too_large(IoData, MaxSize) ->
    iolist_size(IoData) >= MaxSize.   %% was `>=', now `>'
```

MQTT 5.0 §3.1.2.11.4 forbids only packets *exceeding* the limit:

> The Server MUST NOT send packets exceeding Maximum Packet Size to the Client [MQTT-3.1.2-24].

So a packet equal to the limit is compliant and must be sent.

### Why this reads as a slip rather than a deliberate margin

- The parser already applies the strict comparison for the reciprocal requirement — `FrameLen > MaxSize` at `emqx_frame.erl:277`. The two halves of the same rule disagreed.
- Both operators were introduced by the same commit, `8ab682151d` (2019-09-29). A deliberate one-byte margin would have been applied to both sides.
- Nothing compensates: `MaxSize` is used raw at both call sites, with no adjustment in between.
- No test pinned the behaviour. `t_parse_frame_too_large` uses a 1000-byte payload against limits of 256/512/2048, nowhere near the boundary.

A side effect of the same line: the default `?MAX_PACKET_SIZE` is `16#FFFFFFF`, the protocol ceiling, so EMQX could not send a maximally-sized packet even with no client limit in play.

### Verified

Serializing a 108-byte PUBLISH with the limit set to exactly 108, and to 107:

```
                              before    after
serialize_pkt   at limit   :  dropped   sent
serialize_iovec at limit   :  dropped   sent
serialize_pkt   over limit :  dropped   dropped
serialize_iovec over limit :  dropped   dropped
```

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)