### PR TITLE
fix(mgmt): do not skip client messages cut off by max_payload_bytes

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1895,7 +1895,7 @@ format_msgs(MsgType, [FirstMsg | Msgs], PayloadFmt, MaxBytes) ->
             Msgs
         ),
     Data = lists:reverse(Msgs1),
-    case length(Data) < 1 + length(Msgs) of
+    case length(Data) =< length(Msgs) of
         true -> {Data, {truncated, LastMsg}};
         false -> {Data, all}
     end;

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1859,8 +1859,9 @@ format_msgs_resp(MsgType, Msgs, Meta, QString) ->
         <<"payload">> := PayloadFmt,
         <<"max_payload_bytes">> := MaxBytes
     } = QString,
-    Meta1 = encode_msgs_meta(MsgType, Meta),
-    Resp = #{meta => Meta1, data => format_msgs(MsgType, Msgs, PayloadFmt, MaxBytes)},
+    {Data, Truncation} = format_msgs(MsgType, Msgs, PayloadFmt, MaxBytes),
+    Meta1 = encode_msgs_meta(MsgType, adjust_pager_position(MsgType, Truncation, Meta)),
+    Resp = #{meta => Meta1, data => Data},
     %% Make sure minirest won't set another content-type for self-encoded JSON response body
     Headers = #{<<"content-type">> => <<"application/json">>},
     case emqx_utils_json:safe_encode(Resp) of
@@ -1879,23 +1880,40 @@ format_msgs_resp(MsgType, Msgs, Meta, QString) ->
 format_msgs(MsgType, [FirstMsg | Msgs], PayloadFmt, MaxBytes) ->
     %% Always include at least one message payload, even if it exceeds the limit
     {FirstMsg1, PayloadSize0} = format_msg(MsgType, FirstMsg, PayloadFmt),
-    {Msgs1, _} =
+    {Msgs1, {LastMsg, _}} =
         emqx_utils:foldl_while(
-            fun(Msg, {MsgsAcc, SizeAcc} = Acc) ->
+            fun(Msg, {MsgsAcc, {_LastMsg, SizeAcc}} = Acc) ->
                 {Msg1, PayloadSize} = format_msg(MsgType, Msg, PayloadFmt),
                 case SizeAcc + PayloadSize of
                     SizeAcc1 when SizeAcc1 =< MaxBytes ->
-                        {cont, {[Msg1 | MsgsAcc], SizeAcc1}};
+                        {cont, {[Msg1 | MsgsAcc], {Msg, SizeAcc1}}};
                     _ ->
                         {halt, Acc}
                 end
             end,
-            {[FirstMsg1], PayloadSize0},
+            {[FirstMsg1], {FirstMsg, PayloadSize0}},
             Msgs
         ),
-    lists:reverse(Msgs1);
+    Data = lists:reverse(Msgs1),
+    case length(Data) < 1 + length(Msgs) of
+        true -> {Data, {truncated, LastMsg}};
+        false -> {Data, all}
+    end;
 format_msgs(_MsgType, [], _PayloadFmt, _MaxBytes) ->
