### PR TITLE
fix(stomp): decode header escape sequences and accept CRLF line endings

### DIFF
--- a/apps/emqx_gateway_stomp/src/emqx_stomp_frame.erl
+++ b/apps/emqx_gateway_stomp/src/emqx_stomp_frame.erl
@@ -85,6 +85,10 @@
 -define(BSL, $\\).
 -define(COLON, $:).
 
+%% CONNECT and CONNECTED frames do not use header escaping, for backward
+%% compatibility with STOMP 1.0 (STOMP 1.2, "Value Encoding").
+-define(NO_HEADER_ESCAPE(Cmd), (Cmd =:= ?CMD_CONNECT orelse Cmd =:= ?CMD_CONNECTED)).
+
 -record(parser_state, {
     cmd,
     headers = [],
@@ -174,6 +178,10 @@ parse(hdname, <<?CR, _Rest/binary>>, _State) ->
     error(unexpected_linefeed);
 parse(hdname, <<?COLON, Rest/binary>>, State = #parser_state{acc = Acc}) ->
     parse(hdvalue, Rest, State#parser_state{hdname = Acc, acc = <<>>});
+parse(hdname, <<?BSL, Rest/binary>>, State = #parser_state{cmd = Cmd}) when
+    ?NO_HEADER_ESCAPE(Cmd)
+->
+    parse(hdname, Rest, acc(?BSL, State));
 parse(hdname, <<?BSL>>, State) ->
     {more, #{phase => hdname, pre => <<?BSL>>, state => State}};
 parse(hdname, <<?BSL, Ch:8, Rest/binary>>, State) ->
@@ -199,6 +207,10 @@ parse(hdvalue, <<?CR, ?LF, Rest/binary>>, State) ->
     parse(hdvalue, <<?LF, Rest/binary>>, State);
 parse(hdvalue, <<?CR, _Rest/binary>>, _State) ->
     error(linefeed_expected);
+parse(hdvalue, <<?BSL, Rest/binary>>, State = #parser_state{cmd = Cmd}) when
+    ?NO_HEADER_ESCAPE(Cmd)
+->
+    parse(hdvalue, Rest, acc(?BSL, State));
 parse(hdvalue, <<?BSL>>, State) ->
     {more, #{phase => hdvalue, pre => <<?BSL>>, state => State}};
 parse(hdvalue, <<?BSL, Ch:8, Rest/binary>>, State) ->

--- a/apps/emqx_gateway_stomp/src/emqx_stomp_frame.erl
+++ b/apps/emqx_gateway_stomp/src/emqx_stomp_frame.erl
@@ -126,58 +126,58 @@ g(Key, Opts, Val) ->
 -spec parse(binary(), parse_state()) -> parse_result().
 parse(<<>>, Parser) ->
     {more, Parser};
-%% treat the \n as a heartbeat frame
-parse(<<$\n>>, Parser = #{phase := none}) ->
-    {ok, #stomp_frame{command = ?CMD_HEARTBEAT}, <<>>, Parser};
-parse(Bytes, #{phase := body, length := Len, state := State}) ->
-    parse(body, Bytes, State, Len);
-parse(<<?LF, Bytes/binary>>, #{phase := hdname, state := State}) ->
-    parse(body, Bytes, State, content_len(State));
-parse(Bytes, #{phase := Phase, state := State}) when Phase =/= none ->
-    parse(Phase, Bytes, State);
+%% a byte kept from the previous chunk (a trailing `\r` or `\\`)
 parse(Bytes, Parser = #{pre := Pre}) ->
     parse(<<Pre/binary, Bytes/binary>>, maps:without([pre], Parser));
-parse(<<?CR, ?LF, Rest/binary>>, #{phase := Phase, state := State}) ->
-    parse(Phase, <<?LF, Rest/binary>>, State);
-parse(<<?CR>>, Parser) ->
-    {more, Parser#{pre => <<?CR>>}};
-parse(<<?CR, _Ch:8, _Rest/binary>>, _Parser) ->
-    error(linefeed_expected);
-parse(<<?BSL>>, Parser = #{phase := Phase}) when
-    Phase =:= hdname;
-    Phase =:= hdvalue
-->
-    {more, Parser#{pre => <<?BSL>>}};
-parse(
-    <<?BSL, Ch:8, Rest/binary>>,
-    #{phase := Phase, state := State}
-) when
-    Phase =:= hdname;
-    Phase =:= hdvalue
-->
-    parse(Phase, Rest, acc(unescape(Ch), State));
+%% treat a standalone EOL as a heartbeat frame
 parse(<<?LF>>, Parser = #{phase := none}) ->
-    {more, Parser};
+    {ok, #stomp_frame{command = ?CMD_HEARTBEAT}, <<>>, Parser};
+parse(<<?CR, ?LF>>, Parser = #{phase := none}) ->
+    {ok, #stomp_frame{command = ?CMD_HEARTBEAT}, <<>>, Parser};
+parse(<<?CR>>, Parser = #{phase := none}) ->
+    {more, Parser#{pre => <<?CR>>}};
+parse(Bytes, #{phase := body, length := Len, state := State}) ->
+    parse(body, Bytes, State, Len);
+parse(Bytes, #{phase := Phase, state := State}) when Phase =/= none ->
+    parse(Phase, Bytes, State);
 parse(Bytes, #{phase := none, state := State}) ->
     parse(command, Bytes, State).
 
 %% @private
 parse(command, <<?LF, Rest/binary>>, State = #parser_state{acc = Acc}) ->
     parse(headers, Rest, State#parser_state{cmd = Acc, acc = <<>>});
+parse(command, <<?CR>>, State) ->
+    {more, #{phase => command, pre => <<?CR>>, state => State}};
+parse(command, <<?CR, ?LF, Rest/binary>>, State) ->
+    parse(command, <<?LF, Rest/binary>>, State);
+parse(command, <<?CR, _Rest/binary>>, _State) ->
+    error(linefeed_expected);
 parse(command, <<Ch:8, Rest/binary>>, State) ->
     parse(command, Rest, acc(Ch, State));
 parse(command, <<>>, State) ->
     {more, #{phase => command, state => State}};
 parse(headers, <<?LF, Rest/binary>>, State) ->
     parse(body, Rest, State, content_len(State#parser_state{acc = <<>>}));
+parse(headers, <<?CR>>, State) ->
+    {more, #{phase => headers, pre => <<?CR>>, state => State}};
+parse(headers, <<?CR, ?LF, Rest/binary>>, State) ->
+    parse(headers, <<?LF, Rest/binary>>, State);
+parse(headers, <<?CR, _Rest/binary>>, _State) ->
+    error(linefeed_expected);
+parse(headers, <<>>, State) ->
+    {more, #{phase => headers, state => State}};
 parse(headers, Bin, State) ->
     parse(hdname, Bin, State);
 parse(hdname, <<?LF, _Rest/binary>>, _State) ->
     error(unexpected_linefeed);
-parse(hdname, <<?COLON, $\s, Rest/binary>>, State = #parser_state{acc = Acc}) ->
-    parse(hdvalue, Rest, State#parser_state{hdname = Acc, acc = <<>>});
+parse(hdname, <<?CR, _Rest/binary>>, _State) ->
+    error(unexpected_linefeed);
 parse(hdname, <<?COLON, Rest/binary>>, State = #parser_state{acc = Acc}) ->
     parse(hdvalue, Rest, State#parser_state{hdname = Acc, acc = <<>>});
+parse(hdname, <<?BSL>>, State) ->
+    {more, #{phase => hdname, pre => <<?BSL>>, state => State}};
+parse(hdname, <<?BSL, Ch:8, Rest/binary>>, State) ->
+    parse(hdname, Rest, acc(unescape(Ch), State));
 parse(hdname, <<Ch:8, Rest/binary>>, State) ->
     parse(hdname, Rest, acc(Ch, State));
 parse(hdname, <<>>, State) ->
@@ -193,6 +193,16 @@ parse(
         acc = <<>>
     },
     parse(headers, Rest, NState);
+parse(hdvalue, <<?CR>>, State) ->
+    {more, #{phase => hdvalue, pre => <<?CR>>, state => State}};
+parse(hdvalue, <<?CR, ?LF, Rest/binary>>, State) ->
+    parse(hdvalue, <<?LF, Rest/binary>>, State);
+parse(hdvalue, <<?CR, _Rest/binary>>, _State) ->
+    error(linefeed_expected);
+parse(hdvalue, <<?BSL>>, State) ->
+    {more, #{phase => hdvalue, pre => <<?BSL>>, state => State}};
+parse(hdvalue, <<?BSL, Ch:8, Rest/binary>>, State) ->
+    parse(hdvalue, Rest, acc(unescape(Ch), State));
 parse(hdvalue, <<Ch:8, Rest/binary>>, State) ->
     parse(hdvalue, Rest, acc(Ch, State));
 parse(hdvalue, <<>>, State) ->
@@ -252,7 +262,7 @@ unescape($r) -> ?CR;
 unescape($n) -> ?LF;
 unescape($c) -> ?COLON;
 unescape($\\) -> ?BSL;
-unescape(_Ch) -> error(cannnot_unescape).
+unescape(Ch) -> error({cannot_unescape, <<?BSL, Ch>>}).
 
 check_max_headers(
     Headers,

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -197,6 +197,41 @@ t_auth_failed(_) ->
     end),
     meck:unload(emqx_access_control).
 
+-doc """
+A CONNECT whose passcode contains a colon, sent escaped as `\c` per STOMP 1.2,
+authenticates with the original password (#12917).
+""".
+t_auth_passcode_with_colon(_) ->
+    ok = meck:new(emqx_access_control, [passthrough, no_history]),
+    ok = meck:expect(
+        emqx_access_control,
+        authenticate,
+        fun
+            (#{password := <<"pa:ss">>}) -> {ok, #{is_superuser => false}};
+            (_) -> {error, bad_username_or_password}
+        end
+    ),
+    try
+        with_connection(fun(Sock) ->
+            Wire = iolist_to_binary(
+                serialize(<<"CONNECT">>, [
+                    {<<"accept-version">>, ?STOMP_VER},
+                    {<<"host">>, <<"127.0.0.1:61613">>},
+                    {<<"login">>, <<"admin">>},
+                    {<<"passcode">>, <<"pa:ss">>}
+                ])
+            ),
+            %% the serializer escapes the colon on the wire
+            ?assertNotEqual(nomatch, binary:match(Wire, <<"pa\\css">>)),
+            ok = gen_tcp:send(Sock, Wire),
+            ?assertMatch(
+                {ok, #stomp_frame{command = <<"CONNECTED">>}}, recv_a_frame(Sock)
+            )
+        end)
+    after
+        meck:unload(emqx_access_control)
+    end.
+
 t_heartbeat(_) ->
     %% Test heartbeat
     with_connection(fun(Sock) ->

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -198,8 +198,9 @@ t_auth_failed(_) ->
     meck:unload(emqx_access_control).
 
 -doc """
-A CONNECT whose passcode contains a colon, sent escaped as `\c` per STOMP 1.2,
-authenticates with the original password (#12917).
+A CONNECT whose passcode contains a colon authenticates with the original
+password (#12917).  CONNECT headers carry the colon raw: STOMP 1.2 exempts
+CONNECT and CONNECTED frames from header escaping.
 """.
 t_auth_passcode_with_colon(_) ->
     ok = meck:new(emqx_access_control, [passthrough, no_history]),
@@ -213,16 +214,15 @@ t_auth_passcode_with_colon(_) ->
     ),
     try
         with_connection(fun(Sock) ->
-            Wire = iolist_to_binary(
-                serialize(<<"CONNECT">>, [
-                    {<<"accept-version">>, ?STOMP_VER},
-                    {<<"host">>, <<"127.0.0.1:61613">>},
-                    {<<"login">>, <<"admin">>},
-                    {<<"passcode">>, <<"pa:ss">>}
-                ])
-            ),
-            %% the serializer escapes the colon on the wire
-            ?assertNotEqual(nomatch, binary:match(Wire, <<"pa\\css">>)),
+            Wire = <<
+                "CONNECT\n"
+                "accept-version:1.2\n"
+                "host:127.0.0.1:61613\n"
+                "login:admin\n"
+                "passcode:pa:ss\n"
+                "\n",
+                0
+            >>,
             ok = gen_tcp:send(Sock, Wire),
             ?assertMatch(
                 {ok, #stomp_frame{command = <<"CONNECTED">>}}, recv_a_frame(Sock)
@@ -231,6 +231,28 @@ t_auth_passcode_with_colon(_) ->
     after
         meck:unload(emqx_access_control)
     end.
+
+-doc """
+A destination containing a colon works end to end: SUBSCRIBE and SEND carry it
+escaped as `\c` per STOMP 1.2, the broker decodes it, and the MESSAGE frame
+returns it escaped on the wire and decoded after parsing.
+""".
+t_escaped_destination_roundtrip(_) ->
+    Topic = <<"t/a:b">>,
+    with_connection(fun(Sock) ->
+        ok = send_connection_frame(Sock, <<"guest">>, <<"guest">>),
+        ?assertMatch({ok, #stomp_frame{command = <<"CONNECTED">>}}, recv_a_frame(Sock)),
+        %% the serializer escapes the colon in these frames
+        ok = send_subscribe_frame(Sock, 0, Topic),
+        ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),
+        ok = send_message_frame(Sock, Topic, <<"hello">>),
+        ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),
+        {ok, Frame} = recv_a_frame(Sock),
+        ?assertMatch(#stomp_frame{command = <<"MESSAGE">>, body = <<"hello">>}, Frame),
+        ?assertEqual(
+            Topic, proplists:get_value(<<"destination">>, Frame#stomp_frame.headers)
+        )
+    end).
 
 t_heartbeat(_) ->
     %% Test heartbeat

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_frame_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_frame_SUITE.erl
@@ -31,8 +31,14 @@ parse_chunks([Chunk | Rest], Parser) ->
             Result
     end.
 
+send_frame(Destination) ->
+    <<"SEND\ndestination:", Destination/binary, "\n\nhi", 0>>.
+
 connect_frame(Passcode) ->
     <<"CONNECT\nlogin:admin\npasscode:", Passcode/binary, "\n\n", 0>>.
+
+destination(#stomp_frame{headers = Headers}) ->
+    proplists:get_value(<<"destination">>, Headers).
 
 passcode(#stomp_frame{headers = Headers}) ->
     proplists:get_value(<<"passcode">>, Headers).
@@ -49,38 +55,65 @@ split_after(Byte, Bin) ->
 
 -doc "Escaped colon in a header value decodes to a literal colon (#12917).".
 t_unescape_colon(_) ->
-    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa\\css">>)),
-    ?assertEqual(<<"pa:ss">>, passcode(Frame)).
+    {ok, Frame, <<>>, _} = parse_frame(send_frame(<<"a\\cb">>)),
+    ?assertEqual(<<"a:b">>, destination(Frame)).
 
 -doc "Escaped backslash in a header value decodes to a literal backslash.".
 t_unescape_backslash(_) ->
-    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa\\\\ss">>)),
-    ?assertEqual(<<"pa\\ss">>, passcode(Frame)).
+    {ok, Frame, <<>>, _} = parse_frame(send_frame(<<"a\\\\b">>)),
+    ?assertEqual(<<"a\\b">>, destination(Frame)).
 
 -doc "Escaped newline in a header value decodes to a literal line feed.".
 t_unescape_newline(_) ->
-    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa\\nss">>)),
-    ?assertEqual(<<"pa\nss">>, passcode(Frame)).
+    {ok, Frame, <<>>, _} = parse_frame(send_frame(<<"a\\nb">>)),
+    ?assertEqual(<<"a\nb">>, destination(Frame)).
 
 -doc "Escaped carriage return in a header value decodes to a literal CR.".
 t_unescape_cr(_) ->
-    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa\\rss">>)),
-    ?assertEqual(<<"pa\rss">>, passcode(Frame)).
+    {ok, Frame, <<>>, _} = parse_frame(send_frame(<<"a\\rb">>)),
+    ?assertEqual(<<"a\rb">>, destination(Frame)).
 
 -doc "A raw colon in a header value still passes through unchanged.".
 t_raw_colon_in_value(_) ->
-    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa:ss">>)),
-    ?assertEqual(<<"pa:ss">>, passcode(Frame)).
+    {ok, Frame, <<>>, _} = parse_frame(send_frame(<<"a:b">>)),
+    ?assertEqual(<<"a:b">>, destination(Frame)).
 
 -doc "Escape sequences decode in header names as well as values.".
 t_unescape_header_name(_) ->
     {ok, #stomp_frame{headers = Headers}, <<>>, _} =
-        parse_frame(<<"CONNECT\na\\cb:v\n\n", 0>>),
+        parse_frame(<<"SEND\na\\cb:v\n\nhi", 0>>),
     ?assertEqual([{<<"a:b">>, <<"v">>}], Headers).
 
 -doc "An undefined escape sequence such as \\t is a fatal frame error (STOMP 1.2).".
 t_invalid_escape_is_fatal(_) ->
-    ?assertError({cannot_unescape, <<"\\t">>}, parse_frame(connect_frame(<<"pa\\tss">>))).
+    ?assertError({cannot_unescape, <<"\\t">>}, parse_frame(send_frame(<<"a\\tb">>))).
+
+-doc """
+Headers of a STOMP-command frame decode escape sequences: the command was added
+in STOMP 1.1, so the CONNECT/CONNECTED escaping exemption does not apply to it.
+""".
+t_stomp_command_unescapes(_) ->
+    {ok, #stomp_frame{headers = Headers}, <<>>, _} =
+        parse_frame(<<"STOMP\naccept-version:1.2\nlogin:pa\\css\n\n", 0>>),
+    ?assertEqual(<<"pa:ss">>, proplists:get_value(<<"login">>, Headers)).
+
+-doc """
+CONNECT headers are not unescaped: STOMP 1.2 exempts CONNECT and CONNECTED
+frames from header escaping for backward compatibility with STOMP 1.0.
+A backslash in a CONNECT passcode is a literal octet, and sequences that are
+undefined escapes elsewhere are not an error here.
+""".
+t_connect_headers_not_unescaped(_) ->
+    {ok, Frame1, <<>>, _} = parse_frame(connect_frame(<<"pa\\css">>)),
+    ?assertEqual(<<"pa\\css">>, passcode(Frame1)),
+    {ok, Frame2, <<>>, _} = parse_frame(connect_frame(<<"pa\\tss">>)),
+    ?assertEqual(<<"pa\\tss">>, passcode(Frame2)).
+
+-doc "CONNECTED headers are not unescaped, same as CONNECT (STOMP 1.0 compatibility).".
+t_connected_headers_not_unescaped(_) ->
+    {ok, #stomp_frame{headers = Headers}, <<>>, _} =
+        parse_frame(<<"CONNECTED\nsession:s\\cid\n\n", 0>>),
+    ?assertEqual(<<"s\\cid">>, proplists:get_value(<<"session">>, Headers)).
 
 -doc "CRLF line endings are accepted everywhere LF is (STOMP 1.2 EOL = [CR] LF).".
 t_crlf_line_endings(_) ->
@@ -103,12 +136,18 @@ t_crlf_heartbeat(_) ->
 t_bare_cr_is_fatal(_) ->
     ?assertError(linefeed_expected, parse_frame(<<"CONNECT\rX">>)).
 
--doc "A chunk ending in a bare backslash continues correctly into the next chunk.".
+-doc "A chunk ending in a bare backslash continues the escape into the next chunk.".
 t_split_at_bare_backslash(_) ->
-    Chunks = split_after($\\, connect_frame(<<"pa\\css">>)),
-    ?assertMatch([<<"CONNECT\nlogin:admin\npasscode:pa\\">>, <<"css\n\n", 0>>], Chunks),
+    Chunks = split_after($\\, send_frame(<<"a\\cb">>)),
+    ?assertMatch([<<"SEND\ndestination:a\\">>, <<"cb\n\nhi", 0>>], Chunks),
     {ok, Frame, <<>>, _} = parse_chunks(Chunks),
-    ?assertEqual(<<"pa:ss">>, passcode(Frame)).
+    ?assertEqual(<<"a:b">>, destination(Frame)).
+
+-doc "A CONNECT chunk ending in a bare backslash continues as a literal octet.".
+t_connect_split_at_bare_backslash(_) ->
+    Chunks = split_after($\\, connect_frame(<<"pa\\css">>)),
+    {ok, Frame, <<>>, _} = parse_chunks(Chunks),
+    ?assertEqual(<<"pa\\css">>, passcode(Frame)).
 
 -doc "A chunk ending in a bare CR continues correctly into the next chunk.".
 t_split_at_bare_cr(_) ->
@@ -119,10 +158,10 @@ t_split_at_bare_cr(_) ->
 
 -doc "A frame with CRLF line endings and escapes parses when fed one byte at a time.".
 t_parse_byte_by_byte(_) ->
-    Frame = <<"CONNECT\r\nlogin:admin\r\npasscode:pa\\css\r\n\r\n", 0>>,
+    Frame = <<"SEND\r\ndestination:a\\cb\r\n\r\nhi", 0>>,
     Chunks = [<<B>> || <<B>> <= Frame],
     {ok, Parsed, <<>>, _} = parse_chunks(Chunks),
-    ?assertEqual(<<"pa:ss">>, passcode(Parsed)).
+    ?assertEqual(<<"a:b">>, destination(Parsed)).
 
 -doc "serialize_pkt then parse returns the original headers and body unchanged.".
 t_roundtrip(_) ->

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_frame_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_frame_SUITE.erl
@@ -1,0 +1,166 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_stomp_frame_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("emqx_stomp.hrl").
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+parse_frame(Bytes) ->
+    parse_chunks([Bytes]).
+
+parse_chunks(Chunks) ->
+    parse_chunks(Chunks, emqx_stomp_frame:initial_parse_state(#{})).
+
+parse_chunks([Chunk | Rest], Parser) ->
+    case emqx_stomp_frame:parse(Chunk, Parser) of
+        {more, NParser} when Rest =/= [] ->
+            parse_chunks(Rest, NParser);
+        Result ->
+            Result
+    end.
+
+connect_frame(Passcode) ->
+    <<"CONNECT\nlogin:admin\npasscode:", Passcode/binary, "\n\n", 0>>.
+
+passcode(#stomp_frame{headers = Headers}) ->
+    proplists:get_value(<<"passcode">>, Headers).
+
+%% split the binary right after its first occurrence of Byte
+split_after(Byte, Bin) ->
+    {Pos, 1} = binary:match(Bin, <<Byte>>),
+    <<A:(Pos + 1)/binary, B/binary>> = Bin,
+    [A, B].
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+-doc "Escaped colon in a header value decodes to a literal colon (#12917).".
+t_unescape_colon(_) ->
+    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa\\css">>)),
+    ?assertEqual(<<"pa:ss">>, passcode(Frame)).
+
+-doc "Escaped backslash in a header value decodes to a literal backslash.".
+t_unescape_backslash(_) ->
+    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa\\\\ss">>)),
+    ?assertEqual(<<"pa\\ss">>, passcode(Frame)).
+
+-doc "Escaped newline in a header value decodes to a literal line feed.".
+t_unescape_newline(_) ->
+    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa\\nss">>)),
+    ?assertEqual(<<"pa\nss">>, passcode(Frame)).
+
+-doc "Escaped carriage return in a header value decodes to a literal CR.".
+t_unescape_cr(_) ->
+    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa\\rss">>)),
+    ?assertEqual(<<"pa\rss">>, passcode(Frame)).
+
+-doc "A raw colon in a header value still passes through unchanged.".
+t_raw_colon_in_value(_) ->
+    {ok, Frame, <<>>, _} = parse_frame(connect_frame(<<"pa:ss">>)),
+    ?assertEqual(<<"pa:ss">>, passcode(Frame)).
+
+-doc "Escape sequences decode in header names as well as values.".
+t_unescape_header_name(_) ->
+    {ok, #stomp_frame{headers = Headers}, <<>>, _} =
+        parse_frame(<<"CONNECT\na\\cb:v\n\n", 0>>),
+    ?assertEqual([{<<"a:b">>, <<"v">>}], Headers).
+
+-doc "An undefined escape sequence such as \\t is a fatal frame error (STOMP 1.2).".
+t_invalid_escape_is_fatal(_) ->
+    ?assertError({cannot_unescape, <<"\\t">>}, parse_frame(connect_frame(<<"pa\\tss">>))).
+
+-doc "CRLF line endings are accepted everywhere LF is (STOMP 1.2 EOL = [CR] LF).".
+t_crlf_line_endings(_) ->
+    {ok, Frame, <<>>, _} =
+        parse_frame(<<"CONNECT\r\nlogin:admin\r\npasscode:pa:ss\r\n\r\n", 0>>),
+    ?assertEqual(<<"pa:ss">>, passcode(Frame)).
+
+-doc "A standalone CRLF is a heartbeat frame, like a standalone LF.".
+t_crlf_heartbeat(_) ->
+    ?assertMatch(
+        {ok, #stomp_frame{command = ?CMD_HEARTBEAT}, <<>>, _},
+        parse_frame(<<"\r\n">>)
+    ),
+    ?assertMatch(
+        {ok, #stomp_frame{command = ?CMD_HEARTBEAT}, <<>>, _},
+        parse_chunks([<<"\r">>, <<"\n">>])
+    ).
+
+-doc "A CR not followed by LF is a fatal frame error.".
+t_bare_cr_is_fatal(_) ->
+    ?assertError(linefeed_expected, parse_frame(<<"CONNECT\rX">>)).
+
+-doc "A chunk ending in a bare backslash continues correctly into the next chunk.".
+t_split_at_bare_backslash(_) ->
+    Chunks = split_after($\\, connect_frame(<<"pa\\css">>)),
+    ?assertMatch([<<"CONNECT\nlogin:admin\npasscode:pa\\">>, <<"css\n\n", 0>>], Chunks),
+    {ok, Frame, <<>>, _} = parse_chunks(Chunks),
+    ?assertEqual(<<"pa:ss">>, passcode(Frame)).
+
+-doc "A chunk ending in a bare CR continues correctly into the next chunk.".
+t_split_at_bare_cr(_) ->
+    Chunks = split_after($\r, <<"CONNECT\r\nlogin:admin\npasscode:pa:ss\n\n", 0>>),
+    ?assertMatch([<<"CONNECT\r">>, <<"\nlogin:admin\npasscode:pa:ss\n\n", 0>>], Chunks),
+    {ok, Frame, <<>>, _} = parse_chunks(Chunks),
+    ?assertEqual(<<"pa:ss">>, passcode(Frame)).
+
+-doc "A frame with CRLF line endings and escapes parses when fed one byte at a time.".
+t_parse_byte_by_byte(_) ->
+    Frame = <<"CONNECT\r\nlogin:admin\r\npasscode:pa\\css\r\n\r\n", 0>>,
+    Chunks = [<<B>> || <<B>> <= Frame],
+    {ok, Parsed, <<>>, _} = parse_chunks(Chunks),
+    ?assertEqual(<<"pa:ss">>, passcode(Parsed)).
+
+-doc "serialize_pkt then parse returns the original headers and body unchanged.".
+t_roundtrip(_) ->
+    Headers = [
+        {<<"destination">>, <<"a:b\\c\rd\ne">>},
+        {<<"plain">>, <<"value">>}
+    ],
+    Body = <<"body">>,
+    Frame = emqx_stomp_frame:make(<<"SEND">>, Headers, Body),
+    Bin = iolist_to_binary(emqx_stomp_frame:serialize_pkt(Frame, #{})),
+    {ok, #stomp_frame{command = Cmd, headers = ParsedHeaders, body = ParsedBody}, <<>>, _} =
+        parse_frame(Bin),
+    ?assertEqual(<<"SEND">>, Cmd),
+    ?assertEqual(Body, ParsedBody),
+    ?assertEqual(
+        lists:sort(Headers),
+        lists:sort(proplists:delete(<<"content-length">>, ParsedHeaders))
+    ).
+
+-doc "Escape sequences in the body stay literal; unescaping applies to headers only.".
+t_body_not_unescaped(_) ->
+    {ok, #stomp_frame{body = Body}, <<>>, _} =
+        parse_frame(<<"SEND\ndestination:/queue/a\n\n\\c\\n\\\\", 0>>),
+    ?assertEqual(<<"\\c\\n\\\\">>, Body).
+
+-doc "A space after the header colon is part of the value, not a separator.".
+t_space_after_colon_preserved(_) ->
+    {ok, #stomp_frame{headers = Headers}, <<>>, _} =
+        parse_frame(<<"CONNECT\nfoo: bar\n\n", 0>>),
+    ?assertEqual([{<<"foo">>, <<" bar">>}], Headers).
+
+-doc "Two frames in one chunk parse one after the other.".
+t_pipelined_frames(_) ->
+    Bytes = <<"CONNECT\na:1\n\n", 0, "SEND\nb:2\n\nhi", 0>>,
+    {ok, Frame1, Rest, Parser} = parse_frame(Bytes),
+    ?assertMatch(#stomp_frame{command = <<"CONNECT">>, headers = [{<<"a">>, <<"1">>}]}, Frame1),
+    {ok, Frame2, <<>>, _} = emqx_stomp_frame:parse(Rest, Parser),
+    ?assertMatch(
+        #stomp_frame{command = <<"SEND">>, headers = [{<<"b">>, <<"2">>}], body = <<"hi">>},
+        Frame2
+    ).

--- a/changes/ee/fix-18504.en.md
+++ b/changes/ee/fix-18504.en.md
@@ -1,0 +1,5 @@
+Fixed STOMP frame parsing of escaped header characters and CRLF line endings.
+
+The STOMP gateway now decodes the escape sequences `\c`, `\r`, `\n`, and `\\` in header names and values, as required by STOMP 1.2. Before this fix, a client that escaped special characters could not authenticate when its password contained a colon, because the escaped value was used verbatim. Frames with an undefined escape sequence are now rejected as a frame error.
+
+The gateway now also accepts CRLF (`\r\n`) line endings in frames and CRLF heartbeats. Before this fix, clients using CRLF line endings could not connect.

--- a/changes/ee/fix-18504.en.md
+++ b/changes/ee/fix-18504.en.md
@@ -1,5 +1,5 @@
 Fixed STOMP frame parsing of escaped header characters and CRLF line endings.
 
-The STOMP gateway now decodes the escape sequences `\c`, `\r`, `\n`, and `\\` in header names and values, as required by STOMP 1.2. Before this fix, a client that escaped special characters could not authenticate when its password contained a colon, because the escaped value was used verbatim. Frames with an undefined escape sequence are now rejected as a frame error.
+The STOMP gateway now decodes the escape sequences `\c`, `\r`, `\n`, and `\\` in header names and values, as required by STOMP 1.2. CONNECT and CONNECTED frames are exempt: STOMP 1.2 excludes them from header escaping for backward compatibility with STOMP 1.0, so their headers, including a password containing a colon or a backslash, pass through unchanged. In other frames, an undefined escape sequence is now rejected as a frame error.
 
 The gateway now also accepts CRLF (`\r\n`) line endings in frames and CRLF heartbeats. Before this fix, clients using CRLF line endings could not connect.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
v5.0.0 (cce0b1ca34, #6650)

## Summary

Fixes #12917. Port of #18495 to `dev-60`; the parser code is identical on both branches.

The STOMP frame parser never decoded any header escape sequence and rejected CRLF line endings. A client that escapes a colon in its passcode as `\c`, as STOMP 1.2 requires, could not authenticate: the password arrived at the authenticator as `pa\css` instead of `pa:ss`. Clients that send a raw colon worked, which is why the bug depended on how spec-compliant the client library is.

### Root cause

Commit cce0b1ca34 (#6650, v5.0.0) fixed sticky TCP stream parsing by adding a catch-all clause to `emqx_stomp_frame:parse/2`:

```erlang
parse(Bytes, #{phase := Phase, state := State}) when Phase =/= none ->
    parse(Phase, Bytes, State);
```

This clause matches every parser state with a non-`none` phase, so the later `parse/2` clauses that handled CR, backslash escapes, and the partial-escape continuation became unreachable, and `unescape/1` became dead code. The guard hides the shadowing from the compiler.

### Fix

Bytes are consumed in the `parse/3` state machine, so escape and CR handling now lives in the `parse/3` clauses instead of being reordered in `parse/2`:

* `hdname` and `hdvalue` decode `\c`, `\r`, `\n`, `\\`. A chunk ending in a bare `\` or bare `\r` returns `{more, ...}` with the byte kept in `pre`, and the next chunk continues the sequence, preserving the sticky-stream behavior #6650 fixed. A test feeds a frame one byte at a time.
* `command`, `headers`, `hdname` and `hdvalue` accept CRLF wherever LF is accepted, and a standalone CRLF is a heartbeat. Previously a client using CRLF line endings could not connect at all.
* The `headers` phase now has its own continuation state, so "between header lines" and "in the middle of a header name" are distinct. This also fixes a corner where a chunk boundary inside a header name followed by LF jumped to body parsing.

Behavior decisions:

* **CONNECT and CONNECTED frames are exempt from unescaping.** STOMP 1.2 ("Value Encoding") excludes them from header escaping for backward compatibility with STOMP 1.0, so their headers pass through verbatim: a password containing a literal backslash is preserved, and sequences that are undefined escapes elsewhere are not an error there. A password containing a colon is sent raw in CONNECT, which the parser already accepts. The `STOMP` command, added in 1.1, is not exempt and decodes escapes.
* **In escaping frames, undefined escape sequences are a fatal frame error** (`\t` etc.), as STOMP 1.2 requires ("MUST be treated as a fatal protocol error"). Previously they passed through silently, but only because the escape handling was unreachable; the pre-#6650 parser also raised on them.
* **A space after the header colon is now part of the value.** The old parser stripped one space after the colon. STOMP 1.2 forbids trimming or padding header values. No test or shipped client relied on the strip.
* **Only header names and values are unescaped.** The command line and the body pass through untouched.

The serialize side (`escape/1`) is unchanged; for escaping frames, serialize-then-parse now round-trips exactly, including values containing `:`, `\`, CR and LF. Serialize still escapes CONNECTED headers even though the spec exempts them: the only such value EMQX emits that a client could influence is `session`, and escaping keeps a value containing LF from injecting a header line. In practice these headers never contain escapable octets.

### Measured behavior, before and after

Parsing a `SEND` frame with `emqx_stomp_frame:parse/2`, destination value shown:

| input | before | after |
|---|---|---|
| `a\cb` | `a\cb` | `a:b` |
| `a:b` (raw colon) | `a:b` | `a:b` |
| `a\\b` | `a\\b` | `a\b` |
| `a\nb` | `a\nb` | `a` LF `b` |
| `a\tb` (undefined) | `a\tb` | fatal frame error |
| CRLF line endings | `unexpected_linefeed` error | parses |
| chunk split at bare `\` | escape left undecoded | `a:b` |
| chunk split at bare `\r` | `unexpected_linefeed` error | parses |

`CONNECT` and `CONNECTED` headers are exempt from escaping (STOMP 1.0 compatibility) and pass through verbatim, before and after; a raw colon in a `CONNECT` passcode parses correctly. The `STOMP` command decodes escapes like any other frame.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
