### PR TITLE
fix: validate JT808 and Prometheus outbound URLs against SSRF policy

### DIFF
--- a/apps/emqx_gateway_jt808/src/emqx_jt808_auth.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_auth.erl
@@ -32,8 +32,8 @@ register(RegFrame, #auth{registry = RegUrl}) ->
     case request(RegUrl, Params) of
         {ok, 200, Body} ->
             case emqx_utils_json:safe_decode(Body) of
-                {ok, #{<<"code">> := 0, <<"authcode">> := Authcode}} ->
-                    {ok, Authcode};
+                {ok, #{<<"code">> := 0, <<"authcode">> := AuthCode}} ->
+                    {ok, AuthCode};
                 {ok, #{<<"code">> := Code}} ->
                     {error, Code};
                 _ ->
@@ -70,7 +70,9 @@ authenticate(AuthFrame, #auth{authentication = AuthUrl}) ->
 request(Url, Params) ->
     RetryOpts = #{times => 3, interval => 1000, backoff => 2.0},
     Req = {Url, [], "application/json", emqx_utils_json:encode(Params)},
-    reply(request_(post, Req, [{autoredirect, true}], [{body_format, binary}], RetryOpts)).
+    %% Redirects are not followed so a validated target cannot bounce the
+    %% request to an internal address.
+    reply(request_(post, Req, [{autoredirect, false}], [{body_format, binary}], RetryOpts)).
 
 request_(
     Method,

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
@@ -9,7 +9,7 @@
 -include_lib("typerefl/include/types.hrl").
 
 -behaviour(hocon_schema).
--export([roots/0, namespace/0, fields/1, desc/1]).
+-export([roots/0, namespace/0, fields/1, desc/1, validate_auth_url/1]).
 
 -define(NOT_EMPTY(MSG), emqx_resource_validator:not_empty(MSG)).
 
@@ -94,7 +94,10 @@ fields_reg_auth_required(Required) ->
         {registry,
             sc(binary(), #{
                 desc => ?DESC(registry_url),
-                validator => [?NOT_EMPTY("the value of the field 'registry' cannot be empty")],
+                validator => [
+                    ?NOT_EMPTY("the value of the field 'registry' cannot be empty"),
+                    fun ?MODULE:validate_auth_url/1
+                ],
                 required => Required
             })},
         {authentication,
@@ -103,12 +106,30 @@ fields_reg_auth_required(Required) ->
                 #{
                     desc => ?DESC(authentication_url),
                     validator => [
-                        ?NOT_EMPTY("the value of the field 'authentication' cannot be empty")
+                        ?NOT_EMPTY("the value of the field 'authentication' cannot be empty"),
+                        fun ?MODULE:validate_auth_url/1
                     ],
                     required => Required
                 }
             )}
     ].
+
+validate_auth_url(Url) when is_binary(Url) ->
+    case emqx_utils_uri:parse(Url) of
+        #{
+            scheme := Scheme,
+            authority := #{host := Host, userinfo := undefined},
+            fragment := undefined
+        } when Scheme =:= <<"http">>; Scheme =:= <<"https">> ->
+            case emqx_utils_ssrf:check_host(Host) of
+                ok -> ok;
+                {error, Error} -> {error, emqx_utils_ssrf:format_error(Error)}
+            end;
+        _ ->
+            {error, "Invalid url, expected http(s)://host[:port][/path]"}
+    end;
+validate_auth_url(_) ->
+    {error, "Invalid url, expected http(s)://host[:port][/path]"}.
 
 jt808_frame_max_length(type) ->
     non_neg_integer();

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -76,22 +76,6 @@ gateway.jt808 {
 ">>).
 
 %% erlfmt-ignore
--define(CONF_INVALID_AUTH_SERVER, <<"
-gateway.jt808 {
-  listeners.tcp.default {
-    bind = ", ?PORT_STR, "
-  }
-  proto {
-    auth {
-      allow_anonymous = false
-      registry = \"abc://abc\"
-      authentication = \"abc://abc\"
-    }
-  }
-}
-">>).
-
-%% erlfmt-ignore
 -define(CONF_GBK_ENCODING, <<"
 gateway.jt808 {
   listeners.tcp.default {
@@ -135,9 +119,6 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_testcase(Case = t_case_invalid_auth_reg_server, Config) ->
-    Apps = boot_apps(Case, ?CONF_INVALID_AUTH_SERVER, Config),
-    [{suite_apps, Apps} | Config];
 init_per_testcase(Case, Config) when
     Case =:= t_case02_anonymous_register_and_auth;
     Case =:= t_jt808_reject_anonymous_auth_with_unregistered_phone
@@ -3313,50 +3294,34 @@ t_case_dl_invalid_msg(_Config) ->
     ok = gen_tcp:close(Socket).
 
 t_case_invalid_auth_reg_server(_Config) ->
-    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
-    %
-    % send REGISTER
-    %
-    Manuf = <<"examp">>,
-    Model = <<"33333333333333333333">>,
-    DevId = <<"1234567">>,
-
-    Color = 3,
-    Plate = <<"ujvl239">>,
-    RegisterPacket =
-        <<58:?WORD, 59:?WORD, Manuf/binary, Model/binary, DevId/binary, Color, Plate/binary>>,
-    MsgId = ?MC_REGISTER,
-    PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
-    MsgSn = 78,
-    Size = size(RegisterPacket),
-    Header =
-        <<MsgId:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size), PhoneBCD/binary,
-            MsgSn:?WORD>>,
-    S1 = gen_packet(Header, RegisterPacket),
-
-    %% Send REGISTER Packet
-    ok = gen_tcp:send(Socket, S1),
-    %% Receive REGISTER_ACK Packet
-    {ok, RecvPacket} = gen_tcp:recv(Socket, 0, 50_000),
-
-    %% No AuthCode when register failed
-    AuthCode = <<>>,
-
-    AckPacket = <<MsgSn:?WORD, 1, AuthCode/binary>>,
-    Size2 = size(AckPacket),
-    MsgId2 = ?MS_REGISTER_ACK,
-    MsgSn2 = 0,
-    Header2 =
-        <<MsgId2:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size2),
-            PhoneBCD/binary, MsgSn2:?WORD>>,
-    S2 = gen_packet(Header2, AckPacket),
-
-    ?LOGT("S1=~p", [binary_to_hex_string(S1)]),
-    ?LOGT("S2=~p", [binary_to_hex_string(S2)]),
-    ?LOGT("Received REGISTER_ACK Packet=~p", [binary_to_hex_string(RecvPacket)]),
-
-    ?assertEqual(S2, RecvPacket),
-    ok.
+    %% Invalid registry/authentication URLs are now rejected at config time.
+    Base = raw_jt808_config(false),
+    Invalid1 = emqx_utils_maps:deep_put(
+        [<<"proto">>, <<"auth">>],
+        Base,
+        #{
+            <<"allow_anonymous">> => false,
+            <<"registry">> => <<"abc://abc">>,
+            <<"authentication">> => <<?PROTO_REG_SERVER_HOST, ?PROTO_REG_AUTH_PATH>>
+        }
+    ),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:update_gateway(jt808, Invalid1)
+    ),
+    Invalid2 = emqx_utils_maps:deep_put(
+        [<<"proto">>, <<"auth">>],
+        Base,
+        #{
+            <<"allow_anonymous">> => false,
+            <<"registry">> => <<?PROTO_REG_SERVER_HOST, ?PROTO_REG_REGISTRY_PATH>>,
+            <<"authentication">> => <<"not a url">>
+        }
+    ),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:update_gateway(jt808, Invalid2)
+    ).
 
 t_create_ALLOW_invalid_auth_config(_Config) ->
     test_invalid_config(create, true).

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_ssrf_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_ssrf_SUITE.erl
@@ -1,0 +1,171 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_jt808_ssrf_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include("emqx_jt808.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(CACHE_KEY, {emqx_utils_ssrf, cache}).
+-define(REGISTRY_URL, <<"http://127.0.0.1:8991/jt808/registry">>).
+-define(AUTH_URL, <<"http://127.0.0.1:8991/jt808/auth">>).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_gateway
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{suite_apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    persistent_term:erase(?CACHE_KEY),
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
+
+init_per_testcase(_Case, Config) ->
+    set_ssrf_deny([<<"169.254.0.0/16">>]),
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    persistent_term:erase(?CACHE_KEY),
+    _ = emqx_gateway_conf:unload_gateway(jt808),
+    ok.
+
+t_registry_url_denied_rejected(_Config) ->
+    Conf = jt808_config(
+        #{<<"registry">> => <<"http://169.254.169.254:8991/jt808/registry">>}
+    ),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:load_gateway(jt808, Conf)
+    ).
+
+t_authentication_url_denied_rejected(_Config) ->
+    Conf = jt808_config(
+        #{<<"authentication">> => <<"http://169.254.169.254:8991/jt808/auth">>}
+    ),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:load_gateway(jt808, Conf)
+    ).
+
+t_allowed_url_accepted(_Config) ->
+    Conf = jt808_config(
+        #{
+            <<"registry">> => <<"http://8.8.8.8:8991/jt808/registry">>,
+            <<"authentication">> => <<"http://8.8.8.8:8991/jt808/auth">>
+        }
+    ),
+    {ok, _} = emqx_gateway_conf:load_gateway(jt808, Conf).
+
+t_bad_scheme_rejected(_Config) ->
+    Conf = jt808_config(#{<<"registry">> => <<"abc://abc">>}),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:load_gateway(jt808, Conf)
+    ).
+
+t_bad_url_format_rejected(_Config) ->
+    Conf = jt808_config(#{<<"authentication">> => <<"not a url">>}),
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:load_gateway(jt808, Conf)
+    ).
+
+t_anonymous_without_urls_accepted(_Config) ->
+    Conf = jt808_config(
+        #{
+            <<"allow_anonymous">> => true,
+            <<"registry">> => undefined,
+            <<"authentication">> => undefined
+        }
+    ),
+    {ok, _} = emqx_gateway_conf:load_gateway(jt808, Conf).
+
+t_autoredirect_disabled(_Config) ->
+    Self = self(),
+    meck:new(httpc, [passthrough, no_link]),
+    meck:expect(
+        httpc,
+        request,
+        fun(_Method, _Req, HttpOpts, _Opts) ->
+            Self ! {http_opts, HttpOpts},
+            {ok, {{"HTTP/1.1", 200, "OK"}, [], <<"{\"code\":0,\"authcode\":\"123\"}">>}}
+        end
+    ),
+    try
+        Auth = #auth{
+            allow_anonymous = false,
+            registry = ?REGISTRY_URL,
+            authentication = ?AUTH_URL
+        },
+        RegFrame = #{
+            <<"header">> => #{<<"phone">> => <<"000123456789">>},
+            <<"body">> => #{}
+        },
+        ?assertEqual({ok, <<"123">>}, emqx_jt808_auth:register(RegFrame, Auth)),
+        receive
+            {http_opts, HttpOpts} ->
+                ?assertEqual(false, proplists:get_value(autoredirect, HttpOpts))
+        after 2000 ->
+            ct:fail(no_http_request_made)
+        end
+    after
+        meck:unload(httpc)
+    end.
+
+%%--------------------------------------------------------------------
+%% Helpers
+
+set_ssrf_deny(DenyCidrs) ->
+    persistent_term:put(
+        ?CACHE_KEY,
+        #{
+            enable => true,
+            allow_cidrs => [],
+            deny_cidrs => emqx_utils_ssrf:compile_cidrs(DenyCidrs),
+            deny_hosts => []
+        }
+    ).
+
+jt808_config(AuthOverrides) ->
+    Auth =
+        maps:merge(
+            #{
+                <<"allow_anonymous">> => false,
+                <<"registry">> => ?REGISTRY_URL,
+                <<"authentication">> => ?AUTH_URL
+            },
+            maps:filter(fun(_K, V) -> V =/= undefined end, AuthOverrides)
+        ),
+    base_config(#{<<"proto">> => #{<<"auth">> => Auth}}).
+
+base_config(Overrides) ->
+    maps:merge(
+        #{
+            <<"enable">> => true,
+            <<"enable_stats">> => true,
+            <<"frame">> => #{<<"max_length">> => 8192},
+            <<"idle_timeout">> => <<"30s">>,
+            <<"max_retry_times">> => 3,
+            <<"message_queue_len">> => 10,
+            <<"mountpoint">> => <<"jt808/${clientid}/">>,
+            <<"proto">> => #{
+                <<"dn_topic">> => <<"${phone}/dn">>,
+                <<"up_topic">> => <<"${phone}/up">>
+            },
+            <<"retry_interval">> => <<"8s">>
+        },
+        Overrides
+    ).

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -73,7 +73,7 @@
 
 -define(TIMER_MSG, '#interval').
 
