### PR TITLE
fix(bridges): implement context-aware SQL rendering

### DIFF
--- a/.ci/docker-compose-file/docker-compose-mysql-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-mysql-tcp.yaml
@@ -22,3 +22,21 @@ services:
       # so that we hit potential resource exhaustion earlier in tests.
       - --max-prepared-stmt-count=64
       - --skip-symbolic-links
+  mysql_server_nbe:
+    container_name: mysql-nbe
+    image: public.ecr.aws/docker/library/mysql:${MYSQL_TAG}
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: public
+      MYSQL_DATABASE: mqtt
+    networks:
+      - emqx_bridge
+    command:
+      - --bind-address=0.0.0.0
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_general_ci
+      - --lower-case-table-names=1
+      - --max-allowed-packet=128M
+      - --max-prepared-stmt-count=64
+      - --skip-symbolic-links
+      - --sql-mode=NO_BACKSLASH_ESCAPES,ANSI_QUOTES

--- a/.ci/docker-compose-file/docker-compose-toxiproxy.yaml
+++ b/.ci/docker-compose-file/docker-compose-toxiproxy.yaml
@@ -23,6 +23,8 @@ services:
       - 13306:3306
       # MySQL TLS
       - 13307:3307
+      # MySQL NO_BACKSLASH_ESCAPES and ANSI_QUOTES
+      - 13308:3308
       # PostgreSQL
       - 15432:5432
       # PostgreSQL TLS

--- a/.ci/docker-compose-file/toxiproxy.json
+++ b/.ci/docker-compose-file/toxiproxy.json
@@ -29,6 +29,12 @@
     "upstream": "mysql-tls:3306",
     "enabled": true
   },
+  {
+    "name": "mysql_nbe",
+    "listen": "0.0.0.0:3308",
+    "upstream": "mysql-nbe:3306",
+    "enabled": true
+  },
 
   {
     "name": "redis_single_tcp",

--- a/.gitignore
+++ b/.gitignore
@@ -82,14 +82,7 @@ rebar-git-cache.tar
 .git/
 apps/emqx_utils/src/emqx_variform_parser.erl
 apps/emqx_utils/src/emqx_variform_scan.erl
-apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.erl
-apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_parser.erl
-apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_lexer.erl
-apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_parser.erl
-apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.erl
-apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_parser.erl
-apps/emqx_mysql/src/emqx_mysql_sql_lexer.erl
-apps/emqx_mysql/src/emqx_mysql_sql_parser.erl
+apps/*/src/*_sql_lexer.erl
+apps/*/src/*_sql_parser.erl
 default-profile.mk
 __pycache__/
-docs/

--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,12 @@ rebar-git-cache.tar
 .git/
 apps/emqx_utils/src/emqx_variform_parser.erl
 apps/emqx_utils/src/emqx_variform_scan.erl
+apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.erl
+apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_parser.erl
+apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_lexer.erl
+apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_parser.erl
+apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.erl
+apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_parser.erl
 default-profile.mk
 __pycache__/
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,8 @@ apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_lexer.erl
 apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_parser.erl
 apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.erl
 apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_parser.erl
+apps/emqx_mysql/src/emqx_mysql_sql_lexer.erl
+apps/emqx_mysql/src/emqx_mysql_sql_parser.erl
 default-profile.mk
 __pycache__/
 docs/

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse.app.src
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_clickhouse, [
     {description, "EMQX Enterprise ClickHouse Bridge"},
-    {vsn, "0.4.5"},
+    {vsn, "0.4.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
@@ -51,10 +51,6 @@
     execute_sql_in_clickhouse_server_using_connection/2
 ]).
 
--ifdef(TEST).
--export([split_clickhouse_insert_sql/1]).
--endif.
-
 %%=====================================================================
 %% Types
 %%=====================================================================
@@ -66,8 +62,7 @@
 -type templates() ::
     #{}
     | #{
-        send_message_template := term(),
-        extend_send_message_template := term()
+        sql_plan := term()
     }.
 
 -type state() ::
@@ -79,75 +74,6 @@
     }.
 
 -type clickhouse_config() :: map().
-
-%%=====================================================================
-%% Macros and On load
-%%=====================================================================
-
-%% Copied from emqx_utils_sql:parse_insert/1
-%% Can also handle Clickhouse's SQL extension for INSERT statments that allows the
-%% user to specify different formats:
-%%
-%% https://clickhouse.com/docs/en/sql-reference/statements/insert-into/
-%%
--define(INSERT_RE_MP_KEY, {?MODULE, insert_re_mp}).
--define(INSERT_RE_BIN, <<
-    %% case-insensitive
-    "(?i)^",
-    %% Leading spaces
-    "\\s*",
-    %% Group-1: insert into, table name and columns (when existed).
-    %% All space characters suffixed to <TABLE_NAME> will be kept
-    %% `INSERT INTO <TABLE_NAME> [(<COLUMN>, ..)]`
-    "(insert\\s+into\\s+[^\\s\\(\\)]+\\s*(?:(?:\\((?:[^()]++|(?2))*\\)\\s*,?\\s*)*))",
-    "\\s*",
-    %% Ignore Group
-    "(?:",
-    %% Group-2 (Optional for FORMAT clause):
-    %% literals value(s) or placeholder(s) with round brackets.
-    %% And the sub-pattern in brackets does not do any capturing
-    %% Ignore Group:
-    %%     `VALUES [([<VALUE> | <PLACEHOLDER>], ...)]`
-    %% Keep Capturing-Group:
-    %%     `([<VALUE> | <PLACEHOLDER>], ...) [, ([<VALUE> | <PLACEHOLDER>], ..)]`
-    "(?:values\\s*(\\((?:[^()]++|(?2))*\\)(?:\\s*,\\s*\\((?:[^()]++|(?2)*)\\))*)\\s*;?\\s*)",
-    %% End Group-2
-    %% or
-    "|",
-    %% Group-3:
-    %% literals value(s) or placeholder(s) as `<FORMAT_DATA>`
-    %% Ignore Group:
-    %%     `FORMAT <FORMAT_NAME> <FORMAT_DATA>`
-    %% Keep Capturing-Group `<FORMAT_DATA>` without any check
-    %%   Could be:
-    %%     `([<VALUE> | <PLACEHOLDER>], ...) [, ([<VALUE> | <PLACEHOLDER>], ...)]`
-    %%     `[([<VALUE> | <PLACEHOLDER>], ...) [, ([<VALUE> | <PLACEHOLDER>], ...)]]`
-    %%     ...
-    "(?:format\\s+[a-zA-Z]+\\s+)((?!\\s)(?=.*\\s).*)",
-    %% End Group-3
-    ")",
-    %% End Ignored Group
-    "\\s*$"
->>).
-
--on_load(on_load/0).
-
-on_load() ->
-    put_insert_mp(),
-    ok.
-
-put_insert_mp() ->
-    persistent_term:put(?INSERT_RE_MP_KEY, re:compile(?INSERT_RE_BIN)),
-    ok.
-
-get_insert_mp() ->
-    case persistent_term:get(?INSERT_RE_MP_KEY, undefined) of
-        undefined ->
-            ok = put_insert_mp(),
-            get_insert_mp();
-        {ok, MP} ->
-            {ok, MP}
-    end.
 
 %%=====================================================================
 %% Configuration and default values
@@ -273,38 +199,15 @@ on_start(
 
 prepare_sql_templates(#{
     sql := Template,
-    batch_value_separator := Separator
+    batch_value_separator := _ConfiguredSeparator
 }) ->
-    InsertTemplate = emqx_placeholder:preproc_tmpl(Template),
-    BulkExtendInsertTemplate = prepare_sql_bulk_extend_template(Template, Separator),
-    #{
-        send_message_template => InsertTemplate,
-        extend_send_message_template => BulkExtendInsertTemplate
-    };
+    case emqx_bridge_clickhouse_sql:compile(Template) of
+        {ok, Plan} -> {ok, #{sql_plan => Plan}};
+        {error, Reason} -> {error, Reason}
+    end;
 prepare_sql_templates(_) ->
     %% We don't create any templates if this is a non-bridge connector
-    #{}.
-
-prepare_sql_bulk_extend_template(Template, Separator) ->
-    ValuesTemplate = split_clickhouse_insert_sql(Template),
-    %% The value part has been extracted
-    %% Add separator before ValuesTemplate so that one can append it
-    %% to an insert template
-    ExtendParamTemplate = iolist_to_binary([Separator, ValuesTemplate]),
-    emqx_placeholder:preproc_tmpl(ExtendParamTemplate).
-
-split_clickhouse_insert_sql(SQL) ->
-    ErrorMsg = <<"The SQL template should be an SQL INSERT statement but it is something else.">>,
-    {ok, MP} = get_insert_mp(),
-    case re:run(SQL, MP, [{capture, all_but_first, binary}]) of
-        {match, [_InsertInto, ValuesTemplate]} ->
-            ValuesTemplate;
-        %% Group2 is empty (not `VALUES` statement)
-        {match, [_InsertInto, <<>>, FormatTemplate]} ->
-            FormatTemplate;
-        _ ->
-            erlang:error(ErrorMsg)
-    end.
+    {ok, #{}}.
 
 % This is a callback for ecpool which is triggered by the call to
 % emqx_resource_pool:start in on_start/2
@@ -356,10 +259,15 @@ on_stop(InstanceID, _State) ->
 %% -------------------------------------------------------------------
 on_add_channel(_InstId, #{channels := Channs} = OldState, ChannId, ChannConf0) ->
     #{parameters := ChannelConf} = ChannConf0,
-    NewChanns = Channs#{
-        ChannId => #{templates => prepare_sql_templates(ChannelConf), channel_conf => ChannelConf}
-    },
-    {ok, OldState#{channels => NewChanns}}.
+    case prepare_sql_templates(ChannelConf) of
+        {ok, Templates} ->
+            NewChanns = Channs#{
+                ChannId => #{templates => Templates, channel_conf => ChannelConf}
+            },
+            {ok, OldState#{channels => NewChanns}};
+        {error, _} = Error ->
+            Error
+    end.
 
 on_remove_channel(_InstanceId, #{channels := Channels} = State, ChannId) ->
     NewState = State#{channels => maps:remove(ChannId, Channels)},
@@ -452,11 +360,17 @@ on_query(
     SimplifiedRequestType = query_type(RequestType),
     ChannelState = get_channel_state(RequestType, State),
     Templates = get_templates(RequestType, State),
-    SQL = get_sql(
-        SimplifiedRequestType, Templates, DataOrSQL, maps:get(channel_conf, ChannelState, #{})
-    ),
-    ClickhouseResult = execute_sql_in_clickhouse_server(RequestType, PoolName, SQL),
-    transform_and_log_clickhouse_result(ClickhouseResult, ResourceID, SQL).
+    case
+        get_sql(
+            SimplifiedRequestType, Templates, DataOrSQL, maps:get(channel_conf, ChannelState, #{})
+        )
+    of
+        {ok, SQL} ->
+            ClickhouseResult = execute_sql_in_clickhouse_server(RequestType, PoolName, SQL),
+            transform_and_log_clickhouse_result(ClickhouseResult, ResourceID, SQL);
+        {error, Reason} ->
+            {error, {unrecoverable_error, Reason}}
+    end.
 
 get_templates(ChannId, State) ->
     maps:get(templates, get_channel_state(ChannId, State), #{}).
@@ -469,10 +383,10 @@ get_channel_state(ChannId, State) ->
             #{}
     end.
 
-get_sql(channel_message, #{send_message_template := PreparedSQL}, Data, ChannelConf) ->
-    proc_nullable_tmpl(PreparedSQL, Data, ChannelConf);
+get_sql(channel_message, #{sql_plan := Plan}, Data, ChannelConf) ->
+    emqx_bridge_clickhouse_sql:render(Plan, Data, render_opts(ChannelConf));
 get_sql(_, _, SQL, _) ->
-    SQL.
+    {ok, SQL}.
 
 query_type(sql) ->
     query;
@@ -493,14 +407,16 @@ on_batch_query(ResourceID, BatchReq, #{pool_name := PoolName} = State) ->
     %% Currently we only support batch requests with a binary ChannId
     {[ChannId | _] = Keys, ObjectsToInsert} = lists:unzip(BatchReq),
     ensure_channel_messages(Keys),
-    Templates = get_templates(ChannId, State),
+    #{sql_plan := Plan} = get_templates(ChannId, State),
     ChannelState = get_channel_state(ChannId, State),
-    %% Create batch insert SQL statement
-    SQL = objects_to_sql(ObjectsToInsert, Templates, maps:get(channel_conf, ChannelState, #{})),
-    %% Do the actual query in the database
-    ResultFromClickhouse = execute_sql_in_clickhouse_server(ChannId, PoolName, SQL),
-    %% Transform the result to a better format
-    transform_and_log_clickhouse_result(ResultFromClickhouse, ResourceID, SQL).
+    Opts = render_opts(maps:get(channel_conf, ChannelState, #{})),
+    case emqx_bridge_clickhouse_sql:render_batch(Plan, ObjectsToInsert, Opts) of
+        {ok, SQL} ->
+            ResultFromClickhouse = execute_sql_in_clickhouse_server(ChannId, PoolName, SQL),
+            transform_and_log_clickhouse_result(ResultFromClickhouse, ResourceID, SQL);
+        {error, Reason} ->
+            {error, {unrecoverable_error, Reason}}
+    end.
 
 ensure_channel_messages(Keys) ->
     case lists:all(fun is_binary/1, Keys) of
@@ -512,30 +428,8 @@ ensure_channel_messages(Keys) ->
             )
     end.
 
-objects_to_sql(
-    [FirstObject | RemainingObjects] = _ObjectsToInsert,
-    #{
-        send_message_template := InsertTemplate,
-        extend_send_message_template := BulkExtendInsertTemplate
-    },
-    ChannelConf
-) ->
-    %% Prepare INSERT-statement and the first row after VALUES
-    InsertStatementHead = proc_nullable_tmpl(InsertTemplate, FirstObject, ChannelConf),
-    FormatObjectDataFunction =
-        fun(Object) ->
-            proc_nullable_tmpl(BulkExtendInsertTemplate, Object, ChannelConf)
-        end,
-    InsertStatementTail = lists:map(FormatObjectDataFunction, RemainingObjects),
-    CompleteStatement = erlang:iolist_to_binary([InsertStatementHead, InsertStatementTail]),
-    CompleteStatement;
-objects_to_sql(_, _, _) ->
-    erlang:error(<<"Templates for bulk insert missing.">>).
-
-proc_nullable_tmpl(Template, Data, #{undefined_vars_as_null := true}) ->
-    emqx_placeholder:proc_nullable_tmpl(Template, Data);
-proc_nullable_tmpl(Template, Data, _) ->
-    emqx_placeholder:proc_tmpl(Template, Data).
+render_opts(ChannelConf) ->
+    #{undefined_vars_as_null => maps:get(undefined_vars_as_null, ChannelConf, false)}.
 
 %% -------------------------------------------------------------------
 %% Helper functions that are used by both on_query/3 and on_batch_query/3

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
@@ -1,0 +1,924 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc Compile and render restricted ClickHouse INSERT templates.
+-module(emqx_bridge_clickhouse_sql).
+
+-export([compile/1, render/3, render_batch/3, parse_placeholder/1]).
+-export_type([plan/0]).
+
+-type placeholder() :: emqx_template:placeholder().
+
+-record(tpl_text, {text :: binary()}).
+-record(tpl_placeholder, {placeholder :: placeholder()}).
+-record(part_text, {text :: binary()}).
+-record(part_value, {value :: term()}).
+
+-type template_part() :: #tpl_text{} | #tpl_placeholder{}.
+-type part() :: #part_text{} | #part_value{}.
+
+-record(raw, {sql :: binary()}).
+-record(sql_value, {placeholder :: placeholder()}).
+-record(json_value, {placeholder :: placeholder()}).
+-record(sql_string, {parts :: [template_part()]}).
+-record(json_string, {parts :: [template_part()]}).
+
+-type sql_render_op() :: #raw{} | #sql_value{} | #sql_string{}.
+-type json_render_op() :: #raw{} | #json_value{} | #json_string{}.
+-type sql_render_plan() :: [sql_render_op()].
+-type json_render_plan() :: [json_render_op()].
+
+-record(clickhouse_values_plan, {
+    insert_prefix :: binary(),
+    plan :: sql_render_plan()
+}).
+-record(clickhouse_json_plan, {
+    insert_prefix :: binary(),
+    plan :: json_render_plan()
+}).
+
+-opaque plan() :: #clickhouse_values_plan{} | #clickhouse_json_plan{}.
+
+-define(VALUES_BATCH_SEPARATOR, <<", ">>).
+-define(JSON_BATCH_SEPARATOR, <<>>).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec compile(unicode:chardata()) -> {ok, plan()} | {error, term()}.
+compile(SQL0) ->
+    SQL = unicode:characters_to_binary(SQL0),
+    try
+        case emqx_bridge_clickhouse_sql_lexer:string(binary_to_list(SQL)) of
+            {ok, Tokens, _EndLine} ->
+                case emqx_bridge_clickhouse_sql_parser:parse(Tokens) of
+                    {ok, AST} -> compile_ast(AST);
+                    {error, Reason} -> {error, {invalid_clickhouse_insert_template, Reason}}
+                end;
+            {error, Reason, _EndLine} ->
+                {error, {invalid_clickhouse_insert_template, Reason}}
+        end
+    catch
+        Class:CatchReason -> {error, {invalid_clickhouse_insert_template, {Class, CatchReason}}}
+    end.
+
+-spec render(plan(), map(), map()) -> {ok, iolist()} | {error, term()}.
+render(#clickhouse_values_plan{insert_prefix = Prefix, plan = Plan}, Data, Opts) ->
+    render_insert(Prefix, Plan, Data, Opts);
+render(#clickhouse_json_plan{insert_prefix = Prefix, plan = Plan}, Data, Opts) ->
+    render_insert(Prefix, Plan, Data, Opts).
+
+-spec render_batch(plan(), [map()], map()) -> {ok, iolist()} | {error, term()}.
+render_batch(
+    #clickhouse_values_plan{insert_prefix = Prefix, plan = Plan}, DataList, Opts
+) ->
+    render_batch_insert(Prefix, Plan, DataList, Opts, ?VALUES_BATCH_SEPARATOR);
+render_batch(
+    #clickhouse_json_plan{insert_prefix = Prefix, plan = Plan}, DataList, Opts
+) ->
+    render_batch_insert(Prefix, Plan, DataList, Opts, ?JSON_BATCH_SEPARATOR).
+
+-spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
+parse_placeholder(Source) ->
+    case valid_placeholder_source(Source) of
+        true ->
+            case emqx_template:parse(Source) of
+                [{var, _, _} = Placeholder] -> {ok, Placeholder};
+                _ -> {error, invalid_placeholder}
+            end;
+        false ->
+            {error, invalid_placeholder}
+    end.
+
+%%------------------------------------------------------------------------------
+%% Private funs
+%%------------------------------------------------------------------------------
+
+render_insert(Prefix, Template, Data, Opts) ->
+    case render_unit(Template, Data, Opts) of
+        {ok, Rendered} -> {ok, [Prefix, Rendered]};
+        {error, _} = Error -> Error
+    end.
+
+render_batch_insert(Prefix, Plan, DataList, Opts, Separator) ->
+    case render_batch_units(DataList, Plan, Opts, _Index = 1, _Acc = [], Separator) of
+        {ok, Rendered} -> {ok, [Prefix, Rendered]};
+        {error, _} = Error -> Error
+    end.
+
+render_batch_units([Data | Rest], Unit, Opts, Index, Acc, Separator) ->
+    case render_unit(Unit, Data, Opts) of
+        {ok, Rendered} ->
+            render_batch_units(Rest, Unit, Opts, Index + 1, [Rendered | Acc], Separator);
+        {error, Reason} ->
+            {error, {clickhouse_template_render_failed, #{batch_index => Index, reason => Reason}}}
+    end;
+render_batch_units([], _Unit, _Opts, _Index, Acc, Separator) ->
+    {ok, lists:join(Separator, lists:reverse(Acc))}.
+
+render_unit(Unit, Data, Opts) ->
+    render_plan(Unit, Data, Opts, #{}, []).
+
+render_plan([#raw{sql = SQL} | Rest], Data, Opts, Cache, Acc) ->
+    render_plan(Rest, Data, Opts, Cache, [SQL | Acc]);
+render_plan([#sql_value{placeholder = Placeholder} | Rest], Data, Opts, Cache0, Acc) ->
+    render_value_op(
+        Placeholder,
+        fun(Value) -> encode_value(Value, Opts) end,
+        Rest,
+        Data,
+        Opts,
+        Cache0,
+        Acc
+    );
+render_plan([#json_value{placeholder = Placeholder} | Rest], Data, Opts, Cache0, Acc) ->
+    render_value_op(
+        Placeholder,
+        fun(Value) -> encode_json_value(Value, Opts) end,
+        Rest,
+        Data,
+        Opts,
+        Cache0,
+        Acc
+    );
+render_plan([#sql_string{parts = Parts} | Rest], Data, Opts, Cache0, Acc) ->
+    render_template_op(
+        Parts,
+        fun(Resolved) -> encode_sql_string(render_text_parts(Resolved, Opts)) end,
+        Rest,
+        Data,
+        Opts,
+        Cache0,
+        Acc
+    );
+render_plan([#json_string{parts = Parts} | Rest], Data, Opts, Cache0, Acc) ->
+    render_template_op(
+        Parts,
+        fun(Resolved) -> emqx_utils_json:encode(render_text_parts(Resolved, Opts)) end,
+        Rest,
+        Data,
+        Opts,
+        Cache0,
+        Acc
+    );
+render_plan([], _Data, _Opts, _Cache, Acc) ->
+    {ok, lists:reverse(Acc)}.
+
+render_value_op(Placeholder, Encoder, Rest, Data, Opts, Cache0, Acc) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            case encode_result(fun() -> Encoder(Value) end) of
+                {ok, Encoded} -> render_plan(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} -> {error, render_error(Placeholder, Reason)}
+            end;
+        {error, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end.
+
+render_template_op(Parts, Encoder, Rest, Data, Opts, Cache0, Acc) ->
+    case resolve_template_parts(Parts, Data, Cache0, []) of
+        {ok, Resolved, Cache} ->
+            case encode_result(fun() -> Encoder(Resolved) end) of
+                {ok, Encoded} -> render_plan(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} -> {error, render_template_error(Parts, Reason)}
+            end;
+        {error, Placeholder, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end.
+
+encode_result(Encoder) ->
+    try Encoder() of
+        {ok, _} = Ok -> Ok;
+        {error, _} = Error -> Error;
+        Encoded -> {ok, Encoded}
+    catch
+        Class:Reason -> {error, {Class, Reason}}
+    end.
+
+resolve_template_parts([#tpl_text{text = Text} | Rest], Data, Cache, Acc) ->
+    resolve_template_parts(Rest, Data, Cache, [#part_text{text = Text} | Acc]);
+resolve_template_parts([#tpl_placeholder{placeholder = Placeholder} | Rest], Data, Cache0, Acc) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            resolve_template_parts(Rest, Data, Cache, [#part_value{value = Value} | Acc]);
+        {error, Reason} ->
+            {error, Placeholder, Reason}
+    end;
+resolve_template_parts([], _Data, Cache, Acc) ->
+    {ok, lists:reverse(Acc), Cache}.
+
+resolve_placeholder({var, _Name, Accessor} = Placeholder, Data, Cache) ->
+    case Cache of
+        #{Placeholder := Value} ->
+            {ok, Value, Cache};
+        #{} ->
+            try emqx_jsonish:lookup(Accessor, Data) of
+                {ok, Value} -> {ok, Value, Cache#{Placeholder => Value}};
+                {error, _Reason} -> {ok, undefined, Cache#{Placeholder => undefined}}
+            catch
+                Class:Reason -> {error, {placeholder_lookup_failed, {Class, Reason}}}
+            end
+    end.
+
+render_error({var, Name, _Accessor}, Reason) ->
+    {invalid_sql_template_value, #{placeholder => Name, reason => Reason}}.
+
+render_template_error(Parts, Reason) ->
+    Placeholders = lists:usort([Placeholder || #tpl_placeholder{placeholder = Placeholder} <- Parts]),
+    case Placeholders of
+        [Placeholder] ->
+            render_error(Placeholder, Reason);
+        [] ->
+            {invalid_sql_template_value, Reason};
+        _ ->
+            Names = [Name || {var, Name, _Accessor} <- Placeholders],
+            {invalid_sql_template_value, #{placeholders => Names, reason => Reason}}
+    end.
+
+compile_ast({insert, #{target := Target, columns := Columns, source := Source}}) ->
+    TargetSQL = serialize_target(Target),
+    ColumnsSQL = serialize_columns(Columns),
+    case Source of
+        {values, Rows} ->
+            compile_rows(<<"INSERT INTO ", TargetSQL/binary, ColumnsSQL/binary, " VALUES ">>, Rows);
+        {format_rows, Format, Rows} ->
+            case string:lowercase(Format) of
+                <<"values">> ->
+                    Head =
+                        <<"INSERT INTO ", TargetSQL/binary, ColumnsSQL/binary, " FORMAT Values ">>,
+                    compile_rows(Head, Rows);
+                _ ->
+                    {error, {unsupported_clickhouse_format, Format}}
+            end;
+        {format_json, Format, JSON} ->
+            case string:lowercase(Format) of
+                <<"jsoncompacteachrow">> ->
+                    Head = <<
+                        "INSERT INTO ",
+                        TargetSQL/binary,
+                        ColumnsSQL/binary,
+                        " FORMAT JSONCompactEachRow "
+                    >>,
+                    {ok, #clickhouse_json_plan{
+                        insert_prefix = Head,
+                        plan = merge_json_render_ops(compile_json(JSON))
+                    }};
+                _ ->
+                    {error, {unsupported_clickhouse_format, Format}}
+            end
+    end.
+
+compile_rows(Head, Rows) ->
+    Unit = merge_sql_render_ops(join_ops(<<", ">>, [compile_row(Row) || Row <- Rows])),
+    {ok, #clickhouse_values_plan{insert_prefix = Head, plan = Unit}}.
+
+serialize_target(Identifiers) ->
+    iolist_to_binary(
+        lists:join($., [serialize_identifier(Identifier) || Identifier <- Identifiers])
+    ).
+
+serialize_columns(undefined) ->
+    <<>>;
+serialize_columns(Columns) ->
+    Content = [serialize_column(Column) || Column <- Columns],
+    iolist_to_binary([" (", lists:join(<<", ">>, Content), ")"]).
+
+serialize_column(star) ->
+    <<"*">>;
+serialize_column({except, Identifiers}) ->
+    [
+        <<"* EXCEPT (">>,
+        lists:join(<<", ">>, [serialize_identifier(I) || I <- Identifiers]),
+        <<")">>
+    ];
+serialize_column(Identifier) ->
+    serialize_identifier(Identifier).
+
+serialize_identifier({identifier, bare, Name}) ->
+    quote_identifier(Name);
+serialize_identifier({identifier, Style, Source}) when Style =:= double; Style =:= backtick ->
+    quote_identifier(decode_identifier(Source, Style)).
+
+quote_identifier(Name) ->
+    Escaped = binary:replace(
+        Name,
+        [<<"\\">>, <<"`">>],
+        <<"\\">>,
+        [global, {insert_replaced, 1}]
+    ),
+    <<"`", Escaped/binary, "`">>.
+
+decode_identifier(Source, double) ->
+    ok = assert_no_identifier_placeholder(Source),
+    decode_quoted_identifier(strip_quotes(Source), $", []);
+decode_identifier(Source, backtick) ->
+    ok = assert_no_identifier_placeholder(Source),
+    decode_quoted_identifier(strip_quotes(Source), $`, []).
+
+assert_no_identifier_placeholder(Source) ->
+    case binary:match(Source, <<"${">>) of
+        nomatch -> ok;
+        _ -> error(dynamic_identifier_not_allowed)
+    end.
+
+decode_quoted_identifier(<<Quote, Quote, Rest/binary>>, Quote, Acc) ->
+    decode_quoted_identifier(Rest, Quote, [Quote | Acc]);
+decode_quoted_identifier(<<$\\, $x, High, Low, Rest/binary>>, Quote, Acc) ->
+    decode_quoted_identifier(Rest, Quote, [hex_byte(High, Low) | Acc]);
+decode_quoted_identifier(<<$\\, $N, Rest/binary>>, Quote, Acc) ->
+    decode_quoted_identifier(Rest, Quote, Acc);
+decode_quoted_identifier(<<$\\, Escaped, Rest/binary>>, Quote, Acc) ->
+    decode_quoted_identifier(Rest, Quote, [decode_sql_escape(Escaped) | Acc]);
+decode_quoted_identifier(<<Char, Rest/binary>>, Quote, Acc) ->
+    decode_quoted_identifier(Rest, Quote, [Char | Acc]);
+decode_quoted_identifier(<<>>, _Quote, Acc) ->
+    iolist_to_binary(lists:reverse(Acc)).
+
+compile_row({row, Expressions}) ->
+    [#raw{sql = <<"(">>} | join_ops(<<", ">>, [compile_expression(E) || E <- Expressions])] ++
+        [#raw{sql = <<")">>}].
+
+compile_expression({var, Placeholder}) ->
+    [#sql_value{placeholder = Placeholder}];
+compile_expression({string, Source}) ->
+    Parts = parse_sql_string(Source),
+    compile_sql_string(Parts);
+compile_expression({number, Number}) ->
+    [#raw{sql = Number}];
+compile_expression(null) ->
+    [#raw{sql = <<"NULL">>}];
+compile_expression(true) ->
+    [#raw{sql = <<"true">>}];
+compile_expression(false) ->
+    [#raw{sql = <<"false">>}];
+compile_expression({identifier_value, Name}) ->
+    [#raw{sql = Name}];
+compile_expression({call, Name, Args}) ->
+    [#raw{sql = <<Name/binary, "(">>} | join_ops(<<", ">>, [compile_expression(E) || E <- Args])] ++
+        [#raw{sql = <<")">>}];
+compile_expression({group, Expression}) ->
+    [#raw{sql = <<"(">>} | compile_expression(Expression)] ++ [#raw{sql = <<")">>}];
+compile_expression({array, Expressions}) ->
+    [#raw{sql = <<"[">>} | join_ops(<<", ">>, [compile_expression(E) || E <- Expressions])] ++
+        [#raw{sql = <<"]">>}];
+compile_expression({unary, Operator, Expression}) ->
+    [#raw{sql = <<(atom_to_binary(Operator))/binary, "(">>} | compile_expression(Expression)] ++
+        [#raw{sql = <<")">>}];
+compile_expression({binary, Operator, Left, Right}) ->
+    compile_expression(Left) ++
+        [#raw{sql = <<" ", (atom_to_binary(Operator))/binary, " ">>}] ++
+        compile_expression(Right).
+
+compile_json({json_array, Values}) ->
+    [#raw{sql = <<"[">>} | join_ops(<<",">>, [compile_json(V) || V <- Values])] ++
+        [#raw{sql = <<"]">>}];
+compile_json({json_object, Members}) ->
+    Compiled = [compile_json_member(Member) || Member <- Members],
+    [#raw{sql = <<"{">>} | join_ops(<<",">>, Compiled)] ++ [#raw{sql = <<"}">>}];
+compile_json({json_var, Placeholder}) ->
+    [#json_value{placeholder = Placeholder}];
+compile_json({json_string, Source}) ->
+    Parts = parse_json_string(Source),
+    compile_json_string(Parts);
+compile_json({json_number, Number}) ->
+    case
+        re:run(
+            Number,
+            <<"^-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?(?:[eE][+-]?[0-9]+)?$">>,
+            [{capture, none}]
+        )
+    of
+        match -> [#raw{sql = Number}];
+        nomatch -> error({invalid_json_number, Number})
+    end;
+compile_json(true) ->
+    [#raw{sql = <<"true">>}];
+compile_json(false) ->
+    [#raw{sql = <<"false">>}];
+compile_json(null) ->
+    [#raw{sql = <<"null">>}].
+
+compile_json_member({KeySource, Value}) ->
+    Key = json_parts_to_static(parse_json_string(KeySource)),
+    [#raw{sql = emqx_utils_json:encode(Key)}, #raw{sql = <<":">>} | compile_json(Value)].
+
+json_parts_to_static([#tpl_text{text = Text}]) ->
+    Text;
+json_parts_to_static(_) ->
+    error(dynamic_json_object_key_not_allowed).
+
+compile_sql_string([#tpl_text{text = Text}]) ->
+    [#raw{sql = encode_sql_string(Text)}];
+compile_sql_string(Parts) ->
+    [#sql_string{parts = Parts}].
+
+compile_json_string([#tpl_text{text = Text}]) ->
+    [#raw{sql = emqx_utils_json:encode(Text)}];
+compile_json_string(Parts) ->
+    [#json_string{parts = Parts}].
+
+join_ops(_Separator, []) ->
+    [];
+join_ops(Separator, [Ops | Rest]) ->
+    lists:foldl(fun(Next, Acc) -> Acc ++ [#raw{sql = Separator} | Next] end, Ops, Rest).
+
+-spec merge_sql_render_ops(sql_render_plan()) -> sql_render_plan().
+merge_sql_render_ops(Ops) ->
+    merge_render_ops(Ops).
+
+-spec merge_json_render_ops(json_render_plan()) -> json_render_plan().
+merge_json_render_ops(Ops) ->
+    merge_render_ops(Ops).
+
+merge_render_ops(Ops) ->
+    lists:reverse(
+        lists:foldl(
+            fun
+                (#raw{sql = <<>>}, Acc) ->
+                    Acc;
+                (#raw{sql = SQL}, [#raw{sql = Previous} | Acc]) ->
+                    [#raw{sql = <<Previous/binary, SQL/binary>>} | Acc];
+                (Op, Acc) ->
+                    [Op | Acc]
+            end,
+            [],
+            Ops
+        )
+    ).
+
+parse_sql_string(Source) ->
+    parse_sql_string_body(strip_quotes(Source), [], []).
+
+parse_sql_string_body(<<>>, Text, Parts) ->
+    finish_parts(Text, Parts);
+parse_sql_string_body(<<$\\, $x, High, Low, Rest/binary>>, Text, Parts) ->
+    parse_sql_string_body(Rest, [hex_byte(High, Low) | Text], Parts);
+parse_sql_string_body(<<$\\, $N, Rest/binary>>, Text, Parts) ->
+    parse_sql_string_body(Rest, Text, Parts);
+parse_sql_string_body(<<$\\, Escaped, Rest/binary>>, Text, Parts) ->
+    parse_sql_string_body(Rest, [decode_sql_escape(Escaped) | Text], Parts);
+parse_sql_string_body(<<$', $', Rest/binary>>, Text, Parts) ->
+    parse_sql_string_body(Rest, [$' | Text], Parts);
+parse_sql_string_body(<<"${$}", Rest/binary>>, Text, Parts) ->
+    parse_sql_string_body(Rest, [$$ | Text], Parts);
+parse_sql_string_body(<<"${", _/binary>> = Bin, Text, Parts) ->
+    {Placeholder, Rest} = take_placeholder(Bin),
+    parse_sql_string_body(
+        Rest,
+        [],
+        [#tpl_placeholder{placeholder = Placeholder} | flush_text(Text, Parts)]
+    );
+parse_sql_string_body(<<Char, Rest/binary>>, Text, Parts) ->
+    parse_sql_string_body(Rest, [Char | Text], Parts).
+
+decode_sql_escape($a) ->
+    7;
+decode_sql_escape($n) ->
+    $\n;
+decode_sql_escape($r) ->
+    $\r;
+decode_sql_escape($t) ->
+    $\t;
+decode_sql_escape($b) ->
+    $\b;
+decode_sql_escape($f) ->
+    $\f;
+decode_sql_escape($e) ->
+    27;
+decode_sql_escape($v) ->
+    11;
+decode_sql_escape($0) ->
+    0;
+decode_sql_escape(Char) when
+    Char =:= $\\; Char =:= $'; Char =:= $"; Char =:= $`; Char =:= $/; Char =:= $=
+->
+    Char;
+decode_sql_escape(Char) ->
+    <<$\\, Char>>.
+
+parse_json_string(Source) ->
+    parse_json_string_body(strip_quotes(Source), [], []).
+
+parse_json_string_body(<<>>, Text, Parts) ->
+    finish_parts(Text, Parts);
+parse_json_string_body(<<$\\, $u, H1, H2, H3, H4, Rest/binary>>, Text, Parts) ->
+    Codepoint = hex_codepoint(H1, H2, H3, H4),
+    case Codepoint >= 16#D800 andalso Codepoint =< 16#DBFF of
+        true ->
+            case Rest of
+                <<$\\, $u, L1, L2, L3, L4, Tail/binary>> ->
+                    Low = hex_codepoint(L1, L2, L3, L4),
+                    case Low >= 16#DC00 andalso Low =< 16#DFFF of
+                        true ->
+                            Combined =
+                                16#10000 +
+                                    ((Codepoint - 16#D800) bsl 10) +
+                                    (Low - 16#DC00),
+                            parse_json_string_body(
+                                Tail,
+                                [unicode:characters_to_binary([Combined]) | Text],
+                                Parts
+                            );
+                        false ->
+                            error(invalid_json_surrogate_pair)
+                    end;
+                _ ->
+                    error(invalid_json_surrogate_pair)
+            end;
+        false when Codepoint >= 16#DC00, Codepoint =< 16#DFFF ->
+            error(invalid_json_surrogate);
+        false ->
+            parse_json_string_body(Rest, [unicode:characters_to_binary([Codepoint]) | Text], Parts)
+    end;
+parse_json_string_body(<<$\\, Escaped, Rest/binary>>, Text, Parts) ->
+    parse_json_string_body(Rest, [decode_json_escape(Escaped) | Text], Parts);
+parse_json_string_body(<<"${$}", Rest/binary>>, Text, Parts) ->
+    parse_json_string_body(Rest, [$$ | Text], Parts);
+parse_json_string_body(<<"${", _/binary>> = Bin, Text, Parts) ->
+    {Placeholder, Rest} = take_placeholder(Bin),
+    parse_json_string_body(
+        Rest,
+        [],
+        [#tpl_placeholder{placeholder = Placeholder} | flush_text(Text, Parts)]
+    );
+parse_json_string_body(<<Char, _/binary>>, _Text, _Parts) when Char < 16#20; Char =:= $" ->
+    error(invalid_json_string);
+parse_json_string_body(<<Char, Rest/binary>>, Text, Parts) ->
+    parse_json_string_body(Rest, [Char | Text], Parts).
+
+decode_json_escape($") -> $";
+decode_json_escape($\\) -> $\\;
+decode_json_escape($/) -> $/;
+decode_json_escape($b) -> $\b;
+decode_json_escape($f) -> $\f;
+decode_json_escape($n) -> $\n;
+decode_json_escape($r) -> $\r;
+decode_json_escape($t) -> $\t;
+decode_json_escape(Char) -> error({unsupported_json_escape, Char}).
+
+hex_byte(High, Low) ->
+    (hex_digit(High) bsl 4) bor hex_digit(Low).
+
+hex_codepoint(H1, H2, H3, H4) ->
+    (hex_digit(H1) bsl 12) bor
+        (hex_digit(H2) bsl 8) bor
+        (hex_digit(H3) bsl 4) bor
+        hex_digit(H4).
+
+hex_digit(Char) when Char >= $0, Char =< $9 -> Char - $0;
+hex_digit(Char) when Char >= $A, Char =< $F -> Char - $A + 10;
+hex_digit(Char) when Char >= $a, Char =< $f -> Char - $a + 10;
+hex_digit(Char) -> error({invalid_hex_digit, Char}).
+
+valid_placeholder_source(<<"${}">>) ->
+    true;
+valid_placeholder_source(<<"${.}">>) ->
+    true;
+valid_placeholder_source(Source) ->
+    re:run(
+        Source,
+        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
+        [{capture, none}]
+    ) =:= match.
+
+take_placeholder(Bin) ->
+    case binary:match(Bin, <<"}">>) of
+        {End, 1} ->
+            Size = End + 1,
+            Source = binary:part(Bin, 0, Size),
+            Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
+            case parse_placeholder(Source) of
+                {ok, Placeholder} -> {Placeholder, Rest};
+                {error, _} -> error({invalid_placeholder, Source})
+            end;
+        nomatch ->
+            error(unterminated_placeholder)
+    end.
+
+flush_text([], Parts) ->
+    Parts;
+flush_text(Text, Parts) ->
+    [#tpl_text{text = iolist_to_binary(lists:reverse(Text))} | Parts].
+
+finish_parts(Text, Parts) ->
+    case lists:reverse(flush_text(Text, Parts)) of
+        [] -> [#tpl_text{text = <<>>}];
+        Result -> Result
+    end.
+
+strip_quotes(Source) ->
+    binary:part(Source, 1, byte_size(Source) - 2).
+
+encode_json_value(undefined, #{undefined_vars_as_null := false}) ->
+    emqx_utils_json:encode(<<"undefined">>);
+encode_json_value(undefined, _Opts) ->
+    <<"null">>;
+encode_json_value(Value, _Opts) ->
+    emqx_utils_json:encode(Value).
+
+encode_value(undefined, #{undefined_vars_as_null := false}) ->
+    encode_sql_string(<<"undefined">>);
+encode_value(undefined, _Opts) ->
+    <<"NULL">>;
+encode_value(null, _Opts) ->
+    <<"NULL">>;
+encode_value(true, _Opts) ->
+    <<"true">>;
+encode_value(false, _Opts) ->
+    <<"false">>;
+encode_value(Value, _Opts) when is_integer(Value) ->
+    integer_to_binary(Value);
+encode_value(Value, _Opts) when is_float(Value) ->
+    case Value =:= Value of
+        true -> float_to_binary(Value, [compact]);
+        false -> {error, non_finite_number}
+    end;
+encode_value(Value, _Opts) ->
+    encode_sql_string(to_text(Value)).
+
+-spec render_text_parts([part()], map()) -> binary().
+render_text_parts(Parts, Opts) ->
+    iolist_to_binary([
+        case Part of
+            #part_text{text = Text} ->
+                Text;
+            #part_value{value = undefined} ->
+                case maps:get(undefined_vars_as_null, Opts, true) of
+                    true -> <<"null">>;
+                    false -> <<"undefined">>
+                end;
+            #part_value{value = Value} ->
+                to_text(Value)
+        end
+     || Part <- Parts
+    ]).
+
+to_text(Value) when is_binary(Value) -> Value;
+to_text(Value) -> iolist_to_binary(emqx_template:to_string(Value)).
+
+encode_sql_string(Text) ->
+    Escaped = binary:replace(Text, [<<"\\">>, <<"'">>], <<"\\">>, [global, {insert_replaced, 1}]),
+    <<"'", Escaped/binary, "'">>.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+parse_insert_sql_template_test() ->
+    Accepted = [
+        {<<"insert into tag_VALUES(tag_values,Timestamp) values (${tagvalues},${date})"/utf8>>,
+            <<", ">>, [
+                #raw{sql = <<"(">>},
+                #sql_value{placeholder = test_placeholder(<<"tagvalues">>)},
+                #raw{sql = <<", ">>},
+                #sql_value{placeholder = test_placeholder(<<"date">>)},
+                #raw{sql = <<")">>}
+            ]},
+        {<<"INSERT INTO Values_таблица (идентификатор, имя, возраст)   VALUES \t (${id}, 'Иван', 25)  "/utf8>>,
+            <<", ">>, [
+                #raw{sql = <<"(">>},
+                #sql_value{placeholder = test_placeholder(<<"id">>)},
+                #raw{sql = <<", 'Иван', 25)"/utf8>>}
+            ]},
+        {<<"INSERT INTO Values_таблица (идентификатор, имя, возраст)   VALUES \t (${id}, 'Иван', 25);  "/utf8>>,
+            <<", ">>, [
+                #raw{sql = <<"(">>},
+                #sql_value{placeholder = test_placeholder(<<"id">>)},
+                #raw{sql = <<", 'Иван', 25)"/utf8>>}
+            ]},
+        {<<"  inSErt into 表格(标识,名字,年龄)values(${id},'李四', 35) ; "/utf8>>, <<", ">>, [
+            #raw{sql = <<"(">>},
+            #sql_value{placeholder = test_placeholder(<<"id">>)},
+            #raw{sql = <<", '李四', 35)"/utf8>>}
+        ]},
+        {<<"INSERT INTO mqtt_test(payload, arrived) VALUES (${payload}, FROM_UNIXTIME((${timestamp}/1000)))">>,
+            <<", ">>, [
+                #raw{sql = <<"(">>},
+                #sql_value{placeholder = test_placeholder(<<"payload">>)},
+                #raw{sql = <<", FROM_UNIXTIME((">>},
+                #sql_value{placeholder = test_placeholder(<<"timestamp">>)},
+                #raw{sql = <<" / 1000)))">>}
+            ]},
+        {<<"insert into таблица (идентификатор,имя,возраст) VALUES(${id},'Алексей',30)"/utf8>>,
+            <<", ">>, [
+                #raw{sql = <<"(">>},
+                #sql_value{placeholder = test_placeholder(<<"id">>)},
+                #raw{sql = <<", 'Алексей', 30)"/utf8>>}
+            ]},
+        {<<"INSERT into 表格 (标识, 名字, 年龄) VALUES (${id}, '张三', 22)"/utf8>>, <<", ">>, [
+            #raw{sql = <<"(">>},
+            #sql_value{placeholder = test_placeholder(<<"id">>)},
+            #raw{sql = <<", '张三', 22)"/utf8>>}
+        ]},
+        {<<"  inSErt into 表格(标识,名字,年龄)values(${id},'李四', 35)"/utf8>>, <<", ">>, [
+            #raw{sql = <<"(">>},
+            #sql_value{placeholder = test_placeholder(<<"id">>)},
+            #raw{sql = <<", '李四', 35)"/utf8>>}
+        ]},
+        {<<"inSErt  INTO  table75 (column1, column2, column3) values (${one}, ${two},${three})"/utf8>>,
+            <<", ">>, [
+                #raw{sql = <<"(">>},
+                #sql_value{placeholder = test_placeholder(<<"one">>)},
+                #raw{sql = <<", ">>},
+                #sql_value{placeholder = test_placeholder(<<"two">>)},
+                #raw{sql = <<", ">>},
+                #sql_value{placeholder = test_placeholder(<<"three">>)},
+                #raw{sql = <<")">>}
+            ]},
+        {<<"INSERT Into some_table      values\t(${tag1},   ${tag2}  )">>, <<", ">>, [
+            #raw{sql = <<"(">>},
+            #sql_value{placeholder = test_placeholder(<<"tag1">>)},
+            #raw{sql = <<", ">>},
+            #sql_value{placeholder = test_placeholder(<<"tag2">>)},
+            #raw{sql = <<")">>}
+        ]},
+        {<<"INSERT INTO insert_select_testtable (* EXCEPT(b)) Values (2, 2)">>, <<", ">>, [
+            #raw{sql = <<"(2, 2)">>}
+        ]},
+        {<<"INSERT INTO insert_select_testtable (* EXCEPT(b))Values(2, 2), (3, ${five})">>,
+            <<", ">>, [
+                #raw{sql = <<"(2, 2), (3, ">>},
+                #sql_value{placeholder = test_placeholder(<<"five">>)},
+                #raw{sql = <<")">>}
+            ]},
+        {<<"INSERT INTO   mqtt_test(key, data, arrived) FORMAT Values (v11, v12, v13), (v21, v22, v23)">>,
+            <<", ">>, [#raw{sql = <<"(v11, v12, v13), (v21, v22, v23)">>}]},
+        {<<"INSERT INTO mqtt_test(key, data, arrived) FORMAT Values (1, 'a', 2)">>, <<", ">>, [
+            #raw{sql = <<"(1, 'a', 2)">>}
+        ]},
+        {<<"INSERT INTO mqtt_test(data) VALUES ('xxx${var}yyy')">>, <<", ">>, [
+            #raw{sql = <<"(">>},
+            #sql_string{
+                parts = [
+                    #tpl_text{text = <<"xxx">>},
+                    test_tpl_placeholder(<<"var">>),
+                    #tpl_text{text = <<"yyy">>}
+                ]
+            },
+            #raw{sql = <<")">>}
+        ]},
+        {<<"INSERT INTO mqtt_test(data) VALUES ('${var}')">>, <<", ">>, [
+            #raw{sql = <<"(">>},
+            #sql_string{parts = [test_tpl_placeholder(<<"var">>)]},
+            #raw{sql = <<")">>}
+        ]},
+        {<<"INSERT INTO mqtt_test(key, data, arrived) FORMAT JSONCompactEachRow [${key}, \"${data}\", ${timestamp}]">>,
+            <<>>, [
+                #raw{sql = <<"[">>},
+                #json_value{placeholder = test_placeholder(<<"key">>)},
+                #raw{sql = <<",">>},
+                #json_string{parts = [test_tpl_placeholder(<<"data">>)]},
+                #raw{sql = <<",">>},
+                #json_value{placeholder = test_placeholder(<<"timestamp">>)},
+                #raw{sql = <<"]">>}
+            ]},
+        {<<"INSERT INTO mqtt_test(data) FORMAT JSONCompactEachRow [\"xxx${var}xxx\"]">>, <<>>, [
+            #raw{sql = <<"[">>},
+            #json_string{
+                parts = [
+                    #tpl_text{text = <<"xxx">>},
+                    test_tpl_placeholder(<<"var">>),
+                    #tpl_text{text = <<"xxx">>}
+                ]
+            },
+            #raw{sql = <<"]">>}
+        ]}
+    ],
+    lists:foreach(
+        fun({SQL, ExpectedSeparator, ExpectedTemplate}) ->
+            {ok, Plan} = compile(SQL),
+            {Separator, Template} = test_plan_template(Plan),
+            ?assertEqual(ExpectedSeparator, Separator),
+            ?assertEqual(ExpectedTemplate, Template)
+        end,
+        Accepted
+    ),
+    Rejected = [
+        %% SQL comments are not allowed.
+        <<"INSERT INTO mqtt_test VALUES (1) -- comment">>,
+        %% Target placeholders are not allowed.
+        <<"INSERT INTO ${table} VALUES (1)">>,
+        %% A placeholder must occupy a complete value token.
+        <<"INSERT INTO mqtt_test VALUES (${value}0)">>,
+        %% A target can contain at most database and table components.
+        <<"insert into PI.dbo.tags(tag_values,Timestamp) values (${tagvalues},${date}  )"/utf8>>,
+        %% A target can contain at most database and table components.
+        <<"insert into PI.dbo.tags( tag_value,Timestamp)  VALUES\t\t(   ${tagvalues},   ${date} )"/utf8>>,
+        %% A target can contain at most database and table components.
+        <<"insert into PI.dbo.tags(tag_value , Timestamp )vALues(${tagvalues},${date})"/utf8>>,
+        %% JSONCompactEachRow data must be valid JSON.
+        <<"INSERT INTO mqtt_test(key, data, arrived)",
+            " FORMAT JSONCompactEachRow [(${key}, \"${data}\", ${timestamp})]">>,
+        %% AnyFORMAT is not a supported format.
+        <<"INSERT INTO   mqtt_test(key, data, arrived) FORMAT AnyFORMAT  👋    .."/utf8>>,
+        %% FORMAT Values requires at least one row.
+        <<"INSERT INTO   mqtt_test(key, data, arrived) FORMAT Values">>,
+        %% FORMAT Values requires at least one row.
+        <<"INSERT INTO   mqtt_test(key, data, arrived) FORMAT Values  ">>,
+        %% AnyFORMAT is not a supported format.
+        <<"INSERT INTO mqtt_test FORMAT AnyFORMAT payload">>,
+        %% FORMAT Values requires at least one row.
+        <<"INSERT INTO mqtt_test FORMAT Values">>
+    ],
+    lists:foreach(
+        fun(SQL) ->
+            ?assertMatch({error, _}, compile(SQL))
+        end,
+        Rejected
+    ).
+
+test_placeholder(Name) ->
+    {ok, Placeholder} = parse_placeholder(<<"${", Name/binary, "}">>),
+    Placeholder.
+
+test_tpl_placeholder(Name) ->
+    #tpl_placeholder{placeholder = test_placeholder(Name)}.
+
+test_plan_template(#clickhouse_values_plan{plan = Plan}) ->
+    {<<", ">>, Plan};
+test_plan_template(#clickhouse_json_plan{plan = Plan}) ->
+    {<<>>, Plan}.
+
+compile_merges_raw_segments_test() ->
+    Placeholder = test_placeholder(<<"value">>),
+    {ok, #clickhouse_values_plan{plan = [#raw{sql = <<"(1, 2)">>}]}} =
+        compile(<<"INSERT INTO t VALUES (1, 2)">>),
+    {ok, #clickhouse_values_plan{plan = SQLPlan}} =
+        compile(<<"INSERT INTO t VALUES (1, ${value}, 2)">>),
+    ?assertEqual(
+        [
+            #raw{sql = <<"(1, ">>},
+            #sql_value{placeholder = Placeholder},
+            #raw{sql = <<", 2)">>}
+        ],
+        SQLPlan
+    ),
+    {ok, #clickhouse_json_plan{plan = JSONPlan}} =
+        compile(<<"INSERT INTO t FORMAT JSONCompactEachRow [1, ${value}, 2]">>),
+    ?assertEqual(
+        [
+            #raw{sql = <<"[1,">>},
+            #json_value{placeholder = Placeholder},
+            #raw{sql = <<",2]">>}
+        ],
+        JSONPlan
+    ).
+
+values_compile_and_render_test() ->
+    {ok, Plan} = compile(
+        <<"INSERT INTO mqtt_test(key, data, arrived) VALUES (${key}, '${data}', ${timestamp})">>
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `mqtt_test` (`key`, `data`, `arrived`) VALUES (1, 'hello', 2)">>},
+        rendered_binary(render(Plan, #{key => 1, data => <<"hello">>, timestamp => 2}, null_opts()))
+    ).
+
+leading_dot_placeholder_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO mqtt_test(payload) VALUES (${.payload})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `mqtt_test` (`payload`) VALUES ('hello')">>},
+        rendered_binary(render(Plan, #{payload => <<"hello">>}, null_opts()))
+    ).
+
+json_compile_and_render_test() ->
+    {ok, Plan} = compile(
+        <<"INSERT INTO mqtt_test(key, data) FORMAT JSONCompactEachRow [${key}, \"${data}\"]">>
+    ),
+    ?assertEqual(
+        {ok,
+            <<"INSERT INTO `mqtt_test` (`key`, `data`) FORMAT JSONCompactEachRow [1,\"a\\\"b\"]">>},
+        rendered_binary(render(Plan, #{key => 1, data => <<"a\"b">>}, null_opts()))
+    ).
+
+static_escape_boundary_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES ('\\\\${v}')">>),
+    Attack = <<"'); INSERT INTO t(v) VALUES ('owned'); --">>,
+    {ok, Rendered} = render(Plan, #{v => Attack}, null_opts()),
+    ?assertMatch({ok, _}, compile(Rendered)).
+
+batch_shape_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
+    {ok, Rendered} = render_batch(Plan, [#{v => <<"a');--">>}, #{v => <<"b">>}], null_opts()),
+    ?assert(is_list(Rendered)),
+    ?assertMatch({ok, _}, compile(Rendered)).
+
+reject_unsupported_syntax_test() ->
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1) -- comment">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO ${table} VALUES (1)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO `${table}` VALUES (1)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (${value}0)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t FORMAT CSV ${payload}">>)).
+
+identifier_escape_test() ->
+    ?assertEqual(<<"`a\\\\\\`b`">>, quote_identifier(<<"a\\`b">>)),
+    ?assertEqual(<<"`a\\\\`">>, quote_identifier(<<"a\\">>)).
+
+rendered_binary({ok, SQL}) ->
+    ?assert(is_list(SQL)),
+    {ok, iolist_to_binary(SQL)}.
+
+null_opts() ->
+    #{undefined_vars_as_null => true}.
+
+-endif.

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
@@ -301,6 +301,9 @@ serialize_identifier({identifier, Style, Source}) when Style =:= double; Style =
     quote_identifier(decode_identifier(Source, Style)).
 
 quote_identifier(Name) ->
+    %% ClickHouse's backquoted writer uses generic backslash escaping:
+    %% https://github.com/ClickHouse/ClickHouse/commit/8dfb1700858195fa704221e360fa0798ac6ee9ed
+    %% src/IO/WriteHelpers.h lines 294-362 and 428-477.
     Escaped = binary:replace(
         Name,
         [<<"\\">>, <<"`">>],
@@ -365,10 +368,37 @@ compile_expression({array, Expressions}) ->
 compile_expression({unary, Operator, Expression}) ->
     [#raw{sql = <<(atom_to_binary(Operator))/binary, "(">>} | compile_expression(Expression)] ++
         [#raw{sql = <<")">>}];
+compile_expression({is_null, Expression, Negated}) ->
+    Suffix =
+        case Negated of
+            true -> <<" IS NOT NULL">>;
+            false -> <<" IS NULL">>
+        end,
+    compile_expression(Expression) ++ [#raw{sql = Suffix}];
+compile_expression({case_expression, Operand, Whens, Else}) ->
+    [#raw{sql = <<"CASE">>}] ++
+        compile_case_operand(Operand) ++
+        lists:append([compile_when_clause(Clause) || Clause <- Whens]) ++
+        compile_case_else(Else) ++
+        [#raw{sql = <<" END">>}];
 compile_expression({binary, Operator, Left, Right}) ->
     compile_expression(Left) ++
         [#raw{sql = <<" ", (atom_to_binary(Operator))/binary, " ">>}] ++
         compile_expression(Right).
+
+compile_case_operand(undefined) ->
+    [];
+compile_case_operand(Expression) ->
+    [#raw{sql = <<" ">>} | compile_expression(Expression)].
+
+compile_when_clause({'when', Condition, Result}) ->
+    [#raw{sql = <<" WHEN ">>} | compile_expression(Condition)] ++
+        [#raw{sql = <<" THEN ">>} | compile_expression(Result)].
+
+compile_case_else(undefined) ->
+    [];
+compile_case_else(Expression) ->
+    [#raw{sql = <<" ELSE ">>} | compile_expression(Expression)].
 
 compile_json({json_array, Values}) ->
     [#raw{sql = <<"[">>} | join_ops(<<",">>, [compile_json(V) || V <- Values])] ++
@@ -472,6 +502,9 @@ parse_sql_string_body(<<"${", _/binary>> = Bin, Text, Parts) ->
 parse_sql_string_body(<<Char, Rest/binary>>, Text, Parts) ->
     parse_sql_string_body(Rest, [Char | Text], Parts).
 
+%% Decode ClickHouse SQL escapes before quoted content is re-encoded.
+%% https://github.com/ClickHouse/ClickHouse/commit/8dfb1700858195fa704221e360fa0798ac6ee9ed
+%% src/IO/ReadHelpers.h lines 68-92 and src/IO/ReadHelpers.cpp lines 319-373.
 decode_sql_escape($a) ->
     7;
 decode_sql_escape($n) ->
@@ -493,6 +526,8 @@ decode_sql_escape($0) ->
 decode_sql_escape(Char) when
     Char =:= $\\; Char =:= $'; Char =:= $"; Char =:= $`; Char =:= $/; Char =:= $=
 ->
+    Char;
+decode_sql_escape(Char) when Char =< 16#1F ->
     Char;
 decode_sql_escape(Char) ->
     <<$\\, Char>>.
@@ -547,6 +582,10 @@ parse_json_string_body(<<Char, _/binary>>, _Text, _Parts) when Char < 16#20; Cha
 parse_json_string_body(<<Char, Rest/binary>>, Text, Parts) ->
     parse_json_string_body(Rest, [Char | Text], Parts).
 
+%% Decode JSON escapes before template segments are JSON-encoded again.
+%% https://github.com/ClickHouse/ClickHouse/commit/8dfb1700858195fa704221e360fa0798ac6ee9ed
+%% src/IO/ReadHelpers.cpp lines 376-490.
+%% https://www.rfc-editor.org/rfc/rfc8259.html#section-7
 decode_json_escape($") -> $";
 decode_json_escape($\\) -> $\\;
 decode_json_escape($/) -> $/;
@@ -571,6 +610,9 @@ hex_digit(Char) when Char >= $A, Char =< $F -> Char - $A + 10;
 hex_digit(Char) when Char >= $a, Char =< $f -> Char - $a + 10;
 hex_digit(Char) -> error({invalid_hex_digit, Char}).
 
+%% Restrict emqx_template's envelope to nonempty dotted paths.
+%% Retain `${}` and `${.}`.
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 valid_placeholder_source(<<"${}">>) ->
     true;
 valid_placeholder_source(<<"${.}">>) ->
@@ -658,6 +700,9 @@ to_text(Value) when is_binary(Value) -> Value;
 to_text(Value) -> iolist_to_binary(emqx_template:to_string(Value)).
 
 encode_sql_string(Text) ->
+    %% ClickHouse quoted strings escape backslashes and apostrophes:
+    %% https://github.com/ClickHouse/ClickHouse/commit/8dfb1700858195fa704221e360fa0798ac6ee9ed
+    %% src/IO/WriteHelpers.h lines 294-362.
     Escaped = binary:replace(Text, [<<"\\">>, <<"'">>], <<"\\">>, [global, {insert_replaced, 1}]),
     <<"'", Escaped/binary, "'">>.
 
@@ -674,19 +719,19 @@ parse_insert_sql_template_test() ->
                 #sql_value{placeholder = test_placeholder(<<"date">>)},
                 #raw{sql = <<")">>}
             ]},
-        {<<"INSERT INTO Values_таблица (идентификатор, имя, возраст)   VALUES \t (${id}, 'Иван', 25)  "/utf8>>,
+        {<<"INSERT INTO `Values_таблица` (`идентификатор`, `имя`, `возраст`)   VALUES \t (${id}, 'Иван', 25)  "/utf8>>,
             <<", ">>, [
                 #raw{sql = <<"(">>},
                 #sql_value{placeholder = test_placeholder(<<"id">>)},
                 #raw{sql = <<", 'Иван', 25)"/utf8>>}
             ]},
-        {<<"INSERT INTO Values_таблица (идентификатор, имя, возраст)   VALUES \t (${id}, 'Иван', 25);  "/utf8>>,
+        {<<"INSERT INTO `Values_таблица` (`идентификатор`, `имя`, `возраст`)   VALUES \t (${id}, 'Иван', 25);  "/utf8>>,
             <<", ">>, [
                 #raw{sql = <<"(">>},
                 #sql_value{placeholder = test_placeholder(<<"id">>)},
                 #raw{sql = <<", 'Иван', 25)"/utf8>>}
             ]},
-        {<<"  inSErt into 表格(标识,名字,年龄)values(${id},'李四', 35) ; "/utf8>>, <<", ">>, [
+        {<<"  inSErt into `表格`(`标识`,`名字`,`年龄`)values(${id},'李四', 35) ; "/utf8>>, <<", ">>, [
             #raw{sql = <<"(">>},
             #sql_value{placeholder = test_placeholder(<<"id">>)},
             #raw{sql = <<", '李四', 35)"/utf8>>}
@@ -699,18 +744,18 @@ parse_insert_sql_template_test() ->
                 #sql_value{placeholder = test_placeholder(<<"timestamp">>)},
                 #raw{sql = <<" / 1000)))">>}
             ]},
-        {<<"insert into таблица (идентификатор,имя,возраст) VALUES(${id},'Алексей',30)"/utf8>>,
+        {<<"insert into `таблица` (`идентификатор`,`имя`,`возраст`) VALUES(${id},'Алексей',30)"/utf8>>,
             <<", ">>, [
                 #raw{sql = <<"(">>},
                 #sql_value{placeholder = test_placeholder(<<"id">>)},
                 #raw{sql = <<", 'Алексей', 30)"/utf8>>}
             ]},
-        {<<"INSERT into 表格 (标识, 名字, 年龄) VALUES (${id}, '张三', 22)"/utf8>>, <<", ">>, [
+        {<<"INSERT into `表格` (`标识`, `名字`, `年龄`) VALUES (${id}, '张三', 22)"/utf8>>, <<", ">>, [
             #raw{sql = <<"(">>},
             #sql_value{placeholder = test_placeholder(<<"id">>)},
             #raw{sql = <<", '张三', 22)"/utf8>>}
         ]},
-        {<<"  inSErt into 表格(标识,名字,年龄)values(${id},'李四', 35)"/utf8>>, <<", ">>, [
+        {<<"  inSErt into `表格`(`标识`,`名字`,`年龄`)values(${id},'李四', 35)"/utf8>>, <<", ">>, [
             #raw{sql = <<"(">>},
             #sql_value{placeholder = test_placeholder(<<"id">>)},
             #raw{sql = <<", '李四', 35)"/utf8>>}
@@ -818,7 +863,9 @@ parse_insert_sql_template_test() ->
         %% AnyFORMAT is not a supported format.
         <<"INSERT INTO mqtt_test FORMAT AnyFORMAT payload">>,
         %% FORMAT Values requires at least one row.
-        <<"INSERT INTO mqtt_test FORMAT Values">>
+        <<"INSERT INTO mqtt_test FORMAT Values">>,
+        %% ClickHouse BareWord does not include non-ASCII bytes.
+        <<"INSERT INTO таблица VALUES (1)"/utf8>>
     ],
     lists:foreach(
         fun(SQL) ->
@@ -873,6 +920,26 @@ values_compile_and_render_test() ->
         rendered_binary(render(Plan, #{key => 1, data => <<"hello">>, timestamp => 2}, null_opts()))
     ).
 
+conditional_expression_test() ->
+    SQL = <<
+        "INSERT INTO t(a, b, c, d) VALUES ("
+        "CASE WHEN ${v} >= 10 AND ${v} IS NOT NULL THEN 'large' ELSE 'small' END, "
+        "CASE ${v} WHEN 10 THEN 1 ELSE 0 END, "
+        "if(NOT ${v} == 10 OR ${v} < 0, 1, 0), "
+        "and(equals(${v}, 10), not(isNull(${v}))))"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO `t` (`a`, `b`, `c`, `d`) VALUES ("
+            "CASE WHEN 10 >= 10 AND 10 IS NOT NULL THEN 'large' ELSE 'small' END, "
+            "CASE 10 WHEN 10 THEN 1 ELSE 0 END, "
+            "if(NOT(10 == 10) OR 10 < 0, 1, 0), "
+            "and(equals(10, 10), NOT((isNull(10)))))"
+        >>},
+        rendered_binary(render(Plan, #{v => 10}, null_opts()))
+    ).
+
 leading_dot_placeholder_test() ->
     {ok, Plan} = compile(<<"INSERT INTO mqtt_test(payload) VALUES (${.payload})">>),
     ?assertEqual(
@@ -896,11 +963,78 @@ static_escape_boundary_test() ->
     {ok, Rendered} = render(Plan, #{v => Attack}, null_opts()),
     ?assertMatch({ok, _}, compile(Rendered)).
 
+sql_escape_decode_test() ->
+    {ok, Plan} = compile(
+        <<"INSERT INTO t(v) VALUES ('\\a\\n\\r\\t\\b\\f\\e\\v\\0\\'\\q${v}')">>
+    ),
+    ?assertEqual(
+        {ok,
+            <<"INSERT INTO `t` (`v`) VALUES ('", 7, $\n, $\r, $\t, $\b, $\f, 27, 11, 0,
+                "\\'\\\\qx')">>},
+        rendered_binary(render(Plan, #{v => <<"x">>}, null_opts()))
+    ).
+
+json_escape_decode_test() ->
+    {ok, Plan} = compile(
+        <<
+            "INSERT INTO t(v) FORMAT JSONCompactEachRow "
+            "[\"\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0041\\uD83D\\uDE00${v}\"]"
+        >>
+    ),
+    Decoded = <<$", $\\, $/, $\b, $\f, $\n, $\r, $\t, "A😀x"/utf8>>,
+    Encoded = emqx_utils_json:encode(Decoded),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) FORMAT JSONCompactEachRow [", Encoded/binary, "]">>},
+        rendered_binary(render(Plan, #{v => <<"x">>}, null_opts()))
+    ),
+    ?assertMatch(
+        {error, _},
+        compile(<<"INSERT INTO t(v) FORMAT JSONCompactEachRow [\"\\q${v}\"]">>)
+    ).
+
+lexical_boundary_test() ->
+    SQL = iolist_to_binary([
+        <<"INSERT">>,
+        11,
+        <<"INTO $t VALUES ('a">>,
+        $\\,
+        $\n,
+        <<"b')">>
+    ]),
+    ?assertMatch({ok, _}, compile(SQL)).
+
 batch_shape_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     {ok, Rendered} = render_batch(Plan, [#{v => <<"a');--">>}, #{v => <<"b">>}], null_opts()),
     ?assert(is_list(Rendered)),
-    ?assertMatch({ok, _}, compile(Rendered)).
+    ?assertMatch({ok, _}, compile(Rendered)),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ">>},
+        rendered_binary(render_batch(Plan, [], null_opts()))
+    ).
+
+binary_value_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('", 16#FF, "')">>},
+        rendered_binary(render(Plan, #{v => <<16#FF>>}, null_opts()))
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('a", 0, "b')">>},
+        rendered_binary(render(Plan, #{v => <<"a", 0, "b">>}, null_opts()))
+    ),
+    Unicode = <<"你好😀"/utf8>>,
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('", Unicode/binary, "')">>},
+        rendered_binary(render(Plan, #{v => Unicode}, null_opts()))
+    ).
+
+json_invalid_binary_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) FORMAT JSONCompactEachRow [${v}]">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) FORMAT JSONCompactEachRow [\"�\"]"/utf8>>},
+        rendered_binary(render(Plan, #{v => <<16#FF>>}, null_opts()))
+    ).
 
 reject_unsupported_syntax_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1) -- comment">>)),

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
@@ -1119,6 +1119,42 @@ reject_unsupported_syntax_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (${value}0)">>)),
     ?assertMatch({error, _}, compile(<<"INSERT INTO t FORMAT CSV ${payload}">>)).
 
+%% Checks ClickHouse numeric separators and base-prefixed literals.
+numeric_literals_test() ->
+    {ok, Plan} = compile(
+        <<
+            "INSERT INTO t VALUES (10_000, 1_000.25, 1_0e+1_0, .5_0, "
+            "0xc0_fe, 0XCA_FE, 0b11_01, 0B10_10)"
+        >>
+    ),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO `t` VALUES (10_000, 1_000.25, 1_0e+1_0, .5_0, "
+            "0xc0_fe, 0XCA_FE, 0b11_01, 0B10_10)"
+        >>},
+        rendered_binary(render(Plan, #{}, null_opts()))
+    ).
+
+%% Checks rejection of separators outside digit groups and invalid base digits.
+malformed_numeric_literals_test() ->
+    Invalid = [
+        <<"1__0">>,
+        <<"1_">>,
+        <<"1_e2">>,
+        <<"1e_2">>,
+        <<"0x_FF">>,
+        <<"0xFF_">>,
+        <<"0b_10">>,
+        <<"0b10_">>,
+        <<"0b102">>
+    ],
+    lists:foreach(
+        fun(Number) ->
+            ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (", Number/binary, ")">>))
+        end,
+        Invalid
+    ).
+
 %% Checks escaping of backticks and trailing backslashes in ClickHouse identifiers.
 identifier_escape_test() ->
     ?assertEqual(<<"`a\\\\\\`b`">>, quote_identifier(<<"a\\`b">>)),

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
@@ -10,14 +10,29 @@
 
 -type placeholder() :: emqx_template:placeholder().
 
+%% Represent string templates, e.g. 'aaa ${bbb} ccc' as
+%% [
+%%   #tpl_text{text = <<"aaa ">>},
+%%   #tpl_placeholder{placeholder = {var, "bbb", ...}},
+%%   #tpl_text{text = <<"ccc ">>}
+%% ]
 -record(tpl_text, {text :: binary()}).
 -record(tpl_placeholder, {placeholder :: placeholder()}).
+
+%% Represent resolved parts of a template string,
+%% e.g. 'aaa ${bbb} ccc' might be pre-rendered as
+%% [
+%%   #part_text{text = <<"aaa ">>},
+%%   #part_value{value = BBBValue},
+%%   #part_text{text = <<"ccc ">>}
+%% ]
 -record(part_text, {text :: binary()}).
 -record(part_value, {value :: term()}).
 
 -type template_part() :: #tpl_text{} | #tpl_placeholder{}.
 -type part() :: #part_text{} | #part_value{}.
 
+%% Pre-rendered parts of a full SQL statement
 -record(raw, {sql :: binary()}).
 -record(sql_value, {placeholder :: placeholder()}).
 -record(json_value, {placeholder :: placeholder()}).
@@ -189,9 +204,8 @@ render_template_op(Parts, Encoder, Rest, Data, Opts, Cache0, Acc) ->
     end.
 
 encode_result(Encoder) ->
-    try Encoder() of
-        {error, _} = Error -> Error;
-        Encoded -> {ok, Encoded}
+    try
+        {ok, Encoder()}
     catch
         Class:Reason -> {error, {Class, Reason}}
     end.
@@ -672,10 +686,7 @@ encode_value(false, _Opts) ->
 encode_value(Value, _Opts) when is_integer(Value) ->
     integer_to_binary(Value);
 encode_value(Value, _Opts) when is_float(Value) ->
-    case Value =:= Value of
-        true -> float_to_binary(Value, [compact]);
-        false -> {error, non_finite_number}
-    end;
+    float_to_binary(Value, [compact]);
 encode_value(Value, _Opts) ->
     encode_sql_string(to_text(Value)).
 
@@ -709,6 +720,7 @@ encode_sql_string(Text) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+%% Checks accepted and rejected ClickHouse INSERT forms and their compiled plans.
 parse_insert_sql_template_test() ->
     Accepted = [
         {<<"insert into tag_VALUES(tag_values,Timestamp) values (${tagvalues},${date})"/utf8>>,
@@ -886,6 +898,7 @@ test_plan_template(#clickhouse_values_plan{plan = Plan}) ->
 test_plan_template(#clickhouse_json_plan{plan = Plan}) ->
     {<<>>, Plan}.
 
+%% Checks that compilation merges static SQL while preserving SQL and JSON placeholders.
 compile_merges_raw_segments_test() ->
     Placeholder = test_placeholder(<<"value">>),
     {ok, #clickhouse_values_plan{plan = [#raw{sql = <<"(1, 2)">>}]}} =
@@ -911,6 +924,7 @@ compile_merges_raw_segments_test() ->
         JSONPlan
     ).
 
+%% Checks compilation and rendering of a ClickHouse VALUES template.
 values_compile_and_render_test() ->
     {ok, Plan} = compile(
         <<"INSERT INTO mqtt_test(key, data, arrived) VALUES (${key}, '${data}', ${timestamp})">>
@@ -920,6 +934,7 @@ values_compile_and_render_test() ->
         rendered_binary(render(Plan, #{key => 1, data => <<"hello">>, timestamp => 2}, null_opts()))
     ).
 
+%% Checks rendering of CASE, logical operators, comparisons, and conditional functions.
 conditional_expression_test() ->
     SQL = <<
         "INSERT INTO t(a, b, c, d) VALUES ("
@@ -940,6 +955,54 @@ conditional_expression_test() ->
         rendered_binary(render(Plan, #{v => 10}, null_opts()))
     ).
 
+%% Checks quoted identifiers, SQL literals, arrays, and CASE expressions.
+sql_literal_expression_forms_test() ->
+    SQL = <<
+        "INSERT INTO \"a\"\"b\" (*) VALUES ("
+        "NULL, true, false, [1, 2], CASE WHEN 1 IS NULL THEN 2 END)"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO `a\"b` (*) VALUES ("
+            "NULL, true, false, [1, 2], CASE WHEN 1 IS NULL THEN 2 END)"
+        >>},
+        rendered_binary(render(Plan, #{}, null_opts()))
+    ).
+
+%% Checks static JSON objects, strings, booleans, nulls, and empty arrays.
+static_json_literal_forms_test() ->
+    {ok, Plan} = compile(
+        <<
+            "INSERT INTO t FORMAT JSONCompactEachRow "
+            "[{\"k\":\"x\",\"b\":true,\"f\":false,\"n\":null,\"e\":[]}]"
+        >>
+    ),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO `t` FORMAT JSONCompactEachRow "
+            "[{\"k\":\"x\",\"b\":true,\"f\":false,\"n\":null,\"e\":[]}]"
+        >>},
+        rendered_binary(render(Plan, #{}, null_opts()))
+    ).
+
+%% Checks rendering of missing values with both undefined-value policies.
+undefined_value_test() ->
+    {ok, ValuesPlan} = compile(<<"INSERT INTO t VALUES (${v}, '${v}', ${f})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` VALUES (NULL, 'null', 1.50000000000000000000e+00)">>},
+        rendered_binary(render(ValuesPlan, #{f => 1.5}, null_opts()))
+    ),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO `t` VALUES ('undefined', 'undefined', 1.50000000000000000000e+00)"
+        >>},
+        rendered_binary(
+            render(ValuesPlan, #{f => 1.5}, #{undefined_vars_as_null => false})
+        )
+    ).
+
+%% Checks that a placeholder with a leading dot resolves against the input map.
 leading_dot_placeholder_test() ->
     {ok, Plan} = compile(<<"INSERT INTO mqtt_test(payload) VALUES (${.payload})">>),
     ?assertEqual(
@@ -947,6 +1010,7 @@ leading_dot_placeholder_test() ->
         rendered_binary(render(Plan, #{payload => <<"hello">>}, null_opts()))
     ).
 
+%% Checks compilation and escaping of placeholders in JSONCompactEachRow templates.
 json_compile_and_render_test() ->
     {ok, Plan} = compile(
         <<"INSERT INTO mqtt_test(key, data) FORMAT JSONCompactEachRow [${key}, \"${data}\"]">>
@@ -957,12 +1021,14 @@ json_compile_and_render_test() ->
         rendered_binary(render(Plan, #{key => 1, data => <<"a\"b">>}, null_opts()))
     ).
 
+%% Checks that injected text remains valid SQL next to a statically escaped backslash.
 static_escape_boundary_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES ('\\\\${v}')">>),
     Attack = <<"'); INSERT INTO t(v) VALUES ('owned'); --">>,
     {ok, Rendered} = render(Plan, #{v => Attack}, null_opts()),
     ?assertMatch({ok, _}, compile(Rendered)).
 
+%% Checks decoding and preservation of ClickHouse string escape sequences.
 sql_escape_decode_test() ->
     {ok, Plan} = compile(
         <<"INSERT INTO t(v) VALUES ('\\a\\n\\r\\t\\b\\f\\e\\v\\0\\'\\q${v}')">>
@@ -974,6 +1040,7 @@ sql_escape_decode_test() ->
         rendered_binary(render(Plan, #{v => <<"x">>}, null_opts()))
     ).
 
+%% Checks JSON escapes, surrogate pairs, rendering, and invalid escape rejection.
 json_escape_decode_test() ->
     {ok, Plan} = compile(
         <<
@@ -992,6 +1059,7 @@ json_escape_decode_test() ->
         compile(<<"INSERT INTO t(v) FORMAT JSONCompactEachRow [\"\\q${v}\"]">>)
     ).
 
+%% Checks vertical-tab whitespace and escaped-newline lexical boundaries.
 lexical_boundary_test() ->
     SQL = iolist_to_binary([
         <<"INSERT">>,
@@ -1003,6 +1071,7 @@ lexical_boundary_test() ->
     ]),
     ?assertMatch({ok, _}, compile(SQL)).
 
+%% Checks batch shape, empty batches, safe escaping, and indexed render errors.
 batch_shape_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     {ok, Rendered} = render_batch(Plan, [#{v => <<"a');--">>}, #{v => <<"b">>}], null_opts()),
@@ -1011,8 +1080,13 @@ batch_shape_test() ->
     ?assertEqual(
         {ok, <<"INSERT INTO `t` (`v`) VALUES ">>},
         rendered_binary(render_batch(Plan, [], null_opts()))
+    ),
+    ?assertMatch(
+        {error, {clickhouse_template_render_failed, #{batch_index := 2, reason := _}}},
+        render_batch(Plan, [#{v => 1}, #{v => {unsupported}}], null_opts())
     ).
 
+%% Checks rendering of invalid UTF-8, NUL-containing, and Unicode binary values.
 binary_value_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     ?assertEqual(
@@ -1029,6 +1103,7 @@ binary_value_test() ->
         rendered_binary(render(Plan, #{v => Unicode}, null_opts()))
     ).
 
+%% Checks safe replacement of invalid UTF-8 when rendering JSON values.
 json_invalid_binary_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) FORMAT JSONCompactEachRow [${v}]">>),
     ?assertEqual(
@@ -1036,6 +1111,7 @@ json_invalid_binary_test() ->
         rendered_binary(render(Plan, #{v => <<16#FF>>}, null_opts()))
     ).
 
+%% Checks rejection of comments, dynamic targets, partial placeholders, and unsupported formats.
 reject_unsupported_syntax_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1) -- comment">>)),
     ?assertMatch({error, _}, compile(<<"INSERT INTO ${table} VALUES (1)">>)),
@@ -1043,6 +1119,7 @@ reject_unsupported_syntax_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (${value}0)">>)),
     ?assertMatch({error, _}, compile(<<"INSERT INTO t FORMAT CSV ${payload}">>)).
 
+%% Checks escaping of backticks and trailing backslashes in ClickHouse identifiers.
 identifier_escape_test() ->
     ?assertEqual(<<"`a\\\\\\`b`">>, quote_identifier(<<"a\\`b">>)),
     ?assertEqual(<<"`a\\\\`">>, quote_identifier(<<"a\\">>)).

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
@@ -190,7 +190,6 @@ render_template_op(Parts, Encoder, Rest, Data, Opts, Cache0, Acc) ->
 
 encode_result(Encoder) ->
     try Encoder() of
-        {ok, _} = Ok -> Ok;
         {error, _} = Error -> Error;
         Encoded -> {ok, Encoded}
     catch

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.xrl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.xrl
@@ -19,10 +19,18 @@ IDENTIFIER      = {ID_START}{ID_CONTINUE}*
 %% emqx_template placeholder envelope:
 %% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
-%% ClickHouse decimal token scanning:
+%% ClickHouse numeric token scanning:
 %% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L120-L223
 %% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L250-L287
-NUMBER          = (([0-9]+(\.[0-9]*)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
+DEC_DIGITS      = [0-9](_?[0-9])*
+HEX_DIGITS      = [0-9A-Fa-f](_?[0-9A-Fa-f])*
+BIN_DIGITS      = [01](_?[01])*
+DEC_EXPONENT    = [eE][+-]?{DEC_DIGITS}
+HEX_EXPONENT    = [pP][+-]?{DEC_DIGITS}
+DEC_NUMBER      = (({DEC_DIGITS}(\.{DEC_DIGITS}?)?)|(\.{DEC_DIGITS}))({DEC_EXPONENT})?
+HEX_NUMBER      = 0[xX]{HEX_DIGITS}(\.{HEX_DIGITS}?)?({HEX_EXPONENT})?
+BIN_NUMBER      = 0[bB]{BIN_DIGITS}
+NUMBER          = ({HEX_NUMBER}|{BIN_NUMBER}|{DEC_NUMBER})
 %% A doubled delimiter stays in the token. A backslash consumes the next byte:
 %% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L13-L46
 SQ_STRING       = '([^'\\]|\\[\000-\377]|'')*'

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.xrl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.xrl
@@ -3,33 +3,51 @@
 %%--------------------------------------------------------------------
 
 %% This lexer recognizes the restricted ClickHouse INSERT template token set.
+%% Leex selects the longest prefix. Rule order resolves equal-length matches.
 
 Definitions.
 
-WS              = [\s\t\r\n\f]+
-ID_START        = [A-Za-z_\200-\377]
-ID_CONTINUE     = [A-Za-z0-9_\200-\377]
+%% ClickHouse ASCII whitespace scanning:
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L107-L118
+WS              = [\s\t\r\n\v\f]+
+%% ClickHouse BareWord bytes:
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Common/StringUtils/StringUtils.h#L75-L120
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L425-L465
+ID_START        = [A-Za-z_\$]
+ID_CONTINUE     = [A-Za-z0-9_\$]
 IDENTIFIER      = {ID_START}{ID_CONTINUE}*
+%% emqx_template placeholder envelope:
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
+%% ClickHouse decimal token scanning:
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L120-L223
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L250-L287
 NUMBER          = (([0-9]+(\.[0-9]*)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
-SQ_STRING       = '([^'\\]|\\.|'')*'
-DQ_STRING       = "([^"\\]|\\.|"")*"
-BT_IDENTIFIER   = `([^`\\]|\\.|``)*`
+%% A doubled delimiter stays in the token. A backslash consumes the next byte:
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L13-L46
+SQ_STRING       = '([^'\\]|\\[\000-\377]|'')*'
+DQ_STRING       = "([^"\\]|\\[\000-\377]|"")*"
+BT_IDENTIFIER   = `([^`\\]|\\[\000-\377]|``)*`
 
 Rules.
 
 {WS}            : skip_token.
+%% Reject exact ClickHouse comment openers instead of scanning comment bodies:
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L292-L360
 --               : {error, {comments_not_allowed, TokenLine}}.
 \/\*             : {error, {comments_not_allowed, TokenLine}}.
 \/\/             : {error, {comments_not_allowed, TokenLine}}.
 \#[\s!]          : {error, {comments_not_allowed, TokenLine}}.
-\$[^\{]          : {error, {unsupported_clickhouse_syntax, TokenLine}}.
 {PLACEHOLDER}   : placeholder(TokenChars, TokenLine).
 {SQ_STRING}     : {token, {sq_string, TokenLine, to_binary(TokenChars)}}.
 {DQ_STRING}     : {token, {dq_string, TokenLine, to_binary(TokenChars)}}.
 {BT_IDENTIFIER} : {token, {bt_identifier, TokenLine, to_binary(TokenChars)}}.
 {NUMBER}        : {token, {number, TokenLine, to_binary(TokenChars)}}.
 {IDENTIFIER}    : identifier(TokenChars, TokenLine).
+%% ClickHouse source for the supported one-byte punctuation and operator forms:
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L233-L287
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L290-L363
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/Lexer.cpp#L396-L401
 \(              : {token, {'(', TokenLine}}.
 \)              : {token, {')', TokenLine}}.
 \[              : {token, {'[', TokenLine}}.
@@ -40,6 +58,14 @@ Rules.
 :               : {token, {':', TokenLine}}.
 \.              : {token, {'.', TokenLine}}.
 ;               : {token, {';', TokenLine}}.
+>=              : {token, {'>=', TokenLine}}.
+<=              : {token, {'<=', TokenLine}}.
+<>              : {token, {'<>', TokenLine}}.
+!=              : {token, {'!=', TokenLine}}.
+==              : {token, {'==', TokenLine}}.
+=               : {token, {'=', TokenLine}}.
+>               : {token, {'>', TokenLine}}.
+<               : {token, {'<', TokenLine}}.
 \+              : {token, {'+', TokenLine}}.
 -               : {token, {'-', TokenLine}}.
 \*              : {token, {'*', TokenLine}}.
@@ -64,6 +90,8 @@ placeholder(Chars, Line) ->
     end.
 
 identifier(Chars, Line) ->
+    %% ClickHouse classifies a keyword after scanning the complete BareWord:
+    %% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/CommonParsers.cpp#L7-L39
     Bin = to_binary(Chars),
     case string:lowercase(Bin) of
         <<"insert">> -> {token, {insert, Line}};
@@ -75,5 +103,14 @@ identifier(Chars, Line) ->
         <<"null">> -> {token, {null, Line}};
         <<"true">> -> {token, {true, Line}};
         <<"false">> -> {token, {false, Line}};
+        <<"case">> -> {token, {case_kw, Line}};
+        <<"when">> -> {token, {when_kw, Line}};
+        <<"then">> -> {token, {then_kw, Line}};
+        <<"else">> -> {token, {else_kw, Line}};
+        <<"end">> -> {token, {end_kw, Line}};
+        <<"is">> -> {token, {is_kw, Line}};
+        <<"and">> -> {token, {and_kw, Line}};
+        <<"or">> -> {token, {or_kw, Line}};
+        <<"not">> -> {token, {not_kw, Line}};
         _ -> {token, {identifier, Line, Bin}}
     end.

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.xrl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.xrl
@@ -1,0 +1,79 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% This lexer recognizes the restricted ClickHouse INSERT template token set.
+
+Definitions.
+
+WS              = [\s\t\r\n\f]+
+ID_START        = [A-Za-z_\200-\377]
+ID_CONTINUE     = [A-Za-z0-9_\200-\377]
+IDENTIFIER      = {ID_START}{ID_CONTINUE}*
+PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
+NUMBER          = (([0-9]+(\.[0-9]*)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
+SQ_STRING       = '([^'\\]|\\.|'')*'
+DQ_STRING       = "([^"\\]|\\.|"")*"
+BT_IDENTIFIER   = `([^`\\]|\\.|``)*`
+
+Rules.
+
+{WS}            : skip_token.
+--               : {error, {comments_not_allowed, TokenLine}}.
+\/\*             : {error, {comments_not_allowed, TokenLine}}.
+\/\/             : {error, {comments_not_allowed, TokenLine}}.
+\#[\s!]          : {error, {comments_not_allowed, TokenLine}}.
+\$[^\{]          : {error, {unsupported_clickhouse_syntax, TokenLine}}.
+{PLACEHOLDER}   : placeholder(TokenChars, TokenLine).
+{SQ_STRING}     : {token, {sq_string, TokenLine, to_binary(TokenChars)}}.
+{DQ_STRING}     : {token, {dq_string, TokenLine, to_binary(TokenChars)}}.
+{BT_IDENTIFIER} : {token, {bt_identifier, TokenLine, to_binary(TokenChars)}}.
+{NUMBER}        : {token, {number, TokenLine, to_binary(TokenChars)}}.
+{IDENTIFIER}    : identifier(TokenChars, TokenLine).
+\(              : {token, {'(', TokenLine}}.
+\)              : {token, {')', TokenLine}}.
+\[              : {token, {'[', TokenLine}}.
+\]              : {token, {']', TokenLine}}.
+\{              : {token, {'{', TokenLine}}.
+\}              : {token, {'}', TokenLine}}.
+,               : {token, {',', TokenLine}}.
+:               : {token, {':', TokenLine}}.
+\.              : {token, {'.', TokenLine}}.
+;               : {token, {';', TokenLine}}.
+\+              : {token, {'+', TokenLine}}.
+-               : {token, {'-', TokenLine}}.
+\*              : {token, {'*', TokenLine}}.
+\/              : {token, {'/', TokenLine}}.
+\%              : {token, {'%', TokenLine}}.
+'               : {error, {unterminated_string, TokenLine}}.
+"               : {error, {unterminated_quoted_identifier, TokenLine}}.
+`               : {error, {unterminated_backtick_identifier, TokenLine}}.
+\$              : {error, {invalid_placeholder, TokenLine}}.
+.               : {error, {unsupported_token, TokenLine, to_binary(TokenChars)}}.
+
+Erlang code.
+
+to_binary(Chars) ->
+    list_to_binary(Chars).
+
+placeholder(Chars, Line) ->
+    Bin = to_binary(Chars),
+    case emqx_bridge_clickhouse_sql:parse_placeholder(Bin) of
+        {ok, Placeholder} -> {token, {placeholder, Line, Placeholder}};
+        {error, _} -> {error, {invalid_placeholder, Line, Bin}}
+    end.
+
+identifier(Chars, Line) ->
+    Bin = to_binary(Chars),
+    case string:lowercase(Bin) of
+        <<"insert">> -> {token, {insert, Line}};
+        <<"into">> -> {token, {into, Line}};
+        <<"table">> -> {token, {table, Line}};
+        <<"values">> -> {token, {values, Line}};
+        <<"format">> -> {token, {format, Line}};
+        <<"except">> -> {token, {except, Line}};
+        <<"null">> -> {token, {null, Line}};
+        <<"true">> -> {token, {true, Line}};
+        <<"false">> -> {token, {false, Line}};
+        _ -> {token, {identifier, Line, Bin}}
+    end.

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_parser.yrl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_parser.yrl
@@ -1,0 +1,114 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% Restricted ClickHouse INSERT grammar for VALUES and JSONCompactEachRow templates.
+
+Nonterminals
+    template insert_stmt opt_table target static_identifier opt_columns columns column_items column_item
+    identifier_list source format_name sql_rows row expression_list expression expression_args opt_expression_args
+    json_array json_values opt_json_values json_value json_object json_members opt_json_members json_member
+    opt_semicolon.
+
+Terminals
+    insert into table values format except null true false
+    identifier placeholder number sq_string dq_string bt_identifier
+    '(' ')' '[' ']' '{' '}' ',' ':' '.' ';' '+' '-' '*' '/' '%'.
+
+Rootsymbol template.
+
+Left 100 '+' '-'.
+Left 200 '*' '/' '%'.
+
+template -> insert_stmt : '$1'.
+
+insert_stmt -> insert into opt_table target opt_columns source opt_semicolon :
+    {insert, #{target => '$4', columns => '$5', source => '$6'}}.
+
+opt_table -> '$empty' : false.
+opt_table -> table : true.
+
+target -> static_identifier : ['$1'].
+target -> static_identifier '.' static_identifier : ['$1', '$3'].
+
+static_identifier -> identifier : {identifier, bare, value('$1')}.
+static_identifier -> dq_string : {identifier, double, value('$1')}.
+static_identifier -> bt_identifier : {identifier, backtick, value('$1')}.
+
+opt_columns -> '$empty' : undefined.
+opt_columns -> columns : '$1'.
+
+columns -> '(' column_items ')' : '$2'.
+column_items -> column_item : ['$1'].
+column_items -> column_items ',' column_item : '$1' ++ ['$3'].
+column_item -> static_identifier : '$1'.
+column_item -> '*' : star.
+column_item -> '*' except '(' identifier_list ')' : {except, '$4'}.
+
+identifier_list -> static_identifier : ['$1'].
+identifier_list -> identifier_list ',' static_identifier : '$1' ++ ['$3'].
+
+source -> values sql_rows : {values, '$2'}.
+source -> format format_name sql_rows : {format_rows, '$2', '$3'}.
+source -> format format_name json_array : {format_json, '$2', '$3'}.
+format_name -> identifier : value('$1').
+format_name -> values : <<"Values">>.
+
+sql_rows -> row : ['$1'].
+sql_rows -> sql_rows ',' row : '$1' ++ ['$3'].
+row -> '(' expression_list ')' : {row, '$2'}.
+
+expression_list -> expression : ['$1'].
+expression_list -> expression_list ',' expression : '$1' ++ ['$3'].
+
+opt_expression_args -> '$empty' : [].
+opt_expression_args -> expression_args : '$1'.
+expression_args -> expression : ['$1'].
+expression_args -> expression_args ',' expression : '$1' ++ ['$3'].
+
+expression -> placeholder : {var, value('$1')}.
+expression -> sq_string : {string, value('$1')}.
+expression -> number : {number, value('$1')}.
+expression -> null : null.
+expression -> true : true.
+expression -> false : false.
+expression -> identifier : {identifier_value, value('$1')}.
+expression -> identifier '(' opt_expression_args ')' : {call, value('$1'), '$3'}.
+expression -> '(' expression ')' : {group, '$2'}.
+expression -> '[' opt_expression_args ']' : {array, '$2'}.
+expression -> '+' expression : {unary, '+', '$2'}.
+expression -> '-' expression : {unary, '-', '$2'}.
+expression -> expression '+' expression : {binary, '+', '$1', '$3'}.
+expression -> expression '-' expression : {binary, '-', '$1', '$3'}.
+expression -> expression '*' expression : {binary, '*', '$1', '$3'}.
+expression -> expression '/' expression : {binary, '/', '$1', '$3'}.
+expression -> expression '%' expression : {binary, '%', '$1', '$3'}.
+
+json_array -> '[' opt_json_values ']' : {json_array, '$2'}.
+opt_json_values -> '$empty' : [].
+opt_json_values -> json_values : '$1'.
+json_values -> json_value : ['$1'].
+json_values -> json_values ',' json_value : '$1' ++ ['$3'].
+json_value -> placeholder : {json_var, value('$1')}.
+json_value -> dq_string : {json_string, value('$1')}.
+json_value -> number : {json_number, value('$1')}.
+json_value -> '-' number : {json_number, <<"-", (value('$2'))/binary>>}.
+json_value -> true : true.
+json_value -> false : false.
+json_value -> null : null.
+json_value -> json_array : '$1'.
+json_value -> json_object : '$1'.
+
+json_object -> '{' opt_json_members '}' : {json_object, '$2'}.
+opt_json_members -> '$empty' : [].
+opt_json_members -> json_members : '$1'.
+json_members -> json_member : ['$1'].
+json_members -> json_members ',' json_member : '$1' ++ ['$3'].
+json_member -> dq_string ':' json_value : {value('$1'), '$3'}.
+
+opt_semicolon -> '$empty' : false.
+opt_semicolon -> ';' : true.
+
+Erlang code.
+
+value({_Token, _Line, Value}) -> Value.

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_parser.yrl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_parser.yrl
@@ -111,4 +111,6 @@ opt_semicolon -> ';' : true.
 
 Erlang code.
 
+-ignore_xref({return_error, 2}).
+
 value({_Token, _Line, Value}) -> Value.

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_parser.yrl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_parser.yrl
@@ -7,21 +7,31 @@
 Nonterminals
     template insert_stmt opt_table target static_identifier opt_columns columns column_items column_item
     identifier_list source format_name sql_rows row expression_list expression expression_args opt_expression_args
+    case_expression opt_case_operand when_clauses when_clause opt_case_else
     json_array json_values opt_json_values json_value json_object json_members opt_json_members json_member
     opt_semicolon.
 
 Terminals
     insert into table values format except null true false
+    case_kw when_kw then_kw else_kw end_kw is_kw and_kw or_kw not_kw
     identifier placeholder number sq_string dq_string bt_identifier
-    '(' ')' '[' ']' '{' '}' ',' ':' '.' ';' '+' '-' '*' '/' '%'.
+    '(' ')' '[' ']' '{' '}' ',' ':' '.' ';' '=' '==' '!=' '<>' '<=' '>=' '<' '>'
+    '+' '-' '*' '/' '%'.
 
+%% Trailing unconsumed tokens do not match and cause a parse error.
 Rootsymbol template.
 
+Left 10 or_kw.
+Left 20 and_kw.
+Right 30 not_kw.
+Nonassoc 40 '=' '==' '!=' '<>' '<=' '>=' '<' '>' is_kw.
 Left 100 '+' '-'.
 Left 200 '*' '/' '%'.
 
 template -> insert_stmt : '$1'.
 
+%% This grammar is a restricted subset of ClickHouse INSERT:
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/ParserInsertQuery.cpp#L26-L115
 insert_stmt -> insert into opt_table target opt_columns source opt_semicolon :
     {insert, #{target => '$4', columns => '$5', source => '$6'}}.
 
@@ -48,6 +58,9 @@ column_item -> '*' except '(' identifier_list ')' : {except, '$4'}.
 identifier_list -> static_identifier : ['$1'].
 identifier_list -> identifier_list ',' static_identifier : '$1' ++ ['$3'].
 
+%% ClickHouse hands inline INSERT data to the selected format reader:
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Parsers/ParserInsertQuery.cpp#L143-L163
+%% https://github.com/ClickHouse/ClickHouse/blob/8dfb1700858195fa704221e360fa0798ac6ee9ed/src/Processors/Transforms/getSourceFromASTInsertQuery.cpp#L29-L64
 source -> values sql_rows : {values, '$2'}.
 source -> format format_name sql_rows : {format_rows, '$2', '$3'}.
 source -> format format_name json_array : {format_json, '$2', '$3'}.
@@ -72,17 +85,43 @@ expression -> number : {number, value('$1')}.
 expression -> null : null.
 expression -> true : true.
 expression -> false : false.
+expression -> case_expression : '$1'.
 expression -> identifier : {identifier_value, value('$1')}.
 expression -> identifier '(' opt_expression_args ')' : {call, value('$1'), '$3'}.
+expression -> and_kw '(' opt_expression_args ')' : {call, <<"and">>, '$3'}.
+expression -> or_kw '(' opt_expression_args ')' : {call, <<"or">>, '$3'}.
 expression -> '(' expression ')' : {group, '$2'}.
 expression -> '[' opt_expression_args ']' : {array, '$2'}.
 expression -> '+' expression : {unary, '+', '$2'}.
 expression -> '-' expression : {unary, '-', '$2'}.
+expression -> not_kw expression : {unary, 'NOT', '$2'}.
+expression -> expression '=' expression : {binary, '=', '$1', '$3'}.
+expression -> expression '==' expression : {binary, '==', '$1', '$3'}.
+expression -> expression '!=' expression : {binary, '!=', '$1', '$3'}.
+expression -> expression '<>' expression : {binary, '<>', '$1', '$3'}.
+expression -> expression '<=' expression : {binary, '<=', '$1', '$3'}.
+expression -> expression '>=' expression : {binary, '>=', '$1', '$3'}.
+expression -> expression '<' expression : {binary, '<', '$1', '$3'}.
+expression -> expression '>' expression : {binary, '>', '$1', '$3'}.
+expression -> expression is_kw null : {is_null, '$1', false}.
+expression -> expression is_kw not_kw null : {is_null, '$1', true}.
+expression -> expression and_kw expression : {binary, 'AND', '$1', '$3'}.
+expression -> expression or_kw expression : {binary, 'OR', '$1', '$3'}.
 expression -> expression '+' expression : {binary, '+', '$1', '$3'}.
 expression -> expression '-' expression : {binary, '-', '$1', '$3'}.
 expression -> expression '*' expression : {binary, '*', '$1', '$3'}.
 expression -> expression '/' expression : {binary, '/', '$1', '$3'}.
 expression -> expression '%' expression : {binary, '%', '$1', '$3'}.
+
+case_expression -> case_kw opt_case_operand when_clauses opt_case_else end_kw :
+    {case_expression, '$2', '$3', '$4'}.
+opt_case_operand -> '$empty' : undefined.
+opt_case_operand -> expression : '$1'.
+when_clauses -> when_clause : ['$1'].
+when_clauses -> when_clauses when_clause : '$1' ++ ['$2'].
+when_clause -> when_kw expression then_kw expression : {'when', '$2', '$4'}.
+opt_case_else -> '$empty' : undefined.
+opt_case_else -> else_kw expression : '$2'.
 
 json_array -> '[' opt_json_values ']' : {json_array, '$2'}.
 opt_json_values -> '$empty' : [].

--- a/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
+++ b/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
@@ -260,29 +260,41 @@ t_send_message_query(Config) ->
     ok.
 
 t_sql_value_escaping(Config) ->
-    Payload = <<"x\\'); DROP TABLE mqtt.mqtt_test; --">>,
+    Attack = <<"x\\'); DROP TABLE mqtt.mqtt_test; --">>,
+    Cases = [
+        {0, Attack},
+        {1, <<16#FF>>},
+        {2, <<"a", 0, "b">>},
+        {3, <<"你好😀"/utf8>>}
+    ],
     lists:foreach(
-        fun({EnableBatch, Key}) ->
+        fun({EnableBatch, BaseKey}) ->
             BridgeID = make_bridge(#{
                 enable_batch => EnableBatch,
                 batch_size => 1
             }),
-            Message = #{key => Key, data => Payload, timestamp => 10000},
-            emqx_bridge:send_message(BridgeID, Message),
-            check_key_in_clickhouse(Key, Config),
-            ClickhouseConnection = proplists:get_value(clickhouse_connection, Config),
-            {ok, 200, Result} = clickhouse:query(
-                ClickhouseConnection,
-                sql_find_data(Key),
-                []
-            ),
-            ?assertEqual(
-                binary:encode_hex(Payload),
-                iolist_to_binary(string:trim(Result))
+            lists:foreach(
+                fun({Offset, Payload}) ->
+                    Key = BaseKey + Offset,
+                    Message = #{key => Key, data => Payload, timestamp => 10000},
+                    emqx_bridge:send_message(BridgeID, Message),
+                    check_key_in_clickhouse(Key, Config),
+                    ClickhouseConnection = proplists:get_value(clickhouse_connection, Config),
+                    {ok, 200, Result} = clickhouse:query(
+                        ClickhouseConnection,
+                        sql_find_data(Key),
+                        []
+                    ),
+                    ?assertEqual(
+                        binary:encode_hex(Payload),
+                        iolist_to_binary(string:trim(Result))
+                    )
+                end,
+                Cases
             ),
             delete_bridge()
         end,
-        [{false, 4201}, {true, 4202}]
+        [{false, 4210}, {true, 4220}]
     ),
     JSONPayload = <<"x\"], [999, \"injected\", 0]">>,
     BridgeID = make_bridge(#{
@@ -297,6 +309,21 @@ t_sql_value_escaping(Config) ->
     ClickhouseConnection = proplists:get_value(clickhouse_connection, Config),
     {ok, 200, Result} = clickhouse:query(ClickhouseConnection, sql_find_data(4203), []),
     ?assertEqual(binary:encode_hex(JSONPayload), iolist_to_binary(string:trim(Result))),
+    delete_bridge(),
+    CasePayload = <<"case-null">>,
+    CaseBridgeID = make_bridge(#{
+        enable_batch => false,
+        sql =>
+            "INSERT INTO mqtt_test(key, data, arrived) VALUES "
+            "(${key}, CASE WHEN ${data} = 'null' THEN 'case-null' ELSE ${data} END, ${timestamp})"
+    }),
+    emqx_bridge:send_message(
+        CaseBridgeID,
+        #{key => 4204, data => <<"null">>, timestamp => 10000}
+    ),
+    check_key_in_clickhouse(4204, Config),
+    {ok, 200, CaseResult} = clickhouse:query(ClickhouseConnection, sql_find_data(4204), []),
+    ?assertEqual(binary:encode_hex(CasePayload), iolist_to_binary(string:trim(CaseResult))),
     delete_bridge().
 
 t_undefined_vars_as_null(Config) ->

--- a/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
+++ b/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
@@ -259,6 +259,7 @@ t_send_message_query(Config) ->
     delete_bridge(),
     ok.
 
+%% Checks safe storage of injected, binary, JSON, Unicode, NUL, and CASE-derived values.
 t_sql_value_escaping(Config) ->
     Attack = <<"x\\'); DROP TABLE mqtt.mqtt_test; --">>,
     Cases = [

--- a/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
+++ b/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
@@ -117,6 +117,9 @@ sql_create_table() ->
 sql_find_key(Key) ->
     io_lib:format("SELECT key FROM mqtt.mqtt_test WHERE key = ~p", [Key]).
 
+sql_find_data(Key) ->
+    io_lib:format("SELECT hex(data) FROM mqtt.mqtt_test WHERE key = ~p", [Key]).
+
 sql_find_all_keys() ->
     "SELECT key FROM mqtt.mqtt_test".
 
@@ -135,9 +138,6 @@ clickhouse_url() ->
     Host = clickhouse_host(),
     Port = clickhouse_port(),
     erlang:iolist_to_binary(["http://", Host, ":", Port]).
-
-parse_insert(SQL) ->
-    emqx_bridge_clickhouse_connector:split_clickhouse_insert_sql(SQL).
 
 clickhouse_config(Config) ->
     SQL = maps:get(sql, Config, sql_insert_template_for_bridge()),
@@ -248,139 +248,6 @@ t_make_delete_bridge(_Config) ->
     false = lists:any(IsRightName, BridgesAfterDelete),
     ok.
 
-t_parse_insert_sql_template(_Config) ->
-    ?assertEqual(
-        <<"(${tagvalues},${date})"/utf8>>,
-        parse_insert(
-            <<"insert into tag_VALUES(tag_values,Timestamp) values (${tagvalues},${date})"/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(${id}, 'Иван', 25)"/utf8>>,
-        parse_insert(
-            <<"INSERT INTO Values_таблица (идентификатор, имя, возраст)   VALUES \t (${id}, 'Иван', 25)  "/utf8>>
-        )
-    ),
-    %% with `;` suffix, bug-to-bug compatibility
-    ?assertEqual(
-        <<"(${id}, 'Иван', 25)"/utf8>>,
-        parse_insert(
-            <<"INSERT INTO Values_таблица (идентификатор, имя, возраст)   VALUES \t (${id}, 'Иван', 25);  "/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(${id},'李四', 35)"/utf8>>,
-        parse_insert(
-            <<"  inSErt into 表格(标识,名字,年龄)values(${id},'李四', 35) ; "/utf8>>
-        )
-    ),
-
-    %% `values` in column name
-    ?assertEqual(
-        <<"(${tagvalues},${date}  )"/utf8>>,
-        parse_insert(
-            <<"insert into PI.dbo.tags(tag_values,Timestamp) values (${tagvalues},${date}  )"/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(${payload}, FROM_UNIXTIME((${timestamp}/1000)))">>,
-        parse_insert(
-            <<"INSERT INTO mqtt_test(payload, arrived) VALUES (${payload}, FROM_UNIXTIME((${timestamp}/1000)))"/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(${id},'Алексей',30)"/utf8>>,
-        parse_insert(
-            <<"insert into таблица (идентификатор,имя,возраст) VALUES(${id},'Алексей',30)"/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(${id}, '张三', 22)"/utf8>>,
-        parse_insert(
-            <<"INSERT into 表格 (标识, 名字, 年龄) VALUES (${id}, '张三', 22)"/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(${id},'李四', 35)"/utf8>>,
-        parse_insert(
-            <<"  inSErt into 表格(标识,名字,年龄)values(${id},'李四', 35)"/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(   ${tagvalues},   ${date} )"/utf8>>,
-        parse_insert(
-            <<"insert into PI.dbo.tags( tag_value,Timestamp)  VALUES\t\t(   ${tagvalues},   ${date} )"/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(${tagvalues},${date})"/utf8>>,
-        parse_insert(
-            <<"insert into PI.dbo.tags(tag_value , Timestamp )vALues(${tagvalues},${date})"/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(${one}, ${two},${three})"/utf8>>,
-        parse_insert(
-            <<"inSErt  INTO  table75 (column1, column2, column3) values (${one}, ${two},${three})"/utf8>>
-        )
-    ),
-    ?assertEqual(
-        <<"(${tag1},   ${tag2}  )">>,
-        parse_insert(
-            <<"INSERT Into some_table      values\t(${tag1},   ${tag2}  )">>
-        )
-    ),
-    ?assertEqual(
-        <<"(2, 2)">>,
-        parse_insert(
-            <<"INSERT INTO insert_select_testtable (* EXCEPT(b)) Values (2, 2)">>
-        )
-    ),
-    ?assertEqual(
-        <<"(2, 2), (3, ${five})">>,
-        parse_insert(
-            <<"INSERT INTO insert_select_testtable (* EXCEPT(b))Values(2, 2), (3, ${five})">>
-        )
-    ),
-
-    %% `format`
-    ?assertEqual(
-        <<"[(${key}, \"${data}\", ${timestamp})]">>,
-        parse_insert(
-            <<"INSERT INTO mqtt_test(key, data, arrived)",
-                " FORMAT JSONCompactEachRow [(${key}, \"${data}\", ${timestamp})]">>
-        )
-    ),
-    ?assertEqual(
-        <<"(v11, v12, v13), (v21, v22, v23)">>,
-        parse_insert(
-            <<"INSERT INTO   mqtt_test(key, data, arrived) FORMAT Values (v11, v12, v13), (v21, v22, v23)">>
-        )
-    ),
-
-    ?assertEqual(
-        <<"👋    .."/utf8>>,
-        %% Only check if FORMAT_DATA existed after `FORMAT FORMAT_NAME`
-        parse_insert(
-            <<"INSERT INTO   mqtt_test(key, data, arrived) FORMAT AnyFORMAT  👋    .."/utf8>>
-        )
-    ),
-
-    ErrMsg = <<"The SQL template should be an SQL INSERT statement but it is something else.">>,
-    %% No `FORMAT_DATA`
-    ?assertError(
-        ErrMsg,
-        parse_insert(
-            <<"INSERT INTO   mqtt_test(key, data, arrived) FORMAT Values">>
-        )
-    ),
-    ?assertError(
-        ErrMsg,
-        parse_insert(
-            <<"INSERT INTO   mqtt_test(key, data, arrived) FORMAT Values  ">>
-        )
-    ).
-
 t_send_message_query(Config) ->
     BridgeID = make_bridge(#{enable_batch => false}),
     Key = 42,
@@ -391,6 +258,46 @@ t_send_message_query(Config) ->
     check_key_in_clickhouse(Key, Config),
     delete_bridge(),
     ok.
+
+t_sql_value_escaping(Config) ->
+    Payload = <<"x\\'); DROP TABLE mqtt.mqtt_test; --">>,
+    lists:foreach(
+        fun({EnableBatch, Key}) ->
+            BridgeID = make_bridge(#{
+                enable_batch => EnableBatch,
+                batch_size => 1
+            }),
+            Message = #{key => Key, data => Payload, timestamp => 10000},
+            emqx_bridge:send_message(BridgeID, Message),
+            check_key_in_clickhouse(Key, Config),
+            ClickhouseConnection = proplists:get_value(clickhouse_connection, Config),
+            {ok, 200, Result} = clickhouse:query(
+                ClickhouseConnection,
+                sql_find_data(Key),
+                []
+            ),
+            ?assertEqual(
+                binary:encode_hex(Payload),
+                iolist_to_binary(string:trim(Result))
+            ),
+            delete_bridge()
+        end,
+        [{false, 4201}, {true, 4202}]
+    ),
+    JSONPayload = <<"x\"], [999, \"injected\", 0]">>,
+    BridgeID = make_bridge(#{
+        enable_batch => true,
+        batch_size => 1,
+        sql => sql_insert_template_for_bridge_json(),
+        batch_value_separator => <<>>
+    }),
+    Message = #{key => 4203, data => JSONPayload, timestamp => 10000},
+    emqx_bridge:send_message(BridgeID, Message),
+    check_key_in_clickhouse(4203, Config),
+    ClickhouseConnection = proplists:get_value(clickhouse_connection, Config),
+    {ok, 200, Result} = clickhouse:query(ClickhouseConnection, sql_find_data(4203), []),
+    ?assertEqual(binary:encode_hex(JSONPayload), iolist_to_binary(string:trim(Result))),
+    delete_bridge().
 
 t_undefined_vars_as_null(Config) ->
     BridgeID = make_bridge(#{enable_batch => false}, #{<<"undefined_vars_as_null">> => true}),

--- a/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
+++ b/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
@@ -269,10 +269,9 @@ t_sql_value_escaping(Config) ->
         {3, <<"你好😀"/utf8>>}
     ],
     lists:foreach(
-        fun({EnableBatch, BaseKey}) ->
+        fun({BatchSize, BaseKey}) ->
             BridgeID = make_bridge(#{
-                enable_batch => EnableBatch,
-                batch_size => 1
+                batch_size => BatchSize
             }),
             lists:foreach(
                 fun({Offset, Payload}) ->
@@ -295,11 +294,10 @@ t_sql_value_escaping(Config) ->
             ),
             delete_bridge()
         end,
-        [{false, 4210}, {true, 4220}]
+        [{1, 4210}, {100, 4220}]
     ),
     JSONPayload = <<"x\"], [999, \"injected\", 0]">>,
     BridgeID = make_bridge(#{
-        enable_batch => true,
         batch_size => 1,
         sql => sql_insert_template_for_bridge_json(),
         batch_value_separator => <<>>
@@ -313,7 +311,6 @@ t_sql_value_escaping(Config) ->
     delete_bridge(),
     CasePayload = <<"case-null">>,
     CaseBridgeID = make_bridge(#{
-        enable_batch => false,
         sql =>
             "INSERT INTO mqtt_test(key, data, arrived) VALUES "
             "(${key}, CASE WHEN ${data} = 'null' THEN 'case-null' ELSE ${data} END, ${timestamp})"

--- a/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
+++ b/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
@@ -259,6 +259,21 @@ t_send_message_query(Config) ->
     delete_bridge(),
     ok.
 
+%% Checks decimal separators and base-prefixed literals against ClickHouse.
+t_numeric_literals(Config) ->
+    BridgeID = make_bridge(#{
+        batch_size => 1,
+        sql =>
+            "INSERT INTO mqtt_test(key, data, arrived) VALUES "
+            "(0x2_A, toString(0b10_1010), 4_2)"
+    }),
+    emqx_bridge:send_message(BridgeID, #{}),
+    check_key_in_clickhouse(42, Config),
+    ClickhouseConnection = proplists:get_value(clickhouse_connection, Config),
+    {ok, 200, Result} = clickhouse:query(ClickhouseConnection, sql_find_data(42), []),
+    ?assertEqual(binary:encode_hex(<<"42">>), iolist_to_binary(string:trim(Result))),
+    delete_bridge().
+
 %% Checks safe storage of injected, binary, JSON, Unicode, NUL, and CASE-derived values.
 t_sql_value_escaping(Config) ->
     Attack = <<"x\\'); DROP TABLE mqtt.mqtt_test; --">>,

--- a/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_connector_SUITE.erl
+++ b/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_connector_SUITE.erl
@@ -12,7 +12,6 @@
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
 
--define(APP, emqx_bridge_clickhouse).
 -define(CLICKHOUSE_RESOURCE_MOD, emqx_bridge_clickhouse_connector).
 -define(CLICKHOUSE_PASSWORD, "public").
 

--- a/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
+++ b/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
@@ -28,6 +28,7 @@
 -define(MYSQL_USERNAME, "root").
 -define(MYSQL_PASSWORD, "public").
 -define(MYSQL_POOL_SIZE, 4).
+-define(UNSAFE_SQL_MODES, [<<"ANSI_QUOTES">>, <<"NO_BACKSLASH_ESCAPES">>]).
 
 -define(WORKER_POOL_SIZE, 4).
 
@@ -42,11 +43,19 @@
 all() ->
     [
         {group, tcp},
-        {group, tls}
+        {group, tls},
+        {group, tcp_nbe}
     ].
 
 groups() ->
     TCs = emqx_common_test_helpers:all(?MODULE),
+    SecurityCases = [
+        t_sql_injection_through_comment_placeholder,
+        t_sql_injection_through_no_backslash,
+        t_nbe_session_mode,
+        t_nbe_session_mode_after_reconnect
+    ],
+    RegularTCs = TCs -- SecurityCases,
     NonBatchCases = [
         t_write_timeout,
         t_uninitialized_prepared_statement,
@@ -63,12 +72,19 @@ groups() ->
     ],
     QueryModeGroups = [{group, async}, {group, sync}],
     [
-        {tcp, QueryModeGroups},
+        {tcp, QueryModeGroups ++ [{group, security_with_batch}]},
         {tls, QueryModeGroups},
+        {tcp_nbe, [{group, nbe_with_batch}]},
         {async, BatchingGroups},
         {sync, BatchingGroups},
-        {with_batch, TCs -- NonBatchCases},
-        {without_batch, TCs -- OnlyBatchCases}
+        {with_batch, RegularTCs -- NonBatchCases},
+        {without_batch, RegularTCs -- OnlyBatchCases},
+        {security_with_batch, [t_sql_injection_through_comment_placeholder]},
+        {nbe_with_batch, [
+            t_sql_injection_through_no_backslash,
+            t_nbe_session_mode,
+            t_nbe_session_mode_after_reconnect
+        ]}
     ].
 
 init_per_group(tcp, Config) ->
@@ -91,6 +107,16 @@ init_per_group(tls, Config) ->
         {proxy_name, "mysql_tls"}
         | Config
     ];
+init_per_group(tcp_nbe, Config) ->
+    MysqlHost = os:getenv("MYSQL_NBE_HOST", "toxiproxy"),
+    MysqlPort = list_to_integer(os:getenv("MYSQL_NBE_PORT", "3308")),
+    [
+        {mysql_host, MysqlHost},
+        {mysql_port, MysqlPort},
+        {enable_tls, false},
+        {proxy_name, "mysql_nbe"}
+        | Config
+    ];
 init_per_group(async, Config) ->
     [{query_mode, async} | Config];
 init_per_group(sync, Config) ->
@@ -101,10 +127,18 @@ init_per_group(with_batch, Config0) ->
 init_per_group(without_batch, Config0) ->
     Config = [{batch_size, 1} | Config0],
     common_init(Config);
+init_per_group(Group, Config0) when Group =:= security_with_batch; Group =:= nbe_with_batch ->
+    Config = [{batch_size, 100}, {query_mode, sync} | Config0],
+    common_init(Config);
 init_per_group(_Group, Config) ->
     Config.
 
-end_per_group(Group, Config) when Group =:= with_batch; Group =:= without_batch ->
+end_per_group(Group, Config) when
+    Group =:= with_batch;
+    Group =:= without_batch;
+    Group =:= security_with_batch;
+    Group =:= nbe_with_batch
+->
     Apps = ?config(apps, Config),
     connect_and_drop_table(Config),
     ProxyHost = ?config(proxy_host, Config),
@@ -307,6 +341,9 @@ receive_result(Ref, Timeout) ->
     end.
 
 unprepare(Config, Key) ->
+    [ok = mysql:unprepare(Conn, Key) || Conn <- pool_connections(Config)].
+
+pool_connections(Config) ->
     Name = ?config(mysql_name, Config),
     BridgeType = ?config(mysql_bridge_type, Config),
     ResourceID = emqx_bridge_resource:resource_id(BridgeType, Name),
@@ -316,10 +353,32 @@ unprepare(Config, Key) ->
     [
         begin
             {ok, Conn} = ecpool_worker:client(Worker),
-            ok = mysql:unprepare(Conn, Key)
+            Conn
         end
      || {_Name, Worker} <- ecpool:workers(PoolName)
     ].
+
+assert_pool_session_modes(Config) ->
+    Connections = pool_connections(Config),
+    ?assertEqual(?MYSQL_POOL_SIZE, length(Connections)),
+    lists:foreach(
+        fun(Conn) -> ?assertEqual([], connection_session_modes(Conn)) end,
+        Connections
+    ),
+    Connections.
+
+connection_session_modes(Conn) ->
+    {ok, _, [[Modes]]} = mysql:query(Conn, <<"SELECT @@SESSION.sql_mode">>),
+    decode_sql_modes(Modes).
+
+direct_session_modes(Config) ->
+    {ok, _, [[Modes]]} = query_direct_mysql(Config, <<"SELECT @@SESSION.sql_mode">>),
+    decode_sql_modes(Modes).
+
+decode_sql_modes(<<>>) ->
+    [];
+decode_sql_modes(Modes) ->
+    lists:sort(binary:split(Modes, <<",">>, [global])).
 
 % We need to create and drop the test table outside of using bridges
 % since a bridge expects the table to exist when enabling it. We
@@ -711,6 +770,96 @@ t_nasty_sql_string(Config) ->
     ?assertMatch(
         {ok, [<<"payload">>], [[Payload]]},
         connect_and_get_payload(Config)
+    ).
+
+t_sql_injection_through_comment_placeholder(Config) ->
+    ok = query_direct_mysql(Config, <<"DROP TABLE IF EXISTS mqtt_users">>),
+    ok = query_direct_mysql(Config, <<
+        "CREATE TABLE mqtt_users (username varchar(255) NOT NULL, arrived datetime NOT NULL) "
+        "DEFAULT CHARSET=utf8MB4"
+    >>),
+    on_exit(fun() -> query_direct_mysql(Config, <<"DROP TABLE IF EXISTS mqtt_users">>) end),
+    SQL = <<
+        "INSERT INTO mqtt_users(username, arrived) "
+        "VALUES ('regular_user', NOW() /* ${payload} */)"
+    >>,
+    Overrides = #{<<"sql">> => SQL},
+    %% Batch templates containing comments must be rejected before rendering values into them.
+    ProbeResult = emqx_bridge_testlib:probe_bridge_api(Config, Overrides),
+    ?assertMatch(
+        {error, {{_, 400, _}, _, _}},
+        ProbeResult
+    ),
+    {error, {{_, 400, _}, _, ProbeBody}} = ProbeResult,
+    ?assertEqual(
+        match,
+        re:run(ProbeBody, <<"failed_to_prepare_statement">>, [{capture, none}])
+    ).
+
+t_sql_injection_through_no_backslash(Config) ->
+    ok = query_direct_mysql(Config, <<"DROP TABLE IF EXISTS mqtt_users">>),
+    ok = query_direct_mysql(Config, <<
+        "CREATE TABLE mqtt_users ("
+        "username varchar(255) NOT NULL, note varchar(255) NOT NULL, arrived datetime NOT NULL) "
+        "DEFAULT CHARSET=utf8MB4"
+    >>),
+    on_exit(fun() -> query_direct_mysql(Config, <<"DROP TABLE IF EXISTS mqtt_users">>) end),
+    ?assertEqual(?UNSAFE_SQL_MODES, direct_session_modes(Config)),
+    SQL = <<
+        "INSERT INTO mqtt_users(username, note, arrived) "
+        "VALUES ('regular_user', ${payload}, NOW())"
+    >>,
+    ?assertMatch({ok, _}, create_bridge(Config, #{<<"sql">> => SQL})),
+    %% Vulnerable backslash escaping lets this value inject a second row for `admin`.
+    Payload = <<"\\', NOW()),(CHAR(97,100,109,105,110),CHAR(112,119,110),NOW()) -- ">>,
+    {Result, {ok, _}} =
+        ?wait_async_action(
+            send_message(Config, #{payload => Payload}),
+            #{?snk_kind := mysql_connector_query_return},
+            10_000
+        ),
+    ?assertEqual(ok, Result),
+    ?assertEqual(
+        {ok, [<<"username">>, <<"note">>], [[<<"regular_user">>, Payload]]},
+        query_direct_mysql(Config, <<"SELECT username, note FROM mqtt_users">>)
+    ),
+    ?assertEqual(
+        {ok, [<<"username">>], []},
+        query_direct_mysql(Config, <<"SELECT username FROM mqtt_users WHERE username = 'admin'">>)
+    ).
+
+t_nbe_session_mode(Config) ->
+    ?assertEqual(?UNSAFE_SQL_MODES, direct_session_modes(Config)),
+    ?assertMatch({ok, _}, create_bridge(Config)),
+    _ = assert_pool_session_modes(Config),
+    ok.
+
+t_nbe_session_mode_after_reconnect(Config) ->
+    ?assertEqual(?UNSAFE_SQL_MODES, direct_session_modes(Config)),
+    ?assertMatch({ok, _}, create_bridge(Config)),
+    OldConnections = assert_pool_session_modes(Config),
+    ProxyName = ?config(proxy_name, Config),
+    ProxyHost = ?config(proxy_host, Config),
+    ProxyPort = ?config(proxy_port, Config),
+    emqx_common_test_helpers:enable_failure(down, ProxyName, ProxyHost, ProxyPort),
+    ?retry(
+        100,
+        50,
+        ?assert(lists:all(fun(Conn) -> not is_process_alive(Conn) end, OldConnections))
+    ),
+    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
+    ?retry(
+        500,
+        20,
+        begin
+            NewConnections = assert_pool_session_modes(Config),
+            ?assert(
+                lists:all(
+                    fun(Conn) -> not lists:member(Conn, OldConnections) end,
+                    NewConnections
+                )
+            )
+        end
     ).
 
 t_workload_fits_prepared_statement_limit(Config) ->

--- a/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
+++ b/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
@@ -772,6 +772,7 @@ t_nasty_sql_string(Config) ->
         connect_and_get_payload(Config)
     ).
 
+%% Checks rejection of batch SQL templates with a placeholder inside a comment.
 t_sql_injection_through_comment_placeholder(Config) ->
     ok = query_direct_mysql(Config, <<"DROP TABLE IF EXISTS mqtt_users">>),
     ok = query_direct_mysql(Config, <<
@@ -796,6 +797,7 @@ t_sql_injection_through_comment_placeholder(Config) ->
         re:run(ProbeBody, <<"failed_to_prepare_statement">>, [{capture, none}])
     ).
 
+%% Checks that payloads cannot inject rows when MySQL disables backslash escaping.
 t_sql_injection_through_no_backslash(Config) ->
     ok = query_direct_mysql(Config, <<"DROP TABLE IF EXISTS mqtt_users">>),
     ok = query_direct_mysql(Config, <<
@@ -828,12 +830,14 @@ t_sql_injection_through_no_backslash(Config) ->
         query_direct_mysql(Config, <<"SELECT username FROM mqtt_users WHERE username = 'admin'">>)
     ).
 
+%% Checks that connector pool sessions remove unsafe MySQL SQL modes.
 t_nbe_session_mode(Config) ->
     ?assertEqual(?UNSAFE_SQL_MODES, direct_session_modes(Config)),
     ?assertMatch({ok, _}, create_bridge(Config)),
     _ = assert_pool_session_modes(Config),
     ok.
 
+%% Checks that replacement pool connections remove unsafe SQL modes after reconnecting.
 t_nbe_session_mode_after_reconnect(Config) ->
     ?assertEqual(?UNSAFE_SQL_MODES, direct_session_modes(Config)),
     ?assertMatch({ok, _}, create_bridge(Config)),

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver.app.src
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_sqlserver, [
     {description, "EMQX Enterprise SQL Server Bridge"},
-    {vsn, "0.2.9"},
+    {vsn, "0.2.10"},
     {registered, []},
     {applications, [kernel, stdlib, emqx_resource, odbc]},
     {env, [

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -70,11 +70,6 @@
     maps:get(request_ttl, RESOURCE_OPTS, ?DEFAULT_REQUEST_TTL)
 ).
 
--define(BATCH_INSERT_TEMP, batch_insert_temp).
-
--define(BATCH_INSERT_PART, batch_insert_part).
--define(BATCH_PARAMS_TOKENS, batch_insert_tks).
-
 -define(FILE_MODE_755, 33261).
 %% 32768 + 8#00400 + 8#00200 + 8#00100 + 8#00040 + 8#00010 + 8#00004 + 8#00001
 %% See also
@@ -86,7 +81,7 @@
 %% as returned by connect/2
 -type connection_reference() :: term().
 -type time_out() :: milliseconds() | infinity.
--type sql() :: string() | binary().
+-type sql() :: iolist().
 -type milliseconds() :: pos_integer().
 %% Tuple of column values e.g. one row of the result set.
 %% it's a variable size tuple of column values.
@@ -248,17 +243,30 @@ on_add_channel(
     ChannelId,
     ChannelConfig
 ) ->
-    {ok, ChannelState} = create_channel_state(ChannelConfig),
-    NewInstalledChannels = maps:put(ChannelId, ChannelState, InstalledChannels),
-    %% Update state
-    NewState = OldState#{installed_channels => NewInstalledChannels},
-    {ok, NewState}.
+    case create_channel_state(ChannelConfig) of
+        {ok, ChannelState} ->
+            NewInstalledChannels = maps:put(ChannelId, ChannelState, InstalledChannels),
+            %% Update state
+            NewState = OldState#{installed_channels => NewInstalledChannels},
+            {ok, NewState};
+        {error, _} = Error ->
+            Error
+    end.
 
 create_channel_state(
     #{parameters := ChannelConf}
 ) ->
-    State = #{sql_templates => parse_sql_template(ChannelConf), channel_conf => ChannelConf},
-    {ok, State}.
+    case maps:get(sql, ChannelConf, undefined) of
+        undefined ->
+            {error, missing_sql_template};
+        <<>> ->
+            {error, missing_sql_template};
+        SQL ->
+            case emqx_bridge_sqlserver_sql:compile(SQL) of
+                {ok, Plan} -> {ok, #{sql_plan => Plan, channel_conf => ChannelConf}};
+                {error, _} = Error -> Error
+            end
+    end.
 
 on_remove_channel(
     _InstId,
@@ -360,7 +368,7 @@ disconnect(ConnectionPid) ->
 
 -spec do_get_status(connection_reference()) -> ok | {error, term()}.
 do_get_status(Conn) ->
-    case execute(Conn, <<"SELECT 1">>) of
+    case execute(Conn, "SELECT 1") of
         {selected, [[]], [{1}]} ->
             ok;
         Other ->
@@ -428,11 +436,11 @@ do_query(
 
     ChannelId = get_channel_id(Query),
     QueryTuple = get_query_tuple(Query),
-    #{sql_templates := Templates} = ChannelState = maps:get(ChannelId, Channels),
+    #{sql_plan := Plan} = ChannelState = maps:get(ChannelId, Channels),
     ChannelConf = maps:get(channel_conf, ChannelState, #{}),
     %% only insert sql statement for single query and batch query
-    case apply_template(QueryTuple, Templates, ChannelConf) of
-        {?ACTION_SEND_MESSAGE, SQL} ->
+    case apply_template(QueryTuple, Plan, ChannelConf) of
+        {ok, SQL} ->
             emqx_trace:rendered_action_template(ChannelId, #{
                 sql => SQL
             }),
@@ -441,10 +449,8 @@ do_query(
                 {?MODULE, worker_do_insert, [SQL, State]},
                 ApplyMode
             );
-        QueryTuple ->
-            Result = {error, {unrecoverable_error, invalid_query}};
-        _ ->
-            Result = {error, {unrecoverable_error, failed_to_apply_sql_template}}
+        {error, Reason} ->
+            Result = {error, {unrecoverable_error, Reason}}
     end,
     handle_result(Result, ResourceId, Query).
 
@@ -527,7 +533,8 @@ is_connection_broken_error(MsgStr) ->
     | [selected_tuple()]
     | {error, common_reason()}.
 execute(Conn, SQL) ->
-    odbc:sql_query(Conn, str(SQL)).
+    %% ODBC forwards the outer list to gen_tcp:send/2 as iodata.
+    odbc:sql_query(Conn, SQL).
 
 -spec execute(connection_reference(), sql(), time_out()) ->
     updated_tuple()
@@ -536,7 +543,7 @@ execute(Conn, SQL) ->
     | [selected_tuple()]
     | {error, common_reason()}.
 execute(Conn, SQL, Timeout) ->
-    odbc:sql_query(Conn, str(SQL), Timeout).
+    odbc:sql_query(Conn, SQL, Timeout).
 
 get_channel_id([{ChannelId, _Req} | _]) ->
     ChannelId;
@@ -555,89 +562,26 @@ get_query_tuple([{_ChannelId, {_QueryType, _Data}} | _]) ->
 get_query_tuple([_InsertQuery | _] = Reqs) ->
     lists:map(fun get_query_tuple/1, Reqs).
 
-%% for bridge data to sql server
-parse_sql_template(Config) ->
-    RawSQLTemplates =
-        case maps:get(sql, Config, undefined) of
-            undefined -> #{};
-            <<>> -> #{};
-            SQLTemplate -> #{?ACTION_SEND_MESSAGE => SQLTemplate}
-        end,
-
-    BatchInsertTks = #{},
-    parse_sql_template(maps:to_list(RawSQLTemplates), BatchInsertTks).
-
-parse_sql_template([{Key, H} | T], BatchInsertTks) ->
-    case emqx_utils_sql:get_statement_type(H) of
-        select ->
-            parse_sql_template(T, BatchInsertTks);
-        insert ->
-            case emqx_utils_sql:parse_insert(H) of
-                {ok, {InsertSQL, Params}} ->
-                    parse_sql_template(
-                        T,
-                        BatchInsertTks#{
-                            Key =>
-                                #{
-                                    ?BATCH_INSERT_PART => InsertSQL,
-                                    ?BATCH_PARAMS_TOKENS => emqx_placeholder:preproc_tmpl(Params)
-                                }
-                        }
-                    );
-                {error, Reason} ->
-                    ?SLOG(error, #{msg => "split_sql_failed", sql => H, reason => Reason}),
-                    parse_sql_template(T, BatchInsertTks)
-            end;
-        Type when is_atom(Type) ->
-            ?SLOG(error, #{msg => "detect_sql_type_unsupported", sql => H, type => Type}),
-            parse_sql_template(T, BatchInsertTks);
-        {error, Reason} ->
-            ?SLOG(error, #{msg => "detect_sql_type_failed", sql => H, reason => Reason}),
-            parse_sql_template(T, BatchInsertTks)
-    end;
-parse_sql_template([], BatchInsertTks) ->
-    #{
-        ?BATCH_INSERT_TEMP => BatchInsertTks
-    }.
-
 %% single insert
 apply_template(
-    {?ACTION_SEND_MESSAGE = _Key, _Msg} = Query, Templates, ChannelConf
+    {?ACTION_SEND_MESSAGE, Msg}, Plan, ChannelConf
 ) ->
-    %% TODO: fix emqx_placeholder:proc_tmpl/2
-    %% it won't add single quotes for string
-    apply_template([Query], Templates, ChannelConf);
+    emqx_bridge_sqlserver_sql:render(Plan, Msg, render_opts(ChannelConf));
 %% batch inserts
 apply_template(
-    [{?ACTION_SEND_MESSAGE = Key, _Msg} | _T] = BatchReqs,
-    #{?BATCH_INSERT_TEMP := BatchInsertsTks} = _Templates,
+    [{?ACTION_SEND_MESSAGE, _Msg} | _] = BatchReqs,
+    Plan,
     ChannelConf
 ) ->
-    case maps:get(Key, BatchInsertsTks, undefined) of
-        undefined ->
-            BatchReqs;
-        #{?BATCH_INSERT_PART := BatchInserts, ?BATCH_PARAMS_TOKENS := BatchParamsTks} ->
-            SQL = proc_batch_sql(BatchReqs, BatchInserts, BatchParamsTks, ChannelConf),
-            {Key, SQL}
-    end;
-apply_template(Query, Templates, _) ->
+    DataList = [Msg || {?ACTION_SEND_MESSAGE, Msg} <- BatchReqs],
+    emqx_bridge_sqlserver_sql:render_batch(Plan, DataList, render_opts(ChannelConf));
+apply_template(Query, _Plan, _) ->
     %% TODO: more detail information
-    ?SLOG(error, #{msg => "apply_sql_template_failed", query => Query, templates => Templates}),
+    ?SLOG(error, #{msg => "apply_sql_template_failed", query => Query}),
     {error, failed_to_apply_sql_template}.
 
-proc_batch_sql(BatchReqs, BatchInserts, Tokens, ChannelConf) ->
-    Values = erlang:iolist_to_binary(
-        lists:join($,, [
-            proc_msg(Tokens, Msg, ChannelConf)
-         || {_, Msg} <- BatchReqs
-        ])
-    ),
-    <<BatchInserts/binary, " values ", Values/binary>>.
-
-proc_msg(Tokens, Msg, #{undefined_vars_as_null := true}) ->
-    emqx_placeholder:proc_sqlserver_param_str2(Tokens, Msg);
-proc_msg(Tokens, Msg, _) ->
-    emqx_placeholder:proc_sqlserver_param_str(Tokens, Msg).
+render_opts(ChannelConf) ->
+    #{undefined_vars_as_null => maps:get(undefined_vars_as_null, ChannelConf, false)}.
 
 to_bin(List) when is_list(List) ->
     unicode:characters_to_binary(List, utf8).

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
@@ -169,6 +169,10 @@ resolve_placeholder({var, _Name, Accessor} = Placeholder, Data, Cache) ->
 render_error({var, Name, _Accessor}, Reason) ->
     {invalid_sql_template_value, #{placeholder => Name, reason => Reason}}.
 
+%% Encoding fails after all string parts are combined, so no single part owns the error.
+%% Report one placeholder with the regular error shape.
+%% Report every unique placeholder when the template contains several,
+%% and return the reason directly when it contains none.
 render_template_error(Parts, Reason) ->
     Placeholders = lists:usort([Placeholder || #tpl_placeholder{placeholder = Placeholder} <- Parts]),
     case Placeholders of
@@ -203,11 +207,15 @@ serialize_identifier({identifier, bare, Name}) ->
     quote_identifier(Name);
 serialize_identifier({identifier, double, Source}) ->
     ok = assert_no_identifier_placeholder(Source),
-    quote_identifier(decode_doubled(strip_quotes(Source), $", []));
+    Name = decode_doubled(strip_quotes(Source), $", []),
+    ok = assert_no_nul(Name),
+    quote_identifier(Name);
 serialize_identifier({identifier, bracket, Source}) ->
     ok = assert_no_identifier_placeholder(Source),
     Body = binary:part(Source, 1, byte_size(Source) - 2),
-    quote_identifier(decode_bracket(Body, [])).
+    Name = decode_bracket(Body, []),
+    ok = assert_no_nul(Name),
+    quote_identifier(Name).
 
 assert_no_identifier_placeholder(Source) ->
     case binary:match(Source, <<"${">>) of
@@ -246,7 +254,7 @@ compile_expression({string, Style, Source}) ->
             [compile_string_op(Style, Parts)];
         false ->
             [#tpl_text{text = Text}] = Parts,
-            [#raw{sql = encode_string(Text, Style)}]
+            [#raw{sql = iolist_to_binary(encode_string(Text, Style))}]
     end;
 compile_expression({number, Number}) ->
     [#raw{sql = Number}];
@@ -272,10 +280,37 @@ compile_expression({group, Expression}) ->
 compile_expression({unary, Operator, Expression}) ->
     [#raw{sql = <<(atom_to_binary(Operator))/binary, "(">>} | compile_expression(Expression)] ++
         [#raw{sql = <<")">>}];
+compile_expression({is_null, Expression, Negated}) ->
+    Suffix =
+        case Negated of
+            true -> <<" IS NOT NULL">>;
+            false -> <<" IS NULL">>
+        end,
+    compile_expression(Expression) ++ [#raw{sql = Suffix}];
+compile_expression({case_expression, Operand, Whens, Else}) ->
+    [#raw{sql = <<"CASE">>}] ++
+        compile_case_operand(Operand) ++
+        lists:append([compile_when_clause(Clause) || Clause <- Whens]) ++
+        compile_case_else(Else) ++
+        [#raw{sql = <<" END">>}];
 compile_expression({binary, Operator, Left, Right}) ->
     compile_expression(Left) ++
         [#raw{sql = <<" ", (atom_to_binary(Operator))/binary, " ">>}] ++
         compile_expression(Right).
+
+compile_case_operand(undefined) ->
+    [];
+compile_case_operand(Expression) ->
+    [#raw{sql = <<" ">>} | compile_expression(Expression)].
+
+compile_when_clause({'when', Condition, Result}) ->
+    [#raw{sql = <<" WHEN ">>} | compile_expression(Condition)] ++
+        [#raw{sql = <<" THEN ">>} | compile_expression(Result)].
+
+compile_case_else(undefined) ->
+    [];
+compile_case_else(Expression) ->
+    [#raw{sql = <<" ELSE ">>} | compile_expression(Expression)].
 
 compile_string_op(varchar, Parts) ->
     #varchar_string{parts = Parts};
@@ -288,6 +323,10 @@ serialize_function_part(Identifier) ->
     serialize_identifier(Identifier).
 
 parse_string(Source, nvarchar) ->
+    %% SQL Server keeps doubled apostrophes inside one string token:
+    %% https://github.com/microsoft/SqlScriptDOM/commit/01aa17bfa32f25f1b1084b72c2e6a1a92b44633a
+    %% SqlScriptDom/Parser/TSql/TSql160.g lines 34233-34259.
+    %% Skip the two-byte N' prefix and exclude the closing apostrophe.
     Body = binary:part(Source, 2, byte_size(Source) - 3),
     parse_string_body(Body, [], []);
 parse_string(Source, varchar) ->
@@ -309,6 +348,9 @@ parse_string_body(<<"${", _/binary>> = Bin, Text, Parts) ->
 parse_string_body(<<Char, Rest/binary>>, Text, Parts) ->
     parse_string_body(Rest, [Char | Text], Parts).
 
+%% Restrict emqx_template's envelope to nonempty dotted paths.
+%% Retain `${}` and `${.}`.
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 valid_placeholder_source(<<"${}">>) ->
     true;
 valid_placeholder_source(<<"${.}">>) ->
@@ -416,13 +458,23 @@ to_text(Value) when is_binary(Value) -> Value;
 to_text(Value) -> iolist_to_binary(emqx_template:to_string(Value)).
 
 encode_string(Text, Style) ->
+    %% OTP ODBC uses SQL_NTS. An embedded NUL would truncate the statement:
+    %% https://github.com/erlang/otp/blob/OTP-26.2.5.14/lib/odbc/c_src/odbcserver.c#L620-L642
+    %% https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/using-length-and-indicator-values
+    ok = assert_no_nul(Text),
     Escaped = binary:replace(Text, <<"'">>, <<"''">>, [global]),
     Prefix =
         case Style of
             nvarchar -> <<"N">>;
             varchar -> <<>>
         end,
-    <<Prefix/binary, "'", Escaped/binary, "'">>.
+    [Prefix, $', Escaped, $'].
+
+assert_no_nul(Text) ->
+    case binary:match(Text, <<0>>) of
+        nomatch -> ok;
+        _ -> error(nul_character_not_allowed)
+    end.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -453,6 +505,24 @@ function_expression_test() ->
         render(Plan, #{id => <<"m1">>, ms_shift => 1, s_shift => 2}, null_opts())
     ).
 
+conditional_expression_test() ->
+    SQL = <<
+        "INSERT INTO t(a, b, c) VALUES ("
+        "CASE WHEN ${v} >= 10 AND ${v} IS NOT NULL THEN N'large' ELSE N'small' END, "
+        "CASE ${v} WHEN 10 THEN 1 ELSE 0 END, "
+        "IIF(NOT ${v} = 10 OR ${v} < 0, 1, 0))"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO [t] ([a], [b], [c]) VALUES ("
+            "CASE WHEN 10 >= 10 AND 10 IS NOT NULL THEN N'large' ELSE N'small' END, "
+            "CASE 10 WHEN 10 THEN 1 ELSE 0 END, "
+            "IIF(NOT(10 = 10) OR 10 < 0, 1, 0))"
+        >>},
+        rendered_binary(render(Plan, #{v => 10}, null_opts()))
+    ).
+
 leading_dot_placeholder_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${.payload})">>),
     ?assertEqual(
@@ -477,6 +547,40 @@ batch_shape_test() ->
     ?assertEqual(
         <<"INSERT INTO [t] ([v]) VALUES ('a'');--'), ('b')">>,
         iolist_to_binary(Rendered)
+    ),
+    ?assertEqual(
+        {error,
+            {sqlserver_template_render_failed, #{
+                batch_index => 2,
+                reason =>
+                    {invalid_sql_template_value, #{
+                        placeholder => "payload", reason => {error, nul_character_not_allowed}
+                    }}
+            }}},
+        render_batch(
+            Plan,
+            [#{payload => <<"ok">>}, #{payload => <<"a", 0, "b">>}],
+            null_opts()
+        )
+    ),
+    Rows = lists:duplicate(1000, #{payload => <<"ok">>}),
+    ?assertMatch({ok, _}, render_batch(Plan, Rows, null_opts())),
+    ?assertEqual(
+        {error, sqlserver_values_row_limit_exceeded},
+        render_batch(Plan, [#{payload => <<"extra">>} | Rows], null_opts())
+    ).
+
+binary_and_unicode_value_test() ->
+    {ok, ValuePlan} = compile(<<"INSERT INTO t(v) VALUES (${payload})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [t] ([v]) VALUES ('", 16#FF, "')">>},
+        rendered_binary(render(ValuePlan, #{payload => <<16#FF>>}, null_opts()))
+    ),
+    Unicode = <<"你好😀"/utf8>>,
+    {ok, UnicodePlan} = compile(<<"INSERT INTO t(v) VALUES (N'pre${payload}post')">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [t] ([v]) VALUES (N'pre", Unicode/binary, "post')">>},
+        rendered_binary(render(UnicodePlan, #{payload => Unicode}, null_opts()))
     ).
 
 binary_literal_test() ->
@@ -519,6 +623,31 @@ reject_unsupported_syntax_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO [${table}](v) VALUES (1)">>)),
     ?assertMatch({error, _}, compile(<<"INSERT INTO t(v) VALUES (${value}0)">>)),
     ?assertMatch({error, _}, compile(<<"INSERT INTO t(v) VALUES (1), (2)">>)).
+
+lexical_boundary_test() ->
+    Accepted = [
+        <<"INSERT INTO @t(v) VALUES (1)">>,
+        <<"INSERT INTO #t(v) VALUES (1)">>,
+        <<"INSERT INTO \"t\"(v) VALUES (1)">>,
+        <<"INSERT", 11, "INTO t(v) VALUES (1)">>,
+        <<"INSERT INTO t(v) VALUES (DEFAULT + 1)">>,
+        iolist_to_binary([<<"INSERT INTO [">>, binary:copy(<<"a">>, 129), <<"](v) VALUES (1)">>])
+    ],
+    lists:foreach(fun(SQL) -> ?assertMatch({ok, _}, compile(SQL)) end, Accepted),
+    Rejected = [
+        <<"INSERT INTO [](v) VALUES (1)">>,
+        <<"INSERT INTO t(v) VALUES (0x)">>,
+        <<"INSERT INTO t(v) VALUES (1e)">>,
+        <<"INSERT INTO t(v) VALUES (1e+)">>,
+        <<"INSERT INTO таблица(v) VALUES (1)"/utf8>>,
+        <<"INSERT INTO foo", 16#C2, 16#A0, "bar(v) VALUES (1)">>,
+        iolist_to_binary([<<"INSERT INTO [a">>, 0, <<"b](v) VALUES (1)">>]),
+        iolist_to_binary([<<"INSERT INTO \"a">>, 0, <<"b\"(v) VALUES (1)">>]),
+        iolist_to_binary([<<"INSERT INTO t(v) VALUES ('a">>, 0, <<"b')">>])
+    ],
+    lists:foreach(fun(SQL) -> ?assertMatch({error, _}, compile(SQL)) end, Rejected),
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${payload})">>),
+    ?assertMatch({error, _}, render(Plan, #{payload => <<"a", 0, "b">>}, null_opts())).
 
 rendered_binary({ok, SQL}) ->
     ?assert(is_list(SQL)),

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
@@ -437,7 +437,8 @@ encode_value(true, _Opts) ->
     encode_string(<<"true">>, varchar);
 encode_value(false, _Opts) ->
     encode_string(<<"false">>, varchar);
-encode_value(Value, _Opts) when is_integer(Value) -> integer_to_binary(Value);
+encode_value(Value, _Opts) when is_integer(Value) ->
+    integer_to_binary(Value);
 encode_value(Value, _Opts) when is_float(Value) ->
     emqx_template:to_string(Value);
 encode_value(<<"0x", Rest/binary>> = Value, _Opts) ->

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
@@ -1,0 +1,531 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc Compile and render restricted SQL Server INSERT INTO VALUES templates.
+-module(emqx_bridge_sqlserver_sql).
+
+-export([compile/1, render/3, render_batch/3, parse_placeholder/1]).
+-export_type([plan/0]).
+
+-type placeholder() :: emqx_template:placeholder().
+
+-record(tpl_text, {text :: binary()}).
+-record(tpl_placeholder, {placeholder :: placeholder()}).
+-record(part_text, {text :: binary()}).
+-record(part_value, {value :: term()}).
+
+-type template_part() :: #tpl_text{} | #tpl_placeholder{}.
+-type part() :: #part_text{} | #part_value{}.
+
+-record(raw, {sql :: binary()}).
+-record(value, {placeholder :: placeholder()}).
+-record(varchar_string, {parts :: [template_part()]}).
+-record(nvarchar_string, {parts :: [template_part()]}).
+
+-type render_op() :: #raw{} | #value{} | #varchar_string{} | #nvarchar_string{}.
+-type render_plan() :: [render_op()].
+
+-record(sqlserver_plan, {insert_prefix :: binary(), plan :: render_plan()}).
+
+-define(BATCH_SEPARATOR, <<", ">>).
+
+-opaque plan() :: #sqlserver_plan{}.
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec compile(unicode:chardata()) -> {ok, plan()} | {error, term()}.
+compile(SQL0) ->
+    SQL = unicode:characters_to_binary(SQL0),
+    try
+        case emqx_bridge_sqlserver_sql_lexer:string(binary_to_list(SQL)) of
+            {ok, Tokens, _EndLine} ->
+                case emqx_bridge_sqlserver_sql_parser:parse(Tokens) of
+                    {ok, AST} -> compile_ast(AST);
+                    {error, Reason} -> {error, {invalid_sqlserver_insert_template, Reason}}
+                end;
+            {error, Reason, _EndLine} ->
+                {error, {invalid_sqlserver_insert_template, Reason}}
+        end
+    catch
+        Class:CatchReason -> {error, {invalid_sqlserver_insert_template, {Class, CatchReason}}}
+    end.
+
+-spec render(plan(), map(), map()) -> {ok, iolist()} | {error, term()}.
+render(#sqlserver_plan{insert_prefix = Prefix, plan = Plan}, Data, Opts) ->
+    case render_unit(Plan, Data, Opts) of
+        {ok, Rendered} -> {ok, [Prefix, Rendered]};
+        {error, _} = Error -> Error
+    end.
+
+-spec render_batch(plan(), [map()], map()) -> {ok, iolist()} | {error, term()}.
+render_batch(#sqlserver_plan{insert_prefix = Prefix, plan = Plan}, DataList, Opts) when
+    %% https://learn.microsoft.com/en-us/sql/t-sql/queries/table-value-constructor-transact-sql#limitations
+    length(DataList) =< 1000
+->
+    case render_batch_units(DataList, Plan, Opts, _Index = 1, _Acc = []) of
+        {ok, Rendered} -> {ok, [Prefix, Rendered]};
+        {error, _} = Error -> Error
+    end;
+render_batch(_Plan, _DataList, _Opts) ->
+    {error, sqlserver_values_row_limit_exceeded}.
+
+-spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
+parse_placeholder(Source) ->
+    case valid_placeholder_source(Source) of
+        true ->
+            case emqx_template:parse(Source) of
+                [{var, _, _} = Placeholder] -> {ok, Placeholder};
+                _ -> {error, invalid_placeholder}
+            end;
+        false ->
+            {error, invalid_placeholder}
+    end.
+
+%%------------------------------------------------------------------------------
+%% Private funs
+%%------------------------------------------------------------------------------
+
+render_batch_units([Data | Rest], Unit, Opts, Index, Acc) ->
+    case render_unit(Unit, Data, Opts) of
+        {ok, Rendered} ->
+            render_batch_units(Rest, Unit, Opts, Index + 1, [Rendered | Acc]);
+        {error, Reason} ->
+            {error, {sqlserver_template_render_failed, #{batch_index => Index, reason => Reason}}}
+    end;
+render_batch_units([], _Unit, _Opts, _Index, Acc) ->
+    {ok, lists:join(?BATCH_SEPARATOR, lists:reverse(Acc))}.
+
+render_unit(Unit, Data, Opts) ->
+    render_plan(Unit, Data, Opts, #{}, []).
+
+render_plan([#raw{sql = SQL} | Rest], Data, Opts, Cache, Acc) ->
+    render_plan(Rest, Data, Opts, Cache, [SQL | Acc]);
+render_plan([#value{placeholder = Placeholder} | Rest], Data, Opts, Cache0, Acc) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            case encode_result(fun() -> encode_value(Value, Opts) end) of
+                {ok, Encoded} -> render_plan(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} -> {error, render_error(Placeholder, Reason)}
+            end;
+        {error, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end;
+render_plan([#varchar_string{parts = Parts} | Rest], Data, Opts, Cache0, Acc) ->
+    render_template_op(varchar, Parts, Rest, Data, Opts, Cache0, Acc);
+render_plan([#nvarchar_string{parts = Parts} | Rest], Data, Opts, Cache0, Acc) ->
+    render_template_op(nvarchar, Parts, Rest, Data, Opts, Cache0, Acc);
+render_plan([], _Data, _Opts, _Cache, Acc) ->
+    {ok, lists:reverse(Acc)}.
+
+render_template_op(Style, Parts, Rest, Data, Opts, Cache0, Acc) ->
+    case resolve_template_parts(Parts, Data, Cache0, []) of
+        {ok, Resolved, Cache} ->
+            case
+                encode_result(fun() -> encode_string(render_text_parts(Resolved, Opts), Style) end)
+            of
+                {ok, Encoded} -> render_plan(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} -> {error, render_template_error(Parts, Reason)}
+            end;
+        {error, Placeholder, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end.
+
+encode_result(Encoder) ->
+    try Encoder() of
+        {ok, _} = Ok -> Ok;
+        {error, _} = Error -> Error;
+        Encoded -> {ok, Encoded}
+    catch
+        Class:Reason -> {error, {Class, Reason}}
+    end.
+
+resolve_template_parts([#tpl_text{text = Text} | Rest], Data, Cache, Acc) ->
+    resolve_template_parts(Rest, Data, Cache, [#part_text{text = Text} | Acc]);
+resolve_template_parts([#tpl_placeholder{placeholder = Placeholder} | Rest], Data, Cache0, Acc) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            resolve_template_parts(Rest, Data, Cache, [#part_value{value = Value} | Acc]);
+        {error, Reason} ->
+            {error, Placeholder, Reason}
+    end;
+resolve_template_parts([], _Data, Cache, Acc) ->
+    {ok, lists:reverse(Acc), Cache}.
+
+resolve_placeholder({var, _Name, Accessor} = Placeholder, Data, Cache) ->
+    case Cache of
+        #{Placeholder := Value} ->
+            {ok, Value, Cache};
+        #{} ->
+            try emqx_jsonish:lookup(Accessor, Data) of
+                {ok, Value} -> {ok, Value, Cache#{Placeholder => Value}};
+                {error, _Reason} -> {ok, undefined, Cache#{Placeholder => undefined}}
+            catch
+                Class:Reason -> {error, {placeholder_lookup_failed, {Class, Reason}}}
+            end
+    end.
+
+render_error({var, Name, _Accessor}, Reason) ->
+    {invalid_sql_template_value, #{placeholder => Name, reason => Reason}}.
+
+render_template_error(Parts, Reason) ->
+    Placeholders = lists:usort([Placeholder || #tpl_placeholder{placeholder = Placeholder} <- Parts]),
+    case Placeholders of
+        [Placeholder] ->
+            render_error(Placeholder, Reason);
+        [] ->
+            {invalid_sql_template_value, Reason};
+        _ ->
+            Names = [Name || {var, Name, _Accessor} <- Placeholders],
+            {invalid_sql_template_value, #{placeholders => Names, reason => Reason}}
+    end.
+
+compile_ast({insert, #{target := Target, columns := Columns, row := Row}}) ->
+    TargetSQL = iolist_to_binary(lists:join($., [serialize_target_part(I) || I <- Target])),
+    ColumnsSQL = serialize_columns(Columns),
+    Head = <<"INSERT INTO ", TargetSQL/binary, ColumnsSQL/binary, " VALUES ">>,
+    Unit = merge_render_ops(compile_row(Row)),
+    {ok, #sqlserver_plan{insert_prefix = Head, plan = Unit}}.
+
+serialize_target_part(empty) ->
+    <<>>;
+serialize_target_part(Identifier) ->
+    serialize_identifier(Identifier).
+
+serialize_columns(undefined) ->
+    <<>>;
+serialize_columns(Identifiers) ->
+    Content = lists:join(<<", ">>, [serialize_identifier(I) || I <- Identifiers]),
+    iolist_to_binary([" (", Content, ")"]).
+
+serialize_identifier({identifier, bare, Name}) ->
+    quote_identifier(Name);
+serialize_identifier({identifier, double, Source}) ->
+    ok = assert_no_identifier_placeholder(Source),
+    quote_identifier(decode_doubled(strip_quotes(Source), $", []));
+serialize_identifier({identifier, bracket, Source}) ->
+    ok = assert_no_identifier_placeholder(Source),
+    Body = binary:part(Source, 1, byte_size(Source) - 2),
+    quote_identifier(decode_bracket(Body, [])).
+
+assert_no_identifier_placeholder(Source) ->
+    case binary:match(Source, <<"${">>) of
+        nomatch -> ok;
+        _ -> error(dynamic_identifier_not_allowed)
+    end.
+
+quote_identifier(Name) ->
+    Escaped = binary:replace(Name, <<"]">>, <<"]]">>, [global]),
+    <<"[", Escaped/binary, "]">>.
+
+decode_doubled(<<Quote, Quote, Rest/binary>>, Quote, Acc) ->
+    decode_doubled(Rest, Quote, [Quote | Acc]);
+decode_doubled(<<Char, Rest/binary>>, Quote, Acc) ->
+    decode_doubled(Rest, Quote, [Char | Acc]);
+decode_doubled(<<>>, _Quote, Acc) ->
+    iolist_to_binary(lists:reverse(Acc)).
+
+decode_bracket(<<"]]", Rest/binary>>, Acc) ->
+    decode_bracket(Rest, [$] | Acc]);
+decode_bracket(<<Char, Rest/binary>>, Acc) ->
+    decode_bracket(Rest, [Char | Acc]);
+decode_bracket(<<>>, Acc) ->
+    iolist_to_binary(lists:reverse(Acc)).
+
+compile_row({row, Expressions}) ->
+    [#raw{sql = <<"(">>} | join_ops(<<", ">>, [compile_expression(E) || E <- Expressions])] ++
+        [#raw{sql = <<")">>}].
+
+compile_expression({var, Placeholder}) ->
+    [#value{placeholder = Placeholder}];
+compile_expression({string, Style, Source}) ->
+    Parts = parse_string(Source, Style),
+    case lists:any(fun is_variable_part/1, Parts) of
+        true ->
+            [compile_string_op(Style, Parts)];
+        false ->
+            [#tpl_text{text = Text}] = Parts,
+            [#raw{sql = encode_string(Text, Style)}]
+    end;
+compile_expression({number, Number}) ->
+    [#raw{sql = Number}];
+compile_expression({hex, Hex}) ->
+    [#raw{sql = Hex}];
+compile_expression(null) ->
+    [#raw{sql = <<"NULL">>}];
+compile_expression(default) ->
+    [#raw{sql = <<"DEFAULT">>}];
+compile_expression(current_timestamp) ->
+    [#raw{sql = <<"CURRENT_TIMESTAMP">>}];
+compile_expression({identifier_value, Name}) ->
+    [#raw{sql = Name}];
+compile_expression({call, Name, Args}) ->
+    FunctionName = iolist_to_binary(lists:join($., [serialize_function_part(I) || I <- Name])),
+    [
+        #raw{sql = <<FunctionName/binary, "(">>}
+        | join_ops(<<", ">>, [compile_expression(E) || E <- Args])
+    ] ++
+        [#raw{sql = <<")">>}];
+compile_expression({group, Expression}) ->
+    [#raw{sql = <<"(">>} | compile_expression(Expression)] ++ [#raw{sql = <<")">>}];
+compile_expression({unary, Operator, Expression}) ->
+    [#raw{sql = <<(atom_to_binary(Operator))/binary, "(">>} | compile_expression(Expression)] ++
+        [#raw{sql = <<")">>}];
+compile_expression({binary, Operator, Left, Right}) ->
+    compile_expression(Left) ++
+        [#raw{sql = <<" ", (atom_to_binary(Operator))/binary, " ">>}] ++
+        compile_expression(Right).
+
+compile_string_op(varchar, Parts) ->
+    #varchar_string{parts = Parts};
+compile_string_op(nvarchar, Parts) ->
+    #nvarchar_string{parts = Parts}.
+
+serialize_function_part({identifier, bare, Name}) ->
+    Name;
+serialize_function_part(Identifier) ->
+    serialize_identifier(Identifier).
+
+parse_string(Source, nvarchar) ->
+    Body = binary:part(Source, 2, byte_size(Source) - 3),
+    parse_string_body(Body, [], []);
+parse_string(Source, varchar) ->
+    parse_string_body(strip_quotes(Source), [], []).
+
+parse_string_body(<<>>, Text, Parts) ->
+    finish_parts(Text, Parts);
+parse_string_body(<<$', $', Rest/binary>>, Text, Parts) ->
+    parse_string_body(Rest, [$' | Text], Parts);
+parse_string_body(<<"${$}", Rest/binary>>, Text, Parts) ->
+    parse_string_body(Rest, [$$ | Text], Parts);
+parse_string_body(<<"${", _/binary>> = Bin, Text, Parts) ->
+    {Placeholder, Rest} = take_placeholder(Bin),
+    parse_string_body(
+        Rest,
+        [],
+        [#tpl_placeholder{placeholder = Placeholder} | flush_text(Text, Parts)]
+    );
+parse_string_body(<<Char, Rest/binary>>, Text, Parts) ->
+    parse_string_body(Rest, [Char | Text], Parts).
+
+valid_placeholder_source(<<"${}">>) ->
+    true;
+valid_placeholder_source(<<"${.}">>) ->
+    true;
+valid_placeholder_source(Source) ->
+    re:run(
+        Source,
+        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
+        [{capture, none}]
+    ) =:= match.
+
+take_placeholder(Bin) ->
+    case binary:match(Bin, <<"}">>) of
+        {End, 1} ->
+            Size = End + 1,
+            Source = binary:part(Bin, 0, Size),
+            Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
+            case parse_placeholder(Source) of
+                {ok, Placeholder} -> {Placeholder, Rest};
+                {error, _} -> error({invalid_placeholder, Source})
+            end;
+        nomatch ->
+            error(unterminated_placeholder)
+    end.
+
+flush_text([], Parts) -> Parts;
+flush_text(Text, Parts) -> [#tpl_text{text = iolist_to_binary(lists:reverse(Text))} | Parts].
+
+finish_parts(Text, Parts) ->
+    case lists:reverse(flush_text(Text, Parts)) of
+        [] -> [#tpl_text{text = <<>>}];
+        Result -> Result
+    end.
+
+strip_quotes(Source) ->
+    binary:part(Source, 1, byte_size(Source) - 2).
+
+is_variable_part(#tpl_placeholder{}) -> true;
+is_variable_part(_) -> false.
+
+join_ops(_Separator, []) ->
+    [];
+join_ops(Separator, [Ops | Rest]) ->
+    lists:foldl(fun(Next, Acc) -> Acc ++ [#raw{sql = Separator} | Next] end, Ops, Rest).
+
+-spec merge_render_ops(render_plan()) -> render_plan().
+merge_render_ops(Ops) ->
+    lists:reverse(
+        lists:foldl(
+            fun
+                (#raw{sql = <<>>}, Acc) ->
+                    Acc;
+                (#raw{sql = SQL}, [#raw{sql = Previous} | Acc]) ->
+                    [#raw{sql = <<Previous/binary, SQL/binary>>} | Acc];
+                (Op, Acc) ->
+                    [Op | Acc]
+            end,
+            [],
+            Ops
+        )
+    ).
+
+encode_value(undefined, #{undefined_vars_as_null := false}) ->
+    encode_string(<<"undefined">>, varchar);
+encode_value(undefined, _Opts) ->
+    <<"NULL">>;
+encode_value(null, _Opts) ->
+    <<"NULL">>;
+encode_value(true, _Opts) ->
+    encode_string(<<"true">>, varchar);
+encode_value(false, _Opts) ->
+    encode_string(<<"false">>, varchar);
+encode_value(Value, _Opts) when is_integer(Value) -> integer_to_binary(Value);
+encode_value(Value, _Opts) when is_float(Value) ->
+    case Value =:= Value of
+        true -> emqx_template:to_string(Value);
+        false -> {error, non_finite_number}
+    end;
+encode_value(<<"0x", Rest/binary>> = Value, _Opts) ->
+    case Rest =/= <<>> andalso re:run(Rest, <<"^[0-9A-Fa-f]+$">>, [{capture, none}]) =:= match of
+        true -> Value;
+        false -> encode_string(Value, varchar)
+    end;
+encode_value(Value, _Opts) ->
+    encode_string(to_text(Value), varchar).
+
+-spec render_text_parts([part()], map()) -> binary().
+render_text_parts(Parts, Opts) ->
+    iolist_to_binary([
+        case Part of
+            #part_text{text = Text} ->
+                Text;
+            #part_value{value = undefined} ->
+                case maps:get(undefined_vars_as_null, Opts, true) of
+                    true -> <<"null">>;
+                    false -> <<"undefined">>
+                end;
+            #part_value{value = Value} ->
+                to_text(Value)
+        end
+     || Part <- Parts
+    ]).
+
+to_text(Value) when is_binary(Value) -> Value;
+to_text(Value) -> iolist_to_binary(emqx_template:to_string(Value)).
+
+encode_string(Text, Style) ->
+    Escaped = binary:replace(Text, <<"'">>, <<"''">>, [global]),
+    Prefix =
+        case Style of
+            nvarchar -> <<"N">>;
+            varchar -> <<>>
+        end,
+    <<Prefix/binary, "'", Escaped/binary, "'">>.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+compile_merges_raw_segments_test() ->
+    {ok, Placeholder} = parse_placeholder(<<"${value}">>),
+    {ok, #sqlserver_plan{plan = [#raw{sql = <<"(1, 2)">>}]}} =
+        compile(<<"INSERT INTO t VALUES (1, 2)">>),
+    {ok, #sqlserver_plan{plan = Plan}} =
+        compile(<<"INSERT INTO t VALUES (1, ${value}, 2)">>),
+    ?assertEqual(
+        [
+            #raw{sql = <<"(1, ">>},
+            #value{placeholder = Placeholder},
+            #raw{sql = <<", 2)">>}
+        ],
+        Plan
+    ).
+
+function_expression_test() ->
+    SQL = <<
+        "INSERT INTO TransactionLog(MessageId, DateStamp) VALUES ("
+        "${id}, DATEADD(MS, ${ms_shift}, DATEADD(S, ${s_shift}, '19700101 00:00:00:000')))"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertMatch(
+        {ok, _},
+        render(Plan, #{id => <<"m1">>, ms_shift => 1, s_shift => 2}, null_opts())
+    ).
+
+leading_dot_placeholder_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${.payload})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [t] ([v]) VALUES ('hello')">>},
+        rendered_binary(render(Plan, #{payload => <<"hello">>}, null_opts()))
+    ).
+
+quoted_string_boundary_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (N'pre${payload}post')">>),
+    Attack = <<"'); DROP TABLE t; --\\">>,
+    {ok, Rendered} = render(Plan, #{payload => Attack}, null_opts()),
+    ?assertMatch({ok, _}, compile(Rendered)).
+
+batch_shape_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${payload})">>),
+    {ok, Rendered} = render_batch(
+        Plan,
+        [#{payload => <<"a');--">>}, #{payload => <<"b">>}],
+        null_opts()
+    ),
+    ?assert(is_list(Rendered)),
+    ?assertEqual(
+        <<"INSERT INTO [t] ([v]) VALUES ('a'');--'), ('b')">>,
+        iolist_to_binary(Rendered)
+    ).
+
+binary_literal_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${payload})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [t] ([v]) VALUES (0x0010)">>},
+        rendered_binary(render(Plan, #{payload => <<"0x0010">>}, null_opts()))
+    ).
+
+null_value_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${payload})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [t] ([v]) VALUES (NULL)">>},
+        rendered_binary(render(Plan, #{payload => null}, null_opts()))
+    ).
+
+qualified_names_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO mqtt..t(v) VALUES (dbo.fn(${payload}))">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [mqtt]..[t] ([v]) VALUES (dbo.fn(1))">>},
+        rendered_binary(render(Plan, #{payload => 1}, null_opts()))
+    ),
+    {ok, OmittedPlan} = compile(<<"INSERT INTO server...t(v) VALUES (${payload})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [server]...[t] ([v]) VALUES (1)">>},
+        rendered_binary(render(OmittedPlan, #{payload => 1}, null_opts()))
+    ),
+    {ok, QuotedFunctionPlan} = compile(
+        <<"INSERT INTO t(v) VALUES ([sys].[fn_varbintohexstr](0x01))">>
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [t] ([v]) VALUES ([sys].[fn_varbintohexstr](0x01))">>},
+        rendered_binary(render(QuotedFunctionPlan, #{}, null_opts()))
+    ),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO a.b.c.d.e(v) VALUES (1)">>)).
+
+reject_unsupported_syntax_test() ->
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1) --(* comment">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO ${table}(v) VALUES (1)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO [${table}](v) VALUES (1)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t(v) VALUES (${value}0)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t(v) VALUES (1), (2)">>)).
+
+rendered_binary({ok, SQL}) ->
+    ?assert(is_list(SQL)),
+    {ok, iolist_to_binary(SQL)}.
+
+null_opts() ->
+    #{undefined_vars_as_null => true}.
+
+-endif.

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
@@ -10,14 +10,29 @@
 
 -type placeholder() :: emqx_template:placeholder().
 
+%% Represent string templates, e.g. 'aaa ${bbb} ccc' as
+%% [
+%%   #tpl_text{text = <<"aaa ">>},
+%%   #tpl_placeholder{placeholder = {var, "bbb", ...}},
+%%   #tpl_text{text = <<"ccc ">>}
+%% ]
 -record(tpl_text, {text :: binary()}).
 -record(tpl_placeholder, {placeholder :: placeholder()}).
+
+%% Represent resolved parts of a template string,
+%% e.g. 'aaa ${bbb} ccc' might be pre-rendered as
+%% [
+%%   #part_text{text = <<"aaa ">>},
+%%   #part_value{value = BBBValue},
+%%   #part_text{text = <<"ccc ">>}
+%% ]
 -record(part_text, {text :: binary()}).
 -record(part_value, {value :: term()}).
 
 -type template_part() :: #tpl_text{} | #tpl_placeholder{}.
 -type part() :: #part_text{} | #part_value{}.
 
+%% Pre-rendered parts of a full SQL statement
 -record(raw, {sql :: binary()}).
 -record(value, {placeholder :: placeholder()}).
 -record(varchar_string, {parts :: [template_part()]}).
@@ -134,9 +149,8 @@ render_template_op(Style, Parts, Rest, Data, Opts, Cache0, Acc) ->
     end.
 
 encode_result(Encoder) ->
-    try Encoder() of
-        {error, _} = Error -> Error;
-        Encoded -> {ok, Encoded}
+    try
+        {ok, Encoder()}
     catch
         Class:Reason -> {error, {Class, Reason}}
     end.
@@ -425,10 +439,7 @@ encode_value(false, _Opts) ->
     encode_string(<<"false">>, varchar);
 encode_value(Value, _Opts) when is_integer(Value) -> integer_to_binary(Value);
 encode_value(Value, _Opts) when is_float(Value) ->
-    case Value =:= Value of
-        true -> emqx_template:to_string(Value);
-        false -> {error, non_finite_number}
-    end;
+    emqx_template:to_string(Value);
 encode_value(<<"0x", Rest/binary>> = Value, _Opts) ->
     case Rest =/= <<>> andalso re:run(Rest, <<"^[0-9A-Fa-f]+$">>, [{capture, none}]) =:= match of
         true -> Value;
@@ -479,6 +490,7 @@ assert_no_nul(Text) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+%% Checks that compilation merges adjacent static SQL around a value placeholder.
 compile_merges_raw_segments_test() ->
     {ok, Placeholder} = parse_placeholder(<<"${value}">>),
     {ok, #sqlserver_plan{plan = [#raw{sql = <<"(1, 2)">>}]}} =
@@ -494,6 +506,7 @@ compile_merges_raw_segments_test() ->
         Plan
     ).
 
+%% Checks nested SQL Server function calls containing placeholders.
 function_expression_test() ->
     SQL = <<
         "INSERT INTO TransactionLog(MessageId, DateStamp) VALUES ("
@@ -505,6 +518,7 @@ function_expression_test() ->
         render(Plan, #{id => <<"m1">>, ms_shift => 1, s_shift => 2}, null_opts())
     ).
 
+%% Checks rendering of CASE, IIF, comparisons, null predicates, and logical expressions.
 conditional_expression_test() ->
     SQL = <<
         "INSERT INTO t(a, b, c) VALUES ("
@@ -523,6 +537,66 @@ conditional_expression_test() ->
         rendered_binary(render(Plan, #{v => 10}, null_opts()))
     ).
 
+%% Checks timestamps, grouped values, null predicates, DEFAULT, functions, and quoted identifiers.
+timestamp_default_and_grouped_expression_forms_test() ->
+    SQL = <<
+        "INSERT INTO \"a\"\"b\"([c]]d]) VALUES ("
+        "CURRENT_TIMESTAMP, (1), ${v} IS NULL, "
+        "CASE WHEN 1 = 1 THEN DEFAULT END, GETDATE(), '')"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO [a\"b] ([c]]d]) VALUES ("
+            "CURRENT_TIMESTAMP, (1), 1 IS NULL, "
+            "CASE WHEN 1 = 1 THEN DEFAULT END, GETDATE(), '')"
+        >>},
+        rendered_binary(render(Plan, #{v => 1}, null_opts()))
+    ).
+
+%% Checks booleans, floats, numbers, and literal dollar text inside and outside strings.
+scalar_template_value_types_test() ->
+    SQL = <<
+        "INSERT INTO t VALUES ("
+        "'pre${$}${text}post', ${yes}, ${no}, ${float}, ${hexish}, '${number}')"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO [t] VALUES ("
+            "'pre$okpost', 'true', 'false', 1.5, '0xyz', '42')"
+        >>},
+        rendered_binary(
+            render(
+                Plan,
+                #{
+                    text => <<"ok">>,
+                    yes => true,
+                    no => false,
+                    float => 1.5,
+                    hexish => <<"0xyz">>,
+                    number => 42
+                },
+                null_opts()
+            )
+        )
+    ).
+
+%% Checks missing string values with both undefined-value policies.
+undefined_string_template_values_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t VALUES ('${missing}')">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [t] VALUES ('null')">>},
+        rendered_binary(render(Plan, #{}, null_opts()))
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO [t] VALUES ('undefined')">>},
+        rendered_binary(
+            render(Plan, #{}, #{undefined_vars_as_null => false})
+        )
+    ).
+
+%% Checks that a placeholder with a leading dot resolves against the input map.
 leading_dot_placeholder_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${.payload})">>),
     ?assertEqual(
@@ -530,12 +604,14 @@ leading_dot_placeholder_test() ->
         rendered_binary(render(Plan, #{payload => <<"hello">>}, null_opts()))
     ).
 
+%% Checks that an injection payload remains valid SQL inside an interpolated Unicode string.
 quoted_string_boundary_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (N'pre${payload}post')">>),
     Attack = <<"'); DROP TABLE t; --\\">>,
     {ok, Rendered} = render(Plan, #{payload => Attack}, null_opts()),
     ?assertMatch({ok, _}, compile(Rendered)).
 
+%% Checks batch escaping, indexed NUL errors, and the SQL Server row limit.
 batch_shape_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${payload})">>),
     {ok, Rendered} = render_batch(
@@ -570,6 +646,7 @@ batch_shape_test() ->
         render_batch(Plan, [#{payload => <<"extra">>} | Rows], null_opts())
     ).
 
+%% Checks rendering of arbitrary binary and Unicode values in SQL Server strings.
 binary_and_unicode_value_test() ->
     {ok, ValuePlan} = compile(<<"INSERT INTO t(v) VALUES (${payload})">>),
     ?assertEqual(
@@ -583,6 +660,7 @@ binary_and_unicode_value_test() ->
         rendered_binary(render(UnicodePlan, #{payload => Unicode}, null_opts()))
     ).
 
+%% Checks that a hexadecimal binary literal renders without string quoting.
 binary_literal_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${payload})">>),
     ?assertEqual(
@@ -590,6 +668,7 @@ binary_literal_test() ->
         rendered_binary(render(Plan, #{payload => <<"0x0010">>}, null_opts()))
     ).
 
+%% Checks that the null input value renders as SQL NULL.
 null_value_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${payload})">>),
     ?assertEqual(
@@ -597,6 +676,7 @@ null_value_test() ->
         rendered_binary(render(Plan, #{payload => null}, null_opts()))
     ).
 
+%% Checks qualified object and function names and rejects excessive qualification.
 qualified_names_test() ->
     {ok, Plan} = compile(<<"INSERT INTO mqtt..t(v) VALUES (dbo.fn(${payload}))">>),
     ?assertEqual(
@@ -617,6 +697,7 @@ qualified_names_test() ->
     ),
     ?assertMatch({error, _}, compile(<<"INSERT INTO a.b.c.d.e(v) VALUES (1)">>)).
 
+%% Checks rejection of comments, dynamic targets, partial placeholders, and multiple rows.
 reject_unsupported_syntax_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1) --(* comment">>)),
     ?assertMatch({error, _}, compile(<<"INSERT INTO ${table}(v) VALUES (1)">>)),
@@ -624,6 +705,7 @@ reject_unsupported_syntax_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO t(v) VALUES (${value}0)">>)),
     ?assertMatch({error, _}, compile(<<"INSERT INTO t(v) VALUES (1), (2)">>)).
 
+%% Checks identifier, whitespace, expression, length, and NUL lexical boundaries.
 lexical_boundary_test() ->
     Accepted = [
         <<"INSERT INTO @t(v) VALUES (1)">>,

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
@@ -135,7 +135,6 @@ render_template_op(Style, Parts, Rest, Data, Opts, Cache0, Acc) ->
 
 encode_result(Encoder) ->
     try Encoder() of
-        {ok, _} = Ok -> Ok;
         {error, _} = Error -> Error;
         Encoded -> {ok, Encoded}
     catch

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_lexer.xrl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_lexer.xrl
@@ -1,0 +1,72 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% This lexer recognizes the restricted SQL Server INSERT template token set.
+
+Definitions.
+
+WS              = [\s\t\r\n\f]+
+ID_START        = [A-Za-z_@\#\200-\377]
+ID_CONTINUE     = [A-Za-z0-9_@\#\$\200-\377]
+IDENTIFIER      = {ID_START}{ID_CONTINUE}*
+PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
+NUMBER          = (([0-9]+(\.[0-9]*)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
+HEX             = 0[xX][0-9A-Fa-f]+
+SQ_STRING       = '([^']|'')*'
+NQ_STRING       = [nN]'([^']|'')*'
+DQ_IDENTIFIER   = "([^"]|"")*"
+BR_IDENTIFIER   = \[([^\]]|\]\])*\]
+
+Rules.
+
+{WS}            : skip_token.
+--               : {error, {comments_not_allowed, TokenLine}}.
+\/\*             : {error, {comments_not_allowed, TokenLine}}.
+{PLACEHOLDER}   : placeholder(TokenChars, TokenLine).
+{NQ_STRING}     : {token, {nq_string, TokenLine, to_binary(TokenChars)}}.
+{SQ_STRING}     : {token, {sq_string, TokenLine, to_binary(TokenChars)}}.
+{DQ_IDENTIFIER} : {token, {dq_identifier, TokenLine, to_binary(TokenChars)}}.
+{BR_IDENTIFIER} : {token, {br_identifier, TokenLine, to_binary(TokenChars)}}.
+{HEX}           : {token, {hex, TokenLine, to_binary(TokenChars)}}.
+{NUMBER}        : {token, {number, TokenLine, to_binary(TokenChars)}}.
+{IDENTIFIER}    : identifier(TokenChars, TokenLine).
+\(              : {token, {'(', TokenLine}}.
+\)              : {token, {')', TokenLine}}.
+,               : {token, {',', TokenLine}}.
+\.              : {token, {'.', TokenLine}}.
+;               : {token, {';', TokenLine}}.
+\+              : {token, {'+', TokenLine}}.
+-               : {token, {'-', TokenLine}}.
+\*              : {token, {'*', TokenLine}}.
+\/              : {token, {'/', TokenLine}}.
+\%              : {token, {'%', TokenLine}}.
+'               : {error, {unterminated_string, TokenLine}}.
+"               : {error, {unterminated_quoted_identifier, TokenLine}}.
+\[              : {error, {unterminated_bracket_identifier, TokenLine}}.
+\$              : {error, {invalid_placeholder, TokenLine}}.
+.               : {error, {unsupported_token, TokenLine, to_binary(TokenChars)}}.
+
+Erlang code.
+
+to_binary(Chars) ->
+    list_to_binary(Chars).
+
+placeholder(Chars, Line) ->
+    Bin = to_binary(Chars),
+    case emqx_bridge_sqlserver_sql:parse_placeholder(Bin) of
+        {ok, Placeholder} -> {token, {placeholder, Line, Placeholder}};
+        {error, _} -> {error, {invalid_placeholder, Line, Bin}}
+    end.
+
+identifier(Chars, Line) ->
+    Bin = to_binary(Chars),
+    case string:lowercase(Bin) of
+        <<"insert">> -> {token, {insert, Line}};
+        <<"into">> -> {token, {into, Line}};
+        <<"values">> -> {token, {values, Line}};
+        <<"null">> -> {token, {null, Line}};
+        <<"default">> -> {token, {default, Line}};
+        <<"current_timestamp">> -> {token, {current_timestamp, Line}};
+        _ -> {token, {identifier, Line, Bin}}
+    end.

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_lexer.xrl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_lexer.xrl
@@ -3,24 +3,40 @@
 %%--------------------------------------------------------------------
 
 %% This lexer recognizes the restricted SQL Server INSERT template token set.
+%% Leex selects the longest prefix. Rule order resolves equal-length matches.
 
 Definitions.
 
-WS              = [\s\t\r\n\f]+
-ID_START        = [A-Za-z_@\#\200-\377]
-ID_CONTINUE     = [A-Za-z0-9_@\#\$\200-\377]
+%% SqlScriptDOM defines SQL whitespace separately from identifier characters:
+%% https://github.com/microsoft/SqlScriptDOM/blob/01aa17bfa32f25f1b1084b72c2e6a1a92b44633a/SqlScriptDom/Parser/TSql/TSql160.g#L33997-L34107
+WS              = [\s\t\r\n\v\f]+
+%% Use the ASCII subset of SQL Server regular identifier categories:
+%% https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver16#rules-for-regular-identifiers
+ID_START        = [A-Za-z_@\#]
+ID_CONTINUE     = [A-Za-z0-9_@\#\$]
 IDENTIFIER      = {ID_START}{ID_CONTINUE}*
+%% emqx_template placeholder envelope; parse_placeholder/1 applies local validation:
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
+%% Accept only complete forms. ScriptDOM also tokenizes incomplete forms:
+%% https://github.com/microsoft/SqlScriptDOM/blob/01aa17bfa32f25f1b1084b72c2e6a1a92b44633a/SqlScriptDom/Parser/TSql/TSql160.g#L34147-L34198
 NUMBER          = (([0-9]+(\.[0-9]*)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
 HEX             = 0[xX][0-9A-Fa-f]+
 SQ_STRING       = '([^']|'')*'
+%% '
 NQ_STRING       = [nN]'([^']|'')*'
+%% '
+%% SqlScriptDOM scans doubled double quotes and brackets as one token:
+%% https://github.com/microsoft/SqlScriptDOM/blob/01aa17bfa32f25f1b1084b72c2e6a1a92b44633a/SqlScriptDom/Parser/TSql/TSql160.g#L34308-L34342
 DQ_IDENTIFIER   = "([^"]|"")*"
-BR_IDENTIFIER   = \[([^\]]|\]\])*\]
+%% "
+BR_IDENTIFIER   = \[([^\]]|\]\])+\]
 
 Rules.
 
 {WS}            : skip_token.
+%% Reject SQL Server comment openers instead of implementing complete comments:
+%% https://github.com/microsoft/SqlScriptDOM/blob/01aa17bfa32f25f1b1084b72c2e6a1a92b44633a/SqlScriptDom/Parser/TSql/TSql160.g#L34351-L34392
 --               : {error, {comments_not_allowed, TokenLine}}.
 \/\*             : {error, {comments_not_allowed, TokenLine}}.
 {PLACEHOLDER}   : placeholder(TokenChars, TokenLine).
@@ -31,18 +47,31 @@ Rules.
 {HEX}           : {token, {hex, TokenLine, to_binary(TokenChars)}}.
 {NUMBER}        : {token, {number, TokenLine, to_binary(TokenChars)}}.
 {IDENTIFIER}    : identifier(TokenChars, TokenLine).
+%% TSql160 defines these punctuation and arithmetic tokens directly.
+%% Its Number rule decides whether a dot starts a decimal:
+%% https://github.com/microsoft/SqlScriptDOM/blob/01aa17bfa32f25f1b1084b72c2e6a1a92b44633a/SqlScriptDom/Parser/TSql/TSql160.g#L33934-L33971
+%% https://github.com/microsoft/SqlScriptDOM/blob/01aa17bfa32f25f1b1084b72c2e6a1a92b44633a/SqlScriptDom/Parser/TSql/TSql160.g#L34147-L34193
 \(              : {token, {'(', TokenLine}}.
 \)              : {token, {')', TokenLine}}.
 ,               : {token, {',', TokenLine}}.
 \.              : {token, {'.', TokenLine}}.
 ;               : {token, {';', TokenLine}}.
+>=              : {token, {'>=', TokenLine}}.
+<=              : {token, {'<=', TokenLine}}.
+<>              : {token, {'<>', TokenLine}}.
+!=              : {token, {'!=', TokenLine}}.
+=               : {token, {'=', TokenLine}}.
+>               : {token, {'>', TokenLine}}.
+<               : {token, {'<', TokenLine}}.
 \+              : {token, {'+', TokenLine}}.
 -               : {token, {'-', TokenLine}}.
 \*              : {token, {'*', TokenLine}}.
 \/              : {token, {'/', TokenLine}}.
 \%              : {token, {'%', TokenLine}}.
 '               : {error, {unterminated_string, TokenLine}}.
+%% '
 "               : {error, {unterminated_quoted_identifier, TokenLine}}.
+%% "
 \[              : {error, {unterminated_bracket_identifier, TokenLine}}.
 \$              : {error, {invalid_placeholder, TokenLine}}.
 .               : {error, {unsupported_token, TokenLine, to_binary(TokenChars)}}.
@@ -68,5 +97,14 @@ identifier(Chars, Line) ->
         <<"null">> -> {token, {null, Line}};
         <<"default">> -> {token, {default, Line}};
         <<"current_timestamp">> -> {token, {current_timestamp, Line}};
+        <<"case">> -> {token, {case_kw, Line}};
+        <<"when">> -> {token, {when_kw, Line}};
+        <<"then">> -> {token, {then_kw, Line}};
+        <<"else">> -> {token, {else_kw, Line}};
+        <<"end">> -> {token, {end_kw, Line}};
+        <<"is">> -> {token, {is_kw, Line}};
+        <<"and">> -> {token, {and_kw, Line}};
+        <<"or">> -> {token, {or_kw, Line}};
+        <<"not">> -> {token, {not_kw, Line}};
         _ -> {token, {identifier, Line, Bin}}
     end.

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_parser.yrl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_parser.yrl
@@ -78,4 +78,6 @@ opt_semicolon -> ';' : true.
 
 Erlang code.
 
+-ignore_xref({return_error, 2}).
+
 value({_Token, _Line, Value}) -> Value.

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_parser.yrl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_parser.yrl
@@ -1,0 +1,81 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% Restricted SQL Server INSERT INTO VALUES grammar.
+
+Nonterminals
+    template insert_stmt target static_identifier opt_static_identifier opt_columns columns identifier_list row
+    expression_list expression expression_args opt_expression_args function_name opt_semicolon.
+
+Terminals
+    insert into values null default current_timestamp
+    identifier placeholder number hex sq_string nq_string dq_identifier br_identifier
+    '(' ')' ',' '.' ';' '+' '-' '*' '/' '%'.
+
+Rootsymbol template.
+
+Left 100 '+' '-'.
+Left 200 '*' '/' '%'.
+
+template -> insert_stmt : '$1'.
+
+insert_stmt -> insert into target opt_columns values row opt_semicolon :
+    {insert, #{target => '$3', columns => '$4', row => '$6'}}.
+
+target -> static_identifier : ['$1'].
+target -> static_identifier '.' static_identifier : ['$1', '$3'].
+target -> static_identifier '.' opt_static_identifier '.' static_identifier : ['$1', '$3', '$5'].
+target -> static_identifier '.' opt_static_identifier '.' opt_static_identifier '.' static_identifier :
+    ['$1', '$3', '$5', '$7'].
+
+static_identifier -> identifier : {identifier, bare, value('$1')}.
+static_identifier -> dq_identifier : {identifier, double, value('$1')}.
+static_identifier -> br_identifier : {identifier, bracket, value('$1')}.
+
+opt_static_identifier -> '$empty' : empty.
+opt_static_identifier -> static_identifier : '$1'.
+
+opt_columns -> '$empty' : undefined.
+opt_columns -> columns : '$1'.
+columns -> '(' identifier_list ')' : '$2'.
+identifier_list -> static_identifier : ['$1'].
+identifier_list -> identifier_list ',' static_identifier : '$1' ++ ['$3'].
+
+row -> '(' expression_list ')' : {row, '$2'}.
+expression_list -> expression : ['$1'].
+expression_list -> expression_list ',' expression : '$1' ++ ['$3'].
+
+opt_expression_args -> '$empty' : [].
+opt_expression_args -> expression_args : '$1'.
+expression_args -> expression : ['$1'].
+expression_args -> expression_args ',' expression : '$1' ++ ['$3'].
+
+expression -> placeholder : {var, value('$1')}.
+expression -> sq_string : {string, varchar, value('$1')}.
+expression -> nq_string : {string, nvarchar, value('$1')}.
+expression -> number : {number, value('$1')}.
+expression -> hex : {hex, value('$1')}.
+expression -> null : null.
+expression -> default : default.
+expression -> current_timestamp : current_timestamp.
+expression -> identifier : {identifier_value, value('$1')}.
+expression -> function_name '(' opt_expression_args ')' : {call, '$1', '$3'}.
+expression -> '(' expression ')' : {group, '$2'}.
+expression -> '+' expression : {unary, '+', '$2'}.
+expression -> '-' expression : {unary, '-', '$2'}.
+expression -> expression '+' expression : {binary, '+', '$1', '$3'}.
+expression -> expression '-' expression : {binary, '-', '$1', '$3'}.
+expression -> expression '*' expression : {binary, '*', '$1', '$3'}.
+expression -> expression '/' expression : {binary, '/', '$1', '$3'}.
+expression -> expression '%' expression : {binary, '%', '$1', '$3'}.
+
+function_name -> static_identifier : ['$1'].
+function_name -> function_name '.' static_identifier : '$1' ++ ['$3'].
+
+opt_semicolon -> '$empty' : false.
+opt_semicolon -> ';' : true.
+
+Erlang code.
+
+value({_Token, _Line, Value}) -> Value.

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_parser.yrl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_parser.yrl
@@ -6,20 +6,30 @@
 
 Nonterminals
     template insert_stmt target static_identifier opt_static_identifier opt_columns columns identifier_list row
-    expression_list expression expression_args opt_expression_args function_name opt_semicolon.
+    expression_list expression expression_args opt_expression_args function_name opt_semicolon
+    case_expression opt_case_operand when_clauses when_clause opt_case_else.
 
 Terminals
     insert into values null default current_timestamp
+    case_kw when_kw then_kw else_kw end_kw is_kw and_kw or_kw not_kw
     identifier placeholder number hex sq_string nq_string dq_identifier br_identifier
-    '(' ')' ',' '.' ';' '+' '-' '*' '/' '%'.
+    '(' ')' ',' '.' ';' '=' '>=' '<=' '<>' '!=' '>' '<' '+' '-' '*' '/' '%'.
 
+%% Trailing unconsumed tokens do not match and cause a parse error.
 Rootsymbol template.
 
+Left 10 or_kw.
+Left 20 and_kw.
+Right 30 not_kw.
+Nonassoc 40 '=' '>=' '<=' '<>' '!=' '>' '<' is_kw.
 Left 100 '+' '-'.
 Left 200 '*' '/' '%'.
 
 template -> insert_stmt : '$1'.
 
+%% This grammar is a restricted subset of SQL Server INSERT:
+%% https://github.com/microsoft/SqlScriptDOM/blob/01aa17bfa32f25f1b1084b72c2e6a1a92b44633a/SqlScriptDom/Parser/TSql/TSql160.g#L19710-L19781
+%% https://github.com/microsoft/SqlScriptDOM/blob/01aa17bfa32f25f1b1084b72c2e6a1a92b44633a/SqlScriptDom/Parser/TSql/TSql160.g#L19976-L20029
 insert_stmt -> insert into target opt_columns values row opt_semicolon :
     {insert, #{target => '$3', columns => '$4', row => '$6'}}.
 
@@ -59,16 +69,39 @@ expression -> hex : {hex, value('$1')}.
 expression -> null : null.
 expression -> default : default.
 expression -> current_timestamp : current_timestamp.
+expression -> case_expression : '$1'.
 expression -> identifier : {identifier_value, value('$1')}.
 expression -> function_name '(' opt_expression_args ')' : {call, '$1', '$3'}.
 expression -> '(' expression ')' : {group, '$2'}.
 expression -> '+' expression : {unary, '+', '$2'}.
 expression -> '-' expression : {unary, '-', '$2'}.
+expression -> not_kw expression : {unary, 'NOT', '$2'}.
+expression -> expression '=' expression : {binary, '=', '$1', '$3'}.
+expression -> expression '>=' expression : {binary, '>=', '$1', '$3'}.
+expression -> expression '<=' expression : {binary, '<=', '$1', '$3'}.
+expression -> expression '<>' expression : {binary, '<>', '$1', '$3'}.
+expression -> expression '!=' expression : {binary, '!=', '$1', '$3'}.
+expression -> expression '>' expression : {binary, '>', '$1', '$3'}.
+expression -> expression '<' expression : {binary, '<', '$1', '$3'}.
+expression -> expression is_kw null : {is_null, '$1', false}.
+expression -> expression is_kw not_kw null : {is_null, '$1', true}.
+expression -> expression and_kw expression : {binary, 'AND', '$1', '$3'}.
+expression -> expression or_kw expression : {binary, 'OR', '$1', '$3'}.
 expression -> expression '+' expression : {binary, '+', '$1', '$3'}.
 expression -> expression '-' expression : {binary, '-', '$1', '$3'}.
 expression -> expression '*' expression : {binary, '*', '$1', '$3'}.
 expression -> expression '/' expression : {binary, '/', '$1', '$3'}.
 expression -> expression '%' expression : {binary, '%', '$1', '$3'}.
+
+case_expression -> case_kw opt_case_operand when_clauses opt_case_else end_kw :
+    {case_expression, '$2', '$3', '$4'}.
+opt_case_operand -> '$empty' : undefined.
+opt_case_operand -> expression : '$1'.
+when_clauses -> when_clause : ['$1'].
+when_clauses -> when_clauses when_clause : '$1' ++ ['$2'].
+when_clause -> when_kw expression then_kw expression : {'when', '$2', '$4'}.
+opt_case_else -> '$empty' : undefined.
+opt_case_else -> else_kw expression : '$2'.
 
 function_name -> static_identifier : ['$1'].
 function_name -> function_name '.' static_identifier : '$1' ++ ['$3'].

--- a/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
+++ b/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
@@ -223,6 +223,33 @@ t_undefined_vars_as_null(Config) ->
     ),
     ok.
 
+t_null_value(Config) ->
+    ?assertMatch(
+        {ok, _},
+        create_bridge(Config, #{})
+    ),
+    SentData = maps:put(payload, null, sent_data("tmp")),
+    ?check_trace(
+        begin
+            ?wait_async_action(
+                ?assertEqual(ok, send_message(Config, SentData)),
+                #{?snk_kind := sqlserver_connector_query_return},
+                10_000
+            ),
+            ?assertMatch(
+                [{null}],
+                connect_and_get_payload(Config)
+            ),
+            ok
+        end,
+        fun(Trace0) ->
+            Trace = ?of_kind(sqlserver_connector_query_return, Trace0),
+            ?assertMatch([#{result := ok}], Trace),
+            ok
+        end
+    ),
+    ok.
+
 t_setup_via_http_api_and_publish(Config) ->
     BridgeType = ?config(sqlserver_bridge_type, Config),
     Name = ?config(sqlserver_name, Config),
@@ -424,6 +451,25 @@ t_simple_query(Config) ->
         end
     ),
     ok.
+
+t_sql_value_escaping(Config) ->
+    BatchSize = batch_size(Config),
+    ?assertMatch({ok, _}, create_bridge(Config)),
+    Payload = <<"x\\'); DROP TABLE mqtt.dbo.t_mqtt_msg; --">>,
+    Fillers = [integer_to_binary(N) || N <- lists:seq(2, BatchSize)],
+    Payloads = [Payload | Fillers],
+    BridgeType = ?config(sqlserver_bridge_type, Config),
+    Name = ?config(sqlserver_name, Config),
+    ActionId = emqx_bridge_v2:id(BridgeType, Name),
+    Requests = [{ActionId, sent_data(Value)} || Value <- Payloads],
+
+    ?wait_async_action(
+        [?assertEqual(ok, query_resource(Config, Request)) || Request <- Requests],
+        #{?snk_kind := sqlserver_connector_query_return},
+        10_000
+    ),
+    ?assertEqual(BatchSize, connect_and_get_count(Config)),
+    ?assert(lists:member({str(Payload)}, connect_and_get_payload(Config))).
 
 -define(MISSING_TINYINT_ERROR,
     "[Microsoft][ODBC Driver 18 for SQL Server][SQL Server]"

--- a/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
+++ b/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
@@ -113,13 +113,13 @@ init_per_group(async, Config) ->
 init_per_group(sync, Config) ->
     [{query_mode, sync} | Config];
 init_per_group(with_batch, Config0) ->
-    Config = [{enable_batch, true}, {pool_size, ?WORKER_POOL_SIZE} | Config0],
+    Config = [{batch_size, ?BATCH_SIZE}, {pool_size, ?WORKER_POOL_SIZE} | Config0],
     common_init(Config);
 init_per_group(without_batch, Config0) ->
-    Config = [{enable_batch, false}, {pool_size, ?WORKER_POOL_SIZE} | Config0],
+    Config = [{batch_size, 1}, {pool_size, ?WORKER_POOL_SIZE} | Config0],
     common_init(Config);
 init_per_group(health_check, Config0) ->
-    Config = [{query_mode, async}, {enable_batch, false}, {pool_size, 1} | Config0],
+    Config = [{query_mode, async}, {batch_size, 1}, {pool_size, 1} | Config0],
     common_init(Config);
 init_per_group(_Group, Config) ->
     Config.
@@ -413,7 +413,7 @@ t_write_timeout(_Config) ->
     ok.
 
 t_simple_query(Config) ->
-    BatchSize = batch_size(Config),
+    BatchSize = ?config(batch_size, Config),
     ?assertMatch(
         {ok, _},
         create_bridge(Config)
@@ -455,7 +455,7 @@ t_simple_query(Config) ->
 
 %% Checks that an injection payload remains one stored value in single and batch modes.
 t_sql_value_escaping(Config) ->
-    BatchSize = batch_size(Config),
+    BatchSize = ?config(batch_size, Config),
     SQL =
         "insert into t_mqtt_msg(msgid, topic, qos, payload) "
         "values (${id}, ${topic}, ${qos}, "
@@ -545,8 +545,7 @@ common_init(ConfigT) ->
         {sqlserver_host, Host},
         {sqlserver_port, Port},
         %% see also for `proxy_name` : $PROJ_ROOT/.ci/docker-compose-file/toxiproxy.json
-        {proxy_name, "sqlserver"},
-        {batch_size, batch_size(ConfigT)}
+        {proxy_name, "sqlserver"}
         | ConfigT
     ],
     BridgeType = proplists:get_value(bridge_type, Config0, <<"sqlserver">>),
@@ -597,7 +596,7 @@ sqlserver_config(BridgeType, Config) ->
     Port = integer_to_list(?config(sqlserver_port, Config)),
     Server = ?config(sqlserver_host, Config) ++ ":" ++ Port,
     Name = atom_to_binary(?MODULE),
-    BatchSize = batch_size(Config),
+    BatchSize = ?config(batch_size, Config),
     QueryMode = ?config(query_mode, Config),
     Passfile = ?config(sqlserver_passfile, Config),
     PoolSize = ?config(pool_size, Config),
@@ -787,12 +786,6 @@ directly_query(Con, Query, Timeout) ->
 %%--------------------------------------------------------------------
 %% help functions
 %%--------------------------------------------------------------------
-
-batch_size(Config) ->
-    case ?config(enable_batch, Config) of
-        true -> ?BATCH_SIZE;
-        false -> 1
-    end.
 
 conn_str([], Acc) ->
     lists:join(";", ["Encrypt=YES", "TrustServerCertificate=YES" | Acc]);

--- a/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
+++ b/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
@@ -223,6 +223,7 @@ t_undefined_vars_as_null(Config) ->
     ),
     ok.
 
+%% Checks that a literal null payload is inserted as SQL NULL.
 t_null_value(Config) ->
     ?assertMatch(
         {ok, _},
@@ -452,6 +453,7 @@ t_simple_query(Config) ->
     ),
     ok.
 
+%% Checks that an injection payload remains one stored value in single and batch modes.
 t_sql_value_escaping(Config) ->
     BatchSize = batch_size(Config),
     SQL =

--- a/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
+++ b/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
@@ -454,7 +454,11 @@ t_simple_query(Config) ->
 
 t_sql_value_escaping(Config) ->
     BatchSize = batch_size(Config),
-    ?assertMatch({ok, _}, create_bridge(Config)),
+    SQL =
+        "insert into t_mqtt_msg(msgid, topic, qos, payload) "
+        "values (${id}, ${topic}, ${qos}, "
+        "CASE WHEN ${payload} = N'null' THEN NULL ELSE N'${payload}' END)",
+    ?assertMatch({ok, _}, create_bridge(Config, #{<<"sql">> => SQL})),
     Payload = <<"x\\'); DROP TABLE mqtt.dbo.t_mqtt_msg; --">>,
     Fillers = [integer_to_binary(N) || N <- lists:seq(2, BatchSize)],
     Payloads = [Payload | Fillers],
@@ -469,7 +473,8 @@ t_sql_value_escaping(Config) ->
         10_000
     ),
     ?assertEqual(BatchSize, connect_and_get_count(Config)),
-    ?assert(lists:member({str(Payload)}, connect_and_get_payload(Config))).
+    Rows = connect_and_get_payload(Config),
+    ?assert(lists:member({str(Payload)}, Rows)).
 
 -define(MISSING_TINYINT_ERROR,
     "[Microsoft][ODBC Driver 18 for SQL Server][SQL Server]"

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.app.src
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_tdengine, [
     {description, "EMQX Enterprise TDengine Bridge"},
-    {vsn, "0.2.7"},
+    {vsn, "0.2.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
@@ -232,10 +232,15 @@ on_stop(InstanceId, _State) ->
 
 on_query(InstanceId, {ChannelId, Data}, #{channels := Channels} = State) ->
     case maps:find(ChannelId, Channels) of
-        {ok, #{insert := Tokens, opts := Opts} = ChannelState} ->
-            Query = proc_nullable_tmpl(Tokens, Data, maps:get(channel_conf, ChannelState, #{})),
-            emqx_trace:rendered_action_template(ChannelId, #{query => Query}),
-            do_query_job(InstanceId, {?MODULE, execute, [Query, Opts]}, State);
+        {ok, #{sql_plan := Plan, opts := Opts} = ChannelState} ->
+            RenderOpts = render_opts(maps:get(channel_conf, ChannelState, #{})),
+            case emqx_bridge_tdengine_sql:render(Plan, Data, RenderOpts) of
+                {ok, Query} ->
+                    emqx_trace:rendered_action_template(ChannelId, #{query => Query}),
+                    do_query_job(InstanceId, {?MODULE, execute, [Query, Opts]}, State);
+                {error, Reason} ->
+                    {error, {unrecoverable_error, Reason}}
+            end;
         _ ->
             {error, {unrecoverable_error, {invalid_channel_id, InstanceId}}}
     end.
@@ -247,12 +252,12 @@ on_batch_query(
     #{channels := Channels} = State
 ) ->
     case maps:find(ChannelId, Channels) of
-        {ok, #{batch := Tokens, opts := Opts} = ChannelState} ->
+        {ok, #{sql_plan := Plan, opts := Opts} = ChannelState} ->
             TraceRenderedCTX = emqx_trace:make_rendered_action_template_trace_context(ChannelId),
             ChannelConf = maps:get(channel_conf, ChannelState, #{}),
             do_query_job(
                 InstanceId,
-                {?MODULE, do_batch_insert, [Tokens, BatchReq, Opts, TraceRenderedCTX, ChannelConf]},
+                {?MODULE, do_batch_insert, [Plan, BatchReq, Opts, TraceRenderedCTX, ChannelConf]},
                 State
             );
         _ ->
@@ -378,33 +383,23 @@ do_query_job(InstanceId, Job, #{pool_name := PoolName} = State) ->
 execute(Conn, Query, Opts) ->
     tdengine:insert(Conn, Query, Opts).
 
-do_batch_insert(Conn, Tokens, BatchReqs, Opts, TraceRenderedCTX, ChannelConf) ->
-    SQL = aggregate_query(Tokens, BatchReqs, <<"INSERT INTO">>, ChannelConf),
-    try
-        emqx_trace:rendered_action_template_with_ctx(
-            TraceRenderedCTX,
-            #{query => SQL}
-        ),
-        execute(Conn, SQL, Opts)
-    catch
-        error:?EMQX_TRACE_STOP_ACTION_MATCH = Reason ->
-            {error, Reason}
+do_batch_insert(Conn, Plan, BatchReqs, Opts, TraceRenderedCTX, ChannelConf) ->
+    DataList = [Data || {_, Data} <- BatchReqs],
+    case emqx_bridge_tdengine_sql:render_batch(Plan, DataList, render_opts(ChannelConf)) of
+        {ok, SQL} ->
+            try
+                emqx_trace:rendered_action_template_with_ctx(
+                    TraceRenderedCTX,
+                    #{query => SQL}
+                ),
+                execute(Conn, SQL, Opts)
+            catch
+                error:?EMQX_TRACE_STOP_ACTION_MATCH = Reason ->
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, {unrecoverable_error, Reason}}
     end.
-
-aggregate_query(BatchTks, BatchReqs, Acc, ChannelConf) ->
-    lists:foldl(
-        fun({_, Data}, InAcc) ->
-            InsertPart = proc_nullable_tmpl(BatchTks, Data, ChannelConf),
-            <<InAcc/binary, " ", InsertPart/binary>>
-        end,
-        Acc,
-        BatchReqs
-    ).
-
-proc_nullable_tmpl(Template, Data, #{undefined_vars_as_null := true}) ->
-    emqx_placeholder:proc_nullable_tmpl(Template, Data);
-proc_nullable_tmpl(Template, Data, _) ->
-    emqx_placeholder:proc_tmpl(Template, Data).
 
 connect(Opts) ->
     %% TODO: teach `tdengine` to accept 0-arity closures as passwords.
@@ -413,42 +408,13 @@ connect(Opts) ->
     tdengine:start_link(NOpts).
 
 parse_prepare_sql(SQL) ->
-    case emqx_utils_sql:get_statement_type(SQL) of
-        insert ->
-            InsertTks = emqx_placeholder:preproc_tmpl(SQL),
-            SQL1 = string:trim(SQL, trailing, ";"),
-            case split_insert_sql(SQL1) of
-                [_InsertPart, BatchDesc] ->
-                    BatchTks = emqx_placeholder:preproc_tmpl(BatchDesc),
-                    {ok, #{insert => InsertTks, batch => BatchTks}};
-                Result ->
-                    {error, #{msg => "split_sql_failed", sql => SQL, result => Result}}
-            end;
-        Type when is_atom(Type) ->
-            {error, #{msg => "detect_sql_type_unsupported", sql => SQL, type => Type}};
-        {error, Reason} ->
-            {error, #{msg => "detect_sql_type_failed", sql => SQL, reason => Reason}}
+    case emqx_bridge_tdengine_sql:compile(SQL) of
+        {ok, Plan} -> {ok, #{sql_plan => Plan}};
+        {error, Reason} -> {error, Reason}
     end.
 
 to_bin(List) when is_list(List) ->
     unicode:characters_to_binary(List, utf8).
 
-split_insert_sql(SQL0) ->
-    SQL = formalize_sql(SQL0),
-    lists:filtermap(
-        fun(E) ->
-            case string:trim(E) of
-                <<>> ->
-                    false;
-                E1 ->
-                    {true, E1}
-            end
-        end,
-        re:split(SQL, "(?i)(insert into)")
-    ).
-
-formalize_sql(Input) ->
-    %% 1. replace all whitespaces like '\r' '\n' or spaces to a single space char.
-    SQL = re:replace(Input, "\\s+", " ", [global, {return, binary}]),
-    %% 2. trims the result
-    string:trim(SQL).
+render_opts(ChannelConf) ->
+    #{undefined_vars_as_null => maps:get(undefined_vars_as_null, ChannelConf, false)}.

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
@@ -489,7 +489,8 @@ encode_value(true, _Opts) ->
     <<"true">>;
 encode_value(false, _Opts) ->
     <<"false">>;
-encode_value(Value, _Opts) when is_integer(Value) -> integer_to_binary(Value);
+encode_value(Value, _Opts) when is_integer(Value) ->
+    integer_to_binary(Value);
 encode_value(Value, _Opts) when is_float(Value) ->
     float_to_binary(Value, [compact]);
 encode_value(Value, _Opts) ->

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
@@ -40,6 +40,10 @@
 compile(SQL0) ->
     SQL = unicode:characters_to_binary(SQL0),
     try
+        %% TDengine consumes null-terminated SQL. NUL cannot belong to any token:
+        %% https://github.com/taosdata/TDengine/commit/4bde7ac8fbebc3aa9143124bfcbd08645c46a037
+        %% source/libs/parser/src/parTokenizer.c lines 623-630.
+        ok = assert_no_nul(SQL),
         case emqx_bridge_tdengine_sql_lexer:string(binary_to_list(SQL)) of
             {ok, Tokens, _EndLine} ->
                 case emqx_bridge_tdengine_sql_parser:parse(Tokens) of
@@ -328,7 +332,13 @@ parse_string(Source, single) ->
 parse_string(Source, double) ->
     parse_string_body(strip_quotes(Source), $", [], []).
 
-parse_string_body(<<>>, _Quote, Text, Parts) ->
+%% Source contains the remaining string bytes.
+%% Quote identifies the active delimiter.
+%% Text collects the current decoded literal bytes in reverse order.
+%% Parts collects completed template parts in reverse order.
+%% Escapes and doubled quotes append literal text.
+%% A placeholder flushes Text into Parts, and the final clause restores the source order.
+parse_string_body(_Source = <<>>, _Quote, Text, Parts) ->
     finish_parts(Text, Parts);
 parse_string_body(<<$\\, Escaped, Rest/binary>>, Quote, Text, Parts) ->
     parse_string_body(Rest, Quote, [decode_escape(Escaped) | Text], Parts);
@@ -347,7 +357,12 @@ parse_string_body(<<"${", _/binary>> = Bin, Quote, Text, Parts) ->
 parse_string_body(<<Char, Rest/binary>>, Quote, Text, Parts) ->
     parse_string_body(Rest, Quote, [Char | Text], Parts).
 
-parse_identifier_parts(<<>>, _Style, Text, Parts) ->
+%% Source contains the remaining identifier bytes.
+%% Style controls doubled-backtick decoding.
+%% Text collects the current literal bytes in reverse order.
+%% Parts collects completed template parts in reverse order.
+%% A placeholder flushes Text into Parts, and the final clause restores the source order.
+parse_identifier_parts(_Source = <<>>, _Style, Text, Parts) ->
     lists:reverse(flush_text(Text, Parts));
 parse_identifier_parts(<<$`, $`, Rest/binary>>, backtick, Text, Parts) ->
     parse_identifier_parts(Rest, backtick, [$` | Text], Parts);
@@ -362,6 +377,9 @@ parse_identifier_parts(<<"${", _/binary>> = Bin, Style, Text, Parts) ->
 parse_identifier_parts(<<Char, Rest/binary>>, Style, Text, Parts) ->
     parse_identifier_parts(Rest, Style, [Char | Text], Parts).
 
+%% Decode TDengine string escapes before template segments are re-encoded.
+%% https://github.com/taosdata/TDengine/commit/4bde7ac8fbebc3aa9143124bfcbd08645c46a037
+%% source/libs/parser/src/parUtil.c lines 262-307.
 decode_escape($n) -> $\n;
 decode_escape($r) -> $\r;
 decode_escape($t) -> $\t;
@@ -369,6 +387,9 @@ decode_escape($%) -> <<"\\%">>;
 decode_escape($_) -> <<"\\_">>;
 decode_escape(Char) -> Char.
 
+%% Restrict emqx_template's envelope to nonempty dotted paths.
+%% Retain `${}` and `${.}`.
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 valid_placeholder_source(<<"${}">>) ->
     true;
 valid_placeholder_source(<<"${.}">>) ->
@@ -432,9 +453,15 @@ merge_render_ops(Ops) ->
     ).
 
 encode_identifier(Parts) ->
+    %% A doubled backtick keeps dynamic data inside one identifier token:
+    %% https://github.com/taosdata/TDengine/commit/4bde7ac8fbebc3aa9143124bfcbd08645c46a037
+    %% source/libs/parser/src/parTokenizer.c lines 457-485.
     case render_identifier_parts(Parts) of
-        {ok, Identifier} -> quote_identifier(Identifier);
-        {error, _} = Error -> Error
+        {ok, Identifier} ->
+            ok = assert_no_nul(Identifier),
+            quote_identifier(Identifier);
+        {error, _} = Error ->
+            Error
     end.
 
 encode_value(undefined, #{undefined_vars_as_null := false}) ->
@@ -522,8 +549,18 @@ identifier_text(Value) ->
     end.
 
 encode_string(Text) ->
+    %% TDengine strings use backslash escaping at these token boundaries:
+    %% https://github.com/taosdata/TDengine/commit/4bde7ac8fbebc3aa9143124bfcbd08645c46a037
+    %% docs/en/12-taos-sql/18-escape.md lines 5-25.
+    ok = assert_no_nul(Text),
     Escaped = binary:replace(Text, [<<"\\">>, <<"'">>], <<"\\">>, [global, {insert_replaced, 1}]),
     <<"'", Escaped/binary, "'">>.
+
+assert_no_nul(Text) ->
+    case binary:match(Text, <<0>>) of
+        nomatch -> ok;
+        _ -> error(nul_character_not_allowed)
+    end.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -627,7 +664,50 @@ batch_shape_test() ->
         null_opts()
     ),
     ?assert(is_list(Rendered)),
-    ?assertMatch({ok, _}, compile(Rendered)).
+    ?assertMatch({ok, _}, compile(Rendered)),
+    ?assertEqual(
+        {ok, <<"INSERT INTO ">>},
+        rendered_binary(render_batch(Plan, [], null_opts()))
+    ),
+    ?assertMatch(
+        {error, {tdengine_template_render_failed, #{batch_index := 2, reason := _}}},
+        render_batch(
+            Plan,
+            [
+                #{clientid => <<"a">>, timestamp => 1, payload => <<"ok">>},
+                #{clientid => <<"b">>, timestamp => 2, payload => <<"a", 0, "b">>}
+            ],
+            null_opts()
+        )
+    ).
+
+binary_and_unicode_value_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t VALUES (${value})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO t VALUES ('", 16#FF, "')">>},
+        rendered_binary(render(Plan, #{value => <<16#FF>>}, null_opts()))
+    ),
+    Unicode = <<"你好😀"/utf8>>,
+    ?assertEqual(
+        {ok, <<"INSERT INTO t VALUES ('", Unicode/binary, "')">>},
+        rendered_binary(render(Plan, #{value => Unicode}, null_opts()))
+    ).
+
+escape_decode_test() ->
+    {ok, Plan} = compile(
+        <<"INSERT INTO t VALUES ('\\n\\r\\t\\%\\_\\q${value}')">>
+    ),
+    Expected = iolist_to_binary([
+        <<"INSERT INTO t VALUES ('">>,
+        $\n,
+        $\r,
+        $\t,
+        <<"\\\\%\\\\_qx')">>
+    ]),
+    ?assertEqual(
+        {ok, Expected},
+        rendered_binary(render(Plan, #{value => <<"x">>}, null_opts()))
+    ).
 
 reject_unsupported_syntax_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1) -- comment">>)),
@@ -660,11 +740,36 @@ row_and_table_clause_commas_test() ->
     ).
 
 decimal_forms_test() ->
-    {ok, Plan} = compile(<<"INSERT INTO t VALUES (.5, 1., -.5, -1.)">>),
+    {ok, Plan} = compile(<<"INSERT INTO t VALUES (.5, 1.5, -.5, -1.5)">>),
     ?assertEqual(
-        {ok, <<"INSERT INTO t VALUES (.5, 1., -.5, -1.)">>},
+        {ok, <<"INSERT INTO t VALUES (.5, 1.5, -.5, -1.5)">>},
         rendered_binary(render(Plan, #{}, null_opts()))
-    ).
+    ),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1.)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1.e2)">>)).
+
+literal_boundary_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t VALUES (NOW+1s+1n-1y)">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO t VALUES (NOW+1s+1n-1y)">>},
+        rendered_binary(render(Plan, #{}, null_opts()))
+    ),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (NOW+1second)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (NOW+1s_)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO таблица VALUES (1)"/utf8>>)),
+    EscapedLF = iolist_to_binary([<<"INSERT INTO t VALUES ('a">>, $\\, $\n, <<"b')">>]),
+    ?assertMatch({ok, _}, compile(EscapedLF)).
+
+nul_boundary_test() ->
+    Rejected = [
+        iolist_to_binary([<<"INSERT INTO t VALUES ('a">>, 0, <<"b')">>]),
+        iolist_to_binary([<<"INSERT INTO `a">>, 0, <<"b` VALUES (1)">>])
+    ],
+    lists:foreach(fun(SQL) -> ?assertMatch({error, _}, compile(SQL)) end, Rejected),
+    {ok, ValuePlan} = compile(<<"INSERT INTO t VALUES (${value})">>),
+    ?assertMatch({error, _}, render(ValuePlan, #{value => <<"a", 0, "b">>}, null_opts())),
+    {ok, IdentifierPlan} = compile(<<"INSERT INTO ${table} VALUES (1)">>),
+    ?assertMatch({error, _}, render(IdentifierPlan, #{table => <<"a", 0, "b">>}, null_opts())).
 
 identifier_error_placeholder_test() ->
     {ok, Plan} = compile(<<"INSERT INTO ${clientid} VALUES (1)">>),

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
@@ -1,0 +1,726 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc Compile and render restricted TDengine multi-table INSERT templates.
+-module(emqx_bridge_tdengine_sql).
+
+-export([compile/1, render/3, render_batch/3, parse_placeholder/1, parse_identifier_parts/2]).
+-export_type([plan/0]).
+
+-type placeholder() :: emqx_template:placeholder().
+
+-record(tpl_text, {text :: binary()}).
+-record(tpl_placeholder, {placeholder :: placeholder()}).
+-record(part_text, {text :: binary()}).
+-record(part_value, {value :: term()}).
+
+-type template_part() :: #tpl_text{} | #tpl_placeholder{}.
+-type part() :: #part_text{} | #part_value{}.
+
+-record(raw, {sql :: binary()}).
+-record(value, {placeholder :: placeholder()}).
+-record(string, {parts :: [template_part()]}).
+-record(identifier, {parts :: [template_part()]}).
+
+-type render_op() :: #raw{} | #value{} | #string{} | #identifier{}.
+-type render_plan() :: [render_op()].
+
+-record(tdengine_plan, {plan :: render_plan()}).
+
+-define(BATCH_SEPARATOR, <<" ">>).
+
+-opaque plan() :: #tdengine_plan{}.
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec compile(unicode:chardata()) -> {ok, plan()} | {error, term()}.
+compile(SQL0) ->
+    SQL = unicode:characters_to_binary(SQL0),
+    try
+        case emqx_bridge_tdengine_sql_lexer:string(binary_to_list(SQL)) of
+            {ok, Tokens, _EndLine} ->
+                case emqx_bridge_tdengine_sql_parser:parse(Tokens) of
+                    {ok, AST} -> compile_ast(AST);
+                    {error, Reason} -> {error, {invalid_tdengine_insert_template, Reason}}
+                end;
+            {error, Reason, _EndLine} ->
+                {error, {invalid_tdengine_insert_template, Reason}}
+        end
+    catch
+        Class:CatchReason -> {error, {invalid_tdengine_insert_template, {Class, CatchReason}}}
+    end.
+
+-spec render(plan(), map(), map()) -> {ok, iolist()} | {error, term()}.
+render(#tdengine_plan{plan = Plan}, Data, Opts) ->
+    case render_unit(Plan, Data, Opts) of
+        {ok, Rendered} -> {ok, [<<"INSERT INTO ">>, Rendered]};
+        {error, _} = Error -> Error
+    end.
+
+-spec render_batch(plan(), [map()], map()) -> {ok, iolist()} | {error, term()}.
+render_batch(#tdengine_plan{plan = Plan}, DataList, Opts) ->
+    case render_batch_units(DataList, Plan, Opts, 1, []) of
+        {ok, Rendered} -> {ok, [<<"INSERT INTO ">>, Rendered]};
+        {error, _} = Error -> Error
+    end.
+
+-spec parse_identifier_parts(binary(), bare | backtick) ->
+    {ok, [template_part()]} | {error, term()}.
+parse_identifier_parts(Source, Style) ->
+    try
+        {ok, parse_identifier_parts(Source, Style, [], [])}
+    catch
+        error:Reason -> {error, Reason}
+    end.
+
+-spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
+parse_placeholder(Source) ->
+    case valid_placeholder_source(Source) of
+        true ->
+            case emqx_template:parse(Source) of
+                [{var, _, _} = Placeholder] -> {ok, Placeholder};
+                _ -> {error, invalid_placeholder}
+            end;
+        false ->
+            {error, invalid_placeholder}
+    end.
+
+%%------------------------------------------------------------------------------
+%% Private funs
+%%------------------------------------------------------------------------------
+
+render_batch_units([Data | Rest], Template, Opts, Index, Acc) ->
+    case render_unit(Template, Data, Opts) of
+        {ok, Rendered} ->
+            render_batch_units(Rest, Template, Opts, Index + 1, [Rendered | Acc]);
+        {error, Reason} ->
+            {error, {tdengine_template_render_failed, #{batch_index => Index, reason => Reason}}}
+    end;
+render_batch_units([], _Template, _Opts, _Index, Acc) ->
+    {ok, lists:join(?BATCH_SEPARATOR, lists:reverse(Acc))}.
+
+render_unit(Unit, Data, Opts) ->
+    render_plan(Unit, Data, Opts, #{}, []).
+
+render_plan([#raw{sql = SQL} | Rest], Data, Opts, Cache, Acc) ->
+    render_plan(Rest, Data, Opts, Cache, [SQL | Acc]);
+render_plan([#value{placeholder = Placeholder} | Rest], Data, Opts, Cache0, Acc) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            case encode_result(fun() -> encode_value(Value, Opts) end) of
+                {ok, Encoded} -> render_plan(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} -> {error, render_error(Placeholder, Reason)}
+            end;
+        {error, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end;
+render_plan([#string{parts = Parts} | Rest], Data, Opts, Cache0, Acc) ->
+    render_template_op(
+        Parts,
+        fun(Resolved) -> encode_string(render_text_parts(Resolved, Opts)) end,
+        Rest,
+        Data,
+        Opts,
+        Cache0,
+        Acc
+    );
+render_plan([#identifier{parts = Parts} | Rest], Data, Opts, Cache0, Acc) ->
+    render_template_op(
+        Parts,
+        fun encode_identifier/1,
+        Rest,
+        Data,
+        Opts,
+        Cache0,
+        Acc
+    );
+render_plan([], _Data, _Opts, _Cache, Acc) ->
+    {ok, lists:reverse(Acc)}.
+
+render_template_op(Parts, Encoder, Rest, Data, Opts, Cache0, Acc) ->
+    case resolve_template_parts(Parts, Data, Cache0, []) of
+        {ok, Resolved, Cache} ->
+            case encode_result(fun() -> Encoder(Resolved) end) of
+                {ok, Encoded} -> render_plan(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} -> {error, render_template_error(Parts, Reason)}
+            end;
+        {error, Placeholder, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end.
+
+encode_result(Encoder) ->
+    try Encoder() of
+        {ok, _} = Ok -> Ok;
+        {error, _} = Error -> Error;
+        Encoded -> {ok, Encoded}
+    catch
+        Class:Reason -> {error, {Class, Reason}}
+    end.
+
+resolve_template_parts([#tpl_text{text = Text} | Rest], Data, Cache, Acc) ->
+    resolve_template_parts(Rest, Data, Cache, [#part_text{text = Text} | Acc]);
+resolve_template_parts([#tpl_placeholder{placeholder = Placeholder} | Rest], Data, Cache0, Acc) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            resolve_template_parts(Rest, Data, Cache, [#part_value{value = Value} | Acc]);
+        {error, Reason} ->
+            {error, Placeholder, Reason}
+    end;
+resolve_template_parts([], _Data, Cache, Acc) ->
+    {ok, lists:reverse(Acc), Cache}.
+
+resolve_placeholder({var, _Name, Accessor} = Placeholder, Data, Cache) ->
+    case Cache of
+        #{Placeholder := Value} ->
+            {ok, Value, Cache};
+        #{} ->
+            try emqx_jsonish:lookup(Accessor, Data) of
+                {ok, Value} -> {ok, Value, Cache#{Placeholder => Value}};
+                {error, _Reason} -> {ok, undefined, Cache#{Placeholder => undefined}}
+            catch
+                Class:Reason -> {error, {placeholder_lookup_failed, {Class, Reason}}}
+            end
+    end.
+
+render_error({var, Name, _Accessor}, Reason) ->
+    {invalid_sql_template_value, #{placeholder => Name, reason => Reason}}.
+
+render_template_error(Parts, Reason) ->
+    Placeholders = lists:usort([Placeholder || #tpl_placeholder{placeholder = Placeholder} <- Parts]),
+    case Placeholders of
+        [Placeholder] ->
+            render_error(Placeholder, Reason);
+        [] ->
+            {invalid_sql_template_value, Reason};
+        _ ->
+            Names = [Name || {var, Name, _Accessor} <- Placeholders],
+            {invalid_sql_template_value, #{placeholders => Names, reason => Reason}}
+    end.
+
+compile_ast({insert, #{clauses := Clauses}}) ->
+    case compile_clauses(Clauses, []) of
+        {ok, ClauseOps} ->
+            Unit = merge_render_ops(join_ops(<<" ">>, lists:reverse(ClauseOps))),
+            {ok, #tdengine_plan{plan = Unit}};
+        {error, _} = Error ->
+            Error
+    end.
+
+compile_clauses([Clause | Rest], Acc) ->
+    case compile_clause(Clause) of
+        {ok, Ops} -> compile_clauses(Rest, [Ops | Acc]);
+        {error, _} = Error -> Error
+    end;
+compile_clauses([], Acc) ->
+    {ok, Acc}.
+
+compile_clause({table_clause, Clause}) ->
+    Before = maps:get(columns_before_using, Clause),
+    Using = maps:get(using, Clause),
+    After = maps:get(columns_after_using, Clause),
+    case valid_column_positions(Before, Using, After) of
+        true ->
+            Ops =
+                compile_target(maps:get(target, Clause)) ++
+                    compile_columns(Before) ++
+                    compile_using(Using) ++
+                    compile_columns(After) ++
+                    [#raw{sql = <<" VALUES ">>}] ++
+                    join_ops(<<" ">>, [compile_row(Row) || Row <- maps:get(rows, Clause)]),
+            {ok, Ops};
+        false ->
+            {error, invalid_tdengine_column_positions}
+    end.
+
+valid_column_positions(_Before, undefined, undefined) -> true;
+valid_column_positions(_Before, undefined, _After) -> false;
+valid_column_positions(undefined, _Using, _After) -> true;
+valid_column_positions(_Before, _Using, undefined) -> true;
+valid_column_positions(_Before, _Using, _After) -> false.
+
+compile_target({target, Database, Component}) ->
+    DatabaseOps =
+        case Database of
+            undefined -> [];
+            _ -> [#raw{sql = <<(serialize_identifier(Database))/binary, ".">>}]
+        end,
+    DatabaseOps ++ compile_target_component(Component).
+
+compile_target_component({identifier_parts, Parts} = Identifier) ->
+    case lists:any(fun is_variable_part/1, Parts) of
+        true -> [#identifier{parts = Parts}];
+        false -> [#raw{sql = serialize_identifier(Identifier)}]
+    end;
+compile_target_component({identifier_placeholder, Placeholder}) ->
+    [#identifier{parts = [#tpl_placeholder{placeholder = Placeholder}]}];
+compile_target_component(Identifier) ->
+    [#raw{sql = serialize_identifier(Identifier)}].
+
+compile_columns(undefined) ->
+    [];
+compile_columns(Identifiers) ->
+    SQL = lists:join(<<", ">>, [serialize_identifier(I) || I <- Identifiers]),
+    [#raw{sql = iolist_to_binary([" (", SQL, ")"])}].
+
+compile_using(undefined) ->
+    [];
+compile_using(#{stable := Stable, tag_columns := TagColumns, tags := Tags}) ->
+    StableSQL = serialize_qualified_identifier(Stable),
+    [#raw{sql = <<" USING ", StableSQL/binary>>}] ++
+        compile_columns(TagColumns) ++
+        [#raw{sql = <<" TAGS (">>}] ++
+        join_ops(<<", ">>, [compile_value(Value) || Value <- Tags]) ++
+        [#raw{sql = <<")">>}].
+
+compile_row({row, Values}) ->
+    [#raw{sql = <<"(">>} | join_ops(<<", ">>, [compile_value(Value) || Value <- Values])] ++
+        [#raw{sql = <<")">>}].
+
+compile_value({var, Placeholder}) ->
+    [#value{placeholder = Placeholder}];
+compile_value({string, Style, Source}) ->
+    Parts = parse_string(Source, Style),
+    case lists:any(fun is_variable_part/1, Parts) of
+        true ->
+            [#string{parts = Parts}];
+        false ->
+            [#tpl_text{text = Text}] = Parts,
+            [#raw{sql = encode_string(Text)}]
+    end;
+compile_value({number, Number}) ->
+    [#raw{sql = Number}];
+compile_value(null) ->
+    [#raw{sql = <<"NULL">>}];
+compile_value(true) ->
+    [#raw{sql = <<"true">>}];
+compile_value(false) ->
+    [#raw{sql = <<"false">>}];
+compile_value(now) ->
+    [#raw{sql = <<"NOW">>}];
+compile_value(today) ->
+    [#raw{sql = <<"TODAY">>}];
+compile_value({time_arithmetic, Base, Ops}) ->
+    compile_value(Base) ++
+        [
+            #raw{sql = <<(atom_to_binary(Operator))/binary, Duration/binary>>}
+         || {Operator, Duration} <- Ops
+        ].
+
+serialize_identifier({identifier, bare, Name}) ->
+    Name;
+serialize_identifier({identifier_parts, Parts}) ->
+    case Parts of
+        [#tpl_text{text = Text}] -> quote_identifier(Text);
+        _ -> error(dynamic_identifier_not_allowed)
+    end.
+
+serialize_qualified_identifier(Identifiers) ->
+    iolist_to_binary(lists:join($., [serialize_identifier(I) || I <- Identifiers])).
+
+quote_identifier(Name) ->
+    Escaped = binary:replace(Name, <<"`">>, <<"``">>, [global]),
+    <<"`", Escaped/binary, "`">>.
+
+parse_string(Source, single) ->
+    parse_string_body(strip_quotes(Source), $', [], []);
+parse_string(Source, double) ->
+    parse_string_body(strip_quotes(Source), $", [], []).
+
+parse_string_body(<<>>, _Quote, Text, Parts) ->
+    finish_parts(Text, Parts);
+parse_string_body(<<$\\, Escaped, Rest/binary>>, Quote, Text, Parts) ->
+    parse_string_body(Rest, Quote, [decode_escape(Escaped) | Text], Parts);
+parse_string_body(<<Quote, Quote, Rest/binary>>, Quote, Text, Parts) ->
+    parse_string_body(Rest, Quote, [Quote | Text], Parts);
+parse_string_body(<<"${$}", Rest/binary>>, Quote, Text, Parts) ->
+    parse_string_body(Rest, Quote, [$$ | Text], Parts);
+parse_string_body(<<"${", _/binary>> = Bin, Quote, Text, Parts) ->
+    {Placeholder, Rest} = take_placeholder(Bin),
+    parse_string_body(
+        Rest,
+        Quote,
+        [],
+        [#tpl_placeholder{placeholder = Placeholder} | flush_text(Text, Parts)]
+    );
+parse_string_body(<<Char, Rest/binary>>, Quote, Text, Parts) ->
+    parse_string_body(Rest, Quote, [Char | Text], Parts).
+
+parse_identifier_parts(<<>>, _Style, Text, Parts) ->
+    lists:reverse(flush_text(Text, Parts));
+parse_identifier_parts(<<$`, $`, Rest/binary>>, backtick, Text, Parts) ->
+    parse_identifier_parts(Rest, backtick, [$` | Text], Parts);
+parse_identifier_parts(<<"${", _/binary>> = Bin, Style, Text, Parts) ->
+    {Placeholder, Rest} = take_placeholder(Bin),
+    parse_identifier_parts(
+        Rest,
+        Style,
+        [],
+        [#tpl_placeholder{placeholder = Placeholder} | flush_text(Text, Parts)]
+    );
+parse_identifier_parts(<<Char, Rest/binary>>, Style, Text, Parts) ->
+    parse_identifier_parts(Rest, Style, [Char | Text], Parts).
+
+decode_escape($n) -> $\n;
+decode_escape($r) -> $\r;
+decode_escape($t) -> $\t;
+decode_escape($%) -> <<"\\%">>;
+decode_escape($_) -> <<"\\_">>;
+decode_escape(Char) -> Char.
+
+valid_placeholder_source(<<"${}">>) ->
+    true;
+valid_placeholder_source(<<"${.}">>) ->
+    true;
+valid_placeholder_source(Source) ->
+    re:run(
+        Source,
+        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
+        [{capture, none}]
+    ) =:= match.
+
+take_placeholder(Bin) ->
+    case binary:match(Bin, <<"}">>) of
+        {End, 1} ->
+            Size = End + 1,
+            Source = binary:part(Bin, 0, Size),
+            Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
+            case parse_placeholder(Source) of
+                {ok, Placeholder} -> {Placeholder, Rest};
+                {error, _} -> error({invalid_placeholder, Source})
+            end;
+        nomatch ->
+            error(unterminated_placeholder)
+    end.
+
+flush_text([], Parts) -> Parts;
+flush_text(Text, Parts) -> [#tpl_text{text = iolist_to_binary(lists:reverse(Text))} | Parts].
+
+finish_parts(Text, Parts) ->
+    case lists:reverse(flush_text(Text, Parts)) of
+        [] -> [#tpl_text{text = <<>>}];
+        Result -> Result
+    end.
+
+strip_quotes(Source) ->
+    binary:part(Source, 1, byte_size(Source) - 2).
+
+is_variable_part(#tpl_placeholder{}) -> true;
+is_variable_part(_) -> false.
+
+join_ops(_Separator, []) ->
+    [];
+join_ops(Separator, [Ops | Rest]) ->
+    lists:foldl(fun(Next, Acc) -> Acc ++ [#raw{sql = Separator} | Next] end, Ops, Rest).
+
+-spec merge_render_ops(render_plan()) -> render_plan().
+merge_render_ops(Ops) ->
+    lists:reverse(
+        lists:foldl(
+            fun
+                (#raw{sql = <<>>}, Acc) ->
+                    Acc;
+                (#raw{sql = SQL}, [#raw{sql = Previous} | Acc]) ->
+                    [#raw{sql = <<Previous/binary, SQL/binary>>} | Acc];
+                (Op, Acc) ->
+                    [Op | Acc]
+            end,
+            [],
+            Ops
+        )
+    ).
+
+encode_identifier(Parts) ->
+    case render_identifier_parts(Parts) of
+        {ok, Identifier} -> quote_identifier(Identifier);
+        {error, _} = Error -> Error
+    end.
+
+encode_value(undefined, #{undefined_vars_as_null := false}) ->
+    encode_string(<<"undefined">>);
+encode_value(undefined, _Opts) ->
+    <<"NULL">>;
+encode_value(null, _Opts) ->
+    <<"NULL">>;
+encode_value(true, _Opts) ->
+    <<"true">>;
+encode_value(false, _Opts) ->
+    <<"false">>;
+encode_value(Value, _Opts) when is_integer(Value) -> integer_to_binary(Value);
+encode_value(Value, _Opts) when is_float(Value) ->
+    case Value =:= Value of
+        true -> float_to_binary(Value, [compact]);
+        false -> {error, non_finite_number}
+    end;
+encode_value(Value, _Opts) ->
+    encode_string(to_text(Value)).
+
+-spec render_text_parts([part()], map()) -> binary().
+render_text_parts(Parts, Opts) ->
+    iolist_to_binary([
+        case Part of
+            #part_text{text = Text} ->
+                Text;
+            #part_value{value = undefined} ->
+                case maps:get(undefined_vars_as_null, Opts, true) of
+                    true -> <<"null">>;
+                    false -> <<"undefined">>
+                end;
+            #part_value{value = Value} ->
+                to_text(Value)
+        end
+     || Part <- Parts
+    ]).
+
+render_identifier_parts(Parts) ->
+    try
+        Identifier = iolist_to_binary([
+            case Part of
+                #part_text{text = Text} ->
+                    Text;
+                #part_value{value = undefined} ->
+                    error(undefined_identifier);
+                #part_value{value = null} ->
+                    error(null_identifier);
+                #part_value{value = Value} when
+                    is_binary(Value); is_atom(Value); is_number(Value)
+                ->
+                    to_text(Value);
+                #part_value{value = Value} when is_list(Value) ->
+                    identifier_text(Value);
+                #part_value{} ->
+                    error(invalid_identifier_type)
+            end
+         || Part <- Parts
+        ]),
+        case validate_dynamic_identifier(Identifier) of
+            ok -> {ok, Identifier};
+            {error, ValidationReason} -> {error, {invalid_tdengine_identifier, ValidationReason}}
+        end
+    catch
+        error:Reason -> {error, Reason}
+    end.
+
+validate_dynamic_identifier(<<>>) ->
+    {error, empty};
+validate_dynamic_identifier(Identifier) when byte_size(Identifier) > 192 ->
+    {error, too_long};
+validate_dynamic_identifier(Identifier) ->
+    case binary:match(Identifier, <<".">>) of
+        nomatch -> ok;
+        _ -> {error, contains_dot}
+    end.
+
+to_text(Value) when is_binary(Value) -> Value;
+to_text(Value) -> iolist_to_binary(emqx_template:to_string(Value)).
+
+identifier_text(Value) ->
+    case io_lib:printable_unicode_list(Value) of
+        true -> unicode:characters_to_binary(Value);
+        false -> error(invalid_identifier_type)
+    end.
+
+encode_string(Text) ->
+    Escaped = binary:replace(Text, [<<"\\">>, <<"'">>], <<"\\">>, [global, {insert_replaced, 1}]),
+    <<"'", Escaped/binary, "'">>.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+compile_merges_raw_segments_test() ->
+    {ok, Placeholder} = parse_placeholder(<<"${value}">>),
+    {ok, #tdengine_plan{plan = [#raw{sql = <<"t VALUES (1, 2)">>}]}} =
+        compile(<<"INSERT INTO t VALUES (1, 2)">>),
+    {ok, #tdengine_plan{plan = Plan}} =
+        compile(<<"INSERT INTO t VALUES (1, ${value}, 2)">>),
+    ?assertEqual(
+        [
+            #raw{sql = <<"t VALUES (1, ">>},
+            #value{placeholder = Placeholder},
+            #raw{sql = <<", 2)">>}
+        ],
+        Plan
+    ).
+
+multi_table_compile_and_render_test() ->
+    SQL = <<
+        "INSERT INTO ${clientid} USING s_tab TAGS ('${clientid}') "
+        "VALUES (${timestamp}, '${payload}') "
+        "test_${clientid} USING s_tab TAGS ('${clientid}') "
+        "VALUES (${second_ts}, '${payload}')"
+    >>,
+    {ok, Plan} = compile(SQL),
+    {ok, Rendered} = render(
+        Plan,
+        #{
+            clientid => <<"client-1">>,
+            timestamp => 1,
+            second_ts => 2,
+            payload => <<"hello">>
+        },
+        null_opts()
+    ),
+    ?assert(is_list(Rendered)),
+    ?assertEqual(
+        <<
+            "INSERT INTO `client-1` USING s_tab TAGS ('client-1') VALUES (1, 'hello') "
+            "`test_client-1` USING s_tab TAGS ('client-1') VALUES (2, 'hello')"
+        >>,
+        iolist_to_binary(Rendered)
+    ).
+
+leading_dot_placeholder_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO test_${.clientid} VALUES (${.payload})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `test_client-1` VALUES ('hello')">>},
+        rendered_binary(
+            render(Plan, #{clientid => <<"client-1">>, payload => <<"hello">>}, null_opts())
+        )
+    ).
+
+identifier_boundary_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO test_${clientid} VALUES (${timestamp}, ${payload})">>),
+    {ok, Rendered} = render(
+        Plan,
+        #{clientid => <<"t`; DROP TABLE t; --">>, timestamp => 1, payload => <<"text">>},
+        null_opts()
+    ),
+    ?assertEqual(
+        <<"INSERT INTO `test_t``; DROP TABLE t; --` VALUES (1, 'text')">>,
+        iolist_to_binary(Rendered)
+    ),
+    ?assertMatch({ok, _}, compile(Rendered)).
+
+identifier_template_test() ->
+    {ok, BarePlan} = compile(
+        <<"INSERT INTO pre_${tenant}_${clientid} VALUES (1)">>
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `pre_acme_client-1` VALUES (1)">>},
+        rendered_binary(
+            render(BarePlan, #{tenant => <<"acme">>, clientid => <<"client-1">>}, null_opts())
+        )
+    ),
+    {ok, BacktickPlan} = compile(
+        <<"INSERT INTO `test_``${clientid}` VALUES (1)">>
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `test_``client-1` VALUES (1)">>},
+        rendered_binary(render(BacktickPlan, #{clientid => <<"client-1">>}, null_opts()))
+    ).
+
+static_escape_boundary_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t VALUES (1, '\\\\${payload}')">>),
+    Attack = <<"') t VALUES (2, 'owned'); --">>,
+    {ok, Rendered} = render(Plan, #{payload => Attack}, null_opts()),
+    ?assertMatch({ok, _}, compile(Rendered)).
+
+batch_shape_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO ${clientid} VALUES (${timestamp}, '${payload}')">>),
+    {ok, Rendered} = render_batch(
+        Plan,
+        [
+            #{clientid => <<"a">>, timestamp => 1, payload => <<"x');--">>},
+            #{clientid => <<"b">>, timestamp => 2, payload => <<"y">>}
+        ],
+        null_opts()
+    ),
+    ?assert(is_list(Rendered)),
+    ?assertMatch({ok, _}, compile(Rendered)).
+
+reject_unsupported_syntax_test() ->
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1) -- comment">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t FILE 'rows.csv'">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (${value}0)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO test_ ${clientid} VALUES (1)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO ${clientid} _suffix VALUES (1)">>)),
+    ?assertMatch(
+        {error, _},
+        compile(<<"INSERT INTO t USING stable_${tenant} TAGS (1) VALUES (1)">>)
+    ).
+
+comma_separated_table_clauses_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t VALUES (1), u VALUES (2)">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO t VALUES (1) u VALUES (2)">>},
+        rendered_binary(render(Plan, #{}, null_opts()))
+    ).
+
+row_and_table_clause_commas_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t VALUES (1), (2), u VALUES (3), (4)">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO t VALUES (1) (2) u VALUES (3) (4)">>},
+        rendered_binary(render(Plan, #{}, null_opts()))
+    ),
+    {ok, MixedPlan} = compile(<<"INSERT INTO t VALUES (1) (2), u VALUES (3), (4)">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO t VALUES (1) (2) u VALUES (3) (4)">>},
+        rendered_binary(render(MixedPlan, #{}, null_opts()))
+    ).
+
+decimal_forms_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t VALUES (.5, 1., -.5, -1.)">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO t VALUES (.5, 1., -.5, -1.)">>},
+        rendered_binary(render(Plan, #{}, null_opts()))
+    ).
+
+identifier_error_placeholder_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO ${clientid} VALUES (1)">>),
+    ?assertEqual(
+        {error,
+            {invalid_sql_template_value, #{
+                placeholder => "clientid", reason => invalid_identifier_type
+            }}},
+        render(Plan, #{clientid => #{}}, null_opts())
+    ).
+
+invalid_dynamic_identifier_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO ${clientid} VALUES (1)">>),
+    ?assertMatch(
+        {error,
+            {invalid_sql_template_value, #{
+                placeholder := "clientid", reason := {invalid_tdengine_identifier, empty}
+            }}},
+        render(Plan, #{clientid => <<>>}, null_opts())
+    ),
+    ?assertMatch(
+        {error,
+            {invalid_sql_template_value, #{
+                placeholder := "clientid", reason := {invalid_tdengine_identifier, contains_dot}
+            }}},
+        render(Plan, #{clientid => <<"a.b">>}, null_opts())
+    ),
+    ?assertMatch(
+        {error,
+            {invalid_sql_template_value, #{
+                placeholder := "clientid", reason := {invalid_tdengine_identifier, too_long}
+            }}},
+        render(Plan, #{clientid => binary:copy(<<"a">>, 193)}, null_opts())
+    ),
+    {ok, PrefixedPlan} = compile(<<"INSERT INTO test_${clientid} VALUES (1)">>),
+    ?assertMatch(
+        {error,
+            {invalid_sql_template_value, #{
+                placeholder := "clientid", reason := {invalid_tdengine_identifier, contains_dot}
+            }}},
+        render(PrefixedPlan, #{clientid => <<"a.b">>}, null_opts())
+    ),
+    ?assertMatch(
+        {error,
+            {invalid_sql_template_value, #{
+                placeholder := "clientid", reason := {invalid_tdengine_identifier, too_long}
+            }}},
+        render(PrefixedPlan, #{clientid => binary:copy(<<"a">>, 188)}, null_opts())
+    ).
+
+rendered_binary({ok, SQL}) ->
+    ?assert(is_list(SQL)),
+    {ok, iolist_to_binary(SQL)}.
+
+null_opts() ->
+    #{undefined_vars_as_null => true}.
+
+-endif.

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
@@ -10,14 +10,29 @@
 
 -type placeholder() :: emqx_template:placeholder().
 
+%% Represent string templates, e.g. 'aaa ${bbb} ccc' as
+%% [
+%%   #tpl_text{text = <<"aaa ">>},
+%%   #tpl_placeholder{placeholder = {var, "bbb", ...}},
+%%   #tpl_text{text = <<"ccc ">>}
+%% ]
 -record(tpl_text, {text :: binary()}).
 -record(tpl_placeholder, {placeholder :: placeholder()}).
+
+%% Represent resolved parts of a template string,
+%% e.g. 'aaa ${bbb} ccc' might be pre-rendered as
+%% [
+%%   #part_text{text = <<"aaa ">>},
+%%   #part_value{value = BBBValue},
+%%   #part_text{text = <<"ccc ">>}
+%% ]
 -record(part_text, {text :: binary()}).
 -record(part_value, {value :: term()}).
 
 -type template_part() :: #tpl_text{} | #tpl_placeholder{}.
 -type part() :: #part_text{} | #part_value{}.
 
+%% Pre-rendered parts of a full SQL statement
 -record(raw, {sql :: binary()}).
 -record(value, {placeholder :: placeholder()}).
 -record(string, {parts :: [template_part()]}).
@@ -476,10 +491,7 @@ encode_value(false, _Opts) ->
     <<"false">>;
 encode_value(Value, _Opts) when is_integer(Value) -> integer_to_binary(Value);
 encode_value(Value, _Opts) when is_float(Value) ->
-    case Value =:= Value of
-        true -> float_to_binary(Value, [compact]);
-        false -> {error, non_finite_number}
-    end;
+    float_to_binary(Value, [compact]);
 encode_value(Value, _Opts) ->
     encode_string(to_text(Value)).
 
@@ -565,6 +577,7 @@ assert_no_nul(Text) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+%% Checks that compilation merges adjacent static SQL around a value placeholder.
 compile_merges_raw_segments_test() ->
     {ok, Placeholder} = parse_placeholder(<<"${value}">>),
     {ok, #tdengine_plan{plan = [#raw{sql = <<"t VALUES (1, 2)">>}]}} =
@@ -580,6 +593,7 @@ compile_merges_raw_segments_test() ->
         Plan
     ).
 
+%% Checks placeholder compilation and rendering across multiple TDengine table clauses.
 multi_table_compile_and_render_test() ->
     SQL = <<
         "INSERT INTO ${clientid} USING s_tab TAGS ('${clientid}') "
@@ -607,6 +621,7 @@ multi_table_compile_and_render_test() ->
         iolist_to_binary(Rendered)
     ).
 
+%% Checks leading-dot placeholders in dynamic identifiers and values.
 leading_dot_placeholder_test() ->
     {ok, Plan} = compile(<<"INSERT INTO test_${.clientid} VALUES (${.payload})">>),
     ?assertEqual(
@@ -616,6 +631,7 @@ leading_dot_placeholder_test() ->
         )
     ).
 
+%% Checks that hostile dynamic identifier text is quoted and remains valid SQL.
 identifier_boundary_test() ->
     {ok, Plan} = compile(<<"INSERT INTO test_${clientid} VALUES (${timestamp}, ${payload})">>),
     {ok, Rendered} = render(
@@ -629,6 +645,7 @@ identifier_boundary_test() ->
     ),
     ?assertMatch({ok, _}, compile(Rendered)).
 
+%% Checks multiple placeholders in bare and backtick-quoted identifiers.
 identifier_template_test() ->
     {ok, BarePlan} = compile(
         <<"INSERT INTO pre_${tenant}_${clientid} VALUES (1)">>
@@ -647,12 +664,14 @@ identifier_template_test() ->
         rendered_binary(render(BacktickPlan, #{clientid => <<"client-1">>}, null_opts()))
     ).
 
+%% Checks that injected text remains valid SQL next to a statically escaped backslash.
 static_escape_boundary_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t VALUES (1, '\\\\${payload}')">>),
     Attack = <<"') t VALUES (2, 'owned'); --">>,
     {ok, Rendered} = render(Plan, #{payload => Attack}, null_opts()),
     ?assertMatch({ok, _}, compile(Rendered)).
 
+%% Checks multi-table batches, empty batches, safe escaping, and indexed render errors.
 batch_shape_test() ->
     {ok, Plan} = compile(<<"INSERT INTO ${clientid} VALUES (${timestamp}, '${payload}')">>),
     {ok, Rendered} = render_batch(
@@ -681,6 +700,7 @@ batch_shape_test() ->
         )
     ).
 
+%% Checks rendering of arbitrary binary and Unicode values.
 binary_and_unicode_value_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t VALUES (${value})">>),
     ?assertEqual(
@@ -693,6 +713,7 @@ binary_and_unicode_value_test() ->
         rendered_binary(render(Plan, #{value => Unicode}, null_opts()))
     ).
 
+%% Checks decoding and preservation of TDengine string escape sequences.
 escape_decode_test() ->
     {ok, Plan} = compile(
         <<"INSERT INTO t VALUES ('\\n\\r\\t\\%\\_\\q${value}')">>
@@ -709,6 +730,43 @@ escape_decode_test() ->
         rendered_binary(render(Plan, #{value => <<"x">>}, null_opts()))
     ).
 
+%% Checks qualified table clauses, tag clauses, and static literal values.
+qualified_table_clause_and_literal_forms_test() ->
+    SQL = <<
+        "INSERT INTO db.t (c1, c2, c3, c4, c5) "
+        "USING db.st TAGS (1) "
+        "VALUES (NULL, true, false, TODAY, 1.25)"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok, SQL},
+        rendered_binary(render(Plan, #{}, null_opts()))
+    ).
+
+%% Checks rejection of columns placed both before and after a USING clause.
+invalid_column_position_test() ->
+    ?assertMatch(
+        {error, invalid_tdengine_column_positions},
+        compile(<<"INSERT INTO t (c) USING s TAGS (1) (c) VALUES (1)">>)
+    ).
+
+%% Checks missing, null, boolean, and float values rendered through placeholders.
+dynamic_scalar_value_forms_test() ->
+    {ok, Plan} = compile(
+        <<"INSERT INTO t VALUES (${missing}, ${null}, ${yes}, ${no}, ${float})">>
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO t VALUES (NULL, NULL, true, false, 1.50000000000000000000e+00)">>},
+        rendered_binary(
+            render(
+                Plan,
+                #{null => null, yes => true, no => false, float => 1.5},
+                null_opts()
+            )
+        )
+    ).
+
+%% Checks rejection of comments, file inserts, partial placeholders, and dynamic stable names.
 reject_unsupported_syntax_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1) -- comment">>)),
     ?assertMatch({error, _}, compile(<<"INSERT INTO t FILE 'rows.csv'">>)),
@@ -720,6 +778,7 @@ reject_unsupported_syntax_test() ->
         compile(<<"INSERT INTO t USING stable_${tenant} TAGS (1) VALUES (1)">>)
     ).
 
+%% Checks normalization of commas between TDengine table clauses.
 comma_separated_table_clauses_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t VALUES (1), u VALUES (2)">>),
     ?assertEqual(
@@ -727,6 +786,7 @@ comma_separated_table_clauses_test() ->
         rendered_binary(render(Plan, #{}, null_opts()))
     ).
 
+%% Checks normalization of commas between rows and table clauses.
 row_and_table_clause_commas_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t VALUES (1), (2), u VALUES (3), (4)">>),
     ?assertEqual(
@@ -739,6 +799,7 @@ row_and_table_clause_commas_test() ->
         rendered_binary(render(MixedPlan, #{}, null_opts()))
     ).
 
+%% Checks accepted leading-dot decimals and rejected trailing-dot decimal forms.
 decimal_forms_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t VALUES (.5, 1.5, -.5, -1.5)">>),
     ?assertEqual(
@@ -748,6 +809,7 @@ decimal_forms_test() ->
     ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1.)">>)),
     ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (1.e2)">>)).
 
+%% Checks time suffixes, identifiers, Unicode, and escaped-newline lexical boundaries.
 literal_boundary_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t VALUES (NOW+1s+1n-1y)">>),
     ?assertEqual(
@@ -760,6 +822,7 @@ literal_boundary_test() ->
     EscapedLF = iolist_to_binary([<<"INSERT INTO t VALUES ('a">>, $\\, $\n, <<"b')">>]),
     ?assertMatch({ok, _}, compile(EscapedLF)).
 
+%% Checks NUL rejection in SQL strings, identifiers, values, and dynamic identifiers.
 nul_boundary_test() ->
     Rejected = [
         iolist_to_binary([<<"INSERT INTO t VALUES ('a">>, 0, <<"b')">>]),
@@ -771,6 +834,7 @@ nul_boundary_test() ->
     {ok, IdentifierPlan} = compile(<<"INSERT INTO ${table} VALUES (1)">>),
     ?assertMatch({error, _}, render(IdentifierPlan, #{table => <<"a", 0, "b">>}, null_opts())).
 
+%% Checks that invalid identifier types report the responsible placeholder.
 identifier_error_placeholder_test() ->
     {ok, Plan} = compile(<<"INSERT INTO ${clientid} VALUES (1)">>),
     ?assertEqual(
@@ -781,6 +845,7 @@ identifier_error_placeholder_test() ->
         render(Plan, #{clientid => #{}}, null_opts())
     ).
 
+%% Checks detailed errors for empty, qualified, and oversized dynamic identifiers.
 invalid_dynamic_identifier_test() ->
     {ok, Plan} = compile(<<"INSERT INTO ${clientid} VALUES (1)">>),
     ?assertMatch(

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
@@ -153,7 +153,6 @@ render_template_op(Parts, Encoder, Rest, Data, Opts, Cache0, Acc) ->
 
 encode_result(Encoder) ->
     try Encoder() of
-        {ok, _} = Ok -> Ok;
         {error, _} = Error -> Error;
         Encoded -> {ok, Encoded}
     catch

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.xrl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.xrl
@@ -21,10 +21,14 @@ IDENTIFIER      = {ID_START}{ID_CONTINUE}*
 %% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
 %% Match an identifier template that contains at least one placeholder.
-%% It may start with an identifier, or with a placeholder followed by an identifier byte
-%% or another placeholder. The tail may mix identifier bytes and placeholders.
+%% First match a prefix that proves this is an identifier template rather than a
+%% standalone placeholder:
+%% `id_part_${ph}`,
+%% `${ph}_id_part` or
+%% `${ph1}${ph2}`.
+%% Then, we allow any number of identifier bytes or placeholders to follow.
 %% A lone placeholder does not match, so the PLACEHOLDER rule handles it.
-IDENTIFIER_TEMPLATE = ({IDENTIFIER}{PLACEHOLDER}|{PLACEHOLDER}({ID_CONTINUE}|{PLACEHOLDER}))({ID_CONTINUE}|{PLACEHOLDER})*
+IDENTIFIER_TEMPLATE = ({IDENTIFIER}{PLACEHOLDER}|{PLACEHOLDER}{ID_CONTINUE}|{PLACEHOLDER}{PLACEHOLDER})({ID_CONTINUE}|{PLACEHOLDER})*
 %% A decimal point joins a TDengine number only when a digit follows it:
 %% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L487-L510
 %% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L538-L586

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.xrl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.xrl
@@ -1,0 +1,87 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% This lexer recognizes the restricted TDengine multi-table INSERT template token set.
+
+Definitions.
+
+WS              = [\s\t\r\n\f]+
+ID_START        = [A-Za-z_\200-\377]
+ID_CONTINUE     = [A-Za-z0-9_\200-\377]
+IDENTIFIER      = {ID_START}{ID_CONTINUE}*
+PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
+IDENTIFIER_TEMPLATE = ({IDENTIFIER}{PLACEHOLDER}|{PLACEHOLDER}({ID_CONTINUE}|{PLACEHOLDER}))({ID_CONTINUE}|{PLACEHOLDER})*
+NUMBER          = (([0-9]+(\.[0-9]*)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
+DURATION        = [0-9]+[buasmhdnywBUASMHDNYW]
+SQ_STRING       = '([^'\\]|\\.|'')*'
+DQ_STRING       = "([^"\\]|\\.|"")*"
+BT_IDENTIFIER   = `([^`]|``)*`
+
+Rules.
+
+{WS}            : skip_token.
+--              : {error, {comments_not_allowed, TokenLine}}.
+\/\*            : {error, {comments_not_allowed, TokenLine}}.
+{IDENTIFIER_TEMPLATE} : identifier_template(TokenChars, TokenLine).
+{PLACEHOLDER}   : placeholder(TokenChars, TokenLine).
+{SQ_STRING}     : {token, {sq_string, TokenLine, to_binary(TokenChars)}}.
+{DQ_STRING}     : {token, {dq_string, TokenLine, to_binary(TokenChars)}}.
+{BT_IDENTIFIER} : backtick_identifier(TokenChars, TokenLine).
+{DURATION}      : {token, {duration, TokenLine, to_binary(TokenChars)}}.
+{NUMBER}        : {token, {number, TokenLine, to_binary(TokenChars)}}.
+{IDENTIFIER}    : identifier(to_binary(TokenChars), TokenLine).
+\(              : {token, {'(', TokenLine}}.
+\)              : {token, {')', TokenLine}}.
+,               : {token, {',', TokenLine}}.
+\.              : {token, {'.', TokenLine}}.
+;               : {token, {';', TokenLine}}.
+\+              : {token, {'+', TokenLine}}.
+-               : {token, {'-', TokenLine}}.
+'               : {error, {unterminated_string, TokenLine}}.
+"               : {error, {unterminated_double_string, TokenLine}}.
+`               : {error, {unterminated_backtick_identifier, TokenLine}}.
+\$              : {error, {invalid_placeholder, TokenLine}}.
+.               : {error, {unsupported_token, TokenLine, to_binary(TokenChars)}}.
+
+Erlang code.
+
+to_binary(Chars) ->
+    list_to_binary(Chars).
+
+placeholder(Chars, Line) ->
+    Bin = to_binary(Chars),
+    case emqx_bridge_tdengine_sql:parse_placeholder(Bin) of
+        {ok, Placeholder} -> {token, {placeholder, Line, Placeholder}};
+        {error, _} -> {error, {invalid_placeholder, Line, Bin}}
+    end.
+
+backtick_identifier(Chars, Line) ->
+    Bin = to_binary(Chars),
+    Body = binary:part(Bin, 1, byte_size(Bin) - 2),
+    case emqx_bridge_tdengine_sql:parse_identifier_parts(Body, backtick) of
+        {ok, Parts} -> {token, {bt_identifier, Line, Parts}};
+        {error, Reason} -> {error, {invalid_tdengine_identifier, Line, Reason}}
+    end.
+
+identifier_template(Chars, Line) ->
+    Bin = to_binary(Chars),
+    case emqx_bridge_tdengine_sql:parse_identifier_parts(Bin, bare) of
+        {ok, Parts} -> {token, {identifier_template, Line, Parts}};
+        {error, Reason} -> {error, {invalid_tdengine_identifier, Line, Reason}}
+    end.
+
+identifier(Bin, Line) ->
+    case string:lowercase(Bin) of
+        <<"insert">> -> {token, {insert, Line}};
+        <<"into">> -> {token, {into, Line}};
+        <<"using">> -> {token, {using, Line}};
+        <<"tags">> -> {token, {tags, Line}};
+        <<"values">> -> {token, {values, Line}};
+        <<"null">> -> {token, {null, Line}};
+        <<"true">> -> {token, {true, Line}};
+        <<"false">> -> {token, {false, Line}};
+        <<"now">> -> {token, {now, Line}};
+        <<"today">> -> {token, {today, Line}};
+        _ -> {token, {identifier, Line, Bin}}
+    end.

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.xrl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.xrl
@@ -3,24 +3,49 @@
 %%--------------------------------------------------------------------
 
 %% This lexer recognizes the restricted TDengine multi-table INSERT template token set.
+%% Leex selects the longest prefix. Rule order resolves equal-length matches.
+%% compile/1 rejects NUL bytes before invoking this lexer.
 
 Definitions.
 
-WS              = [\s\t\r\n\f]+
-ID_START        = [A-Za-z_\200-\377]
-ID_CONTINUE     = [A-Za-z0-9_\200-\377]
+%% TDengine whitespace scanning:
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L327-L339
+WS              = [\s\t\r\n\v\f]+
+%% TDengine bare identifier bytes:
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L272-L282
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L594-L615
+ID_START        = [A-Za-z_]
+ID_CONTINUE     = [A-Za-z0-9_]
 IDENTIFIER      = {ID_START}{ID_CONTINUE}*
+%% emqx_template placeholder envelope; parse_placeholder/1 applies local validation:
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
+%% Match an identifier template that contains at least one placeholder.
+%% It may start with an identifier, or with a placeholder followed by an identifier byte
+%% or another placeholder. The tail may mix identifier bytes and placeholders.
+%% A lone placeholder does not match, so the PLACEHOLDER rule handles it.
 IDENTIFIER_TEMPLATE = ({IDENTIFIER}{PLACEHOLDER}|{PLACEHOLDER}({ID_CONTINUE}|{PLACEHOLDER}))({ID_CONTINUE}|{PLACEHOLDER})*
-NUMBER          = (([0-9]+(\.[0-9]*)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
+%% A decimal point joins a TDengine number only when a digit follows it:
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L487-L510
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L538-L586
+NUMBER          = (([0-9]+(\.[0-9]+)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
+%% TDengine recognizes a duration unit only at an identifier boundary:
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L547-L586
 DURATION        = [0-9]+[buasmhdnywBUASMHDNYW]
-SQ_STRING       = '([^'\\]|\\.|'')*'
-DQ_STRING       = "([^"\\]|\\.|"")*"
+DURATION_CONTINUATION = {DURATION}[A-Za-z0-9_]+
+%% Strings consume backslash escapes or doubled quotes. Backticks double only:
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L457-L485
+SQ_STRING       = '([^'\\]|\\(.|\n)|'')*'
+%% '
+DQ_STRING       = "([^"\\]|\\(.|\n)|"")*"
+%% "
 BT_IDENTIFIER   = `([^`]|``)*`
 
 Rules.
 
 {WS}            : skip_token.
+%% Reject TDengine comment openers instead of scanning comment bodies:
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L344-L386
 --              : {error, {comments_not_allowed, TokenLine}}.
 \/\*            : {error, {comments_not_allowed, TokenLine}}.
 {IDENTIFIER_TEMPLATE} : identifier_template(TokenChars, TokenLine).
@@ -28,9 +53,13 @@ Rules.
 {SQ_STRING}     : {token, {sq_string, TokenLine, to_binary(TokenChars)}}.
 {DQ_STRING}     : {token, {dq_string, TokenLine, to_binary(TokenChars)}}.
 {BT_IDENTIFIER} : backtick_identifier(TokenChars, TokenLine).
+{DURATION_CONTINUATION} : {error, {ambiguous_duration_boundary, TokenLine}}.
 {DURATION}      : {token, {duration, TokenLine, to_binary(TokenChars)}}.
 {NUMBER}        : {token, {number, TokenLine, to_binary(TokenChars)}}.
 {IDENTIFIER}    : identifier(to_binary(TokenChars), TokenLine).
+%% TDengine source for the supported one-byte punctuation and operator forms:
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L344-L443
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L487-L510
 \(              : {token, {'(', TokenLine}}.
 \)              : {token, {')', TokenLine}}.
 ,               : {token, {',', TokenLine}}.
@@ -39,7 +68,9 @@ Rules.
 \+              : {token, {'+', TokenLine}}.
 -               : {token, {'-', TokenLine}}.
 '               : {error, {unterminated_string, TokenLine}}.
+%% '
 "               : {error, {unterminated_double_string, TokenLine}}.
+%% "
 `               : {error, {unterminated_backtick_identifier, TokenLine}}.
 \$              : {error, {invalid_placeholder, TokenLine}}.
 .               : {error, {unsupported_token, TokenLine, to_binary(TokenChars)}}.
@@ -72,6 +103,9 @@ identifier_template(Chars, Line) ->
     end.
 
 identifier(Bin, Line) ->
+    %% TDengine performs keyword lookup after scanning the complete identifier:
+    %% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L594-L615
+    %% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parTokenizer.c#L299-L320
     case string:lowercase(Bin) of
         <<"insert">> -> {token, {insert, Line}};
         <<"into">> -> {token, {into, Line}};

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_parser.yrl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_parser.yrl
@@ -1,0 +1,111 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% Restricted TDengine multi-table INSERT grammar.
+
+Nonterminals
+    template insert_stmt table_clauses table_clause target target_component static_identifier static_qualified_identifier
+    opt_columns columns identifier_list using_clause opt_tag_columns opt_post_columns
+    value_list row values_list value time_base opt_call duration_ops
+    opt_semicolon.
+
+Terminals
+    insert into using tags values null true false now today
+    identifier identifier_template bt_identifier placeholder number duration sq_string dq_string
+    '(' ')' ',' '.' ';' '+' '-'.
+
+Rootsymbol template.
+
+template -> insert_stmt : '$1'.
+
+insert_stmt -> insert into table_clauses opt_semicolon :
+    {insert, #{clauses => lists:reverse('$3')}}.
+
+table_clauses -> table_clause : ['$1'].
+table_clauses -> table_clauses table_clause : ['$2' | '$1'].
+table_clauses -> table_clauses ',' table_clause : ['$3' | '$1'].
+table_clauses -> table_clauses row : add_row('$1', '$2').
+table_clauses -> table_clauses ',' row : add_row('$1', '$3').
+
+table_clause -> target opt_columns values row :
+    {table_clause, #{
+        target => '$1',
+        columns_before_using => '$2',
+        using => undefined,
+        columns_after_using => undefined,
+        rows => ['$4']
+    }}.
+table_clause -> target opt_columns using_clause opt_post_columns values row :
+    {table_clause, #{
+        target => '$1',
+        columns_before_using => '$2',
+        using => '$3',
+        columns_after_using => '$4',
+        rows => ['$6']
+    }}.
+
+target -> target_component : {target, undefined, '$1'}.
+target -> static_identifier '.' target_component : {target, '$1', '$3'}.
+
+target_component -> static_identifier : '$1'.
+target_component -> identifier_template : {identifier_parts, value('$1')}.
+target_component -> placeholder : {identifier_placeholder, value('$1')}.
+
+static_identifier -> identifier : {identifier, bare, value('$1')}.
+static_identifier -> bt_identifier : {identifier_parts, value('$1')}.
+static_qualified_identifier -> static_identifier : ['$1'].
+static_qualified_identifier -> static_identifier '.' static_identifier : ['$1', '$3'].
+
+opt_columns -> '$empty' : undefined.
+opt_columns -> columns : '$1'.
+columns -> '(' identifier_list ')' : '$2'.
+identifier_list -> static_identifier : ['$1'].
+identifier_list -> identifier_list ',' static_identifier : '$1' ++ ['$3'].
+
+using_clause -> using static_qualified_identifier opt_tag_columns tags value_list :
+    #{stable => '$2', tag_columns => '$3', tags => '$5'}.
+
+opt_tag_columns -> '$empty' : undefined.
+opt_tag_columns -> columns : '$1'.
+opt_post_columns -> '$empty' : undefined.
+opt_post_columns -> columns : '$1'.
+
+value_list -> '(' values_list ')' : '$2'.
+row -> '(' values_list ')' : {row, '$2'}.
+values_list -> value : ['$1'].
+values_list -> values_list ',' value : '$1' ++ ['$3'].
+
+value -> time_base : '$1'.
+value -> time_base duration_ops : apply_duration_ops('$1', '$2').
+time_base -> placeholder : {var, value('$1')}.
+time_base -> sq_string : {string, single, value('$1')}.
+time_base -> dq_string : {string, double, value('$1')}.
+time_base -> number : {number, value('$1')}.
+time_base -> '+' number : {number, <<"+", (value('$2'))/binary>>}.
+time_base -> '-' number : {number, <<"-", (value('$2'))/binary>>}.
+time_base -> null : null.
+time_base -> true : true.
+time_base -> false : false.
+time_base -> now opt_call : now.
+time_base -> today opt_call : today.
+
+opt_call -> '$empty' : false.
+opt_call -> '(' ')' : true.
+duration_ops -> '+' duration : [{'+', value('$2')}].
+duration_ops -> '-' duration : [{'-', value('$2')}].
+duration_ops -> duration_ops '+' duration : '$1' ++ [{'+', value('$3')}].
+duration_ops -> duration_ops '-' duration : '$1' ++ [{'-', value('$3')}].
+
+opt_semicolon -> '$empty' : false.
+opt_semicolon -> ';' : true.
+
+Erlang code.
+
+value({_Token, _Line, Value}) -> Value.
+
+apply_duration_ops(Base, []) -> Base;
+apply_duration_ops(Base, Ops) -> {time_arithmetic, Base, Ops}.
+
+add_row([{table_clause, #{rows := Rows} = Clause} | Rest], Row) ->
+    [{table_clause, Clause#{rows := Rows ++ [Row]}} | Rest].

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_parser.yrl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_parser.yrl
@@ -102,9 +102,10 @@ opt_semicolon -> ';' : true.
 
 Erlang code.
 
+-ignore_xref({return_error, 2}).
+
 value({_Token, _Line, Value}) -> Value.
 
-apply_duration_ops(Base, []) -> Base;
 apply_duration_ops(Base, Ops) -> {time_arithmetic, Base, Ops}.
 
 add_row([{table_clause, #{rows := Rows} = Clause} | Rest], Row) ->

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_parser.yrl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_parser.yrl
@@ -15,10 +15,15 @@ Terminals
     identifier identifier_template bt_identifier placeholder number duration sq_string dq_string
     '(' ')' ',' '.' ';' '+' '-'.
 
+%% Trailing unconsumed tokens do not match and cause a parse error.
 Rootsymbol template.
 
 template -> insert_stmt : '$1'.
 
+%% This grammar is a restricted subset of TDengine multi-table INSERT:
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parInsertSql.c#L1866-L1877
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parInsertSql.c#L929-L1049
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parInsertSql.c#L1508-L1651
 insert_stmt -> insert into table_clauses opt_semicolon :
     {insert, #{clauses => lists:reverse('$3')}}.
 
@@ -77,6 +82,8 @@ values_list -> value : ['$1'].
 values_list -> values_list ',' value : '$1' ++ ['$3'].
 
 value -> time_base : '$1'.
+%% TDengine's INSERT parser reads one signed duration after a time base:
+%% https://github.com/taosdata/TDengine/blob/4bde7ac8fbebc3aa9143124bfcbd08645c46a037/source/libs/parser/src/parInsertSql.c#L300-L329
 value -> time_base duration_ops : apply_duration_ops('$1', '$2').
 time_base -> placeholder : {var, value('$1')}.
 time_base -> sq_string : {string, single, value('$1')}.

--- a/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
+++ b/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
@@ -427,6 +427,7 @@ t_simple_insert(Config) ->
         connect_and_get_payload(Config)
     ).
 
+%% Checks safe insertion of Unicode, invalid UTF-8, and SQL injection text into multiple rows.
 t_sql_value_escaping(Config) ->
     connect_and_clear_table(Config),
     Payload = <<"你好😀 x\\'); DROP TABLE t_mqtt_msg; --"/utf8, 16#FF>>,
@@ -439,6 +440,7 @@ t_sql_value_escaping(Config) ->
     StoredPayload = <<"你好😀 x\\'); DROP TABLE t_mqtt_msg; --"/utf8, 16#FFFD/utf8>>,
     ?assertEqual([[StoredPayload], [StoredPayload]], connect_and_get_payload(Config)).
 
+%% Checks safe insertion of an injection payload through double-quoted string templates.
 t_double_quoted_sql_value(Config0) ->
     SQL =
         "insert into t_mqtt_msg(ts, payload) values (${timestamp}, \"${payload}\")"

--- a/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
+++ b/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
@@ -361,11 +361,17 @@ connect_and_get_column(Config, Select) ->
     Result.
 
 connect_and_exec(Config, SQL) ->
-    ?WITH_CON({ok, _} = directly_query(Con, SQL)).
+    connect_and_exec(Config, SQL, [{db_name, ?TD_DATABASE}]).
+
+connect_and_exec(Config, SQL, QueryOpts) ->
+    ?WITH_CON({ok, #{<<"code">> := 0}} = directly_query(Con, SQL, QueryOpts)).
 
 connect_and_query(Config, SQL) ->
+    connect_and_query(Config, SQL, [{db_name, ?TD_DATABASE}]).
+
+connect_and_query(Config, SQL, QueryOpts) ->
     ?WITH_CON(
-        {ok, #{<<"code">> := 0, <<"data">> := Data}} = directly_query(Con, SQL)
+        {ok, #{<<"code">> := 0, <<"data">> := Data}} = directly_query(Con, SQL, QueryOpts)
     ),
     Data.
 
@@ -457,6 +463,62 @@ t_double_quoted_sql_value(Config0) ->
     ),
 
     ?assertEqual([[Payload], [Payload]], connect_and_get_payload(Config)).
+
+%% Checks doubled backticks with and without a preceding backslash in dynamic identifiers.
+t_dynamic_identifier_escaping(Config0) ->
+    Cases = [
+        #{
+            identifier => <<"xxx`; DROP TABLE t; --">>,
+            table => <<"xxx`; DROP TABLE t; --">>,
+            timestamp => 1668602148000
+        },
+        %% TDengine normalizes the suffix after this backslash-prefixed backtick to lowercase.
+        #{
+            identifier => <<"xxxx\\`; DROP TABLE t; --">>,
+            table => <<"xxxx\\`; drop table t; --">>,
+            timestamp => 1668602148001
+        }
+    ],
+    Database = <<"identifier_escaping">>,
+    QueryOpts = [{db_name, Database}],
+    SQL =
+        <<
+            "insert into ${clientid} USING s_tab TAGS ('${clientid}') "
+            "values (${timestamp}, '${payload}')"
+        >>,
+    Config = patch_bridge_config(Config0, #{
+        <<"parameters">> => #{<<"database">> => Database, <<"sql">> => SQL}
+    }),
+    ok = connect_and_exec(Config, <<"DROP DATABASE IF EXISTS identifier_escaping">>, []),
+    emqx_common_test_helpers:on_exit(fun() ->
+        ok = connect_and_exec(Config, <<"DROP DATABASE IF EXISTS identifier_escaping">>, [])
+    end),
+    ok = connect_and_exec(Config, <<"CREATE DATABASE identifier_escaping">>, []),
+    ok = connect_and_exec(Config, ?SQL_CREATE_STABLE, QueryOpts),
+    ok = connect_and_exec(
+        Config, <<"CREATE TABLE t (ts timestamp, payload BINARY(1024))">>, QueryOpts
+    ),
+    ?assertMatch({ok, _}, emqx_bridge_v2_testlib:create_bridge(Config)),
+    ResourceId = emqx_bridge_v2_testlib:resource_id(Config),
+    BridgeId = emqx_bridge_v2_testlib:bridge_id(Config),
+    lists:foreach(
+        fun(#{identifier := Identifier, timestamp := Timestamp}) ->
+            Message = {
+                BridgeId,
+                #{clientid => Identifier, payload => ?PAYLOAD, timestamp => Timestamp}
+            },
+            is_success_check(
+                emqx_resource:simple_sync_query(ResourceId, Message)
+            )
+        end,
+        Cases
+    ),
+    Tables = connect_and_query(Config, <<"SHOW TABLES">>, QueryOpts),
+    ?assertEqual([[0]], connect_and_query(Config, <<"SELECT COUNT(1) FROM t">>, QueryOpts)),
+    lists:foreach(
+        fun(#{table := Table}) -> ?assert(lists:member([Table], Tables)) end,
+        Cases
+    ).
 
 t_simple_insert_undefined(Config) ->
     connect_and_clear_table(Config),

--- a/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
+++ b/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
@@ -109,16 +109,16 @@ init_per_group(sync, Config) ->
 init_per_group(cloud, Config0) ->
     Config = [
         {query_mode, async},
-        {enable_batch, true},
+        {batch_size, ?BATCH_SIZE},
         {cloud, true}
         | Config0
     ],
     common_init(Config);
 init_per_group(with_batch, Config0) ->
-    Config = [{enable_batch, true} | Config0],
+    Config = [{batch_size, ?BATCH_SIZE} | Config0],
     common_init(Config);
 init_per_group(without_batch, Config0) ->
-    Config = [{enable_batch, false} | Config0],
+    Config = [{batch_size, 1} | Config0],
     common_init(Config);
 init_per_group(_Group, Config) ->
     Config.
@@ -205,11 +205,7 @@ common_init(ConfigT) ->
 
 action_config(TestCase, Name, Config) ->
     Type = ?config(bridge_type, Config),
-    BatchSize =
-        case ?config(enable_batch, Config) of
-            true -> ?BATCH_SIZE;
-            false -> 1
-        end,
+    BatchSize = ?config(batch_size, Config),
     QueryMode = ?config(query_mode, Config),
     ConfigString =
         io_lib:format(

--- a/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
+++ b/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
@@ -429,19 +429,15 @@ t_simple_insert(Config) ->
 
 t_sql_value_escaping(Config) ->
     connect_and_clear_table(Config),
-    Payload = <<"x\\'); DROP TABLE t_mqtt_msg; --">>,
+    Payload = <<"你好😀 x\\'); DROP TABLE t_mqtt_msg; --"/utf8, 16#FF>>,
     MakeMessageFun = fun() ->
         #{payload => Payload, timestamp => 1668602148000, second_ts => 1668602148010}
     end,
-
     ok = emqx_bridge_v2_testlib:t_sync_query(
         Config, MakeMessageFun, fun is_success_check/1, tdengine_connector_query_return
     ),
-
-    ?assertEqual(
-        [[Payload], [Payload]],
-        connect_and_get_payload(Config)
-    ).
+    StoredPayload = <<"你好😀 x\\'); DROP TABLE t_mqtt_msg; --"/utf8, 16#FFFD/utf8>>,
+    ?assertEqual([[StoredPayload], [StoredPayload]], connect_and_get_payload(Config)).
 
 t_double_quoted_sql_value(Config0) ->
     SQL =

--- a/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
+++ b/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
@@ -427,6 +427,39 @@ t_simple_insert(Config) ->
         connect_and_get_payload(Config)
     ).
 
+t_sql_value_escaping(Config) ->
+    connect_and_clear_table(Config),
+    Payload = <<"x\\'); DROP TABLE t_mqtt_msg; --">>,
+    MakeMessageFun = fun() ->
+        #{payload => Payload, timestamp => 1668602148000, second_ts => 1668602148010}
+    end,
+
+    ok = emqx_bridge_v2_testlib:t_sync_query(
+        Config, MakeMessageFun, fun is_success_check/1, tdengine_connector_query_return
+    ),
+
+    ?assertEqual(
+        [[Payload], [Payload]],
+        connect_and_get_payload(Config)
+    ).
+
+t_double_quoted_sql_value(Config0) ->
+    SQL =
+        "insert into t_mqtt_msg(ts, payload) values (${timestamp}, \"${payload}\")"
+        "t_mqtt_msg(ts, payload) values (${second_ts}, \"${payload}\")",
+    Config = patch_bridge_config(Config0, #{<<"parameters">> => #{<<"sql">> => SQL}}),
+    connect_and_clear_table(Config),
+    Payload = <<"x\\\"); DROP TABLE t_mqtt_msg; --">>,
+    MakeMessageFun = fun() ->
+        #{payload => Payload, timestamp => 1668602148000, second_ts => 1668602148010}
+    end,
+
+    ok = emqx_bridge_v2_testlib:t_sync_query(
+        Config, MakeMessageFun, fun is_success_check/1, tdengine_connector_query_return
+    ),
+
+    ?assertEqual([[Payload], [Payload]], connect_and_get_payload(Config)).
+
 t_simple_insert_undefined(Config) ->
     connect_and_clear_table(Config),
 

--- a/apps/emqx_mysql/src/emqx_mysql.app.src
+++ b/apps/emqx_mysql/src/emqx_mysql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_mysql, [
     {description, "EMQX MySQL Database Connector"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -55,7 +55,7 @@
     default_port => ?MYSQL_DEFAULT_PORT
 }).
 
--type template() :: {unicode:chardata(), emqx_template:str()}.
+-type template() :: {unicode:chardata(), emqx_template:str()} | emqx_mysql_sql:plan().
 -type state() ::
     #{
         pool_name := binary(),
@@ -461,10 +461,9 @@ parse_prepare_sql(Key, Query, Acc) ->
 parse_batch_sql(Key, Query, Acc) ->
     case emqx_utils_sql:get_statement_type(Query) of
         insert ->
-            case emqx_utils_sql:parse_insert(Query) of
-                {ok, {Insert, Params}} ->
-                    RowTemplate = emqx_template_sql:parse(Params),
-                    Acc#{{Key, batch} => {Insert, RowTemplate}};
+            case emqx_mysql_sql:compile(Query) of
+                {ok, Plan} ->
+                    Acc#{{Key, batch} => Plan};
                 {error, Reason} ->
                     ?SLOG(error, #{
                         msg => "parse insert sql statement failed",
@@ -504,22 +503,17 @@ proc_sql_params(TypeOrKey, SQLOrData, Params, #{query_templates := Templates}) -
 proc_sql_params(_TypeOrKey, SQLOrData, Params, _State) ->
     {SQLOrData, Params}.
 
-on_batch_insert(InstId, BatchReqs, {InsertPart, RowTemplate}, State, ChannelConfig) ->
-    Rows = [render_row(RowTemplate, Msg, ChannelConfig) || {_, Msg} <- BatchReqs],
-    Query = [InsertPart, <<" values ">> | lists:join($,, Rows)],
-    on_sql_query(InstId, query, Query, no_params, default_timeout, State).
-
-render_row(RowTemplate, Data, ChannelConfig) ->
-    RenderOpts =
-        case maps:get(undefined_vars_as_null, ChannelConfig, false) of
-            % NOTE:
-            %  Ignoring errors here, missing variables are set to "'undefined'" due to backward
-            %  compatibility requirements.
-            false -> #{escaping => mysql, undefined => <<"undefined">>};
-            true -> #{escaping => mysql}
-        end,
-    {Row, _Errors} = emqx_template_sql:render(RowTemplate, {emqx_jsonish, Data}, RenderOpts),
-    Row.
+on_batch_insert(InstId, BatchReqs, Plan, State, ChannelConfig) ->
+    DataList = [Msg || {_, Msg} <- BatchReqs],
+    RenderOpts = #{
+        undefined_vars_as_null => maps:get(undefined_vars_as_null, ChannelConfig, false)
+    },
+    case emqx_mysql_sql:render_batch(Plan, DataList, RenderOpts) of
+        {ok, Query} ->
+            on_sql_query(InstId, query, Query, no_params, default_timeout, State);
+        {error, Reason} ->
+            {error, {unrecoverable_error, Reason}}
+    end.
 
 on_sql_query(
     InstId,

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -55,6 +55,13 @@
     default_port => ?MYSQL_DEFAULT_PORT
 }).
 
+%% Remove ANSI_QUOTES and NO_BACKSLASH_ESCAPES from session's sql_mode
+-define(SQL_MODE_QUERY, <<
+    "SET SESSION sql_mode = TRIM(BOTH ',' FROM "
+    "REPLACE(REPLACE(CONCAT(',', @@SESSION.sql_mode, ','), "
+    "',ANSI_QUOTES,', ','), ',NO_BACKSLASH_ESCAPES,', ','))"
+>>).
+
 -type template() :: {unicode:chardata(), emqx_template:str()} | emqx_mysql_sql:plan().
 -type state() ::
     #{
@@ -389,16 +396,22 @@ get_reconnect_callback_signature([Templates]) ->
     ),
     ChannelID.
 
-prepare_sql_to_conn(_Conn, []) ->
+prepare_sql_to_conn(Conn, Templates) ->
+    case mysql:query(Conn, ?SQL_MODE_QUERY) of
+        ok -> do_prepare_sql_to_conn(Conn, Templates);
+        {error, _} = Error -> Error
+    end.
+
+do_prepare_sql_to_conn(_Conn, []) ->
     ok;
-prepare_sql_to_conn(Conn, [{{Key, prepstmt}, {SQL, _RowTemplate}} | Rest]) ->
+do_prepare_sql_to_conn(Conn, [{{Key, prepstmt}, {SQL, _RowTemplate}} | Rest]) ->
     LogMeta = #{msg => "MySQL Prepare Statement", name => Key, prepare_sql => SQL},
     ?SLOG(info, LogMeta),
     _ = unprepare_sql_to_conn(Conn, Key),
     case mysql:prepare(Conn, Key, SQL) of
         {ok, _Key} ->
             ?SLOG(info, LogMeta#{result => success}),
-            prepare_sql_to_conn(Conn, Rest);
+            do_prepare_sql_to_conn(Conn, Rest);
         {error, {1146, _, _} = Reason} ->
             %% Target table is not created
             ?tp(mysql_undefined_table, #{}),
@@ -410,8 +423,8 @@ prepare_sql_to_conn(Conn, [{{Key, prepstmt}, {SQL, _RowTemplate}} | Rest]) ->
             ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
             {error, Reason}
     end;
-prepare_sql_to_conn(Conn, [{_Key, _Template} | Rest]) ->
-    prepare_sql_to_conn(Conn, Rest).
+do_prepare_sql_to_conn(Conn, [{_Key, _Template} | Rest]) ->
+    do_prepare_sql_to_conn(Conn, Rest).
 
 unprepare_sql(ChannelID, #{query_templates := Templates, pool_name := PoolName}) ->
     lists:foreach(

--- a/apps/emqx_mysql/src/emqx_mysql_sql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql.erl
@@ -10,12 +10,20 @@
 
 -type placeholder() :: emqx_template:placeholder().
 
--record(raw, {sql :: binary()}).
--record(value, {placeholder :: placeholder()}).
+%% Represent string templates, e.g. 'aaa ${bbb} ccc' as
+%% [
+%%   #string_raw{sql = <<"aaa ">>},
+%%   #string_placeholder{placeholder = {var, "bbb", ...}},
+%%   #string_raw{sql = <<"ccc ">>}
+%% ]
 -record(string_raw, {sql :: binary()}).
 -record(string_placeholder, {placeholder :: placeholder()}).
 -type string_part() :: #string_raw{} | #string_placeholder{}.
 -record(string_template, {parts :: [string_part()]}).
+
+%% Pre-rendered parts of a full SQL statement
+-record(raw, {sql :: binary()}).
+-record(value, {placeholder :: placeholder()}).
 
 -type render_op() :: #raw{} | #value{} | #string_template{}.
 -type render_plan() :: [render_op()].
@@ -160,9 +168,8 @@ render_error({var, Name, _Accessor}, Reason) ->
     {invalid_sql_template_value, #{placeholder => Name, reason => Reason}}.
 
 encode_result(Encoder) ->
-    try Encoder() of
-        {error, _} = Error -> Error;
-        Encoded -> {ok, Encoded}
+    try
+        {ok, Encoder()}
     catch
         Class:Reason -> {error, {Class, Reason}}
     end.
@@ -424,10 +431,7 @@ encode_value(undefined, _Opts) ->
 encode_value(Value, _Opts) when is_integer(Value) ->
     integer_to_binary(Value);
 encode_value(Value, _Opts) when is_float(Value) ->
-    case Value =:= Value of
-        true -> emqx_template:to_string(Value);
-        false -> {error, non_finite_number}
-    end;
+    emqx_template:to_string(Value);
 encode_value(Value, _Opts) ->
     encode_string(to_text(Value)).
 
@@ -492,6 +496,7 @@ escape_string(<<Char, Rest/binary>>, Acc) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+%% Checks basic compilation and rendering of a MySQL INSERT template.
 basic_compile_and_render_test() ->
     {ok, Plan} = compile(
         <<"INSERT INTO mqtt_test(payload, arrived) ",
@@ -504,6 +509,7 @@ basic_compile_and_render_test() ->
         rendered_binary(render(Plan, #{payload => <<"hello">>, timestamp => 2}, null_opts()))
     ).
 
+%% Checks that multiline client CASE expressions compile after rendering placeholder values.
 client_case_expression_test() ->
     SQL = <<
         "INSERT INTO tab1 (field1, field2)\r\n"
@@ -517,6 +523,7 @@ client_case_expression_test() ->
     {ok, Rendered} = rendered_binary(render(Plan, Data, null_opts())),
     ?assertMatch({ok, _}, compile(Rendered)).
 
+%% Checks rendering of CASE, IF, null predicates, logical operators, and null-safe comparisons.
 conditional_expression_test() ->
     SQL = <<
         "INSERT INTO t(a, b) VALUES ("
@@ -533,6 +540,26 @@ conditional_expression_test() ->
         rendered_binary(render(Plan, #{v => <<"x">>}, null_opts()))
     ).
 
+%% Checks booleans, DEFAULT, grouping, null predicates, CASE, aliases, and duplicate-key updates.
+boolean_default_alias_and_duplicate_key_forms_test() ->
+    SQL = <<
+        "INSERT INTO t VALUES ("
+        "TRUE, FALSE, DEFAULT, (${v}), ${v} IS NOT NULL, "
+        "CASE WHEN TRUE THEN 1 END) AS new(c1) "
+        "ON DUPLICATE KEY UPDATE `t`.`c` = `new`.`c`"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO `t` VALUES ("
+            "TRUE, FALSE, DEFAULT, (1), 1 IS NOT NULL, "
+            "CASE WHEN TRUE THEN 1 END) AS `new`(`c1`) "
+            "ON DUPLICATE KEY UPDATE `t`.`c` = `new`.`c`"
+        >>},
+        rendered_binary(render(Plan, #{v => 1}, null_opts()))
+    ).
+
+%% Checks that an apostrophe in a rendered value receives MySQL string escaping.
 single_quote_doubling_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     ?assertEqual(
@@ -540,6 +567,7 @@ single_quote_doubling_test() ->
         rendered_binary(render(Plan, #{v => <<"a'b">>}, null_opts()))
     ).
 
+%% Checks that a backslash-and-quote injection payload is escaped as one string value.
 backslash_escape_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     Attack = <<"\\'); DROP TABLE t; --">>,
@@ -548,6 +576,7 @@ backslash_escape_test() ->
         rendered_binary(render(Plan, #{v => Attack}, null_opts()))
     ).
 
+%% Checks batch rendering, backslash escaping, empty batches, and indexed render errors.
 batch_shape_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     Unsafe = <<"a\\b">>,
@@ -558,8 +587,13 @@ batch_shape_test() ->
     ?assertEqual(
         {ok, <<"INSERT INTO `t` (`v`) VALUES ">>},
         rendered_binary(render_batch(Plan, [], null_opts()))
+    ),
+    ?assertMatch(
+        {error, {mysql_template_render_failed, #{batch_index := 2, reason := _}}},
+        render_batch(Plan, [#{v => 1}, #{v => {unsupported}}], null_opts())
     ).
 
+%% Checks MySQL escaping of control bytes, quotes, and backslashes.
 string_escape_bytes_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     Value = <<$\b, $\t, $\n, $\r, 16#1A, $", $', $\\>>,
@@ -568,6 +602,7 @@ string_escape_bytes_test() ->
         rendered_binary(render(Plan, #{v => Value}, null_opts()))
     ).
 
+%% Checks CONCAT rendering and escaping for placeholders embedded in single-quoted strings.
 single_quoted_template_segments_test() ->
     {ok, Plan} = compile(
         <<"INSERT INTO t(v) VALUES ('prefix\\n ${v} suffix')">>
@@ -577,6 +612,7 @@ single_quoted_template_segments_test() ->
         rendered_binary(render(Plan, #{v => <<"a'b">>}, null_opts()))
     ).
 
+%% Checks interpolation in double-quoted strings, static strings, and backtick-quoted identifiers.
 double_quoted_string_test() ->
     SQL = <<"INSERT INTO t(v) VALUES (\"prefix ${value}\")">>,
     {ok, Plan} = compile(SQL),
@@ -596,6 +632,7 @@ double_quoted_string_test() ->
         rendered_binary(render(BacktickPlan, #{value => <<"changed">>}, null_opts()))
     ).
 
+%% Checks escaped-quote boundaries and rejection of placeholders preceded by an invalid escape.
 quoted_template_boundary_test() ->
     ?assertMatch(
         {ok, _},
@@ -610,6 +647,7 @@ quoted_template_boundary_test() ->
         compile(<<"INSERT INTO t(v) VALUES ('prefix\\${v} suffix')">>)
     ).
 
+%% Checks preservation and quoting of mixed-case identifiers that match SQL keywords.
 keyword_identifier_case_test() ->
     {ok, Plan} = compile(
         <<"INSERT INTO VaLuEs(KeY, UpDaTe) VALUES (${key}, ${update})">>
@@ -619,6 +657,7 @@ keyword_identifier_case_test() ->
         rendered_binary(render(Plan, #{key => 1, update => 2}, null_opts()))
     ).
 
+%% Checks rendering of Unicode lists, invalid UTF-8, and NUL-containing UTF-8 values.
 charset_and_unicode_value_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     ?assertEqual(
@@ -635,6 +674,7 @@ charset_and_unicode_value_test() ->
         rendered_binary(render(Plan, #{v => <<"a", 0, "b">>}, null_opts()))
     ).
 
+%% Checks batch aliases and duplicate-key updates and rejects dynamic update expressions.
 on_duplicate_key_update_test() ->
     SQL = <<
         "INSERT INTO t(c1, c2) VALUES (${a}, ${b}) AS new ",
@@ -656,6 +696,7 @@ on_duplicate_key_update_test() ->
         )
     ).
 
+%% Checks missing-value rendering as either SQL NULL or the string undefined.
 undefined_value_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${missing})">>),
     ?assertEqual(
@@ -667,6 +708,7 @@ undefined_value_test() ->
         rendered_binary(render(Plan, #{}, #{undefined_vars_as_null => false}))
     ).
 
+%% Checks rejection of multiple template rows, comments, dynamic targets, aliases, and INSERT SELECT.
 reject_unsupported_syntax_test() ->
     Rejected = [
         <<"INSERT INTO t VALUES (${a}), (${b})">>,
@@ -678,6 +720,7 @@ reject_unsupported_syntax_test() ->
     ],
     lists:foreach(fun(SQL) -> ?assertMatch({error, _}, compile(SQL)) end, Rejected).
 
+%% Checks whitespace, identifiers, literals, unterminated tokens, and NUL lexical boundaries.
 lexical_boundary_test() ->
     ?assertMatch({ok, _}, compile(<<"INSERT", 11, "INTO t VALUES (1)">>)),
     ?assertMatch({ok, _}, compile(<<"INSERT INTO таблица VALUES (0x12)"/utf8>>)),

--- a/apps/emqx_mysql/src/emqx_mysql_sql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql.erl
@@ -196,8 +196,6 @@ serialize_identifier({identifier, bare, Name}) ->
     quote_identifier(Name);
 serialize_identifier({identifier, backtick, Source}) ->
     ok = assert_no_placeholder(Source),
-    Source;
-serialize_identifier({identifier, double_opaque, Source}) ->
     Source.
 
 serialize_reference_path(Identifiers) ->
@@ -207,8 +205,6 @@ serialize_reference_part({identifier, bare, Name}) ->
     Name;
 serialize_reference_part({identifier, backtick, Source}) ->
     ok = assert_no_placeholder(Source),
-    Source;
-serialize_reference_part({identifier, double_opaque, Source}) ->
     Source.
 
 quote_identifier(Name) ->
@@ -288,41 +284,77 @@ compile_expression({group, Expression}) ->
 compile_expression({unary, Operator, Expression}) ->
     [#raw{sql = <<(atom_to_binary(Operator))/binary, "(">>} | compile_expression(Expression)] ++
         [#raw{sql = <<")">>}];
+compile_expression({is_null, Expression, Negated}) ->
+    Suffix =
+        case Negated of
+            true -> <<" IS NOT NULL">>;
+            false -> <<" IS NULL">>
+        end,
+    compile_expression(Expression) ++ [#raw{sql = Suffix}];
+compile_expression({case_expression, Operand, Whens, Else}) ->
+    [#raw{sql = <<"CASE">>}] ++
+        compile_case_operand(Operand) ++
+        lists:append([compile_when_clause(Clause) || Clause <- Whens]) ++
+        compile_case_else(Else) ++
+        [#raw{sql = <<" END">>}];
 compile_expression({binary, Operator, Left, Right}) ->
     compile_expression(Left) ++
         [#raw{sql = <<" ", (atom_to_binary(Operator))/binary, " ">>}] ++
         compile_expression(Right).
 
-parse_sql_string(Source) ->
-    Body = binary:part(Source, 1, byte_size(Source) - 2),
-    parse_sql_string_body(Body, [], [], false).
+compile_case_operand(undefined) ->
+    [];
+compile_case_operand(Expression) ->
+    [#raw{sql = <<" ">>} | compile_expression(Expression)].
 
-parse_sql_string_body(<<>>, Text, _Parts, false) ->
-    {static, quote_static_string(iolist_to_binary(lists:reverse(Text)))};
-parse_sql_string_body(<<>>, Text, Parts, true) ->
+compile_when_clause({'when', Condition, Result}) ->
+    [#raw{sql = <<" WHEN ">>} | compile_expression(Condition)] ++
+        [#raw{sql = <<" THEN ">>} | compile_expression(Result)].
+
+compile_case_else(undefined) ->
+    [];
+compile_case_else(Expression) ->
+    [#raw{sql = <<" ELSE ">>} | compile_expression(Expression)].
+
+parse_sql_string(Source) ->
+    Delimiter = binary:first(Source),
+    Body = binary:part(Source, 1, byte_size(Source) - 2),
+    parse_sql_string_body(Body, Delimiter, Source, [], [], false).
+
+%% Arguments are
+%% * the remaining body
+%% * quote delimiter
+%% * original token
+%% * reversed text acc
+%% * reversed compiled parts
+%% * IsDynamic flag
+%% IsDynamic starts as false. When no placeholder is found, return the original token.
+%% The first placeholder switches IsDynamic to true and starts accumulating compiled parts.
+parse_sql_string_body(_Body = <<>>, _Delimiter, Source, _Text, _Parts, _IsDynamic = false) ->
+    {static, Source};
+parse_sql_string_body(<<>>, Delimiter, _Source, Text, Parts, _IsDynamic = true) ->
     ok = assert_safe_string_split(Text),
-    {dynamic, lists:reverse(flush_string_text(Text, Parts))};
-parse_sql_string_body(<<"${$}", Rest/binary>>, Text, Parts, Dynamic) ->
-    parse_sql_string_body(Rest, [$$ | Text], Parts, Dynamic);
-parse_sql_string_body(<<"${", _/binary>> = Bin, Text, Parts, _Dynamic) ->
+    {dynamic, lists:reverse(flush_string_text(Text, Delimiter, Parts))};
+parse_sql_string_body(<<"${$}", Rest/binary>>, Delimiter, Source, Text, Parts, IsDynamic) ->
+    parse_sql_string_body(Rest, Delimiter, Source, [$$ | Text], Parts, IsDynamic);
+parse_sql_string_body(
+    <<"${", _/binary>> = Bin, Delimiter, Source, Text, Parts, _IsDynamic
+) ->
     ok = assert_safe_string_split(Text),
     {Placeholder, Rest} = take_placeholder(Bin),
     PartsNext = [
         #string_placeholder{placeholder = Placeholder}
-        | flush_string_text(Text, Parts)
+        | flush_string_text(Text, Delimiter, Parts)
     ],
-    parse_sql_string_body(Rest, [], PartsNext, true);
-parse_sql_string_body(<<Char, Rest/binary>>, Text, Parts, Dynamic) ->
-    parse_sql_string_body(Rest, [Char | Text], Parts, Dynamic).
+    parse_sql_string_body(Rest, Delimiter, Source, [], PartsNext, true);
+parse_sql_string_body(<<Char, Rest/binary>>, Delimiter, Source, Text, Parts, IsDynamic) ->
+    parse_sql_string_body(Rest, Delimiter, Source, [Char | Text], Parts, IsDynamic).
 
-flush_string_text([], Parts) ->
+flush_string_text([], _Delimiter, Parts) ->
     Parts;
-flush_string_text(Text, Parts) ->
+flush_string_text(Text, Delimiter, Parts) ->
     Body = iolist_to_binary(lists:reverse(Text)),
-    [#string_raw{sql = quote_static_string(Body)} | Parts].
-
-quote_static_string(Body) ->
-    <<"'", Body/binary, "'">>.
+    [#string_raw{sql = <<Delimiter, Body/binary, Delimiter>>} | Parts].
 
 assert_safe_string_split(ReversedText) ->
     case count_leading_backslashes(ReversedText, 0) rem 2 of
@@ -357,6 +389,9 @@ merge_render_ops(Ops) ->
         )
     ).
 
+%% Restrict emqx_template's envelope to nonempty dotted paths.
+%% Retain `${}` and `${.}`.
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 valid_placeholder_source(<<"${}">>) ->
     true;
 valid_placeholder_source(<<"${.}">>) ->
@@ -415,12 +450,9 @@ to_text(Value) ->
 encode_string(Text) ->
     case unicode:characters_to_list(Text) of
         Chars when is_list(Chars) ->
-            case lists:all(fun safe_single_quoted_character/1, Chars) of
-                true ->
-                    Escaped = binary:replace(Text, <<"'">>, <<"''">>, [global]),
-                    <<"'", Escaped/binary, "'">>;
-                false ->
-                    encode_hex_string(<<"_utf8mb4 ">>, Text)
+            case binary:match(Text, <<0>>) of
+                nomatch -> [<<"'">>, escape_string(Text), <<"'">>];
+                _ -> encode_hex_string(<<"_utf8mb4 ">>, Text)
             end;
         _ ->
             encode_hex_string(<<>>, Text)
@@ -430,10 +462,32 @@ encode_hex_string(Prefix, Text) ->
     Hex = binary:encode_hex(Text),
     <<Prefix/binary, "X'", Hex/binary, "'">>.
 
-safe_single_quoted_character($\\) -> false;
-safe_single_quoted_character(Char) when Char < 16#20 -> false;
-safe_single_quoted_character(Char) when Char >= 16#7F, Char =< 16#9F -> false;
-safe_single_quoted_character(_Char) -> true.
+escape_string(Text) ->
+    escape_string(Text, []).
+
+%% MySQL defines these backslash escape sequences for string literals:
+%% https://dev.mysql.com/doc/refman/8.0/en/string-literals.html
+%% https://dev.mysql.com/doc/refman/8.4/en/string-literals.html
+escape_string(<<>>, Acc) ->
+    lists:reverse(Acc);
+escape_string(<<$\b, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\b">> | Acc]);
+escape_string(<<$\t, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\t">> | Acc]);
+escape_string(<<$\n, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\n">> | Acc]);
+escape_string(<<$\r, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\r">> | Acc]);
+escape_string(<<16#1A, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\Z">> | Acc]);
+escape_string(<<$", Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\\"">> | Acc]);
+escape_string(<<$', Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\'">> | Acc]);
+escape_string(<<$\\, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\\\">> | Acc]);
+escape_string(<<Char, Rest/binary>>, Acc) ->
+    escape_string(Rest, [Char | Acc]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -450,31 +504,68 @@ basic_compile_and_render_test() ->
         rendered_binary(render(Plan, #{payload => <<"hello">>, timestamp => 2}, null_opts()))
     ).
 
+client_case_expression_test() ->
+    SQL = <<
+        "INSERT INTO tab1 (field1, field2)\r\n"
+        "VALUES (\r\n"
+        "    CASE WHEN ${field1} = 'null' THEN NULL ELSE ${field1} END,\r\n"
+        "    CASE WHEN ${field2} = 'null' THEN NULL ELSE ${field2} END\r\n"
+        ");"
+    >>,
+    {ok, Plan} = compile(SQL),
+    Data = #{field1 => <<"null">>, field2 => <<"null">>},
+    {ok, Rendered} = rendered_binary(render(Plan, Data, null_opts())),
+    ?assertMatch({ok, _}, compile(Rendered)).
+
+conditional_expression_test() ->
+    SQL = <<
+        "INSERT INTO t(a, b) VALUES ("
+        "CASE ${v} WHEN 'x' THEN 1 ELSE 0 END, "
+        "IF(${v} IS NULL OR NOT ${v} <=> 'x', 1, 0))"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok, <<
+            "INSERT INTO `t` (`a`, `b`) VALUES ("
+            "CASE 'x' WHEN 'x' THEN 1 ELSE 0 END, "
+            "IF('x' IS NULL OR NOT('x' <=> 'x'), 1, 0))"
+        >>},
+        rendered_binary(render(Plan, #{v => <<"x">>}, null_opts()))
+    ).
+
 single_quote_doubling_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     ?assertEqual(
-        {ok, <<"INSERT INTO `t` (`v`) VALUES ('a''b')">>},
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('a\\'b')">>},
         rendered_binary(render(Plan, #{v => <<"a'b">>}, null_opts()))
     ).
 
-mode_sensitive_value_uses_hex_test() ->
+backslash_escape_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     Attack = <<"\\'); DROP TABLE t; --">>,
-    Hex = binary:encode_hex(Attack),
-    Expected = <<"INSERT INTO `t` (`v`) VALUES (_utf8mb4 X'", Hex/binary, "')">>,
     ?assertEqual(
-        {ok, Expected},
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('\\\\\\'); DROP TABLE t; --')">>},
         rendered_binary(render(Plan, #{v => Attack}, null_opts()))
     ).
 
 batch_shape_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
     Unsafe = <<"a\\b">>,
-    Hex = binary:encode_hex(Unsafe),
-    Expected = <<"INSERT INTO `t` (`v`) VALUES (_utf8mb4 X'", Hex/binary, "'), ('ok')">>,
     ?assertEqual(
-        {ok, Expected},
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('a\\\\b'), ('ok')">>},
         rendered_binary(render_batch(Plan, [#{v => Unsafe}, #{v => <<"ok">>}], null_opts()))
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ">>},
+        rendered_binary(render_batch(Plan, [], null_opts()))
+    ).
+
+string_escape_bytes_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
+    Value = <<$\b, $\t, $\n, $\r, 16#1A, $", $', $\\>>,
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('\\b\\t\\n\\r\\Z\\\"\\'\\\\')">>},
+        rendered_binary(render(Plan, #{v => Value}, null_opts()))
     ).
 
 single_quoted_template_segments_test() ->
@@ -482,30 +573,36 @@ single_quoted_template_segments_test() ->
         <<"INSERT INTO t(v) VALUES ('prefix\\n ${v} suffix')">>
     ),
     ?assertEqual(
-        {ok, <<"INSERT INTO `t` (`v`) VALUES ", "(CONCAT('prefix\\n ', 'a''b', ' suffix'))">>},
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ", "(CONCAT('prefix\\n ', 'a\\'b', ' suffix'))">>},
         rendered_binary(render(Plan, #{v => <<"a'b">>}, null_opts()))
     ).
 
-opaque_double_quoted_token_test() ->
-    SQL = <<"INSERT INTO \"t${ignored}\"(\"v\") VALUES (\"${ignored}\")">>,
+double_quoted_string_test() ->
+    SQL = <<"INSERT INTO t(v) VALUES (\"prefix ${value}\")">>,
     {ok, Plan} = compile(SQL),
     ?assertEqual(
-        {ok, <<"INSERT INTO \"t${ignored}\" (\"v\") VALUES (\"${ignored}\")">>},
-        rendered_binary(render(Plan, #{ignored => <<"changed">>}, null_opts()))
+        {ok, <<"INSERT INTO `t` (`v`) VALUES (CONCAT(\"prefix \", 'changed'))">>},
+        rendered_binary(render(Plan, #{value => <<"changed">>}, null_opts()))
     ),
+    {ok, StaticPlan} = compile(<<"INSERT INTO t(v) VALUES (\"xsdf\")">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES (\"xsdf\")">>},
+        rendered_binary(render(StaticPlan, #{}, null_opts()))
+    ),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO \"t\"(v) VALUES (1)">>)),
     {ok, BacktickPlan} = compile(<<"INSERT INTO `a``b` (`c``d`) VALUES (${value})">>),
     ?assertEqual(
         {ok, <<"INSERT INTO `a``b` (`c``d`) VALUES ('changed')">>},
         rendered_binary(render(BacktickPlan, #{value => <<"changed">>}, null_opts()))
     ).
 
-reject_ambiguous_quoted_tokens_test() ->
+quoted_template_boundary_test() ->
     ?assertMatch(
-        {error, _},
+        {ok, _},
         compile(<<"INSERT INTO t(v) VALUES ('prefix\\'${v} suffix')">>)
     ),
     ?assertMatch(
-        {error, _},
+        {ok, _},
         compile(<<"INSERT INTO t(v) VALUES (\"prefix\\\"${v} suffix\")">>)
     ),
     ?assertMatch(
@@ -532,6 +629,10 @@ charset_and_unicode_value_test() ->
     ?assertEqual(
         {ok, <<"INSERT INTO `t` (`v`) VALUES (X'FF')">>},
         rendered_binary(render(Plan, #{v => InvalidUTF8}, null_opts()))
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES (_utf8mb4 X'610062')">>},
+        rendered_binary(render(Plan, #{v => <<"a", 0, "b">>}, null_opts()))
     ).
 
 on_duplicate_key_update_test() ->
@@ -576,6 +677,26 @@ reject_unsupported_syntax_test() ->
         <<"INSERT INTO t SELECT ${a}">>
     ],
     lists:foreach(fun(SQL) -> ?assertMatch({error, _}, compile(SQL)) end, Rejected).
+
+lexical_boundary_test() ->
+    ?assertMatch({ok, _}, compile(<<"INSERT", 11, "INTO t VALUES (1)">>)),
+    ?assertMatch({ok, _}, compile(<<"INSERT INTO таблица VALUES (0x12)"/utf8>>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO t VALUES (0X12)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO $table VALUES (1)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO $tag$text$tag$ VALUES (1)">>)),
+    ?assertMatch({error, _}, compile(<<"INSERT INTO $tag$unterminated VALUES (1)">>)),
+    ?assertMatch(
+        {error, _},
+        compile(iolist_to_binary([<<"INSERT INTO t VALUES ('a">>, 0, <<"b')">>]))
+    ),
+    ?assertMatch(
+        {error, _},
+        compile(iolist_to_binary([<<"INSERT INTO t VALUES (\"a">>, 0, <<"b\")">>]))
+    ),
+    ?assertMatch(
+        {error, _},
+        compile(iolist_to_binary([<<"INSERT INTO `a">>, 0, <<"b` VALUES (1)">>]))
+    ).
 
 rendered_binary({ok, SQL}) ->
     ?assert(is_list(SQL)),

--- a/apps/emqx_mysql/src/emqx_mysql_sql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql.erl
@@ -1,0 +1,587 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc Compile and render restricted MySQL INSERT INTO VALUES templates.
+-module(emqx_mysql_sql).
+
+-export([compile/1, render/3, render_batch/3, parse_placeholder/1]).
+-export_type([plan/0]).
+
+-type placeholder() :: emqx_template:placeholder().
+
+-record(raw, {sql :: binary()}).
+-record(value, {placeholder :: placeholder()}).
+-record(string_raw, {sql :: binary()}).
+-record(string_placeholder, {placeholder :: placeholder()}).
+-type string_part() :: #string_raw{} | #string_placeholder{}.
+-record(string_template, {parts :: [string_part()]}).
+
+-type render_op() :: #raw{} | #value{} | #string_template{}.
+-type render_plan() :: [render_op()].
+
+-record(mysql_plan, {
+    insert_prefix :: binary(),
+    row_plan :: render_plan(),
+    suffix :: binary()
+}).
+
+-opaque plan() :: #mysql_plan{}.
+
+-define(BATCH_SEPARATOR, <<", ">>).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec compile(unicode:chardata()) -> {ok, plan()} | {error, term()}.
+compile(SQL0) ->
+    SQL = unicode:characters_to_binary(SQL0),
+    try
+        case emqx_mysql_sql_lexer:string(binary_to_list(SQL)) of
+            {ok, Tokens, _EndLine} ->
+                case emqx_mysql_sql_parser:parse(Tokens) of
+                    {ok, AST} -> compile_ast(AST);
+                    {error, Reason} -> {error, {invalid_mysql_insert_template, Reason}}
+                end;
+            {error, Reason, _EndLine} ->
+                {error, {invalid_mysql_insert_template, Reason}}
+        end
+    catch
+        Class:CatchReason -> {error, {invalid_mysql_insert_template, {Class, CatchReason}}}
+    end.
+
+-spec render(plan(), map(), map()) -> {ok, iolist()} | {error, term()}.
+render(#mysql_plan{insert_prefix = Prefix, row_plan = Plan, suffix = Suffix}, Data, Opts) ->
+    case render_unit(Plan, Data, Opts) of
+        {ok, Rendered} -> {ok, [Prefix, Rendered, Suffix]};
+        {error, _} = Error -> Error
+    end.
+
+-spec render_batch(plan(), [map()], map()) -> {ok, iolist()} | {error, term()}.
+render_batch(
+    #mysql_plan{insert_prefix = Prefix, row_plan = Plan, suffix = Suffix}, DataList, Opts
+) ->
+    case render_batch_units(DataList, Plan, Opts, _Index = 1, _Acc = []) of
+        {ok, Rendered} -> {ok, [Prefix, Rendered, Suffix]};
+        {error, _} = Error -> Error
+    end.
+
+-spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
+parse_placeholder(Source) ->
+    case valid_placeholder_source(Source) of
+        true ->
+            case emqx_template:parse(Source) of
+                [{var, _, _} = Placeholder] -> {ok, Placeholder};
+                _ -> {error, invalid_placeholder}
+            end;
+        false ->
+            {error, invalid_placeholder}
+    end.
+
+%%------------------------------------------------------------------------------
+%% Private
+%%------------------------------------------------------------------------------
+
+render_batch_units([Data | Rest], Plan, Opts, Index, Acc) ->
+    case render_unit(Plan, Data, Opts) of
+        {ok, Rendered} ->
+            render_batch_units(Rest, Plan, Opts, Index + 1, [Rendered | Acc]);
+        {error, Reason} ->
+            {error, {mysql_template_render_failed, #{batch_index => Index, reason => Reason}}}
+    end;
+render_batch_units([], _Plan, _Opts, _Index, Acc) ->
+    {ok, lists:join(?BATCH_SEPARATOR, lists:reverse(Acc))}.
+
+render_unit(Plan, Data, Opts) ->
+    render_plan(Plan, Data, Opts, #{}, []).
+
+render_plan([#raw{sql = SQL} | Rest], Data, Opts, Cache, Acc) ->
+    render_plan(Rest, Data, Opts, Cache, [SQL | Acc]);
+render_plan([#value{placeholder = Placeholder} | Rest], Data, Opts, Cache0, Acc) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            case encode_result(fun() -> encode_value(Value, Opts) end) of
+                {ok, Encoded} -> render_plan(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} -> {error, render_error(Placeholder, Reason)}
+            end;
+        {error, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end;
+render_plan([#string_template{parts = Parts} | Rest], Data, Opts, Cache0, Acc) ->
+    case render_string_parts(Parts, Data, Opts, Cache0, []) of
+        {ok, RenderedParts, Cache} ->
+            Rendered = render_concat(RenderedParts),
+            render_plan(Rest, Data, Opts, Cache, [Rendered | Acc]);
+        {error, Placeholder, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end;
+render_plan([], _Data, _Opts, _Cache, Acc) ->
+    {ok, lists:reverse(Acc)}.
+
+render_string_parts([#string_raw{sql = SQL} | Rest], Data, Opts, Cache, Acc) ->
+    render_string_parts(Rest, Data, Opts, Cache, [SQL | Acc]);
+render_string_parts(
+    [#string_placeholder{placeholder = Placeholder} | Rest], Data, Opts, Cache0, Acc
+) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            case encode_result(fun() -> encode_string(string_value(Value, Opts)) end) of
+                {ok, Encoded} ->
+                    render_string_parts(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} ->
+                    {error, Placeholder, Reason}
+            end;
+        {error, Reason} ->
+            {error, Placeholder, Reason}
+    end;
+render_string_parts([], _Data, _Opts, Cache, Acc) ->
+    {ok, lists:reverse(Acc), Cache}.
+
+render_concat([Only]) ->
+    Only;
+render_concat(Parts) ->
+    [<<"CONCAT(">>, lists:join(<<", ">>, Parts), <<")">>].
+
+resolve_placeholder({var, _Name, Accessor} = Placeholder, Data, Cache) ->
+    case Cache of
+        #{Placeholder := Value} ->
+            {ok, Value, Cache};
+        #{} ->
+            try emqx_jsonish:lookup(Accessor, Data) of
+                {ok, Value} -> {ok, Value, Cache#{Placeholder => Value}};
+                {error, _Reason} -> {ok, undefined, Cache#{Placeholder => undefined}}
+            catch
+                Class:Reason -> {error, {placeholder_lookup_failed, {Class, Reason}}}
+            end
+    end.
+
+render_error({var, Name, _Accessor}, Reason) ->
+    {invalid_sql_template_value, #{placeholder => Name, reason => Reason}}.
+
+encode_result(Encoder) ->
+    try Encoder() of
+        {error, _} = Error -> Error;
+        Encoded -> {ok, Encoded}
+    catch
+        Class:Reason -> {error, {Class, Reason}}
+    end.
+
+compile_ast(
+    {insert, #{
+        target := Target,
+        columns := Columns,
+        row := Row,
+        alias := Alias,
+        on_duplicate := OnDuplicate
+    }}
+) ->
+    TargetSQL = serialize_target(Target),
+    ColumnsSQL = serialize_columns(Columns),
+    Prefix = <<"INSERT INTO ", TargetSQL/binary, ColumnsSQL/binary, " VALUES ">>,
+    RowPlan = merge_render_ops(compile_row(Row)),
+    Suffix = iolist_to_binary([serialize_alias(Alias), serialize_on_duplicate(OnDuplicate)]),
+    {ok, #mysql_plan{insert_prefix = Prefix, row_plan = RowPlan, suffix = Suffix}}.
+
+serialize_target(Identifiers) ->
+    iolist_to_binary(lists:join($., [serialize_identifier(I) || I <- Identifiers])).
+
+serialize_columns(undefined) ->
+    <<>>;
+serialize_columns(Identifiers) ->
+    Content = lists:join(<<", ">>, [serialize_identifier(I) || I <- Identifiers]),
+    iolist_to_binary([" (", Content, ")"]).
+
+serialize_identifier({identifier, bare, Name}) ->
+    quote_identifier(Name);
+serialize_identifier({identifier, backtick, Source}) ->
+    ok = assert_no_placeholder(Source),
+    Source;
+serialize_identifier({identifier, double_opaque, Source}) ->
+    Source.
+
+serialize_reference_path(Identifiers) ->
+    iolist_to_binary(lists:join($., [serialize_reference_part(I) || I <- Identifiers])).
+
+serialize_reference_part({identifier, bare, Name}) ->
+    Name;
+serialize_reference_part({identifier, backtick, Source}) ->
+    ok = assert_no_placeholder(Source),
+    Source;
+serialize_reference_part({identifier, double_opaque, Source}) ->
+    Source.
+
+quote_identifier(Name) ->
+    Escaped = binary:replace(Name, <<"`">>, <<"``">>, [global]),
+    <<"`", Escaped/binary, "`">>.
+
+assert_no_placeholder(Source) ->
+    case binary:match(Source, <<"${">>) of
+        nomatch -> ok;
+        _ -> error(dynamic_identifier_not_allowed)
+    end.
+
+serialize_alias(undefined) ->
+    <<>>;
+serialize_alias({alias, Identifier, Columns}) ->
+    [<<" AS ">>, serialize_identifier(Identifier), serialize_alias_columns(Columns)].
+
+serialize_alias_columns(undefined) ->
+    <<>>;
+serialize_alias_columns(Columns) ->
+    [<<"(">>, lists:join(<<", ">>, [serialize_identifier(I) || I <- Columns]), <<")">>].
+
+serialize_on_duplicate(undefined) ->
+    <<>>;
+serialize_on_duplicate({on_duplicate, Assignments}) ->
+    [
+        <<" ON DUPLICATE KEY UPDATE ">>,
+        lists:join(<<", ">>, [serialize_assignment(A) || A <- Assignments])
+    ].
+
+serialize_assignment({assignment, Target, Expression}) ->
+    ExpressionSQL = serialize_static_expression(Expression),
+    [serialize_reference_path(Target), <<" = ">>, ExpressionSQL].
+
+serialize_static_expression(Expression) ->
+    case merge_render_ops(compile_expression(Expression)) of
+        [#raw{sql = SQL}] -> SQL;
+        _ -> error(dynamic_on_duplicate_key_update_not_allowed)
+    end.
+
+compile_row({row, Expressions}) ->
+    [#raw{sql = <<"(">>} | join_ops(<<", ">>, [compile_expression(E) || E <- Expressions])] ++
+        [#raw{sql = <<")">>}].
+
+compile_expression({var, Placeholder}) ->
+    [#value{placeholder = Placeholder}];
+compile_expression({string, Source}) ->
+    case parse_sql_string(Source) of
+        {static, SQL} -> [#raw{sql = SQL}];
+        {dynamic, Parts} -> [#string_template{parts = Parts}]
+    end;
+compile_expression({number, Number}) ->
+    [#raw{sql = Number}];
+compile_expression({hex, Hex}) ->
+    [#raw{sql = Hex}];
+compile_expression(null) ->
+    [#raw{sql = <<"NULL">>}];
+compile_expression(true) ->
+    [#raw{sql = <<"TRUE">>}];
+compile_expression(false) ->
+    [#raw{sql = <<"FALSE">>}];
+compile_expression(default) ->
+    [#raw{sql = <<"DEFAULT">>}];
+compile_expression({identifier_ref, Name}) ->
+    [#raw{sql = serialize_reference_path(Name)}];
+compile_expression({call, Name, Args}) ->
+    FunctionName = serialize_reference_path(Name),
+    [
+        #raw{sql = <<FunctionName/binary, "(">>}
+        | join_ops(<<", ">>, [
+            compile_expression(E)
+         || E <- Args
+        ])
+    ] ++ [#raw{sql = <<")">>}];
+compile_expression({group, Expression}) ->
+    [#raw{sql = <<"(">>} | compile_expression(Expression)] ++ [#raw{sql = <<")">>}];
+compile_expression({unary, Operator, Expression}) ->
+    [#raw{sql = <<(atom_to_binary(Operator))/binary, "(">>} | compile_expression(Expression)] ++
+        [#raw{sql = <<")">>}];
+compile_expression({binary, Operator, Left, Right}) ->
+    compile_expression(Left) ++
+        [#raw{sql = <<" ", (atom_to_binary(Operator))/binary, " ">>}] ++
+        compile_expression(Right).
+
+parse_sql_string(Source) ->
+    Body = binary:part(Source, 1, byte_size(Source) - 2),
+    parse_sql_string_body(Body, [], [], false).
+
+parse_sql_string_body(<<>>, Text, _Parts, false) ->
+    {static, quote_static_string(iolist_to_binary(lists:reverse(Text)))};
+parse_sql_string_body(<<>>, Text, Parts, true) ->
+    ok = assert_safe_string_split(Text),
+    {dynamic, lists:reverse(flush_string_text(Text, Parts))};
+parse_sql_string_body(<<"${$}", Rest/binary>>, Text, Parts, Dynamic) ->
+    parse_sql_string_body(Rest, [$$ | Text], Parts, Dynamic);
+parse_sql_string_body(<<"${", _/binary>> = Bin, Text, Parts, _Dynamic) ->
+    ok = assert_safe_string_split(Text),
+    {Placeholder, Rest} = take_placeholder(Bin),
+    PartsNext = [
+        #string_placeholder{placeholder = Placeholder}
+        | flush_string_text(Text, Parts)
+    ],
+    parse_sql_string_body(Rest, [], PartsNext, true);
+parse_sql_string_body(<<Char, Rest/binary>>, Text, Parts, Dynamic) ->
+    parse_sql_string_body(Rest, [Char | Text], Parts, Dynamic).
+
+flush_string_text([], Parts) ->
+    Parts;
+flush_string_text(Text, Parts) ->
+    Body = iolist_to_binary(lists:reverse(Text)),
+    [#string_raw{sql = quote_static_string(Body)} | Parts].
+
+quote_static_string(Body) ->
+    <<"'", Body/binary, "'">>.
+
+assert_safe_string_split(ReversedText) ->
+    case count_leading_backslashes(ReversedText, 0) rem 2 of
+        0 -> ok;
+        1 -> error(ambiguous_string_placeholder_boundary)
+    end.
+
+count_leading_backslashes([$\\ | Rest], Count) ->
+    count_leading_backslashes(Rest, Count + 1);
+count_leading_backslashes(_, Count) ->
+    Count.
+
+join_ops(_Separator, []) ->
+    [];
+join_ops(Separator, [Ops | Rest]) ->
+    lists:foldl(fun(Next, Acc) -> Acc ++ [#raw{sql = Separator} | Next] end, Ops, Rest).
+
+-spec merge_render_ops(render_plan()) -> render_plan().
+merge_render_ops(Ops) ->
+    lists:reverse(
+        lists:foldl(
+            fun
+                (#raw{sql = <<>>}, Acc) ->
+                    Acc;
+                (#raw{sql = SQL}, [#raw{sql = Previous} | Acc]) ->
+                    [#raw{sql = <<Previous/binary, SQL/binary>>} | Acc];
+                (Op, Acc) ->
+                    [Op | Acc]
+            end,
+            [],
+            Ops
+        )
+    ).
+
+valid_placeholder_source(<<"${}">>) ->
+    true;
+valid_placeholder_source(<<"${.}">>) ->
+    true;
+valid_placeholder_source(Source) ->
+    re:run(
+        Source,
+        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
+        [{capture, none}]
+    ) =:= match.
+
+take_placeholder(Bin) ->
+    case binary:match(Bin, <<"}">>) of
+        {End, 1} ->
+            Size = End + 1,
+            Source = binary:part(Bin, 0, Size),
+            Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
+            case parse_placeholder(Source) of
+                {ok, Placeholder} -> {Placeholder, Rest};
+                {error, _} -> error({invalid_placeholder, Source})
+            end;
+        nomatch ->
+            error(unterminated_placeholder)
+    end.
+
+encode_value(undefined, #{undefined_vars_as_null := false}) ->
+    encode_string(<<"undefined">>);
+encode_value(undefined, _Opts) ->
+    <<"NULL">>;
+encode_value(Value, _Opts) when is_integer(Value) ->
+    integer_to_binary(Value);
+encode_value(Value, _Opts) when is_float(Value) ->
+    case Value =:= Value of
+        true -> emqx_template:to_string(Value);
+        false -> {error, non_finite_number}
+    end;
+encode_value(Value, _Opts) ->
+    encode_string(to_text(Value)).
+
+string_value(undefined, Opts) ->
+    case maps:get(undefined_vars_as_null, Opts, true) of
+        true -> <<"null">>;
+        false -> <<"undefined">>
+    end;
+string_value(Value, _Opts) ->
+    to_text(Value).
+
+to_text(Value) when is_binary(Value) ->
+    Value;
+to_text(Value) ->
+    case unicode:characters_to_binary(emqx_template:to_string(Value)) of
+        Text when is_binary(Text) -> Text;
+        Error -> error({invalid_unicode, Error})
+    end.
+
+encode_string(Text) ->
+    case unicode:characters_to_list(Text) of
+        Chars when is_list(Chars) ->
+            case lists:all(fun safe_single_quoted_character/1, Chars) of
+                true ->
+                    Escaped = binary:replace(Text, <<"'">>, <<"''">>, [global]),
+                    <<"'", Escaped/binary, "'">>;
+                false ->
+                    encode_hex_string(<<"_utf8mb4 ">>, Text)
+            end;
+        _ ->
+            encode_hex_string(<<>>, Text)
+    end.
+
+encode_hex_string(Prefix, Text) ->
+    Hex = binary:encode_hex(Text),
+    <<Prefix/binary, "X'", Hex/binary, "'">>.
+
+safe_single_quoted_character($\\) -> false;
+safe_single_quoted_character(Char) when Char < 16#20 -> false;
+safe_single_quoted_character(Char) when Char >= 16#7F, Char =< 16#9F -> false;
+safe_single_quoted_character(_Char) -> true.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+basic_compile_and_render_test() ->
+    {ok, Plan} = compile(
+        <<"INSERT INTO mqtt_test(payload, arrived) ",
+            "VALUES (${payload}, FROM_UNIXTIME(${timestamp}/1000))">>
+    ),
+    ?assertEqual(
+        {ok,
+            <<"INSERT INTO `mqtt_test` (`payload`, `arrived`) ",
+                "VALUES ('hello', FROM_UNIXTIME(2 / 1000))">>},
+        rendered_binary(render(Plan, #{payload => <<"hello">>, timestamp => 2}, null_opts()))
+    ).
+
+single_quote_doubling_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('a''b')">>},
+        rendered_binary(render(Plan, #{v => <<"a'b">>}, null_opts()))
+    ).
+
+mode_sensitive_value_uses_hex_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
+    Attack = <<"\\'); DROP TABLE t; --">>,
+    Hex = binary:encode_hex(Attack),
+    Expected = <<"INSERT INTO `t` (`v`) VALUES (_utf8mb4 X'", Hex/binary, "')">>,
+    ?assertEqual(
+        {ok, Expected},
+        rendered_binary(render(Plan, #{v => Attack}, null_opts()))
+    ).
+
+batch_shape_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
+    Unsafe = <<"a\\b">>,
+    Hex = binary:encode_hex(Unsafe),
+    Expected = <<"INSERT INTO `t` (`v`) VALUES (_utf8mb4 X'", Hex/binary, "'), ('ok')">>,
+    ?assertEqual(
+        {ok, Expected},
+        rendered_binary(render_batch(Plan, [#{v => Unsafe}, #{v => <<"ok">>}], null_opts()))
+    ).
+
+single_quoted_template_segments_test() ->
+    {ok, Plan} = compile(
+        <<"INSERT INTO t(v) VALUES ('prefix\\n ${v} suffix')">>
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ", "(CONCAT('prefix\\n ', 'a''b', ' suffix'))">>},
+        rendered_binary(render(Plan, #{v => <<"a'b">>}, null_opts()))
+    ).
+
+opaque_double_quoted_token_test() ->
+    SQL = <<"INSERT INTO \"t${ignored}\"(\"v\") VALUES (\"${ignored}\")">>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok, <<"INSERT INTO \"t${ignored}\" (\"v\") VALUES (\"${ignored}\")">>},
+        rendered_binary(render(Plan, #{ignored => <<"changed">>}, null_opts()))
+    ),
+    {ok, BacktickPlan} = compile(<<"INSERT INTO `a``b` (`c``d`) VALUES (${value})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `a``b` (`c``d`) VALUES ('changed')">>},
+        rendered_binary(render(BacktickPlan, #{value => <<"changed">>}, null_opts()))
+    ).
+
+reject_ambiguous_quoted_tokens_test() ->
+    ?assertMatch(
+        {error, _},
+        compile(<<"INSERT INTO t(v) VALUES ('prefix\\'${v} suffix')">>)
+    ),
+    ?assertMatch(
+        {error, _},
+        compile(<<"INSERT INTO t(v) VALUES (\"prefix\\\"${v} suffix\")">>)
+    ),
+    ?assertMatch(
+        {error, _},
+        compile(<<"INSERT INTO t(v) VALUES ('prefix\\${v} suffix')">>)
+    ).
+
+keyword_identifier_case_test() ->
+    {ok, Plan} = compile(
+        <<"INSERT INTO VaLuEs(KeY, UpDaTe) VALUES (${key}, ${update})">>
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `VaLuEs` (`KeY`, `UpDaTe`) VALUES (1, 2)">>},
+        rendered_binary(render(Plan, #{key => 1, update => 2}, null_opts()))
+    ).
+
+charset_and_unicode_value_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${v})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('🙂')"/utf8>>},
+        rendered_binary(render(Plan, #{v => [16#1F642]}, null_opts()))
+    ),
+    InvalidUTF8 = <<16#FF>>,
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES (X'FF')">>},
+        rendered_binary(render(Plan, #{v => InvalidUTF8}, null_opts()))
+    ).
+
+on_duplicate_key_update_test() ->
+    SQL = <<
+        "INSERT INTO t(c1, c2) VALUES (${a}, ${b}) AS new ",
+        "ON DUPLICATE KEY UPDATE c1 = new.c1, c2 = VALUES(c2)"
+    >>,
+    {ok, Plan} = compile(SQL),
+    ?assertEqual(
+        {ok,
+            <<"INSERT INTO `t` (`c1`, `c2`) VALUES (1, 2), (3, 4) AS `new` ",
+                "ON DUPLICATE KEY UPDATE c1 = new.c1, c2 = VALUES(c2)">>},
+        rendered_binary(
+            render_batch(Plan, [#{a => 1, b => 2}, #{a => 3, b => 4}], null_opts())
+        )
+    ),
+    ?assertMatch(
+        {error, _},
+        compile(
+            <<"INSERT INTO t(c1) VALUES (${a}) ON DUPLICATE KEY UPDATE c1 = ${a}">>
+        )
+    ).
+
+undefined_value_test() ->
+    {ok, Plan} = compile(<<"INSERT INTO t(v) VALUES (${missing})">>),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES (NULL)">>},
+        rendered_binary(render(Plan, #{}, #{undefined_vars_as_null => true}))
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` (`v`) VALUES ('undefined')">>},
+        rendered_binary(render(Plan, #{}, #{undefined_vars_as_null => false}))
+    ).
+
+reject_unsupported_syntax_test() ->
+    Rejected = [
+        <<"INSERT INTO t VALUES (${a}), (${b})">>,
+        <<"INSERT INTO t VALUES (${a}) -- comment">>,
+        <<"INSERT INTO ${table} VALUES (${a})">>,
+        <<"INSERT INTO `t${suffix}` VALUES (${a})">>,
+        <<"INSERT INTO t VALUES (${a}) alias">>,
+        <<"INSERT INTO t SELECT ${a}">>
+    ],
+    lists:foreach(fun(SQL) -> ?assertMatch({error, _}, compile(SQL)) end, Rejected).
+
+rendered_binary({ok, SQL}) ->
+    ?assert(is_list(SQL)),
+    {ok, iolist_to_binary(SQL)}.
+
+null_opts() ->
+    #{undefined_vars_as_null => true}.
+
+-endif.

--- a/apps/emqx_mysql/src/emqx_mysql_sql_lexer.xrl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql_lexer.xrl
@@ -3,56 +3,94 @@
 %%--------------------------------------------------------------------
 
 %% This lexer recognizes the restricted MySQL INSERT INTO VALUES token set.
+%% Leex selects the longest prefix. Rule order resolves equal-length matches:
+%% https://github.com/erlang/otp/blob/OTP-26.2.5.14/lib/parsetools/src/leex.erl#L1333-L1365
+%% https://github.com/erlang/otp/blob/OTP-26.2.5.14/lib/parsetools/src/leex.erl#L1142-L1163
+%% https://github.com/erlang/otp/blob/OTP-26.2.5.14/lib/parsetools/src/leex.erl#L1270-L1278
 
 Definitions.
 
-WS              = [\s\t\r\n\f]+
-ID_START        = [A-Za-z_\$\200-\377]
+%% MySQL's state map classifies vertical tab as whitespace:
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/strings/sql_chars.cc#L86-L130
+WS              = [\s\t\r\n\v\f]+
+%% MySQL permits extended bytes. Reject leading $ because MySQL 8.4 dispatches it to dollar quoting:
+%% https://dev.mysql.com/doc/refman/8.4/en/identifiers.html
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L2158-L2190
+ID_START        = [A-Za-z_\200-\377]
 ID_CONTINUE     = [A-Za-z0-9_\$\200-\377]
 IDENTIFIER      = {ID_START}{ID_CONTINUE}*
+%% emqx_template placeholder envelope; parse_placeholder/1 applies local validation:
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
 PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/sql/sql_lex.cc#L1620-L1772
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/sql/sql_lex.cc#L2025-L2033
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L1674-L1826
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L2089-L2097
 NUMBER          = (([0-9]+(\.[0-9]*)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
-HEX_NUMBER      = 0[xX][0-9A-Fa-f]+
+%% Only lowercase 0x is HEX_NUM. Reject the uppercase identifier-path form:
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/sql/sql_lex.cc#L1620-L1707
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L1674-L1761
+HEX_NUMBER      = 0x[0-9A-Fa-f]+
+%% Both versions route x/X to quoted-hex scanning and require an even hex-digit count:
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/mysys/sql_chars.cc#L125-L128
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/sql/sql_lex.cc#L1774-L1785
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/strings/sql_chars.cc#L124-L127
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L1828-L1839
 HEX_STRING      = [xX]'([0-9A-Fa-f][0-9A-Fa-f])*'
-SQ_COMMON       = '([^'\\]|\\[^']|'')*'
-SQ_BACKSLASH    = '([^'\\]|\\.|'')*'
-SQ_PLAIN        = '([^']|'')*'
-DQ_COMMON       = "([^"\\]|\\[^"]|"")*"
-DQ_BACKSLASH    = "([^"\\]|\\.|"")*"
-DQ_PLAIN        = "([^"]|"")*"
-BT_IDENTIFIER   = `([^`]|``)*`
+%% The connector clears ANSI_QUOTES and NO_BACKSLASH_ESCAPES for every session.
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L1023-L1127
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L1763-L1801
+SQ_STRING       = '([^\000'\\]|\\(.|\n)|'')*'
+%% '
+DQ_STRING       = "([^\000"\\]|\\(.|\n)|"")*"
+%% "
+%% Backtick identifiers use doubled backticks and stop before NUL:
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L1763-L1801
+BT_IDENTIFIER   = `([^\000`]|``)*`
 
 Rules.
 
 {WS}            : skip_token.
+%% Reject all MySQL comment openers. '--' is intentionally over-rejected:
+%% https://dev.mysql.com/doc/refman/8.4/en/comments.html
 --               : {error, {comments_not_allowed, TokenLine}}.
 \/\*             : {error, {comments_not_allowed, TokenLine}}.
 \#               : {error, {comments_not_allowed, TokenLine}}.
 {PLACEHOLDER}   : placeholder(TokenChars, TokenLine).
 {HEX_STRING}    : {token, {hex_string, TokenLine, to_binary(TokenChars)}}.
 {HEX_NUMBER}    : {token, {hex_number, TokenLine, to_binary(TokenChars)}}.
-{SQ_COMMON}     : {token, {sq_string, TokenLine, to_binary(TokenChars)}}.
-{SQ_BACKSLASH}  : {error, {ambiguous_single_quoted_string, TokenLine}}.
-{SQ_PLAIN}      : {error, {ambiguous_single_quoted_string, TokenLine}}.
-{DQ_COMMON}     : {token, {dq_opaque, TokenLine, to_binary(TokenChars)}}.
-{DQ_BACKSLASH}  : {error, {ambiguous_double_quoted_token, TokenLine}}.
-{DQ_PLAIN}      : {error, {ambiguous_double_quoted_token, TokenLine}}.
+{SQ_STRING}     : {token, {string, TokenLine, to_binary(TokenChars)}}.
+{DQ_STRING}     : {token, {string, TokenLine, to_binary(TokenChars)}}.
 {BT_IDENTIFIER} : {token, {bt_identifier, TokenLine, to_binary(TokenChars)}}.
 {NUMBER}        : {token, {number, TokenLine, to_binary(TokenChars)}}.
 {IDENTIFIER}    : identifier(TokenChars, TokenLine).
+%% MySQL source for the supported one-byte punctuation and operator forms:
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/sql/sql_lex.cc#L1426-L1469
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/sql/sql_lex.cc#L1799-L2033
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L1487-L1530
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L1853-L2097
 \(              : {token, {'(', TokenLine}}.
 \)              : {token, {')', TokenLine}}.
 ,               : {token, {',', TokenLine}}.
 \.              : {token, {'.', TokenLine}}.
 ;               : {token, {';', TokenLine}}.
+<=>             : {token, {'<=>', TokenLine}}.
+>=              : {token, {'>=', TokenLine}}.
+<=              : {token, {'<=', TokenLine}}.
+<>              : {token, {'<>', TokenLine}}.
+!=              : {token, {'!=', TokenLine}}.
 =               : {token, {'=', TokenLine}}.
+>               : {token, {'>', TokenLine}}.
+<               : {token, {'<', TokenLine}}.
 \+              : {token, {'+', TokenLine}}.
 -               : {token, {'-', TokenLine}}.
 \*              : {token, {'*', TokenLine}}.
 \/              : {token, {'/', TokenLine}}.
 \%              : {token, {'%', TokenLine}}.
 '               : {error, {unterminated_single_quoted_string, TokenLine}}.
+%% '
 "               : {error, {unterminated_double_quoted_token, TokenLine}}.
+%% "
 `               : {error, {unterminated_backtick_identifier, TokenLine}}.
 \$              : {error, {invalid_placeholder, TokenLine}}.
 .               : {error, {unsupported_token, TokenLine, to_binary(TokenChars)}}.
@@ -70,6 +108,8 @@ placeholder(Chars, Line) ->
     end.
 
 identifier(Chars, Line) ->
+    %% MySQL performs keyword lookup after scanning the complete identifier:
+    %% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_lex.cc#L1558-L1619
     Bin = to_binary(Chars),
     case string:lowercase(Bin) of
         <<"insert">> -> {token, {insert, Line}};
@@ -84,5 +124,14 @@ identifier(Chars, Line) ->
         <<"true">> -> {token, {true, Line}};
         <<"false">> -> {token, {false, Line}};
         <<"default">> -> {token, {default, Line}};
+        <<"case">> -> {token, {case_kw, Line}};
+        <<"when">> -> {token, {when_kw, Line}};
+        <<"then">> -> {token, {then_kw, Line}};
+        <<"else">> -> {token, {else_kw, Line}};
+        <<"end">> -> {token, {end_kw, Line}};
+        <<"is">> -> {token, {is_kw, Line}};
+        <<"and">> -> {token, {and_kw, Line}};
+        <<"or">> -> {token, {or_kw, Line}};
+        <<"not">> -> {token, {not_kw, Line}};
         _ -> {token, {identifier, Line, Bin}}
     end.

--- a/apps/emqx_mysql/src/emqx_mysql_sql_lexer.xrl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql_lexer.xrl
@@ -1,0 +1,88 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% This lexer recognizes the restricted MySQL INSERT INTO VALUES token set.
+
+Definitions.
+
+WS              = [\s\t\r\n\f]+
+ID_START        = [A-Za-z_\$\200-\377]
+ID_CONTINUE     = [A-Za-z0-9_\$\200-\377]
+IDENTIFIER      = {ID_START}{ID_CONTINUE}*
+PLACEHOLDER     = \$\{[A-Za-z0-9_.]*\}
+NUMBER          = (([0-9]+(\.[0-9]*)?)|(\.[0-9]+))([eE][+-]?[0-9]+)?
+HEX_NUMBER      = 0[xX][0-9A-Fa-f]+
+HEX_STRING      = [xX]'([0-9A-Fa-f][0-9A-Fa-f])*'
+SQ_COMMON       = '([^'\\]|\\[^']|'')*'
+SQ_BACKSLASH    = '([^'\\]|\\.|'')*'
+SQ_PLAIN        = '([^']|'')*'
+DQ_COMMON       = "([^"\\]|\\[^"]|"")*"
+DQ_BACKSLASH    = "([^"\\]|\\.|"")*"
+DQ_PLAIN        = "([^"]|"")*"
+BT_IDENTIFIER   = `([^`]|``)*`
+
+Rules.
+
+{WS}            : skip_token.
+--               : {error, {comments_not_allowed, TokenLine}}.
+\/\*             : {error, {comments_not_allowed, TokenLine}}.
+\#               : {error, {comments_not_allowed, TokenLine}}.
+{PLACEHOLDER}   : placeholder(TokenChars, TokenLine).
+{HEX_STRING}    : {token, {hex_string, TokenLine, to_binary(TokenChars)}}.
+{HEX_NUMBER}    : {token, {hex_number, TokenLine, to_binary(TokenChars)}}.
+{SQ_COMMON}     : {token, {sq_string, TokenLine, to_binary(TokenChars)}}.
+{SQ_BACKSLASH}  : {error, {ambiguous_single_quoted_string, TokenLine}}.
+{SQ_PLAIN}      : {error, {ambiguous_single_quoted_string, TokenLine}}.
+{DQ_COMMON}     : {token, {dq_opaque, TokenLine, to_binary(TokenChars)}}.
+{DQ_BACKSLASH}  : {error, {ambiguous_double_quoted_token, TokenLine}}.
+{DQ_PLAIN}      : {error, {ambiguous_double_quoted_token, TokenLine}}.
+{BT_IDENTIFIER} : {token, {bt_identifier, TokenLine, to_binary(TokenChars)}}.
+{NUMBER}        : {token, {number, TokenLine, to_binary(TokenChars)}}.
+{IDENTIFIER}    : identifier(TokenChars, TokenLine).
+\(              : {token, {'(', TokenLine}}.
+\)              : {token, {')', TokenLine}}.
+,               : {token, {',', TokenLine}}.
+\.              : {token, {'.', TokenLine}}.
+;               : {token, {';', TokenLine}}.
+=               : {token, {'=', TokenLine}}.
+\+              : {token, {'+', TokenLine}}.
+-               : {token, {'-', TokenLine}}.
+\*              : {token, {'*', TokenLine}}.
+\/              : {token, {'/', TokenLine}}.
+\%              : {token, {'%', TokenLine}}.
+'               : {error, {unterminated_single_quoted_string, TokenLine}}.
+"               : {error, {unterminated_double_quoted_token, TokenLine}}.
+`               : {error, {unterminated_backtick_identifier, TokenLine}}.
+\$              : {error, {invalid_placeholder, TokenLine}}.
+.               : {error, {unsupported_token, TokenLine, to_binary(TokenChars)}}.
+
+Erlang code.
+
+to_binary(Chars) ->
+    list_to_binary(Chars).
+
+placeholder(Chars, Line) ->
+    Bin = to_binary(Chars),
+    case emqx_mysql_sql:parse_placeholder(Bin) of
+        {ok, Placeholder} -> {token, {placeholder, Line, Placeholder}};
+        {error, _} -> {error, {invalid_placeholder, Line, Bin}}
+    end.
+
+identifier(Chars, Line) ->
+    Bin = to_binary(Chars),
+    case string:lowercase(Bin) of
+        <<"insert">> -> {token, {insert, Line}};
+        <<"into">> -> {token, {into, Line}};
+        <<"values">> -> {token, {values, Line, Bin}};
+        <<"on">> -> {token, {on, Line}};
+        <<"duplicate">> -> {token, {duplicate, Line}};
+        <<"key">> -> {token, {key, Line, Bin}};
+        <<"update">> -> {token, {update, Line, Bin}};
+        <<"as">> -> {token, {as, Line}};
+        <<"null">> -> {token, {null, Line}};
+        <<"true">> -> {token, {true, Line}};
+        <<"false">> -> {token, {false, Line}};
+        <<"default">> -> {token, {default, Line}};
+        _ -> {token, {identifier, Line, Bin}}
+    end.

--- a/apps/emqx_mysql/src/emqx_mysql_sql_parser.yrl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql_parser.yrl
@@ -1,0 +1,109 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% Restricted MySQL INSERT INTO VALUES grammar.
+
+Nonterminals
+    template insert_stmt target static_identifier name_path opt_columns columns identifier_list row
+    expression_list expression named_expression opt_call expression_args opt_expression_args
+    opt_alias alias alias_identifier opt_alias_columns opt_on_duplicate assignments assignment
+    opt_semicolon.
+
+Terminals
+    insert into values on duplicate key update as null true false default
+    identifier placeholder number hex_number hex_string sq_string dq_opaque bt_identifier
+    '(' ')' ',' '.' ';' '=' '+' '-' '*' '/' '%'.
+
+Rootsymbol template.
+
+Left 100 '+' '-'.
+Left 200 '*' '/' '%'.
+
+template -> insert_stmt : '$1'.
+
+insert_stmt -> insert into target opt_columns values row opt_alias opt_on_duplicate opt_semicolon :
+    {insert, #{
+        target => '$3',
+        columns => '$4',
+        row => '$6',
+        alias => '$7',
+        on_duplicate => '$8'
+    }}.
+
+target -> name_path : '$1'.
+
+static_identifier -> identifier : {identifier, bare, value('$1')}.
+static_identifier -> bt_identifier : {identifier, backtick, value('$1')}.
+static_identifier -> dq_opaque : {identifier, double_opaque, value('$1')}.
+static_identifier -> values : {identifier, bare, value('$1')}.
+static_identifier -> key : {identifier, bare, value('$1')}.
+static_identifier -> update : {identifier, bare, value('$1')}.
+
+name_path -> static_identifier : ['$1'].
+name_path -> name_path '.' static_identifier : '$1' ++ ['$3'].
+
+opt_columns -> '$empty' : undefined.
+opt_columns -> columns : '$1'.
+columns -> '(' identifier_list ')' : '$2'.
+identifier_list -> static_identifier : ['$1'].
+identifier_list -> identifier_list ',' static_identifier : '$1' ++ ['$3'].
+
+row -> '(' expression_list ')' : {row, '$2'}.
+expression_list -> expression : ['$1'].
+expression_list -> expression_list ',' expression : '$1' ++ ['$3'].
+
+opt_expression_args -> '$empty' : [].
+opt_expression_args -> expression_args : '$1'.
+expression_args -> expression : ['$1'].
+expression_args -> expression_args ',' expression : '$1' ++ ['$3'].
+
+expression -> placeholder : {var, value('$1')}.
+expression -> sq_string : {string, value('$1')}.
+expression -> number : {number, value('$1')}.
+expression -> hex_number : {hex, value('$1')}.
+expression -> hex_string : {hex, value('$1')}.
+expression -> null : null.
+expression -> true : true.
+expression -> false : false.
+expression -> default : default.
+expression -> named_expression : '$1'.
+expression -> '(' expression ')' : {group, '$2'}.
+expression -> '+' expression : {unary, '+', '$2'}.
+expression -> '-' expression : {unary, '-', '$2'}.
+expression -> expression '+' expression : {binary, '+', '$1', '$3'}.
+expression -> expression '-' expression : {binary, '-', '$1', '$3'}.
+expression -> expression '*' expression : {binary, '*', '$1', '$3'}.
+expression -> expression '/' expression : {binary, '/', '$1', '$3'}.
+expression -> expression '%' expression : {binary, '%', '$1', '$3'}.
+
+named_expression -> name_path opt_call : make_named_expression('$1', '$2').
+opt_call -> '$empty' : reference.
+opt_call -> '(' opt_expression_args ')' : {call, '$2'}.
+
+opt_alias -> '$empty' : undefined.
+opt_alias -> alias : '$1'.
+alias -> as alias_identifier opt_alias_columns : {alias, '$2', '$3'}.
+alias_identifier -> identifier : {identifier, bare, value('$1')}.
+alias_identifier -> bt_identifier : {identifier, backtick, value('$1')}.
+alias_identifier -> dq_opaque : {identifier, double_opaque, value('$1')}.
+opt_alias_columns -> '$empty' : undefined.
+opt_alias_columns -> '(' identifier_list ')' : '$2'.
+
+opt_on_duplicate -> '$empty' : undefined.
+opt_on_duplicate -> on duplicate key update assignments : {on_duplicate, '$5'}.
+assignments -> assignment : ['$1'].
+assignments -> assignments ',' assignment : '$1' ++ ['$3'].
+assignment -> name_path '=' expression : {assignment, '$1', '$3'}.
+
+opt_semicolon -> '$empty' : false.
+opt_semicolon -> ';' : true.
+
+Erlang code.
+
+-ignore_xref({return_error, 2}).
+
+value({_Token, _Line, Value}) -> Value.
+
+make_named_expression(Name, reference) -> {identifier_ref, Name};
+make_named_expression(Name, {call, Args}) -> {call, Name, Args}.

--- a/apps/emqx_mysql/src/emqx_mysql_sql_parser.yrl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql_parser.yrl
@@ -7,21 +7,37 @@
 Nonterminals
     template insert_stmt target static_identifier name_path opt_columns columns identifier_list row
     expression_list expression named_expression opt_call expression_args opt_expression_args
+    case_expression opt_case_operand when_clauses when_clause opt_case_else
     opt_alias alias alias_identifier opt_alias_columns opt_on_duplicate assignments assignment
     opt_semicolon.
 
 Terminals
     insert into values on duplicate key update as null true false default
-    identifier placeholder number hex_number hex_string sq_string dq_opaque bt_identifier
-    '(' ')' ',' '.' ';' '=' '+' '-' '*' '/' '%'.
+    case_kw when_kw then_kw else_kw end_kw is_kw and_kw or_kw not_kw
+    identifier placeholder number hex_number hex_string string bt_identifier
+    '(' ')' ',' '.' ';' '=' '<=>' '>=' '<=' '<>' '!=' '>' '<' '+' '-' '*' '/' '%'.
 
+%% Trailing unconsumed tokens do not match and cause a parse error.
 Rootsymbol template.
 
+Left 10 or_kw.
+Left 20 and_kw.
+Right 30 not_kw.
+Nonassoc 40 '=' '<=>' '>=' '<=' '<>' '!=' '>' '<' is_kw.
 Left 100 '+' '-'.
 Left 200 '*' '/' '%'.
 
 template -> insert_stmt : '$1'.
 
+%% This grammar is a restricted subset of both supported MySQL INSERT grammars.
+%% MySQL 8.0.46:
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/sql/sql_yacc.yy#L13104-L13124
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/sql/sql_yacc.yy#L13241-L13323
+%% https://github.com/mysql/mysql-server/blob/0a7df2e4693d8f10901a26034ae6257699356e30/sql/sql_yacc.yy#L13410-L13420
+%% MySQL 8.4.11:
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_yacc.yy#L13064-L13084
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_yacc.yy#L13201-L13287
+%% https://github.com/mysql/mysql-server/blob/99960bf74fa919347e4f4e3ca47672f333d6e91f/sql/sql_yacc.yy#L13375-L13385
 insert_stmt -> insert into target opt_columns values row opt_alias opt_on_duplicate opt_semicolon :
     {insert, #{
         target => '$3',
@@ -35,7 +51,6 @@ target -> name_path : '$1'.
 
 static_identifier -> identifier : {identifier, bare, value('$1')}.
 static_identifier -> bt_identifier : {identifier, backtick, value('$1')}.
-static_identifier -> dq_opaque : {identifier, double_opaque, value('$1')}.
 static_identifier -> values : {identifier, bare, value('$1')}.
 static_identifier -> key : {identifier, bare, value('$1')}.
 static_identifier -> update : {identifier, bare, value('$1')}.
@@ -59,7 +74,7 @@ expression_args -> expression : ['$1'].
 expression_args -> expression_args ',' expression : '$1' ++ ['$3'].
 
 expression -> placeholder : {var, value('$1')}.
-expression -> sq_string : {string, value('$1')}.
+expression -> string : {string, value('$1')}.
 expression -> number : {number, value('$1')}.
 expression -> hex_number : {hex, value('$1')}.
 expression -> hex_string : {hex, value('$1')}.
@@ -67,15 +82,39 @@ expression -> null : null.
 expression -> true : true.
 expression -> false : false.
 expression -> default : default.
+expression -> case_expression : '$1'.
 expression -> named_expression : '$1'.
 expression -> '(' expression ')' : {group, '$2'}.
 expression -> '+' expression : {unary, '+', '$2'}.
 expression -> '-' expression : {unary, '-', '$2'}.
+expression -> not_kw expression : {unary, 'NOT', '$2'}.
+expression -> expression '=' expression : {binary, '=', '$1', '$3'}.
+expression -> expression '<=>' expression : {binary, '<=>', '$1', '$3'}.
+expression -> expression '>=' expression : {binary, '>=', '$1', '$3'}.
+expression -> expression '<=' expression : {binary, '<=', '$1', '$3'}.
+expression -> expression '<>' expression : {binary, '<>', '$1', '$3'}.
+expression -> expression '!=' expression : {binary, '!=', '$1', '$3'}.
+expression -> expression '>' expression : {binary, '>', '$1', '$3'}.
+expression -> expression '<' expression : {binary, '<', '$1', '$3'}.
+expression -> expression is_kw null : {is_null, '$1', false}.
+expression -> expression is_kw not_kw null : {is_null, '$1', true}.
+expression -> expression and_kw expression : {binary, 'AND', '$1', '$3'}.
+expression -> expression or_kw expression : {binary, 'OR', '$1', '$3'}.
 expression -> expression '+' expression : {binary, '+', '$1', '$3'}.
 expression -> expression '-' expression : {binary, '-', '$1', '$3'}.
 expression -> expression '*' expression : {binary, '*', '$1', '$3'}.
 expression -> expression '/' expression : {binary, '/', '$1', '$3'}.
 expression -> expression '%' expression : {binary, '%', '$1', '$3'}.
+
+case_expression -> case_kw opt_case_operand when_clauses opt_case_else end_kw :
+    {case_expression, '$2', '$3', '$4'}.
+opt_case_operand -> '$empty' : undefined.
+opt_case_operand -> expression : '$1'.
+when_clauses -> when_clause : ['$1'].
+when_clauses -> when_clauses when_clause : '$1' ++ ['$2'].
+when_clause -> when_kw expression then_kw expression : {'when', '$2', '$4'}.
+opt_case_else -> '$empty' : undefined.
+opt_case_else -> else_kw expression : '$2'.
 
 named_expression -> name_path opt_call : make_named_expression('$1', '$2').
 opt_call -> '$empty' : reference.
@@ -86,7 +125,6 @@ opt_alias -> alias : '$1'.
 alias -> as alias_identifier opt_alias_columns : {alias, '$2', '$3'}.
 alias_identifier -> identifier : {identifier, bare, value('$1')}.
 alias_identifier -> bt_identifier : {identifier, backtick, value('$1')}.
-alias_identifier -> dq_opaque : {identifier, double_opaque, value('$1')}.
 opt_alias_columns -> '$empty' : undefined.
 opt_alias_columns -> '(' identifier_list ')' : '$2'.
 

--- a/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
+++ b/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
@@ -60,6 +60,7 @@ t_lifecycle_passwordless(_Config) ->
         mysql_config(passwordless)
     ).
 
+%% Checks execution of rendered injection text, typed values, and CASE-produced NULL values.
 t_sql_renderer(_Config) ->
     Conn = connect_mysql(),
     Table = <<"mqtt.emqx_mysql_sql_modes">>,
@@ -119,6 +120,7 @@ t_sql_renderer(_Config) ->
     ok = mysql:query(Conn, [<<"DROP TABLE ">>, Table]),
     ok = mysql:stop(Conn).
 
+%% Checks a batch template containing static and dynamic single-quoted string segments.
 t_segmented_batch_template(_Config) ->
     Conn = connect_mysql(),
     Table = <<"mqtt.emqx_mysql_segmented">>,

--- a/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
+++ b/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
@@ -60,50 +60,66 @@ t_lifecycle_passwordless(_Config) ->
         mysql_config(passwordless)
     ).
 
-t_sql_renderer_modes(_Config) ->
+t_sql_renderer(_Config) ->
     Conn = connect_mysql(),
     Table = <<"mqtt.emqx_mysql_sql_modes">>,
     ok = mysql:query(Conn, [<<"DROP TABLE IF EXISTS ">>, Table]),
     ok = mysql:query(Conn, [
         <<"CREATE TABLE ">>,
         Table,
-        <<" (txt TEXT CHARACTER SET utf8mb4, json_value JSON, binary_value BLOB)">>
+        <<
+            " (txt TEXT CHARACTER SET utf8mb4, encoded_text TEXT CHARACTER SET utf8mb4, "
+            "json_value JSON, binary_value BLOB)"
+        >>
     ]),
     SQL = <<
         "INSERT INTO mqtt.emqx_mysql_sql_modes",
-        "(txt, json_value, binary_value) ",
-        "VALUES (${txt}, ${json}, ${binary})"
+        "(txt, encoded_text, json_value, binary_value) ",
+        "VALUES (${txt}, ${encoded_text}, ${json}, ${binary})"
     >>,
     {ok, Plan} = emqx_mysql_sql:compile(SQL),
     Attack = <<"'); DROP TABLE mqtt.emqx_mysql_sql_modes; -- ">>,
+    EncodedText = <<"你好", 0, "😀"/utf8>>,
     Data = #{
         txt => Attack,
+        encoded_text => EncodedText,
         json => #{<<"key">> => <<"a\\b">>},
         binary => <<16#FF>>
     },
-    lists:foreach(
-        fun(Mode) ->
-            ok = set_sql_mode(Conn, Mode),
-            {ok, Query} = emqx_mysql_sql:render(Plan, Data, #{undefined_vars_as_null => true}),
-            ok = mysql:query(Conn, Query),
-            ?assertEqual(
-                {ok, [<<"txt">>, <<"json_text">>, <<"binary_hex">>], [
-                    [Attack, <<"a\\b">>, <<"FF">>]
-                ]},
-                mysql:query(
-                    Conn,
-                    <<"SELECT txt, JSON_UNQUOTE(JSON_EXTRACT(json_value, '$.key')) AS json_text, ",
-                        "HEX(binary_value) AS binary_hex ", "FROM mqtt.emqx_mysql_sql_modes">>
-                )
-            ),
-            ok = mysql:query(Conn, [<<"TRUNCATE TABLE ">>, Table])
-        end,
-        sql_modes()
+    {ok, Query} = emqx_mysql_sql:render(Plan, Data, #{undefined_vars_as_null => true}),
+    ok = mysql:query(Conn, Query),
+    {ok, Columns, [[Attack, EncodedTextHex, <<"a\\b">>, <<"FF">>]]} = mysql:query(
+        Conn,
+        <<"SELECT txt, HEX(encoded_text) AS encoded_text_hex, ",
+            "JSON_UNQUOTE(JSON_EXTRACT(json_value, '$.key')) AS json_text, ",
+            "HEX(binary_value) AS binary_hex ", "FROM mqtt.emqx_mysql_sql_modes">>
+    ),
+    ?assertEqual(
+        [<<"txt">>, <<"encoded_text_hex">>, <<"json_text">>, <<"binary_hex">>],
+        Columns
+    ),
+    ?assertEqual(binary:encode_hex(EncodedText), EncodedTextHex),
+    CaseSQL = <<
+        "INSERT INTO mqtt.emqx_mysql_sql_modes"
+        "(txt, encoded_text, json_value, binary_value) "
+        "VALUES (CASE WHEN ${txt} = 'null' THEN NULL ELSE ${txt} END, "
+        "${encoded_text}, ${json}, ${binary})"
+    >>,
+    {ok, CasePlan} = emqx_mysql_sql:compile(CaseSQL),
+    {ok, CaseQuery} = emqx_mysql_sql:render(
+        CasePlan,
+        #{txt => <<"null">>, encoded_text => <<"case">>, json => #{}, binary => <<>>},
+        #{undefined_vars_as_null => true}
+    ),
+    ok = mysql:query(Conn, CaseQuery),
+    ?assertEqual(
+        {ok, [<<"COUNT(*)">>], [[1]]},
+        mysql:query(Conn, [<<"SELECT COUNT(*) FROM ">>, Table, <<" WHERE txt IS NULL">>])
     ),
     ok = mysql:query(Conn, [<<"DROP TABLE ">>, Table]),
     ok = mysql:stop(Conn).
 
-t_segmented_batch_template_modes(_Config) ->
+t_segmented_batch_template(_Config) ->
     Conn = connect_mysql(),
     Table = <<"mqtt.emqx_mysql_segmented">>,
     ok = mysql:query(Conn, [<<"DROP TABLE IF EXISTS ">>, Table]),
@@ -119,25 +135,18 @@ t_segmented_batch_template_modes(_Config) ->
     #{query_templates := #{{send_message, batch} := Plan}} =
         emqx_mysql:parse_prepare_sql(#{sql => SQL}),
     BatchValue = <<"batch\\value">>,
-    lists:foreach(
-        fun(Mode) ->
-            ok = set_sql_mode(Conn, Mode),
-            {ok, BatchSQL} = emqx_mysql_sql:render_batch(
-                Plan,
-                [#{value => BatchValue}],
-                #{undefined_vars_as_null => true}
-            ),
-            ok = mysql:query(Conn, BatchSQL),
-            ?assertEqual(
-                {ok, [<<"txt">>], [[expected_segmented_value(Mode, BatchValue)]]},
-                mysql:query(
-                    Conn,
-                    <<"SELECT txt FROM mqtt.emqx_mysql_segmented ORDER BY id">>
-                )
-            ),
-            ok = mysql:query(Conn, [<<"TRUNCATE TABLE ">>, Table])
-        end,
-        sql_modes()
+    {ok, BatchSQL} = emqx_mysql_sql:render_batch(
+        Plan,
+        [#{value => BatchValue}],
+        #{undefined_vars_as_null => true}
+    ),
+    ok = mysql:query(Conn, BatchSQL),
+    ?assertEqual(
+        {ok, [<<"txt">>], [[<<"prefix\n ", BatchValue/binary, " suffix">>]]},
+        mysql:query(
+            Conn,
+            <<"SELECT txt FROM mqtt.emqx_mysql_segmented ORDER BY id">>
+        )
     ),
     ok = mysql:query(Conn, [<<"DROP TABLE ">>, Table]),
     ok = mysql:stop(Conn).
@@ -262,25 +271,6 @@ connect_mysql() ->
     ],
     {ok, Pid} = mysql:start_link(Opts),
     Pid.
-
-sql_modes() ->
-    [
-        <<>>,
-        <<"NO_BACKSLASH_ESCAPES">>,
-        <<"ANSI_QUOTES">>,
-        <<"ANSI_QUOTES,NO_BACKSLASH_ESCAPES">>
-    ].
-
-set_sql_mode(Conn, Mode) ->
-    mysql:query(Conn, [<<"SET SESSION sql_mode = '">>, Mode, <<"'">>]).
-
-expected_segmented_value(Mode, Value) ->
-    Prefix =
-        case binary:match(Mode, <<"NO_BACKSLASH_ESCAPES">>) of
-            nomatch -> <<"prefix\n ">>;
-            _ -> <<"prefix\\n ">>
-        end,
-    <<Prefix/binary, Value/binary, " suffix">>.
 
 test_query_no_params() ->
     {sql, <<"SELECT 1">>}.

--- a/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
+++ b/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
@@ -60,6 +60,88 @@ t_lifecycle_passwordless(_Config) ->
         mysql_config(passwordless)
     ).
 
+t_sql_renderer_modes(_Config) ->
+    Conn = connect_mysql(),
+    Table = <<"mqtt.emqx_mysql_sql_modes">>,
+    ok = mysql:query(Conn, [<<"DROP TABLE IF EXISTS ">>, Table]),
+    ok = mysql:query(Conn, [
+        <<"CREATE TABLE ">>,
+        Table,
+        <<" (txt TEXT CHARACTER SET utf8mb4, json_value JSON, binary_value BLOB)">>
+    ]),
+    SQL = <<
+        "INSERT INTO mqtt.emqx_mysql_sql_modes",
+        "(txt, json_value, binary_value) ",
+        "VALUES (${txt}, ${json}, ${binary})"
+    >>,
+    {ok, Plan} = emqx_mysql_sql:compile(SQL),
+    Attack = <<"'); DROP TABLE mqtt.emqx_mysql_sql_modes; -- ">>,
+    Data = #{
+        txt => Attack,
+        json => #{<<"key">> => <<"a\\b">>},
+        binary => <<16#FF>>
+    },
+    lists:foreach(
+        fun(Mode) ->
+            ok = set_sql_mode(Conn, Mode),
+            {ok, Query} = emqx_mysql_sql:render(Plan, Data, #{undefined_vars_as_null => true}),
+            ok = mysql:query(Conn, Query),
+            ?assertEqual(
+                {ok, [<<"txt">>, <<"json_text">>, <<"binary_hex">>], [
+                    [Attack, <<"a\\b">>, <<"FF">>]
+                ]},
+                mysql:query(
+                    Conn,
+                    <<"SELECT txt, JSON_UNQUOTE(JSON_EXTRACT(json_value, '$.key')) AS json_text, ",
+                        "HEX(binary_value) AS binary_hex ", "FROM mqtt.emqx_mysql_sql_modes">>
+                )
+            ),
+            ok = mysql:query(Conn, [<<"TRUNCATE TABLE ">>, Table])
+        end,
+        sql_modes()
+    ),
+    ok = mysql:query(Conn, [<<"DROP TABLE ">>, Table]),
+    ok = mysql:stop(Conn).
+
+t_segmented_batch_template_modes(_Config) ->
+    Conn = connect_mysql(),
+    Table = <<"mqtt.emqx_mysql_segmented">>,
+    ok = mysql:query(Conn, [<<"DROP TABLE IF EXISTS ">>, Table]),
+    ok = mysql:query(Conn, [
+        <<"CREATE TABLE ">>,
+        Table,
+        <<" (id BIGINT AUTO_INCREMENT PRIMARY KEY, txt TEXT CHARACTER SET utf8mb4)">>
+    ]),
+    SQL = <<
+        "INSERT INTO mqtt.emqx_mysql_segmented(txt) ",
+        "VALUES ('prefix\\n ${value} suffix')"
+    >>,
+    #{query_templates := #{{send_message, batch} := Plan}} =
+        emqx_mysql:parse_prepare_sql(#{sql => SQL}),
+    BatchValue = <<"batch\\value">>,
+    lists:foreach(
+        fun(Mode) ->
+            ok = set_sql_mode(Conn, Mode),
+            {ok, BatchSQL} = emqx_mysql_sql:render_batch(
+                Plan,
+                [#{value => BatchValue}],
+                #{undefined_vars_as_null => true}
+            ),
+            ok = mysql:query(Conn, BatchSQL),
+            ?assertEqual(
+                {ok, [<<"txt">>], [[expected_segmented_value(Mode, BatchValue)]]},
+                mysql:query(
+                    Conn,
+                    <<"SELECT txt FROM mqtt.emqx_mysql_segmented ORDER BY id">>
+                )
+            ),
+            ok = mysql:query(Conn, [<<"TRUNCATE TABLE ">>, Table])
+        end,
+        sql_modes()
+    ),
+    ok = mysql:query(Conn, [<<"DROP TABLE ">>, Table]),
+    ok = mysql:stop(Conn).
+
 perform_lifecycle_check(ResourceId, InitialConfig) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(?MYSQL_RESOURCE_MOD, InitialConfig),
@@ -180,6 +262,25 @@ connect_mysql() ->
     ],
     {ok, Pid} = mysql:start_link(Opts),
     Pid.
+
+sql_modes() ->
+    [
+        <<>>,
+        <<"NO_BACKSLASH_ESCAPES">>,
+        <<"ANSI_QUOTES">>,
+        <<"ANSI_QUOTES,NO_BACKSLASH_ESCAPES">>
+    ].
+
+set_sql_mode(Conn, Mode) ->
+    mysql:query(Conn, [<<"SET SESSION sql_mode = '">>, Mode, <<"'">>]).
+
+expected_segmented_value(Mode, Value) ->
+    Prefix =
+        case binary:match(Mode, <<"NO_BACKSLASH_ESCAPES">>) of
+            nomatch -> <<"prefix\n ">>;
+            _ -> <<"prefix\\n ">>
+        end,
+    <<Prefix/binary, Value/binary, " suffix">>.
 
 test_query_no_params() ->
     {sql, <<"SELECT 1">>}.

--- a/changes/ee/fix-18465.en.md
+++ b/changes/ee/fix-18465.en.md
@@ -1,0 +1,11 @@
+Fixed handling of templated INSERT SQL statements in the ClickHouse, TDengine, SQL Server, and MySQL bridges (when batch insert is enabled).
+
+Previously, rendering SQL templates could often produce malformed SQL due to syntax errors in the manually entered template itself and due to interpolation issues.
+
+Now, SQL statements are fully parsed when an action is created, and invalid SQL is rejected. During rendering, correct escaping is enforced. To provide consistent and predictable behavior, we limit the SQL features that can be used. Most notably, we reject comments in SQL statements. However, we support a large subset of syntax features: constant values, strings and string interpolation, arithmetic, functions, conditions, and conditional operators.
+
+MySQL also supports `ON DUPLICATE KEY UPDATE`, ClickHouse supports `FORMAT Values` and `FORMAT JSONCompactEachRow`, and TDengine supports `INSERT ... USING ... TAGS` and table identifier interpolation.
+
+To provide consistent rendering for MySQL templates, the MySQL bridge unconditionally disables `ANSI_QUOTES` and `NO_BACKSLASH_ESCAPES` modes for all connections, and treats the statements accordingly.
+
+The ClickHouse bridge now infers the batch value separator from the SQL template and ignores the configured `batch_value_separator` value.

--- a/rel/i18n/emqx_bridge_clickhouse.hocon
+++ b/rel/i18n/emqx_bridge_clickhouse.hocon
@@ -51,7 +51,7 @@ local_topic.label:
 """Local Topic"""
 
 sql_template.desc:
-"""A restricted ClickHouse INSERT template. It supports VALUES, FORMAT Values, and FORMAT JSONCompactEachRow. Placeholders are allowed only in value positions and string values. Comments, extra statements, and dynamic identifiers are not allowed."""
+"""A restricted ClickHouse `INSERT` template. It supports `VALUES`, `FORMAT Values`, and `JSONCompactEachRow`. Placeholders are allowed only in value positions and string values. Comments, extra statements, and dynamic identifiers are not allowed."""
 
 sql_template.label:
 """SQL Template"""

--- a/rel/i18n/emqx_bridge_clickhouse.hocon
+++ b/rel/i18n/emqx_bridge_clickhouse.hocon
@@ -1,7 +1,7 @@
 emqx_bridge_clickhouse {
 
 batch_value_separator.desc:
-"""The default value ',' works for the VALUES format. You can also use other separator if other format is specified. See [INSERT INTO Statement](https://clickhouse.com/docs/en/sql-reference/statements/insert-into)."""
+"""This argument is ignored and retained for compatibility. The action derives the batch separator from the SQL format."""
 
 batch_value_separator.label:
 """Batch Value Separator"""
@@ -51,7 +51,7 @@ local_topic.label:
 """Local Topic"""
 
 sql_template.desc:
-"""The template string can contain ${field} placeholders for message metadata and payload field. Make sure that the inserted values are formatted and escaped correctly. [Prepared Statement](https://docs.emqx.com/en/enterprise/v5.0/data-integration/data-bridges.html#Prepared-Statement) is not supported."""
+"""A restricted ClickHouse INSERT template. It supports VALUES, FORMAT Values, and FORMAT JSONCompactEachRow. Placeholders are allowed only in value positions and string values. Comments, extra statements, and dynamic identifiers are not allowed."""
 
 sql_template.label:
 """SQL Template"""

--- a/rel/i18n/emqx_bridge_sqlserver.hocon
+++ b/rel/i18n/emqx_bridge_sqlserver.hocon
@@ -41,7 +41,7 @@ local_topic.label:
 """Local Topic"""
 
 sql_template.desc:
-"""SQL Template"""
+"""A restricted SQL Server INSERT INTO VALUES template. Placeholders are allowed only in value positions and string values. Comments, extra statements, multiple configured rows, and dynamic identifiers are not allowed."""
 
 sql_template.label:
 """SQL Template"""

--- a/rel/i18n/emqx_bridge_tdengine.hocon
+++ b/rel/i18n/emqx_bridge_tdengine.hocon
@@ -35,7 +35,7 @@ local_topic.label:
 """Local Topic"""
 
 sql_template.desc:
-"""SQL Template"""
+"""A restricted TDengine INSERT template. It supports multi-table VALUES inserts and USING stable TAGS clauses. A bare or backtick-quoted target table may contain placeholders, for example, `test_${clientid}`. EMQX renders the complete target as one quoted identifier. Comments, FILE input, and extra statements are not allowed."""
 
 sql_template.label:
 """SQL Template"""

--- a/scripts/spellcheck/dicts/emqx.txt
+++ b/scripts/spellcheck/dicts/emqx.txt
@@ -153,7 +153,6 @@ jenkins
 jq
 json
 JSON
-JSONCompactEachRow
 JWK
 JWKs
 JWT

--- a/scripts/spellcheck/dicts/emqx.txt
+++ b/scripts/spellcheck/dicts/emqx.txt
@@ -153,6 +153,7 @@ jenkins
 jq
 json
 JSON
+JSONCompactEachRow
 JWK
 JWKs
 JWT


### PR DESCRIPTION
Release versions:
5.8.12

Introduced in:
pre-5.8

## Summary

We fix emqx/emqx-dev-team-tasks#306, a problem with SQL injections in templated SQL in bridges where db-side placeholders are not available.

To fix it, we introduce placeholder-aware SQL parsers. They parse a **limited but known** subset of each SQL dialect and safely render interpolated values according to their context.

The PR is somewhat large, but it mostly repeats the same approach four times.

**Motivation**

The existing "SQL templating" never seemed robust. Logically, there are two possible models for SQL templating:

- **A.** A template is first rendered as a string and then treated as SQL. In other words, interpolate first and interpret the SQL structure afterwards. This is unsafe because the rendered data can change the SQL structure.
- **B.** SQL is extended with special values (placeholders) in explicitly allowed contexts. The SQL structure is checked first, and placeholders are then rendered according to their parsed context.

The previous solution implemented neither model fully, although it was closer to the first. It performed some ad hoc parsing, such as checking the basic structure with regular expressions, but not enough parsing to determine the context of each placeholder.

There is no safe universal quotation working for any lexical and syntactic context. For example:

```sql
VALUES ('${a}', ${b})
```

`${a}` is content inside an existing string literal. Its value must be escaped without adding another pair of quotes. `${b}` is a complete SQL value. It must preserve numbers, booleans, and `NULL`, while adding and escaping quotes for strings.

There is no "simple" way to detect the context by inspecting the surroundings of a placeholder:

```sql
/* '${a}' */
/* ${a} */
'/* ${a} */'
```

The first two occurrences are inside comments and **must not** allow `*/`. The third occurrence is inside a string and must be rendered allowing `*/`. (In the new implementation we reject comments entirely). On the contrary, `'` must be forbidden (escaped) in the third variant but must be allowed without escaping in the first two. (N.B. we disallow comments entirely).

We now follow the *B* model, implementing placeholder-aware SQL parsers. The main guiding principle when choosing this way is that when security is concerned, we should **root out entire classes of vulnerabilities rather than address them on a case-by-case basis**. This follows the [Secure by Design](https://www.cisa.gov/news-events/news/categorically-unsafe-software) approach. We should not keep adding more ad hoc checks. We also should not handover to the user verification of query security.

The approach is not completely perfect. We still may receive some very tricky SQL that we misinterpret. However, the SQL is provided by an admin, not an attacker, so the chances are low. Additionally, even if we misinterpret some SQL, on render we still correctly produce some valid SQL in which the placeholders cannot escape.

As a result of the fix, we also:

- Remove [regular-expression parsing of `INSERT` statements](https://github.com/emqx/emqx/blob/4dea601c1c38196b1b7832fc160e5396262a2748/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl#L94), which was already a form of ad hoc SQL parsing.
- Remove SQL normalization that [possibly changed the values](https://github.com/emqx/emqx/blob/4dea601c1c38196b1b7832fc160e5396262a2748/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl#L450), including whitespace inside quoted strings.
- Do not reuse the common quoting functions from `emqx_template_sql`. Combining backend-specific quoting rules behind switches in a universal quotation function is more error-prone than keeping quotation local to each backend.

**Resulting inprovements** 

Besides fixing security.
- We are able to much better validate SQL on creation, not on actual requests.
- We now correctly and safely support interpolation inside string literals, for example:
```sql
VALUES ('xxx ${yyy} zzz')
```
- With the approach we are able to safely interpolate integers, booleans, nulls and any types with special syntax.

**Incompatibilities**

* This is a compatibility-breaking change because it significantly narrows the accepted SQL syntax. Templates using unknown or unsupported syntax are now rejected. The supported subsets cover common `INSERT ... VALUES` templates, but they do not cover every valid construction in each backend dialect. Hovewer, we expect most of the reasonable cases to be accepted.
* For MySQL correct quotation is particularly hard ([emqx code](https://github.com/emqx/emqx-dev-team-tasks/issues/306#issuecomment-5399584274), [1](https://nvd.nist.gov/vuln/detail/CVE-2026-44172), [2](https://nvd.nist.gov/vuln/detail/CVE-2026-48188), [3](https://nvd.nist.gov/vuln/detail/CVE-2026-33468), [4](https://nvd.nist.gov/vuln/detail/CVE-2026-33442), [5](https://nvd.nist.gov/vuln/detail/CVE-2019-10748), [6](https://nvd.nist.gov/vuln/detail/CVE-2006-2753)). See also  [2025 PDO parser research](https://www.slcyber.io/research/a-novel-technique-for-sql-injection-in-pdos-prepared-statements). MySQL has session/server setting that make interpret `'single quoted'` and `"double quoted"` strings differently. For ensuring seecure interpolation, we explicitly disable `ANSI_QUOTES` and `NO_BACKSLASH_ESCAPE` features in each connection (as by default server settings), and treat string tokens accordingly. This may break some obscure clients who have `NO_BACKSLASH_ESCAPE/ANSI_QUOTES` enabled in their server settings and who composed their templates relying on that.

**Rejected alternatives**

- Trying to limit the fix to tracing only the lexical context (whether we are inside a string, comment, or identifier), but it looked like one more ad hoc addition. Also, the chances of failing to detect some unknown syntax are high. With the current implementation, we reject any unknown syntax. 
- Introducing explicit placeholders like `'xxx $sq_str{a.b.c} yyy'`, `"xxx $dq_str{a.b.c} yyy"`, etc. This approach is not foolproof by default and shifts responsibility to the user.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
