### PR TITLE
fix(shutdown): stop listeners before stopping applications

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -339,7 +339,9 @@ stop() ->
     %% so we uninstall the config handler here.
     ok = emqx_config_handler:remove_handler(?CONF_KEY_PATH),
     ok = emqx_config_handler:remove_handler([?ROOT_KEY]),
-    foreach_listeners(fun stop_listener/3).
+    ok = foreach_listeners(fun stop_listener/3),
+    ?tp(emqx_listeners_stopped, #{}),
+    ok.
 
 -spec stop_listener(listener_id()) -> ok | {error, term()}.
 stop_listener(ListenerId) ->

--- a/apps/emqx_machine/mix.exs
+++ b/apps/emqx_machine/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMachine.MixProject do
   def project do
     [
       app: :emqx_machine,
-      version: "6.0.3",
+      version: "6.0.4",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -66,10 +66,30 @@ start_autocluster() ->
 
 stop_apps() ->
     ?SLOG(notice, #{msg => "stopping_emqx_apps"}),
+    %% Stop listeners first, so no client traffic reaches hook callbacks
+    %% while the apps behind them (plugins, rule engine, ...) are stopped.
+    ok = stop_listeners(),
     _ = emqx_alarm_handler:unload(),
     ok = emqx_conf_app:unset_config_loaded(),
     ok = emqx_plugins:ensure_stopped(),
     lists:foreach(fun stop_one_app/1, lists:reverse(sorted_reboot_apps())).
+
+%% Listeners are stopped again from `emqx_app:prep_stop/1' when the `emqx'
+%% app stops; `emqx_listeners:stop/0' is idempotent.
+stop_listeners() ->
+    try
+        _ = emqx_boot:is_enabled(listeners) andalso emqx_listeners:stop(),
+        ok
+    catch
+        C:E:Stacktrace ->
+            ?SLOG(error, #{
+                msg => "failed_to_stop_listeners",
+                exception => C,
+                reason => E,
+                stacktrace => Stacktrace
+            }),
+            ok
+    end.
 
 %% Those port apps are terminated after the main apps
 %% Don't need to stop when reboot.
@@ -87,6 +107,7 @@ stop_port_apps() ->
 
 stop_one_app(App) ->
     ?SLOG(debug, #{msg => "stopping_app", app => App}),
+    ?tp(machine_stopping_app, #{app => App}),
     try
         _ = application:stop(App)
     catch

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -66,7 +66,12 @@ start_autocluster() ->
 
 stop_apps() ->
     ?SLOG(notice, #{msg => "stopping_emqx_apps"}),
-    %% Stop listeners first, so no client traffic reaches hook callbacks
+    %% Shut the readiness gate first: `GET /status' reports not_running
+    %% (HTTP 503) so load balancers stop routing to this node, and
+    %% connections accepted before the listen sockets close are refused.
+    %% `ensure_apps_started/0' marks the node ready again after a reboot.
+    ok = emqx_node_readiness:mark_not_ready(),
+    %% Stop listeners next, so no client traffic reaches hook callbacks
     %% while the apps behind them (plugins, rule engine, ...) are stopped.
     ok = stop_listeners(),
     _ = emqx_alarm_handler:unload(),

--- a/apps/emqx_machine/test/emqx_machine_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_SUITE.erl
@@ -122,10 +122,11 @@ t_shutdown_reboot(Config) ->
     end.
 
 -doc """
-Verify `emqx_machine_boot:stop_apps/0' stops the MQTT listeners before it stops
-the applications, so no client traffic reaches hook callbacks (e.g. the rule
-engine) while their state is torn down.  Also verify `stop_apps/0' does not
-raise when called twice, and that `ensure_apps_started/0' brings listeners back.
+Verify `emqx_machine_boot:stop_apps/0' shuts the readiness gate and stops the
+MQTT listeners before it stops the applications, so no client traffic reaches
+hook callbacks (e.g. the rule engine) while their state is torn down.  Also
+verify `stop_apps/0' does not raise when called twice, and that
+`ensure_apps_started/0' restores listeners and readiness.
 """.
 t_stop_apps_stops_listeners_first(Config) ->
     [Node] = emqx_cth_cluster:start(
@@ -151,13 +152,15 @@ t_stop_apps_stops_listeners_first(Config) ->
                 ?assertMatch([#{?snk_kind := emqx_listeners_stopped} | _], Events)
             end
         ),
-        %% The listener no longer accepts connections.
+        %% The readiness gate is shut and the listener no longer accepts.
+        ?assertNot(erpc:call(Node, emqx_node_readiness, is_ready, [])),
         ?assertEqual({error, econnrefused}, gen_tcp:connect("127.0.0.1", Port, [], 5000)),
         %% A second stop does not raise.
         ok = erpc:call(Node, emqx_machine_boot, stop_apps, []),
-        %% The reboot path (cluster join/leave) restores the listeners.
+        %% The reboot path (cluster join/leave) restores listeners and readiness.
         ok = erpc:call(Node, emqx_app, set_config_loader, [emqx_cth_suite]),
         ok = erpc:call(Node, emqx_machine_boot, ensure_apps_started, []),
+        ?assert(erpc:call(Node, emqx_node_readiness, is_ready, [])),
         {ok, Sock1} = gen_tcp:connect("127.0.0.1", Port, [], 5000),
         ok = gen_tcp:close(Sock1)
     after

--- a/apps/emqx_machine/test/emqx_machine_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_SUITE.erl
@@ -121,6 +121,49 @@ t_shutdown_reboot(Config) ->
         catch emqx_cth_cluster:stop([Node])
     end.
 
+-doc """
+Verify `emqx_machine_boot:stop_apps/0' stops the MQTT listeners before it stops
+the applications, so no client traffic reaches hook callbacks (e.g. the rule
+engine) while their state is torn down.  Also verify `stop_apps/0' does not
+raise when called twice, and that `ensure_apps_started/0' brings listeners back.
+""".
+t_stop_apps_stops_listeners_first(Config) ->
+    [Node] = emqx_cth_cluster:start(
+        [{machine_listeners_SUITE1, #{role => core, apps => app_specs()}}],
+        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+    ),
+    try
+        Port = emqx_cth_cluster:get_tcp_mqtt_port(Node),
+        %% The listener accepts connections before shutdown.
+        {ok, Sock0} = gen_tcp:connect("127.0.0.1", Port, [], 5000),
+        ok = gen_tcp:close(Sock0),
+        ?check_trace(
+            ok = erpc:call(Node, emqx_machine_boot, stop_apps, []),
+            fun(Trace) ->
+                %% Listeners must be stopped before the rule engine app.
+                Events = [
+                    Event
+                 || #{?snk_kind := Kind} = Event <- Trace,
+                    Kind =:= emqx_listeners_stopped orelse
+                        (Kind =:= machine_stopping_app andalso
+                            maps:get(app, Event) =:= emqx_rule_engine)
+                ],
+                ?assertMatch([#{?snk_kind := emqx_listeners_stopped} | _], Events)
+            end
+        ),
+        %% The listener no longer accepts connections.
+        ?assertEqual({error, econnrefused}, gen_tcp:connect("127.0.0.1", Port, [], 5000)),
+        %% A second stop does not raise.
+        ok = erpc:call(Node, emqx_machine_boot, stop_apps, []),
+        %% The reboot path (cluster join/leave) restores the listeners.
+        ok = erpc:call(Node, emqx_app, set_config_loader, [emqx_cth_suite]),
+        ok = erpc:call(Node, emqx_machine_boot, ensure_apps_started, []),
+        {ok, Sock1} = gen_tcp:connect("127.0.0.1", Port, [], 5000),
+        ok = gen_tcp:close(Sock1)
+    after
+        catch emqx_cth_cluster:stop([Node])
+    end.
+
 t_sorted_reboot_apps(_Config) ->
     Apps = emqx_machine_boot:sorted_reboot_apps(),
     SortApps = [App || App <- Apps, (App =:= emqx_dashboard orelse App =:= emqx_license)],

--- a/changes/ee/fix-18523.en.md
+++ b/changes/ee/fix-18523.en.md
@@ -1,3 +1,5 @@
 Stop MQTT listeners before stopping applications during node shutdown.
 
 Previously, listeners kept accepting and processing client traffic while the applications behind the publish path were already stopped. Publishing clients could then trigger a burst of `hook_callback_exception` errors in the log, for example from the rule engine, until the listeners stopped a few seconds later. Listeners now stop first, so no client traffic is processed during application shutdown.
+
+The node now also reports itself as not running in `GET /status` as soon as shutdown begins, so load balancers stop routing new connections to it.

--- a/changes/ee/fix-18523.en.md
+++ b/changes/ee/fix-18523.en.md
@@ -1,0 +1,3 @@
+Stop MQTT listeners before stopping applications during node shutdown.
+
+Previously, listeners kept accepting and processing client traffic while the applications behind the publish path were already stopped. Publishing clients could then trigger a burst of `hook_callback_exception` errors in the log, for example from the rule engine, until the listeners stopped a few seconds later. Listeners now stop first, so no client traffic is processed during application shutdown.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

During node shutdown, MQTT listeners stayed open while the applications behind the publish path were stopped. Listeners were stopped from `emqx_app:prep_stop/1`, which runs when the `emqx` application stops. `emqx_machine_boot:stop_apps/0` stops applications in reverse dependency order, so `emqx` stops after every business application. Clients kept publishing through the open listeners, and each publish crashed in the hook chain once the state it needs was gone.

A production log contained 4963 `hook_callback_exception` errors, all inside two ~2-second windows between the terminate signal and the listeners stopping. Every one is the same crash:

```
{ets,next,[emqx_rule_engine_topic_index,{[],{}}],
     [{error_info,#{cause => id, module => erl_stdlib_errors}}]},
{emqx_topic_index,'-make_nextf/1-fun-0-',2,...},
{emqx_rule_engine,get_rules_for_topic,1,...},
{emqx_rule_events,on_message_publish,2,...},
```

`emqx_rule_engine_topic_index` dies with the rule engine application while listeners still feed publishes into the hook.

The change: `stop_apps/0` now shuts the readiness gate and stops the listeners first, before `emqx_plugins:ensure_stopped/0` and the per-application stop loop. A plugin holding a hook has the same exposure as the rule engine, so listeners stop before plugins too.

Notes:

* `emqx_node_readiness:mark_not_ready/0` runs first. `GET /status` reports `not_running` (HTTP 503) as soon as shutdown begins, so load balancers stop routing to the node, and connections accepted in the window before the listen sockets close are refused at init instead of served during teardown. `ensure_apps_started/0` already re-marks the node ready on the reboot (cluster join/leave) path.

* The call in `emqx_app:prep_stop/1` stays, because the `emqx` application can be stopped without going through `stop_apps/0`. `emqx_listeners:stop/0` therefore runs twice on the normal path. It is idempotent: `emqx_config_handler:remove_handler/1` is a cast that removes a missing entry as a no-op, and esockd, cowboy and quicer all return `{error, not_found}` for an already-stopped listener, which `stop_listener/3` maps to `ok` without logging.
* The early stop is wrapped in a try/catch, so a listener stop failure cannot abort the application shutdown loop.
* `stop_apps/0` is also the ekka reboot callback (cluster join/leave). `ensure_apps_started/0` restarts the `emqx` application, which starts the listeners again; the new test covers this round trip. The listener-less window during a reboot now also covers the application stop phase; that is the point of the change: the node must not serve traffic while its applications are torn down.
* Gateway listeners (`emqx_gateway`) have the same exposure but are managed by the gateway application; they are out of scope here and can get the same treatment in a separate change.

Manual verification: a node with one rule (`SELECT * FROM "t/#"`), 10 connections publishing ~20k msg/s, then SIGTERM.

Before (this branch with the two changed files reverted to dev-60):

```
2026-08-26T20:10:57.662058+02:00 [critical] msg: received_terminate_signal, pid: <0.3836.0>
2026-08-26T20:10:57.741174+02:00 [error] clientid: zmd_bench_pub_2509450267_1, msg: hook_callback_exception, peername: 127.0.0.1:48132, pid: <0.6648.0>, reason: badarg, stacktrace: [{ets,next,[emqx_rule_engine_topic_index,{[],{}}],[{error_info,#{cause => id,module => erl_stdlib_errors}}]},...
... 21 hook_callback_exception errors in total ...
Listener tcp:default on 127.0.0.1:41883 stopped.
```

After (this branch):

```
2026-08-26T20:05:32.900442+02:00 [critical] msg: received_terminate_signal, pid: <0.3836.0>
Listener tcp:default on 127.0.0.1:41884 stopped.
```

0 `hook_callback_exception` errors under the same load.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
