### PR TITLE
feat(zerobus): follow ups

### DIFF
--- a/.ci/docker-compose-file/databricks/Dockerfile
+++ b/.ci/docker-compose-file/databricks/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3-slim
+
+RUN pip install flask databricks-sql-connector[pyarrow]
+
+CMD ["python", "/work/main.py"]

--- a/.ci/docker-compose-file/databricks/main.py
+++ b/.ci/docker-compose-file/databricks/main.py
@@ -1,0 +1,33 @@
+from databricks import sql
+from flask import Flask, request
+import logging
+
+app = Flask(__name__)
+
+
+@app.route("/sql", methods=["POST"])
+def run_sql():
+    req = request.get_json()
+    hostname = req['hostname']
+    path = req['path']
+    token = req['token']
+    req_sql = req['sql']
+    with sql.connect(
+            server_hostname = hostname,
+            http_path = path,
+            access_token = token) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(req_sql)
+            rows = cursor.fetchall()
+            col_names = [d[0] for d in cursor.description]
+            res = [
+                dict(zip(col_names, row))
+                for row in rows
+            ]
+            return res
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    app.logger.setLevel(logging.INFO)
+    app.run(host="0.0.0.0", port=8000, debug=True)

--- a/.ci/docker-compose-file/databricks/zerobus.hocon.example
+++ b/.ci/docker-compose-file/databricks/zerobus.hocon.example
@@ -1,0 +1,34 @@
+zerobus_sql_warehouse_hostname = "<HOSTNAME>.cloud.databricks.com"
+zerobus_sql_warehouse_http_path = "/sql/1.0/warehouses/<PATH>"
+zerobus_sql_warehouse_access_token = "<ACCESS TOKEN>"
+
+actions {
+  zerobus {
+    test {
+      connector = test
+      parameters {
+        catalog = "<CATALOG>"
+        schema = "<SCHEMA>"
+        table = "<TABLE>"
+      }
+    }
+  }
+}
+connectors {
+  zerobus {
+    test {
+      connect_timeout = "10s"
+      zerobus_endpoint = "https://<WORKSPACE ID>.zerobus.<REGION>.cloud.databricks.com:443"
+      authentication {
+        workspace_id = "<WORKSPACE ID>"
+        client_id = "<CLIENT ID>"
+        client_secret = "<CLIENT SECRET>"
+        workspace_url = "https://<WORKSPACE HOSTNAME>.cloud.databricks.com"
+      }
+      pool_size = 3
+      ssl {
+        enable = true
+      }
+    }
+  }
+}

--- a/.ci/docker-compose-file/docker-compose-databricks.yaml
+++ b/.ci/docker-compose-file/docker-compose-databricks.yaml
@@ -1,0 +1,16 @@
+# docker compose -f .ci/docker-compose-file/docker-compose-databricks.yaml up --build
+services:
+  databricks_sql:
+    container_name: databricks_sql
+    image: python:3-slim
+    build: ./databricks/
+    working_dir: /work
+    networks:
+        emqx_bridge:
+    volumes:
+      - ./databricks:/work
+    stop_grace_period: 0s
+
+networks:
+  emqx_bridge:
+    external: true

--- a/apps/emqx/src/emqx_hookpoints.erl
+++ b/apps/emqx/src/emqx_hookpoints.erl
@@ -73,7 +73,8 @@
     'config.zones_updated',
     'api_actor.pre_create',
     'namespace.delete',
-    'namespace.resource_pre_create'
+    'namespace.resource_pre_create',
+    'schema_registry.serde_updated'
 ]).
 
 -define(HOOKPOINTS, (?MQTT_CLIENT_LIFECYCLE_HOOKPOINTS ++ ?MANAGEMENT_HOOKPOINTS)).

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_app.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_app.erl
@@ -17,9 +17,11 @@
 %%------------------------------------------------------------------------------
 
 start(_StartType, _StartArgs) ->
+    emqx_bridge_zerobus_hookcb:register_hooks(),
     emqx_bridge_zerobus_sup:start_link().
 
 stop(_State) ->
+    emqx_bridge_zerobus_hookcb:unregister_hooks(),
     ok.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_async_receiver_worker.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_async_receiver_worker.erl
@@ -160,7 +160,12 @@ recover(ActionResId, Idx) ->
     maybe
         [?META_ROW(_, Val)] ?=
             ets:lookup(?META_TAB, ?META_STREAM_KEY(ActionResId, Idx)),
-        #{?writer := Writer} ?= Val,
+        #{
+            ?writer := Writer,
+            ?n_restarts := _,
+            ?stream := _,
+            ?opts := _
+        } ?= Val,
         true ?= is_pid(Writer) andalso is_process_alive(Writer),
         Val
     else
@@ -202,15 +207,6 @@ handle_follow_stream(FollowReq, State0) ->
     },
     {Reply, State}.
 
