### PR TITLE
fix(relup): reject bad target version before touching the node tree

### DIFF
--- a/changes/ee/fix-18469.en.md
+++ b/changes/ee/fix-18469.en.md
@@ -1,0 +1,1 @@
+The hot-upgrade (relup) plugin now validates the target version string and checks upgrade-path compatibility before it modifies any files. An incompatible or malformed upgrade package is rejected without deleting or overwriting the installed release.

--- a/plugins/emqx_relup/src/emqx_relup_handler.erl
+++ b/plugins/emqx_relup/src/emqx_relup_handler.erl
@@ -341,7 +341,7 @@ read_rel_vsn(UnpackDir) ->
 %% subdir); accept only a plain version string like "6.0.1" or
 %% "6.0.1-beta.1", never a path.
 validate_rel_vsn(Vsn, File) ->
-    case re:run(Vsn, "^[0-9]+\\.[0-9]+\\.[0-9]+([.+-][0-9A-Za-z.+-]+)?$", [{capture, none}]) of
+    case re:run(Vsn, "^[0-9]+\\.[0-9]+\\.[0-9]+([.-][0-9A-Za-z.-]+)?$", [{capture, none}]) of
         match -> Vsn;
         nomatch -> throw(make_error(bad_target_vsn, #{vsn => bin(Vsn), file => File}))
     end.

--- a/plugins/emqx_relup/src/emqx_relup_handler.erl
+++ b/plugins/emqx_relup/src/emqx_relup_handler.erl
@@ -42,8 +42,10 @@ check_and_unpack(CurrVsn, RootDir, #{tarball := TarFile} = Opts) ->
         ok = check_otp_comaptibility(CurrVsn, RootDir, UnpackDir, TargetVsn),
         {ok, OldRel} = consult_rel_file(RootDir, CurrVsn),
         {ok, NewRel} = consult_rel_file(UnpackDir, TargetVsn),
-        ok = deploy_files(TargetVsn, RootDir, UnpackDir, OldRel, NewRel, Opts),
+        %% All acceptance checks must run before deploy_files/6: a
+        %% package that ends up rejected must not mutate the node tree.
         Relup = get_relup_entry(CurrVsn, TargetVsn),
+        ok = deploy_files(TargetVsn, RootDir, UnpackDir, OldRel, NewRel, Opts),
         {ok, Opts#{
             target_vsn => TargetVsn,
             unpack_dir => UnpackDir,
@@ -330,9 +332,18 @@ read_rel_vsn(UnpackDir) ->
             case
                 re:run(Bin, <<"^REL_VSN=\"([^\"]+)\"">>, [multiline, {capture, all_but_first, list}])
             of
-                {match, [Vsn]} -> Vsn;
+                {match, [Vsn]} -> validate_rel_vsn(Vsn, File);
                 nomatch -> throw(make_error(rel_vsn_not_found, #{file => File}))
             end
+    end.
+
+%% REL_VSN is later used as a path component (deploy dir, releases
+%% subdir); accept only a plain version string like "6.0.1" or
+%% "6.0.1-beta.1", never a path.
+validate_rel_vsn(Vsn, File) ->
+    case re:run(Vsn, "^[0-9]+\\.[0-9]+\\.[0-9]+([.+-][0-9A-Za-z.+-]+)?$", [{capture, none}]) of
+        match -> Vsn;
+        nomatch -> throw(make_error(bad_target_vsn, #{vsn => bin(Vsn), file => File}))
     end.
 
 %% Lowercase hex sha256 of `TarFile`'s contents.
@@ -847,8 +858,18 @@ get_upgrade_mod(TargetVsn) ->
 independent_deploy_root(RootDir) ->
     filename:join([RootDir, "relup"]).
 
+%% TargetVsn is validated at read_rel_vsn/1; keep a last-resort check
+%% here so the deploy dir can never resolve outside <RootDir>/relup.
 get_deploy_dir(RootDir, TargetVsn) ->
-    filename:join([independent_deploy_root(RootDir), TargetVsn]).
+    DeployRoot = independent_deploy_root(RootDir),
+    Dir = filename:join([DeployRoot, TargetVsn]),
+    IsContained =
+        filename:dirname(Dir) =:= DeployRoot andalso
+            not lists:member(filename:basename(Dir), [".", ".."]),
+    case IsContained of
+        true -> Dir;
+        false -> throw(make_error(bad_target_vsn, #{vsn => bin(TargetVsn)}))
+    end.
 
 read_build_info(RootDir, Vsn) ->
     BuildInfoFile = filename:join([RootDir, "releases", Vsn, "BUILD_INFO"]),

--- a/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
+++ b/plugins/emqx_relup/test/emqx_relup_round_trip_SUITE.erl
@@ -230,16 +230,44 @@ t_missing_emqx_vars_rejects(Config) ->
     ),
     ?assertMatch({error, #{err_type := cannot_read_emqx_vars}}, Result).
 
--doc "No catalog entry for {From, Target} → `no_relup_entry`.".
+-doc """
+No catalog entry for {From, Target} → `no_relup_entry`, and the
+rejected package must not mutate the node tree: no deploy dir is
+created and existing files stay intact.
+""".
 t_no_matching_catalog_entry(Config) ->
     RootDir = ?config(root_dir, Config),
+    Canary = write_canary(RootDir),
     Tarball = forge_target_tarball(RootDir, ?TARGET_VSN, default_arch()),
     ok = write_sha256_sidecar(Tarball),
     %% no .relup file — list_supported_paths is empty
     Result = emqx_relup_handler:check_and_unpack(
         ?CURR_VSN, RootDir, #{tarball => Tarball}
     ),
-    ?assertMatch({error, #{err_type := no_relup_entry}}, Result).
+    ?assertMatch({error, #{err_type := no_relup_entry}}, Result),
+    DeployDir = filename:join([RootDir, "relup", ?TARGET_VSN]),
+    ?assertNot(filelib:is_dir(DeployDir), "rejected package must not be deployed"),
+    ?assert(filelib:is_regular(Canary), "rejected package must not touch existing files").
+
+-doc """
+A crafted package whose `releases/emqx_vars` declares `REL_VSN=".."`
+makes the deploy dir resolve to RootDir itself. It must be rejected
+as a bad target version before any file is deleted or overwritten.
+""".
+t_rel_vsn_path_traversal_rejected(Config) ->
+    RootDir = ?config(root_dir, Config),
+    Canary = write_canary(RootDir),
+    Tarball = forge_traversal_tarball(RootDir, default_arch()),
+    ok = write_sha256_sidecar(Tarball),
+    Result = emqx_relup_handler:check_and_unpack(
+        ?CURR_VSN, RootDir, #{tarball => Tarball}
+    ),
+    ?assertMatch({error, #{err_type := bad_target_vsn}}, Result),
+    ?assert(filelib:is_regular(Canary), "RootDir contents must not be deleted"),
+    ?assert(
+        filelib:is_regular(filename:join([RootDir, "releases", ?CURR_VSN, "emqx.rel"])),
+        "the running release tree must not be deleted"
+    ).
 
 -doc "Tarball contains non-runtime dirs (data/, etc/, log/, plugins/) — "
 "deploy_files must copy only bin/, erts-*/, lib/, releases/. The "
@@ -526,6 +554,35 @@ fake_app_desc(Description) ->
             [?FAKE_APP, Description, ?FAKE_APP_VSN]
         )
     ).
+
+%% A crafted package declaring `REL_VSN=".."`. The pre-deploy reads
+%% resolve `releases/../BUILD_INFO` and `releases/../emqx.rel` to the
+%% unpack-dir root, so place those members there.
+forge_traversal_tarball(RootDir, Arch) ->
+    StageDir = filename:join([RootDir, "_stage", "traversal"]),
+    MneDir = filename:join([StageDir, "lib", "mnesia-9.9", "ebin"]),
+    ok = filelib:ensure_path(filename:join(StageDir, "releases")),
+    ok = filelib:ensure_path(MneDir),
+    EmqxVarsFile = filename:join([StageDir, "releases", "emqx_vars"]),
+    RelFile = filename:join(StageDir, "emqx.rel"),
+    BuildFile = filename:join(StageDir, "BUILD_INFO"),
+    BeamFile = filename:join(MneDir, "mnesia_hook.beam"),
+    ok = file:write_file(EmqxVarsFile, emqx_vars_content("..")),
+    ok = file:write_file(RelFile, rel_file_content("..")),
+    ok = file:write_file(BuildFile, build_info_content(Arch)),
+    ok = file:write_file(BeamFile, <<>>),
+    Members = [
+        {archive_name(F, StageDir), F}
+     || F <- [EmqxVarsFile, RelFile, BuildFile, BeamFile]
+    ],
+    TarPath = filename:join(tarball_dir(RootDir), "emqx-test-traversal.tar.gz"),
+    ok = erl_tar:create(TarPath, Members, [compressed]),
+    TarPath.
+
+write_canary(RootDir) ->
+    Canary = filename:join(RootDir, "canary.txt"),
+    ok = file:write_file(Canary, <<"untouched">>),
+    Canary.
 
 tarball_dir(RootDir) ->
     %% Models "operator scp'd to some path readable by emqx" — the


### PR DESCRIPTION
Release version:
5.10.5

Introduced in:
5.10.4

## Summary

Fixes emqx/emqx-dev-team-tasks#353 for the 5.10 line. Port of #18468 (dev-60).

`emqx_relup_handler:check_and_unpack/3` deployed the unpacked package into `<root>/relup/<vsn>` before the upgrade-path catalog check ran. A package that ends up rejected (for example with `no_relup_entry`) had already deleted and overwritten files on disk. The target version string read from the package was also used as a path component without validation.

Changes in `plugins/emqx_relup/src/emqx_relup_handler.erl`:
* Validate the target version read from `releases/emqx_vars` as a plain version string. Reject anything else with `bad_target_vsn`.
* Refuse a deploy dir that resolves outside `<root>/relup` as a last-resort check in `get_deploy_dir/2`.
* Run the relup catalog lookup before `deploy_files/6`, so a rejected package does not mutate the filesystem.

Package authenticity verification (a signature, as opposed to the existing `.sha256` integrity check) is intentionally out of scope here and can be a follow-up.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
