### PR TITLE
chore: keep test tarballs out of the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ bom.json
 ct_run*/
 apps/emqx_conf/etc/emqx.conf.all.rendered*
 rebar-git-cache.tar
+# test-generated plugin packages; root-anchored to keep tracked
+# test fixtures under apps/*/test/*_SUITE_data/ addable
+/*.tar.gz
 # build docker image locally
 .dockerignore
 .docker_image_tag

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -1702,12 +1702,16 @@ t_start_node_with_plugin_enabled(Config) when is_list(Config) ->
 make_tar(Cwd, NameWithVsn) ->
     make_tar(Cwd, NameWithVsn, NameWithVsn).
 
-make_tar(Cwd, NameWithVsn, TarfileVsn) ->
+make_tar(Cwd0, NameWithVsn, TarfileVsn) ->
+    %% absolute output path: a bare relative name would land wherever
+    %% the cwd happens to point if set_cwd is skipped or misdirected
+    Cwd = filename:absname(Cwd0),
+    TarFile = filename:join(Cwd, TarfileVsn ++ ".tar.gz"),
     {ok, OriginalCwd} = file:get_cwd(),
+    %% archive entries must stay relative to Cwd
     ok = file:set_cwd(Cwd),
     try
         Files = filelib:wildcard(NameWithVsn ++ "/**"),
-        TarFile = TarfileVsn ++ ".tar.gz",
         ok = erl_tar:create(TarFile, Files, [compressed])
     after
         file:set_cwd(OriginalCwd)


### PR DESCRIPTION
Two small changes to stop test-generated plugin tarballs from being committed at the repository root:

- Add a root-anchored `/*.tar.gz` to `.gitignore`. The anchor keeps the tracked test fixtures under `apps/emqx_management/test/*_SUITE_data/` addable.
- Make `emqx_plugins_SUITE:make_tar/3` write the archive to an absolute path instead of a bare relative filename. The archive members are unchanged.

The files that already got committed (`my_emqx_plugin-5.9.0-beta.3.tar.gz`, `my_emqx_plugin_a-5.9.0-beta.3.tar.gz`) exist only on `dev-63` and later; a companion `dev-63` PR removes them. This PR is based on `dev-60` so the ignore rule reaches all downstream branches through the forward-sync chain.