### PR TITLE
build: use + instead of , as mix do command separator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ ifneq ($(RESOLVED_SUITES),)
 	    TEST=1 \
 	    MIX_ENV=$(CT_MIX_ENV) \
 	    PROFILE=$(PROFILE)-test \
-	        $(MIX) do deps.get, compile --force, emqx.ct \
+	        $(MIX) do deps.get + compile --force + emqx.ct \
 		$(call cover_args,$1) \
 		--suites $(RESOLVED_SUITES) \
 		$(GROUPS_ARG) \
@@ -198,14 +198,14 @@ endif
 ct-suite: $(REBAR) merge-config clean-test-cluster-config render-test-env
 ifneq ($(TESTCASE),)
 ifneq ($(GROUP),)
-	env PROFILE=$(PROFILE)-test $(MIX) do deps.get, ct --suites $(SUITE) --cases $(TESTCASE) --group-paths $(GROUP)
+	env PROFILE=$(PROFILE)-test $(MIX) do deps.get + ct --suites $(SUITE) --cases $(TESTCASE) --group-paths $(GROUP)
 else
-	env PROFILE=$(PROFILE)-test $(MIX) do deps.get,  ct --suites $(SUITE)  --cases $(TESTCASE)
+	env PROFILE=$(PROFILE)-test $(MIX) do deps.get + ct --suites $(SUITE) --cases $(TESTCASE)
 endif
 else ifneq ($(GROUP),)
-	env PROFILE=$(PROFILE)-test $(MIX) do deps.get,  ct --suites $(SUITE)  --group-paths $(GROUP)
+	env PROFILE=$(PROFILE)-test $(MIX) do deps.get + ct --suites $(SUITE) --group-paths $(GROUP)
 else
-	env PROFILE=$(PROFILE)-test $(MIX) do deps.get,  ct --suites $(SUITE)
+	env PROFILE=$(PROFILE)-test $(MIX) do deps.get + ct --suites $(SUITE)
 endif
 
 .PHONY: cover


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 7.0.0

<!--
run script ./scripts/rel-versions to get release versions
-->

Introduced in:
N/A
<!--
N/A: If this is a pre-release fix (e.g. found in QA phase).
pre-5.8: If it's an old one (5.8 is the earliest minor actively maintained).
VSN: The exact version wihch introduced the bug.
-->

## Summary

Elixir 1.19 deprecates commas as command separators in `mix do` and prints this on every affected `make` invocation:

```
warning: using commas as separators in "mix do" is deprecated, use + between commands instead
  (mix 1.19.1) lib/mix/tasks/do.ex:129: Mix.Tasks.Do.gather_commands/3
```

This PR switches the five `$(MIX) do` invocations in the root `Makefile` (the `ct-suite` target and the `apps/<app>-ct` helper) from `,` to `+`. `static_checks` already used `+`. No other file in the tree uses the comma form.

The `+` separator is accepted by the pinned Elixir 1.18.3 (`lib/mix/tasks/do.ex:124`, `gather_commands(["+" | rest], ...)`) and by every Elixir release since 1.14, so this does not require an Elixir bump.

Build tooling only, no user-facing behaviour change, so no changelog entry.

### Validation

Each edited line was run, not only read.

Pinned Elixir 1.18.3 / OTP 27:

| Makefile line | Command | Result |
| --- | --- | --- |
| 208 | `make ct-suite SUITE=apps/emqx/test/emqx_frame_SUITE.erl` | 55 ok, 0 failed |
| 203 | `... TESTCASE=t_parse_cont` | 1 ok, 0 failed |
| 206 | `... GROUP=parse` | 6 ok, 0 failed |
| 201 | `... TESTCASE=t_parse_cont GROUP=parse` | 1 ok, 0 failed |
| 166 | `make apps/emqx_gateway_coap-ct` | 31 ok, 0 failed (3 suites) |

Elixir 1.19.1 / OTP 28, `make ct-suite SUITE=apps/emqx/test/emqx_frame_SUITE.erl TESTCASE=t_parse_cont`:

Before (comma):

```
env PROFILE=emqx-enterprise-test .../mix do deps.get,  ct --suites apps/emqx/test/emqx_frame_SUITE.erl  --cases t_parse_cont
warning: using commas as separators in "mix do" is deprecated, use + between commands instead
  (mix 1.19.1) lib/mix/tasks/do.ex:129: Mix.Tasks.Do.gather_commands/3
  (mix 1.19.1) lib/mix/tasks/do.ex:75: Mix.Tasks.Do.run/1
```

After (`+`):

```
env PROFILE=emqx-enterprise-test .../mix do deps.get + ct --suites apps/emqx/test/emqx_frame_SUITE.erl --cases t_parse_cont
Resolving Hex dependencies...
Resolution completed in 1.409s
```

No warning. Both Elixir 1.19.1 runs then stop at the same unrelated point (the `grpc` rebar plugin does not build under OTP 28 in an isolated build tree), before and after alike; `dev-60` is an OTP 27 line, and the separator is parsed before any task runs, so the warning check is complete.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
