### PR TITLE
docs(i18n): explain the memory cost of session_expiry_interval

### DIFF
--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -211,7 +211,20 @@ fields_deflate_opts_server_context_takeover.label:
 """Server context takeover"""
 
 mqtt_session_expiry_interval.desc:
-"""Specifies how long the session will expire after the connection is disconnected, only for non-MQTT 5.0 connections."""
+"""Specifies how long EMQX keeps a session after the client disconnects.
+It applies to MQTT 3.1 and 3.1.1 clients connecting with `Clean Session = false`.
+MQTT 5.0 clients set their own value with the `Session-Expiry-Interval` CONNECT property.
+
+Note the memory cost: with the default in-memory session store, a session whose expiry interval is
+greater than zero is not removed when the client disconnects. EMQX keeps the session, its
+subscriptions and its message queue in memory until the client reconnects or the interval elapses.
+The number of such sessions on a node is roughly the client disconnect rate multiplied by the expiry
+interval, so a large fleet on unstable links combined with a long interval can leave a node holding
+many disconnected sessions. This is the intended behavior of persistent sessions; size the deployment
+for it, keep this value to the shortest interval that covers the reconnect window of your clients,
+use `max_mqueue_len` to bound the messages queued for each disconnected session, or use durable
+sessions, which store session state on disk and release the session process when the client
+disconnects."""
 
 mqtt_session_expiry_interval.label:
 """Session Expiry Interval"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -215,16 +215,8 @@ mqtt_session_expiry_interval.desc:
 It applies to MQTT 3.1 and 3.1.1 clients connecting with `Clean Session = false`.
 MQTT 5.0 clients set their own value with the `Session-Expiry-Interval` CONNECT property.
 
-Note the memory cost: with the default in-memory session store, a session whose expiry interval is
-greater than zero is not removed when the client disconnects. EMQX keeps the session, its
-subscriptions and its message queue in memory until the client reconnects or the interval elapses.
-The number of such sessions on a node is roughly the client disconnect rate multiplied by the expiry
-interval, so a large fleet on unstable links combined with a long interval can leave a node holding
-many disconnected sessions. This is the intended behavior of persistent sessions; size the deployment
-for it, keep this value to the shortest interval that covers the reconnect window of your clients,
-use `max_mqueue_len` to bound the messages queued for each disconnected session, or use durable
-sessions, which store session state on disk and release the session process when the client
-disconnects."""
+With the default in-memory session store, a disconnected session stays in memory for the whole
+interval. Allocate memory for this, or use durable sessions, which store session state on disk."""
 
 mqtt_session_expiry_interval.label:
 """Session Expiry Interval"""


### PR DESCRIPTION
Symmetric to [emqx/emqx-docs#3810](https://github.com/emqx/emqx-docs/pull/3810), which adds the same explanation to the configuration guide. Both come out of [#14482](https://github.com/emqx/emqx/issues/14482), where an operator hit this in production and had to read `emqx_channel.erl` to work out what was happening.

## Summary

`mqtt_session_expiry_interval.desc` in `rel/i18n/emqx_schema.hocon` said only how long a session survives a disconnect:

> Specifies how long the session will expire after the connection is disconnected, only for non-MQTT 5.0 connections.

It did not say that the session stays **resident in memory** for that entire interval, so the memory cost of a long interval was invisible to anyone reading the config reference or the Dashboard tooltip.

The behaviour is `emqx_channel:maybe_shutdown/2` — a client disconnecting idle with a positive expiry interval leaves its connection process alive holding the session until reconnect or expiry:

```erlang
maybe_shutdown(Reason, _Intent = idle, Channel = #channel{conninfo = ConnInfo}) ->
    case maps:get(expiry_interval, ConnInfo) of
        ?EXPIRE_INTERVAL_INFINITE -> {ok, Channel};
        I when I > 0 -> {ok, ensure_timer(expire_session, I, Channel)};
        _ -> shutdown(Reason, Channel)
    end;
```

The new text describes the retention, gives the rough population as disconnect rate multiplied by expiry interval, states plainly that this is intended behaviour for persistent sessions, and points at the levers: a shorter interval, `max_mqueue_len`, or durable sessions.

## Scope

`max_session_expiry_interval` is covered in the docs PR but **not** mirrored here. That config does not exist before 6.3, so referencing it from a `dev-60` description would be wrong for 6.0-6.2, and on 6.3+ its own description already documents it.

Both cross-references used here (`max_mqueue_len`, durable sessions) exist on `dev-60`.

Only `rel/i18n/emqx_schema.hocon` is touched; the generated `desc.en.hocon` / `desc.zh.hocon` artifacts are not.