### PR TITLE
docs(mt): record that PUBREL await-timeout is not a message drop

### DIFF
--- a/apps/emqx_mt/src/emqx_mt_hookcb.erl
+++ b/apps/emqx_mt/src/emqx_mt_hookcb.erl
@@ -244,13 +244,14 @@ on_namespace_resource_pre_create(#{?namespace := Namespace}, ResCtx) when is_bin
 %%   * Reason `no_subscribers' is the only one that has a dedicated
 %%     fine-grained global counter ticked at the call site
 %%     (`emqx_broker:inc_dropped_cnt/1'); we mirror it per-namespace.
-%%   * QoS2 PUBREL await-timeout drops bump the global
-%%     `messages.dropped.await_pubrel_timeout' counter via
-%%     `emqx_session_events:inc_await_pubrel_timeout/1' but do not fire the
-%%     `message.dropped' hook (the event carries only a count, not the
-%%     `#message{}'s). So the per-namespace counter for that reason stays at
-%%     zero until the upstream gap is closed. Tracked in
-%%     https://github.com/emqx/emqx/issues/17663.
+%%   * QoS2 PUBREL await-timeout is not a message drop and must not fire the
+%%     `message.dropped' hook. EMQX publishes a QoS2 message to subscribers when
+%%     the PUBLISH arrives, not when the PUBREL does (see
+%%     `emqx_session_mem:publish/3'). What expires afterwards is the packet-ID
+%%     de-duplication state, so the message was delivered. The global
+%%     `messages.dropped.await_pubrel_timeout' counter is kept for backwards
+%%     compatibility but counts expired receive-flow state, not undelivered
+%%     messages. There is therefore no per-namespace counter for that reason.
 on_message_dropped(Msg, _Info, Reason) ->
     inc_ns(ns_from_msg(Msg), drop_metric_names('messages.dropped', Reason)).
 

--- a/changes/ee/feat-17665.en.md
+++ b/changes/ee/feat-17665.en.md
@@ -1,3 +1,1 @@
 Added per-namespace counters for dropped messages and dropped deliveries in the multi-tenancy app. These are exposed at `/api/v5/prometheus/namespaced_stats` with a `namespace` label, alongside the existing per-namespace metric families. Operators can now diagnose drop rates per tenant from Prometheus without resorting to log inspection.
-
-Known limitation: QoS2 PUBREL await-timeout drops do not yet have per-namespace attribution because that drop path bumps the global counter without firing the `message.dropped` hook. Tracked separately.


### PR DESCRIPTION
Commit a8a4ec72ee (from #17665) described the missing per-namespace counter for QoS 2 PUBREL await-timeout as a gap tracked in #17663. That framing is wrong, so this replaces it with the reasoning and drops the known-limitation paragraph from the changelog.

EMQX publishes a QoS 2 message to subscribers when the PUBLISH arrives, not when the PUBREL does:

```erlang
                false ->
                    Results = emqx_broker:publish(Msg),
                    AwaitingRel1 = maps:put(PacketId, Ts, AwaitingRel),
```

What expires while awaiting PUBREL is the packet-ID de-duplication state, so the message was already delivered. Firing `message.dropped` there would report a loss that did not happen.

The awaiting-PUBREL state also holds no message:

```erlang
-type awaiting_rel() :: #{emqx_types:packet_id() => unix_timestamp_ms()}.
```

so there is nothing to pass to the hook without retaining every in-flight QoS 2 message.

The global `messages.dropped.await_pubrel_timeout` counter is kept for backwards compatibility. No behaviour change.

Release version:
6.1.5, 6.2.4, 6.3.0, 7.0.0