### PR TITLE
fix(clink): correctly classify recoverable forwarding errors

### DIFF
--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -199,19 +199,21 @@ on_query(
 ) ->
     QoS = min(?QOS_1, FwdQoS),
     Payload = encode_payload(FwdMsg#message{extra = #{}}),
-    PubResult = ecpool:pick_and_do(
-        {PoolName, PoolKey},
-        fun(ConnPid) ->
-            emqtt:publish(ConnPid, LinkTopic, Payload, QoS)
-        end,
-        no_handover
-    ),
-    ?tp_debug("cluster_link_message_forwarded", #{
-        pool => PoolName,
-        message => FwdMsg,
-        pub_result => PubResult
-    }),
-    handle_send_result(PubResult).
+    handle_ecpool_result(
+        ecpool:pick_and_do(
+            {PoolName, PoolKey},
+            fun(ConnPid) ->
+                Result = emqtt:publish(ConnPid, LinkTopic, Payload, QoS),
+                ?tp_debug("cluster_link_message_forwarded", #{
+                    pool => PoolName,
+                    message => FwdMsg,
+                    pub_result => Result
+                }),
+                handle_send_result(Result)
+            end,
+            no_handover
+        )
+    ).
 
 on_query_async(
     _ResourceId,
@@ -222,22 +224,26 @@ on_query_async(
     Callback = {fun on_async_result/2, [CallbackIn]},
     QoS = min(?QOS_1, FwdQoS),
     Payload = encode_payload(FwdMsg#message{extra = #{}}),
-    Result = ecpool:pick_and_do(
-        {PoolName, PoolKey},
-        fun(ConnPid) ->
-            PubResult = emqtt:publish_async(ConnPid, LinkTopic, Payload, QoS, Callback),
-            ?tp_debug("cluster_link_message_forwarded", #{
-                pool => PoolName,
-                message => FwdMsg,
-                pub_result => PubResult
-            }),
-            PubResult
-        end,
-        no_handover
-    ),
-    %% This result could be `{error, ecpool_empty}', for example, which should be
-    %% recoverable.  If we didn't handle it here, it would be considered unrecoverable.
-    handle_send_result(Result).
+    handle_ecpool_result(
+        ecpool:pick_and_do(
+            {PoolName, PoolKey},
+            fun(ConnPid) ->
+                Result = emqtt:publish_async(ConnPid, LinkTopic, Payload, QoS, Callback),
+                ?tp_debug("cluster_link_message_forwarded", #{
+                    pool => PoolName,
+                    message => FwdMsg,
+                    pub_result => Result
+                }),
+                case handle_send_result(Result) of
+                    ok ->
+                        {ok, ConnPid};
+                    Error ->
+                        Error
+                end
+            end,
+            no_handover
+        )
+    ).
 
 %% copied from emqx_bridge_mqtt_connector
 
@@ -262,18 +268,38 @@ handle_send_result({ok, Reply}) ->
 handle_send_result({error, Reason}) ->
     {error, classify_error(Reason)}.
 
+handle_ecpool_result({error, disconnected}) ->
+    {error, {recoverable_error, disconnected}};
+handle_ecpool_result({error, ecpool_empty}) ->
+    {error, {recoverable_error, disconnected}};
+handle_ecpool_result(Result) ->
+    Result.
+
 classify_reply(Reply = #{reason_code := _}) ->
     {unrecoverable_error, Reply}.
 
-classify_error(disconnected = Reason) ->
-    {recoverable_error, Reason};
-classify_error(ecpool_empty) ->
-    {recoverable_error, disconnected};
 classify_error({disconnected, _RC, _} = Reason) ->
     {recoverable_error, Reason};
 classify_error({shutdown, _} = Reason) ->
     {recoverable_error, Reason};
 classify_error(shutdown = Reason) ->
+    {recoverable_error, Reason};
+classify_error(Reason) when
+    Reason =:= closed;
+    Reason =:= tcp_closed;
+    Reason =:= ssl_closed;
+    Reason =:= einval;
+    Reason =:= enotconn;
+    Reason =:= econnaborted;
+    Reason =:= econnrefused;
+    Reason =:= econnreset;
+    Reason =:= ehostdown;
+    Reason =:= ehostunreach;
+    Reason =:= enetdown;
+    Reason =:= enetreset;
+    Reason =:= enetunreach;
+    Reason =:= etimedout
+->
     {recoverable_error, Reason};
 classify_error(Reason) ->
     {unrecoverable_error, Reason}.

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_SUITE.erl
@@ -304,6 +304,154 @@ t_message_forwarding_ordering(Config) ->
         []
     ).
 
+%% Allow enough time for a sustained network outage and for the buffered
+%% messages to drain afterwards.
+t_message_forwarding_adverse_network_conditions() ->
+    [{timetrap, {minutes, 2}}].
+
+t_message_forwarding_adverse_network_conditions('init', Config) ->
+    ok = snabbkaffe:start_trace(),
+    LinkConf = #{
+        <<"pool_size">> => 1,
+        <<"resource_opts">> => #{
+            <<"worker_pool_size">> => 1,
+            <<"inflight_window">> => 10,
+            <<"max_buffer_bytes">> => <<"10MB">>,
+            <<"request_ttl">> => <<"2m">>,
+            <<"resume_interval">> => <<"1s">>,
+            <<"health_check_interval">> => <<"1s">>
+        }
+    },
+    {SourceClusterSpec, TargetClusterSpec} =
+        mk_interlinked_clusters(?FUNCTION_NAME, 1, 1, LinkConf, Config),
+    SourceNodes = emqx_cth_cluster:start(SourceClusterSpec),
+    TargetNodes = emqx_cth_cluster:start(TargetClusterSpec),
+    ok = wait_link_online_on(SourceNodes ++ TargetNodes),
+    [
+        {source_nodes, SourceNodes},
+        {target_nodes, TargetNodes}
+        | Config
+    ];
+t_message_forwarding_adverse_network_conditions('end', Config) ->
+    ok = snabbkaffe:stop(),
+    ok = emqx_cth_cluster:stop(?config(source_nodes, Config)),
+    ok = emqx_cth_cluster:stop(?config(target_nodes, Config)).
+
+%% Verifies that the message forwarding resource buffers messages during a
+%% network outage and delivers every buffered message after recovery.
+t_message_forwarding_adverse_network_conditions(Config) ->
+    [SourceNode] = nodes_source(Config),
+    [TargetNode] = nodes_target(Config),
+    TargetName = atom_to_binary(emqx_cluster_link_cth:cluster_name(TargetNode)),
+    ResourceId = emqx_cluster_link_mqtt:resource_id(TargetName),
+    Topic = <<"t/adverse-network">>,
+    TargetClient = emqx_cluster_link_cth:connect_client(
+        "t_message_forwarding_adverse_network_conditions_target",
+        TargetNode
+    ),
+    ?check_trace(
+        #{timetrap => 90_000},
+        try
+            %% 1. Subscribe to the topic on the target cluser, wait for route replication.
+            {ok, _, _} = emqtt:subscribe(TargetClient, Topic, qos1),
+            {ok, _} = ?block_until(#{
+                ?snk_kind := "cluster_link_route_sync_complete",
+                ?snk_meta := #{node := TargetNode}
+            }),
+            %% 2. Start async publisher to the source cluster.
+            Publisher = start_async_publisher(SourceNode, Topic, 10),
+            %% 3. Keep the link running smoothly for 2.5 seconds.
+            ct:sleep(2_500),
+            %% 4. Sever the link connection, wait the source cluster notices.
+            ok = ?ON(TargetNode, emqx_listeners:stop_listener('tcp:clink')),
+            wait_forwarding_resource_disconnected(SourceNode, ResourceId),
+            %% 5. Keep the link down for 10 seconds:
+            ct:sleep(10_000),
+            %% 6. Restore the connectivity, wait the source cluster notices.
+            ok = ?ON(TargetNode, emqx_listeners:start_listener('tcp:clink')),
+            wait_forwarding_resource_connected(SourceNode, ResourceId),
+            %% 7. Keep the link running smoothly for 2.5 seconds more.
+            ct:sleep(2_500),
+            %% 8. Stop async publisher, verify each published message was delivered to the
+            %%    target cluster.
+            NPublished = stop_async_publisher(Publisher),
+            Publishes = [
+                M
+             || {publish, M} <- ?drainMailbox(5_000),
+                maps:get(client_pid, M) =:= TargetClient,
+                maps:get(topic, M) =:= Topic
+            ],
+            Received = [binary_to_integer(Payload) || #{payload := Payload} <- Publishes],
+            Expected = lists:seq(1, NPublished),
+            ?assertEqual([], Expected -- Received, #{received => Received}),
+            ?assertEqual([], Received -- Expected, #{received => Received}),
+            %% 9. Verify metrics reflect full recovery:
+            ?assertMatch(
+                #{
+                    counters := #{
+                        dropped := 0,
+                        failed := 0,
+                        retried := Retried,
+                        success := NPublished
+                    },
+                    gauges := #{
+                        inflight := 0,
+                        queuing := 0
+                    }
+                } when Retried > 0,
+                ?ON(SourceNode, emqx_resource:get_metrics(ResourceId))
+            )
+        after
+            ok = emqtt:stop(TargetClient)
+        end,
+        fun(Trace) ->
+            ?assertMatch([_ | _], ?of_kind(buffer_worker_appended_to_queue, Trace)),
+            ?assertMatch([_ | _], ?of_kind(buffer_worker_retry_inflight_succeeded, Trace))
+        end
+    ).
+
+wait_forwarding_resource_disconnected(SourceNode, ResourceId) ->
+    ?retry(
+        500,
+        20,
+        ?assertMatch(
+            {ok, _, #{status := Status}} when Status =/= connected,
+            ?ON(SourceNode, emqx_resource:get_instance(ResourceId))
+        )
+    ).
+
+wait_forwarding_resource_connected(SourceNode, ResourceId) ->
+    ?retry(
+        500,
+        20,
+        ?assertMatch(
+            {ok, _, #{status := connected}},
+            ?ON(SourceNode, emqx_resource:get_instance(ResourceId))
+        )
+    ).
+
+start_async_publisher(SourceNode, Topic, Interval) ->
+    spawn_link(SourceNode, ?MODULE, async_publisher_loop, [Topic, 1, Interval, self()]).
+
+stop_async_publisher(Publisher) ->
+    Publisher ! {self(), stop},
+    receive
+        {Publisher, NPublished} ->
+            NPublished
+    after 5_000 ->
+        ct:fail("publisher ~p did not stop", [Publisher])
+    end.
+
+async_publisher_loop(Topic, N, Interval, Controller) ->
+    Message = emqx_message:make(?MODULE, ?QOS_1, Topic, integer_to_binary(N)),
+    _ = emqx:publish(Message),
+    receive
+        {Controller, stop} ->
+            Controller ! {self(), N}
+    after Interval ->
+        async_publisher_loop(Topic, N + 1, Interval, Controller)
+    end.
+
 t_message_forwarding_disconnect_reason_reported('init', Config) ->
     ok = snabbkaffe:start_trace(),
     SourceName = fmt("~p_s", [?FUNCTION_NAME]),

--- a/changes/ee/fix-18537.en.md
+++ b/changes/ee/fix-18537.en.md
@@ -1,0 +1,1 @@
+Fixed Cluster Linking to classify temporary message-forwarding connection errors as recoverable. Messages affected by transient network outages are now buffered and retried instead of being counted as failed.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in: N/A

## Summary

This PR corrects what error conditions Cluster Link message forwarding facility considers recoverable.
1. Unwrapped, non-`{shutdown, ...}` reasons are now correctly evaluated.
2. Most common network-level errors are marked recoverable.
3. Buffer worker is now aware of MQTT client PIDs so it now cleanly recovers from client exits.

Additionally tested through a black-box test script simulating network blackholes through `docker-tc`:

* [cluster-link-loss-test.sh](https://github.com/user-attachments/files/31502612/cluster-link-loss-test.sh)

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible