### PR TITLE
fix(mt): follow namespace change when a session is resumed

### DIFF
--- a/apps/emqx_mt/src/emqx_mt.app.src
+++ b/apps/emqx_mt/src/emqx_mt.app.src
@@ -1,6 +1,6 @@
 {application, emqx_mt, [
     {description, "Multi-tenancy"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, []},
     {mod, {emqx_mt_app, []}},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_mt/src/emqx_mt_hookcb.erl
+++ b/apps/emqx_mt/src/emqx_mt_hookcb.erl
@@ -9,6 +9,7 @@
     register_hooks/0,
     unregister_hooks/0,
     on_session_created/2,
+    on_session_resumed/2,
     on_authenticate/2
 ]).
 
@@ -18,31 +19,43 @@
 
 -define(TRACE(MSG, META), ?TRACE("MULTI_TENANCY", MSG, META)).
 -define(SESSION_HOOK, {?MODULE, on_session_created, []}).
+-define(SESSION_RESUMED_HOOK, {?MODULE, on_session_resumed, []}).
 -define(AUTHN_HOOK, {?MODULE, on_authenticate, []}).
 -define(LIMITER_HOOK, {emqx_mt_limiter, adjust_limiter, []}).
 
 register_hooks() ->
     ok = emqx_hooks:add('session.created', ?SESSION_HOOK, ?HP_HIGHEST),
+    ok = emqx_hooks:add('session.resumed', ?SESSION_RESUMED_HOOK, ?HP_HIGHEST),
     ok = emqx_hooks:add('client.authenticate', ?AUTHN_HOOK, ?HP_HIGHEST),
     ok = emqx_hooks:add('channel.limiter_adjustment', ?LIMITER_HOOK, ?HP_HIGHEST),
     ok.
 
 unregister_hooks() ->
     ok = emqx_hooks:del('session.created', ?SESSION_HOOK),
+    ok = emqx_hooks:del('session.resumed', ?SESSION_RESUMED_HOOK),
     ok = emqx_hooks:del('client.authenticate', ?AUTHN_HOOK),
     ok = emqx_hooks:del('channel.limiter_adjustment', ?LIMITER_HOOK),
     ok.
 
