### PR TITLE
feat(packaging): install /etc/emqx/emqx.env and read it from the systemd unit

### DIFF
--- a/apps/emqx_conf/etc/emqx.env
+++ b/apps/emqx_conf/etc/emqx.env
@@ -1,15 +1,17 @@
 # EMQX boot-time environment variables.
 #
-# The emqx systemd service reads this file (EnvironmentFile=) before it starts
-# the node. EMQX reads these variables before it parses emqx.conf, so they
-# cannot be set in emqx.conf.
+# The emqx command (bin/emqx, /usr/bin/emqx on package installs) sources this
+# file on every invocation: service start, foreground start, `emqx ctl`, and
+# so on. EMQX reads these variables before it parses emqx.conf, so they cannot
+# be set in emqx.conf.
 #
+# Values in this file override variables inherited from the environment.
 # A package upgrade keeps your edits to this file.
-# Uncomment a line, set the value, then run: systemctl restart emqx
+# Uncomment a line, set the value, then restart the node.
 #
-# Syntax: one KEY=value per line. No `export`, no shell expansion.
-# Other EMQX_* variables, for example EMQX_NODE__COOKIE=..., can also be set
-# here.
+# Syntax: shell assignments, one KEY=value per line. Quote values that contain
+# spaces. Other EMQX_* variables, for example EMQX_NODE__COOKIE=..., can also
+# be set here.
 
 # EMQX_FEATURES selects the set of applications the node boots.
 #   FULL       (default) boots every application.

--- a/apps/emqx_conf/etc/emqx.env
+++ b/apps/emqx_conf/etc/emqx.env
@@ -1,0 +1,60 @@
+# EMQX boot-time environment variables.
+#
+# The emqx systemd service reads this file (EnvironmentFile=) before it starts
+# the node. EMQX reads these variables before it parses emqx.conf, so they
+# cannot be set in emqx.conf.
+#
+# A package upgrade keeps your edits to this file.
+# Uncomment a line, set the value, then run: systemctl restart emqx
+#
+# Syntax: one KEY=value per line. No `export`, no shell expansion.
+# Other EMQX_* variables, for example EMQX_NODE__COOKIE=..., can also be set
+# here.
+
+# EMQX_FEATURES selects the set of applications the node boots.
+#   FULL       (default) boots every application.
+#   ESSENTIAL  boots only the core broker with authentication and
+#              authorization. The dashboard, REST API, data integration,
+#              gateways, plugins and other optional features do not start.
+#   <list>     a comma-separated list of feature names, for example
+#              "dashboard,data_integration", boots the core broker plus the
+#              listed features.
+# A feature that did not boot cannot be enabled at runtime. Change the value
+# and restart the node to change the set. An unknown feature name stops the
+# node from starting.
+#EMQX_FEATURES=FULL
+
+# EMQX_SECURITY_PROFILE selects the node-wide security profile.
+# Valid values: legacy | hardened
+#
+# The profile sets the default of a group of security behaviours at once.
+# Compared to `legacy`, `hardened`:
+#   - Binds the default MQTT listener and the dashboard HTTP listener to
+#     loopback instead of all interfaces.
+#   - Denies clients when no authenticator is configured.
+#   - Denies clients when an authentication or authorization backend fails,
+#     instead of ignoring the failure.
+#   - Denies clients when a JWT authenticator receives no token.
+#   - Interrupts authentication and authorization when a hook callback
+#     crashes, instead of ignoring the crash.
+#   - Denies dashboard login while the default admin password is unchanged.
+#   - Verifies SAML SSO signatures.
+#   - Defaults outbound TLS peer verification to verify_peer (for example the
+#     JWKS endpoint of JWT authentication).
+#   - Authorizes subscriptions made on behalf of a client (REST API, CLI,
+#     auto-subscribe) like client subscriptions.
+#   - Re-authorizes delayed messages when they are published.
+#   - Denies a publish when the ExHook on_message_publish callback fails.
+#   - Refuses to start with the default Erlang cookie.
+# Cost of switching an existing node: whatever relied on a legacy default
+# stops working until it is configured explicitly. Remote clients cannot reach
+# a loopback-bound listener, an unauthenticated setup rejects every client,
+# and outbound TLS fails until a trusted CA is configured. Most of these
+# behaviours have their own configuration option; the profile only changes the
+# default. Set the same value on every node of a cluster. An unknown value
+# stops the node from starting.
+#
+# `hardened` becomes the default in EMQX 7.0. Set it now to test a deployment
+# against the 7.0 defaults.
+# Details: https://docs.emqx.com/en/emqx/latest/access-control/security-profile.html
+#EMQX_SECURITY_PROFILE=legacy

