### PR TITLE
test(pgsql): close the blocked-worker window in t_write_failure

### DIFF
--- a/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
+++ b/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
@@ -445,15 +445,21 @@ t_write_failure() ->
 t_write_failure(matrix) ->
     full_matrix();
 t_write_failure(TCConfig) when is_list(TCConfig) ->
-    %% Use a short health-check interval so that, once the proxy is switched
-    %% off, the connector is promptly marked `disconnected'.  With the default
-    %% 15s interval the detection races the 15s `buffer_worker_flush_nack' wait
-    %% below: the message would otherwise stay queued against a still-`connecting'
-    %% resource until `request_ttl', making this test flaky.
+    %% Use a short health-check interval on both the connector and the action.
+    %% The connector interval makes the health check mark the resource
+    %% `disconnected' promptly once the proxy is down; with the 15s default the
+    %% message would stay queued against a still-`connecting' resource until
+    %% `request_ttl'. The action interval also sets the buffer-worker
+    %% `resume_interval': when the health check wins the race against the first
+    %% flush, the worker enters `blocked' and only retries every
+    %% `resume_interval', so with the 15s default the nack event lands after
+    %% the 15s wait below.
     {201, _} = create_connector_api(TCConfig, #{
         <<"resource_opts">> => #{<<"health_check_interval">> => <<"1s">>}
     }),
-    {201, _} = create_action_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{
+        <<"resource_opts">> => #{<<"health_check_interval">> => <<"1s">>}
+    }),
     #{topic := Topic} = simple_create_rule_api(TCConfig),
     C = start_client(),
     Payload = unique_payload(),
@@ -462,12 +468,16 @@ t_write_failure(TCConfig) when is_list(TCConfig) ->
             {_, {ok, _}} =
                 ?wait_async_action(
                     emqtt:publish(C, Topic, Payload, [{qos, 0}]),
-                    #{?snk_kind := buffer_worker_flush_nack},
+                    #{?snk_kind := Evt} when
+                        Evt =:= buffer_worker_flush_nack orelse
+                            Evt =:= buffer_worker_retry_inflight_failed,
                     15_000
                 )
         end),
         fun(Trace0) ->
-            Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
+            Trace = ?of_kind(
+                [buffer_worker_flush_nack, buffer_worker_retry_inflight_failed], Trace0
+            ),
             ?assertMatch([#{result := {error, _}} | _], Trace),
             [#{result := {error, Error}} | _] = Trace,
             case Error of


### PR DESCRIPTION
## Summary

De-flake `emqx_bridge_pgsql_SUITE:t_write_failure`, seen twice in four days on the `sync.without_batch` variants:

- dev-62 (tls): https://github.com/emqx/emqx/actions/runs/32384482495/job/96479504483?pr=18418
- dev-63 (tcp): https://github.com/emqx/emqx/actions/runs/32706326521/job/97371209140?pr=18452

```
{badmatch,{ok,timeout}}   %% ?wait_async_action(publish, buffer_worker_flush_nack, 15_000)
```

The previous de-flake (d4e6c8db1a) set the connector health-check interval to 1s so the resource is marked `disconnected` promptly. The action kept default resource opts, so the buffer-worker `resume_interval` defaulted to ~15s. Normal run: the flush attempt races ahead of the health check, errors on the dead connection, and nacks within milliseconds. Flaky run: the health check wins, the worker enters `blocked` before the first flush, and a blocked worker only retries every `resume_interval` — the first nack lands after the 15s wait.

Fix (test-only):

- Set `health_check_interval => 1s` on the action as well; `resume_interval` defaults from it, so a blocked worker nacks within ~1s.
- Accept `buffer_worker_retry_inflight_failed` as an alternative event in the wait pattern and trace assertion, as `emqx_bridge_cassandra_SUITE:t_write_failure` already does.

Base `dev-61`: the suite blob is identical on dev-61/62/63, so the fix reaches 62, 63, and 70 through the sync chain (dev-60 carries an older variant of this suite without d4e6c8db1a).