-on_session_created(
+on_session_created(ClientInfo, _SessionInfo) ->
+    register_in_namespace(ClientInfo).
+
+%% A session resumed with clean_start=false fires 'session.resumed' instead of
+%% 'session.created'; register it too so the client index follows the client's
+%% current (possibly changed) namespace.  The entry for the previous channel
+%% process is removed by its 'DOWN' monitor in emqx_mt_pool.
+on_session_resumed(ClientInfo, _SessionInfo) ->
+    register_in_namespace(ClientInfo).
+
+register_in_namespace(
     #{
         clientid := ClientId,
         client_attrs := #{?CLIENT_ATTR_NAME_TNS := Tns}
-    },
-    _SessionInfo
+    }
 ) ->
     ?TRACE("session_registered_in_namespace", #{}),
     ok = emqx_mt_pool:add(Tns, ClientId, self());
-on_session_created(_ClientInfo, _SessionInfo) ->
+register_in_namespace(_ClientInfo) ->
     %% not a multi-tenant client
     ok.
 

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -87,12 +87,10 @@ t_connect_disconnect(_Config) ->
     ok.
 
 connect(ClientId, Username) ->
-    Opts = [
-        {clientid, ClientId},
-        {username, Username},
-        {proto_ver, v5}
-    ],
-    {ok, Pid} = emqtt:start_link(Opts),
+    connect(#{clientid => ClientId, username => Username}).
+
+connect(Opts) when is_map(Opts) ->
+    {ok, Pid} = emqtt:start_link(maps:merge(#{proto_ver => v5}, Opts)),
     monitor(process, Pid),
     unlink(Pid),
     case emqtt:connect(Pid) of
@@ -171,4 +169,166 @@ t_session_reconnect(_Config) ->
     ),
     ok = emqx_mt_state:evict_ccache(Ns),
     ?assertEqual({ok, 0}, emqx_mt:count_clients(Ns)),
+    ok.
+
+%% A persistent session that disconnects and then reconnects with
+%% clean_start=false under a different namespace moves to the new namespace in
+%% the client index.  Regression test for emqx/emqx#18533: the resume path
+%% fires 'session.resumed' instead of 'session.created', which used to leave
+%% the client listed under the old namespace.
+t_session_resume_namespace_change({init, _Config}) ->
+    ok;
+t_session_resume_namespace_change({'end', _Config}) ->
+    ok;
+t_session_resume_namespace_change(_Config) ->
+    Ns1 = iolist_to_binary([atom_to_list(?FUNCTION_NAME), "-ns1"]),
+    Ns2 = iolist_to_binary([atom_to_list(?FUNCTION_NAME), "-ns2"]),
+    C = ?NEW_CLIENTID(),
+    Pid1 = connect(#{
+        clientid => C,
+        username => Ns1,
+        clean_start => false,
+        properties => #{'Session-Expiry-Interval' => 300}
+    }),
+    {ok, #{proc := CPid1}} =
+        ?block_until(#{?snk_kind := multi_tenant_client_added, tns := Ns1}, 3000),
+    ?assertEqual({ok, [C]}, emqx_mt:list_clients(Ns1)),
+    ok = emqtt:disconnect(Pid1),
+    _ = ?WAIT_FOR_DOWN(Pid1, 3000),
+    {Pid2, {ok, _}} =
+        ?wait_async_action(
+            connect(#{
+                clientid => C,
+                username => Ns2,
+                clean_start => false,
+                properties => #{'Session-Expiry-Interval' => 300}
+            }),
+            #{?snk_kind := multi_tenant_client_added, tns := Ns2},
+            3000
+        ),
+    %% The resumed session took over the old channel process; its 'DOWN'
+    %% removes the stale entry from the old namespace.
+    {ok, _} =
+        ?block_until(#{?snk_kind := multi_tenant_client_proc_deleted, proc := CPid1}, 3000),
+    ?assertEqual({ok, [C]}, emqx_mt:list_clients(Ns2)),
+    ?assertEqual({ok, []}, emqx_mt:list_clients(Ns1)),
+    ?assertEqual({ok, 1}, emqx_mt:count_clients(Ns2)),
+    ?assertEqual({ok, 0}, emqx_mt:count_clients(Ns1)),
+    ok = emqtt:stop(Pid2),
+    ok.
+
+%% A persistent session taken over while the previous connection is still
+%% live, under a different namespace, moves to the new namespace in the
+%% client index.
+t_session_takeover_namespace_change({init, _Config}) ->
+    ok;
+t_session_takeover_namespace_change({'end', _Config}) ->
+    ok;
+t_session_takeover_namespace_change(_Config) ->
+    Ns1 = iolist_to_binary([atom_to_list(?FUNCTION_NAME), "-ns1"]),
+    Ns2 = iolist_to_binary([atom_to_list(?FUNCTION_NAME), "-ns2"]),
+    C = ?NEW_CLIENTID(),
+    Pid1 = connect(#{
+        clientid => C,
+        username => Ns1,
+        clean_start => false,
+        properties => #{'Session-Expiry-Interval' => 300}
+    }),
+    {ok, #{proc := CPid1}} =
+        ?block_until(#{?snk_kind := multi_tenant_client_added, tns := Ns1}, 3000),
+    {Pid2, {ok, _}} =
+        ?wait_async_action(
+            connect(#{
+                clientid => C,
+                username => Ns2,
+                clean_start => false,
+                properties => #{'Session-Expiry-Interval' => 300}
+            }),
+            #{?snk_kind := multi_tenant_client_added, tns := Ns2},
+            3000
+        ),
+    ?assertMatch(
+        {shutdown, {disconnected, ?RC_SESSION_TAKEN_OVER, _}},
+        ?WAIT_FOR_DOWN(Pid1, 3000)
+    ),
+    {ok, _} =
+        ?block_until(#{?snk_kind := multi_tenant_client_proc_deleted, proc := CPid1}, 3000),
+    ?assertEqual({ok, [C]}, emqx_mt:list_clients(Ns2)),
+    ?assertEqual({ok, []}, emqx_mt:list_clients(Ns1)),
+    ok = emqtt:stop(Pid2),
+    ok.
+
+%% A persistent session that reconnects with clean_start=false under the same
+%% namespace stays listed once, with no duplicate entry.
+t_session_resume_same_namespace({init, _Config}) ->
+    ok;
+t_session_resume_same_namespace({'end', _Config}) ->
+    ok;
+t_session_resume_same_namespace(_Config) ->
+    Ns = ?NEW_USERNAME(),
+    C = ?NEW_CLIENTID(),
+    Pid1 = connect(#{
+        clientid => C,
+        username => Ns,
+        clean_start => false,
+        properties => #{'Session-Expiry-Interval' => 300}
+    }),
+    {ok, #{proc := CPid1}} =
+        ?block_until(#{?snk_kind := multi_tenant_client_added, tns := Ns}, 3000),
+    ok = emqtt:disconnect(Pid1),
+    _ = ?WAIT_FOR_DOWN(Pid1, 3000),
+    {Pid2, {ok, _}} =
+        ?wait_async_action(
+            connect(#{
+                clientid => C,
+                username => Ns,
+                clean_start => false,
+                properties => #{'Session-Expiry-Interval' => 300}
+            }),
+            #{?snk_kind := multi_tenant_client_added, tns := Ns},
+            3000
+        ),
+    {ok, _} =
+        ?block_until(#{?snk_kind := multi_tenant_client_proc_deleted, proc := CPid1}, 3000),
+    ?assertEqual({ok, [C]}, emqx_mt:list_clients(Ns)),
+    ?assertEqual({ok, 1}, emqx_mt:count_clients(Ns)),
+    ok = emqtt:stop(Pid2),
+    ok.
+
+%% A client that reconnects with clean_start=true under a different namespace
+%% moves to the new namespace in the client index (the 'session.created' path;
+%% guards against regressing the already-working behavior).
+t_session_clean_start_namespace_change({init, _Config}) ->
+    ok;
+t_session_clean_start_namespace_change({'end', _Config}) ->
+    ok;
+t_session_clean_start_namespace_change(_Config) ->
+    Ns1 = iolist_to_binary([atom_to_list(?FUNCTION_NAME), "-ns1"]),
+    Ns2 = iolist_to_binary([atom_to_list(?FUNCTION_NAME), "-ns2"]),
+    C = ?NEW_CLIENTID(),
+    Pid1 = connect(#{
+        clientid => C,
+        username => Ns1,
+        clean_start => false,
+        properties => #{'Session-Expiry-Interval' => 300}
+    }),
+    {ok, #{proc := CPid1}} =
+        ?block_until(#{?snk_kind := multi_tenant_client_added, tns := Ns1}, 3000),
+    ok = emqtt:disconnect(Pid1),
+    _ = ?WAIT_FOR_DOWN(Pid1, 3000),
+    {Pid2, {ok, _}} =
+        ?wait_async_action(
+            connect(#{
+                clientid => C,
+                username => Ns2,
+                clean_start => true
+            }),
+            #{?snk_kind := multi_tenant_client_added, tns := Ns2},
+            3000
+        ),
+    {ok, _} =
+        ?block_until(#{?snk_kind := multi_tenant_client_proc_deleted, proc := CPid1}, 3000),
+    ?assertEqual({ok, [C]}, emqx_mt:list_clients(Ns2)),
+    ?assertEqual({ok, []}, emqx_mt:list_clients(Ns1)),
+    ok = emqtt:stop(Pid2),
     ok.

--- a/changes/ee/fix-18538.en.md
+++ b/changes/ee/fix-18538.en.md
@@ -1,0 +1,3 @@
+Fixed the multi-tenancy client list not following a persistent session that reconnects under a different namespace.
+
+Previously, when a client resumed an existing session (`clean_start=false`) after its namespace changed, `GET /api/v5/mt/ns/{ns}/client_list` kept listing the client under the old namespace, and the new namespace's list did not include it. The client list and the per-namespace client count now always reflect the namespace the client connected with.


### PR DESCRIPTION
Release versions: 5.9.4, 5.10.5

Introduced in: 5.9.0

## Summary

Fixes #18533 on the v5 line. This is the v5 port of #18535 (dev-63); a dev-60 counterpart is in progress.

The multi-tenancy client index (`emqx_mt`) was populated only from the `session.created` hook (`emqx_mt_hookcb`). A client that resumed an existing session (`clean_start=false`) fired `session.resumed` instead, so the index was never updated. When the client's namespace changed between connections, `GET /api/v5/mt/ns/{new-ns}/client_list` stayed empty and the client remained listed under the old namespace, while `GET /api/v5/clients/{clientid}` correctly showed the new `client_attrs.tns`.

The fix registers the client on `session.resumed` as well, through the same code path as `session.created`.

Why adding on resume is safe (no double listing):

* The index record key is `{Ns, ClientId, Pid}` and removal is driven by the channel-process `DOWN` monitor in `emqx_mt_pool`, which deletes exactly the dead pid's entry. The old and the new connection are different processes, so a late `DOWN` for the old channel cannot remove the new entry.
* Resuming a session always terminates the previous channel process (takeover), so the stale entry is removed by the same mechanism the `clean_start=true` path already relies on. The transient window where both entries exist is the same as in the existing `clean_start=true` reconnect flow.

Limitation on v5: durable sessions (`emqx_persistent_session_ds`) fire no `session.resumed` hook at all on this line, so a durable-session resume stays unindexed even with this fix. Fixing that would require changing hook emission in emqx core; out of scope here. The fix covers in-memory sessions, which is what the reported scenario uses.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
