### PR TITLE
feat(sys): add peername to client connected/disconnected messages

### DIFF
--- a/apps/emqx/src/emqx_sys.erl
+++ b/apps/emqx/src/emqx_sys.erl
@@ -375,7 +375,7 @@ maybe_set_retained_expiry(Msg) ->
     end.
 
 common_infos(
-    _ClientInfo = #{
+    ClientInfo = #{
         clientid := ClientId,
         username := Username,
         peerhost := PeerHost,
@@ -392,6 +392,7 @@ common_infos(
         clientid => ClientId,
         username => Username,
         ipaddress => ntoa(PeerHost),
+        peername => ntoa(maps:get(peername, ClientInfo, undefined)),
         sockport => SockPort,
         protocol => Protocol,
         proto_name => ProtoName,

--- a/apps/emqx/test/emqx_sys_SUITE.erl
+++ b/apps/emqx/test/emqx_sys_SUITE.erl
@@ -8,15 +8,118 @@
 -compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/emqx.hrl").
+
+-define(CONNECTED_TOPIC, <<"$SYS/brokers/+/clients/+/connected">>).
+-define(DISCONNECTED_TOPIC, <<"$SYS/brokers/+/clients/+/disconnected">>).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    application:load(emqx),
-    ok = emqx_logger:set_log_level(emergency),
+    Apps = emqx_cth_suite:start([emqx], #{work_dir => emqx_cth_suite:work_dir(Config)}),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(apps, Config)).
+
+init_per_testcase(_TestCase, Config) ->
     Config.
 
-end_per_suite(_Config) ->
-    application:unload(emqx),
-    ok = emqx_logger:set_log_level(error),
+end_per_testcase(_TestCase, _Config) ->
+    ok = emqx_broker:unsubscribe(?CONNECTED_TOPIC),
+    ok = emqx_broker:unsubscribe(?DISCONNECTED_TOPIC),
     ok.
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+-doc "The connected system message carries `peername` with the client's source IP and port.".
+t_connected_message_peername(_Config) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    ok = emqx_broker:subscribe(?CONNECTED_TOPIC),
+    {ok, Client} = emqtt:start_link([{clientid, ClientId}]),
+    {ok, _} = emqtt:connect(Client),
+    Peername = channel_peername(ClientId),
+    Payload = receive_sys_payload(<<"connected">>),
+    ?assertEqual(peername_bin(Peername), maps:get(<<"peername">>, Payload)),
+    ok = emqtt:disconnect(Client).
+
+-doc "The disconnected system message carries `peername` with the client's source IP and port.".
+t_disconnected_message_peername(_Config) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    ok = emqx_broker:subscribe(?DISCONNECTED_TOPIC),
+    {ok, Client} = emqtt:start_link([{clientid, ClientId}]),
+    {ok, _} = emqtt:connect(Client),
+    Peername = channel_peername(ClientId),
+    ok = emqtt:disconnect(Client),
+    Payload = receive_sys_payload(<<"disconnected">>),
+    ?assertEqual(peername_bin(Peername), maps:get(<<"peername">>, Payload)).
+
+-doc """
+The `ipaddress` field stays a bare IP address without a port
+in both the connected and the disconnected system messages.
+""".
+t_ipaddress_has_no_port(_Config) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    ok = emqx_broker:subscribe(?CONNECTED_TOPIC),
+    ok = emqx_broker:subscribe(?DISCONNECTED_TOPIC),
+    {ok, Client} = emqtt:start_link([{clientid, ClientId}]),
+    {ok, _} = emqtt:connect(Client),
+    ok = emqtt:disconnect(Client),
+    ConnectedPayload = receive_sys_payload(<<"connected">>),
+    DisconnectedPayload = receive_sys_payload(<<"disconnected">>),
+    ?assertEqual(<<"127.0.0.1">>, maps:get(<<"ipaddress">>, ConnectedPayload)),
+    ?assertEqual(<<"127.0.0.1">>, maps:get(<<"ipaddress">>, DisconnectedPayload)).
+
+-doc """
+A client info without the `peername` key does not crash the hook;
+the message is published with `peername` set to `undefined`.
+""".
+t_absent_peername_no_crash(_Config) ->
+    ok = emqx_broker:subscribe(?CONNECTED_TOPIC),
+    ok = emqx_broker:subscribe(?DISCONNECTED_TOPIC),
+    ClientInfo = #{
+        clientid => <<"no-peername">>,
+        username => <<"u">>,
+        peerhost => {127, 0, 0, 1},
+        sockport => 1883,
+        protocol => mqtt
+    },
+    ConnInfo = #{
+        proto_name => <<"MQTT">>,
+        proto_ver => 5,
+        connected_at => erlang:system_time(millisecond),
+        disconnected_at => erlang:system_time(millisecond)
+    },
+    _ = emqx_sys:on_client_connected(ClientInfo, ConnInfo),
+    ConnectedPayload = receive_sys_payload(<<"connected">>),
+    ?assertEqual(<<"undefined">>, maps:get(<<"peername">>, ConnectedPayload)),
+    _ = emqx_sys:on_client_disconnected(ClientInfo, normal, ConnInfo),
+    DisconnectedPayload = receive_sys_payload(<<"disconnected">>),
+    ?assertEqual(<<"undefined">>, maps:get(<<"peername">>, DisconnectedPayload)).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+channel_peername(ClientId) ->
+    [ChanPid] = emqx_cm:lookup_channels(ClientId),
+    #{conninfo := #{peername := Peername}} = emqx_cm:get_chan_info(ClientId, ChanPid),
+    Peername.
+
+peername_bin({IpAddr, Port}) ->
+    iolist_to_binary([inet:ntoa(IpAddr), ":", integer_to_list(Port)]).
+
+receive_sys_payload(Event) ->
+    Suffix = <<"/", Event/binary>>,
+    receive
+        {deliver, _Sub, #message{topic = Topic, payload = Payload}} ->
+            case binary:longest_common_suffix([Topic, Suffix]) =:= byte_size(Suffix) of
+                true -> emqx_utils_json:decode(Payload);
+                false -> receive_sys_payload(Event)
+            end
+    after 5000 ->
+        ct:fail({timeout_waiting_for_sys_message, Event})
+    end.

--- a/apps/emqx/test/emqx_sys_SUITE.erl
+++ b/apps/emqx/test/emqx_sys_SUITE.erl
@@ -35,43 +35,72 @@ end_per_testcase(_TestCase, _Config) ->
 %% Test cases
 %%--------------------------------------------------------------------
 
--doc "The connected system message carries `peername` with the client's source IP and port.".
-t_connected_message_peername(_Config) ->
+-doc """
+The connected system message payload has the expected shape:
+`peername` carries the client's source IP and port, `ipaddress` stays a bare IP.
+""".
+t_connected_message(_Config) ->
     ClientId = atom_to_binary(?FUNCTION_NAME),
     ok = emqx_broker:subscribe(?CONNECTED_TOPIC),
-    {ok, Client} = emqtt:start_link([{clientid, ClientId}]),
+    {ok, Client} = emqtt:start_link([{clientid, ClientId}, {username, <<"u1">>}]),
     {ok, _} = emqtt:connect(Client),
-    Peername = channel_peername(ClientId),
+    Peername = peername_bin(channel_peername(ClientId)),
     Payload = receive_sys_payload(<<"connected">>),
-    ?assertEqual(peername_bin(Peername), maps:get(<<"peername">>, Payload)),
+    ?assertMatch(
+        #{
+            <<"clientid">> := ClientId,
+            <<"username">> := <<"u1">>,
+            <<"ipaddress">> := <<"127.0.0.1">>,
+            <<"peername">> := Peername,
+            <<"sockport">> := 1883,
+            <<"protocol">> := <<"mqtt">>,
+            <<"proto_name">> := <<"MQTT">>,
+            <<"proto_ver">> := 4,
+            <<"connected_at">> := ConnectedAt,
+            <<"ts">> := Ts,
+            <<"conn_props">> := #{},
+            <<"receive_maximum">> := _,
+            <<"keepalive">> := 60,
+            <<"clean_start">> := true,
+            <<"expiry_interval">> := 0,
+            <<"client_attrs">> := #{}
+        } when is_integer(ConnectedAt) andalso is_integer(Ts),
+        Payload
+    ),
     ok = emqtt:disconnect(Client).
 
--doc "The disconnected system message carries `peername` with the client's source IP and port.".
-t_disconnected_message_peername(_Config) ->
+-doc """
+The disconnected system message payload has the expected shape:
+`peername` carries the client's source IP and port, `ipaddress` stays a bare IP.
+""".
+t_disconnected_message(_Config) ->
     ClientId = atom_to_binary(?FUNCTION_NAME),
     ok = emqx_broker:subscribe(?DISCONNECTED_TOPIC),
-    {ok, Client} = emqtt:start_link([{clientid, ClientId}]),
+    {ok, Client} = emqtt:start_link([{clientid, ClientId}, {username, <<"u1">>}]),
     {ok, _} = emqtt:connect(Client),
-    Peername = channel_peername(ClientId),
+    Peername = peername_bin(channel_peername(ClientId)),
     ok = emqtt:disconnect(Client),
     Payload = receive_sys_payload(<<"disconnected">>),
-    ?assertEqual(peername_bin(Peername), maps:get(<<"peername">>, Payload)).
-
--doc """
-The `ipaddress` field stays a bare IP address without a port
-in both the connected and the disconnected system messages.
-""".
-t_ipaddress_has_no_port(_Config) ->
-    ClientId = atom_to_binary(?FUNCTION_NAME),
-    ok = emqx_broker:subscribe(?CONNECTED_TOPIC),
-    ok = emqx_broker:subscribe(?DISCONNECTED_TOPIC),
-    {ok, Client} = emqtt:start_link([{clientid, ClientId}]),
-    {ok, _} = emqtt:connect(Client),
-    ok = emqtt:disconnect(Client),
-    ConnectedPayload = receive_sys_payload(<<"connected">>),
-    DisconnectedPayload = receive_sys_payload(<<"disconnected">>),
-    ?assertEqual(<<"127.0.0.1">>, maps:get(<<"ipaddress">>, ConnectedPayload)),
-    ?assertEqual(<<"127.0.0.1">>, maps:get(<<"ipaddress">>, DisconnectedPayload)).
+    ?assertMatch(
+        #{
+            <<"clientid">> := ClientId,
+            <<"username">> := <<"u1">>,
+            <<"ipaddress">> := <<"127.0.0.1">>,
+            <<"peername">> := Peername,
+            <<"sockport">> := 1883,
+            <<"protocol">> := <<"mqtt">>,
+            <<"proto_name">> := <<"MQTT">>,
+            <<"proto_ver">> := 4,
+            <<"connected_at">> := ConnectedAt,
+            <<"disconnected_at">> := DisconnectedAt,
+            <<"ts">> := Ts,
+            <<"disconn_props">> := #{},
+            <<"client_attrs">> := #{},
+            <<"reason">> := <<"normal">>
+        } when
+            is_integer(ConnectedAt) andalso is_integer(DisconnectedAt) andalso is_integer(Ts),
+        Payload
+    ).
 
 -doc """
 A client info without the `peername` key does not crash the hook;

--- a/changes/ee/feat-18501.en.md
+++ b/changes/ee/feat-18501.en.md
@@ -1,0 +1,1 @@
+Add a `peername` field to the `$SYS` client connected and disconnected messages. The field holds the client's source IP address and port in `IP:port` form, so a connection can be matched against NAT or firewall logs. The `ipaddress` field is unchanged.


### PR DESCRIPTION
Release version:
7.0.0

Introduced in:

## Summary

Closes https://github.com/emqx/emqx/issues/14177.

Add a `peername` field to the `$SYS` client connected and disconnected message payloads. The field holds the client's source IP address and port in `IP:port` form. It lets a payload be matched against NAT or firewall logs, which `ipaddress` alone cannot do.

- `emqx_sys:common_infos/2` builds the shared payload for both events, so one change covers connected and disconnected. It reads `peername` from the client info, which the channel has populated since v5.8.0.
- The field name and format match the `peername` field of the rule-engine client events, so the same name means the same thing in both places.
- `ipaddress` is unchanged: still the bare IP without a port.
- Gateway clients publish through the same function, so their `$SYS` messages get the field too. All gateway channels populate `peername` in the client info.
- `peername` is read with `maps:get/3`, so a client info without the key publishes `"peername":"undefined"` instead of crashing the hook.

Captured from a live node with this change:

```
$SYS/brokers/emqx@127.0.0.1/clients/issue14177-client/connected {"ipaddress":"127.0.0.1","receive_maximum":32,"conn_props":{"User-Property":{}},"expiry_interval":0,"clean_start":true,"proto_name":"MQTT","connected_at":1787728341286,"sockport":1883,"clientid":"issue14177-client","client_attrs":{},"proto_ver":4,"username":"alice","ts":1787728341286,"protocol":"mqtt","keepalive":60,"peername":"127.0.0.1:59980"}
$SYS/brokers/emqx@127.0.0.1/clients/issue14177-client/disconnected {"ipaddress":"127.0.0.1","disconnected_at":1787728341287,"disconn_props":{"User-Property":{}},"proto_name":"MQTT","connected_at":1787728341286,"sockport":1883,"clientid":"issue14177-client","client_attrs":{},"proto_ver":4,"username":"alice","ts":1787728341287,"protocol":"mqtt","peername":"127.0.0.1:59980","reason":"normal"}
```

The payload documentation in emqx-docs (`en_US/observability/mqtt-system-topics.md`) needs a follow-up PR to add the new field to the connected and disconnected examples.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
