### PR TITLE
fix(mqtt): clamp session expiry interval supplied in DISCONNECT

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1199,9 +1199,20 @@ post_process_disconnect(ReasonCode, Properties, Channel) ->
 
 maybe_update_expiry_interval(
     #{'Session-Expiry-Interval' := Interval},
-    Channel = #channel{conninfo = ConnInfo}
+    Channel = #channel{conninfo = ConnInfo, clientinfo = #{zone := Zone}}
 ) ->
-    EI = timer:seconds(Interval),
+    MaxMs = get_mqtt_conf(Zone, max_session_expiry_interval),
+    ClampedSec = clamp_session_expiry(Interval, MaxMs),
+    case ClampedSec < Interval of
+        true ->
+            ?TRACE("MQTT", "session_expiry_interval_clamped", #{
+                requested_seconds => Interval,
+                clamped_seconds => ClampedSec
+            });
+        false ->
+            ok
+    end,
+    EI = timer:seconds(ClampedSec),
     OldEI = maps:get(expiry_interval, ConnInfo, 0),
     case OldEI =:= EI of
         true ->

--- a/apps/emqx/test/emqx_session_expiry_clamp_SUITE.erl
+++ b/apps/emqx/test/emqx_session_expiry_clamp_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("snabbkaffe/include/test_macros.hrl").
 
 -define(HOST, "127.0.0.1").
 -define(PORT, 1883).
@@ -76,6 +77,9 @@ connack_props(?CONNACK_PACKET(?RC_SUCCESS, _SP, Props)) ->
 
 set_max(Value) ->
     ok = emqx_config:put_zone_conf(default, [mqtt, max_session_expiry_interval], Value).
+
+send_disconnect(Client, Props) ->
+    ok = emqx_mqtt_test_client:send(Client, ?DISCONNECT_PACKET(?RC_SUCCESS, Props)).
 
 %%--------------------------------------------------------------------
 %% Test cases
@@ -185,3 +189,77 @@ t_max_zero_clamps_all_v5(_Config) ->
     ?assertEqual(0, maps:get('Session-Expiry-Interval', Props)),
     ?assertEqual(0, stored_expiry_ms(ClientId)),
     ok = emqx_mqtt_test_client:stop(Client).
+
+-doc """
+A Session-Expiry-Interval above the cap in a DISCONNECT packet is clamped
+to the cap, same as at CONNECT.
+""".
+t_disconnect_above_cap_is_clamped(_Config) ->
+    MaxMs = timer:seconds(30),
+    set_max(MaxMs),
+    ClientId = <<"v5-disc-above-cap">>,
+    {Client, _Connack} = connect_v5(
+        ClientId, true, #{'Session-Expiry-Interval' => 10}
+    ),
+    send_disconnect(Client, #{'Session-Expiry-Interval' => 3600}),
+    ?retry(100, 50, ?assertEqual(MaxMs, stored_expiry_ms(ClientId))).
+
+-doc """
+A Session-Expiry-Interval below the cap in a DISCONNECT packet is honored
+unchanged.
+""".
+t_disconnect_below_cap_unchanged(_Config) ->
+    set_max(timer:hours(1)),
+    ClientId = <<"v5-disc-below-cap">>,
+    {Client, _Connack} = connect_v5(
+        ClientId, true, #{'Session-Expiry-Interval' => 10}
+    ),
+    send_disconnect(Client, #{'Session-Expiry-Interval' => 60}),
+    ?retry(100, 50, ?assertEqual(timer:seconds(60), stored_expiry_ms(ClientId))).
+
+-doc """
+With the default `infinity` cap, the Session-Expiry-Interval in a DISCONNECT
+packet is honored verbatim.
+""".
+t_disconnect_infinity_unchanged(_Config) ->
+    %% init_per_testcase already set infinity.
+    ClientId = <<"v5-disc-infinity">>,
+    {Client, _Connack} = connect_v5(
+        ClientId, true, #{'Session-Expiry-Interval' => 10}
+    ),
+    send_disconnect(Client, #{'Session-Expiry-Interval' => 86400}),
+    ?retry(100, 50, ?assertEqual(timer:seconds(86400), stored_expiry_ms(ClientId))).
+
+-doc """
+DISCONNECT with Session-Expiry-Interval = 0 still ends the session when a cap
+is configured; clamping must not turn 0 into a non-zero value.
+""".
+t_disconnect_zero_destroys_session(_Config) ->
+    set_max(timer:seconds(30)),
+    ClientId = <<"v5-disc-zero">>,
+    {Client, _Connack} = connect_v5(
+        ClientId, false, #{'Session-Expiry-Interval' => 10}
+    ),
+    send_disconnect(Client, #{'Session-Expiry-Interval' => 0}),
+    ?retry(100, 50, ?assertEqual(undefined, emqx_cm:get_chan_info(ClientId))),
+    %% The session is gone: a clean_start=false reconnect finds no session.
+    {Client2, Connack2} = connect_v5(ClientId, false, #{}),
+    ?assertMatch(?CONNACK_PACKET(?RC_SUCCESS, 0, _), Connack2),
+    ok = emqx_mqtt_test_client:stop(Client2).
+
+-doc """
+CONNECT with Session-Expiry-Interval = 0 followed by DISCONNECT with a
+non-zero value is still a protocol error [MQTT-5.0 3.14.2.2.2]; clamping
+does not shadow that check.
+""".
+t_disconnect_nonzero_after_zero_protocol_error(_Config) ->
+    set_max(timer:seconds(1)),
+    ClientId = <<"v5-disc-proto-err">>,
+    {Client, _Connack} = connect_v5(
+        ClientId, true, #{'Session-Expiry-Interval' => 0}
+    ),
+    send_disconnect(Client, #{'Session-Expiry-Interval' => 5}),
+    ?assertMatch(
+        {ok, ?DISCONNECT_PACKET(?RC_PROTOCOL_ERROR)},
+        emqx_mqtt_test_client:receive_packet()
+    ).

--- a/changes/ee/fix-18477.en.md
+++ b/changes/ee/fix-18477.en.md
@@ -1,0 +1,1 @@
+Apply `mqtt.max_session_expiry_interval` to the Session Expiry Interval a client supplies in a DISCONNECT packet. Previously the cap applied only to the value supplied at CONNECT, so a client could extend its session expiry beyond the configured limit when disconnecting.


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
N/A (the `mqtt.max_session_expiry_interval` setting is not released yet)

## Summary

`mqtt.max_session_expiry_interval` clamped only the `Session-Expiry-Interval` property of CONNECT. A client could request a value within the cap at connect and then supply a larger value in the DISCONNECT packet; `maybe_update_expiry_interval/2` in `emqx_channel` stored that value unclamped.

The DISCONNECT path now reuses the same `clamp_session_expiry/2` used at CONNECT. The zone is taken from the channel's `clientinfo`, so a `zone_override` applied during authentication is respected. When the value is reduced, the channel emits a `session_expiry_interval_clamped` client trace; DISCONNECT has no response packet, so there is no way to reflect the clamped value back to the client as CONNACK does.

Clamping cannot turn a requested `0` into a non-zero value, so a client can still end its session at disconnect, and the protocol-error check for turning persistence on at disconnect (MQTT 5.0 section 3.14.2.2.2) runs before the clamp and is unchanged.

New cases in `emqx_session_expiry_clamp_SUITE` cover: a DISCONNECT value above the cap is clamped, a value below the cap and the `infinity` default pass through unchanged, `Session-Expiry-Interval = 0` still ends the session when a cap is set, and the protocol-error case is not shadowed.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
