### PR TITLE
fix: deprecate rpc.insecure_fallback and always use secure RPC auth

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -1134,9 +1134,8 @@ fields("rpc") ->
             sc(
                 boolean(),
                 #{
-                    mapping => "gen_rpc.insecure_auth_fallback_allowed",
-                    default => true,
-                    desc => ?DESC(rpc_insecure_fallback)
+                    deprecated => {since, "6.3.0"},
+                    importance => ?IMPORTANCE_HIDDEN
                 }
             )},
         {"ciphers", emqx_schema:ciphers_schema(tls_all_available)},

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -216,12 +216,6 @@ cluster_etcd_ssl.desc:
 cluster_etcd_ssl.label:
 """Cluster Etcd SSL Option"""
 
-rpc_insecure_fallback.desc:
-"""Enable compatibility with old RPC authentication."""
-
-rpc_insecure_fallback.label:
-"""RPC insecure fallback"""
-
 rpc_listen_address.desc:
 """Indicates the IP address for the RPC server to listen on. For example, use <code>"0.0.0.0"</code> for IPv4 or <code>"::"</code> for IPv6."""
 


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in: N/A

## Summary

Deprecate `rpc.insecure_fallback` and always use the secure gen_rpc authentication handshake.

When two nodes establish a gen_rpc connection they run a secure challenge-response handshake. If a peer rejects it, the insecure fallback sends the Erlang cluster cookie in cleartext to complete authentication. An on-path observer can capture that cookie and gain full cluster access.

All EMQX nodes support the secure handshake since 5.0.10 (gen_rpc 3.0.0), so the fallback is no longer needed on any supported cluster. gen_rpc's own default for `insecure_auth_fallback_allowed` is already `false`; only EMQX's schema mapping was forcing it to `true`.

Changes:
- `apps/emqx_conf/src/emqx_conf_schema.erl`: mark the `rpc.insecure_fallback` field `deprecated` and hidden, and drop its `mapping` and `default`. With no mapping, gen_rpc uses its own `false` default, so EMQX always uses the secure handshake.

The config key is kept (hidden) rather than removed, so existing configuration files that still set `rpc.insecure_fallback` continue to parse; the value is ignored.

Resolves emqx/emqx-dev-team-tasks#362.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