--define(HTTP_OPTIONS, [{autoredirect, true}, {timeout, 60000}]).
+-define(HTTP_OPTIONS, [{autoredirect, false}, {timeout, 60000}]).
 
 -define(SAFELY(EXPR, ELSE),
     (try

--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -262,10 +262,17 @@ setting(put, #{body := Body}) ->
     case emqx_prometheus_config:update(Deobfuscated) of
         {ok, NewConfig} ->
             {200, emqx_utils:redact(NewConfig)};
+        {error, #{kind := validation_error, reason := Reason}} ->
+            {400, #{code => 'BAD_REQUEST', message => validation_msg(Reason)}};
         {error, Reason} ->
             Message = list_to_binary(io_lib:format("Update config failed ~p", [Reason])),
             {500, 'INTERNAL_ERROR', Message}
     end.
+
+validation_msg(Reason) when is_binary(Reason) ->
+    Reason;
+validation_msg(Reason) ->
+    list_to_binary(io_lib:format("~p", [Reason])).
 
 stats(get, #{query_string := Qs}) ->
     collect(emqx_prometheus, collect_opts(Qs)).

--- a/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
@@ -16,6 +16,7 @@
     translation/1,
     convert_headers/2,
     validate_url/1,
+    validate_enabled_push_gateway/1,
     is_recommend_type/1
 ]).
 
@@ -28,7 +29,11 @@ roots() ->
         {prometheus,
             ?HOCON(
                 ?UNION(setting_union_schema()),
-                #{translate_to => ["prometheus"], default => #{}}
+                #{
+                    translate_to => ["prometheus"],
+                    default => #{},
+                    validator => fun ?MODULE:validate_enabled_push_gateway/1
+                }
             )}
     ].
 
@@ -378,35 +383,45 @@ convert_headers(Headers, _Opts) when is_list(Headers) ->
     Headers.
 
 validate_url(Url) ->
-    case uri_string:parse(Url) of
-        #{scheme := S} when
-            S =:= "https";
-            S =:= "http";
-            S =:= <<"https">>;
-            S =:= <<"http">>
+    case emqx_utils_uri:parse(iolist_to_binary(Url)) of
+        #{
+            scheme := Scheme,
+            authority := #{host := Host, userinfo := undefined},
+            fragment := undefined
+        } when
+            Scheme =:= <<"http">> orelse Scheme =:= <<"https">>,
+            is_binary(Host),
+            Host =/= <<>>
         ->
-            maybe_check_ssrf(Url);
+            ok;
         _ ->
-            {error, "Invalid url"}
+            {error, "Invalid url, expected http(s)://host[:port][/path]"}
     end.
 
-%% The default push_gateway URL is a documented localhost target which is
-%% not an operator chosen destination, so the SSRF policy does not apply to
-%% it. Any other URL is checked against the policy at config time.
-maybe_check_ssrf(Url) ->
-    UrlBin = iolist_to_binary(Url),
-    case UrlBin =:= ?DEFAULT_PUSH_GATEWAY_URL of
-        true ->
-            ok;
-        false ->
-            case emqx_utils_uri:host(emqx_utils_uri:parse(UrlBin)) of
-                undefined ->
-                    ok;
-                Host ->
-                    case emqx_utils_ssrf:check_host(Host) of
-                        ok -> ok;
-                        {error, Error} -> {error, emqx_utils_ssrf:format_error(Error)}
-                    end
+%% The SSRF policy is enforced only when the push gateway is actually
+%% enabled. A disabled gateway makes no outbound requests, so its (possibly
+%% default) URL must not fail validation: otherwise enabling the global SSRF
+%% policy would reject an untouched stock config whose default URL is a
+%% loopback target.
+validate_enabled_push_gateway(#{push_gateway := #{enable := true, url := Url}}) ->
+    check_ssrf(Url);
+validate_enabled_push_gateway(#{<<"push_gateway">> := #{<<"enable">> := true, <<"url">> := Url}}) ->
+    check_ssrf(Url);
+validate_enabled_push_gateway(#{enable := true, push_gateway_server := Url}) ->
+    check_ssrf(Url);
+validate_enabled_push_gateway(#{<<"enable">> := true, <<"push_gateway_server">> := Url}) ->
+    check_ssrf(Url);
+validate_enabled_push_gateway(_) ->
+    ok.
+
+check_ssrf(Url) ->
+    case emqx_utils_uri:host(emqx_utils_uri:parse(iolist_to_binary(Url))) of
+        undefined ->
+            {error, "Invalid url, expected http(s)://host[:port][/path]"};
+        Host ->
+            case emqx_utils_ssrf:check_host(Host) of
+                ok -> ok;
+                {error, Error} -> {error, emqx_utils_ssrf:format_error(Error)}
             end
     end.
 

--- a/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
@@ -21,6 +21,8 @@
 
 namespace() -> prometheus.
 
+-define(DEFAULT_PUSH_GATEWAY_URL, <<"http://127.0.0.1:9091">>).
+
 roots() ->
     [
         {prometheus,
@@ -99,7 +101,7 @@ fields(push_gateway) ->
                 string(),
                 #{
                     required => false,
-                    default => <<"http://127.0.0.1:9091">>,
+                    default => ?DEFAULT_PUSH_GATEWAY_URL,
                     validator => fun ?MODULE:validate_url/1,
                     desc => ?DESC(push_gateway_url)
                 }
@@ -210,7 +212,7 @@ fields(legacy_deprecated_setting) ->
             ?HOCON(
                 string(),
                 #{
-                    default => <<"http://127.0.0.1:9091">>,
+                    default => ?DEFAULT_PUSH_GATEWAY_URL,
                     required => true,
                     validator => fun ?MODULE:validate_url/1,
                     desc => ?DESC(legacy_push_gateway_server)
@@ -383,9 +385,29 @@ validate_url(Url) ->
             S =:= <<"https">>;
             S =:= <<"http">>
         ->
-            ok;
+            maybe_check_ssrf(Url);
         _ ->
             {error, "Invalid url"}
+    end.
+
+%% The default push_gateway URL is a documented localhost target which is
+%% not an operator chosen destination, so the SSRF policy does not apply to
+%% it. Any other URL is checked against the policy at config time.
+maybe_check_ssrf(Url) ->
+    UrlBin = iolist_to_binary(Url),
+    case UrlBin =:= ?DEFAULT_PUSH_GATEWAY_URL of
+        true ->
+            ok;
+        false ->
+            case emqx_utils_uri:host(emqx_utils_uri:parse(UrlBin)) of
+                undefined ->
+                    ok;
+                Host ->
+                    case emqx_utils_ssrf:check_host(Host) of
+                        ok -> ok;
+                        {error, Error} -> {error, emqx_utils_ssrf:format_error(Error)}
+                    end
+            end
     end.
 
 %% for CI test, CI don't load the whole emqx_conf_schema.

--- a/apps/emqx_prometheus/test/emqx_prometheus_ssrf_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_ssrf_SUITE.erl
@@ -1,0 +1,135 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_prometheus_ssrf_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/emqx.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-define(CACHE_KEY, {emqx_utils_ssrf, cache}).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_rule_engine,
+            emqx_management,
+            {emqx_prometheus, #{start => false}},
+            {emqx_license, "license.key = default"},
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{suite_apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    persistent_term:erase(?CACHE_KEY),
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
+
+init_per_testcase(_Case, Config) ->
+    _ = emqx_cth_suite:start_app(
+        emqx_prometheus,
+        #{config => emqx_prometheus_SUITE:config(default)}
+    ),
+    set_ssrf_deny([<<"169.254.0.0/16">>]),
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    persistent_term:erase(?CACHE_KEY),
+    _ = emqx_cth_suite:stop_apps([emqx_prometheus]),
+    ok.
+
+t_push_gateway_denied_url_rejected(_Config) ->
+    Conf = push_gateway_conf(<<"http://169.254.169.254:9091/metrics">>),
+    ?assertMatch({error, {"HTTP/1.1", 400, _}}, put_prometheus_conf(Conf)).
+
+t_push_gateway_default_url_still_accepted(_Config) ->
+    %% SSRF policy is enabled with default deny CIDRs (loopback included).
+    %% The default push_gateway URL is a documented localhost target and must
+    %% not be rejected when the operator did not configure it explicitly.
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    {ok, Response} = get_prometheus_conf(),
+    #{<<"push_gateway">> := PushGateway} = Conf = emqx_utils_json:decode(Response),
+    EnableConf = Conf#{<<"push_gateway">> => PushGateway#{<<"enable">> => true}},
+    {ok, _} = put_prometheus_conf(EnableConf),
+    ?assert(is_pid(erlang:whereis(emqx_prometheus))).
+
+t_legacy_push_gateway_server_denied_rejected(_Config) ->
+    Conf = legacy_conf(<<"http://169.254.169.254:9091">>),
+    ?assertMatch({error, {"HTTP/1.1", 400, _}}, put_prometheus_conf(Conf)).
+
+t_allowed_url_accepted(_Config) ->
+    Conf = push_gateway_conf(<<"http://8.8.8.8:9091/metrics">>),
+    {ok, _} = put_prometheus_conf(Conf).
+
+t_push_httpc_autoredirect_disabled(_Config) ->
+    Self = self(),
+    meck:new(httpc, [passthrough, no_link]),
+    meck:expect(
+        httpc,
+        request,
+        fun(Method, Req = {_Url, _Headers, _ContentType, _Data}, HttpOpts, Opts) ->
+            Self ! {http_opts, HttpOpts},
+            meck:passthrough([Method, Req, HttpOpts, Opts])
+        end
+    ),
+    try
+        Conf = emqx_prometheus_config:conf(),
+        ?assertMatch(ok, emqx_prometheus_sup:start_child(emqx_prometheus, Conf)),
+        receive
+            {http_opts, HttpOpts} ->
+                ?assertEqual(false, proplists:get_value(autoredirect, HttpOpts))
+        after 5000 ->
+            ct:fail(no_push_request_made)
+        end
+    after
+        meck:unload(httpc)
+    end.
+
+%%--------------------------------------------------------------------
+%% Helpers
+
+set_ssrf_deny(DenyCidrs) ->
+    persistent_term:put(
+        ?CACHE_KEY,
+        #{
+            enable => true,
+            allow_cidrs => [],
+            deny_cidrs => emqx_utils_ssrf:compile_cidrs(DenyCidrs),
+            deny_hosts => []
+        }
+    ).
+
+push_gateway_conf(Url) ->
+    {ok, Response} = get_prometheus_conf(),
+    #{<<"push_gateway">> := PushGateway} = Conf = emqx_utils_json:decode(Response),
+    Conf#{<<"push_gateway">> => PushGateway#{<<"enable">> => true, <<"url">> => Url}}.
+
+legacy_conf(Url) ->
+    {ok, Response} = get_prometheus_conf(),
+    #{<<"push_gateway">> := PushGateway} = Conf = emqx_utils_json:decode(Response),
+    Conf#{
+        <<"push_gateway">> => maps:without([<<"url">>], PushGateway),
+        <<"push_gateway_server">> => Url
+    }.
+
+get_prometheus_conf() ->
+    Auth = emqx_mgmt_api_test_util:auth_header_(),
+    emqx_mgmt_api_test_util:request_api(get, api_path(), "", Auth).
+
+put_prometheus_conf(Conf) ->
+    Auth = emqx_mgmt_api_test_util:auth_header_(),
+    emqx_mgmt_api_test_util:request_api(put, api_path(), "", Auth, Conf).
+
+api_path() ->
+    emqx_mgmt_api_test_util:api_path(["prometheus"]).

--- a/apps/emqx_prometheus/test/emqx_prometheus_ssrf_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_ssrf_SUITE.erl
@@ -53,20 +53,38 @@ t_push_gateway_denied_url_rejected(_Config) ->
     Conf = push_gateway_conf(<<"http://169.254.169.254:9091/metrics">>),
     ?assertMatch({error, {"HTTP/1.1", 400, _}}, put_prometheus_conf(Conf)).
 
-t_push_gateway_default_url_still_accepted(_Config) ->
-    %% SSRF policy is enabled with default deny CIDRs (loopback included).
-    %% The default push_gateway URL is a documented localhost target and must
-    %% not be rejected when the operator did not configure it explicitly.
+t_push_gateway_disabled_default_url_accepted(_Config) ->
+    %% SSRF policy is enabled and denies loopback, but the push gateway stays
+    %% disabled with its untouched default URL: no outbound request can be
+    %% made, so the config must be accepted.
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    {ok, Response} = get_prometheus_conf(),
+    #{<<"push_gateway">> := PushGateway} = Conf = emqx_utils_json:decode(Response),
+    DisableConf = Conf#{<<"push_gateway">> => PushGateway#{<<"enable">> => false}},
+    {ok, _} = put_prometheus_conf(DisableConf).
+
+t_push_gateway_enabled_default_url_rejected(_Config) ->
+    %% Once the push gateway is enabled its URL becomes a live outbound
+    %% target; the default loopback URL must not bypass the SSRF policy.
     set_ssrf_deny([<<"127.0.0.0/8">>]),
     {ok, Response} = get_prometheus_conf(),
     #{<<"push_gateway">> := PushGateway} = Conf = emqx_utils_json:decode(Response),
     EnableConf = Conf#{<<"push_gateway">> => PushGateway#{<<"enable">> => true}},
-    {ok, _} = put_prometheus_conf(EnableConf),
-    ?assert(is_pid(erlang:whereis(emqx_prometheus))).
+    ?assertMatch({error, {"HTTP/1.1", 400, _}}, put_prometheus_conf(EnableConf)).
 
 t_legacy_push_gateway_server_denied_rejected(_Config) ->
-    Conf = legacy_conf(<<"http://169.254.169.254:9091">>),
+    Conf = legacy_conf(true, <<"http://169.254.169.254:9091">>),
     ?assertMatch({error, {"HTTP/1.1", 400, _}}, put_prometheus_conf(Conf)).
+
+t_legacy_enabled_default_url_rejected(_Config) ->
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    Conf = legacy_conf(true, <<"http://127.0.0.1:9091">>),
+    ?assertMatch({error, {"HTTP/1.1", 400, _}}, put_prometheus_conf(Conf)).
+
+t_legacy_disabled_default_url_accepted(_Config) ->
+    set_ssrf_deny([<<"127.0.0.0/8">>]),
+    Conf = legacy_conf(false, <<"http://127.0.0.1:9091">>),
+    {ok, _} = put_prometheus_conf(Conf).
 
 t_allowed_url_accepted(_Config) ->
     Conf = push_gateway_conf(<<"http://8.8.8.8:9091/metrics">>),
@@ -115,11 +133,12 @@ push_gateway_conf(Url) ->
     #{<<"push_gateway">> := PushGateway} = Conf = emqx_utils_json:decode(Response),
     Conf#{<<"push_gateway">> => PushGateway#{<<"enable">> => true, <<"url">> => Url}}.
 
-legacy_conf(Url) ->
-    {ok, Response} = get_prometheus_conf(),
-    #{<<"push_gateway">> := PushGateway} = Conf = emqx_utils_json:decode(Response),
-    Conf#{
-        <<"push_gateway">> => maps:without([<<"url">>], PushGateway),
+%% A minimal legacy-shaped config: at least one legacy-only key so the union
+%% schema picks the legacy struct; all other legacy fields fall back to their
+%% defaults.
+legacy_conf(Enable, Url) ->
+    #{
+        <<"enable">> => Enable,
         <<"push_gateway_server">> => Url
     }.
 

--- a/changes/ee/fix-18517.en.md
+++ b/changes/ee/fix-18517.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the JT808 gateway registry and authentication URLs and the Prometheus push gateway URL were not validated against the outbound SSRF destination policy, which could allow the gateway or the push gateway to reach internal network resources. HTTP redirects are no longer followed by these outbound requests.


### PR DESCRIPTION
Release version: 6.3.2, 7.0.0

Introduced in: pre-5.8

## Summary

Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/308

Outbound HTTP endpoints configured for the JT808 gateway (registry and
authentication URLs) and the Prometheus push gateway were not validated
against the outbound SSRF destination policy (`rule_engine.ssrf`), and
followed HTTP redirects. An administrator with config write access could
point these components at internal network resources.

## Changes

- **JT808 gateway**: `registry` and `authentication` URLs are validated at
  config time (scheme must be http(s), no userinfo/fragment, host must pass
  `emqx_utils_ssrf:check_host/1`); redirect following is disabled for these
  requests.
- **Prometheus push gateway**: the URL is format-validated fail-closed
  (http(s) scheme, parseable host, no userinfo/fragment). The SSRF policy is
  enforced whenever the push gateway is enabled, including when the URL is
  left at its default; a disabled push gateway with the untouched default
  URL is not blocked, so enabling the global SSRF policy does not reject an
  untouched stock config. Redirect following is disabled for push requests.
- **Prometheus config API**: `PUT /prometheus` now returns 400 (instead of
  500) when an update is rejected by schema validation.

## Test plan

- `emqx_gateway_jt808` SSRF SUITE
- `emqx_prometheus_ssrf_SUITE` (denied CIDR rejected, enabled default
  loopback URL rejected, disabled gateway accepted, legacy
  `push_gateway_server` variants, `autoredirect` disabled)
- `emqx_prometheus_SUITE` and `emqx_prometheus_api_SUITE` for regressions

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)