### PR TITLE
fix(template): allow hyphen in placeholder variable names

### DIFF
--- a/apps/emqx_auth/src/emqx_auth_template.erl
+++ b/apps/emqx_auth/src/emqx_auth_template.erl
@@ -174,8 +174,10 @@ prerender_disallowed_placeholders(Template, AllowedVars) ->
         var_trans => fun(Name, _) ->
             % NOTE
             % Rendering disallowed placeholders in escaped form, which will then
-            % parse as a literal string.
-            case lists:member(Name, AllowedVars) of
+            % parse as a literal string.  Allowed-var matching is namespace-aware,
+            % so `${client_attrs.x}` stays a placeholder when the allowed set
+            % contains `{var_namespace, "client_attrs"}`.
+            case emqx_template:is_allowed(Name, AllowedVars) of
                 true -> list_to_binary("${" ++ Name ++ "}");
                 false -> list_to_binary("${$}{" ++ Name ++ "}")
             end

--- a/apps/emqx_auth/test/emqx_authn/emqx_auth_template_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_auth_template_SUITE.erl
@@ -35,6 +35,22 @@ end_per_suite(Config) ->
 %% Tests
 %%------------------------------------------------------------------------------
 
+-doc """
+A template that mixes a disallowed variable with a namespace-allowed one keeps
+the namespace-allowed placeholder working after the disallowed one is escaped.
+""".
+t_escape_namespace_aware(_Config) ->
+    {UsedVars, Template} = emqx_auth_template:parse_str(
+        <<"a:${disallowed},b:${client_attrs.user-token}">>,
+        [{var_namespace, "client_attrs"}]
+    ),
+    ?assertEqual(["client_attrs.user-token"], UsedVars),
+    Rendered = emqx_auth_template:render_str(
+        Template,
+        #{client_attrs => #{<<"user-token">> => <<"tok">>}}
+    ),
+    ?assertEqual(<<"a:${disallowed},b:tok">>, Rendered).
+
 t_parse_sql(_Config) ->
     {UsedVars, Statement, RowTemplate} = emqx_auth_template:parse_sql(
         """

--- a/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
@@ -1507,6 +1507,39 @@ t_templated_host_missing_var(TCConfig) ->
     ).
 
 -doc """
+A header template referencing a hyphenated client attribute key renders the
+attribute value into the request.
+""".
+t_hyphenated_client_attr(TCConfig) ->
+    ok = emqx_utils_http_test_server:set_handler(
+        fun(Req0, State) ->
+            #{
+                username := <<"plain">>,
+                password := <<"plain">>
+            } = cowboy_req:match_qs([username, password], Req0),
+            ?assertEqual(<<"tok-1">>, maps:get(<<"x-user-token">>, cowboy_req:headers(Req0))),
+            Req = cowboy_req:reply(
+                200,
+                #{<<"content-type">> => <<"application/json">>},
+                ?SERVER_RESPONSE_JSON(allow),
+                Req0
+            ),
+            {ok, Req, State}
+        end
+    ),
+    AuthConfig = (raw_http_auth_config(TCConfig))#{
+        <<"headers">> => #{<<"X-User-Token">> => <<"${client_attrs.user-token}">>}
+    },
+    {ok, _} = emqx:update_config(?PATH, {create_authenticator, ?GLOBAL, AuthConfig}),
+    Credentials = maps:merge(?CREDENTIALS, #{
+        client_attrs => #{<<"user-token">> => <<"tok-1">>}
+    }),
+    ?assertMatch(
+        {ok, #{is_superuser := false}},
+        emqx_access_control:authenticate(Credentials)
+    ).
+
+-doc """
 A templated host URL cannot be configured without a non-empty 'allowed_hosts'
 list.
 """.

--- a/apps/emqx_utils/src/emqx_template.erl
+++ b/apps/emqx_utils/src/emqx_template.erl
@@ -36,6 +36,7 @@
 
 -export([to_string/1]).
 -export([escape_disallowed/2]).
+-export([is_allowed/2]).
 
 -export_type([t/0]).
 -export_type([str/0]).
@@ -96,7 +97,7 @@
 %% Access module API
 -callback lookup(accessor(), _Bindings) -> {ok, _Value} | {error, reason()}.
 
--define(RE_PLACEHOLDER, "\\$\\{[.]?([a-zA-Z0-9._]*)\\}").
+-define(RE_PLACEHOLDER, "\\$\\{[.]?([a-zA-Z0-9._-]*)\\}").
 -define(RE_ESCAPE, "\\$\\{(\\$)\\}").
 
 %% @doc Parse a unicode string into a template.
@@ -197,11 +198,13 @@ escape_disallowed(Template, Allowed) ->
 find_disallowed(Vars, Allowed) ->
     lists:filter(fun(Var) -> not is_allowed(Var, Allowed) end, Vars).
 
-%% @private Return 'true' if a variable reference matches
+%% @doc Return 'true' if a variable reference matches
 %% at least one allowed variables.
 %% For `"${var_name}"' kind of reference, its a `=:=' compare
 %% for `{var_namespace, "namespace"}' kind of reference
 %% it matches the `"namespace."' prefix.
+-spec is_allowed(varname(), [varname() | {var_namespace, varname()}]) ->
+    boolean().
 is_allowed(_Var, []) ->
     false;
 is_allowed(Var, [{var_namespace, VarPrefix} | Allowed]) ->

--- a/apps/emqx_utils/test/emqx_template_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_template_SUITE.erl
@@ -362,6 +362,105 @@ t_allow_this(_) ->
         emqx_template:validate(["d"], emqx_template:parse(<<"this:${.}">>))
     ).
 
+-doc "A hyphenated variable name parses as a placeholder and renders its bound value.".
+t_render_hyphen_name(_) ->
+    Context = #{
+        <<"a-b">> => <<"1">>,
+        client_attrs => #{<<"user-token">> => <<"tok">>}
+    },
+    Template = emqx_template:parse(<<"a-b:${a-b},tok:${client_attrs.user-token}">>),
+    ?assertEqual(
+        ["a-b", "client_attrs.user-token"],
+        emqx_template:placeholders(Template)
+    ),
+    ?assertEqual(
+        <<"a-b:1,tok:tok">>,
+        render_strict_string(Template, Context)
+    ).
+
+-doc "`${a}-${b}` parses as two placeholders separated by a literal hyphen, not one match.".
+t_render_hyphen_between_placeholders(_) ->
+    Context = #{a => <<"1">>, b => <<"2">>},
+    Template = emqx_template:parse(<<"${a}-${b}">>),
+    ?assertEqual(
+        ["a", "b"],
+        emqx_template:placeholders(Template)
+    ),
+    ?assertEqual(
+        <<"1-2">>,
+        render_strict_string(Template, Context)
+    ).
+
+-doc "The accessor of a hyphenated name splits on dots only: `${a.b-c}` -> [`a`, `b-c`].".
+t_parse_accessor_hyphen(_) ->
+    ?assertMatch(
+        [{var, "a.b-c", [<<"a">>, <<"b-c">>]}],
+        emqx_template:parse(<<"${a.b-c}">>)
+    ).
+
+-doc """
+Leading or trailing hyphens and a bare `${-}` parse as placeholders with those
+names, rendering `undefined` when no such binding exists.
+""".
+t_render_hyphen_edge_names(_) ->
+    Template = emqx_template:parse(<<"${-a},${a-},${-}">>),
+    ?assertEqual(
+        ["-a", "a-", "-"],
+        emqx_template:placeholders(Template)
+    ),
+    ?assertEqual(
+        <<"x,y,z">>,
+        render_strict_string(Template, #{<<"-a">> => "x", <<"a-">> => "y", <<"-">> => "z"})
+    ),
+    ?assertMatch(
+        {<<"undefined,undefined,undefined">>, [{"-", undefined} | _]},
+        render_string(Template, #{})
+    ).
+
+-doc "A hyphenated disallowed name round-trips through `escape_disallowed/2` and re-parse.".
+t_escape_disallowed_hyphen(_) ->
+    Template = emqx_template:parse(<<"a:${a-b},c:${c-d}">>),
+    Escaped = bin(emqx_template:escape_disallowed(Template, ["a-b"])),
+    ?assertEqual(<<"a:${a-b},c:${$}{c-d}">>, Escaped),
+    Reparsed = emqx_template:parse(Escaped),
+    ?assertEqual(["a-b"], emqx_template:placeholders(Reparsed)),
+    ?assertEqual(
+        <<"a:1,c:${c-d}">>,
+        render_strict_string(Reparsed, #{<<"a-b">> => <<"1">>})
+    ).
+
+-doc "`validate/2` accepts a hyphenated leaf under an allowed namespace and still rejects others.".
+t_validate_hyphen_namespace(_) ->
+    Template = emqx_template:parse(<<"${client_attrs.user-token}">>),
+    ?assertEqual(
+        ok,
+        emqx_template:validate([{var_namespace, "client_attrs"}], Template)
+    ),
+    ?assertEqual(
+        {error, [{"client_attrs.user-token", disallowed}]},
+        emqx_template:validate([{var_namespace, "other_ns"}, "clientid"], Template)
+    ).
+
+-doc "A hyphenated name in an SQL template becomes a parameter; the name never enters the statement.".
+t_parse_sql_prepstmt_hyphen(_) ->
+    Context = #{<<"a-b">> => <<"v1">>, c => #{<<"d-e">> => 42}},
+    {PrepareStatement, RowTemplate} =
+        emqx_template_sql:parse_prepstmt(<<"a:${a-b},b:${c.d-e}">>, #{parameters => '$n'}),
+    ?assertEqual(<<"a:$1,b:$2">>, bin(PrepareStatement)),
+    ?assertEqual(
+        [<<"v1">>, 42],
+        emqx_template_sql:render_prepstmt_strict(RowTemplate, Context)
+    ).
+
+-doc "A hyphenated name in a rendered SQL statement substitutes the escaped value.".
+t_render_sql_hyphen(_) ->
+    Context = #{<<"a-b">> => <<"it's">>},
+    Template = emqx_template:parse(<<"SELECT ${a-b}, '${a-b}'">>),
+    ?assertEqual(
+        <<"SELECT 'it\\'s', ''it\\'s''">>,
+        bin(emqx_template_sql:render_strict(Template, Context, #{}))
+    ).
+
 t_allow_var_by_namespace(_) ->
     Context = #{d => #{d1 => <<"hi">>}},
     Template = emqx_template:parse(<<"d.d1:${d.d1}">>),

--- a/changes/ee/fix-18513.en.md
+++ b/changes/ee/fix-18513.en.md
@@ -1,0 +1,5 @@
+Allow `-` (hyphen) in template placeholder variable names. For example, an HTTP authentication request template can now reference a client attribute with a hyphenated name, such as `${client_attrs.user-token}`.
+
+Previously, a name containing a hyphen did not parse as a placeholder, and the `${...}` text was left in the rendered output verbatim.
+
+Also fixed placeholder escaping in authentication and authorization templates: when a template mixed an unknown placeholder with a `${client_attrs.*}` placeholder, the `${client_attrs.*}` placeholder was left unresolved as well.


### PR DESCRIPTION
Release version:
7.0.0

Introduced in:
pre-5.8

## Summary

Fixes #14916.

Allow `-` (hyphen) in template placeholder variable names, so a client attribute with a hyphenated name can be referenced from templates, e.g. `${client_attrs.user-token}` in an HTTP authentication request. Previously such a name did not match the placeholder regex, and the `${...}` text was silently left in the rendered output verbatim.

Crucial changes:

* `apps/emqx_utils/src/emqx_template.erl`: add `-` to the `?RE_PLACEHOLDER` character class. The class sits strictly inside `${...}`, so `${a}-${b}` still parses as two placeholders separated by a literal hyphen (pinned by a test). Variable names stay opaque strings, and accessors still split on `.` only, so `${a.b-c}` yields the accessor `["a", "b-c"]`.
* `apps/emqx_auth/src/emqx_auth_template.erl`: make the disallowed-placeholder escape pass use namespace-aware matching (newly exported `emqx_template:is_allowed/2`). Before, once any disallowed placeholder was present in a template, `${client_attrs.*}` placeholders in the same template were wrongly escaped into literals as well, because `lists:member/2` cannot match a `{var_namespace, _}` entry. Without this fix, the widening could regress a template that mixes a previously-literal `${...-...}` span with a working `${client_attrs.*}` placeholder.

Every `emqx_template` / `emqx_template_sql` consumer was audited for this widening. In SQL templates the variable name never reaches the statement text: prepared-statement parsing replaces variables with `?`/`$n`/`:n`, and value interpolation goes through `emqx_utils_sql:to_sql_string/2`, so a hyphen in a name cannot affect quoting.

Behavior notes:

* A `${...}` span containing a hyphen that was previously literal text now renders as a placeholder (`undefined` when unbound) where templates are rendered leniently.
* The existing S3 aggregated `key` template validator now rejects such spans at config load, the same way it already rejects any other placeholder outside its allow-list.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
