### PR TITLE
ci(ui-tests): harden test_log waits and report the missing label

### DIFF
--- a/scripts/ui-tests/dashboard_test.py
+++ b/scripts/ui-tests/dashboard_test.py
@@ -135,12 +135,22 @@ def test_log(driver, dashboard_url):
     WebDriverWait(driver, 10).until(
         EC.presence_of_element_located((By.XPATH, "//div[@id='app']//form"))
     )
+    # The form element is an empty shell until the schema and the config
+    # fetches resolve, so wait until it contains at least one field label
+    # before looking for specific labels.
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located((By.XPATH, "//div[@id='app']//form//label"))
+    )
 
     labels_to_find = ["Enable Log Handler", "Log Level", "Log Formatter", "Time Offset"]
     for label_text in labels_to_find:
-        label = WebDriverWait(driver, 10).until(
-            EC.presence_of_element_located((By.XPATH, f"//div[@id='app']//form//label[contains(., '{label_text}')]"))
-        )
+        try:
+            label = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.XPATH, f"//div[@id='app']//form//label[contains(., '{label_text}')]"))
+            )
+        except TimeoutException:
+            form_text = driver.find_element(By.XPATH, "//div[@id='app']//form").text
+            raise AssertionError(f"label '{label_text}' not found on /#/log; form renders: {form_text!r}")
         label_for = label.get_attribute("for")
         if label_for:
             assert driver.find_elements(By.ID, label_for), f"Label '{label_text}' found but associated element with id '{label_for}' not found"


### PR DESCRIPTION
## Summary

De-flake `dashboard_test.py::test_log`, which failed with a bare selenium `TimeoutException` on both docker arches in run 32953001834 (sync PR #18508), while dev-63 base CI passed the same jobs with the same dashboard build.

The log page (`Log.vue`) is a `schema-form`: the `<form>` element renders as an empty shell, and its field labels appear only after the schema and `getLogConfigs()` fetches resolve. `test_log` waited for the form element and then gave each label 10 s, so under CI load a label wait can start against a still-empty form and time out. The exception also carried no message, so the failing label was unknown.

Changes (CI test script only):

- After the form-presence wait, wait up to 30 s until the form contains at least one label.
- On a per-label timeout, raise an `AssertionError` that names the missing label and dumps the rendered form text, so the next occurrence is diagnosable from the log.

Base `dev-61`: `scripts/ui-tests/dashboard_test.py` is identical on dev-61 through master, so the fix follows the sync chain.