### PR TITLE
fix(coap): report configured heartbeat

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -48,6 +48,8 @@
     session :: emqx_coap_session:session() | undefined,
     %% Keepalive
     keepalive :: emqx_keepalive:keepalive() | undefined,
+    %% Configured heartbeat interval in seconds
+    heartbeat :: non_neg_integer(),
     %% Timer
     timers :: #{atom() => disable | undefined | reference()},
     %% Connection mode
@@ -151,6 +153,7 @@ init(
         timers = #{},
         session = emqx_coap_session:new(),
         keepalive = emqx_keepalive:init(Heartbeat),
+        heartbeat = Heartbeat,
         connection_required = maps:get(connection_required, Config, false),
         conn_state = idle,
         blockwise = emqx_coap_blockwise:new(emqx_coap_blockwise:default_opts(coap))
@@ -360,9 +363,6 @@ handle_call(Req, _From, Channel) ->
 handle_cast(close, Channel) ->
     ?SLOG(info, #{msg => "close_connection"}),
     shutdown(normal, Channel);
-handle_cast(inc_recv_pkt, Channel) ->
-    _ = emqx_pd:inc_counter(recv_pkt, 1),
-    {ok, Channel};
 handle_cast(Req, Channel) ->
     ?SLOG(error, #{msg => "unexpected_cast", cast => Req}),
     {ok, Channel}.
@@ -523,7 +523,7 @@ enrich_connectionless_auth_info(Msg, Channel) ->
 enrich_connectionless_conninfo(
     URIQuery,
     Channel = #channel{
-        keepalive = KeepAlive,
+        heartbeat = Heartbeat,
         conninfo = ConnInfo0,
         clientinfo = ClientInfo
     }
@@ -533,14 +533,12 @@ enrich_connectionless_conninfo(
             undefined -> maps:get(clientid, ClientInfo);
             ReqClientId -> ReqClientId
         end,
-    IntervalMs = emqx_keepalive:info(check_interval, KeepAlive),
-    InternalS = floor(IntervalMs / 1000),
     NConnInfo = ConnInfo0#{
         clientid => ClientId,
         proto_name => <<"CoAP">>,
         proto_ver => <<"1">>,
         clean_start => true,
-        keepalive => InternalS,
+        keepalive => Heartbeat,
         expiry_interval => 0
     },
     Channel#channel{conninfo = NConnInfo}.
@@ -670,17 +668,15 @@ run_conn_hooks(Input, Channel) ->
         _NConnProps -> {ok, Input, Channel}
     end.
 enrich_conninfo({Queries, _Msg}, Channel) ->
-    #channel{keepalive = KeepAlive, conninfo = ConnInfo} = Channel,
+    #channel{heartbeat = Heartbeat, conninfo = ConnInfo} = Channel,
     case Queries of
         #{<<"clientid">> := ClientId} ->
-            IntervalMs = emqx_keepalive:info(check_interval, KeepAlive),
-            InternalS = floor(IntervalMs / 1000),
             NConnInfo = ConnInfo#{
                 clientid => ClientId,
                 proto_name => <<"CoAP">>,
                 proto_ver => <<"1">>,
                 clean_start => true,
-                keepalive => InternalS,
+                keepalive => Heartbeat,
                 expiry_interval => 0
             },
             {ok, Channel#channel{conninfo = NConnInfo}};

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -242,6 +242,9 @@ t_heartbeat(Config) ->
     Action = fun(Channel) ->
         Token = connection(Channel),
 
+        {200, Client} = request(get, "/gateways/coap/clients/client1"),
+        ?assertEqual(1, maps:get(keepalive, Client)),
+
         timer:sleep(100),
         ?assertNotEqual(
             [],
@@ -1790,7 +1793,7 @@ t_clients_api(_) ->
         %% assert
         Client1 = Client2 = Client3 = Client4,
         %% assert keepalive
-        ?assertEqual(15, maps:get(keepalive, Client4)),
+        ?assertEqual(30, maps:get(keepalive, Client4)),
         %% kickout
         {204, _} =
             request(delete, "/gateways/coap/clients/client1"),

--- a/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_channel_SUITE.erl
@@ -72,7 +72,6 @@ t_channel_direct(_) ->
     {shutdown, timeout, _} = emqx_coap_channel:handle_timeout(
         foo, {keepalive, KeepAlive#keepalive.statval}, Channel0#channel{keepalive = KeepAlive}
     ),
-    {ok, _} = emqx_coap_channel:handle_cast(inc_recv_pkt, Channel0),
     {ok, _} = emqx_coap_channel:handle_cast(unexpected_cast, Channel0),
     {shutdown, normal, _} = emqx_coap_channel:handle_cast(close, Channel0),
     {ok, _} = emqx_coap_channel:handle_info({subscribe, []}, Channel0),

--- a/apps/emqx_gateway_coap/test/emqx_coap_test.hrl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_test.hrl
@@ -8,6 +8,7 @@
     clientinfo,
     session,
     keepalive,
+    heartbeat,
     timers,
     connection_required,
     conn_state,

--- a/changes/ee/fix-18494.en.md
+++ b/changes/ee/fix-18494.en.md
@@ -1,0 +1,3 @@
+Fixed CoAP gateway clients reporting the internal keepalive check interval instead of the configured heartbeat interval.
+
+The client information returned by the gateway API and `emqx ctl gateway-clients list coap` now reports the configured heartbeat value in seconds.


### PR DESCRIPTION
Release version: 6.3.0
Introduced in: 5.8.1-bg

## Summary

Fixes CoAP client heartbeat reporting by preserving the configured heartbeat interval and returning it in `conninfo.keepalive`. The internal keepalive check interval is no longer exposed as the client heartbeat value.

Also removes the obsolete `inc_recv_pkt` channel cast handler left behind after CoAP moved to the content-sensitive UDP proxy. Incoming packet statistics are already updated by the owning gateway connection.

Fixes #10093

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added
- [x] Schema changes are backward compatible or intentionally breaking (no schema change)