### PR TITLE
feat(node_dump): collect etc/emqx.env with secrets obfuscated

### DIFF
--- a/bin/node_dump
+++ b/bin/node_dump
@@ -82,10 +82,12 @@ done
 } > "${CONF_DUMP}"
 
 
-# Collect the boot-time environment file, with secret values obfuscated:
+# Collect the boot-time settings from the environment file.
+# Only these known non-secret variables; the file can carry arbitrary
+# EMQX_* overrides, including secrets.
 if [ -f "$EMQX_ETC_DIR/emqx.env" ]; then
-    sed -E 's/^([^#=]*(COOKIE|PASSWORD|PASSWD|SECRET|TOKEN|KEY)[^=]*)=.*/\1=********/' \
-        "$EMQX_ETC_DIR/emqx.env" > "${ENV_FILE_DUMP}"
+    grep -E '^(EMQX_FEATURES|EMQX_SECURITY_PROFILE)=' \
+        "$EMQX_ETC_DIR/emqx.env" > "${ENV_FILE_DUMP}" || true
 fi
 
 # Collect license info:

--- a/bin/node_dump
+++ b/bin/node_dump
@@ -15,6 +15,7 @@ DUMP="$EMQX_LOG_DIR/node_dump_$(date +"%Y%m%d_%H%M%S").tar.gz"
 APP_ENV_DUMP="$EMQX_LOG_DIR/app_env.dump"
 CONF_DUMP="$EMQX_LOG_DIR/conf.hocon"
 LICENSE_INFO="$EMQX_LOG_DIR/license_info.txt"
+ENV_FILE_DUMP="$EMQX_LOG_DIR/emqx.env.dump"
 SYSINFO="$EMQX_LOG_DIR/sysinfo.txt"
 
 LOG_MAX_AGE_DAYS=3
@@ -81,6 +82,12 @@ done
 } > "${CONF_DUMP}"
 
 
+# Collect the boot-time environment file, with secret values obfuscated:
+if [ -f "$EMQX_ETC_DIR/emqx.env" ]; then
+    sed -E 's/^([^#=]*(COOKIE|PASSWORD|PASSWD|SECRET|TOKEN|KEY)[^=]*)=.*/\1=********/' \
+        "$EMQX_ETC_DIR/emqx.env" > "${ENV_FILE_DUMP}"
+fi
+
 # Collect license info:
 {
     collect "$RUNNER_BIN_DIR"/emqx ctl license info
@@ -93,6 +100,7 @@ done
     echo "${APP_ENV_DUMP}"
     echo "${CONF_DUMP}"
     echo "${LICENSE_INFO}"
+    if [ -f "${ENV_FILE_DUMP}" ]; then echo "${ENV_FILE_DUMP}"; fi
 } | tar czf "${DUMP}" -T -
 
 ## Cleanup:
@@ -102,5 +110,5 @@ rm "${SYSINFO}" "${LICENSE_INFO}"
 echo "Created a node dump ${DUMP}"
 echo
 echo "WARNING: this script tries to obfuscate secrets, but make sure to
-inspect log/app_env.dump and log/conf.hocon files manually before uploading the node dump
+inspect log/app_env.dump, log/conf.hocon and log/emqx.env.dump files manually before uploading the node dump
 to a public location."

--- a/changes/ee/feat-18471.en.md
+++ b/changes/ee/feat-18471.en.md
@@ -1,0 +1,1 @@
+The `node_dump` diagnostic script now includes the boot-time environment file `etc/emqx.env` in the collected archive when the file exists. Values of variables whose name contains `COOKIE`, `PASSWORD`, `PASSWD`, `SECRET`, `TOKEN`, or `KEY` are obfuscated.

--- a/changes/ee/feat-18471.en.md
+++ b/changes/ee/feat-18471.en.md
@@ -1,1 +1,1 @@
-The `node_dump` diagnostic script now includes the boot-time environment file `etc/emqx.env` in the collected archive when the file exists. Values of variables whose name contains `COOKIE`, `PASSWORD`, `PASSWD`, `SECRET`, `TOKEN`, or `KEY` are obfuscated.
+The `node_dump` diagnostic script now includes the `EMQX_FEATURES` and `EMQX_SECURITY_PROFILE` settings from the boot-time environment file `etc/emqx.env`, when the file exists. Other variables in the file are not collected.


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
N/A

## Summary

Companion to #18451, which ships `etc/emqx.env` and makes `bin/emqx` source it.

`node_dump` now collects the boot-time settings from `etc/emqx.env` when the file exists, so support gets the settings (`EMQX_FEATURES`, `EMQX_SECURITY_PROFILE`) that shape the node but do not appear in `emqx.conf`.

Only these two known non-secret variables are collected (allowlist). The file can carry arbitrary `EMQX_*` overrides, including secrets such as `EMQX_NODE__COOKIE` or a `..._SERVICE_ACCOUNT_JSON`, and no obfuscation pattern matches all of them reliably, so nothing else is copied. The collected lines (`log/emqx.env.dump`) are left next to `app_env.dump` and `conf.hocon` for inspection, and the final warning names the file.

Mergeable independently of #18451: the collection is guarded by a file-existence check, so on a node without `etc/emqx.env` the dump is unchanged.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
