### PR TITLE
build: bump hocon from 0.46.4 to 0.46.5

### DIFF
--- a/changes/ee/fix-18444.en.md
+++ b/changes/ee/fix-18444.en.md
@@ -1,0 +1,3 @@
+Fixed the byte-size units `b` and `B` requiring quotes in configuration files.
+
+`max_packet_size = 1MB` was accepted, but `max_packet_size = 1B` failed to parse and had to be written as `"1B"`. All byte-size units are now accepted without quotes.

--- a/mix.exs
+++ b/mix.exs
@@ -178,7 +178,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.2", override: true}
 
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
-  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.4", override: true}
+  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.5", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}
   # in conflict by ehttpc and emqtt
   def common_dep(:gun), do: {:gun, "2.1.0", override: true}


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.3, 6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

Picks up [emqx/hocon#322](https://github.com/emqx/hocon/pull/322), which fixes [#18422](https://github.com/emqx/emqx/issues/18422): `max_packet_size = 1MB` parses, but `max_packet_size = 1B` requires quotes.

The scanner listed only the two-letter units, so `1B` scanned as `integer(1)` followed by unquoted `B` — two tokens that cannot concatenate — while `1MB` scanned as a single string token:

```
Bytesize = {Digit}+(kb|KB|mb|MB|gb|GB)     %% before
Bytesize = {Digit}+(b|B|kb|KB|mb|MB|gb|GB) %% after
```

`hocon_postprocess:do_bytesize/1` already accepted `b` and `B`, so only the scanner needed them.

## Scope of the bump

`0.46.4..0.46.5` is that fix and nothing else:

```
$ git diff --stat 0.46.4 0.46.5
 etc/convert-sample.conf | 4 ++--
 src/hocon_scanner.xrl   | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
```

Verified after `mix deps.get` that the dependency resolves to the tag carrying the fix:

```
deps/hocon        -> 0.46.5 (84d8a80)
hocon_scanner.xrl -> Bytesize = {Digit}+(b|B|kb|KB|mb|MB|gb|GB)
```

`mix.lock` is gitignored in this repo, so only `mix.exs` changes.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)