### PR TITLE
feat(mqtt): disable await_rel_timeout by default

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2257,7 +2257,7 @@ enrich_conninfo(
         username => Username,
         conn_props => ConnProps,
         expiry_interval => ExpiryInterval,
-        receive_maximum => receive_maximum(Zone, ConnProps)
+        receive_maximum => client_receive_maximum(Zone, ConnProps)
     },
     {ok, Channel#channel{conninfo = NConnInfo}}.
 
@@ -2279,7 +2279,7 @@ clamp_session_expiry(RequestedSec, infinity) ->
 clamp_session_expiry(RequestedSec, MaxMs) when is_integer(MaxMs) ->
     min(RequestedSec, MaxMs div 1000).
 
-receive_maximum(Zone, ConnProps) ->
+client_receive_maximum(Zone, ConnProps) ->
     MaxInflightConfig =
         case get_mqtt_conf(Zone, max_inflight) of
             0 -> ?RECEIVE_MAXIMUM_LIMIT;
@@ -3251,9 +3251,7 @@ enrich_connack_caps(AckProps, ?IS_MQTT_V5 = Channel) ->
         clientinfo = #{
             zone := Zone
         },
-        conninfo = #{
-            receive_maximum := ReceiveMaximum
-        }
+        session = Session
     } = Channel,
     #{
         max_packet_size := MaxPktSize,
@@ -3263,6 +3261,7 @@ enrich_connack_caps(AckProps, ?IS_MQTT_V5 = Channel) ->
         shared_subscription := Shared,
         wildcard_subscription := Wildcard
     } = emqx_mqtt_caps:get_caps(Zone),
+    ReceiveMaximum = server_receive_maximum(emqx_session:info(awaiting_rel_max, Session)),
     NAckProps = AckProps#{
         'Retain-Available' => flag(Retain),
         'Maximum-Packet-Size' => MaxPktSize,
@@ -3282,6 +3281,11 @@ enrich_connack_caps(AckProps, ?IS_MQTT_V5 = Channel) ->
     end;
 enrich_connack_caps(AckProps, _Channel) ->
     AckProps.
+
+server_receive_maximum(infinity) ->
+    ?RECEIVE_MAXIMUM_LIMIT;
+server_receive_maximum(MaxAwaitingRel) ->
+    min(MaxAwaitingRel, ?RECEIVE_MAXIMUM_LIMIT).
 
 %%--------------------------------------------------------------------
 %% Enrich server keepalive

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -4463,7 +4463,7 @@ mqtt_session() ->
             sc(
                 hoconsc:union([non_neg_integer(), infinity]),
                 #{
-                    default => 100,
+                    default => 32,
                     desc => ?DESC(mqtt_max_awaiting_rel),
                     importance => ?IMPORTANCE_LOW
                 }

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -4553,7 +4553,7 @@ mqtt_session() ->
             sc(
                 duration(),
                 #{
-                    default => <<"300s">>,
+                    default => 0,
                     desc => ?DESC(mqtt_await_rel_timeout),
                     importance => ?IMPORTANCE_LOW
                 }

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -308,11 +308,17 @@ try_open([], _ClientInfo, _ConnInfo, _MaybeWillMsg, _Conf) ->
 get_session_conf(_ClientInfo = #{zone := Zone}) ->
     #{
         max_subscriptions => get_mqtt_conf(Zone, max_subscriptions),
-        max_awaiting_rel => get_mqtt_conf(Zone, max_awaiting_rel),
+        max_awaiting_rel => max_awaiting_rel(Zone),
         upgrade_qos => get_mqtt_conf(Zone, upgrade_qos),
         retry_interval => get_mqtt_conf(Zone, retry_interval),
         await_rel_timeout => get_mqtt_conf(Zone, await_rel_timeout)
     }.
+
+max_awaiting_rel(Zone) ->
+    case get_mqtt_conf(Zone, max_awaiting_rel) of
+        infinity -> infinity;
+        Limit -> max(1, Limit)
+    end.
 
 get_mqtt_conf(Zone, Key) ->
     emqx_config:get_zone_conf(Zone, [mqtt, Key]).

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -968,6 +968,8 @@ do_retry_delivery(_ClientInfo, PacketId, Data, Now, Acc, Inflight) ->
 
 -spec expire(clientinfo(), session()) ->
     {ok, replies(), session()} | {ok, replies(), timeout(), session()}.
