### PR TITLE
fix(exhook): honor failed_action when no server is running

### DIFF
--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -57,6 +57,7 @@ Returns policy depending on the current security profile.
     (internal_subscription_checks) -> boolean();
     (authz_context) -> legacy | restricted;
     (delayed_publish_reauthorization) -> boolean();
+    (exhook_server_unavailable) -> honor_failed_action | deny;
     (exhook_message_publish_failure) -> ignore | deny;
     (plugin_install_sha256_binding) -> optional | required.
 policy(mqtt_default_bind) ->
@@ -123,6 +124,11 @@ policy(delayed_publish_reauthorization) ->
     case profile() of
         legacy -> false;
         hardened -> true
+    end;
+policy(exhook_server_unavailable) ->
+    case profile() of
+        legacy -> honor_failed_action;
+        hardened -> deny
     end;
 policy(exhook_message_publish_failure) ->
     case profile() of

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -92,6 +92,10 @@ assert_policies(legacy) ->
     ?assertEqual(false, emqx_security_profile:policy(internal_subscription_checks)),
     ?assertEqual(legacy, emqx_security_profile:policy(authz_context)),
     ?assertEqual(false, emqx_security_profile:policy(delayed_publish_reauthorization)),
+    ?assertEqual(
+        honor_failed_action,
+        emqx_security_profile:policy(exhook_server_unavailable)
+    ),
     ?assertEqual(ignore, emqx_security_profile:policy(exhook_message_publish_failure)),
     ?assertEqual(optional, emqx_security_profile:policy(plugin_install_sha256_binding));
 assert_policies(hardened) ->
@@ -103,6 +107,7 @@ assert_policies(hardened) ->
     ?assertEqual(true, emqx_security_profile:policy(internal_subscription_checks)),
     ?assertEqual(restricted, emqx_security_profile:policy(authz_context)),
     ?assertEqual(true, emqx_security_profile:policy(delayed_publish_reauthorization)),
+    ?assertEqual(deny, emqx_security_profile:policy(exhook_server_unavailable)),
     ?assertEqual(deny, emqx_security_profile:policy(exhook_message_publish_failure)),
     ?assertEqual(required, emqx_security_profile:policy(plugin_install_sha256_binding)).
 

--- a/apps/emqx_exhook/src/emqx_exhook.erl
+++ b/apps/emqx_exhook/src/emqx_exhook.erl
@@ -41,9 +41,39 @@ cast(Hookpoint, Req, [ServerName | More]) ->
 call_fold(Hookpoint, Req, AccFun) ->
     case emqx_exhook_mgr:running() of
         [] ->
-            {stop, deny_action_result(Hookpoint, Req)};
+            no_running_server_result(Hookpoint, Req);
         ServerNames ->
             call_fold(true, Hookpoint, Req, AccFun, ServerNames)
+    end.
+
+no_running_server_result(Hookpoint, Req) ->
+    case no_running_server_action() of
+        ignore ->
+            ignore;
+        deny ->
+            {stop, deny_action_result(Hookpoint, Req)}
+    end.
+
+no_running_server_action() ->
+    case emqx_security_profile:policy(exhook_server_unavailable) of
+        deny ->
+            deny;
+        honor_failed_action ->
+            configured_failed_action()
+    end.
+
+configured_failed_action() ->
+    Servers = emqx:get_config([exhook, servers], []),
+    case
+        lists:any(
+            fun(#{enable := Enable, failed_action := FailedAction}) ->
+                Enable andalso FailedAction =:= deny
+            end,
+            Servers
+        )
+    of
+        true -> deny;
+        false -> ignore
     end.
 
 call_fold(true, _, _Req, _, []) ->

--- a/apps/emqx_exhook/src/emqx_exhook_mgr.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_mgr.erl
@@ -648,8 +648,9 @@ handle_health_check_res(Server, skip) ->
 -spec save(server_name(), emqx_exhook_server:service()) -> ok.
 save(Name, ServerState) ->
     Saved = persistent_term:get(?APP, []),
+    persistent_term:put({?APP, Name}, ServerState),
     persistent_term:put(?APP, delete_server_name(Name, Saved) ++ [Name]),
-    persistent_term:put({?APP, Name}, ServerState).
+    ok.
 
 unsave(Name) ->
     case persistent_term:get(?APP, []) of

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -108,7 +108,12 @@ common_stop(TC, Config) ->
     ok = emqx_cth_suite:stop(?config(tc_apps, Config)).
 
 profile_cases() ->
-    [t_access_failed_if_no_server_running, t_handler_tcp, t_handler_ws].
+    [
+        t_access_failed_if_no_server_running,
+        t_no_running_server_honors_failed_action,
+        t_handler_tcp,
+        t_handler_ws
+    ].
 
 %%--------------------------------------------------------------------
 %% Test cases
@@ -174,6 +179,97 @@ t_access_failed_if_no_server_running(Config) ->
     ),
     emqx_exhook_mgr:enable(<<"default">>),
     assert_get_basic_usage_info(Config).
