### PR TITLE
fix(conf): stop injecting `base.hocon` into cluster conf sync

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -907,7 +907,7 @@ read_override_conf(#{} = Opts) ->
     Files =
         case has_deprecated_file() of
             true -> [deprecated_conf_file(Opts)];
-            false -> [base_hocon_file(), cluster_hocon_file()]
+            false -> [cluster_hocon_file()]
         end,
     load_hocon_files(Files, map).
 

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -233,11 +233,28 @@ t_init_load_with_changed_max_packet_size_before_listeners_start(Config) ->
     end.
 
 t_base_hocon_change_after_rolling_restart(Config) ->
+    test_base_hocon_change_after_rolling_restart(
+        ?FUNCTION_NAME,
+        {[mqtt, max_topic_levels], 100, 200},
+        {[alarm, size_limit], 1000, 2000},
+        Config
+    ).
+
+t_base_hocon_change_after_rolling_restart_same_root(Config) ->
+    test_base_hocon_change_after_rolling_restart(
+        ?FUNCTION_NAME,
+        {[mqtt, max_topic_levels], 100, 200},
+        {[mqtt, max_clientid_len], 65535, 256},
+        Config
+    ).
+
+test_base_hocon_change_after_rolling_restart(
+    TCName,
+    {ConfPath, V0, V1},
+    {RuntimeConfPath, _RV0, RV1},
+    Config
+) ->
     ct:timetrap({seconds, 120}),
-    ConfigPath = [mqtt, max_topic_levels],
-    MkConfig = fun(V) -> #{mqtt => #{max_topic_levels => V}} end,
-    OldValue = 100,
-    NewValue = 200,
     Apps = [
         %% Start `emqx_conf` first.
         %% Set up few `emqx` application environment variables that are usually set up
@@ -260,57 +277,65 @@ t_base_hocon_change_after_rolling_restart(Config) ->
         }}
     ],
     Cluster =
