### PR TITLE
fix(log): add process label to the OOM shutdown reason

### DIFF
--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -275,10 +275,11 @@ check_oom(Pid, #{
         undefined ->
             ok;
         [{message_queue_len, QLen}, {total_heap_size, HeapSize}] ->
-            do_check_oom([
+            Result = do_check_oom([
                 {QLen, MaxQLen, mailbox_overflow},
                 {HeapSize, MaxHeapSize, proc_heap_too_large}
-            ])
+            ]),
+            add_proc_label(Pid, Result)
     end.
 
 do_check_oom([]) ->
@@ -287,6 +288,16 @@ do_check_oom([{Val, Max, Reason} | Rest]) ->
     case is_integer(Max) andalso (0 < Max) andalso (Max < Val) of
         true -> {shutdown, #{reason => Reason, value => Val, max => Max}};
         false -> do_check_oom(Rest)
+    end.
+
+%% Add the process label (e.g. `{clientid, ClientId}') to the shutdown
+%% reason so the supervisor report identifies the offending process.
+add_proc_label(_Pid, ok) ->
+    ok;
+add_proc_label(Pid, {shutdown, Reason}) ->
+    case proc_lib:get_label(Pid) of
+        undefined -> {shutdown, Reason};
+        Label -> {shutdown, Reason#{label => Label}}
     end.
 
 tune_heap_size(#{enable := false}) ->

--- a/apps/emqx_utils/test/emqx_utils_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_utils_SUITE.erl
@@ -140,6 +140,7 @@ t_index_of(_) ->
     end,
     ?assertEqual(3, emqx_utils:index_of(a, [b, c, a, e, f])).
 
+-doc "Check the OOM policy against the calling process's own mailbox size.".
 t_check(_) ->
     Policy = #{
         max_mailbox_size => 10,
@@ -149,10 +150,65 @@ t_check(_) ->
     [self() ! {msg, I} || I <- lists:seq(1, 5)],
     ?assertEqual(ok, emqx_utils:check_oom(Policy)),
     [self() ! {msg, I} || I <- lists:seq(1, 6)],
-    ?assertEqual(
-        {shutdown, #{reason => mailbox_overflow, value => 11, max => 10}},
+    ?assertMatch(
+        {shutdown, #{reason := mailbox_overflow, value := 11, max := 10}},
         emqx_utils:check_oom(Policy)
     ).
+
+-doc """
+The shutdown reason returned by `check_oom/2` carries the checked
+process's label under the `label` key.
+""".
+t_check_oom_with_label(_) ->
+    Policy = #{
+        max_mailbox_size => 10,
+        max_heap_size => 1024 * 1024 * 8,
+        enable => true
+    },
+    Parent = self(),
+    Pid = spawn_link(fun() ->
+        proc_lib:set_label({clientid, <<"oom-client">>}),
+        Parent ! {ready, self()},
+        receive
+            stop -> ok
+        end
+    end),
+    receive
+        {ready, Pid} -> ok
+    end,
+    [Pid ! {msg, I} || I <- lists:seq(1, 11)],
+    ?assertEqual(
+        {shutdown, #{
+            reason => mailbox_overflow,
+            value => 11,
+            max => 10,
+            label => {clientid, <<"oom-client">>}
+        }},
+        emqx_utils:check_oom(Pid, Policy)
+    ),
+    Pid ! stop.
+
+-doc """
+When the checked process has no label, the shutdown reason contains no
+`label` key and keeps the `reason`, `value` and `max` keys unchanged.
+""".
+t_check_oom_without_label(_) ->
+    Policy = #{
+        max_mailbox_size => 10,
+        max_heap_size => 1024 * 1024 * 8,
+        enable => true
+    },
+    Pid = spawn_link(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    [Pid ! {msg, I} || I <- lists:seq(1, 11)],
+    ?assertEqual(
+        {shutdown, #{reason => mailbox_overflow, value => 11, max => 10}},
+        emqx_utils:check_oom(Pid, Policy)
+    ),
+    Pid ! stop.
 
 t_tune_heap_size(_Config) ->
     Policy = #{

--- a/changes/ee/fix-18521.en.md
+++ b/changes/ee/fix-18521.en.md
@@ -1,0 +1,3 @@
+Identify the client in the connection shutdown report emitted when a connection exceeds a force-shutdown limit (`force_shutdown.max_mailbox_size` or `force_shutdown.max_heap_size`).
+
+The shutdown reason now includes a `label` field. For an established connection, it holds the client ID. For a connection shut down before CONNECT completes, it holds the listener name and peer address. Previously the report contained only the limit and the measured value, so the operator could not tell which client was shut down.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

The `connection_shutdown` supervisor report emitted when a connection exceeds a
`force_shutdown` limit did not identify the client:

```
[error] supervisor: {esockd_connection_sup,<0.6548029.0>}, errorContext: connection_shutdown,
reason: #{max => 1000000, reason => mailbox_overflow, value => 1001723},
offender: [{pid,<0.6548029.0>},{name,connection},{mfargs,{emqx_connection,start_link,
[#{listener => {tcp,default},enable_authn => true,zone => default}]}}]
```

This PR adds the process label to the shutdown reason built in
`emqx_utils:check_oom/2`. After the change:

```
[error] supervisor: {esockd_connection_sup,<0.7015.0>}, errorContext: connection_shutdown,
reason: #{label => {clientid,<<"oom-victim">>},max => 50,reason => mailbox_overflow,value => 9989},
offender: [{pid,<0.7015.0>},{name,connection},{mfargs,{emqx_connection,start_link,
[#{listener => {tcp,default},zone => default,enable_authn => true}]}}]
```

Details:

* The fix is in the shared helper, so it covers every transport that calls it:
  `emqx_connection`, `emqx_ws_connection`, `emqx_socket_connection`,
  `emqx_gateway_conn`, `emqx_gateway_conn_ws` and `emqx_ocpp_connection`.
* The label is `{clientid, ClientId}` for an established MQTT connection.
  A connection shut down before CONNECT completes carries the label set at
  accept time: `{Listener, Peername}`. The value is passed through as is.
* When the checked process has no label, the `label` key is omitted.
* The clientid in the label is already truncated by
  `emqx_logger:truncate_procmeta_string/1`, so the reason term stays small.
* The existing `reason`, `value` and `max` keys are unchanged.

Verified on a live node (release build, `max_mailbox_size=50`, slow subscriber,
publish flood). Note that the connection process also logs a
`check_oom_shutdown` warning with full client metadata about 2 ms before the
supervisor report:

```
[warning] clientid: oom-victim, msg: check_oom_shutdown, peername: 127.0.0.1:42260, pid: <0.7015.0>,
shutdown: #{label => {clientid,<<"oom-victim">>},max => 50,reason => mailbox_overflow,value => 9989}, ...
```

So the information was already present in an adjacent line, but the supervisor
report is the line operators grep for, and correlating the two by timestamp is
the friction this PR removes.

An end-to-end CT case that drives a real connection over the limit and asserts
on the supervisor report is not included: the overflow needs a precise race
between delivery flooding and the mailbox-length checkpoint (reproduced
manually with `erlang:suspend_process/1`), and the existing
`t_oom_shutdown` case in `emqx_connection_SUITE` mocks `emqx_utils:check_oom`.
Unit coverage for the new behavior is in `emqx_utils_SUITE`.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
