### PR TITLE
fix(relup): ship priv/config.hocon in the plugin package

### DIFF
--- a/changes/ee/fix-18540.en.md
+++ b/changes/ee/fix-18540.en.md
@@ -1,0 +1,1 @@
+Ship the default configuration file (`priv/config.hocon`) in the `emqx_relup` plugin package. Installing the plugin no longer logs a repeated `failed_to_copy_plugin_default_hocon_config` warning.

--- a/plugins/emqx_relup/priv/config.hocon
+++ b/plugins/emqx_relup/priv/config.hocon
@@ -1,0 +1,3 @@
+## Intentionally empty. The plugin manager copies this file to
+## data/plugins/emqx_relup/config.hocon on install; without it,
+## installation logs failed_to_copy_plugin_default_hocon_config.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
6.0.3

## Summary

Addresses the `failed_to_copy_plugin_default_hocon_config` warning from #18536.

The `emqx_relup` plugin package had no `priv/config.hocon`. On install,
`emqx_plugins_local_config:copy_default/1` checks `filelib:is_regular/1` on that path and logs
`failed_to_copy_plugin_default_hocon_config` with reason `no_source_file`.

This PR adds `plugins/emqx_relup/priv/config.hocon`. The 5.10 line (`dev-510`) already ships this file as a zero-byte file; the v5 line does not forward-sync into v6, so the file was never carried across. Here the file carries a short comment explaining why it exists, so it does not get deleted as junk. A comment-only HOCON file loads to the same empty object as an empty file, and the plugin has no `config_schema.avsc`, so no schema validation applies to it.

Verified the file lands in the built package (`make plugin-emqx_relup`):

```
emqx_relup-1.0.2/README.md
emqx_relup-1.0.2/emqx_relup-1.0.2/ebin/emqx_relup.app
emqx_relup-1.0.2/emqx_relup-1.0.2/ebin/emqx_relup_sup.beam
emqx_relup-1.0.2/emqx_relup-1.0.2/ebin/emqx_relup_app.beam
emqx_relup-1.0.2/emqx_relup-1.0.2/ebin/emqx_relup_libs.beam
emqx_relup-1.0.2/emqx_relup-1.0.2/ebin/emqx_relup_cli.beam
emqx_relup-1.0.2/emqx_relup-1.0.2/ebin/emqx_relup_main.beam
emqx_relup-1.0.2/emqx_relup-1.0.2/ebin/emqx_relup_file_utils.beam
emqx_relup-1.0.2/emqx_relup-1.0.2/ebin/emqx_relup_utils.beam
emqx_relup-1.0.2/emqx_relup-1.0.2/ebin/emqx_relup_handler.beam
emqx_relup-1.0.2/emqx_relup-1.0.2/priv/relup/README.md
emqx_relup-1.0.2/emqx_relup-1.0.2/priv/config.hocon
emqx_relup-1.0.2/release.json
```

Not addressed here: the `no supported upgrade paths in priv catalog` message from #18536 is about `priv/relup/` contents (dev-60 ships only `priv/relup/README.md`), not about `config.hocon`. The `badarg` mentioned in the issue is also untouched. #18536 should not be closed as fully resolved by this PR alone.

No new test: `emqx_plugins_SUITE` already covers the default-config copy behavior with the demo plugin. The defect was the package content, which the listing above verifies.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