-        [SeedSpec, NodeSpec] = emqx_cth_cluster:mk_nodespecs(
+        [NodeSpec1, NodeSpec2] = emqx_cth_cluster:mk_nodespecs(
             [
                 {base_hocon_change_after_rolling_restart1, #{apps => Apps, work_dir_dirty => true}},
                 {base_hocon_change_after_rolling_restart2, #{apps => Apps, work_dir_dirty => true}}
             ],
-            #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+            #{work_dir => emqx_cth_suite:work_dir(TCName, Config)}
         ),
     %% Put node-specific configuration in `emqx.conf`, similar to what `emqx_cth_cluster` sets up:
     lists:foreach(fun write_node_config/1, Cluster),
     %% Put initial value for `mqtt.max_topic_levels` in `base.hocon`:
-    lists:foreach(fun(Spec) -> write_base_hocon(Spec, MkConfig(OldValue)) end, Cluster),
+    lists:foreach(
+        fun(Spec) -> write_base_hocon(Spec, nest_config_value(ConfPath, V0)) end,
+        Cluster
+    ),
     ok = emqx_common_test_helpers:copy_acl_conf(),
     try
         %% 1. Start the first node.
-        [SeedNode] = start_cluster([SeedSpec]),
+        [Node1] = start_cluster([NodeSpec1]),
         %% 2. Change unrelated configuration through cluster RPC mechanism:
         ?assertMatch(
             {ok, #{}},
-            ?ON(SeedNode, emqx_conf:update([alarm, size_limit], 2000, #{override_to => cluster}))
+            ?ON(Node1, emqx_conf:update(RuntimeConfPath, RV1, #{override_to => cluster}))
         ),
         %% 3. Start the second node.
         %% Performs an initial configuration sync from an already running cluster member.
-        [Node] = start_cluster([NodeSpec]),
+        [Node2] = start_cluster([NodeSpec2]),
         %% 4. Verify the second node intantiated its `cluster.hocon` configuration file.
-        assert_config_load_done([Node]),
-        NodeClusterHocon = filename:join([maps:get(work_dir, NodeSpec), "configs", "cluster.hocon"]),
-        ?assertEqual(NodeClusterHocon, ?ON(Node, emqx_config:cluster_hocon_file())),
+        assert_config_load_done([Node2]),
+        NodeClusterHocon = filename:join([maps:get(work_dir, NodeSpec2), "configs", "cluster.hocon"]),
+        ?assertEqual(NodeClusterHocon, ?ON(Node2, emqx_config:cluster_hocon_file())),
         ?assert(filelib:is_regular(NodeClusterHocon)),
-        ?assertEqual(OldValue, ?ON(SeedNode, emqx:get_config(ConfigPath))),
-        ?assertEqual(OldValue, ?ON(Node, emqx:get_config(ConfigPath))),
+        ?assertEqual(V0, ?ON(Node1, emqx:get_config(ConfPath))),
+        ?assertEqual(V0, ?ON(Node2, emqx:get_config(ConfPath))),
         %% 5. Initiate the rolling restart.
         %% Similarly, the first node performs configuration sync from the second node.
-        [SeedNode] = emqx_cth_cluster:restart(SeedSpec),
-        [Node] = emqx_cth_cluster:restart(NodeSpec),
+        [Node1] = emqx_cth_cluster:restart(NodeSpec1),
+        [Node2] = emqx_cth_cluster:restart(NodeSpec2),
         %% 6. Change `base.hocon` on each node after initial rolling restart.
-        ok = write_base_hocon(SeedSpec, MkConfig(NewValue)),
-        ok = write_base_hocon(NodeSpec, MkConfig(NewValue)),
-        ?assertEqual(NewValue, read_base_hocon(SeedNode, ConfigPath)),
-        ?assertEqual(NewValue, read_base_hocon(Node, ConfigPath)),
+        ok = write_base_hocon(NodeSpec1, nest_config_value(ConfPath, V1)),
+        ok = write_base_hocon(NodeSpec2, nest_config_value(ConfPath, V1)),
+        ?assertEqual(V1, read_base_hocon(Node1, ConfPath)),
+        ?assertEqual(V1, read_base_hocon(Node2, ConfPath)),
         %% 7. Restart the second node.
-        [Node] = emqx_cth_cluster:restart(NodeSpec),
+        [Node2] = emqx_cth_cluster:restart(NodeSpec2),
         %% 8. Configuration on `base.hocon` level should still take effect.
-        ?assertEqual(NewValue, read_base_hocon(Node, ConfigPath)),
+        ?assertEqual(V1, read_base_hocon(Node2, ConfPath)),
         ?assertEqual(
-            NewValue,
-            ?ON(Node, emqx:get_config(ConfigPath)),
+            V1,
+            ?ON(Node2, emqx:get_config(ConfPath)),
             #{reason => base_hocon_change_should_survive_rolling_restart}
         )
     after
         stop_cluster(Cluster)
     end.
+
+nest_config_value([K | ConfPath], V) ->
+    #{K => nest_config_value(ConfPath, V)};
+nest_config_value([], V) ->
+    V.
 
 %%------------------------------------------------------------------------------
 %% Helper functions

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -232,19 +232,25 @@ t_init_load_with_changed_max_packet_size_before_listeners_start(Config) ->
         stop_cluster([Node])
     end.
 
+%% Verify that changes to `base.hocon` configuration values after initial rolling
+%% cluster restart take effect afterwards.
+%% Essentially:
+%% 1. Start a cluster with identical `base.hocon` on each node containing
+%%    `mqtt.max_topic_levels = 100`.
+%% 2. Perform a runtime update of `alarm.size_limit = 2000`.
+%% 3. Do a rolling restart.
+%% 4. Update `base.hocon` on each node to `mqtt.max_topic_levels = 200`.
+%% 5. Restart a node and observe it runs with `mqtt.max_topic_levels` updated
+%%    to 200.
+%%
+%% Note that most of the runtime operations introducing configuration changes use
+%% schema-root-level granularity, so for example a runtime update in (2) targeting
+%% `mqtt.max_clientid_len = 256` makes the testcase fail consistently.
 t_base_hocon_change_after_rolling_restart(Config) ->
     test_base_hocon_change_after_rolling_restart(
         ?FUNCTION_NAME,
         {[mqtt, max_topic_levels], 100, 200},
         {[alarm, size_limit], 1000, 2000},
-        Config
-    ).
-
-t_base_hocon_change_after_rolling_restart_same_root(Config) ->
-    test_base_hocon_change_after_rolling_restart(
-        ?FUNCTION_NAME,
-        {[mqtt, max_topic_levels], 100, 200},
-        {[mqtt, max_clientid_len], 65535, 256},
         Config
     ).
 

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
 
@@ -231,9 +232,140 @@ t_init_load_with_changed_max_packet_size_before_listeners_start(Config) ->
         stop_cluster([Node])
     end.
 
+t_base_hocon_change_after_rolling_restart(Config) ->
+    ct:timetrap({seconds, 120}),
+    ConfigPath = [mqtt, max_topic_levels],
+    MkConfig = fun(V) -> #{mqtt => #{max_topic_levels => V}} end,
+    OldValue = 100,
+    NewValue = 200,
+    Apps = [
+        %% Start `emqx_conf` first.
+        %% Set up few `emqx` application environment variables that are usually set up
+        %% through schema-generated app file.
+        {emqx_conf, #{
+            config => false,
+            before_start => fun(_App, _Opts) ->
+                {ok, WorkDir} = file:get_cwd(),
+                ClusterHoconFile = filename:join([WorkDir, "configs", "cluster.hocon"]),
+                ok = application:set_env(emqx, data_dir, WorkDir),
+                ok = application:set_env(emqx, config_files, ["etc/emqx.conf"]),
+                ok = application:set_env(emqx, cluster_hocon_file, ClusterHoconFile)
+            end
+        }},
+        %% Start `emqx` explicitly.
+        %% It owns `emqx_config_handler` needed for cluster config sync.
+        {emqx, #{
+            config => false,
+            before_start => false
+        }}
+    ],
+    Cluster =
+        [SeedSpec, NodeSpec] = emqx_cth_cluster:mk_nodespecs(
+            [
+                {base_hocon_change_after_rolling_restart1, #{apps => Apps, work_dir_dirty => true}},
+                {base_hocon_change_after_rolling_restart2, #{apps => Apps, work_dir_dirty => true}}
+            ],
+            #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+        ),
+    %% Put node-specific configuration in `emqx.conf`, similar to what `emqx_cth_cluster` sets up:
+    lists:foreach(fun write_node_config/1, Cluster),
+    %% Put initial value for `mqtt.max_topic_levels` in `base.hocon`:
+    lists:foreach(fun(Spec) -> write_base_hocon(Spec, MkConfig(OldValue)) end, Cluster),
+    ok = emqx_common_test_helpers:copy_acl_conf(),
+    try
+        %% 1. Start the first node.
+        [SeedNode] = start_cluster([SeedSpec]),
+        %% 2. Change unrelated configuration through cluster RPC mechanism:
+        ?assertMatch(
+            {ok, #{}},
+            ?ON(SeedNode, emqx_conf:update([alarm, size_limit], 2000, #{override_to => cluster}))
+        ),
+        %% 3. Start the second node.
+        %% Performs an initial configuration sync from an already running cluster member.
+        [Node] = start_cluster([NodeSpec]),
+        %% 4. Verify the second node intantiated its `cluster.hocon` configuration file.
+        assert_config_load_done([Node]),
+        NodeClusterHocon = filename:join([maps:get(work_dir, NodeSpec), "configs", "cluster.hocon"]),
+        ?assertEqual(NodeClusterHocon, ?ON(Node, emqx_config:cluster_hocon_file())),
+        ?assert(filelib:is_regular(NodeClusterHocon)),
+        ?assertEqual(OldValue, ?ON(SeedNode, emqx:get_config(ConfigPath))),
+        ?assertEqual(OldValue, ?ON(Node, emqx:get_config(ConfigPath))),
+        %% 5. Initiate the rolling restart.
+        %% Similarly, the first node performs configuration sync from the second node.
+        [SeedNode] = emqx_cth_cluster:restart(SeedSpec),
+        [Node] = emqx_cth_cluster:restart(NodeSpec),
+        %% 6. Change `base.hocon` on each node after initial rolling restart.
+        ok = write_base_hocon(SeedSpec, MkConfig(NewValue)),
+        ok = write_base_hocon(NodeSpec, MkConfig(NewValue)),
+        ?assertEqual(NewValue, read_base_hocon(SeedNode, ConfigPath)),
+        ?assertEqual(NewValue, read_base_hocon(Node, ConfigPath)),
+        %% 7. Restart the second node.
+        [Node] = emqx_cth_cluster:restart(NodeSpec),
+        %% 8. Configuration on `base.hocon` level should still take effect.
+        ?assertEqual(NewValue, read_base_hocon(Node, ConfigPath)),
+        ?assertEqual(
+            NewValue,
+            ?ON(Node, emqx:get_config(ConfigPath)),
+            #{reason => base_hocon_change_should_survive_rolling_restart}
+        )
+    after
+        stop_cluster(Cluster)
+    end.
+
 %%------------------------------------------------------------------------------
 %% Helper functions
 %%------------------------------------------------------------------------------
+
+write_node_config(
+    #{
+        name := Node,
+        role := Role,
+        base_port := BasePort,
+        work_dir := WorkDir,
+        core_nodes := CoreNodes
+    }
+) ->
+    NodeConfig = #{
+        node => #{
+            name => Node,
+            role => Role,
+            cookie => erlang:get_cookie(),
+            data_dir => unicode:characters_to_binary(WorkDir)
+        },
+        cluster => #{
+            discovery_strategy => static,
+            static => #{seeds => CoreNodes}
+        },
+        rpc => #{
+            protocol => tcp,
+            tcp_server_port => BasePort - 1,
+            port_discovery => manual
+        },
+        log => #{file => #{enable => true, level => debug}},
+        listeners => #{
+            tcp => #{default => #{enable => false}},
+            ssl => #{default => #{enable => false}},
+            ws => #{default => #{enable => false}},
+            wss => #{default => #{enable => false}}
+        }
+    },
+    NodeHocon = hocon_pp:do(NodeConfig, #{}),
+    FilePath = filename:join([WorkDir, "etc", "emqx.conf"]),
+    ok = filelib:ensure_dir(FilePath),
+    ok = file:write_file(FilePath, unicode:characters_to_binary(NodeHocon)).
+
+write_base_hocon(#{work_dir := WorkDir}, Config) ->
+    FilePath = filename:join([WorkDir, "etc", "base.hocon"]),
+    ok = filelib:ensure_dir(FilePath),
+    BaseHocon = hocon_pp:do(Config, #{}),
+    file:write_file(FilePath, unicode:characters_to_binary(BaseHocon)).
+
+read_base_hocon(Node, ConfigPath) ->
+    ?ON(Node, begin
+        File = emqx_config:base_hocon_file(),
+        {ok, RawConfig} = hocon:files([File]),
+        emqx_utils_maps:deep_get([emqx_utils_conv:bin(X) || X <- ConfigPath], RawConfig)
+    end).
 
 create_data_dir(File) ->
     NodeDataDir = emqx:data_dir(),

--- a/changes/ee/fix-18447.en.md
+++ b/changes/ee/fix-18447.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where changes to `base.hocon` could be ignored after a node synchronized configuration from another cluster member. Configuration synchronization no longer persists the peer's `base.hocon` values into `cluster.hocon`, so local `base.hocon` changes take effect after restart unless explicitly overridden by cluster configuration.


### PR DESCRIPTION
Release version: 6.3.0

Introduced in: v/e5.8.4

## Summary

This PR changes what a EMQX node replies with when requested for a cluster configuration during `emqx_conf_app` configuration sync.
* Before: node handed off the result of merge of `base.hocon` and `cluster.hocon`, which was persisted on the requesting node as `cluster.hocon`.
* After: node hands off only its own `cluster.hocon`.

Consequences:
1. Global namespace backup will also stop including `base.hocon` configuration in backed-up `cluster.hocon`s.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible