### PR TITLE
test(pgsql): accept async_return results in t_write_failure check

### DIFF
--- a/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
+++ b/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
@@ -478,15 +478,15 @@ t_write_failure(TCConfig) when is_list(TCConfig) ->
             Trace = ?of_kind(
                 [buffer_worker_flush_nack, buffer_worker_retry_inflight_failed], Trace0
             ),
-            ?assertMatch([#{result := {error, _}} | _], Trace),
-            [#{result := {error, Error}} | _] = Trace,
-            case Error of
-                {resource_error, _} ->
+            %% Async workers wrap the result in async_return.
+            [#{result := Result} | _] = Trace,
+            case Result of
+                {error, _} ->
                     ok;
-                {recoverable_error, disconnected} ->
+                {async_return, {error, _}} ->
                     ok;
                 _ ->
-                    ct:fail("unexpected error: ~p", [Error])
+                    ct:fail("unexpected result: ~p", [Result])
             end
         end
     ),


### PR DESCRIPTION
## Summary

Follow-up to #18461. That fix widened the waited event set with `buffer_worker_retry_inflight_failed` but kept the strict `[#{result := {error, _}} | _]` trace assertion. Async buffer workers wrap results as `{async_return, {error, _}}`, so the async matrix variants can now fail the check stage:

```
%%% emqx_bridge_pgsql_SUITE ==> tcp.async.without_batch.t_write_failure: FAILED
{{panic,#{msg => "Unexpected result",result => {error,check_stage_failed}}}, ...}
```

Seen in: https://github.com/emqx/emqx/actions/runs/32935939205/job/98079522676?pr=18496 (dev-70, where #18461 has already synced)

Accept both plain and `async_return`-wrapped error results. A successful write still fails the check. Base `dev-61`, same as #18461, so it follows the same sync path to 62, 63, 70.