### PR TITLE
fix(exhook): avoid manager crash during unhealthy server reorder

### DIFF
--- a/apps/emqx_exhook/src/emqx_exhook_mgr.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_mgr.erl
@@ -16,6 +16,10 @@
 -define(EXHOOK_ROOT, exhook).
 -define(EXHOOK, [?EXHOOK_ROOT]).
 
+%% Servers with a configured order are positioned before servers without one.
+-define(WITH_ORDER, 0).
+-define(WITHOUT_ORDER, 1).
+
 %% APIs
 -export([start_link/0]).
 
@@ -611,9 +615,9 @@ name_of(#{name := Name}) ->
 order_key(Name, Position, Servers) ->
     case emqx_utils_maps:deep_get([Name, order], Servers, undefined) of
         Order when is_integer(Order) ->
-            {0, Order, Position};
+            {?WITH_ORDER, Order, Position};
         _ ->
-            {1, Position, Position}
+            {?WITHOUT_ORDER, Position, Position}
     end.
 
 refresh_tick() ->

--- a/apps/emqx_exhook/src/emqx_exhook_mgr.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_mgr.erl
@@ -596,18 +596,25 @@ restart_server(Name, ConfL, State) ->
             end
     end.
 
-sort_name_by_order(Names, Orders) ->
-    lists:sort(
-        fun
-            (A, B) when is_binary(A) ->
-                emqx_utils_maps:deep_get([A, order], Orders) <
-                    emqx_utils_maps:deep_get([B, order], Orders);
-            (#{name := A}, #{name := B}) ->
-                emqx_utils_maps:deep_get([A, order], Orders) <
-                    emqx_utils_maps:deep_get([B, order], Orders)
-        end,
-        Names
-    ).
+sort_name_by_order(Names, Servers) ->
+    NamesWithKeys = [
+        {order_key(name_of(Item), Position, Servers), Item}
+     || {Position, Item} <- lists:zip(lists:seq(1, length(Names)), Names)
+    ],
+    [Item || {_Key, Item} <- lists:keysort(1, NamesWithKeys)].
+
+name_of(Name) when is_binary(Name) ->
+    Name;
+name_of(#{name := Name}) ->
+    Name.
+
+order_key(Name, Position, Servers) ->
+    case emqx_utils_maps:deep_get([Name, order], Servers, undefined) of
+        Order when is_integer(Order) ->
+            {0, Order, Position};
+        _ ->
+            {1, Position, Position}
+    end.
 
 refresh_tick() ->
     erlang:send_after(?REFRESH_INTERVAL, erlang:whereis(?MODULE), ?FUNCTION_NAME).
@@ -673,16 +680,7 @@ service(Name) ->
 
 update_order(Servers) ->
     Running = running(),
-    Orders = maps:filter(
-        fun
-            (Name, #{status := connected}) ->
-                lists:member(Name, Running);
-            (_, _) ->
-                false
-        end,
-        Servers
-    ),
-    Running2 = sort_name_by_order(Running, Orders),
+    Running2 = sort_name_by_order(Running, Servers),
     persistent_term:put(?APP, Running2).
 
 hooks(Name) ->

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -37,6 +37,19 @@
     }
 """>>).
 
+-define(CONF_TWO_SERVERS, <<"""
+    exhook {
+      servers = [
+        { name = default,
+          url = "http://127.0.0.1:9000"
+        },
+        { name = test1,
+          url = "http://127.0.0.1:9001"
+        }
+      ]
+    }
+""">>).
+
 %%--------------------------------------------------------------------
 %% Setups
 %%--------------------------------------------------------------------
@@ -52,12 +65,20 @@ end_per_suite(Config) ->
 
 init_per_testcase(t_health_check = TC, Config) ->
     common_init(TC, Config);
+init_per_testcase(t_update_order_with_unhealthy_server = TC, Config) ->
+    _ = emqx_exhook_demo_svr:start(),
+    _ = emqx_exhook_demo_svr:start(<<"test1">>, 9001),
+    common_init(TC, Config);
 init_per_testcase(TC, Config) ->
     _ = emqx_exhook_demo_svr:start(),
     common_init(TC, Config).
 
 end_per_testcase(t_health_check, Config) ->
     common_stop(Config);
+end_per_testcase(t_update_order_with_unhealthy_server, Config) ->
+    common_stop(Config),
+    ok = emqx_exhook_demo_svr:stop(<<"test1">>),
+    ok = emqx_exhook_demo_svr:stop();
 end_per_testcase(_, Config) ->
     common_stop(Config),
     ok = emqx_exhook_demo_svr:stop().
@@ -68,11 +89,16 @@ emqx_conf(_) ->
     #{}.
 
 common_init(TC, Config) ->
+    ExHookConf =
+        case TC of
+            t_update_order_with_unhealthy_server -> ?CONF_TWO_SERVERS;
+            _ -> ?CONF_DEFAULT
+        end,
     Apps = emqx_cth_suite:start(
         [
             emqx,
             {emqx_conf, emqx_conf(TC)},
-            {emqx_exhook, ?CONF_DEFAULT}
+            {emqx_exhook, ExHookConf}
         ],
         #{work_dir => emqx_cth_suite:work_dir(TC, Config)}
     ),
@@ -188,6 +214,30 @@ t_running_deduplicated_after_successful_reload(_) ->
 
     ?assertMatch(#{status := connected}, emqx_exhook_mgr:lookup(Name)),
     ?assertEqual([Name], emqx_exhook_mgr:running()).
+
+t_update_order_with_unhealthy_server(_) ->
+    Name = <<"test1">>,
+    MgrPid = erlang:whereis(emqx_exhook_mgr),
+
+    ?assertEqual([<<"default">>, Name], emqx_exhook_mgr:running()),
+
+    ok = emqx_exhook_demo_svr:stop(Name),
+    refresh_tick = erlang:send(MgrPid, refresh_tick),
+    ?retry(
+        100,
+        20,
+        begin
+            #{status := Status} = emqx_exhook_mgr:lookup(Name),
+            ?assert(lists:member(Status, [connecting, disconnected]))
+        end
+    ),
+
+    ?assertEqual(
+        {ok, ok},
+        emqx_exhook_mgr:update_config([exhook, servers], {move, Name, front})
+    ),
+    ?assertEqual(MgrPid, erlang:whereis(emqx_exhook_mgr)),
+    ?assertEqual([Name, <<"default">>], emqx_exhook_mgr:running()).
 
 t_health_check('init', Config) ->
     %% health_check and auto_reconnect logic:

--- a/changes/ee/fix-18464.en.md
+++ b/changes/ee/fix-18464.en.md
@@ -1,0 +1,1 @@
+Fixed a rare crash in the ExHook manager when an ExHook server became unhealthy during a configuration update. The manager now keeps the configured server order and continues serving configuration changes while the server reconnects.


### PR DESCRIPTION
Release version: 6.0.4

## Summary

Prevent `emqx_exhook_mgr` from crashing when a loaded ExHook server becomes unhealthy while its name remains in `running()`. Reorder servers using the complete server state and provide a deterministic fallback for stale names. Add regression coverage for configuration reordering during health-check failure.

Fix: N/A (no external issue or ticket was provided)

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-18464.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