-clear_state(State0) ->
-    State0#{
-        ?writer := ?undefined,
-        ?n_restarts := ?undefined,
-        ?last_acked_seq := -1,
-        ?stream := ?undefined,
-        ?opts := #{}
-    }.
-
 handle_recv(#{?stream := ?undefined} = State0) ->
     ?tp(~"zerobus_receiver_recv_no_stream", #{}),
     State0;
@@ -240,13 +236,13 @@ handle_helper_down({ok, Res}, State0) ->
             Reason = maybe_format_grpc_reason(grpc_client:trailers_to_error(Trailers)),
             Error = {error, Reason},
             notify_errored(Error, State1),
-            State2 = clear_state(State1),
-            {?continue, State2};
+            {?continue, State1};
         {more, Results} ->
             LastAckedSeq = find_last_acked_seq(Results, LastAckedSeq0, State0),
             ?tp("zerobus_last_seq_scanned", #{}),
             State1 = State0#{?last_acked_seq := LastAckedSeq},
             maybe_notify_acked(LastAckedSeq0, State1),
+            ?tp("zerobus_last_seq_notified", #{}),
             {?nudge, State1};
         {error, {deadline_exceeded, _}} ->
             {?nudge, State0};
@@ -254,8 +250,7 @@ handle_helper_down({ok, Res}, State0) ->
             %% stream is gone
             Error = {error, stream_closed},
             notify_errored(Error, State0),
-            State1 = clear_state(State0),
-            {?continue, State1};
+            {?continue, State0};
         {error, Reason} ->
             ?tp(info, "zerobus_receiver_unexpected_error_response", #{
                 action_res_id => ActionResId,
@@ -266,8 +261,7 @@ handle_helper_down({ok, Res}, State0) ->
                 false ?= is_process_alive(Pid),
                 Error = {error, stream_closed},
                 notify_errored(Error, State0),
-                State1 = clear_state(State0),
-                {?continue, State1}
+                {?continue, State0}
             else
                 _ ->
                     {?nudge, State0}

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_async_receiver_worker.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_async_receiver_worker.erl
@@ -207,6 +207,15 @@ handle_follow_stream(FollowReq, State0) ->
     },
     {Reply, State}.
 
+clear_state(State0) ->
+    %% do not clear n_restarts nor last_acked_seq; otherwise, writer will not get the
+    %% latest info when syncing.
+    State0#{
+        ?writer := ?undefined,
+        ?stream := ?undefined,
+        ?opts := #{}
+    }.
+
 handle_recv(#{?stream := ?undefined} = State0) ->
     ?tp(~"zerobus_receiver_recv_no_stream", #{}),
     State0;
@@ -236,7 +245,8 @@ handle_helper_down({ok, Res}, State0) ->
             Reason = maybe_format_grpc_reason(grpc_client:trailers_to_error(Trailers)),
             Error = {error, Reason},
             notify_errored(Error, State1),
-            {?continue, State1};
+            State = clear_state(State1),
+            {?continue, State};
         {more, Results} ->
             LastAckedSeq = find_last_acked_seq(Results, LastAckedSeq0, State0),
             ?tp("zerobus_last_seq_scanned", #{}),
@@ -250,7 +260,8 @@ handle_helper_down({ok, Res}, State0) ->
             %% stream is gone
             Error = {error, stream_closed},
             notify_errored(Error, State0),
-            {?continue, State0};
+            State = clear_state(State0),
+            {?continue, State};
         {error, Reason} ->
             ?tp(info, "zerobus_receiver_unexpected_error_response", #{
                 action_res_id => ActionResId,
@@ -261,7 +272,8 @@ handle_helper_down({ok, Res}, State0) ->
                 false ?= is_process_alive(Pid),
                 Error = {error, stream_closed},
                 notify_errored(Error, State0),
-                {?continue, State0}
+                State = clear_state(State0),
+                {?continue, State}
             else
                 _ ->
                     {?nudge, State0}

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_hookcb.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_hookcb.erl
@@ -1,0 +1,61 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_zerobus_hookcb).
+
+%% API
+-export([
+    register_hooks/0,
+    unregister_hooks/0
+]).
+
+%% Hooks
+-export([schema_registry_serde_updated/1]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-include("emqx_bridge_zerobus.hrl").
+
+-define(PRIO, 500).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+register_hooks() ->
+    ok = emqx_hooks:add(
+        'schema_registry.serde_updated',
+        {?MODULE, schema_registry_serde_updated, []},
+        ?PRIO
+    ),
+    ok.
+
+unregister_hooks() ->
+    ok = emqx_hooks:del(
+        'schema_registry.serde_updated', {?MODULE, schema_registry_serde_updated}
+    ),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Hooks
+%%------------------------------------------------------------------------------
+
+schema_registry_serde_updated(Ctx) ->
+    #{name := SerdeName} = Ctx,
+    notify_actions_updated_serde(SerdeName),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+notify_actions_updated_serde(SerdeName) ->
+    Writers = emqx_bridge_zerobus_utils:list_all_stream_writer_pids(),
+    lists:foreach(
+        fun(Writer) ->
+            emqx_bridge_zerobus_stream_writer_worker:serde_updated(Writer, SerdeName)
+        end,
+        Writers
+    ).

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_impl.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_impl.erl
@@ -562,9 +562,19 @@ do_fold_grpc_optvar_results(Keys) ->
         end,
         Results
     ),
-    %% {disconnected, unhealthy_target} > disconnected > connecting > connected
+    case sort_status(Errors0) of
+        [{Status, Reason} | _] ->
+            {Status, Reason};
+        [Status | _] ->
+            Status;
+        [] ->
+            ?status_connected
+    end.
+
+%% {disconnected, unhealthy_target} > disconnected > connecting > connected
+sort_status(Errors0) ->
     ToStatus = fun
-        ({S, {unhealhy_target, _}}) -> {S, unhealthy_target};
+        ({S, {unhealthy_target, _}}) -> {S, unhealthy_target};
         ({S, _Reason}) -> S;
         (S) -> S
     end,
@@ -573,14 +583,7 @@ do_fold_grpc_optvar_results(Keys) ->
         S2 = ToStatus(S2A),
         S1 > S2
     end,
-    case lists:sort(CompareFn, Errors0) of
-        [{Status, Reason} | _] ->
-            {Status, Reason};
-        [Status | _] ->
-            Status;
-        [] ->
-            ?status_connected
-    end.
+    lists:sort(CompareFn, Errors0).
 
 -spec start_connector(connector_resource_id(), connector_config()) ->
     {ok, connector_state()} | {error, any()}.
@@ -1068,3 +1071,34 @@ reinject_token({Path, Headers0, Body} = Request0, ChanResId) ->
             %% if we can't get the token right now... tough luck.  let it expire.
             Request0
     end.
+
+%%------------------------------------------------------------------------------
+%% Tests
+%%------------------------------------------------------------------------------
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+status_ordering_test() ->
+    Status0 = [
+        ?status_connecting,
+        ?status_connected,
+        {?status_connecting, ~"stream closed"},
+        {?status_connected, ~"shouldn't happen, but..."},
+        {?status_disconnected, ~"boom"},
+        {?status_disconnected, {unhealthy_target, ~"needs manual intervention"}},
+        ?status_disconnected
+    ],
+    ?assertEqual(
+        [
+            {?status_disconnected, {unhealthy_target, ~"needs manual intervention"}},
+            ?status_disconnected,
+            {?status_disconnected, ~"boom"},
+            {?status_connecting, ~"stream closed"},
+            ?status_connecting,
+            {?status_connected, ~"shouldn't happen, but..."},
+            ?status_connected
+        ],
+        sort_status(Status0)
+    ),
+    ok.
+-endif.

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_impl.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_impl.erl
@@ -376,10 +376,11 @@ gun_opts(ConnConfig) ->
         #{scheme := "https"} ->
             #{
                 transport => ssl,
-                tls_opts => emqx_tls_lib:to_client_opts(SSL#{enable => true})
+                tls_opts => emqx_tls_lib:to_client_opts(SSL#{enable => true}),
+                retry => 0
             };
         _ ->
-            #{transport => tcp}
+            #{transport => tcp, retry => 0}
     end.
 
 map_token_errors({token_endpoint_error, 401, Details}) ->
@@ -458,9 +459,9 @@ grpc_connector_health_check(ConnState) ->
                 [] ->
                     ?status_connected;
                 [{error, Reason} | _] ->
-                    {?status_disconnected, Reason};
+                    {?status_disconnected, map_grpc_health_check_error(Reason)};
                 [Error | _] ->
-                    {?status_disconnected, Error}
+                    {?status_disconnected, map_grpc_health_check_error(Error)}
             end
     catch
         exit:timeout ->
@@ -468,6 +469,13 @@ grpc_connector_health_check(ConnState) ->
         Kind:Reason:Stacktrace ->
             {?status_disconnected, {Kind, Reason, Stacktrace}}
     end.
+
+map_grpc_health_check_error({shutdown, Reason}) ->
+    map_grpc_health_check_error(Reason);
+map_grpc_health_check_error({error, Reason}) ->
+    map_grpc_health_check_error(Reason);
+map_grpc_health_check_error(Reason) ->
+    Reason.
 
 ehttpc_connector_health_check(ConnResId) ->
     case ehttpc:check_pool_integrity(ConnResId) of

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_impl.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_impl.erl
@@ -39,6 +39,10 @@
 -export([rest_reply_delegator/3]).
 -export([set_health/3]).
 
+-export_type([
+    proto_record/0
+]).
+
 %%------------------------------------------------------------------------------
 %% Type declarations
 %%------------------------------------------------------------------------------
@@ -550,7 +554,9 @@ do_fold_grpc_optvar_results(Keys) ->
         end,
         Results
     ),
+    %% {disconnected, unhealthy_target} > disconnected > connecting > connected
     ToStatus = fun
+        ({S, {unhealhy_target, _}}) -> {S, unhealthy_target};
         ({S, _Reason}) -> S;
         (S) -> S
     end,
@@ -737,8 +743,16 @@ create_channel(ConnResId, ChanResId, ChanConfig, #{?transport := {?grpc, _}} = C
             #{type := json} ->
                 ?json;
             #{type := proto} ->
-                Proto = get_serde(Record0),
-                {?proto, Proto}
+                case emqx_bridge_zerobus_utils:get_serde(Record0) of
+                    {ok, Proto} ->
+                        {?proto, Proto};
+                    {error, schema_not_found} ->
+                        throw(~"Schema not found");
+                    {error, bad_type} ->
+                        throw(~"Invalid schema type; must be protobuf");
+                    {error, message_type_not_found} ->
+                        throw(~"Message type not found in protobuf schema/bundle")
+                end
         end,
     Opts = #{
         action_res_id => ChanResId,
@@ -876,59 +890,6 @@ unregister_oauth2(ConnResId, ChanResId) ->
     emqx_connector_oauth2:unregister(ChanResId),
     deallocate(ConnResId, ?oauth2(ChanResId)),
     ok.
-
--spec get_serde(record_config()) -> proto_record().
-get_serde(Record) ->
-    #{
-        schema_name := SerdeName,
-        message_type := MessageType
-    } = Record,
-    case emqx_schema_registry:get_serde(SerdeName) of
-        {error, not_found} ->
-            throw(~"Schema not found");
-        {ok, #serde{type = Type}} when Type /= ?protobuf ->
-            throw(~"Invalid schema type; must be protobuf");
-        {ok, #serde{type = ?protobuf, eval_context = SerdeMod}} ->
-            FileDescriptorSetBin = apply(SerdeMod, descriptor, []),
-            FileDescriptorSet = emqx_bridge_zerobus_gen_descriptor_pb:decode_msg(
-                FileDescriptorSetBin, 'FileDescriptorSet'
-            ),
-            DescriptorProtoBin = find_descriptor_proto(FileDescriptorSet, MessageType),
-            MessageTypeAtom = binary_to_existing_atom(MessageType, utf8),
-            #{
-                ?serde_name => SerdeName,
-                ?message_type => MessageTypeAtom,
-                ?descriptor => DescriptorProtoBin
-            }
-    end.
-
-find_descriptor_proto(FileDescriptorSet, MessageType) ->
-    #{file := Files} = FileDescriptorSet,
-    case do_find_descriptor_proto_file(Files, MessageType) of
-        error ->
-            throw(~"Message type not found in protobuf schema/bundle");
-        {ok, DescriptorProto} ->
-            emqx_bridge_zerobus_gen_descriptor_pb:encode_msg(
-                DescriptorProto, 'DescriptorProto'
-            )
-    end.
-
-do_find_descriptor_proto_file([], _MessageType) ->
-    error;
-do_find_descriptor_proto_file([#{message_type := Types} | Rest], MessageType) ->
-    case do_find_descriptor_proto_message_type(Types, MessageType) of
-        error ->
-            do_find_descriptor_proto_file(Rest, MessageType);
-        {ok, DescriptorProto} ->
-            {ok, DescriptorProto}
-    end.
-
-do_find_descriptor_proto_message_type([], _MessageType) ->
-    error;
-do_find_descriptor_proto_message_type([#{name := MessageType} = DescriptorProto | _], MessageType) ->
-    {ok, DescriptorProto};
-do_find_descriptor_proto_message_type([_ | Rest], MessageType) ->
-    do_find_descriptor_proto_message_type(Rest, MessageType).
 
 do_insert_batch(
     Records0, ?sync, ChanState, #{?transport := {?rest, _}} = _ConnState, ConnResId, ChanResId

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_stream_writer_worker.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_stream_writer_worker.erl
@@ -11,6 +11,7 @@
 
     acked/3,
     errored/3,
+    serde_updated/2,
     ingest_record_batch_sync/3,
     ingest_record_batch_async/3
 ]).
@@ -19,6 +20,7 @@
 -export([sync_reply_delegator/2]).
 -export([unregister_stream/2]).
 -export([where/2]).
+-export([gproc_name/2]).
 -export([grpc_recv_single_resp1/2]).
 
 %% `gen_server' API
@@ -50,6 +52,7 @@
 -record(ingest_record_batch_async, {records :: [binary()], reply_fn}).
 -record(acked, {n_restarts, last_acked_seq}).
 -record(errored, {n_restarts, error}).
+-record(serde_updated, {serde_name}).
 
 -define(SERVICE, 'databricks.zerobus.Zerobus').
 -define(PROTO_MODULE, 'emqx_bridge_zerobus_gen_zerobus_service_pb').
@@ -126,6 +129,10 @@ ingest_record_batch_async(Pool, Records, ReplyFnAndArgs) ->
         }),
         {ok, Pid}
     end.
+
+serde_updated(Pid, SerdeName0) ->
+    SerdeName = emqx_utils_conv:bin(SerdeName0),
+    gen_server:cast(Pid, #serde_updated{serde_name = SerdeName}).
 
 %%------------------------------------------------------------------------------
 %% `gen_server' API
@@ -209,6 +216,13 @@ handle_cast(#ingest_record_batch_async{records = Records, reply_fn = ReplyFnAndA
         {?reopen, State} ->
             {noreply, State, {continue, #open_stream{}}}
     end;
+handle_cast(#serde_updated{serde_name = SerdeName}, State0) ->
+    case handle_serde_updated(SerdeName, State0) of
+        {?continue, State} ->
+            {noreply, State};
+        {?reopen, State} ->
+            {noreply, State, {continue, #open_stream{}}}
+    end;
 handle_cast(_Cast, State) ->
     {noreply, State}.
 
@@ -230,6 +244,9 @@ handle_info(_Info, State) ->
 unregister_stream(ActionResId, Idx) ->
     true = ets:delete(?META_TAB, ?META_STREAM_KEY(ActionResId, Idx)),
     ok.
+
+gproc_name(ActionResId, Idx) ->
+    ?name(ActionResId, Idx).
 
 %%------------------------------------------------------------------------------
 %% Internal fns
@@ -467,6 +484,31 @@ handle_ingest_record_batch_async(Records, ReplyFnAndArgs, State0) ->
             {?reopen, State2}
     end.
 
+handle_serde_updated(SerdeName, State0) ->
+    case State0 of
+        #{?record := {?proto, #{?serde_name := SerdeName} = OldProto}} ->
+            #{?message_type := MessageTypeAtom, ?descriptor := OldDescriptor} = OldProto,
+            MessageTypeBin = atom_to_binary(MessageTypeAtom, utf8),
+            Opts = #{schema_name => SerdeName, message_type => MessageTypeBin},
+            case emqx_bridge_zerobus_utils:get_serde(Opts) of
+                {ok, #{?descriptor := OldDescriptor}} ->
+                    {?continue, State0};
+                {ok, NewProto} ->
+                    State = State0#{?record := {?proto, NewProto}},
+                    {?reopen, State};
+                {error, Reason} ->
+                    Msg = map_get_serde_error(Reason),
+                    #{?action_res_id := ActionResId, ?idx := Idx} = State0,
+                    set_health(ActionResId, Idx, {?status_disconnected, {unhealthy_target, Msg}}),
+                    ?tp("zerobus_get_serde_error", #{}),
+                    %% no point in reopening the stream, since this needs manual
+                    %% intervention that'll restart the action.
+                    {?continue, State0}
+            end;
+        _ ->
+            {?continue, State0}
+    end.
+
 grpc_meta(State) ->
     #{
         ?action_res_id := ActionResId,
@@ -672,3 +714,12 @@ handle_insert_result({error, Reason}) ->
     {error, {unrecoverable_error, Reason}};
 handle_insert_result(Res) ->
     Res.
+
+map_get_serde_error(schema_not_found) ->
+    %% should be a rare race condition, since we've just been notified of this serde
+    %% changing (not being deleted).
+    ~"Schema not found";
+map_get_serde_error(bad_type) ->
+    ~"Invalid schema type; must be protobuf";
+map_get_serde_error(message_type_not_found) ->
+    ~"Message type not found in protobuf schema/bundle".

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_stream_writer_worker.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_stream_writer_worker.erl
@@ -659,16 +659,24 @@ is_end_of_stream(Resp) ->
     end.
 
 do_create_stream_impl(Metadata, Opts) ->
-    grpc_client:open(
-        ?DEF(
-            <<"/databricks.zerobus.Zerobus/EphemeralStream">>,
-            'databricks.zerobus.ephemeral_stream_request',
-            'databricks.zerobus.ephemeral_stream_response',
-            <<"databricks.zerobus.EphemeralStreamRequest">>
-        ),
-        Metadata,
-        Opts
-    ).
+    try
+        grpc_client:open(
+            ?DEF(
+                <<"/databricks.zerobus.Zerobus/EphemeralStream">>,
+                'databricks.zerobus.ephemeral_stream_request',
+                'databricks.zerobus.ephemeral_stream_response',
+                <<"databricks.zerobus.EphemeralStreamRequest">>
+            ),
+            Metadata,
+            Opts
+        )
+    catch
+        exit:{noproc, _} ->
+            %% race: client died just as we called it
+            {error, grpc_client_restarting};
+        Class:Reason:Stacktrace ->
+            {error, {Class, Reason, Stacktrace}}
+    end.
 
 ensure_stream_closed(#{?stream := ?undefined} = State0) ->
     State0;

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_stream_writer_worker.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_stream_writer_worker.erl
@@ -407,6 +407,7 @@ handle_acked(OldNRestarts, _LastAckedSeq, #{?n_restarts := NRestarts} = State0) 
     OldNRestarts < NRestarts
 ->
     %% stale response
+    ?tp("zerobus_writer_stale_ack", #{}),
     State0;
 handle_acked(NRestarts, LastAckedSeq, State0) ->
     #{?acked := Acked0} = State0,
@@ -418,6 +419,7 @@ handle_errored(OldNRestarts, _Error, #{?n_restarts := NRestarts} = State0) when
     OldNRestarts < NRestarts
 ->
     %% stale response
+    ?tp("zerobus_writer_stale_error", #{}),
     {?continue, State0};
 handle_errored(_NRestarts, Error0, State0) ->
     #{?action_res_id := ActionResId, ?idx := Idx, ?seq := Seq} = State0,

--- a/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_utils.erl
+++ b/apps/emqx_bridge_zerobus/src/emqx_bridge_zerobus_utils.erl
@@ -1,0 +1,97 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_zerobus_utils).
+
+%% API
+-export([
+    get_serde/1,
+    list_all_stream_writer_pids/0
+]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-include("emqx_bridge_zerobus.hrl").
+-include_lib("emqx_schema_registry/include/emqx_schema_registry.hrl").
+
+-type record_config() :: #{
+    schema_name := binary(),
+    message_type := binary(),
+    any() => term()
+}.
+-type proto_record() :: emqx_bridge_zerobus_impl:proto_record().
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec list_all_stream_writer_pids() -> [pid()].
+list_all_stream_writer_pids() ->
+    Key = emqx_bridge_zerobus_stream_writer_worker:gproc_name('_', '_'),
+    MS = [{{Key, '$1', '_'}, [], ['$1']}],
+    gproc:select({local, names}, MS).
+
+-spec get_serde(record_config()) ->
+    {ok, proto_record()}
+    | {error, schema_not_found | bad_type | message_type_not_found}.
+get_serde(Record) ->
+    #{
+        schema_name := SerdeName,
+        message_type := MessageType
+    } = Record,
+    case emqx_schema_registry:get_serde(SerdeName) of
+        {error, not_found} ->
+            {error, schema_not_found};
+        {ok, #serde{type = Type}} when Type /= ?protobuf ->
+            {error, bad_type};
+        {ok, #serde{type = ?protobuf, eval_context = SerdeMod}} ->
+            FileDescriptorSetBin = apply(SerdeMod, descriptor, []),
+            FileDescriptorSet = emqx_bridge_zerobus_gen_descriptor_pb:decode_msg(
+                FileDescriptorSetBin, 'FileDescriptorSet'
+            ),
+            maybe
+                {ok, DescriptorProtoBin} ?= find_descriptor_proto(FileDescriptorSet, MessageType),
+                MessageTypeAtom = binary_to_existing_atom(MessageType, utf8),
+                Proto = #{
+                    ?serde_name => SerdeName,
+                    ?message_type => MessageTypeAtom,
+                    ?descriptor => DescriptorProtoBin
+                },
+                {ok, Proto}
+            end
+    end.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+find_descriptor_proto(FileDescriptorSet, MessageType) ->
+    #{file := Files} = FileDescriptorSet,
+    case do_find_descriptor_proto_file(Files, MessageType) of
+        error ->
+            {error, message_type_not_found};
+        {ok, DescriptorProto} ->
+            DescriptorProtoBin = emqx_bridge_zerobus_gen_descriptor_pb:encode_msg(
+                DescriptorProto, 'DescriptorProto'
+            ),
+            {ok, DescriptorProtoBin}
+    end.
+
+do_find_descriptor_proto_file([], _MessageType) ->
+    error;
+do_find_descriptor_proto_file([#{message_type := Types} | Rest], MessageType) ->
+    case do_find_descriptor_proto_message_type(Types, MessageType) of
+        error ->
+            do_find_descriptor_proto_file(Rest, MessageType);
+        {ok, DescriptorProto} ->
+            {ok, DescriptorProto}
+    end.
+
+do_find_descriptor_proto_message_type([], _MessageType) ->
+    error;
+do_find_descriptor_proto_message_type([#{name := MessageType} = DescriptorProto | _], MessageType) ->
+    {ok, DescriptorProto};
+do_find_descriptor_proto_message_type([_ | Rest], MessageType) ->
+    do_find_descriptor_proto_message_type(Rest, MessageType).

--- a/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_SUITE.erl
+++ b/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_SUITE.erl
@@ -598,6 +598,17 @@ simple_protobuf_schema1() ->
         }
     """.
 
+simple_protobuf_schema2() ->
+    ~"""
+        syntax = "proto2";
+
+        package air_quality;
+
+        message table_air_quality {
+        	optional string new_field = 1;
+        }
+    """.
+
 create_serde(TCConfig) ->
     create_serde(TCConfig, _Opts = #{}).
 
@@ -767,6 +778,22 @@ run_real_sql(#{mock := false} = TCConfig, Opts) ->
             ),
         emqx_utils_json:decode(RespBody)
     end.
+
+list_create_stream_reqs(TCConfig) when is_list(TCConfig) ->
+    list_create_stream_reqs(maps:from_list(TCConfig));
+list_create_stream_reqs(#{mock := false}) ->
+    error(not_mocked);
+list_create_stream_reqs(#{mock := true} = TCConfig) ->
+    #{mocked_call_tab := Tab} = TCConfig,
+    lists:filtermap(
+        fun
+            ({_, #{type := create_stream} = Call}) ->
+                {true, Call};
+            (_) ->
+                false
+        end,
+        ets:tab2list(Tab)
+    ).
 
 simple_create_rule_api(TCConfig) ->
     simple_create_rule_api(default_sql(), TCConfig).
@@ -2571,17 +2598,161 @@ t_close_stream(TCConfig) ->
     ?assertReceive({grpc_server_handler_exit, _}),
     ok.
 
-%% -doc """
-%% When the schema used by an already-running channel changes, it needs to get the new
-%% descriptor proto and re-open the stream.
-%% """.
-%% t_proto_schema_changed_while_running() ->
-%%     [{matrix, true}, {mock_only, true}].
-%% t_proto_schema_changed_while_running(matrix) ->
-%%     [[?grpc, ?proto, ?async, ?batching]];
-%% t_proto_schema_changed_while_running(TCConfig) when is_list(TCConfig) ->
-%%     ct:fail(todo),
-%%     ok.
+-doc """
+When the schema used by an already-running channel changes, it needs to get the new
+descriptor proto and re-open the stream.
+
+This covers the happy path.
+""".
+t_proto_schema_changed_while_running() ->
+    [{matrix, true}, {mock_only, true}].
+t_proto_schema_changed_while_running(matrix) ->
+    [[?grpc, ?proto, ?async, ?batching]];
+t_proto_schema_changed_while_running(TCConfig) when is_list(TCConfig) ->
+    PoolSize = 2,
+    {201, _} = create_connector_api(TCConfig, #{
+        ~"transport" => #{~"pool_size" => PoolSize}
+    }),
+    {201, _} = create_action_api(TCConfig, #{}),
+    SQL = ~"""
+      select
+        payload.new_field as new_field
+      from '${t}'
+    """,
+    #{topic := RuleTopic} = simple_create_rule_api(SQL, TCConfig),
+    C = start_client(),
+    %% new schema
+    ct:pal("updating schema"),
+    {ok, SRef0} = snabbkaffe:subscribe(
+        ?match_event(#{?snk_kind := "zerobus_opening_stream"}),
+        PoolSize,
+        5_000
+    ),
+    update_serde(TCConfig, #{
+        ~"type" => ~"protobuf",
+        ~"source" => simple_protobuf_schema2()
+    }),
+    {ok, _} = snabbkaffe:receive_events(SRef0),
+    Payload = emqx_utils_json:encode(#{~"new_field" => ~"hello"}),
+    emqtt:publish(C, RuleTopic, Payload, [{qos, 1}]),
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            [
+                #{req := #{descriptor_proto := OldDescriptor}},
+                #{req := #{descriptor_proto := OldDescriptor}},
+                #{req := #{descriptor_proto := NewDescriptor}},
+                #{req := #{descriptor_proto := NewDescriptor}}
+            ] when OldDescriptor /= NewDescriptor,
+            list_create_stream_reqs(TCConfig)
+        )
+    ),
+    ?retry(
+        700,
+        10,
+        ?assertMatch(
+            {200, #{
+                ~"metrics" := #{
+                    ~"matched" := 1,
+                    ~"success" := 1,
+                    ~"failed" := 0
+                }
+            }},
+            get_action_metrics_api(TCConfig)
+        )
+    ),
+    ?retry(
+        500,
+        10,
+        ?assertMatch(
+            {200, #{
+                ~"status" := ~"connected"
+            }},
+            get_action_api(TCConfig)
+        )
+    ),
+    ok.
+
+-doc """
+When the schema used by an already-running channel changes, it needs to get the new
+descriptor proto and re-open the stream.
+
+This covers errors such as message type not found, bad serde type, ...
+""".
+t_proto_schema_changed_while_running_errors() ->
+    [{matrix, true}, {mock_only, true}].
+t_proto_schema_changed_while_running_errors(matrix) ->
+    [[?grpc, ?proto, ?async, ?batching]];
+t_proto_schema_changed_while_running_errors(TCConfig) when is_list(TCConfig) ->
+    PoolSize = 2,
+    {201, _} = create_connector_api(TCConfig, #{
+        ~"transport" => #{~"pool_size" => PoolSize}
+    }),
+    {201, _} = create_action_api(TCConfig, #{}),
+
+    ct:pal("updating schema: message type is gone"),
+    {_, {ok, _}} =
+        ?wait_async_action(
+            update_serde(TCConfig, #{
+                ~"type" => ~"protobuf",
+                ~"source" =>
+                    ~"""
+                        syntax = "proto2";
+
+                        package air_quality;
+
+                        message new_message_type {
+                                optional string new_field = 1;
+                        }
+                    """
+            }),
+            #{?snk_kind := "zerobus_get_serde_error"},
+            5_000
+        ),
+    ExpectedReason1 = iolist_to_binary(
+        io_lib:format("~p", [
+            {unhealthy_target, ~"Message type not found in protobuf schema/bundle"}
+        ])
+    ),
+    ?retry(
+        500,
+        10,
+        ?assertMatch(
+            {200, #{
+                ~"status" := ~"disconnected",
+                ~"status_reason" := ExpectedReason1
+            }},
+            get_action_api(TCConfig)
+        )
+    ),
+
+    ct:pal("updating schema: serde type is wrong"),
+    {_, {ok, _}} =
+        ?wait_async_action(
+            update_serde(TCConfig, #{
+                ~"type" => ~"json",
+                ~"source" => ~"{}"
+            }),
+            #{?snk_kind := "zerobus_get_serde_error"},
+            5_000
+        ),
+    ExpectedReason2 = iolist_to_binary(
+        io_lib:format("~p", [{unhealthy_target, ~"Invalid schema type; must be protobuf"}])
+    ),
+    ?retry(
+        500,
+        10,
+        ?assertMatch(
+            {200, #{
+                ~"status" := ~"disconnected",
+                ~"status_reason" := ExpectedReason2
+            }},
+            get_action_api(TCConfig)
+        )
+    ),
+
+    ok.
 
 %% todo
 %%  - stale responses

--- a/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_SUITE.erl
+++ b/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_SUITE.erl
@@ -2906,3 +2906,23 @@ t_follow_stream_before_processing_ack(TCConfig) when is_list(TCConfig) ->
             1_000
         ),
     ok.
+
+t_connection_down_when_creating() ->
+    [{matrix, true}, {mock_only, true}].
+t_connection_down_when_creating(matrix) ->
+    [
+        [Transport, ?json, ?async, ?not_batching]
+     || Transport <- [?grpc, ?rest]
+    ];
+t_connection_down_when_creating(TCConfig) when is_list(TCConfig) ->
+    WrongZerobusEndpoint = ~"https://127.0.0.2:888",
+    ?assertMatch(
+        {201, #{
+            ~"status" := ~"disconnected",
+            ~"status_reason" := ~"Connection refused"
+        }},
+        create_connector_api(TCConfig, #{
+            ~"zerobus_endpoint" => WrongZerobusEndpoint
+        })
+    ),
+    ok.

--- a/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_SUITE.erl
+++ b/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_SUITE.erl
@@ -14,6 +14,22 @@
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("grpc/include/grpc.hrl").
 
+-moduledoc """
+To run against a real databricks zerobus instance:
+
+  1) Copy `.ci/docker-compose-file/databricks/zerobus.hocon.example` elsewhere and fill in
+     the values.
+  2) Run the sql container with:
+     ```
+     docker compose -f .ci/docker-compose-file/docker-compose-databricks.yaml up
+     ```
+  3) Set the hocon path and run this test suite.
+     ```
+     export REAL_ZEROBUS_HOCON=/emqx/zerobus.hocon
+     mix ct --suites ...
+     ```
+""".
+
 %%------------------------------------------------------------------------------
 %% Defs
 %%------------------------------------------------------------------------------
@@ -55,26 +71,36 @@ groups() ->
     emqx_common_test_helpers:groups_with_matrix(?MODULE).
 
 init_per_suite(TCConfig) ->
-    {Mock, ConnConfig, ActionConfig} =
+    {Mock, ConnConfig, ActionConfig, ExtraRealConfig} =
         case os:getenv("REAL_ZEROBUS_HOCON", "") of
             "" ->
                 {
                     _Mock = true,
-                    _ConnConfig = undefined,
-                    _ActionConfig = undefined
+                    _ConnConfig = not_mocked,
+                    _ActionConfig = not_mocked,
+                    _ExtraRealConfig = not_mocked
                 };
             HoconPath ->
                 case hocon:files([HoconPath]) of
                     {error, Reason} ->
                         error({failed_to_load_real_zerobus_hocon, HoconPath, Reason});
                     {ok, #{
+                        ~"zerobus_sql_warehouse_hostname" := Hostname,
+                        ~"zerobus_sql_warehouse_http_path" := HTTPPath,
+                        ~"zerobus_sql_warehouse_access_token" := Token,
                         ~"connectors" := #{?CONNECTOR_TYPE_BIN := #{~"test" := ConnConfig0}},
                         ~"actions" := #{?ACTION_TYPE_BIN := #{~"test" := ActionConfig0}}
                     }} ->
+                        ExtraRealConfig0 = #{
+                            hostname => Hostname,
+                            http_path => HTTPPath,
+                            token => Token
+                        },
                         {
                             _Mock = false,
                             ConnConfig0,
-                            ActionConfig0
+                            ActionConfig0,
+                            ExtraRealConfig0
                         };
                     {ok, Conf} ->
                         error({invalid_real_zerobus_hocon, HoconPath, Conf})
@@ -102,7 +128,8 @@ init_per_suite(TCConfig) ->
         {apps, Apps},
         {?mock, Mock},
         {real_connector_config, ConnConfig},
-        {real_action_config, ActionConfig}
+        {real_action_config, ActionConfig},
+        {extra_real_config, ExtraRealConfig}
         | TCConfig
     ].
 
@@ -157,6 +184,7 @@ pre_init_per_testcase(TestCase, TCConfig0) when is_list(TCConfig0) ->
                     ]
             end;
         false ->
+            truncate_real_table(TCConfig0),
             TCConfig0
     end.
 
@@ -223,8 +251,9 @@ do_init_per_testcase(TestCase, TCConfig) ->
     ok = create_serde(TCConfig1),
     TCConfig1.
 
-end_per_testcase(_TestCase, _TCConfig) ->
+end_per_testcase(_TestCase, TCConfig) ->
     snabbkaffe:stop(),
+    truncate_real_table(TCConfig),
     emqx_bridge_v2_testlib:delete_all_rules(),
     emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
     emqx_common_test_helpers:call_janitor(),
@@ -240,7 +269,7 @@ now_ns() ->
 skip_invalid(TestCase, TCConfig) ->
     IsMockOnly = get_tc_prop(TestCase, ?mock_only, false),
     IsRealOnly = get_tc_prop(TestCase, ?real_only, false),
-    IsMock = get_config(?mock, TCConfig),
+    IsMock = is_mock(TCConfig),
     case 1 of
         _ when IsMock andalso IsRealOnly ->
             {skip, "test only run with real zerobus"};
@@ -249,6 +278,9 @@ skip_invalid(TestCase, TCConfig) ->
         _ ->
             ok
     end.
+
+is_mock(TCConfig) ->
+    get_config(?mock, TCConfig).
 
 maybe_with_forced_sync_query_mode(TCConfig, Fn) ->
     case query_mode(TCConfig) of
@@ -678,9 +710,63 @@ read_table(#{mock := true} = TCConfig) ->
         end,
         ets:tab2list(Tab)
     );
-read_table(#{mock := false}) ->
-    %% todo: will require a test container that can read the table.
-    ct:fail(unimplemented).
+read_table(#{mock := false} = TCConfig) ->
+    SQL = fmt(~"select * from ${fqn}", #{fqn => real_table_fqn(TCConfig)}),
+    run_real_sql(TCConfig, #{sql => SQL}).
+
+truncate_real_table(TCConfig) when is_list(TCConfig) ->
+    truncate_real_table(maps:from_list(TCConfig));
+truncate_real_table(#{mock := true}) ->
+    ok;
+truncate_real_table(#{mock := false} = TCConfig) ->
+    SQL = fmt(~"truncate table ${fqn}", #{fqn => real_table_fqn(TCConfig)}),
+    run_real_sql(TCConfig, #{sql => SQL}).
+
+real_table_fqn(TCConfig) when is_list(TCConfig) ->
+    real_table_fqn(maps:from_list(TCConfig));
+real_table_fqn(#{mock := true}) ->
+    error(mocked);
+real_table_fqn(#{mock := false} = TCConfig) ->
+    #{
+        real_action_config := #{
+            ~"parameters" := #{
+                ~"catalog" := Catalog,
+                ~"schema" := Schema,
+                ~"table" := Table
+            }
+        }
+    } = TCConfig,
+    fmt(~"${c}.${s}.${t}", #{c => Catalog, s => Schema, t => Table}).
+
+run_real_sql(TCConfig, Opts) when is_list(TCConfig) ->
+    run_real_sql(maps:from_list(TCConfig), Opts);
+run_real_sql(#{mock := true}, _Opts) ->
+    error(mocked);
+run_real_sql(#{mock := false} = TCConfig, Opts) ->
+    #{sql := SQL} = Opts,
+    #{
+        extra_real_config := #{
+            hostname := Hostname,
+            http_path := HTTPPath,
+            token := Token
+        }
+    } = TCConfig,
+    Body = emqx_utils_json:encode(#{
+        hostname => Hostname,
+        path => HTTPPath,
+        token => Token,
+        sql => SQL
+    }),
+    maybe
+        {ok, {{_, 200, _}, _, RespBody}} ?=
+            httpc:request(
+                post,
+                {"http://databricks_sql:8000/sql", [], "application/json", Body},
+                [],
+                []
+            ),
+        emqx_utils_json:decode(RespBody)
+    end.
 
 simple_create_rule_api(TCConfig) ->
     simple_create_rule_api(default_sql(), TCConfig).
@@ -1414,7 +1500,8 @@ t_bad_json_data(TCConfig) when is_list(TCConfig) ->
         "Record decoder/encoder error: invalid digit found in string at"
         " line 1 column 19. Error Code: 4044, Error State: 3."
     >>,
-    case transport_of(TCConfig) of
+    IsMock = is_mock(TCConfig),
+    case IsMock andalso transport_of(TCConfig) of
         ?rest ->
             set_mocked_rest_response(
                 400,
@@ -1428,7 +1515,9 @@ t_bad_json_data(TCConfig) when is_list(TCConfig) ->
                 St#{
                     ingest_record_batch => [{shutdown, ?GRPC_STATUS_INVALID_ARGUMENT, ErrorMsg}]
                 }
-            end)
+            end);
+        _ ->
+            ok
     end,
     %% missing all fields, unknown field
     emqtt:publish(C, RuleTopic, ~|{"a": 1}|, [{qos, 1}]),
@@ -1488,7 +1577,7 @@ Makes a sync call that will timeout.  Even though it's recoverable, the timeout 
 request TTL, so in practice the request will expire.
 """.
 t_grpc_sync_ingest_timeout() ->
-    [{matrix, true}].
+    [{matrix, true}, {mock_only, true}].
 t_grpc_sync_ingest_timeout(matrix) ->
     [[?grpc, ?proto, ?sync, ?not_batching]];
 t_grpc_sync_ingest_timeout(TCConfig) when is_list(TCConfig) ->

--- a/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_SUITE.erl
+++ b/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_SUITE.erl
@@ -559,6 +559,7 @@ spy_create_stream(TCConfig) ->
         ct:pal("msg: ~p;\n  req: ~p", [Msg, Req]),
         #{payload := {create_stream = Type, Req1}} = Msg,
         ets:insert(Tab, {now_ns(), #{type => Type, req => Req1, meta => Meta}}),
+        ct:pal("grpc server ~p acking create stream", [self()]),
         grpc_stream:reply(Req, [#{payload => {create_stream_response, #{}}}]),
         continue
     end.
@@ -568,6 +569,7 @@ spy_ingest_record_batch(TCConfig) ->
     fun(Msg, Req, Meta) ->
         #{payload := {ingest_record_batch = Type, #{offset_id := Id} = Req1}} = Msg,
         ets:insert(Tab, {now_ns(), #{type => Type, req => Req1, meta => Meta}}),
+        ct:pal("grpc server ~p acking seq ~p", [self(), Id]),
         grpc_stream:reply(Req, [
             #{
                 payload =>
@@ -958,6 +960,12 @@ server_shutdown_action() ->
     {shutdown, ?GRPC_STATUS_UNAVAILABLE, <<
         "Stream timeout reached. Closing the stream (ID: ...)."
         " Error Code: 6002, Error State: 0."
+    >>}.
+
+invalid_argument_action() ->
+    {shutdown, ?GRPC_STATUS_INVALID_ARGUMENT, <<
+        "Record decoder/encoder error: invalid digit found in string at"
+        " line 1 column 19. Error Code: 4044, Error State: 3."
     >>}.
 
 %%------------------------------------------------------------------------------
@@ -2754,6 +2762,147 @@ t_proto_schema_changed_while_running_errors(TCConfig) when is_list(TCConfig) ->
 
     ok.
 
-%% todo
-%%  - stale responses
-%%  - connection refused when creating
+-doc """
+Covers the following race:
+
+  1) A message is published.
+  2) Concurrently:
+     i) Receiver receives an ack from the server and casts it to the writer.
+     ii) Writer decides to open a new stream, before handling the above ack.
+
+Since the writer syncs its state with the receiver when opening a new stream, it should
+get the ack from the receiver as the response of the call (not the cast), and then ignore
+the stale cast.
+""".
+t_follow_stream_before_processing_ack() ->
+    [{matrix, true}, {mock_only, true}].
+t_follow_stream_before_processing_ack(matrix) ->
+    [[?grpc, ?proto, ?async, ?not_batching]];
+t_follow_stream_before_processing_ack(TCConfig) when is_list(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{
+        ~"transport" => #{~"pool_size" => 1}
+    }),
+    {201, _} = create_action_api(TCConfig, #{}),
+    #{topic := RuleTopic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+
+    TestPid = self(),
+    mocked_grpc_server_agent_update(fun(St) ->
+        St#{
+            ingest_record_batch => [
+                {ask, TestPid},
+                %% fail the 2nd message
+                invalid_argument_action()
+            ]
+        }
+    end),
+    ct:pal("sending 1st message"),
+    {_, {ok, _}} =
+        ?wait_async_action(
+            emqtt:publish(C, RuleTopic, seq_payload(1), [{qos, 1}]),
+            #{?snk_kind := "zerobus_sent_batch"},
+            5_000
+        ),
+    %% will hold onto this to reply later
+    {ingest_record_batch, AliasServer0, Ctx0} = ?assertReceive({ingest_record_batch, _, _}),
+    {ok, Agent} = emqx_utils_agent:start_link(ask_then_error),
+    emqx_common_test_helpers:with_mock(
+        grpc_client,
+        send,
+        fun
+            (Stream, #{payload := {ingest_record_batch, _}} = Req, Fin, Opts) ->
+                case emqx_utils_agent:get(Agent) of
+                    ask_then_error ->
+                        Alias = alias([reply]),
+                        TestPid ! {will_ingest, Alias, Req},
+                        receive
+                            {Alias, Reason} ->
+                                {error, Reason}
+                        end;
+                    continue ->
+                        meck:passthrough([Stream, Req, Fin, Opts])
+                end;
+            (Stream, Req, Fin, Opts) ->
+                meck:passthrough([Stream, Req, Fin, Opts])
+        end,
+        fun() ->
+            %% second message triggers the reopen; writer will be processing
+            %% `grpc_client:send` when the ack(1) arrives; but it will then proceed
+            %% with `continue` to reopen the stream.
+            ct:pal("sending 2nd message"),
+            emqtt:publish(C, RuleTopic, seq_payload(2), [{qos, 1}]),
+            {will_ingest, AliasWriter0, _} = ?assertReceive({will_ingest, _, _}),
+            %% now the writer is stuck; let's make the server reply an ack to get
+            %% enqueued.
+            #{
+                msg := #{payload := {ingest_record_batch, #{offset_id := 0 = Seq0}}},
+                grpc_req := GRPCReq0
+            } = Ctx0,
+            ct:pal("replying ack"),
+            {_, {ok, _}} =
+                ?wait_async_action(
+                    grpc_stream:reply(GRPCReq0, [
+                        #{
+                            payload =>
+                                {ingest_record_response, #{
+                                    durability_ack_up_to_offset => Seq0
+                                }}
+                        }
+                    ]),
+                    #{?snk_kind := "zerobus_last_seq_notified"},
+                    5_000
+                ),
+            AliasServer0 ! {AliasServer0, continue},
+            %% unblock the writer and make it reopen the stream
+            ct:pal("unblocking writer with error"),
+            emqx_utils_agent:set(Agent, continue),
+            AliasWriter0 ! {AliasWriter0, econnrefused},
+            %% first message should succeed, since we got the ack before opening the
+            %% new stream.
+            ?retry(
+                700,
+                10,
+                ?assertMatch(
+                    {200, #{
+                        ~"metrics" := #{
+                            ~"matched" := 2,
+                            ~"success" := 1,
+                            ~"failed" := 1
+                        }
+                    }},
+                    get_action_metrics_api(TCConfig)
+                )
+            ),
+
+            ok
+        end
+    ),
+    %% for coverage: writer ignores stale acks and errors.
+    %% is there a natural way to cause this?  seems impossible so far...
+    {_, {ok, _}} =
+        ?wait_async_action(
+            lists:foreach(
+                fun(Writer) ->
+                    emqx_bridge_zerobus_stream_writer_worker:acked(
+                        Writer, _NRestarts = 0, _LastAckedSeq = 100
+                    )
+                end,
+                find_stream_writers(TCConfig)
+            ),
+            #{?snk_kind := "zerobus_writer_stale_ack"},
+            1_000
+        ),
+    {_, {ok, _}} =
+        ?wait_async_action(
+            lists:foreach(
+                fun(Writer) ->
+                    emqx_bridge_zerobus_stream_writer_worker:errored(
+                        Writer, _NRestarts = 0, some_error
+                    )
+                end,
+                find_stream_writers(TCConfig)
+            ),
+            #{?snk_kind := "zerobus_writer_stale_error"},
+            1_000
+        ),
+    ok.

--- a/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_test_grpc_server.erl
+++ b/apps/emqx_bridge_zerobus/test/emqx_bridge_zerobus_test_grpc_server.erl
@@ -138,6 +138,7 @@ handle_batch_done_action(Action, Meta, Req0) ->
 
 default_action(create_stream) ->
     Fn = fun(_Msg, Req, _Meta) ->
+        ct:pal("grpc server ~p acking create stream", [self()]),
         grpc_stream:reply(Req, [#{payload => {create_stream_response, #{}}}]),
         continue
     end,
@@ -145,6 +146,7 @@ default_action(create_stream) ->
 default_action(ingest_record_batch) ->
     Fn = fun(Msg, Req, _Meta) ->
         #{payload := {ingest_record_batch, #{offset_id := Id}}} = Msg,
+        ct:pal("grpc server ~p acking seq ~p", [self(), Id]),
         grpc_stream:reply(Req, [
             #{
                 payload =>

--- a/apps/emqx_schema_registry/src/emqx_schema_registry_config.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_config.erl
@@ -23,6 +23,9 @@
 %% Internal exports for application
 -export([protobuf_bundle_data_dir/1]).
 
+%% Hooks
+-export([serde_updated_hook/1]).
+
 %% `emqx_config_handler' API
 -export([pre_config_update/3, post_config_update/5]).
 
@@ -173,6 +176,9 @@ post_config_update(
     end,
     case emqx_schema_registry:build_serdes([{NewName, NewSchema}]) of
         ok ->
+            %% run hook in worker pool to avoid blocking config update for long.
+            Ctx = #{name => NewName},
+            emqx_pool:async_submit(fun ?MODULE:serde_updated_hook/1, [Ctx]),
             {ok, #{NewName => NewSchema}};
         {error, Reason, SerdesToRollback} ->
             lists:foreach(fun emqx_schema_registry:ensure_serde_absent/1, SerdesToRollback),
@@ -240,6 +246,13 @@ prepare_protobuf_files_for_export(
     RawConf0#{<<"schema_registry">> := SR0#{<<"schemas">> := Schemas}};
 prepare_protobuf_files_for_export(RawConf) ->
     RawConf.
+
+%%------------------------------------------------------------------------------
+%% Hooks
+%%------------------------------------------------------------------------------
+
+serde_updated_hook(Ctx) ->
+    emqx_hooks:run('schema_registry.serde_updated', [Ctx]).
 
 %%------------------------------------------------------------------------------
 %% Internal fns


### PR DESCRIPTION
Release version:
7.0.0

## Summary

- update test suite to actually run against real zerobus.
- notify stream writers when protobuf schema changes, so they may reopen their streams if needed.
- set gun connect retries to 0 so we may capture connection errors before calls time out.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
