### PR TITLE
fix(data_backup): list backup files without globbing the namespace name

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -533,9 +533,22 @@ list_files(Namespace) ->
 -spec backup_files(maybe_namespace()) -> [file:filename()].
 backup_files(Namespace) ->
     %% A namespace without a resolvable backup directory owns no backups.
-    case backup_path(Namespace, "*" ++ ?TAR_SUFFIX) of
-        {ok, Pattern} -> filelib:wildcard(Pattern);
+    %% List the directory instead of globbing: the namespace name is caller
+    %% controlled and must never be interpreted as wildcard syntax.
+    case backup_root_dir(Namespace) of
+        {ok, Dir} -> list_tar_files(Dir);
         {error, _} -> []
+    end.
+
+list_tar_files(Dir) ->
+    case file:list_dir(Dir) of
+        {ok, Filenames} ->
+            lists:sort([
+                filename:join(Dir, Filename)
+             || Filename <- Filenames, lists:suffix(?TAR_SUFFIX, Filename)
+            ]);
+        {error, _} ->
+            []
     end.
 
 -spec format_error(atom()) -> string() | term().

--- a/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
@@ -474,6 +474,74 @@ t_dot_namespace_cannot_reach_global_backups(_Config) ->
     ),
     ok.
 
+-doc """
+A namespace name may contain characters that are meaningful to
+`filelib:wildcard/1`. The listing must treat the name literally: a namespace
+whose name contains glob metacharacters sees its own backups.
+""".
+t_ns_with_glob_metachars_lists_own_backups(_Config) ->
+    lists:foreach(
+        fun(Ns) ->
+            {ok, #{filename := File}} = emqx_mgmt_data_backup:export(#{namespace => Ns}),
+            Base = unicode:characters_to_binary(basename(File)),
+            ?assertMatch(
+                [#{filename := Base}],
+                emqx_mgmt_data_backup:list_files(Ns),
+                #{ns => Ns}
+            )
+        end,
+        [
+            %% The namespace name from the original report (EMQX issue #18370).
+            <<"ns~%^&*-={}<>@#1">>,
+            <<"a{b,c}">>,
+            <<"a[b]">>,
+            <<"a?b">>,
+            <<"plain-ns">>
+        ]
+    ),
+    %% A namespace that never exported owns no backups.
+    ?assertEqual([], emqx_mgmt_data_backup:list_files(<<"never-exported">>)),
+    %% The global namespace lists its own backups as before.
+    {ok, #{filename := GlobalFile}} = emqx_mgmt_data_backup:export(),
+    GlobalBase = unicode:characters_to_binary(basename(GlobalFile)),
+    ?assert(
+        lists:any(
+            fun(#{filename := F}) -> F =:= GlobalBase end,
+            emqx_mgmt_data_backup:list_files()
+        )
+    ),
+    ok.
+
+-doc """
+A namespace named `*` maps to the literal directory `ns/*`. Its listing must
+contain only its own backups: the name must not act as a wildcard that matches
+every other namespace's directory. Reading another namespace's file through
+the `*` namespace must fail as well.
+""".
+t_wildcard_ns_sees_only_own_backups(_Config) ->
+    {ok, #{filename := VictimFile}} = emqx_mgmt_data_backup:export(#{namespace => <<"victim">>}),
+    %% Plant a distinctively named backup file in the victim's directory.
+    SecretBase = <<"victim-secret.tar.gz">>,
+    SecretFile = filename:join(filename:dirname(VictimFile), SecretBase),
+    ok = file:write_file(SecretFile, <<"victim-secret-content">>),
+    {ok, #{filename := OwnFile}} = emqx_mgmt_data_backup:export(#{namespace => <<"*">>}),
+    OwnBase = unicode:characters_to_binary(basename(OwnFile)),
+    ?assertMatch(
+        [#{filename := OwnBase}],
+        emqx_mgmt_data_backup:list_files(<<"*">>)
+    ),
+    ?assertEqual(
+        {error, not_found},
+        emqx_mgmt_data_backup:read_file(<<"*">>, SecretBase)
+    ),
+    %% The victim still sees both of its files.
+    VictimBase = unicode:characters_to_binary(basename(VictimFile)),
+    ?assertEqual(
+        lists:sort([VictimBase, SecretBase]),
+        lists:sort([F || #{filename := F} <- emqx_mgmt_data_backup:list_files(<<"victim">>)])
+    ),
+    ok.
+
 t_no_backup_file(_Config) ->
     ?assertMatch([_ | _], emqx_mgmt_data_backup:format_error(not_found)),
     ?assertEqual(

--- a/changes/ee/fix-18466.en.md
+++ b/changes/ee/fix-18466.en.md
@@ -1,0 +1,3 @@
+Fixed listing of backup files for namespaces whose names contain special characters.
+
+Previously, the backup file list was empty for a namespace whose name contained characters such as `*`, `?`, `{`, `}`, `[` or `]`, even though the backup files existed on disk. The listing now treats the namespace name as a literal directory name.


### PR DESCRIPTION
Release version:

6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:

6.1.4

## Summary

Fixes #18370.

`emqx_mgmt_data_backup:backup_files/1` built a wildcard pattern that embedded the namespace name verbatim, so `filelib:wildcard/1` interpreted glob metacharacters in the name. A namespace whose name contains such characters (for example `ns~%^&*-={}<>@#1`) could not list its own backups: export succeeded and the file existed on disk, but the list API returned an empty list.

The listing now calls `file:list_dir/1` on the resolved backup directory and filters on the `.tar.gz` suffix. The namespace name is never interpreted as a pattern. Download, delete, upload and import are unaffected: they already resolve the file path literally through `backup_path/2`.

New test cases in `emqx_mgmt_data_backup_SUITE` cover namespace names with glob metacharacters and assert that a namespace's listing contains exactly its own files. Both fail without the fix.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
