### PR TITLE
fix(postgres): treat `sock_closed` as recoverable

### DIFF
--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -492,12 +492,14 @@ on_sql_query(InstId, PoolName, Type, NameOrSQL, Data, State) ->
                     TranslatedError
                 )
             ),
-            case Reason of
-                sync_required ->
+            case TranslatedError of
+                #{reason := sync_required} ->
                     {error, {recoverable_error, Reason}};
-                ecpool_empty ->
+                #{reason := ecpool_empty} ->
                     {error, {recoverable_error, Reason}};
-                {error, error, _, undefined_table, _, _} ->
+                #{reason := sock_closed} ->
+                    {error, {recoverable_error, Reason}};
+                #{driver_error_codename := undefined_table} ->
                     {error, {unrecoverable_error, export_error(TranslatedError)}};
                 _ ->
                     {error, export_error(TranslatedError)}

--- a/changes/ee/fix-18449.en.md
+++ b/changes/ee/fix-18449.en.md
@@ -1,0 +1,1 @@
+On rare race conditions, the Postgres Action could get a `sock_closed` error while writing data, and would treat that as an unrecoverable error.  Now, it's treated as a recoverable error.


### PR DESCRIPTION
```
2026-08-21T15:13:13.942910+00:00 [error] msg: postgresql_connector_do_sql_query_failed, pid: <0.53964.0>, reason: sock_closed, type: prepared_query, connector: <<"connector:pgsql:t_write_failure">>, sql: Encoded(text)=action:pgsql:t_write_failure:connector:pgsql:t_write_failure, payload_encode: text
2026-08-21T15:13:13.943304+00:00 [error] tag: RESOURCE, msg: unrecoverable_resource_error, pid: <0.53964.0>, reason: {unrecoverable_error,sock_closed}, resource_id: <<"action:pgsql:t_write_failure:connector:pgsql:t_write_failure">>
```

https://github.com/emqx/emqx/actions/runs/32494556677/job/96814236948?pr=18393#step:5:778

Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
