### PR TITLE
feat(plugins): require sha256-bound allow grant under hardened profile

### DIFF
--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -57,7 +57,8 @@ Returns policy depending on the current security profile.
     (internal_subscription_checks) -> boolean();
     (authz_context) -> legacy | restricted;
     (delayed_publish_reauthorization) -> boolean();
-    (exhook_message_publish_failure) -> ignore | deny.
+    (exhook_message_publish_failure) -> ignore | deny;
+    (plugin_install_sha256_binding) -> optional | required.
 policy(mqtt_default_bind) ->
     case profile() of
         legacy -> any;
@@ -127,6 +128,11 @@ policy(exhook_message_publish_failure) ->
     case profile() of
         legacy -> ignore;
         hardened -> deny
+    end;
+policy(plugin_install_sha256_binding) ->
+    case profile() of
+        legacy -> optional;
+        hardened -> required
     end.
 
 -doc """

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -92,7 +92,8 @@ assert_policies(legacy) ->
     ?assertEqual(false, emqx_security_profile:policy(internal_subscription_checks)),
     ?assertEqual(legacy, emqx_security_profile:policy(authz_context)),
     ?assertEqual(false, emqx_security_profile:policy(delayed_publish_reauthorization)),
-    ?assertEqual(ignore, emqx_security_profile:policy(exhook_message_publish_failure));
+    ?assertEqual(ignore, emqx_security_profile:policy(exhook_message_publish_failure)),
+    ?assertEqual(optional, emqx_security_profile:policy(plugin_install_sha256_binding));
 assert_policies(hardened) ->
     ?assertEqual(deny, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(deny, emqx_security_profile:policy(authz_backend_failure)),
@@ -102,7 +103,8 @@ assert_policies(hardened) ->
     ?assertEqual(true, emqx_security_profile:policy(internal_subscription_checks)),
     ?assertEqual(restricted, emqx_security_profile:policy(authz_context)),
     ?assertEqual(true, emqx_security_profile:policy(delayed_publish_reauthorization)),
-    ?assertEqual(deny, emqx_security_profile:policy(exhook_message_publish_failure)).
+    ?assertEqual(deny, emqx_security_profile:policy(exhook_message_publish_failure)),
+    ?assertEqual(required, emqx_security_profile:policy(plugin_install_sha256_binding)).
 
 assert_default_binds(Profile, Source) ->
     ?assertEqual(

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -605,6 +605,15 @@ install_package_on_nodes(NameVsn, Bin) ->
                 NameVsn,
                 <<" sha256:...`">>
             ]),
+            {403, #{code => 'FORBIDDEN', message => Msg}};
+        {error, sha256_required} ->
+            Msg = iolist_to_binary([
+                <<"The hardened security profile requires a sha256-bound grant;">>,
+                <<" allow it to be installed by running:">>,
+                <<" `emqx ctl plugins allow ">>,
+                NameVsn,
+                <<" sha256:<hex>`">>
+            ]),
             {403, #{code => 'FORBIDDEN', message => Msg}}
     end.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -117,12 +117,12 @@ t_plugins(_Config) ->
     ok = emqx_plugins:delete_package(NameVsn),
     %% Must allow via CLI first.
     ?assertMatch({ok, {{_, 403, _}, _, _}}, install_plugin(PackagePath)),
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     %% Test disallow
     ok = disallow_installation(NameVsn),
     ?assertMatch({ok, {{_, 403, _}, _, _}}, install_plugin(PackagePath)),
     %% Now really allow it.
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     ok = install_plugin(PackagePath),
     Node = atom_to_binary(node()),
     ?assertMatch(
@@ -202,6 +202,51 @@ t_install_plugin_sha256_mismatch(_Config) ->
     ok = disallow_installation(NameVsn),
     ok.
 
+%% Unbound `plugins allow' is refused under hardened and the upload stays
+%% forbidden; under legacy the unbound grant keeps working.
+t_install_plugin_unbound_grant_by_profile(Config) ->
+    PackagePath = get_demo_plugin_package(),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ok = emqx_plugins:delete_package(NameVsn),
+    on_exit(fun() -> _ = disallow_installation(NameVsn) end),
+    ok = allow_installation(NameVsn),
+    case ?config(security_profile, Config) of
+        legacy ->
+            ?assert(emqx_plugins:is_allowed_installation(NameVsn)),
+            ok = install_plugin(PackagePath),
+            {ok, []} = uninstall_plugin(NameVsn);
+        hardened ->
+            ?assertNot(emqx_plugins:is_allowed_installation(NameVsn)),
+            {ok, {{_, 403, _}, _, Body}} = install_plugin(PackagePath),
+            #{<<"message">> := Msg} = emqx_utils_json:decode(Body),
+            ?assertNotEqual(nomatch, binary:match(Msg, <<"plugins allow">>))
+    end,
+    ok.
+
+%% An unbound grant issued under legacy is not honoured by the upload path
+%% once the profile requires the binding.
+t_install_plugin_preexisting_unbound_grant_hardened(Config) ->
+    case ?config(security_profile, Config) of
+        legacy ->
+            ok;
+        hardened ->
+            PackagePath = get_demo_plugin_package(),
+            NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+            ok = emqx_plugins:ensure_uninstalled(NameVsn),
+            ok = emqx_plugins:delete_package(NameVsn),
+            on_exit(fun() -> _ = disallow_installation(NameVsn) end),
+            ok = emqx_common_test_helpers:set_security_profile(legacy),
+            ok = allow_installation(NameVsn),
+            ok = emqx_common_test_helpers:set_security_profile(hardened),
+            ?assert(emqx_plugins:is_allowed_installation(NameVsn)),
+            {ok, {{_, 403, _}, _, Body}} = install_plugin(PackagePath),
+            #{<<"message">> := Msg} = emqx_utils_json:decode(Body),
+            ?assertNotEqual(nomatch, binary:match(Msg, <<"sha256">>)),
+            ?assertMatch({error, _}, emqx_plugins:describe(NameVsn))
+    end,
+    ok.
+
 t_install_plugin_with_invalid_schema_returns_bad_plugin_info(Config) ->
     PackagePath = make_test_plugin_package(
         Config,
@@ -213,7 +258,7 @@ t_install_plugin_with_invalid_schema_returns_bad_plugin_info(Config) ->
         _ = disallow_installation(NameVsn),
         _ = emqx_plugins:delete_package(NameVsn)
     end),
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     {ok, {{"HTTP/1.1", 400, "Bad Request"}, _, Body}} = install_plugin(PackagePath),
     #{<<"code">> := <<"BAD_PLUGIN_INFO">>, <<"message">> := Message} =
         emqx_utils_json:decode(Body),
@@ -232,7 +277,7 @@ t_install_plugin_with_bad_app_file_returns_consistent_error(Config) ->
         _ = disallow_installation(NameVsn),
         _ = emqx_plugins:delete_package(NameVsn)
     end),
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     {ok, {{"HTTP/1.1", 400, "Bad Request"}, _, Body}} = install_plugin(PackagePath),
     ?assertEqual(
         #{
@@ -296,8 +341,8 @@ t_uninstall_conflicting_version_keeps_old_running(Config) ->
             [OldNameVsn, NewNameVsn]
         )
     end),
-    ok = allow_installation(OldNameVsn),
-    ok = allow_installation(NewNameVsn),
+    ok = allow_package(OldPackagePath),
+    ok = allow_package(NewPackagePath),
     ok = install_plugin(OldPackagePath),
     ok = install_plugin(NewPackagePath),
     {ok, []} = update_plugin(OldNameVsn, "start"),
@@ -333,7 +378,7 @@ t_update_config(_Config) ->
     NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
     ok = emqx_plugins:ensure_uninstalled(NameVsn),
     ok = emqx_plugins:delete_package(NameVsn),
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     ok = install_plugin(PackagePath),
     OldConfig = emqx_plugins:get_config(NameVsn),
     %% Check config update when plugin is not started
@@ -381,7 +426,7 @@ t_update_config_with_invalid_type_returns_readable_error(Config0) ->
         _ = emqx_plugins:ensure_uninstalled(NameVsn),
         _ = emqx_plugins:delete_package(NameVsn)
     end),
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     ok = install_plugin(PackagePath),
     PluginConfig = emqx_plugins:get_config(NameVsn),
     {ok, 400, Body} = update_plugin_config(NameVsn, PluginConfig#{<<"foo">> => 42}),
@@ -411,7 +456,7 @@ t_upload_download_config(_Config) ->
     NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
     ok = emqx_plugins:ensure_uninstalled(NameVsn),
     ok = emqx_plugins:delete_package(NameVsn),
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     ok = install_plugin(PackagePath),
     DownloadPath = emqx_mgmt_api_test_util:api_path(["plugins", NameVsn, "config", "download"]),
     ?assertMatch(
@@ -435,7 +480,7 @@ t_health_status(_Config) ->
     NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
     ok = emqx_plugins:ensure_uninstalled(NameVsn),
     ok = emqx_plugins:delete_package(NameVsn),
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     ok = install_plugin(PackagePath),
     OldConfig = emqx_plugins:get_config(NameVsn),
     Node = atom_to_binary(node()),
@@ -509,8 +554,8 @@ t_install_plugin_matching_exisiting_name(_Config) ->
     %% First, install plugin "emqx_plugin_template_a", then:
     %% "emqx_plugin_template" which matches the beginning
     %% of the previously installed plugin name
-    ok = allow_installation(NameVsn),
-    ok = allow_installation(NameVsn1),
+    ok = allow_package(PackagePath),
+    ok = allow_package(PackagePath1),
     ok = install_plugin(PackagePath1),
     ok = install_plugin(PackagePath),
     _ = describe_plugin(NameVsn),
@@ -541,8 +586,7 @@ t_bad_plugin(_Config) ->
     %% rename plugin tarball
     file:copy(PackagePathOrig, PackagePath),
     file:delete(PackagePathOrig),
-    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     {ok, {{"HTTP/1.1", 400, "Bad Request"}, _, _}} = install_plugin(PackagePath),
     ?assertEqual(
         {error, enoent},
@@ -598,7 +642,7 @@ t_preinstall_step1_without_plugins_states_is_ignored_by_http_api(_Config) ->
         )
     ),
 
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     ok = install_plugin(PackagePath),
     ?assert(
         lists:any(fun(Plugin) -> plugin_json_name_vsn(Plugin) =:= NameVsnBin end, list_plugins())
@@ -928,7 +972,7 @@ install_test_plugin(Config) ->
         _ = emqx_plugins:ensure_uninstalled(NameVsn),
         _ = emqx_plugins:delete_package(NameVsn)
     end),
-    ok = allow_installation(NameVsn),
+    ok = allow_package(PackagePath),
     ok = install_plugin(PackagePath),
     NameVsn.
 
@@ -1121,6 +1165,21 @@ get_host_and_auth(Config) when is_list(Config) ->
 
 allow_installation(NameVsn) ->
     emqx_ctl:run_command(["plugins", "allow", NameVsn]).
+
+%% Grant installation of the package at `PackagePath'. The hardened profile
+%% requires the grant to bind the package sha256; legacy keeps the unbound grant.
+allow_package(PackagePath) ->
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    case emqx_security_profile:policy(plugin_install_sha256_binding) of
+        optional ->
+            allow_installation(NameVsn);
+        required ->
+            allow_installation(NameVsn, sha256_hex(PackagePath))
+    end.
+
+sha256_hex(PackagePath) ->
+    {ok, Bin} = file:read_file(PackagePath),
+    binary_to_list(binary:encode_hex(crypto:hash(sha256, Bin), lowercase)).
 
 allow_installation(NameVsn, Sha256Hex) ->
     emqx_ctl:run_command(["plugins", "allow", NameVsn, "sha256:" ++ Sha256Hex]).

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -227,25 +227,40 @@ handle_api_call(Plugin0, Request, Timeout) ->
 %% Note: this is only used for the HTTP API.
 %% We could use `application:set_env', but the typespec for it makes dialyzer sad when it
 %% seems a non-atom key...
--spec allow_installation(binary() | string()) -> ok.
+-spec allow_installation(binary() | string()) -> ok | {error, sha256_required}.
 allow_installation(NameVsn) ->
     allow_installation(NameVsn, undefined).
 
 %% @doc Allow installation of `NameVsn'. The entry expires after `allow_ttl_ms/0'
 %% milliseconds. When `Sha256' is a 64-char lowercase hex binary, the upload
 %% bytes must hash to the same value to be accepted; when `undefined', any
-%% bytes named `NameVsn.tar.gz' are accepted (legacy behavior).
--spec allow_installation(binary() | string(), binary() | undefined) -> ok.
+%% bytes named `NameVsn.tar.gz' are accepted.
+%% An unbound (`undefined') grant is refused when the security profile
+%% requires a sha256 binding. This is the single entry point for all grant
+%% paths (CLI, RPC), so the refusal also applies to grants pushed by peers.
+-spec allow_installation(binary() | string(), binary() | undefined) ->
+    ok | {error, sha256_required}.
 allow_installation(NameVsn0, Sha256) when Sha256 =:= undefined; is_binary(Sha256) ->
-    NameVsn = bin(NameVsn0),
-    Entry = #{
-        expires_at => erlang:monotonic_time(millisecond) + allow_ttl_ms(),
-        sha256 => Sha256
-    },
-    Allowed0 = application:get_env(?APP, ?allowed_installations, #{}),
-    Allowed = (prune_expired(Allowed0))#{NameVsn => Entry},
-    application:set_env(?APP, ?allowed_installations, Allowed),
-    ok.
+    case sha256_binding_ok(Sha256) of
+        true ->
+            NameVsn = bin(NameVsn0),
+            Entry = #{
+                expires_at => erlang:monotonic_time(millisecond) + allow_ttl_ms(),
+                sha256 => Sha256
+            },
+            Allowed0 = application:get_env(?APP, ?allowed_installations, #{}),
+            Allowed = (prune_expired(Allowed0))#{NameVsn => Entry},
+            application:set_env(?APP, ?allowed_installations, Allowed),
+            ok;
+        false ->
+            {error, sha256_required}
+    end.
+
+%% `undefined' is only acceptable when the security profile makes the binding optional.
+sha256_binding_ok(undefined) ->
+    emqx_security_profile:policy(plugin_install_sha256_binding) =:= optional;
+sha256_binding_ok(Sha256) when is_binary(Sha256) ->
+    true.
 
 %% Note: this is only used for the HTTP API.
 %% Returns true iff a non-expired allow entry exists for `NameVsn'.
@@ -262,8 +277,10 @@ is_allowed_installation(NameVsn0) ->
 %%   ok                          - allowed and (hash matches or no hash bound)
 %%   {error, not_allowed}        - no non-expired entry exists
 %%   {error, sha256_mismatch}    - entry has a sha256 that doesn't match `Bin'
+%%   {error, sha256_required}    - entry has no sha256 but the security
+%%                                 profile requires one
 -spec is_allowed_installation(binary() | string(), binary()) ->
-    ok | {error, not_allowed | sha256_mismatch}.
+    ok | {error, not_allowed | sha256_mismatch | sha256_required}.
 is_allowed_installation(NameVsn0, Bin) when is_binary(Bin) ->
     NameVsn = bin(NameVsn0),
     Allowed = prune_and_store(application:get_env(?APP, ?allowed_installations, #{})),
@@ -271,7 +288,13 @@ is_allowed_installation(NameVsn0, Bin) when is_binary(Bin) ->
         error ->
             {error, not_allowed};
         {ok, #{sha256 := undefined}} ->
-            ok;
+            %% Re-check at verification time so an unbound grant is never
+            %% honoured under a profile that requires the binding, regardless
+            %% of how the grant entered the store.
+            case sha256_binding_ok(undefined) of
+                true -> ok;
+                false -> {error, sha256_required}
+            end;
         {ok, #{sha256 := Expected}} when is_binary(Expected) ->
             Got = binary:encode_hex(crypto:hash(sha256, Bin), lowercase),
             case Got =:= Expected of

--- a/apps/emqx_plugins/src/emqx_plugins_cli_utils.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_cli_utils.erl
@@ -87,7 +87,8 @@ plugins(_) ->
                 "Allows installation of a plugin in the cluster from Dashboard or API.\n"
                 "The grant expires 5 minutes after issue.\n"
                 "If sha256:HEX (64 lowercase hex chars) is given, the upload bytes\n"
-                "must hash to that value or the install is rejected."},
+                "must hash to that value or the install is rejected.\n"
+                "The hardened security profile requires sha256:HEX."},
             {"plugins disallow  Name-Vsn",
                 "Disallows installation of a plugin in the cluster from Dashboard or API"},
             {"plugins install   Name-Vsn",
@@ -152,11 +153,18 @@ allow_installation(NameVsn, Sha256, LogFun) ->
     end.
 
 do_allow_installation(NameVsn, undefined, LogFun) ->
-    %% No sha256 binding — use proto v3 to remain compatible with older nodes
-    %% in a rolling upgrade.
-    Nodes = nodes_supporting_bpapi_version(3),
-    Results = emqx_plugins_proto_v3:allow_installation(Nodes, NameVsn),
-    print_allow_result(Nodes, Results, NameVsn, LogFun);
+    case emqx_security_profile:policy(plugin_install_sha256_binding) of
+        optional ->
+            %% No sha256 binding — use proto v3 to remain compatible with older nodes
+            %% in a rolling upgrade.
+            Nodes = nodes_supporting_bpapi_version(3),
+            Results = emqx_plugins_proto_v3:allow_installation(Nodes, NameVsn),
+            print_allow_result(Nodes, Results, NameVsn, LogFun);
+        required ->
+            %% Refuse locally before issuing any grant, so no peer is left
+            %% holding an unbound grant that this node would not honour.
+            ?PRINT({error, sha256_required_error(NameVsn)}, LogFun)
+    end;
 do_allow_installation(NameVsn, Sha256, LogFun) when is_binary(Sha256) ->
     %% sha256 binding — needs every running node on proto v4 so the binding is
     %% enforced everywhere. Refuse rather than silently allow on old nodes.
@@ -186,9 +194,32 @@ print_allow_result(Nodes, Results, NameVsn, LogFun) ->
     Result =
         case Errors of
             [] -> {ok, #{expires_in_ms => emqx_plugins:allow_ttl_ms()}};
-            _ -> {error, maps:from_list(Errors)}
+            _ -> {error, allow_errors(NameVsn, Errors)}
         end,
     print(NameVsn, Result, LogFun, allow_installation).
+
+%% Per-node errors; when a peer refused an unbound grant, add the same hint
+%% the local refusal prints.
+allow_errors(NameVsn, Errors) ->
+    ErrorMap = maps:from_list(Errors),
+    case lists:any(fun({_Node, R}) -> R =:= {ok, {error, sha256_required}} end, Errors) of
+        true -> maps:merge(ErrorMap, sha256_required_error(NameVsn));
+        false -> ErrorMap
+    end.
+
+sha256_required_error(NameVsn) ->
+    #{
+        reason => sha256_required,
+        hint => iolist_to_binary([
+            <<"The hardened security profile requires a sha256 binding. Run: ">>,
+            <<"emqx ctl plugins allow ">>,
+            NameVsn,
+            <<" sha256:<hex>">>,
+            <<" (the published ">>,
+            NameVsn,
+            <<".sha256 file contains the hex)">>
+        ])
+    }.
 
 print_cluster_result(Nodes, Results, NameVsn, LogFun) ->
     Errors =

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -1895,6 +1895,122 @@ t_allow_sha256_undefined_accepts_any(_Config) ->
     ?assertEqual(ok, emqx_plugins:is_allowed_installation(NameVsn, <<"other bytes">>)),
     ok.
 
+%% Under the hardened profile an unbound grant is refused at grant time and a
+%% bound grant behaves as in legacy: matching bytes pass, mismatching bytes fail.
+t_allow_hardened_requires_sha256({init, Config}) ->
+    Config;
+t_allow_hardened_requires_sha256({'end', _Config}) ->
+    application:unset_env(emqx_plugins, allowed_installations),
+    ok;
+t_allow_hardened_requires_sha256(_Config) ->
+    NameVsn = <<"foo-1.0.0">>,
+    Bin = <<"hello world">>,
+    Sha = binary:encode_hex(crypto:hash(sha256, Bin), lowercase),
+    emqx_common_test_helpers:with_security_profile(hardened, fun() ->
+        ?assertEqual({error, sha256_required}, emqx_plugins:allow_installation(NameVsn)),
+        ?assertEqual(
+            {error, sha256_required}, emqx_plugins:allow_installation(NameVsn, undefined)
+        ),
+        ?assertNot(emqx_plugins:is_allowed_installation(NameVsn)),
+        ?assertEqual({error, not_allowed}, emqx_plugins:is_allowed_installation(NameVsn, Bin)),
+        ok = emqx_plugins:allow_installation(NameVsn, Sha),
+        ?assertEqual(ok, emqx_plugins:is_allowed_installation(NameVsn, Bin)),
+        ?assertEqual(
+            {error, sha256_mismatch},
+            emqx_plugins:is_allowed_installation(NameVsn, <<"tampered">>)
+        )
+    end),
+    ok.
+
+%% A grant pushed over RPC is applied through the same entry point, so a
+%% hardened node refuses an unbound grant no matter which peer issued it.
+%% Proto v3 is what a legacy peer calls when no hash is given.
+t_allow_hardened_rpc_refuses_unbound({init, Config}) ->
+    Config;
+t_allow_hardened_rpc_refuses_unbound({'end', _Config}) ->
+    application:unset_env(emqx_plugins, allowed_installations),
+    ok;
+t_allow_hardened_rpc_refuses_unbound(_Config) ->
+    NameVsn = <<"foo-1.0.0">>,
+    Sha = binary:encode_hex(crypto:hash(sha256, <<"hello world">>), lowercase),
+    emqx_common_test_helpers:with_security_profile(hardened, fun() ->
+        ?assertEqual(
+            [{ok, {error, sha256_required}}],
+            emqx_plugins_proto_v3:allow_installation([node()], NameVsn)
+        ),
+        ?assertEqual(
+            [{ok, {error, sha256_required}}],
+            emqx_plugins_proto_v4:allow_installation([node()], NameVsn, undefined)
+        ),
+        ?assertNot(emqx_plugins:is_allowed_installation(NameVsn)),
+        ?assertEqual(
+            [{ok, ok}],
+            emqx_plugins_proto_v4:allow_installation([node()], NameVsn, Sha)
+        ),
+        ?assert(emqx_plugins:is_allowed_installation(NameVsn))
+    end),
+    %% Legacy peers still accept the unbound grant.
+    ?assertEqual(
+        [{ok, ok}],
+        emqx_plugins_proto_v3:allow_installation([node()], NameVsn)
+    ),
+    ok.
+
+%% Verification rejects an unbound grant while the profile requires a binding,
+%% even when the grant was issued under legacy.
+t_allow_hardened_rejects_preexisting_unbound_grant({init, Config}) ->
+    Config;
+t_allow_hardened_rejects_preexisting_unbound_grant({'end', _Config}) ->
+    application:unset_env(emqx_plugins, allowed_installations),
+    ok;
+t_allow_hardened_rejects_preexisting_unbound_grant(_Config) ->
+    NameVsn = <<"foo-1.0.0">>,
+    Bin = <<"hello world">>,
+    ok = emqx_plugins:allow_installation(NameVsn),
+    ?assertEqual(ok, emqx_plugins:is_allowed_installation(NameVsn, Bin)),
+    emqx_common_test_helpers:with_security_profile(hardened, fun() ->
+        %% The entry still exists; only the byte check refuses it.
+        ?assert(emqx_plugins:is_allowed_installation(NameVsn)),
+        ?assertEqual(
+            {error, sha256_required}, emqx_plugins:is_allowed_installation(NameVsn, Bin)
+        )
+    end),
+    ?assertEqual(ok, emqx_plugins:is_allowed_installation(NameVsn, Bin)),
+    ok.
+
+%% The CLI refuses an unbound `plugins allow' under hardened with an actionable
+%% hint, without issuing any grant; a bound allow still works.
+t_cli_allow_hardened_requires_sha256({init, Config}) ->
+    Config;
+t_cli_allow_hardened_requires_sha256({'end', _Config}) ->
+    application:unset_env(emqx_plugins, allowed_installations),
+    ok;
+t_cli_allow_hardened_requires_sha256(_Config) ->
+    NameVsn = "foo-1.0.0",
+    Sha = binary:encode_hex(crypto:hash(sha256, <<"hello world">>), lowercase),
+    LogFun = fun(_F, A) -> A end,
+    emqx_common_test_helpers:with_security_profile(hardened, fun() ->
+        [DeniedJson] = emqx_plugins_cli_utils:allow_installation(NameVsn, LogFun),
+        Denied = emqx_utils_json:decode(DeniedJson, [return_maps]),
+        ?assertMatch(
+            #{
+                <<"result">> := <<"not_ok">>,
+                <<"cause">> := #{<<"reason">> := <<"sha256_required">>, <<"hint">> := _}
+            },
+            Denied
+        ),
+        #{<<"cause">> := #{<<"hint">> := Hint}} = Denied,
+        ?assertNotEqual(nomatch, binary:match(Hint, <<"sha256:<hex>">>)),
+        ?assertNot(emqx_plugins:is_allowed_installation(NameVsn)),
+        [OkJson] = emqx_plugins_cli_utils:allow_installation(NameVsn, Sha, LogFun),
+        ?assertMatch(
+            #{<<"result">> := <<"ok">>},
+            emqx_utils_json:decode(OkJson, [return_maps])
+        ),
+        ?assert(emqx_plugins:is_allowed_installation(NameVsn))
+    end),
+    ok.
+
 %% The CLI install path must enforce the same allow gate as the HTTP upload path:
 %% without an `allow_installation' grant the CLI must refuse to install, with a
 %% grant it must install and consume the grant (forget on success, retain on

--- a/changes/ee/feat-18455.en.md
+++ b/changes/ee/feat-18455.en.md
@@ -1,0 +1,3 @@
+Under the `hardened` security profile, `emqx ctl plugins allow <Name-Vsn>` now requires the `sha256:<hex>` argument. The grant binds the plugin package to the given SHA-256 digest. Only an upload whose bytes match the digest is installed. A grant without a digest is refused with a message that shows the required command. A node running the `hardened` profile also refuses a grant without a digest that a cluster peer sends to it.
+
+The `legacy` security profile is unchanged: the `sha256:<hex>` argument stays optional.


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
N/A

## Summary

Under the `hardened` security profile, `emqx ctl plugins allow <Name-Vsn>` now requires `sha256:<hex>`. `legacy` is unchanged.

New policy: `emqx_security_profile:policy(plugin_install_sha256_binding)` → `optional` (legacy) | `required` (hardened).

Where the policy is enforced:

- `emqx_plugins:allow_installation/2` returns `{error, sha256_required}` for an unbound grant when the policy is `required`. This is the single entry point for every grant path: the CLI (`emqx_plugins_cli_utils`), `emqx_plugins_proto_v3:allow_installation/2` and `emqx_plugins_proto_v4:allow_installation/3` all call it on the receiving node. A hardened node therefore refuses an unbound grant that a legacy peer pushes over RPC; the peer sees `{ok, {error, sha256_required}}` in the multicall result. No proto change is needed, both proto specs already allow `{error, term()}`.
- The CLI also checks the policy locally before it issues any grant, so a refusal on a hardened node leaves no unbound grant on peers. The error carries a `hint` with the exact command (`emqx ctl plugins allow <Name-Vsn> sha256:<hex>`, the published `<Name-Vsn>.sha256` file holds the hex). The same hint is added when a peer refuses.
- `emqx_plugins:is_allowed_installation/2` re-checks the policy when the stored grant has no sha256 and returns `{error, sha256_required}`. The HTTP upload path (`emqx_mgmt_api_plugins`) maps it to `403` with the same hint; the CLI install paths print it as the cause.

Why verification also rejects: the grant store is application env on each node and is lost on restart, and the profile is read once at boot, so after this change a hardened node cannot hold an unbound grant through any supported path. The check at verification time costs one clause and makes the guarantee hold at the moment bytes are accepted, independent of how the grant store was written. Grant-time refusal alone would make the property depend on every writer behaving.

No HTTP route creates a grant; the API only verifies (`is_allowed_installation/2`) and revokes.

Out of scope: the cluster-wide `install_package` RPC trusts the originating node's grant check; peers are inside the trust boundary, and a mixed-profile cluster is covered by the profile divergence alarm.

Tests:
- `emqx_plugins_SUITE`: hardened grant refused / bound grant works; proto v3 and v4 unbound grants refused on a hardened node and still accepted on legacy; pre-existing unbound grant rejected at verification under hardened; CLI refusal with hint.
- `emqx_mgmt_api_plugins_SUITE` (runs under both profile groups): unbound CLI allow by profile and HTTP 403 for a pre-existing unbound grant under hardened; the existing cases bind the package hash when the profile requires it.
- `emqx_security_profile_SUITE`: policy values.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