--- a/apps/emqx_conf/etc/emqx.env
+++ b/apps/emqx_conf/etc/emqx.env
@@ -12,6 +12,10 @@
 # Syntax: shell assignments, one KEY=value per line. Quote values that contain
 # spaces. Other EMQX_* variables, for example EMQX_NODE__COOKIE=..., can also
 # be set here.
+#
+# The commented defaults below use the KEY="${KEY:-default}" form: uncommented
+# as shipped, such a line keeps a value already set in the environment and
+# falls back to the default otherwise. Write KEY=value to force a value.
 
 # EMQX_FEATURES selects the set of applications the node boots.
 #   FULL       (default) boots every application.
@@ -24,7 +28,7 @@
 # A feature that did not boot cannot be enabled at runtime. Change the value
 # and restart the node to change the set. An unknown feature name stops the
 # node from starting.
-#EMQX_FEATURES=FULL
+#EMQX_FEATURES="${EMQX_FEATURES:-FULL}"
 
 # EMQX_SECURITY_PROFILE selects the node-wide security profile.
 # Valid values: legacy | hardened
@@ -59,4 +63,4 @@
 # `hardened` becomes the default in EMQX 7.0. Set it now to test a deployment
 # against the 7.0 defaults.
 # Details: https://docs.emqx.com/en/emqx/latest/access-control/security-profile.html
-#EMQX_SECURITY_PROFILE=legacy
+#EMQX_SECURITY_PROFILE="${EMQX_SECURITY_PROFILE:-legacy}"

--- a/bin/emqx
+++ b/bin/emqx
@@ -191,12 +191,6 @@ if [ "${2:-}" = 'help' ]; then
     fi
 fi
 
-## starts only the slim apps list, and we flip code loading to interactive so
-## the skipped apps' .beam files don't sit resident in memory.
-if [ "${EMQX_FEATURES:-}" = 'ESSENTIAL' ]; then
-    export CODE_LOADING_MODE="${CODE_LOADING_MODE:-interactive}"
-fi
-
 ## IS_BOOT_COMMAND is set for later to inspect node name and cookie from hocon config (or env variable)
 case "${COMMAND}" in
     start|console|console_clean|foreground|check_config)
@@ -214,16 +208,6 @@ case "${COMMAND}" in
         IS_BOOT_COMMAND='no'
         ;;
 esac
-
-# Will be set to hardened since v7
-export EMQX_SECURITY_PROFILE="${EMQX_SECURITY_PROFILE:-legacy}"
-
-if [[ "$IS_BOOT_COMMAND" = 'yes' ]]; then
-    if [ "$EMQX_SECURITY_PROFILE" != 'legacy' ] && [ "$EMQX_SECURITY_PROFILE" != 'hardened' ]; then
-        logerr "Invalid security profile: $EMQX_SECURITY_PROFILE. Valid values are: legacy, hardened."
-        exit 1
-    fi
-fi
 
 RELUP_DIR="relup"
 BASE_RUNNER_ROOT_DIR="${BASE_RUNNER_ROOT_DIR:-$RUNNER_ROOT_DIR}"
@@ -248,6 +232,32 @@ export EMQX_ETC_DIR
 export REL_VSN
 export SCHEMA_MOD
 export IS_ENTERPRISE