+expire(_ClientInfo, Session = #session{await_rel_timeout = 0}) ->
+    {ok, [], Session};
 expire(ClientInfo, Session = #session{awaiting_rel = AwaitingRel}) ->
     case maps:size(AwaitingRel) of
         0 ->

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -1455,7 +1455,8 @@ t_enrich_connack_caps(_) ->
             'Topic-Alias-Maximum' := 10,
             'Wildcard-Subscription-Available' := 1,
             'Subscription-Identifier-Available' := 1,
-            'Shared-Subscription-Available' := 1
+            'Shared-Subscription-Available' := 1,
+            'Receive-Maximum' := 100
         },
         AckProps
     ),

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -1456,7 +1456,7 @@ t_enrich_connack_caps(_) ->
             'Wildcard-Subscription-Available' := 1,
             'Subscription-Identifier-Available' := 1,
             'Shared-Subscription-Available' := 1,
-            'Receive-Maximum' := 100
+            'Receive-Maximum' := 32
         },
         AckProps
     ),

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -75,7 +75,9 @@ groups() ->
         ]},
         {mqttv5, [], [
             t_basic_with_props_v5,
-            t_v5_receive_maximim_in_connack,
+            t_v5_receive_maximum_in_connack,
+            t_v5_receive_maximum_clamped_min,
+            t_v5_receive_maximum_clamped_max,
             t_sock_closed_reason_normal,
             t_sock_closed_force_closed_by_client
         ]},
@@ -422,13 +424,28 @@ v5_conn_props(ReceiveMaximum, Config) ->
 t_basic_with_props_v5(Config) ->
     t_basic(v5_conn_props(4, Config)).
 
-t_v5_receive_maximim_in_connack(Config) ->
-    ReceiveMaximum = 7,
-    {ok, C} = emqtt:start_link(v5_conn_props(ReceiveMaximum, Config)),
+t_v5_receive_maximum_in_connack(init, Config) ->
+    save_conf([mqtt, max_awaiting_rel], Config).
+t_v5_receive_maximum_in_connack(Config) ->
+    assert_receive_maximum(17, 17, Config).
+
+t_v5_receive_maximum_clamped_min(init, Config) ->
+    save_conf([mqtt, max_awaiting_rel], Config).
+t_v5_receive_maximum_clamped_min(Config) ->
+    assert_receive_maximum(0, 1, Config).
+
+t_v5_receive_maximum_clamped_max(init, Config) ->
+    save_conf([mqtt, max_awaiting_rel], Config).
+t_v5_receive_maximum_clamped_max(Config) ->
+    assert_receive_maximum(infinity, ?RECEIVE_MAXIMUM_LIMIT, Config).
+
+assert_receive_maximum(MaxAwaitingRel, ServerReceiveMaximum, Config) ->
+    ok = emqx_config:put([mqtt, max_awaiting_rel], MaxAwaitingRel),
+    ClientReceiveMaximum = 7,
+    {ok, C} = emqtt:start_link(v5_conn_props(ClientReceiveMaximum, Config)),
     {ok, Props} = emqtt:connect(C),