+
+t_no_running_server_honors_failed_action(_) ->
+    ClientInfo = #{
+        clientid => <<"user-id-1">>,
+        username => <<"usera">>,
+        peername => {{127, 0, 0, 1}, 3456},
+        peerhost => {127, 0, 0, 1},
+        sockport => 1883,
+        protocol => mqtt,
+        mountpoint => undefined
+    },
+    ok = disable_server(<<"default">>),
+    ok = disable_server(<<"not_reconnect">>),
+    ok = disable_server(<<"error">>),
+    ?assertEqual([], emqx_exhook_mgr:running()),
+    ?assertEqual(
+        ignore,
+        emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+            emqx_exhook_handler:on_client_authenticate(ClientInfo, #{auth_result => success})
+        end)
+    ),
+    ?assertEqual(
+        {stop, {error, not_authorized}},
+        emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+            emqx_exhook_handler:on_client_authenticate(ClientInfo, #{auth_result => success})
+        end)
+    ),
+    ok = update_failed_action(<<"error">>, <<"ignore">>),
+    ?assertEqual([], emqx_exhook_mgr:running()),
+    ?assertEqual(
+        ignore,
+        emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+            emqx_exhook_handler:on_client_authenticate(ClientInfo, #{auth_result => success})
+        end)
+    ),
+    ?assertEqual(
+        {stop, {error, not_authorized}},
+        emqx_common_test_helpers:with_security_profile("hardened", fun() ->
+            emqx_exhook_handler:on_client_authenticate(ClientInfo, #{auth_result => success})
+        end)
+    ),
+    ?assertEqual(
+        ignore,
+        emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+            emqx_exhook_handler:on_client_authorize(
+                ClientInfo,
+                ?AUTHZ_PUBLISH,
+                <<"t/1">>,
+                #{result => allow, from => exhook}
+            )
+        end)
+    ),
+    Message = emqx_message:make(<<"t/1">>, <<"abc">>),
+    ?assertEqual(
+        ignore,
+        emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+            emqx_exhook_handler:on_message_ingress(
+                #{authz_ctx => emqx_authz_context:make(ClientInfo)},
+                Message
+            )
+        end)
+    ),
+    ?assertEqual(
+        ignore,
+        emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+            emqx_exhook_handler:on_message_publish(Message)
+        end)
+    ),
+    ok = update_failed_action(<<"not_reconnect">>, <<"deny">>),
+    ?assertEqual([], emqx_exhook_mgr:running()),
+    ?assertEqual(
+        {stop, {error, not_authorized}},
+        emqx_common_test_helpers:with_security_profile("legacy", fun() ->
+            emqx_exhook_handler:on_client_authenticate(ClientInfo, #{auth_result => success})
+        end)
+    ).
+
+disable_server(Name) ->
+    {ok, _} = emqx_exhook_mgr:disable(Name),
+    ok.
+
+update_failed_action(Name, FailedAction) ->
+    {ok, _} = emqx_exhook_mgr:update_config(
+        [exhook, servers],
+        {update, Name, #{
+            <<"name">> => Name,
+            <<"url">> => <<"http://127.0.0.1:9001">>,
+            <<"failed_action">> => FailedAction
+        }}
+    ),
+    ok.
 
 t_message_ingress(_) ->
     _ = emqx_exhook_demo_svr:flush(),

--- a/changes/ee/fix-18473.en.md
+++ b/changes/ee/fix-18473.en.md
@@ -1,0 +1,1 @@
+Fixed ExHook authentication and authorization behavior when no callback server is running. The legacy security profile now honors the configured `failed_action`, while the hardened security profile remains fail-closed.


### PR DESCRIPTION
Release version: 6.3.0
Introduced in: pre-5.8
Fix: https://github.com/emqx/emqx-dev-team-tasks/issues/411

## Summary

Honor the configured ExHook `failed_action` when no server is currently running under the legacy security profile, while keeping the hardened security profile fail-closed. The change also publishes ExHook services before marking them running to avoid exposing an incomplete service state.

The regression coverage covers empty, ignore-only, deny-only, and mixed enabled-server configurations across authentication, authorization, message ingress, and message publish paths. Provisional authentication hooks are intentionally not registered because the provider hookspec is unavailable before the handshake.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
