### PR TITLE
feat(alarm): raise security_profile_divergence when cluster nodes disagree

### DIFF
--- a/apps/emqx/priv/bpapi.apps
+++ b/apps/emqx/priv/bpapi.apps
@@ -8,6 +8,7 @@
 {emqx_managed_certs,emqx}.
 {emqx_metrics,emqx}.
 {emqx_router,emqx}.
+{emqx_security_profile,emqx}.
 {emqx_session_tool,emqx}.
 {emqx_session_top,emqx}.
 {emqx_shared_sub,emqx}.

--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -100,6 +100,7 @@
 {emqx_router,1}.
 {emqx_rule_engine,1}.
 {emqx_schema_registry_http_api,1}.
+{emqx_security_profile,1}.
 {emqx_session_tool,1}.
 {emqx_session_top,1}.
 {emqx_setopts,1}.

--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -20,6 +20,10 @@ e.g. in schema validation code.
 
 -export([profile/0, policy/1, clear_profile/0]).
 
+-export_type([profile/0]).
+
+-type profile() :: legacy | hardened.
+
 %---------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
@@ -31,7 +35,7 @@ Use this function only for introspection/logging purposes.
 Do not rely on security profile values directly in the code logic,
 use `emqx_security_profile:policy/1` instead.
 """.
--spec profile() -> legacy | hardened.
+-spec profile() -> profile().
 profile() ->
     case persistent_term:get(?PT_KEY, undefined) of
         undefined ->

--- a/apps/emqx/src/emqx_security_profile_monitor.erl
+++ b/apps/emqx/src/emqx_security_profile_monitor.erl
@@ -1,0 +1,188 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_security_profile_monitor).
+
+-moduledoc """
+Raises the `security_profile_divergence` alarm when nodes of one cluster run
+different security profiles.
+
+On every timer tick, the node resolves the security profile of every running
+peer in the cluster, so a peer that restarts with another profile is picked up
+by the next tick.
+
+A peer is resolved through its BPAPI announcement: a peer that announces
+`emqx_security_profile` support is asked for its profile over RPC, and a peer
+whose announcement lacks it runs a release without security profiles, which
+behaves as `legacy`. A peer that has not announced anything yet is still
+booting and stays `unknown` until a later tick, as does a peer whose RPC
+fails.
+
+The process only runs on nodes with the `hardened` profile; `init/1` returns
+`ignore` on `legacy` nodes. Hardened nodes name the running peers that run the
+`legacy` profile. The alarm clears on the node once no running peer runs
+`legacy`.
+""".
+
+-behaviour(gen_server).
+
+-include("logger.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+
+-export([start_link/0]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2
+]).
+
+-ifdef(TEST).
+-export([classify_peers/2]).
+-endif.
+
+-define(ALARM, security_profile_divergence).
+-define(BPAPI_NAME, emqx_security_profile).
+
+-define(DEFAULT_CHECK_INTERVAL, 30_000).
+-define(FIRST_CHECK_DELAY, 1_000).
+-define(RPC_TIMEOUT, 5_000).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+init([]) ->
+    case emqx_security_profile:profile() of
+        hardened ->
+            ok = schedule_check(?FIRST_CHECK_DELAY),
+            {ok, #{}};
+        legacy ->
+            ignore
+    end.
+
+handle_call(Req, _From, State) ->
+    ?SLOG(error, #{msg => "unexpected_call", call => Req}),
+    {reply, ignored, State}.
+
+handle_cast(Msg, State) ->
+    ?SLOG(error, #{msg => "unexpected_cast", cast => Msg}),
+    {noreply, State}.
+
+handle_info(check, State) ->
+    ok = check(),
+    ok = schedule_check(check_interval()),
+    {noreply, State};
+handle_info(Info, State) ->
+    ?SLOG(error, #{msg => "unexpected_info", info => Info}),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+schedule_check(Delay) ->
+    _ = erlang:send_after(Delay, self(), check),
+    ok.
+
+%% The application environment key exists for tests.
+check_interval() ->
+    application:get_env(emqx, security_profile_check_interval, ?DEFAULT_CHECK_INTERVAL).
+
+check() ->
+    Peers = lists:delete(node(), emqx:running_nodes()),
+    Classified = classify_peers(Peers, fetch_profiles(Peers)),
+    ?tp(security_profile_evaluated, Classified),
+    case Classified of
+        #{legacy_nodes := [_ | _]} ->
+            ensure_alarm_activated(Classified);
+        _ ->
+            emqx_alarm:ensure_deactivated(?ALARM)
+    end,
+    ok.
+
+%% Peers that are not resolved are left out and count as unknown.
+-spec fetch_profiles([node()]) -> #{node() => emqx_security_profile:profile()}.
+fetch_profiles([]) ->
+    #{};
+fetch_profiles(Nodes) ->
+    {Supported, Rest} = lists:partition(fun supports_profile_rpc/1, Nodes),
+    %% A peer that has announced its BPAPIs without `emqx_security_profile`
+    %% runs a release without security profiles: it behaves as `legacy`.
+    %% A peer that has not announced anything yet is still booting.
+    OldRelease = [Node || Node <- Rest, emqx_bpapi:supported_apis(Node) =/= []],
+    maps:merge(
+        maps:from_list([{Node, legacy} || Node <- OldRelease]),
+        rpc_profiles(Supported)
+    ).
+
+supports_profile_rpc(Node) ->
+    is_integer(emqx_bpapi:supported_version(Node, ?BPAPI_NAME)).
+
+rpc_profiles([]) ->
+    #{};
+rpc_profiles(Nodes) ->
+    Results = emqx_security_profile_proto_v1:get_profile(Nodes, ?RPC_TIMEOUT),
+    maps:from_list([
+        {Node, Profile}
+     || {Node, {ok, Profile}} <- lists:zip(Nodes, Results),
+        Profile =:= legacy orelse Profile =:= hardened
+    ]).
+
+-spec classify_peers([node()], #{node() => emqx_security_profile:profile()}) ->
+    #{legacy_nodes := [node()], hardened_nodes := [node()], unknown_nodes := [node()]}.
+classify_peers(Peers, Profiles) ->
+    Classified = lists:foldl(
+        fun(Peer, Acc) ->
+            Key = classify_key(maps:get(Peer, Profiles, unknown)),
+            maps:update_with(Key, fun(Nodes) -> [Peer | Nodes] end, Acc)
+        end,
+        #{legacy_nodes => [], hardened_nodes => [], unknown_nodes => []},
+        Peers
+    ),
+    maps:map(fun(_Key, Nodes) -> lists:sort(Nodes) end, Classified).
+
+classify_key(legacy) -> legacy_nodes;
+classify_key(hardened) -> hardened_nodes;
+classify_key(unknown) -> unknown_nodes.
+
+%% The alarm is raised once and stays active while any running peer runs
+%% `legacy`. While active, the details track the current node lists; the
+%% message keeps the node list from activation time.
+ensure_alarm_activated(#{legacy_nodes := Legacy} = Classified) ->
+    Details = Classified#{local_profile => hardened},
+    case emqx_alarm:read_details(?ALARM) of
+        {error, not_found} ->
+            _ = emqx_alarm:activate(?ALARM, Details, message(Legacy)),
+            ok;
+        {ok, Details} ->
+            ok;
+        {ok, _Stale} ->
+            _ = emqx_alarm:update_details(?ALARM, Details),
+            ok
+    end.
+
+message(Legacy) ->
+    Nodes = lists:join(", ", [atom_to_list(N) || N <- Legacy]),
+    iolist_to_binary([
+        "Cluster nodes run different security profiles. ",
+        "This node runs 'hardened'; nodes running 'legacy': ",
+        Nodes,
+        ". A client may be accepted on one node and rejected on another. ",
+        "This is expected during a rolling upgrade until every node restarts with ",
+        "the same EMQX_SECURITY_PROFILE. ",
+        "The alarm details list the current legacy nodes."
+    ]).

--- a/apps/emqx/src/emqx_sys_sup.erl
+++ b/apps/emqx/src/emqx_sys_sup.erl
@@ -29,6 +29,7 @@ init([]) ->
         [
             child_spec(emqx_alarm),
             LoadAlarmHandler,
+            child_spec(emqx_security_profile_monitor),
             child_spec(emqx_sys),
             child_spec(emqx_sys_mon),
             child_spec(emqx_vm_mon),

--- a/apps/emqx/src/proto/emqx_security_profile_proto_v1.erl
+++ b/apps/emqx/src/proto/emqx_security_profile_proto_v1.erl
@@ -1,0 +1,22 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_security_profile_proto_v1).
+
+-behaviour(emqx_bpapi).
+
+-include("bpapi.hrl").
+
+-export([
+    introduced_in/0,
+
+    get_profile/2
+]).
+
+introduced_in() ->
+    "6.3.0".
+
+-spec get_profile([node()], timeout()) ->
+    emqx_rpc:erpc_multicall(emqx_security_profile:profile()).
+get_profile(Nodes, Timeout) ->
+    erpc:multicall(Nodes, emqx_security_profile, profile, [], Timeout).

--- a/apps/emqx/test/emqx_cth_cluster.erl
+++ b/apps/emqx/test/emqx_cth_cluster.erl
@@ -79,6 +79,11 @@
     %% Options that may affect `emqx_cth_peer:start{,_link}', such as `shutdown'.
     start_opts => #{},
 
+    %% Environment variables for this node only.
+    %% Merged over the cluster-wide `env_vars`; an entry with the same name wins.
+    %% Default: `[]`.
+    env_vars => [{string(), string()}],
+
     %% Working directory
     %% If this directory is not empty, starting up the node applications will fail
     %% Default: "${ClusterOpts.work_dir}/${nodename}"
@@ -381,12 +386,13 @@ start_nodes_init(Specs, Timeout, StartOpts) ->
 
 start_bare_nodes(Specs, Timeout, StartOpts) ->
     Args = erl_flags(),
-    Envs = maps:get(env_vars, StartOpts, []),
+    ClusterEnvs = maps:get(env_vars, StartOpts, []),
     Waits = lists:map(
         fun(#{name := Name} = Spec) ->
             WaitTag = {boot_complete, Name},
             WaitBoot = {self(), WaitTag},
             Opts = peer_start_opts(Spec),
+            Envs = merge_env_vars(ClusterEnvs, maps:get(env_vars, Spec, [])),
             {ok, _} = emqx_cth_peer:start(Name, Args, Envs, WaitBoot, Opts),
             WaitTag
         end,
@@ -396,6 +402,13 @@ start_bare_nodes(Specs, Timeout, StartOpts) ->
     Nodes = wait_boot_complete(Waits, Deadline),
     lists:foreach(fun(Node) -> pong = net_adm:ping(Node) end, Nodes),
     Nodes.
+
+merge_env_vars(ClusterEnvs, NodeEnvs) ->
+    lists:foldl(
+        fun({Name, _} = Env, Acc) -> lists:keystore(Name, 1, Acc, Env) end,
+        ClusterEnvs,
+        NodeEnvs
+    ).
 
 peer_start_opts(Spec) ->
     maps:get(start_opts, Spec, #{}).

--- a/apps/emqx/test/emqx_security_profile_monitor_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_monitor_SUITE.erl
@@ -1,0 +1,238 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_security_profile_monitor_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+
+-define(ALARM, security_profile_divergence).
+-define(ENV_VAR, "EMQX_SECURITY_PROFILE").
+-define(TIMEOUT, 15_000).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_testcase(TestCase, Config) ->
+    snabbkaffe:start_trace(),
+    [{work_dir, emqx_cth_suite:work_dir(TestCase, Config)} | Config].
+
+end_per_testcase(_TestCase, _Config) ->
+    emqx_common_test_helpers:call_janitor(),
+    snabbkaffe:stop(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+node_specs(TestCase, Config, Profiles) ->
+    Nodes = [
+        {node_name(TestCase, I), #{
+            apps => [{emqx, #{override_env => [{security_profile_check_interval, 500}]}}],
+            role => Role,
+            env_vars => [{?ENV_VAR, atom_to_list(Profile)}]
+        }}
+     || {I, {Role, Profile}} <- lists:enumerate(Profiles)
+    ],
+    emqx_cth_cluster:mk_nodespecs(Nodes, #{work_dir => ?config(work_dir, Config)}).
+
+node_name(TestCase, I) ->
+    list_to_atom(atom_to_list(TestCase) ++ "_" ++ integer_to_list(I)).
+
+start_cluster(Specs) ->
+    Nodes = emqx_cth_cluster:start(Specs),
+    on_exit(fun() -> emqx_cth_cluster:stop(Nodes) end),
+    Nodes.
+
+active_alarms(Node) ->
+    [A || #{name := ?ALARM} = A <- ?ON(Node, emqx_alarm:get_alarms(activated))].
+
+deactivated_alarms(Node) ->
+    [A || #{name := ?ALARM} = A <- ?ON(Node, emqx_alarm:get_alarms(deactivated))].
+
+%% Block until `Node` evaluated the cluster and classified `Peers` under `Key`.
+wait_evaluated(Node, Key, Peers) ->
+    ?block_until(
+        #{
+            ?snk_kind := security_profile_evaluated,
+            ?snk_meta := #{node := Node},
+            Key := Peers
+        },
+        ?TIMEOUT
+    ).
+
+wait_alarm(Node) ->
+    ?retry(200, 50, begin
+        [Alarm] = active_alarms(Node),
+        Alarm
+    end).
+
+wait_no_alarm(Node) ->
+    ?retry(200, 50, ?assertEqual([], active_alarms(Node))).
+
+%% Legacy nodes do not run the monitor at all.
+assert_monitor_not_running(Node) ->
+    ?assertEqual(undefined, ?ON(Node, erlang:whereis(emqx_security_profile_monitor))),
+    ?assertEqual([], active_alarms(Node)).
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+-doc "A single hardened node has no peers and never raises the alarm.".
+t_single_node_no_alarm(Config) ->
+    [N1] = start_cluster(node_specs(?FUNCTION_NAME, Config, [{core, hardened}])),
+    {ok, _} = wait_evaluated(N1, hardened_nodes, []),
+    ?assertEqual([], active_alarms(N1)).
+
+-doc "Two hardened nodes see each other and neither raises the alarm.".
+t_same_profile_no_alarm(Config) ->
+    Specs = node_specs(?FUNCTION_NAME, Config, [{core, hardened}, {core, hardened}]),
+    [N1, N2] = start_cluster(Specs),
+    {ok, _} = wait_evaluated(N1, hardened_nodes, [N2]),
+    {ok, _} = wait_evaluated(N2, hardened_nodes, [N1]),
+    ?assertEqual([], active_alarms(N1)),
+    ?assertEqual([], active_alarms(N2)).
+
+-doc "Legacy nodes do not run the monitor and never raise the alarm.".
+t_legacy_nodes_never_raise(Config) ->
+    Specs = node_specs(?FUNCTION_NAME, Config, [{core, legacy}, {core, legacy}]),
+    [N1, N2] = start_cluster(Specs),
+    assert_monitor_not_running(N1),
+    assert_monitor_not_running(N2).
+
+-doc """
+The hardened node raises the alarm and names the legacy peer in both
+the message and the details. The legacy node does not raise it.
+""".
+t_divergence_raises(Config) ->
+    Specs = node_specs(?FUNCTION_NAME, Config, [{core, hardened}, {core, legacy}]),
+    [N1, N2] = start_cluster(Specs),
+    #{message := Message, details := Details} = wait_alarm(N1),
+    ?assertEqual(
+        #{
+            local_profile => hardened,
+            legacy_nodes => [N2],
+            hardened_nodes => [],
+            unknown_nodes => []
+        },
+        Details
+    ),
+    ?assertNotEqual(nomatch, binary:match(Message, atom_to_binary(N2))),
+    assert_monitor_not_running(N2).
+
+-doc "A replicant announces its profile through a core, and the core raises the alarm.".
+t_divergence_raises_for_replicant(Config) ->
+    Specs = node_specs(?FUNCTION_NAME, Config, [{core, hardened}, {replicant, legacy}]),
+    [N1, N2] = start_cluster(Specs),
+    #{details := #{legacy_nodes := [N2]}} = wait_alarm(N1),
+    assert_monitor_not_running(N2).
+
+-doc """
+Restarting the legacy node with the hardened profile clears the alarm,
+and the alarm is not raised again once the restarted node announces itself.
+""".
+t_converge_clears(Config) ->
+    [Spec1, Spec2] = node_specs(?FUNCTION_NAME, Config, [{core, hardened}, {core, legacy}]),
+    [N1, N2] = start_cluster([Spec1, Spec2]),
+    _ = wait_alarm(N1),
+    [N2] = emqx_cth_cluster:restart([Spec2#{env_vars => [{?ENV_VAR, "hardened"}]}]),
+    {ok, _} = wait_evaluated(N1, hardened_nodes, [N2]),
+    ?assertEqual([], active_alarms(N1)),
+    ?assertMatch([_], deactivated_alarms(N1)),
+    ?assertEqual([], active_alarms(N2)).
+
+-doc """
+With two legacy peers, the alarm stays active while one of them converges:
+the details shrink to the remaining legacy node and the message is kept.
+""".
+t_partial_convergence_updates_details(Config) ->
+    [Spec1, Spec2, Spec3] = node_specs(
+        ?FUNCTION_NAME, Config, [{core, hardened}, {core, legacy}, {core, legacy}]
+    ),
+    [N1, N2, N3] = start_cluster([Spec1, Spec2, Spec3]),
+    #{message := Message, activate_at := ActivateAt} =
+        ?retry(200, 50, begin
+            [#{details := #{legacy_nodes := [N2, N3]}} = Alarm] = active_alarms(N1),
+            Alarm
+        end),
+    [N3] = emqx_cth_cluster:restart([Spec3#{env_vars => [{?ENV_VAR, "hardened"}]}]),
+    {ok, _} = wait_evaluated(N1, hardened_nodes, [N3]),
+    ?assertMatch(
+        [
+            #{
+                message := Message,
+                activate_at := ActivateAt,
+                details := #{legacy_nodes := [N2], hardened_nodes := [N3]}
+            }
+        ],
+        active_alarms(N1)
+    ),
+    ?assertEqual([], deactivated_alarms(N1)).
+
+-doc "The alarm clears when the only legacy node leaves the cluster.".
+t_leave_clears(Config) ->
+    Specs = node_specs(?FUNCTION_NAME, Config, [{core, hardened}, {core, legacy}]),
+    [N1, N2] = start_cluster(Specs),
+    _ = wait_alarm(N1),
+    ok = ?ON(N2, ekka:leave()),
+    wait_no_alarm(N1),
+    ?assertMatch([_], deactivated_alarms(N1)).
+
+-doc "The alarm clears when the only legacy node goes down.".
+t_peer_down_clears(Config) ->
+    Specs = node_specs(?FUNCTION_NAME, Config, [{core, hardened}, {core, legacy}]),
+    [N1, N2] = start_cluster(Specs),
+    _ = wait_alarm(N1),
+    ok = emqx_cth_cluster:stop([N2]),
+    wait_no_alarm(N1),
+    ?assertMatch([_], deactivated_alarms(N1)).
+
+-doc """
+A peer that announces its BPAPIs without `emqx_security_profile` runs an older
+release without security profiles and counts as `legacy`.
+""".
+t_old_release_peer_is_legacy(Config) ->
+    Specs = node_specs(?FUNCTION_NAME, Config, [{core, hardened}, {core, hardened}]),
+    [N1, N2] = start_cluster(Specs),
+    {ok, _} = wait_evaluated(N1, hardened_nodes, [N2]),
+    ?assertEqual([], active_alarms(N1)),
+    ok = ?ON(N1, meck:new(emqx_bpapi, [passthrough, no_link])),
+    on_exit(fun() -> catch ?ON(N1, meck:unload(emqx_bpapi)) end),
+    ok = ?ON(
+        N1,
+        meck:expect(
+            emqx_bpapi,
+            supported_version,
+            fun
+                (_Node, emqx_security_profile) -> undefined;
+                (Node, API) -> meck:passthrough([Node, API])
+            end
+        )
+    ),
+    %% Every tick re-resolves all peers: no restart of the monitor is needed.
+    ?assertMatch(#{details := #{legacy_nodes := [N2]}}, wait_alarm(N1)),
+    ok = ?ON(N1, meck:unload(emqx_bpapi)),
+    wait_no_alarm(N1).
+
+-doc """
+A peer that restarts with the `legacy` profile is picked up by a later check
+even though it was seen as `hardened` before.
+""".
+t_divergence_after_restart(Config) ->
+    [Spec1, Spec2] = node_specs(?FUNCTION_NAME, Config, [{core, hardened}, {core, hardened}]),
+    [N1, N2] = start_cluster([Spec1, Spec2]),
+    {ok, _} = wait_evaluated(N1, hardened_nodes, [N2]),
+    ?assertEqual([], active_alarms(N1)),
+    [N2] = emqx_cth_cluster:restart([Spec2#{env_vars => [{?ENV_VAR, "legacy"}]}]),
+    ?assertMatch(#{details := #{legacy_nodes := [N2]}}, wait_alarm(N1)).

--- a/apps/emqx/test/emqx_security_profile_monitor_tests.erl
+++ b/apps/emqx/test/emqx_security_profile_monitor_tests.erl
@@ -1,0 +1,26 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_security_profile_monitor_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Peers without a cached profile are unknown and never count as legacy.
+classify_peers_test() ->
+    Peers = [n4, n1, n3, n2, n5],
+    Profiles = #{n1 => legacy, n2 => legacy, n4 => hardened, n_gone => legacy},
+    ?assertEqual(
+        #{
+            legacy_nodes => [n1, n2],
+            hardened_nodes => [n4],
+            unknown_nodes => [n3, n5]
+        },
+        emqx_security_profile_monitor:classify_peers(Peers, Profiles)
+    ).
+
+classify_no_peers_test() ->
+    ?assertEqual(
+        #{legacy_nodes => [], hardened_nodes => [], unknown_nodes => []},
+        emqx_security_profile_monitor:classify_peers([], #{})
+    ).

--- a/changes/ee/feat-18453.en.md
+++ b/changes/ee/feat-18453.en.md
@@ -1,0 +1,15 @@
+Added the `security_profile_divergence` alarm.
+
+Nodes running the `hardened` security profile (`EMQX_SECURITY_PROFILE`)
+periodically check the security profile of the other running nodes in the
+cluster, and raise the alarm when another running node runs the `legacy`
+profile. Nodes running the `legacy` profile do not run the check, and nodes
+running an older EMQX release without security profiles count as `legacy`. The alarm
+message names the `legacy` nodes, and the alarm details keep the current node
+lists while the alarm is active. The alarm clears on its own once every running
+node runs the `hardened` profile, or once the last `legacy` node leaves the
+cluster.
+
+The alarm is expected for a short time during a rolling upgrade that changes
+the security profile. An alarm that stays active points to nodes that were
+not restarted with the new `EMQX_SECURITY_PROFILE` value.


### PR DESCRIPTION
Release version:
6.3.0

Introduced in:
N/A

## Summary

Adds the `security_profile_divergence` alarm. A node running the `hardened` security profile raises it when another running node in the cluster runs `legacy`. The alarm message names the `legacy` nodes; the details keep the current `legacy_nodes` / `hardened_nodes` / `unknown_nodes` lists while the alarm is active. It clears on its own once no running peer runs `legacy` (peer restarted with `hardened`, left the cluster, or went down).

Design decisions:

* **Peer profiles are resolved through BPAPI announcements plus RPC, on every tick.** `emqx_security_profile_monitor` (new, in `emqx_sys_sup` right after `emqx_alarm`; `init/1` returns `ignore` on `legacy` nodes) resolves the profile of every running peer anew on each 30s tick, so a peer that restarts with another profile is picked up by the next tick. A peer that announces the `emqx_security_profile` v1 BPAPI is asked over RPC (new `emqx_security_profile_proto_v1`, `erpc:multicall` of `emqx_security_profile:profile/0`); a peer whose BPAPI announcement lacks it runs an older release without security profiles and counts as `legacy`; a peer with no announcements yet is still booting and stays `unknown` (retried next tick), as do peers whose RPC fails. `unknown` peers never raise the alarm.
* **Only `hardened` nodes raise it.** Alarms are node-local; raising on every node would produce N alarms for one condition. `hardened` nodes are the ones whose expectation a `legacy` peer undermines, so the alarm count tracks converged nodes. On `legacy` nodes the monitor does not start at all (`init/1` returns `ignore`); single nodes never raise it.
* **The message carries the node list** because `emqx_alarm`'s log action logs only `name` and `message`. The alarm is raised once and kept active while divergence persists; the details are updated as the legacy set changes, and it is not re-raised per step, so a rolling upgrade yields one activation per converged node rather than O(N²) log lines.
* **No grace period.** A stalled rollout is indistinguishable from a slow one; the message names a rolling upgrade as the expected benign cause.
* Security profile only — `EMQX_FEATURES` divergence is intentionally not covered (features degrade via BPAPI negotiation and feature topologies can be deliberate).

Test helper: `emqx_cth_cluster` nodespecs accept a per-node `env_vars` list (merged over the cluster-wide one) so a cluster can start with mixed profiles.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
