### PR TITLE
test(pulsar): wait for action to connect instead of matching create

### DIFF
--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_SUITE.erl
@@ -482,6 +482,20 @@ get_connector_api(TCConfig) ->
 get_action_api(TCConfig) ->
     emqx_bridge_v2_testlib:get_action_api2(TCConfig).
 
+%% Pulsar producers connect asynchronously, so the create API can return while
+%% the action is still `connecting'. Create, then wait until it is connected.
+create_action_connected(TCConfig) ->
+    {201, _} = create_action_api(TCConfig, #{}),
+    ?retry(
+        _Sleep = 500,
+        _Attempts = 20,
+        ?assertMatch(
+            {200, #{<<"status">> := <<"connected">>}},
+            get_action_api(TCConfig)
+        )
+    ),
+    ok.
+
 delete_action_api(TCConfig) ->
     #{kind := Kind, type := Type, name := Name} =
         emqx_bridge_v2_testlib:get_common_values(TCConfig),
@@ -627,7 +641,7 @@ t_send_when_timeout(TCConfig) ->
 
 do_t_send_with_failure(TCConfig, FailureType) ->
     {201, _} = create_connector_api(TCConfig, #{}),
-    {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{}),
+    ok = create_action_connected(TCConfig),
     #{topic := Topic} = simple_create_rule_api(TCConfig),
     C = start_client(),
     Payload = unique_payload(),
@@ -910,7 +924,7 @@ t_cluster(TCConfig) ->
             Fun = fun() -> ?ON(N2, emqx_mgmt_api_test_util:auth_header_()) end,
             emqx_bridge_v2_testlib:set_auth_header_getter(Fun),
             {201, #{<<"status">> := <<"connected">>}} = create_connector_api(TCConfig, #{}),
-            {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{}),
+            ok = create_action_connected(TCConfig),
             {ok, _} = snabbkaffe:receive_events(SRef1),
             erpc:multicall(Nodes, fun wait_until_producer_connected/0),
             ?tp(publishing_message, #{}),
@@ -945,7 +959,7 @@ t_resilience(TCConfig) ->
     ?check_trace(
         begin
             {201, #{<<"status">> := <<"connected">>}} = create_connector_api(TCConfig, #{}),
-            {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{}),
+            ok = create_action_connected(TCConfig),
             #{topic := Topic} = simple_create_rule_api(TCConfig),
             C = start_client(),
             ProduceInterval = 100,


### PR DESCRIPTION
## Summary

De-flake `emqx_bridge_pulsar_SUITE` action setup:

```
%%% emqx_bridge_pulsar_SUITE ==> local.tcp.sync.t_send_when_down: FAILED
{{badmatch,{201, #{... <<"status">> => <<"connecting">>,
                   <<"status_reason">> => <<"Not connected for unknown reason">> ...}}}, ...}
```

Seen in: https://github.com/emqx/emqx/actions/runs/32962334187/job/98160575457?pr=18508 (r62→r63 sync PR, which does not touch pulsar)

Pulsar producers connect asynchronously, so the action create API can return 201 while the action is still `connecting` (first health check pending). Three sites hard-matched `{201, #{<<"status">> := <<"connected">>}}` on the create response: `do_t_send_with_failure/2` (feeds `t_send_when_down` and `t_send_when_timeout`) and the cluster/resilience cases.

Fix (test-only): add `create_action_connected/1` — create with `{201, _}`, then `?retry(500, 20, ...)` until `get_action_api` reports `connected`, the same pattern the suite already uses for the connector. All three sites use the helper.

Base `dev-62`: the suite blob is identical on dev-62/63/70, so the fix follows the sync chain. dev-60/61 carry an older variant of this suite and are left alone.