### PR TITLE
test(postgres): fix flaky test

### DIFF
--- a/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
+++ b/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
@@ -468,6 +468,8 @@ t_write_failure(TCConfig) when is_list(TCConfig) ->
                     ok;
                 {recoverable_error, disconnected} ->
                     ok;
+                {recoverable_error, sock_closed} ->
+                    ok;
                 _ ->
                     ct:fail("unexpected error: ~p", [Error])
             end


### PR DESCRIPTION
```
2026-08-25T21:00:54.035798+00:00 [critical] "check stage" failed: exit, {test_case_failed,"unexpected error: {recoverable_error,sock_closed}"}, Stacktrace: [{emqx_bridge_pgsql_SUITE,t_write_failure,1,[{file,"test/emqx_bridge_pgsql_SUITE.erl"},{line,466}]}]
```

Related: https://github.com/emqx/emqx/pull/18449
