### PR TITLE
docs(plugins): explain the cause in plugin_package_not_configured

### DIFF
--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -597,6 +597,18 @@ log_unconfigured_plugin(#{
         msg => plugin_package_not_configured,
         name_vsn => NameVsn,
         running_status => RunningStatus,
+        description => iolist_to_binary([
+            "A plugin package was found unpacked under the plugins directory, but `",
+            NameVsn,
+            "` has no entry in `plugins.states`, so EMQX does not know whether to start it. ",
+            "The match is on the exact name and version, so this is most often a version "
+            "mismatch: `plugins.states` still lists an older version of the same plugin while "
+            "a newer package was unpacked, and the old entry does not carry over. ",
+            "It also happens when a package is copied into the plugins directory by hand or "
+            "restored from a backup, instead of being installed through the API or "
+            "`emqx ctl plugins install`. ",
+            "The plugin is left untouched: it is not started, and no configuration is applied."
+        ]),
         hint => iolist_to_binary([
             "Plugin package is unpacked but is neither enabled nor disabled in plugins.states. ",
             "Run `emqx ctl plugins enable ",


### PR DESCRIPTION
Internal PR — log text only, no behaviour change, no changelog.

## Summary

`plugin_package_not_configured` told the operator what state the plugin was in and how to get out of it, but not how it got there:

```
msg: plugin_package_not_configured
name_vsn: emqx_username_quota-1.2.0
running_status: ...
hint: Plugin package is unpacked but is neither enabled nor disabled in plugins.states. Run `emqx ctl plugins enable ...`
```

Someone reading that still has to work out *why* an installed plugin ended up unconfigured. The usual answer is a version mismatch: `emqx_plugins_info:configured_status/2` matches on the exact `name-vsn`, so if `plugins.states` still lists an older version while a newer package was unpacked, the new one is `not_configured` and the old entry does not carry over.

This adds a `description` field carrying that explanation. `hint` keeps the remediation, so the two are separated by role — `description` says why, `hint` says what to do.

Rendered:

> A plugin package was found unpacked under the plugins directory, but `emqx_username_quota-1.2.0` has no entry in `plugins.states`, so EMQX does not know whether to start it. The match is on the exact name and version, so this is most often a version mismatch: `plugins.states` still lists an older version of the same plugin while a newer package was unpacked, and the old entry does not carry over. It also happens when a package is copied into the plugins directory by hand or restored from a backup, instead of being installed through the API or `emqx ctl plugins install`. The plugin is left untouched: it is not started, and no configuration is applied.

`description` is already used for this purpose in `emqx_router:verify_cluster_schema_vsn/1`, so the field name follows existing practice rather than inventing one.