### PR TITLE
feat(mgmt): expose security_profile and feature_preset in node info

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -158,6 +158,8 @@ node_info() ->
         version => iolist_to_binary(proplists:get_value(version, BrokerInfo)),
         edition => emqx_release:edition_longstr(),
         role => mria_rlog:role(),
+        security_profile => emqx_security_profile:profile(),
+        feature_preset => maps:get(preset, emqx_machine_features:info()),
         log_path => log_path(),
         sys_path => iolist_to_binary(code:root_dir())
     }.
@@ -194,6 +196,8 @@ os_type() ->
 node_info(Nodes) ->
     emqx_rpc:unwrap_erpc(emqx_management_proto_v5:node_info(Nodes)).
 
+%% Only keys that are known without reaching the node.
+%% The schema marks every other `node_info` field as optional.
 stopped_node_info(Node) ->
     {Node, #{node => Node, node_status => 'stopped', role => core}}.
 

--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -245,6 +245,16 @@ fields(node_info) ->
             mk(
                 enum([core, replicant]),
                 #{desc => ?DESC("node_role"), example => "core"}
+            )},
+        {security_profile,
+            mk(
+                enum([legacy, hardened]),
+                #{desc => ?DESC("security_profile"), example => "legacy"}
+            )},
+        {feature_preset,
+            mk(
+                enum([full, essential, custom]),
+                #{desc => ?DESC("feature_preset"), example => "full"}
             )}
     ].
 

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -174,9 +174,7 @@ t_multiple_nodes_api(Config) ->
             get, #{bindings => #{node => Node1}}
         ]),
         ?assertMatch(#{node := Node1, security_profile := legacy, feature_preset := full}, Node11),
-        lists:foreach(fun assert_node_info_schema/1, NodesList),
         %% A stopped node never reports its profile or preset.
-        %% The entry must still validate against the schema.
         ok = emqx_cth_cluster:stop_node(Node2),
         {200, [RunningInfo, StoppedInfo]} = ?retry(
             _Interval = 200,
@@ -192,9 +190,7 @@ t_multiple_nodes_api(Config) ->
         ),
         ?assertMatch(#{node := Node2, node_status := stopped}, StoppedInfo),
         ?assertNot(is_map_key(security_profile, StoppedInfo)),
-        ?assertNot(is_map_key(feature_preset, StoppedInfo)),
-        assert_node_info_schema(RunningInfo),
-        assert_node_info_schema(StoppedInfo)
+        ?assertNot(is_map_key(feature_preset, StoppedInfo))
     after
         emqx_cth_cluster:stop(Nodes)
     end,
@@ -211,24 +207,4 @@ assert_profile_and_preset(Info) ->
     ?assertEqual(
         atom_to_binary(maps:get(preset, emqx_machine_features:info())),
         maps:get(<<"feature_preset">>, Info)
-    ).
-
-%% Check a node info map (as returned by the handler) against `fields(node_info)`.
-%% `memory_total` and `memory_used` are rendered as e.g. `62.74G`, which the
-%% `bytesize()` type does not parse. Skip them.
-assert_node_info_schema(Info0) ->
-    Info = maps:without([memory_total, memory_used], Info0),
-    Json = emqx_utils_json:decode(emqx_utils_json:encode(Info)),
-    Schema = #{
-        roots => [{node_info, hoconsc:ref(emqx_mgmt_api_nodes, node_info)}],
-        fields => #{}
-    },
-    ?assertMatch(
-        #{<<"node_info">> := #{}},
-        hocon_tconf:check_plain(
-            Schema,
-            #{<<"node_info">> => Json},
-            %% same semantics as the swagger layer: only `required => true` is required
-            #{atom_key => false, required => false}
-        )
     ).

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -8,6 +8,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -55,6 +56,7 @@ t_nodes_api(_) ->
     ?assertEqual(Node, node()),
     Edition = maps:get(<<"edition">>, LocalNodeInfo),
     ?assertEqual(emqx_release:edition_longstr(), Edition),
+    assert_profile_and_preset(LocalNodeInfo),
 
     Conns = maps:get(<<"connections">>, LocalNodeInfo),
     ?assertEqual(0, Conns),
@@ -63,9 +65,10 @@ t_nodes_api(_) ->
 
     NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
     {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),
-    NodeNameResponse =
-        binary_to_atom(maps:get(<<"node">>, emqx_utils_json:decode(NodeInfo)), utf8),
+    NodeInfoMap = emqx_utils_json:decode(NodeInfo),
+    NodeNameResponse = binary_to_atom(maps:get(<<"node">>, NodeInfoMap), utf8),
     ?assertEqual(node(), NodeNameResponse),
+    assert_profile_and_preset(NodeInfoMap),
 
     BadNodePath = emqx_mgmt_api_test_util:api_path(["nodes", "badnode"]),
     ?assertMatch(
@@ -80,6 +83,34 @@ t_log_path(_) ->
     ?assertEqual(
         <<"log">>,
         filename:basename(Path)
+    ).
+
+-doc """
+`security_profile` and `feature_preset` reflect non-default settings.
+""".
+t_node_info_non_default_profile_and_preset(_) ->
+    NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
+    os:putenv("EMQX_FEATURES", "ESSENTIAL"),
+    emqx_machine_features:clear_features(),
+    try
+        emqx_common_test_helpers:with_security_profile(hardened, fun() ->
+            {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),
+            ?assertMatch(
+                #{
+                    <<"security_profile">> := <<"hardened">>,
+                    <<"feature_preset">> := <<"essential">>
+                },
+                emqx_utils_json:decode(NodeInfo)
+            )
+        end)
+    after
+        os:unsetenv("EMQX_FEATURES"),
+        emqx_machine_features:clear_features()
+    end,
+    {ok, NodeInfo1} = emqx_mgmt_api_test_util:request_api(get, NodePath),
+    ?assertMatch(
+        #{<<"security_profile">> := <<"legacy">>, <<"feature_preset">> := <<"full">>},
+        emqx_utils_json:decode(NodeInfo1)
     ).
 
 t_node_stats_api(_) ->
@@ -142,8 +173,62 @@ t_multiple_nodes_api(Config) ->
         {200, Node11} = rpc:call(Node1, emqx_mgmt_api_nodes, node, [
             get, #{bindings => #{node => Node1}}
         ]),
-        ?assertMatch(#{node := Node1}, Node11)
+        ?assertMatch(#{node := Node1, security_profile := legacy, feature_preset := full}, Node11),
+        lists:foreach(fun assert_node_info_schema/1, NodesList),
+        %% A stopped node never reports its profile or preset.
+        %% The entry must still validate against the schema.
+        ok = emqx_cth_cluster:stop_node(Node2),
+        {200, [RunningInfo, StoppedInfo]} = ?retry(
+            _Interval = 200,
+            _Attempts = 50,
+            begin
+                {200, [_, #{node_status := stopped}]} =
+                    rpc:call(Node1, emqx_mgmt_api_nodes, nodes, [get, #{}])
+            end
+        ),
+        ?assertMatch(
+            #{node := Node1, security_profile := legacy, feature_preset := full},
+            RunningInfo
+        ),
+        ?assertMatch(#{node := Node2, node_status := stopped}, StoppedInfo),
+        ?assertNot(is_map_key(security_profile, StoppedInfo)),
+        ?assertNot(is_map_key(feature_preset, StoppedInfo)),
+        assert_node_info_schema(RunningInfo),
+        assert_node_info_schema(StoppedInfo)
     after
         emqx_cth_cluster:stop(Nodes)
     end,
     ok.
+
+%%--------------------------------------------------------------------
+%% Helpers
+
+assert_profile_and_preset(Info) ->
+    ?assertEqual(
+        atom_to_binary(emqx_security_profile:profile()),
+        maps:get(<<"security_profile">>, Info)
+    ),
+    ?assertEqual(
+        atom_to_binary(maps:get(preset, emqx_machine_features:info())),
+        maps:get(<<"feature_preset">>, Info)
+    ).
+
+%% Check a node info map (as returned by the handler) against `fields(node_info)`.
+%% `memory_total` and `memory_used` are rendered as e.g. `62.74G`, which the
+%% `bytesize()` type does not parse. Skip them.
+assert_node_info_schema(Info0) ->
+    Info = maps:without([memory_total, memory_used], Info0),
+    Json = emqx_utils_json:decode(emqx_utils_json:encode(Info)),
+    Schema = #{
+        roots => [{node_info, hoconsc:ref(emqx_mgmt_api_nodes, node_info)}],
+        fields => #{}
+    },
+    ?assertMatch(
+        #{<<"node_info">> := #{}},
+        hocon_tconf:check_plain(
+            Schema,
+            #{<<"node_info">> => Json},
+            %% same semantics as the swagger layer: only `required => true` is required
+            #{atom_key => false, required => false}
+        )
+    ).

--- a/changes/ee/feat-18452.en.md
+++ b/changes/ee/feat-18452.en.md
@@ -1,0 +1,3 @@
+Added `security_profile` and `feature_preset` to the node information returned by `GET /nodes` and `GET /nodes/{node}`.
+
+`security_profile` is `legacy` or `hardened`. `feature_preset` is `full`, `essential`, or `custom`. Both values are fixed when the node boots, so the list view shows when nodes in a cluster run with different settings. Stopped nodes do not report these fields.

--- a/rel/i18n/emqx_mgmt_api_nodes.hocon
+++ b/rel/i18n/emqx_mgmt_api_nodes.hocon
@@ -134,6 +134,16 @@ emqx_mgmt_api_nodes {
         label = "Node Role"
     }
 
+    security_profile {
+        desc = "Security profile the node booted with. Set by the <code>EMQX_SECURITY_PROFILE</code> environment variable."
+        label = "Security Profile"
+    }
+
+    feature_preset {
+        desc = "Feature preset the node booted with. Set by the <code>EMQX_FEATURES</code> environment variable. <code>custom</code> means an explicit feature list."
+        label = "Feature Preset"
+    }
+
     node_not_found {
         desc = "Node not found."
         label = "Node Not Found"


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
N/A

## Summary

Add two boot-time node properties to the node info returned by `GET /nodes` and `GET /nodes/{node}`:

- `security_profile`: `legacy` | `hardened`
- `feature_preset`: `full` | `essential` | `custom`

Both come from per-node environment variables and are fixed until restart, so they belong with `edition` and `role` in `node_info` rather than in a new endpoint. Because `/nodes` returns one entry per node, a cluster with divergent settings is visible in the list view. During a rolling upgrade mixed profiles are expected transiently.

Changes:

- `apps/emqx_management/src/emqx_mgmt.erl`: `node_info/0` adds the two keys. Both are `persistent_term` reads (`emqx_security_profile:profile/0`, `emqx_machine_features:info/0`).
- `apps/emqx_management/src/emqx_mgmt_api_nodes.erl`: `fields(node_info)` adds the two fields as enums, so the API docs list the valid values.
- `rel/i18n/emqx_mgmt_api_nodes.hocon`: descriptions.

Design notes:

- Only the preset scalar is exposed. `GET /features` already returns the enabled/disabled arrays.
- Stopped nodes do not report the new keys, the same as `version` and `edition`. The fields are not marked required, so the stopped-node entry still matches the schema. The test validates this with `hocon_tconf:check_plain` against `fields(node_info)`.
- No new BPAPI version. `emqx_management_proto_v5:node_info/1` keeps its signature; an older node in a rolling upgrade answers without the new keys, which the schema tolerates.

The Dashboard indicator that reads these fields is a separate follow-up.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