-    ?assertMatch(#{'Receive-Maximum' := ReceiveMaximum}, Props),
-    ok = emqtt:disconnect(C),
-    ok.
+    ?assertMatch(#{'Receive-Maximum' := ServerReceiveMaximum}, Props),
+    ok = emqtt:disconnect(C).
 
 %%--------------------------------------------------------------------
 %% General test cases.

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -566,7 +566,7 @@ zone_global_defaults() ->
             },
         mqtt =>
             #{
-                await_rel_timeout => 300000,
+                await_rel_timeout => 0,
                 exclusive_subscription => false,
                 idle_timeout => 15000,
                 ignore_loop_deliver => false,

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -573,7 +573,7 @@ zone_global_defaults() ->
                 keepalive_backoff => 0.75,
                 keepalive_multiplier => 1.5,
                 keepalive_check_interval => 30000,
-                max_awaiting_rel => 100,
+                max_awaiting_rel => 32,
                 max_clientid_len => 65535,
                 max_inflight => 32,
                 max_mqueue_len => 1000,

--- a/apps/emqx/test/emqx_session_mem_SUITE.erl
+++ b/apps/emqx/test/emqx_session_mem_SUITE.erl
@@ -87,7 +87,7 @@ t_session_init(_) ->
     ?assertEqual(0, emqx_mqueue:len(emqx_session_mem:info(mqueue, Session))),
     ?assertEqual(0, emqx_session_mem:info(awaiting_rel_cnt, Session)),
     ?assertEqual(100, emqx_session_mem:info(awaiting_rel_max, Session)),
-    ?assertEqual(300000, emqx_session_mem:info(await_rel_timeout, Session)),
+    ?assertEqual(0, emqx_session_mem:info(await_rel_timeout, Session)),
     ?assert(is_integer(emqx_session_mem:info(created_at, Session))).
 
 %%--------------------------------------------------------------------
@@ -101,7 +101,7 @@ t_session_info(_) ->
             subscriptions := #{},
             upgrade_qos := false,
             retry_interval := infinity,
-            await_rel_timeout := 300000
+            await_rel_timeout := 0
         },
         maps:from_list(emqx_session_mem:info(Keys, session()))
     ).

--- a/apps/emqx/test/emqx_session_mem_SUITE.erl
+++ b/apps/emqx/test/emqx_session_mem_SUITE.erl
@@ -86,7 +86,7 @@ t_session_init(_) ->
     ?assertEqual(infinity, emqx_session_mem:info(retry_interval, Session)),
     ?assertEqual(0, emqx_mqueue:len(emqx_session_mem:info(mqueue, Session))),
     ?assertEqual(0, emqx_session_mem:info(awaiting_rel_cnt, Session)),
-    ?assertEqual(100, emqx_session_mem:info(awaiting_rel_max, Session)),
+    ?assertEqual(32, emqx_session_mem:info(awaiting_rel_max, Session)),
     ?assertEqual(0, emqx_session_mem:info(await_rel_timeout, Session)),
     ?assert(is_integer(emqx_session_mem:info(created_at, Session))).
 
@@ -117,7 +117,7 @@ t_session_stats(_) ->
             mqueue_dropped := 0,
             next_pkt_id := 1,
             awaiting_rel_cnt := 0,
-            awaiting_rel_max := 100
+            awaiting_rel_max := 32
         },
         maps:from_list(Stats)
     ).

--- a/apps/emqx/test/emqx_session_mem_SUITE.erl
+++ b/apps/emqx/test/emqx_session_mem_SUITE.erl
@@ -904,9 +904,15 @@ t_expire_awaiting_rel(_) ->
     ?assert(Timeout =< AwaitRelTimeout).
 
 t_expire_awaiting_rel_all(_) ->
