### PR TITLE
test(listener): accept einval as a ws connection-refused shape

### DIFF
--- a/apps/emqx/test/emqx_listeners_limits_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_limits_SUITE.erl
@@ -221,6 +221,10 @@ assert_connect_refused(Host, Port, Config) ->
         error:tcp_closed when Type == tcp -> ok;
         error:{ws_upgrade_failed, closed} when Type == ws -> ok;
         error:{ws_upgrade_failed, {error, closed}} when Type == ws -> ok;
+        %% The throttled listener can close the pending connection while the
+        %% client writes the upgrade request. The client then reports a
+        %% socket-level einval instead of closed.
+        error:{ws_upgrade_failed, {error, einval}} when Type == ws -> ok;
         error:timeout when Type == wss -> ok
     end.
 


### PR DESCRIPTION
## Summary

De-flake `emqx_listeners_limits_SUITE:ws.t_max_conn_rate_update`:

```
emqx_listeners_limits_SUITE:emqtt_do_connect failed on line 278
Reason: {ws_upgrade_failed,{error,einval}}
```

Seen in: https://github.com/emqx/emqx/actions/runs/32852114177/job/97819361860?pr=18453

The listener refused the connection as the test expects — the broker log shows `listener_accept_throttled_due_to_quota_exceeded` at the failure time. The flake is only in the error shape: when the throttled listener closes the pending connection while the client writes the websocket upgrade request, the client reports `{ws_upgrade_failed, {error, einval}}` instead of a `closed` variant, and `assert_connect_refused/3` crashes on the unexpected shape.

Accept `einval` in the `ws` clause of `assert_connect_refused/3`. The catch remains an explicit allowlist of refusal shapes; a successful connect still fails the test. Full suite passes locally: 12 ok, 0 failed.

Base `dev-60`: the suite blob is identical on dev-60..63, so the fix propagates through the sync chain.