### PR TITLE
fix(dashboard): add security response headers

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_middleware.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_middleware.erl
@@ -8,8 +8,17 @@
 
 -export([execute/2]).
 
+-define(SECURITY_HEADERS, #{
+    <<"x-content-type-options">> => <<"nosniff">>,
+    <<"x-frame-options">> => <<"SAMEORIGIN">>,
+    <<"referrer-policy">> => <<"no-referrer">>,
+    <<"x-permitted-cross-domain-policies">> => <<"none">>,
+    <<"x-download-options">> => <<"noopen">>
+}).
+
 execute(Req, Env) ->
-    add_cors_flag(Req, Env).
+    Req2 = cowboy_req:set_resp_headers(?SECURITY_HEADERS, Req),
+    add_cors_flag(Req2, Env).
 
 add_cors_flag(Req, Env) ->
     CORS = emqx_conf:get([dashboard, cors], false),

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -94,6 +94,19 @@ t_overview(_) ->
      || Overview <- ?OVERVIEWS
     ].
 
+t_security_response_headers(_Config) ->
+    {ok, {{_, 200, _}, DashboardHeaders, _}} =
+        httpc:request(get, {?HOST ++ "/", []}, [], [{body_format, binary}]),
+    assert_security_response_headers(DashboardHeaders),
+
+    {ok, {{_, 200, _}, ApiHeaders, _}} =
+        httpc:request(get, {?HOST ++ "/api/v5/status", []}, [], [{body_format, binary}]),
+    assert_security_response_headers(ApiHeaders),
+
+    {ok, {{_, 404, _}, NotFoundHeaders, _}} =
+        httpc:request(get, {?HOST ++ "/api/v5/does-not-exist", []}, [], [{body_format, binary}]),
+    assert_security_response_headers(NotFoundHeaders).
+
 t_dashboard_restart(Config) ->
     emqx_config:put([dashboard], #{
         i18n_lang => en,
@@ -823,6 +836,16 @@ http_put(Parts, Body) ->
 request_dashboard(Method, Url, Auth) ->
     Request = {Url, [Auth]},
     do_request_dashboard(Method, Request).
+
+assert_security_response_headers(Headers) ->
+    ?assertEqual("nosniff", proplists:get_value("x-content-type-options", Headers)),
+    ?assertEqual("SAMEORIGIN", proplists:get_value("x-frame-options", Headers)),
+    ?assertEqual("no-referrer", proplists:get_value("referrer-policy", Headers)),
+    ?assertEqual(
+        "none", proplists:get_value("x-permitted-cross-domain-policies", Headers)
+    ),
+    ?assertEqual("noopen", proplists:get_value("x-download-options", Headers)).
+
 request_dashboard(Method, Url, QueryParams, Auth) ->
     Request = {Url ++ "?" ++ QueryParams, [Auth]},
     do_request_dashboard(Method, Request).

--- a/changes/ee/fix-18481.en.md
+++ b/changes/ee/fix-18481.en.md
@@ -1,0 +1,1 @@
+Added standard HTTP security response headers to the Dashboard and REST API responses, including protection against MIME sniffing and clickjacking.


### PR DESCRIPTION
Release version: 7.0.0

Introduced in: pre-5.8

Fix: https://github.com/emqx/emqx-dev-team-tasks/issues/342

## Summary

Add standard HTTP security response headers to Dashboard and REST API responses through the existing Cowboy middleware. The middleware now sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: no-referrer`, `X-Permitted-Cross-Domain-Policies: none`, and `X-Download-Options: noopen`. `SAMEORIGIN` preserves the existing same-origin plugin UI iframe flow.

Add Common Test coverage for Dashboard, REST API, and 404 responses. CSP is intentionally excluded from this change because it requires separate SPA and plugin iframe compatibility testing.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)