-    Session = session(#{awaiting_rel => #{1 => 1, 2 => 2}}),
+    Session = session(#{await_rel_timeout => 1, awaiting_rel => #{1 => 1, 2 => 2}}),
     {ok, [], Session1} = emqx_session_mem:expire(clientinfo(), Session),
     ?assertEqual(#{}, emqx_session_mem:info(awaiting_rel, Session1)).
+
+t_expire_awaiting_rel_disabled(_) ->
+    AwaitingRel = #{1 => 1, 2 => 2},
+    Session = session(#{await_rel_timeout => 0, awaiting_rel => AwaitingRel}),
+    {ok, [], Session1} = emqx_session_mem:expire(clientinfo(), Session),
+    ?assertEqual(AwaitingRel, emqx_session_mem:info(awaiting_rel, Session1)).
 
 %%--------------------------------------------------------------------
 %% CT for utility functions

--- a/changes/ee/feat-18485.en.md
+++ b/changes/ee/feat-18485.en.md
@@ -1,3 +1,3 @@
 Changed the default value of `mqtt.await_rel_timeout` to `0`, so EMQX no longer expires inbound QoS 2 exchanges waiting for `PUBREL` unless a positive timeout is configured.
 
-For MQTT 5.0 clients, EMQX now advertises the effective `mqtt.max_awaiting_rel` as Receive Maximum in `CONNACK`. Values below 1 are treated as 1, and `infinity` is advertised as 65535.
+The default value of `mqtt.max_awaiting_rel` has been reduced from `100` to `32`. For MQTT 5.0 clients, EMQX now advertises the effective value as Receive Maximum in `CONNACK`. Values below 1 are treated as 1, and `infinity` is advertised as 65535.

--- a/changes/ee/feat-18485.en.md
+++ b/changes/ee/feat-18485.en.md
@@ -1,0 +1,3 @@
+Changed the default value of `mqtt.await_rel_timeout` to `0`, so EMQX no longer expires inbound QoS 2 exchanges waiting for `PUBREL` unless a positive timeout is configured.
+
+For MQTT 5.0 clients, EMQX now advertises the effective `mqtt.max_awaiting_rel` as Receive Maximum in `CONNACK`. Values below 1 are treated as 1, and `infinity` is advertised as 65535.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -587,7 +587,11 @@ mqtt_max_mqueue_len.label:
 """Max Message Queue Length"""
 
 mqtt_max_inflight.desc:
-"""Maximum number of QoS 1 and QoS 2 messages that are allowed to be delivered simultaneously before completing the acknowledgment."""
+"""Maximum number of QoS 1 and QoS 2 `PUBLISH` packets EMQX sends concurrently to a client.
+
+A message occupies inflight window until corresponding `PUBACK` or `PUBCOMP` is received from the client. EMQX does not start further QoS 1 or QoS 2 deliveries while the inflight window is full.
+
+For MQTT 5.0 clients, the `Receive Maximum` property in the `CONNECT` packet specifies the maximum number of incoming QoS 1 and QoS 2 messages the client is willing to process concurrently. EMQX uses that value as the broker-to-client inflight limit if it's lower than `mqtt.max_inflight`. Otherwise, this configured limit applies directly."""
 
 mqtt_max_inflight.label:
 """Max Inflight"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -511,9 +511,12 @@ base_listener_mountpoint.desc: """~
 base_listener_mountpoint.label: "Mountpoint"
 
 mqtt_max_awaiting_rel.desc:
-"""For each publisher session, the maximum number of QoS 2 messages for which EMQX is waiting to receive `PUBREL`. Once this limit is reached, EMQX rejects a further QoS 2 `PUBLISH` by disconnecting the client with "Receive Maximum Exceeded" error code (0x93). An entry is removed when its `PUBREL` is received or when `mqtt.await_rel_timeout` expires.
+"""For each publisher session, the maximum number of QoS1 and QoS 2 messages that EMQX is willing process concurrently.
 
-Values below 1 are treated as 1. For MQTT 5.0 clients, the effective limit is advertised as Receive Maximum in `CONNACK`, capped at `65535`."""
+* For QoS 1, EMQX does not reject a `PUBLISH` because of this setting. It accepts the packet and sends `PUBACK` as soon as the packet is processed.
+* For QoS 2, this setting limits the number of exchanges EMQX retains while waiting for `PUBREL`. Once that limit is reached, EMQX rejects a further QoS 2 `PUBLISH` by disconnecting the client with the "Receive Maximum Exceeded" error code (0x93). `mqtt.await_rel_timeout` controls when the retained entries expire, disabled by default.
+
+EMQX advertises the effective value as `Receive Maximum` in `CONNACK`. This is the maximum number of QoS 1 and QoS 2 `PUBLISH` packets that the client may have awaiting acknowledgment at one time. The client is responsible for flow control and must not exceed the advertised quota. Values below 1 are treated as 1; values above 65535, including `infinity`, are advertised as 65535."""
 
 mqtt_max_awaiting_rel.label:
 """Max Awaiting PUBREL"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -511,7 +511,9 @@ base_listener_mountpoint.desc: """~
 base_listener_mountpoint.label: "Mountpoint"
 
 mqtt_max_awaiting_rel.desc:
-"""For each publisher session, the maximum number of QoS 2 messages for which EMQX is waiting to receive `PUBREL`. Once this limit is reached, EMQX rejects a further QoS 2 `PUBLISH` by disconnecting the client. For MQTT 5.0 clients, the `DISCONNECT` packet has reason code `0x93` (Receive Maximum exceeded). An entry is removed when its `PUBREL` is received or when `mqtt.await_rel_timeout` expires."""
+"""For each publisher session, the maximum number of QoS 2 messages for which EMQX is waiting to receive `PUBREL`. Once this limit is reached, EMQX rejects a further QoS 2 `PUBLISH` by disconnecting the client with reason code `0x93` (Receive Maximum exceeded). An entry is removed when its `PUBREL` is received or when `mqtt.await_rel_timeout` expires.
+
+Values below 1 are treated as 1. For MQTT 5.0 clients, the effective limit is advertised as Receive Maximum in `CONNACK`, capped at `65535`."""
 
 mqtt_max_awaiting_rel.label:
 """Max Awaiting PUBREL"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -791,7 +791,9 @@ sys_msg_interval.desc:
   - `$SYS/brokers/<node>/metrics/<name>`"""
 
 mqtt_await_rel_timeout.desc:
-"""For client to broker QoS 2 message, the time limit for the broker to wait before the `PUBREL` message is received. The wait is aborted after timed out, meaning the packet ID is freed for new `PUBLISH` requests. Receiving a stale `PUBREL` causes a warning level log. Note, the message is delivered to subscribers before entering the wait for PUBREL."""
+"""Maximum time EMQX waits for `PUBREL` after sending `PUBREC`.
+
+MQTT does not define a timeout for this stage of a QoS 2 exchange. Until it receives the corresponding `PUBREL`, the receiver must retain enough state to recognize a retransmitted `PUBLISH` and prevent duplicate delivery. This timeout is disabled by default (`0`), so EMQX retains pending entries until their `PUBREL` packets are received or the session ends. Set a positive duration to enable the timeout. When it expires, EMQX removes the pending entry and frees its packet identifier. Disabling the timeout can let incomplete QoS 2 exchanges accumulate until `mqtt.max_awaiting_rel` is reached."""
 
 mqtt_await_rel_timeout.label:
 """Max Awaiting PUBREL TIMEOUT"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -511,7 +511,7 @@ base_listener_mountpoint.desc: """~
 base_listener_mountpoint.label: "Mountpoint"
 
 mqtt_max_awaiting_rel.desc:
-"""For each publisher session, the maximum number of outstanding QoS 2 messages pending on the client to send PUBREL. After reaching this limit, new QoS 2 PUBLISH requests will be rejected with `147(0x93)` until either PUBREL is received or timed out."""
+"""For each publisher session, the maximum number of QoS 2 messages for which EMQX is waiting to receive `PUBREL`. Once this limit is reached, EMQX rejects a further QoS 2 `PUBLISH` by disconnecting the client. For MQTT 5.0 clients, the `DISCONNECT` packet has reason code `0x93` (Receive Maximum exceeded). An entry is removed when its `PUBREL` is received or when `mqtt.await_rel_timeout` expires."""
 
 mqtt_max_awaiting_rel.label:
 """Max Awaiting PUBREL"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -511,7 +511,7 @@ base_listener_mountpoint.desc: """~
 base_listener_mountpoint.label: "Mountpoint"
 
 mqtt_max_awaiting_rel.desc:
-"""For each publisher session, the maximum number of QoS 2 messages for which EMQX is waiting to receive `PUBREL`. Once this limit is reached, EMQX rejects a further QoS 2 `PUBLISH` by disconnecting the client with reason code `0x93` (Receive Maximum exceeded). An entry is removed when its `PUBREL` is received or when `mqtt.await_rel_timeout` expires.
+"""For each publisher session, the maximum number of QoS 2 messages for which EMQX is waiting to receive `PUBREL`. Once this limit is reached, EMQX rejects a further QoS 2 `PUBLISH` by disconnecting the client with "Receive Maximum Exceeded" error code (0x93). An entry is removed when its `PUBREL` is received or when `mqtt.await_rel_timeout` expires.
 
 Values below 1 are treated as 1. For MQTT 5.0 clients, the effective limit is advertised as Receive Maximum in `CONNACK`, capped at `65535`."""
 


### PR DESCRIPTION
Release version: 7.0.0

## Summary

This PR changes few things around default `await_rel_timeout`.
1. `await_rel_timeout` is now disabled by default.
2. `max_awaiting_rel` is now advertised in CONNACK, which better agrees with MQTT specification.
3. `max_awaiting_rel` is soft-clamped to 1.
4. Affected schema field descriptions are corrected.

See also: #18470, #16721.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
    Defaults are changed however.
