### PR TITLE
fix(mqtt): trace acks with unknown packet id instead of warning

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -898,7 +898,7 @@ process_puback(
             ok = inc_metrics('packets.puback.inuse', Channel),
             {ok, Channel};
         {error, ?RC_PACKET_IDENTIFIER_NOT_FOUND} ->
-            ?SLOG(warning, #{msg => "puback_packetId_not_found", packetId => PacketId}),
+            ?TRACE("MQTT", "puback_packetId_not_found", #{packetId => PacketId}),
             ok = inc_metrics('packets.puback.missed', Channel),
             {ok, Channel}
     end.
@@ -925,7 +925,7 @@ process_pubrec(
             ok = inc_metrics('packets.pubrec.inuse', Channel),
             handle_out(pubrel, {PacketId, RC}, Channel);
         {error, RC = ?RC_PACKET_IDENTIFIER_NOT_FOUND} ->
-            ?SLOG(info, #{msg => "pubrec_packetId_not_found", packetId => PacketId}),
+            ?TRACE("MQTT", "pubrec_packetId_not_found", #{packetId => PacketId}),
             ok = inc_metrics('packets.pubrec.missed', Channel),
             handle_out(pubrel, {PacketId, RC}, Channel)
     end.
@@ -946,7 +946,7 @@ process_pubrel(
             NChannel = Channel#channel{session = NSession},
             handle_out(pubcomp, {PacketId, ?RC_SUCCESS}, NChannel);
         {error, RC = ?RC_PACKET_IDENTIFIER_NOT_FOUND} ->
-            ?SLOG(info, #{msg => "pubrel_packetId_not_found", packetId => PacketId}),
+            ?TRACE("MQTT", "pubrel_packetId_not_found", #{packetId => PacketId}),
             ok = inc_metrics('packets.pubrel.missed', Channel),
             handle_out(pubcomp, {PacketId, RC}, Channel)
     end.
@@ -974,7 +974,7 @@ process_pubcomp(
             ok = inc_metrics('packets.pubcomp.inuse', Channel),
             {ok, Channel};
         {error, ?RC_PACKET_IDENTIFIER_NOT_FOUND} ->
-            ?SLOG(info, #{msg => "pubcomp_packetId_not_found", packetId => PacketId}),
+            ?TRACE("MQTT", "pubcomp_packetId_not_found", #{packetId => PacketId}),
             ok = inc_metrics('packets.pubcomp.missed', Channel),
             {ok, Channel}
     end.

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -499,21 +499,34 @@ t_handle_in_pubrel_not_found_bounded_log(_) ->
     %% produce warning-level log output: the event is recorded by the
     %% packets.pubrel.missed counter and logged at info instead. A fresh
     %% channel has an empty session, so every PUBREL is not_found.
-    N = 100,
-    Flood = fun() ->
-        lists:foreach(
-            fun(_) ->
-                {ok, {outgoing, ?PUBCOMP_PACKET(1, ?RC_PACKET_IDENTIFIER_NOT_FOUND)}, _} =
-                    emqx_channel:handle_in(?PUBREL_PACKET(1, ?RC_SUCCESS), channel())
-            end,
-            lists:seq(1, N)
-        )
+    Send = fun() ->
+        {ok, {outgoing, ?PUBCOMP_PACKET(1, ?RC_PACKET_IDENTIFIER_NOT_FOUND)}, _} =
+            emqx_channel:handle_in(?PUBREL_PACKET(1, ?RC_SUCCESS), channel())
     end,
-    IsPubrelMissed = fun(#{msg := Msg}) -> Msg =:= "pubrel_packetId_not_found" end,
-    WarningReports = emqx_cth_log_capture:capture(warning, Flood),
-    ?assertEqual([], lists:filter(IsPubrelMissed, WarningReports)),
-    InfoReports = emqx_cth_log_capture:capture(info, Flood),
-    ?assertEqual(N, length(lists:filter(IsPubrelMissed, InfoReports))).
+    assert_ack_flood_bounded_log(Send, "pubrel_packetId_not_found").
+
+t_handle_in_puback_not_found_bounded_log(_) ->
+    %% Same as the PUBREL case for PUBACK. A PUBACK with an unknown Packet
+    %% Identifier is ignored (no reply), so the only per-packet output is the
+    %% log, which must not be at warning level.
+    Send = fun() ->
+        {ok, _} = emqx_channel:handle_in(?PUBACK_PACKET(1, ?RC_SUCCESS), channel())
+    end,
+    assert_ack_flood_bounded_log(Send, "puback_packetId_not_found").
+
+%% Send N acknowledgement packets with an unknown Packet Identifier and assert
+%% that MsgStr is logged at debug only: zero reports at warning and info levels,
+%% N reports at debug level.
+assert_ack_flood_bounded_log(Send, MsgStr) ->
+    N = 100,
+    Flood = fun() -> lists:foreach(fun(_) -> Send() end, lists:seq(1, N)) end,
+    IsMsg = fun(#{msg := Msg}) -> Msg =:= MsgStr end,
+    Count = fun(Level) ->
+        length(lists:filter(IsMsg, emqx_cth_log_capture:capture(Level, Flood)))
+    end,
+    ?assertEqual(0, Count(warning)),
+    ?assertEqual(0, Count(info)),
+    ?assertEqual(N, Count(debug)).
 
 t_handle_in_pubcomp_ok(_) ->
     ok = meck:expect(emqx_session, pubcomp, fun(_, _, _ReasonCode, Session) -> {ok, [], Session} end),

--- a/changes/ee/fix-18482.en.md
+++ b/changes/ee/fix-18482.en.md
@@ -1,7 +1,0 @@
-Reduced log volume for PUBREL, PUBREC, and PUBCOMP packets that carry an unknown Packet Identifier.
-
-A client that repeatedly sends acknowledgement packets with a Packet Identifier the broker has no
-state for could fill the log with warnings, one per packet. These events are now logged at the
-`info` level instead of `warning`, so they are quiet at the default log level. The
-`packets.pubrel.missed`, `packets.pubrec.missed`, and `packets.pubcomp.missed` counters still
-record every occurrence, and the broker still replies to each packet as before.

--- a/changes/ee/fix-18487.en.md
+++ b/changes/ee/fix-18487.en.md
@@ -1,0 +1,2 @@
+Reduced log volume for PUBACK, PUBREC, PUBREL, and PUBCOMP packets that carry an unknown Packet
+Identifier. Now only logged as client debug trace.


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

Addresses [#18483](https://github.com/emqx/emqx/issues/18483) (PUBACK) and refines
[#18482](https://github.com/emqx/emqx/pull/18482) (PUBREC/PUBREL/PUBCOMP), which is already merged.

An acknowledgement packet (PUBACK, PUBREC, PUBREL, PUBCOMP) carrying a Packet Identifier the broker
has no state for triggered a `warning` log per packet in `emqx_channel.erl`. There is no response
amplification: PUBACK for an unknown identifier is ignored, and for MQTT 3.1.1 the PUBREL→PUBCOMP
reply is the same 4 bytes as the request. The reported delay to a new connection's CONNACK comes
from the shared log handler — at the default `warning` level the per-packet warnings fill the
handler queue, and OTP logger overload protection (`sync_mode_qlen`, default 100) then puts every
logging process, including other connections, into synchronous mode behind that one handler.

These four events are already recorded by the `packets.puback.missed`, `packets.pubrec.missed`,
`packets.pubrel.missed`, and `packets.pubcomp.missed` counters. They are now emitted through the
`?TRACE` macro (debug level plus the client trace facility, matching the nearby `unexpected_packet`
and `invalid_publish_packet` events) instead of `?SLOG(warning, ...)`. They produce no output at
any normal log level, and an operator can still see them by starting a trace for a specific client.
#18482 moved three of them to `info`; this change routes all four through `?TRACE` and adds PUBACK.

Protocol behavior is unchanged. MQTT 3.1.1 requires the PUBREL→PUBCOMP reply
([MQTT-3.6.4-1], [MQTT-4.3.3-2]); an unknown Packet Identifier is not a protocol violation, so the
reply is still sent and an unexpected PUBACK is still ignored. No rate-limiting or disconnect is
added; the zero TCP receive window is normal flow control (`active_n` plus the `check_oom` guard)
and recovers when the flood stops.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)