### PR TITLE
fix(mqtt): lower log level for acks with unknown packet id

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -925,7 +925,7 @@ process_pubrec(
             ok = inc_metrics('packets.pubrec.inuse', Channel),
             handle_out(pubrel, {PacketId, RC}, Channel);
         {error, RC = ?RC_PACKET_IDENTIFIER_NOT_FOUND} ->
-            ?SLOG(warning, #{msg => "pubrec_packetId_not_found", packetId => PacketId}),
+            ?SLOG(info, #{msg => "pubrec_packetId_not_found", packetId => PacketId}),
             ok = inc_metrics('packets.pubrec.missed', Channel),
             handle_out(pubrel, {PacketId, RC}, Channel)
     end.
@@ -946,7 +946,7 @@ process_pubrel(
             NChannel = Channel#channel{session = NSession},
             handle_out(pubcomp, {PacketId, ?RC_SUCCESS}, NChannel);
         {error, RC = ?RC_PACKET_IDENTIFIER_NOT_FOUND} ->
-            ?SLOG(warning, #{msg => "pubrel_packetId_not_found", packetId => PacketId}),
+            ?SLOG(info, #{msg => "pubrel_packetId_not_found", packetId => PacketId}),
             ok = inc_metrics('packets.pubrel.missed', Channel),
             handle_out(pubcomp, {PacketId, RC}, Channel)
     end.
@@ -974,7 +974,7 @@ process_pubcomp(
             ok = inc_metrics('packets.pubcomp.inuse', Channel),
             {ok, Channel};
         {error, ?RC_PACKET_IDENTIFIER_NOT_FOUND} ->
-            ?SLOG(warning, #{msg => "pubcomp_packetId_not_found", packetId => PacketId}),
+            ?SLOG(info, #{msg => "pubcomp_packetId_not_found", packetId => PacketId}),
             ok = inc_metrics('packets.pubcomp.missed', Channel),
             {ok, Channel}
     end.

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -494,6 +494,33 @@ t_handle_in_pubrel_not_found_error(_) ->
     {ok, {outgoing, ?PUBCOMP_PACKET(1, ?RC_PACKET_IDENTIFIER_NOT_FOUND)}, _Channel} =
         emqx_channel:handle_in(?PUBREL_PACKET(1, ?RC_SUCCESS), channel()).
 
+t_handle_in_pubrel_not_found_bounded_log(_) ->
+    %% A flood of PUBREL packets with an unknown Packet Identifier must not
+    %% produce warning-level log output: the event is recorded by the
+    %% packets.pubrel.missed counter and logged at info instead.
+    ok = meck:expect(
+        emqx_session,
+        pubrel,
+        fun(_, _PacketId, _Session) ->
+            {error, ?RC_PACKET_IDENTIFIER_NOT_FOUND}
+        end
+    ),
+    N = 100,
+    Flood = fun() ->
+        lists:foreach(
+            fun(_) ->
+                {ok, {outgoing, ?PUBCOMP_PACKET(1, ?RC_PACKET_IDENTIFIER_NOT_FOUND)}, _} =
+                    emqx_channel:handle_in(?PUBREL_PACKET(1, ?RC_SUCCESS), channel())
+            end,
+            lists:seq(1, N)
+        )
+    end,
+    IsPubrelMissed = fun(#{msg := Msg}) -> Msg =:= "pubrel_packetId_not_found" end,
+    WarningReports = emqx_cth_log_capture:capture(warning, Flood),
+    ?assertEqual([], lists:filter(IsPubrelMissed, WarningReports)),
+    InfoReports = emqx_cth_log_capture:capture(info, Flood),
+    ?assertEqual(N, length(lists:filter(IsPubrelMissed, InfoReports))).
+
 t_handle_in_pubcomp_ok(_) ->
     ok = meck:expect(emqx_session, pubcomp, fun(_, _, _ReasonCode, Session) -> {ok, [], Session} end),
     {ok, _Channel} = emqx_channel:handle_in(?PUBCOMP_PACKET(1, ?RC_SUCCESS), channel()).

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -497,14 +497,8 @@ t_handle_in_pubrel_not_found_error(_) ->
 t_handle_in_pubrel_not_found_bounded_log(_) ->
     %% A flood of PUBREL packets with an unknown Packet Identifier must not
     %% produce warning-level log output: the event is recorded by the
-    %% packets.pubrel.missed counter and logged at info instead.
-    ok = meck:expect(
-        emqx_session,
-        pubrel,
-        fun(_, _PacketId, _Session) ->
-            {error, ?RC_PACKET_IDENTIFIER_NOT_FOUND}
-        end
-    ),
+    %% packets.pubrel.missed counter and logged at info instead. A fresh
+    %% channel has an empty session, so every PUBREL is not_found.
     N = 100,
     Flood = fun() ->
         lists:foreach(

--- a/changes/ee/fix-18482.en.md
+++ b/changes/ee/fix-18482.en.md
@@ -1,0 +1,7 @@
+Reduced log volume for PUBREL, PUBREC, and PUBCOMP packets that carry an unknown Packet Identifier.
+
+A client that repeatedly sends acknowledgement packets with a Packet Identifier the broker has no
+state for could fill the log with warnings, one per packet. These events are now logged at the
+`info` level instead of `warning`, so they are quiet at the default log level. The
+`packets.pubrel.missed`, `packets.pubrec.missed`, and `packets.pubcomp.missed` counters still
+record every occurrence, and the broker still replies to each packet as before.


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

Addresses [#18478](https://github.com/emqx/emqx/issues/18478). A client that repeatedly sends
PUBREL, PUBREC, or PUBCOMP packets carrying a Packet Identifier the broker has no state for could
fill the log with warnings, one line per packet. For MQTT 3.1.1 each such acknowledgement is 4
bytes and the broker's reply is also 4 bytes, so there is no response amplification, but a 4-byte
packet produced a 130–180 byte warning line on disk, and the default log level is `warning`.

These three events (`emqx_channel.erl`, in `process_pubrec/2`, `process_pubrel/2`, and
`process_pubcomp/2`) are already recorded by the `packets.pubrec.missed`, `packets.pubrel.missed`,
and `packets.pubcomp.missed` counters. Following the project convention that a counted event is
logged at `info` rather than `warning`, the three log calls are moved to `info`. The flood then
writes nothing at the default level, while the counters keep the aggregate observable and the
per-packet detail remains available at `info`.

Protocol behavior is unchanged. MQTT 3.1.1 requires the broker to answer a PUBREL with a PUBCOMP
carrying the same Packet Identifier ([MQTT-3.6.4-1], [MQTT-4.3.3-2]); an unknown Packet Identifier
is not a protocol violation, so the reply is still sent. No rate-limiting or disconnect is added,
because neither is warranted by the input and disconnecting on a valid packet would violate the
MUST-respond requirement.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)