-    [].
+    {[], all}.
+
+%% When `max_payload_bytes` cuts the page short, move the continuation position back to
+%% the last returned message, so that the next page starts at the first message that was
+%% cut off. Otherwise paging from the reported position skips the cut messages.
+adjust_pager_position(_MsgType, all, Meta) ->
+    Meta;
+adjust_pager_position(MsgType, {truncated, LastMsg}, Meta) ->
+    Meta#{position := msg_position(MsgType, LastMsg)}.
+
+msg_position(mqueue_msgs, #message{extra = #{mqueue_insert_ts := Ts, mqueue_priority := Prio}}) ->
+    {Ts, Prio};
+msg_position(inflight_msgs, #message{extra = #{inflight_insert_ts := Ts}}) ->
+    Ts.
 
 format_msg(
     MsgType,

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1880,24 +1880,25 @@ format_msgs_resp(MsgType, Msgs, Meta, QString) ->
 format_msgs(MsgType, [FirstMsg | Msgs], PayloadFmt, MaxBytes) ->
     %% Always include at least one message payload, even if it exceeds the limit
     {FirstMsg1, PayloadSize0} = format_msg(MsgType, FirstMsg, PayloadFmt),
-    {Msgs1, {LastMsg, _}} =
+    Result =
         emqx_utils:foldl_while(
-            fun(Msg, {MsgsAcc, {_LastMsg, SizeAcc}} = Acc) ->
+            fun(Msg, {MsgsAcc, LastMsg, SizeAcc}) ->
                 {Msg1, PayloadSize} = format_msg(MsgType, Msg, PayloadFmt),
                 case SizeAcc + PayloadSize of
                     SizeAcc1 when SizeAcc1 =< MaxBytes ->
-                        {cont, {[Msg1 | MsgsAcc], {Msg, SizeAcc1}}};
+                        {cont, {[Msg1 | MsgsAcc], Msg, SizeAcc1}};
                     _ ->
-                        {halt, Acc}
+                        {halt, {truncated, MsgsAcc, LastMsg}}
                 end
             end,
-            {[FirstMsg1], {FirstMsg, PayloadSize0}},
+            {[FirstMsg1], FirstMsg, PayloadSize0},
             Msgs
         ),
-    Data = lists:reverse(Msgs1),
-    case length(Data) =< length(Msgs) of
-        true -> {Data, {truncated, LastMsg}};
-        false -> {Data, all}
+    case Result of
+        {truncated, Msgs1, LastMsg} ->
+            {lists:reverse(Msgs1), {truncated, LastMsg}};
+        {Msgs1, _LastMsg, _SizeAcc} ->
+            {lists:reverse(Msgs1), all}
     end;
 format_msgs(_MsgType, [], _PayloadFmt, _MaxBytes) ->
     {[], all}.

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1284,10 +1284,35 @@ test_messages(Path, Topic, Count, AuthHeader, PayloadEncoding, IsMqueue) ->
     {ok, LimitedMsgsResp} = emqx_mgmt_api_test_util:request_api(
         get, Path, QsPayloadLimit, AuthHeader
     ),
-    #{<<"meta">> := _, <<"data">> := FirstMsgOnly} = emqx_utils_json:decode(LimitedMsgsResp),
+    #{<<"meta">> := #{<<"position">> := TruncatedPos}, <<"data">> := FirstMsgOnly} =
+        emqx_utils_json:decode(LimitedMsgsResp),
     ?assertEqual(1, length(FirstMsgOnly)),
     ?assertEqual(
         <<"1">>, decode_payload(maps:get(<<"payload">>, hd(FirstMsgOnly)), PayloadEncoding)
+    ),
+    %% When `max_payload_bytes` cuts the page short, the position must point at the last
+    %% returned message, not at the last message walked before the cut, so that paging
+    %% skips no message.
+    ?assertEqual(TruncatedPos, msg_pos(hd(FirstMsgOnly), IsMqueue)),
+    %% Page through the remaining messages one message per page.
+    lists:foldl(
+        fun(Seq, PosIn) ->
+            PageQs = io_lib:format(
+                "payload=~s&max_payload_bytes=1&position=~s", [PayloadEncoding, PosIn]
+            ),
+            {ok, PageResp} = emqx_mgmt_api_test_util:request_api(get, Path, PageQs, AuthHeader),
+            #{<<"meta">> := #{<<"position">> := PosOut}, <<"data">> := PageMsgs} =
+                emqx_utils_json:decode(PageResp),
+            ?assertEqual(1, length(PageMsgs)),
+            ?assertEqual(
+                integer_to_binary(Seq),
+                decode_payload(maps:get(<<"payload">>, hd(PageMsgs)), PayloadEncoding)
+            ),
+            ?assertEqual(PosOut, msg_pos(hd(PageMsgs), IsMqueue)),
+            PosOut
+        end,
+        TruncatedPos,
+        lists:seq(2, Count)
     ),
 
     Limit = 19,

--- a/changes/ee/fix-18509.en.md
+++ b/changes/ee/fix-18509.en.md
@@ -1,0 +1,3 @@
+Fixed message paging in `GET /clients/{clientid}/mqueue_messages` and `GET /clients/{clientid}/inflight_messages`.
+
+These APIs limit the total payload size of one response page by the `max_payload_bytes` parameter (default 1MB). When this limit cut a page short, the returned `meta.position` pointed past the messages that were left out, so requesting the next page from that position skipped them. This could look like lost messages, for example a `mqueue_len` count higher than the number of messages the API returns. Now `meta.position` points at the last returned message, and the next page continues with the first message that was left out.

--- a/rel/i18n/emqx_mgmt_api_clients.hocon
+++ b/rel/i18n/emqx_mgmt_api_clients.hocon
@@ -556,7 +556,7 @@ payload_encoding.label:
 """Payload Encoding"""
 
 max_payload_bytes.desc:
-"""Client's inflight/mqueue messages payload limit. The total payload size of all messages in the response will not exceed this value. Messages beyond the limit will be silently omitted in the response. The only exception to this rule is when the first message payload is already larger than the limit, in this case, the first message will be returned in the response."""
+"""Client's inflight/mqueue messages payload limit. The total payload size of all messages in the response will not exceed this value. When the limit is reached, the response may contain fewer messages than `limit`; `meta.position` points to the last returned message, so the omitted messages can be fetched by requesting the next page from that position. The only exception to this rule is when the first message payload is already larger than the limit, in this case, the first message will be returned in the response."""
 max_payload_bytes.label:
 """Max Payload Bytes"""
 

--- a/rel/i18n/emqx_mgmt_api_clients.hocon
+++ b/rel/i18n/emqx_mgmt_api_clients.hocon
@@ -556,7 +556,7 @@ payload_encoding.label:
 """Payload Encoding"""
 
 max_payload_bytes.desc:
-"""Client's inflight/mqueue messages payload limit. The total payload size of all messages in the response will not exceed this value. When the limit is reached, the response may contain fewer messages than `limit`; `meta.position` points to the last returned message, so the omitted messages can be fetched by requesting the next page from that position. The only exception to this rule is when the first message payload is already larger than the limit, in this case, the first message will be returned in the response."""
+"""Client's inflight/mqueue messages payload limit. The total payload size of all messages in the response will not exceed this value. When the limit is reached, the response may contain fewer messages than `limit`; `meta.position` points to the last returned message, so the omitted messages can be fetched by requesting the next page from that position. The only exception to this rule is when the first message payload is already larger than the limit, in this case, only the first message will be returned in the response."""
 max_payload_bytes.label:
 """Max Payload Bytes"""
 


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

`GET /clients/{clientid}/mqueue_messages` and `GET /clients/{clientid}/inflight_messages` bound each response page by the `max_payload_bytes` parameter (default 1MB). When this bound cut a page short, the returned `meta.position` pointed at the last message walked under the `limit` parameter, past the messages that were cut off. Requesting the next page from that position skipped the cut messages, so a client following the pager could never list them. Reported in #18506 as `mqueue_len` reporting more messages than the mqueue messages API returns.

The fix is in `emqx_mgmt_api_clients`: `format_msgs/4` now reports whether the page was cut short and which message was the last one included; `format_msgs_resp/4` then recomputes `meta.position` from that message, so the next page starts at the first cut-off message. The `max_payload_bytes` parameter description is updated to document the paging behavior.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