+
+## Boot-time environment variables (EMQX_FEATURES, EMQX_SECURITY_PROFILE, ...).
+## The file is optional. Values in the file override the inherited environment.
+if [ -f "$EMQX_ETC_DIR/emqx.env" ]; then
+    set -a
+    # shellcheck disable=SC1090,SC1091
+    . "$EMQX_ETC_DIR/emqx.env"
+    set +a
+fi
+
+## starts only the slim apps list, and we flip code loading to interactive so
+## the skipped apps' .beam files don't sit resident in memory.
+if [ "${EMQX_FEATURES:-}" = 'ESSENTIAL' ]; then
+    export CODE_LOADING_MODE="${CODE_LOADING_MODE:-interactive}"
+fi
+
+# Will be set to hardened since v7
+export EMQX_SECURITY_PROFILE="${EMQX_SECURITY_PROFILE:-legacy}"
+
+if [[ "$IS_BOOT_COMMAND" = 'yes' ]]; then
+    if [ "$EMQX_SECURITY_PROFILE" != 'legacy' ] && [ "$EMQX_SECURITY_PROFILE" != 'hardened' ]; then
+        logerr "Invalid security profile: $EMQX_SECURITY_PROFILE. Valid values are: legacy, hardened."
+        exit 1
+    fi
+fi
+
 
 RUNNER_SCRIPT="$RUNNER_BIN_DIR/$REL_NAME"
 CODE_LOADING_MODE="${CODE_LOADING_MODE:-embedded}"

--- a/changes/ee/feat-18451.en.md
+++ b/changes/ee/feat-18451.en.md
@@ -1,3 +1,3 @@
-The rpm and deb packages now install `/etc/emqx/emqx.env`, an environment file read by the `emqx` systemd service.
+EMQX now reads boot-time environment variables from `etc/emqx.env` (`/etc/emqx/emqx.env` on rpm and deb installs, `/opt/emqx/etc/emqx.env` in the docker image).
 
-The file lists the boot-time environment variables `EMQX_FEATURES` and `EMQX_SECURITY_PROFILE` with their defaults commented out and a description of what each one does. These variables are read before `emqx.conf` is parsed, so they cannot be set in `emqx.conf`. Set them in `/etc/emqx/emqx.env` instead of editing the systemd unit. Package upgrades keep edits to the file.
+The file lists `EMQX_FEATURES` and `EMQX_SECURITY_PROFILE` with their defaults commented out and a description of what each one does. These variables are read before `emqx.conf` is parsed, so they cannot be set in `emqx.conf`. The `emqx` command sources the file on every invocation, so a service start, a foreground start and `emqx ctl` all see the same values. Values in the file override the inherited environment. Package upgrades keep edits to the file.

--- a/changes/ee/feat-18451.en.md
+++ b/changes/ee/feat-18451.en.md
@@ -1,0 +1,3 @@
+The rpm and deb packages now install `/etc/emqx/emqx.env`, an environment file read by the `emqx` systemd service.
+
+The file lists the boot-time environment variables `EMQX_FEATURES` and `EMQX_SECURITY_PROFILE` with their defaults commented out and a description of what each one does. These variables are read before `emqx.conf` is parsed, so they cannot be set in `emqx.conf`. Set them in `/etc/emqx/emqx.env` instead of editing the systemd unit. Package upgrades keep edits to the file.

--- a/deploy/packages/emqx.service
+++ b/deploy/packages/emqx.service
@@ -13,6 +13,11 @@ Environment=HOME=/var/lib/emqx
 # log to file by default (if no log handler config)
 Environment=EMQX_DEFAULT_LOG_HANDLER=file
 
+# Boot-time environment variables (EMQX_FEATURES, EMQX_SECURITY_PROFILE, ...).
+# Values in this file override the Environment= lines above.
+# The leading '-' makes the file optional.
+EnvironmentFile=-/etc/emqx/emqx.env
+
 # Start 'foreground' but not 'start' (daemon) mode.
 # Because systemd monitor/restarts 'simple' services
 ExecStart=/bin/bash /usr/bin/emqx foreground

