### PR TITLE
fix(sessmem): always deliver unseen QoS2 DUP publishes

### DIFF
--- a/apps/emqx/mix.exs
+++ b/apps/emqx/mix.exs
@@ -6,7 +6,7 @@ defmodule EMQX.MixProject do
   def project do
     [
       app: :emqx,
-      version: "6.2.3",
+      version: "6.2.4",
       build_path: "../../_build",
       erlc_paths: erlc_paths(),
       erlc_options: [

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -388,11 +388,6 @@ publish(
             case is_awaiting_full(Session) of
                 true ->
                     {error, ?RC_RECEIVE_MAXIMUM_EXCEEDED};
-                false when Dup ->
-                    %% The original awaiting_rel state may have been expired already.
-                    %% Keep awaiting PUBREL state and acknowledge without re-delivery.
-                    AwaitingRel1 = maps:put(PacketId, Ts, AwaitingRel),
-                    {ok, dup_publish_result(Msg), Session#session{awaiting_rel = AwaitingRel1}};
                 false ->
                     Results = emqx_broker:publish(Msg),
                     AwaitingRel1 = maps:put(PacketId, Ts, AwaitingRel),
@@ -410,6 +405,9 @@ is_awaiting_full(#session{
     max_awaiting_rel = MaxLimit
 }) ->
     maps:size(AwaitingRel) >= MaxLimit.
+
+dup_publish_result(#message{topic = Topic}) ->
+    [{node(), Topic, ok}].
 
 %%--------------------------------------------------------------------
 %% Client -> Broker: PUBACK
@@ -649,9 +647,6 @@ maybe_nack(Msg) ->
 
 mark_begin_deliver(Msg) ->
     emqx_message:set_header(deliver_begin_at, erlang:system_time(millisecond), Msg).
-
-dup_publish_result(#message{topic = Topic}) ->
-    [{node(), Topic, ok}].
 
 %%--------------------------------------------------------------------
 %% Timeouts

--- a/apps/emqx/test/emqx_channel_await_rel_expire_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_await_rel_expire_SUITE.erl
@@ -21,7 +21,7 @@ all() ->
 init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
-            {emqx, "mqtt { await_rel_timeout = 100ms, max_awaiting_rel = 5 }"}
+            {emqx, "mqtt { await_rel_timeout = 1s, max_awaiting_rel = 5 }"}
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
@@ -70,7 +70,7 @@ t_check_rel_cleanup(_Config) ->
     ),
 
     %% Wait for the queue to be cleaned up
-    ct:sleep(200),
+    ct:sleep(1500),
 
     %% Reconnect after the queue is cleaned up
     {ok, Client1} = emqx_mqtt_test_client:start_link(Host, Port),
@@ -88,7 +88,7 @@ t_check_rel_cleanup(_Config) ->
     %% Disconnect the client
     emqx_mqtt_test_client:stop(Client1).
 
-t_qos2_dup_publish_not_redelivered_after_await_rel_expired(_Config) ->
+t_qos2_dup_publish_not_redelivered(_Config) ->
     Topic = <<"topic/qos2/dup/rel-expire">>,
     Payload = <<"hello">>,
     PacketId = 100,
@@ -115,8 +115,7 @@ t_qos2_dup_publish_not_redelivered_after_await_rel_expired(_Config) ->
         ),
         ?assertMatch({deliver, Topic, #message{payload = Payload}}, receive_deliver(1000)),
 
-        %% let awaiting_rel expire, then resend PUBLISH with DUP=1
-        ct:sleep(200),
+        %% resend PUBLISH with DUP=1
         HeaderDup = (Publish#mqtt_packet.header)#mqtt_packet_header{dup = true},
         PublishDup = Publish#mqtt_packet{header = HeaderDup},
         ok = emqx_mqtt_test_client:send(Client, PublishDup),

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -84,7 +84,8 @@ groups() ->
             t_sub_non_utf8_topic,
             t_congestion_send_timeout,
             t_congestion_decongested,
-            t_first_packet_not_connect
+            t_first_packet_not_connect,
+            t_sock_closed_incomplete_qos2_transmission
         ]},
         {socket, [], [
             t_sock_keepalive,
@@ -1005,6 +1006,56 @@ t_first_packet_not_connect(_) ->
     after 5000 ->
         ct:fail("Expected socket to be closed")
     end.
+
+t_sock_closed_incomplete_qos2_transmission(_) ->
+    Topic = <<"t">>,
+    SubscriberId = <<"s">>,
+    PublisherId = <<"p">>,
+    PacketId = 1,
+    Payload = <<"payload">>,
+    PublishPkt = ?PUBLISH_PACKET(?QOS_2, Topic, PacketId, Payload),
+    Publish = emqx_frame:serialize(PublishPkt),
+    IncompletePublish = binary:part(iolist_to_binary(Publish), 0, iolist_size(Publish) - 1),
+    %% Connect the subscriber "s", subscribe to topic "t" with QoS2:
+    {ok, Subscriber} = emqtt:start_link([{clientid, SubscriberId}]),
+    {ok, _} = emqtt:connect(Subscriber),
+    {ok, _, [?QOS_2]} = emqtt:subscribe(Subscriber, Topic, ?QOS_2),
+    %% Connect the publisher "p":
+    ConnPkt = ?CONNECT_PACKET(#mqtt_packet_connect{clean_start = false, clientid = PublisherId}),
+    Connect = emqx_frame:serialize(ConnPkt),
+    {ok, Socket1} = gen_tcp:connect({127, 0, 0, 1}, 1883, [{active, false}, binary]),
+    ok = gen_tcp:send(Socket1, Connect),
+    %% Send incomplete QoS2 publish and close the connection abruptly:
+    ok = gen_tcp:send(Socket1, IncompletePublish),
+    ok = timer:sleep(1000),
+    ok = gen_tcp:close(Socket1),
+    ?retry(100, 20, begin
+        [ChanPid] = emqx_cm:lookup_channels(PublisherId),
+        false = emqx_cm:is_channel_connected(ChanPid)
+    end),
+    %% Prepare a duplicate publish:
+    #mqtt_packet{header = PublishHd} = PublishPkt,
+    DupPublishPkt = PublishPkt#mqtt_packet{header = PublishHd#mqtt_packet_header{dup = true}},
+    DupPublish = emqx_frame:serialize(DupPublishPkt),
+    %% Connect the publisher "p" and resend the complete publish with DUP flag:
+    {ok, Socket2} = gen_tcp:connect({127, 0, 0, 1}, 1883, [{active, false}, binary]),
+    ok = gen_tcp:send(Socket2, Connect),
+    ok = gen_tcp:send(Socket2, DupPublish),
+    %% Subscriber should receive the publish:
+    ?assertReceive(
+        {publish, #{
+            client_pid := Subscriber,
+            topic := Topic,
+            qos := ?QOS_2,
+            dup := false,
+            payload := Payload
+        }},
+        3000
+    ),
+    %% Cleanup:
+    ok = gen_tcp:close(Socket2),
+    ok = emqx_cm:discard_session(PublisherId),
+    ok = emqtt:stop(Subscriber).
 
 %%--------------------------------------------------------------------
 %% Helper functions

--- a/changes/ee/fix-18470.en.md
+++ b/changes/ee/fix-18470.en.md
@@ -1,1 +1,3 @@
 Fixed an issue where EMQX acknowledged but did not deliver a retransmitted QoS 2 PUBLISH packet when the original packet had not been received before the publisher disconnected.
+
+This fix partially reverts the QoS 2 duplicate-handling change introduced in [#16721](https://github.com/emqx/emqx/pull/16721). After the awaiting-PUBREL state expires, a retransmitted QoS 2 PUBLISH packet is again treated as a new QoS 2 exchange and may be delivered to subscribers more than once. Starting with EMQX 7.0.0, awaiting-PUBREL state expiration will be disabled by default, preventing such redelivery.

--- a/changes/ee/fix-18470.en.md
+++ b/changes/ee/fix-18470.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where EMQX acknowledged but did not deliver a retransmitted QoS 2 PUBLISH packet when the original packet had not been received before the publisher disconnected.


### PR DESCRIPTION
Release version: 6.2.4, 6.3.0

Introduced in: 6.2.0 https://github.com/emqx/emqx/pull/16721

Fixes: #18441

## Summary

This PR fixes a subtle MQTT specification violation: QoS2 publishes with DUP flag were silently discarded even they were never seen by the broker / client session.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible