### PR TITLE
feat(mgmt): add POST /certs/pem_cache_clean HTTP API

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_certs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_certs.erl
@@ -29,7 +29,8 @@
     '/certs/global/list'/2,
     '/certs/global/name/:name'/2,
     '/certs/ns/:namespace/list'/2,
-    '/certs/ns/:namespace/name/:name'/2
+    '/certs/ns/:namespace/name/:name'/2,
+    '/certs/pem_cache_clean'/2
 ]).
 -export([ns_bundle_filter/2]).
 
@@ -57,7 +58,8 @@ paths() ->
         "/certs/global/list",
         "/certs/global/name/:name",
         "/certs/ns/:namespace/list",
-        "/certs/ns/:namespace/name/:name"
+        "/certs/ns/:namespace/name/:name",
+        "/certs/pem_cache_clean"
     ].
 
 schema("/certs/global/list") ->
@@ -180,6 +182,19 @@ schema("/certs/ns/:namespace/name/:name") ->
                 #{
                     204 => <<"">>,
                     400 => bad_request(?DESC("bad_request")),
+                    500 => internal_error(?DESC("internal_error"))
+                }
+        }
+    };
+schema("/certs/pem_cache_clean") ->
+    #{
+        'operationId' => '/certs/pem_cache_clean',
+        post => #{
+            tags => ?TAGS,
+            description => ?DESC("pem_cache_clean"),
+            responses =>
+                #{
+                    204 => <<"">>,
                     500 => internal_error(?DESC("internal_error"))
                 }
         }
@@ -320,6 +335,19 @@ internal_error(Desc) -> emqx_dashboard_swagger:error_codes([?INTERNAL_ERROR], De
             handle_delete_file(Namespace, BundleName, Kind);
         _ ->
             handle_delete_bundle(Namespace, BundleName)
+    end.
+
+'/certs/pem_cache_clean'(post, _Req) ->
+    case emqx_mgmt:clean_pem_cache_all() of
+        ok ->
+            ?NO_CONTENT;
+        {error, BadNodes} ->
+            Msg = ?ERROR_MSG(?INTERNAL_ERROR, <<"Failed to clean PEM cache on some nodes">>),
+            NodeErrors = [
+                #{node => Node, reason => emqx_utils:readable_error_msg(Reason)}
+             || {Node, Reason} <- BadNodes
+            ],
+            {500, Msg#{node_errors => NodeErrors}}
     end.
 
 %%-------------------------------------------------------------------------------------------------

--- a/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
@@ -317,6 +317,39 @@ upload_files_multipart_ns(Ns, BundleName, Files) ->
     }),
     emqx_mgmt_api_test_util:simplify_decode_result(Res).
 
+clean_pem_cache_api() ->
+    URL = emqx_mgmt_api_test_util:api_path(["certs", "pem_cache_clean"]),
+    simple_request(#{
+        method => post,
+        url => URL
+    }).
+
+ssl_listener_port() ->
+    case emqx_config:get([listeners, ssl, default, bind]) of
+        Port when is_integer(Port) -> Port;
+        {_Addr, Port} -> Port
+    end.
+
+populate_pem_cache() ->
+    %% A TLS handshake against the local default SSL listener makes `ssl` read the
+    %% listener certificate files through `ssl_pem_cache`.
+    Port = ssl_listener_port(),
+    {ok, Sock} = ssl:connect(
+        "127.0.0.1", Port, [{verify, verify_none}, {active, false}], 5_000
+    ),
+    ok = ssl:close(Sock),
+    %% `ssl_pem_cache` inserts entries with async casts; a synchronous call flushes
+    %% its queue so all entries from the handshake are in the table before the test
+    %% proceeds.
+    _ = sys:get_state(ssl_pem_cache),
+    ok.
+
+ssl_listener_certfile() ->
+    %% `ssl_pem_cache` keys entries by the resolved path the listener passes to
+    %% `ssl`; the checked config may still hold `${EMQX_ETC_DIR}`.
+    Raw = emqx_config:get([listeners, ssl, default, ssl_options, certfile]),
+    emqx_utils_conv:bin(emqx_schema:naive_env_interpolation(Raw)).
+
 gen_cert(Opts) ->
     #{
         cert := Cert,
@@ -1454,4 +1487,81 @@ t_prometheus_stats_dangling_managed_certs(_TCConfig) ->
         Expiry
     ),
 
+    ok.
+
+-doc """
+Verifies that `POST /certs/pem_cache_clean` returns 204 and evicts cached PEM
+files from the OTP `ssl_pem_cache` table on every node in the cluster, after the
+cache has been populated by real TLS handshakes.
+
+The assertion targets the listener certificate file entry rather than an empty
+table: clearing also refreshes the trusted CA database, which re-inserts CA
+files still referenced by live TLS connections.
+""".
+t_pem_cache_clean() ->
+    [{matrix, true}].
+t_pem_cache_clean(matrix) ->
+    [[?local], [?cluster]];
+t_pem_cache_clean(TCConfig) when is_list(TCConfig) ->
+    Nodes = get_config(nodes, TCConfig),
+    CertFiles = lists:map(
+        fun(Node) ->
+            CertFile = ?ON(Node, begin
+                populate_pem_cache(),
+                CF = ssl_listener_certfile(),
+                ?assertMatch([{CF, _}], ets:lookup(ssl_pem_cache, CF)),
+                CF
+            end),
+            {Node, CertFile}
+        end,
+        Nodes
+    ),
+    ?assertMatch({204, _}, clean_pem_cache_api()),
+    lists:foreach(
+        fun({Node, CertFile}) ->
+            ?assertEqual([], ?ON(Node, ets:lookup(ssl_pem_cache, CertFile)), #{node => Node})
+        end,
+        CertFiles
+    ),
+    ok.
+
+-doc """
+Verifies that an unauthenticated `POST /certs/pem_cache_clean` call is rejected.
+""".
+t_pem_cache_clean_unauthenticated() ->
+    [{matrix, true}].
+t_pem_cache_clean_unauthenticated(matrix) ->
+    [[?local]];
+t_pem_cache_clean_unauthenticated(_TCConfig) ->
+    URL = emqx_mgmt_api_test_util:api_path(["certs", "pem_cache_clean"]),
+    ?assertMatch(
+        {401, _},
+        emqx_mgmt_api_test_util:simple_request(#{
+            method => post,
+            url => URL,
+            auth_header => {"no", "auth"}
+        })
+    ),
+    ok.
+
+-doc """
+Verifies the response shape when cleaning the PEM cache fails on some node: the
+endpoint returns 500 with a per-node failure list.
+""".
+t_pem_cache_clean_bad_node() ->
+    [{matrix, true}].
+t_pem_cache_clean_bad_node(matrix) ->
+    [[?local]];
+t_pem_cache_clean_bad_node(_TCConfig) ->
+    on_exit(fun meck:unload/0),
+    meck:new(emqx, [non_strict, passthrough, no_link]),
+    meck:expect(emqx, running_nodes, 0, [node(), 'fake@nohost']),
+    ?assertMatch(
+        {500, #{
+            <<"code">> := <<"INTERNAL_ERROR">>,
+            <<"message">> := _,
+            <<"node_errors">> := [#{<<"node">> := <<"fake@nohost">>, <<"reason">> := _}]
+        }},
+        clean_pem_cache_api()
+    ),
     ok.

--- a/changes/ee/feat-18493.en.md
+++ b/changes/ee/feat-18493.en.md
@@ -1,0 +1,1 @@
+Added a new HTTP API `POST /certs/pem_cache_clean` to clean the x509 certificate (PEM) cache on all nodes in the cluster. It does the same as the existing CLI command `emqx ctl pem_cache clean all`: cached certificate files are re-read from disk on the next TLS handshake, so certificate file updates take effect without restarting listeners.

--- a/rel/i18n/emqx_mgmt_api_certs.hocon
+++ b/rel/i18n/emqx_mgmt_api_certs.hocon
@@ -49,6 +49,15 @@ emqx_mgmt_api_certs {
         label: "Delete Bundle"
     }
 
+    pem_cache_clean {
+        desc: """~
+            Clean the x509 certificate (PEM) cache on all nodes in the cluster:
+            cached entries are evicted, and certificate files are re-read from disk
+            on the next TLS handshake.
+            Equivalent to the CLI command `emqx ctl pem_cache clean all`.~"""
+        label: "Clean PEM Cache"
+    }
+
     bundle_not_found {
         desc: """~
             Bundle not found.~"""


### PR DESCRIPTION
Release version:
7.0.0

Introduced in:

## Summary

Closes #11110.

Adds `POST /certs/pem_cache_clean`: an HTTP API that cleans the x509 certificate (PEM) cache on all nodes, equivalent to the CLI command `emqx ctl pem_cache clean all`.

The endpoint lives in `emqx_mgmt_api_certs` and calls the existing `emqx_mgmt:clean_pem_cache_all/0` (over the existing `emqx_proto_v1:clean_pem_cache/1` BPAPI); no new RPC plumbing.

Decisions taken:

* Method and path: `POST /certs/pem_cache_clean`, mirroring the CLI subcommand name (`pem_cache clean`) so the two stay discoverable from each other. `POST` (rather than `DELETE` on a cache resource) because the operation is an action, not a plain eviction: clearing also refreshes the trusted CA database, which re-reads CA files still referenced by live TLS connections, and evicted entries are re-read from disk on the next handshake. The path sits under the module's `/certs` prefix but outside the bundle paths (`/certs/global/...`, `/certs/ns/...`), so it does not read as an operation on managed certificate bundles.
* Cluster-wide only. The issue asks for the `clean all` form; a per-node endpoint would be a second path to document and test for little gain, and the per-node form stays available via the CLI. On partial failure the response body lists the failing nodes, so the operator can retry the failed nodes from the CLI.
* Error status is 500 (`INTERNAL_ERROR` with a `node_errors` list), not the 400 the authz cache endpoint returns: a node RPC failure is a server-side error, not a malformed request.
* Scope: the endpoint inherits the module's `system` API-key scope. TLS certificate handling is system configuration (the listeners API is also `system`); the `access_control` scope of the authz analogue covers authn/authz, which the PEM cache is not part of.

The test populates the cache with a real TLS handshake against the default SSL listener and asserts the listener certificate entry is present in the `ssl_pem_cache` table before and gone after the call, on every node (single-node and 2-node cluster matrix).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