--- a/deploy/packages/emqx.service
+++ b/deploy/packages/emqx.service
@@ -13,10 +13,8 @@ Environment=HOME=/var/lib/emqx
 # log to file by default (if no log handler config)
 Environment=EMQX_DEFAULT_LOG_HANDLER=file
 
-# Boot-time environment variables (EMQX_FEATURES, EMQX_SECURITY_PROFILE, ...).
-# Values in this file override the Environment= lines above.
-# The leading '-' makes the file optional.
-EnvironmentFile=-/etc/emqx/emqx.env
+# Boot-time environment variables (EMQX_FEATURES, EMQX_SECURITY_PROFILE, ...)
+# are set in /etc/emqx/emqx.env, which /usr/bin/emqx reads on every command.
 
 # Start 'foreground' but not 'start' (daemon) mode.
 # Because systemd monitor/restarts 'simple' services

--- a/mix.exs
+++ b/mix.exs
@@ -730,6 +730,13 @@ defmodule EMQXUmbrella.MixProject do
       force: overwrite?
     )
 
+    # boot-time environment variables, read by the systemd service
+    Mix.Generator.copy_file(
+      "apps/emqx_conf/etc/emqx.env",
+      Path.join(etc, "emqx.env"),
+      force: overwrite?
+    )
+
     # required by emqx_auth
     File.cp_r!(
       "apps/emqx/etc/certs",

--- a/scripts/test/test_emqx_boot.py
+++ b/scripts/test/test_emqx_boot.py
@@ -259,6 +259,66 @@ def test_invalid_security_profile_fails_fast(emqx_bin_path, security_profile):
     assert "hardened" in output
 
 
+@pytest.fixture
+def env_file(emqx_rel_path):
+    """Yield the etc/emqx.env path and restore the shipped file afterwards."""
+    path = emqx_rel_path / "etc" / "emqx.env"
+    backup = path.read_bytes() if path.exists() else None
+    yield path
+    if backup is None:
+        path.unlink(missing_ok=True)
+    else:
+        path.write_bytes(backup)
+
+
+def test_shipped_env_file_sets_nothing(env_file):
+    """The shipped etc/emqx.env must keep every assignment commented out."""
+    assert env_file.exists()
+    active = [
+        line
+        for line in env_file.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert active == []
+
+
+def test_env_file_sets_security_profile(emqx_bin_path, env_file):
+    """bin/emqx sources etc/emqx.env; a profile set there is enforced."""
+    env_file.write_text("# comment\n\nEMQX_SECURITY_PROFILE=hardened\n")
+    result = run_emqx_console(
+        emqx_bin_path,
+        {"EMQX_NODE__COOKIE": "emqxsecretcookie"},
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Cannot continue with default cookie" in output
+    assert "hardened" in output
+
+
+def test_env_file_overrides_environment(emqx_bin_path, env_file):
+    """A value in etc/emqx.env wins over the inherited environment."""
+    env_file.write_text("EMQX_SECURITY_PROFILE=hardened\n")
+    result = run_emqx_console(
+        emqx_bin_path,
+        {
+            "EMQX_SECURITY_PROFILE": "legacy",
+            "EMQX_NODE__COOKIE": "emqxsecretcookie",
+        },
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Cannot continue with default cookie" in output
+
+
+def test_env_file_invalid_security_profile_fails_fast(emqx_bin_path, env_file):
+    """An invalid profile in etc/emqx.env fails before boot."""
+    env_file.write_text("EMQX_SECURITY_PROFILE=bogus\n")
+    result = run_emqx_console(emqx_bin_path, {})
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "Invalid security profile: bogus" in output
+
+
 def test_corrupted_cluster_override_conf(emqx_bin_path, emqx_rel_path):
     """Test that emqx boot fails with corrupted cluster-override.conf."""
     conffile = emqx_rel_path / "data" / "configs" / "cluster-override.conf"


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
N/A

## Summary

EMQX now reads boot-time environment variables from `etc/emqx.env`. The deb and rpm packages install it as `/etc/emqx/emqx.env`; the docker image carries it at `/opt/emqx/etc/emqx.env`; a tgz install has it at `etc/emqx.env`.

`EMQX_FEATURES` and `EMQX_SECURITY_PROFILE` are read before `emqx.conf` is parsed (`emqx_security_profile` decides schema defaults such as the default bind address), so they cannot be HOCON settings. Until now a systemd install had no discoverable place to set them: editing the unit is lost on upgrade, and `systemctl edit emqx` is folklore. Docker takes them as plain environment variables. This PR gives every install form the same file.

Changes:

- `apps/emqx_conf/etc/emqx.env` (new): both variables commented out at their current defaults in the `KEY="${KEY:-default}"` form (uncommenting a shipped line keeps a value already set in the environment; writing a literal value forces it), each with a comment on what it does and what changing it costs. The security profile comment enumerates the behaviours `hardened` flips, taken from `emqx_security_profile:policy/1` and `bin/emqx` (default cookie refusal), and states that `hardened` becomes the default in 7.0. It points at the docs page from emqx/emqx-docs#3768 rather than carrying a full policy table. `policy(authz_context)` is intentionally not listed: `emqx_authz_context:make/1` only honours it under `-ifdef(TEST)`, so it changes nothing in a release build.
- `bin/emqx`: source `$EMQX_ETC_DIR/emqx.env` (with `set -a`) right after `releases/emqx_vars`, on every command. The `EMQX_FEATURES` and `EMQX_SECURITY_PROFILE` handling moves below that point; nothing between the old and new position used either variable. The file is optional. Values in the file override the inherited environment, the same precedence systemd's `EnvironmentFile=` has, so the file can override the unit's `Environment=EMQX_DEFAULT_LOG_HANDLER=file`. Sourcing a file from `etc/` adds no new trust boundary: `releases/emqx_vars` is already sourced from a tree that `postinst` chowns to `emqx:emqx`.
- `mix.exs`: copy the file into the release `etc/`, same as `acl.conf`. The deb rules (`cp -R etc/*`) and the rpm spec (`%config(noreplace) %{_conf_dir}/*`) pick it up without changes.
- `deploy/packages/emqx.service` (the deb and rpm units are symlinks to it): a comment pointing at the file. No `EnvironmentFile=`, so there is one parser, and `emqx ctl` run from a shell sees the same variables (for example `EMQX_NODE__COOKIE`) as the service.
- `scripts/test/test_emqx_boot.py`: the shipped file must keep every assignment commented out (a shipped active value would override `-e` flags in docker); a profile set in the file is enforced; the file wins over the inherited environment; an invalid value in the file fails before boot.

Verified with the built deb (Ubuntu 20.04, systemd 249 in a privileged container) and an rpm built from the same release tarball (Rocky 9):

- `dpkg-deb -e` lists `/etc/emqx/emqx.env` in `conffiles`; rpm file flags are 17 (config + noreplace).
- Untouched file: node boots, `emqx_is_running ... security_profile: legacy`.
- `EMQX_SECURITY_PROFILE=hardened` with the default cookie: boot refused with `Cannot continue with default cookie and EMQX_SECURITY_PROFILE set to 'hardened'`. With `EMQX_NODE__COOKIE` added to the same file: `security_profile: hardened`.
- `EMQX_SECURITY_PROFILE=bogus`: boot fails with `Invalid security profile: bogus`.
- Upgrade to a version-bumped package (`dpkg -i`, `rpm -U`): the edited file keeps its md5 and the node boots `hardened` again.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

Follow-up: #18471 collects `etc/emqx.env` (secrets obfuscated) in `node_dump`.
