### PR TITLE
docs(otel): unhide exporter protocol config field

### DIFF
--- a/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
@@ -207,7 +207,7 @@ fields("otel_exporter") ->
                 #{
                     default => grpc,
                     desc => ?DESC(exporter_protocol),
-                    importance => ?IMPORTANCE_HIDDEN
+                    importance => ?IMPORTANCE_LOW
                 }
             )},
         {ssl_options,

--- a/rel/i18n/emqx_otel_schema.hocon
+++ b/rel/i18n/emqx_otel_schema.hocon
@@ -39,7 +39,9 @@ exporter_headers.desc:
 The headers are a map with header names as keys."""
 exporter_headers.label: "Exporter Headers"
 
-exporter_protocol.desc: "The transport protocol of Open Telemetry Exporter"
+exporter_protocol.desc:
+"""The transport protocol of the OpenTelemetry exporter.
+Only `grpc` is supported. The exporter cannot send to an OTLP/HTTP endpoint."""
 exporter_protocol.label: "Exporter Protocol"
 
 exporter_ssl.desc: "SSL configuration for the Open Telemetry exporter"

--- a/scripts/spellcheck/dicts/emqx.txt
+++ b/scripts/spellcheck/dicts/emqx.txt
@@ -208,6 +208,7 @@ opentelemetry
 OpenTelemetry
 OpenTSDB
 os
+OTLP
 OTP
 params
 peerhost


### PR DESCRIPTION
The OpenTelemetry exporter only supports gRPC transport, but the `protocol` field was marked hidden, so the constraint never appeared in the generated configuration reference.

Users pointing the exporter at an OTLP/HTTP endpoint get an unexplained export failure with no indication that HTTP is unsupported — see #16720.

Make the field visible and state the limitation in its description. No behaviour change.

Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0