### PR TITLE
fix(log): log OOM shutdown via SLOG and count it in esockd

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -1277,16 +1277,17 @@ signal_channel_congestion(Status, SQSize, State = #state{channel = Channel}) ->
 
 check_oom(Pubs, Bytes, #state{conf = #conf{force_shutdown = ShutdownPolicy}}) ->
     case emqx_utils:check_oom(ShutdownPolicy) of
-        {shutdown, Reason} ->
-            %% triggers terminate/2 callback immediately
-            ?tp(warning, check_oom_shutdown, #{
+        {shutdown, #{reason := OomReason} = Detail} ->
+            ?SLOG(error, Detail#{msg => connection_shutdown_due_to_oom}),
+            ?tp_ignore_side_effects_in_prod(check_oom_shutdown, #{
                 policy => ShutdownPolicy,
                 %% FIXME
                 incoming_pubs => Pubs,
                 incoming_bytes => Bytes,
-                shutdown => Reason
+                shutdown => Detail
             }),
-            erlang:exit({shutdown, Reason});
+            %% triggers terminate/2 callback immediately
+            erlang:exit({shutdown, OomReason});
         Result ->
             ?tp(debug, check_oom_ok, #{
                 policy => ShutdownPolicy,

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1402,15 +1402,16 @@ run_minor_gc() ->
 
 check_oom(Pubs, Bytes, #state{conf = #conf{force_shutdown = ShutdownPolicy}}) ->
     case emqx_utils:check_oom(ShutdownPolicy) of
-        {shutdown, Reason} ->
-            %% triggers terminate/2 callback immediately
-            ?tp(warning, check_oom_shutdown, #{
+        {shutdown, #{reason := OomReason} = Detail} ->
+            ?SLOG(error, Detail#{msg => connection_shutdown_due_to_oom}),
+            ?tp_ignore_side_effects_in_prod(check_oom_shutdown, #{
                 policy => ShutdownPolicy,
                 incoming_pubs => Pubs,
                 incoming_bytes => Bytes,
-                shutdown => Reason
+                shutdown => Detail
             }),
-            erlang:exit({shutdown, Reason});
+            %% triggers terminate/2 callback immediately
+            erlang:exit({shutdown, OomReason});
         Result ->
             ?tp(debug, check_oom_ok, #{
                 policy => ShutdownPolicy,

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -552,8 +552,9 @@ check_oom(State = #state{zone = Zone}) ->
             {ok, State};
         #{enable := true} ->
             case emqx_utils:check_oom(ShutdownPolicy) of
-                Shutdown = {shutdown, _Reason} ->
-                    {[Shutdown], State};
+                {shutdown, #{reason := OomReason} = Detail} ->
+                    ?SLOG(error, Detail#{msg => connection_shutdown_due_to_oom}),
+                    {[{shutdown, OomReason}], State};
                 _Other ->
                     {ok, State}
             end

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -569,7 +569,7 @@ t_oom_shutdown(init, Config) ->
     meck:expect(
         emqx_utils,
         check_oom,
-        fun(_) -> {shutdown, "fake_oom"} end
+        fun(_) -> {shutdown, #{reason => mailbox_overflow, value => 11, max => 10}} end
     ),
     Config;
 t_oom_shutdown('end', _Config) ->
@@ -588,7 +588,7 @@ t_oom_shutdown(_) ->
             ?assertEqual(1, length(?of_kind(terminate, Trace))),
             receive
                 {'EXIT', Pid, Reason} ->
-                    ?assertEqual({shutdown, "fake_oom"}, Reason)
+                    ?assertEqual({shutdown, mailbox_overflow}, Reason)
             after 1000 ->
                 error(timeout)
             end,

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -1190,9 +1190,10 @@ run_gc(Pubs, Bytes, State = #state{gc_state = GcSt}) ->
 
 check_oom(State = #state{oom_policy = OomPolicy}) ->
     case ?ENABLED(OomPolicy) andalso emqx_utils:check_oom(OomPolicy) of
-        {shutdown, Reason} ->
+        {shutdown, #{reason := OomReason} = Detail} ->
+            ?SLOG(error, Detail#{msg => connection_shutdown_due_to_oom}),
             %% triggers terminate/2 callback immediately
-            erlang:exit({shutdown, Reason});
+            erlang:exit({shutdown, OomReason});
         _Other ->
             ok
     end,

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn_ws.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn_ws.erl
@@ -569,12 +569,12 @@ run_gc(Cnt, Oct, State = #state{gc_state = GcSt}) ->
 
 check_oom(State = #state{oom_policy = OomPolicy}) ->
     case ?ENABLED(OomPolicy) andalso emqx_utils:check_oom(OomPolicy) of
-        Shutdown = {shutdown, _Reason} ->
-            postpone(Shutdown, State);
+        {shutdown, #{reason := OomReason} = Detail} ->
+            ?SLOG(error, Detail#{msg => connection_shutdown_due_to_oom}),
+            postpone({shutdown, OomReason}, State);
         _Other ->
-            ok
-    end,
-    State.
+            State
+    end.
 
 %%--------------------------------------------------------------------
 %% Parse incoming data

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
@@ -600,12 +600,12 @@ run_gc(Cnt, Oct, State = #state{gc_state = GcSt}) ->
 
 check_oom(State = #state{oom_policy = OomPolicy}) ->
     case ?ENABLED(OomPolicy) andalso emqx_utils:check_oom(OomPolicy) of
-        Shutdown = {shutdown, _Reason} ->
-            postpone(Shutdown, State);
+        {shutdown, #{reason := OomReason} = Detail} ->
+            ?SLOG(error, Detail#{msg => connection_shutdown_due_to_oom}),
+            postpone({shutdown, OomReason}, State);
         _Other ->
-            ok
-    end,
-    State.
+            State
+    end.
 
 %%--------------------------------------------------------------------
 %% Parse incoming data

--- a/changes/ee/fix-18543.en.md
+++ b/changes/ee/fix-18543.en.md
@@ -1,0 +1,6 @@
+Improved observability of connection shutdowns caused by the `force_shutdown` (OOM protection) policy.
+
+- The connection process now logs one readable error line (`connection_shutdown_due_to_oom`) identifying the client, with the measured value and the configured limit, before it exits. Previously the only record was a hard-to-read supervisor report.
+- The shutdown is now counted in the per-listener shutdown counters shown by `emqx ctl listeners` (TCP and SSL listeners).
+- The connection exit reason is now the plain reason atom, for example `{shutdown, mailbox_overflow}` or `{shutdown, proc_heap_too_large}`, instead of `{shutdown, #{...}}` with a detail map. This new reason shape is visible to the `session.terminated` hook and in the `$SYS` client disconnected events.
+- Fixed WebSocket-based gateway connections (for example OCPP) ignoring the `force_shutdown` policy: the shutdown request was computed but never applied, so oversized connection processes were not stopped.


### PR DESCRIPTION
Release version:
7.0.0

Introduced in:
pre-5.8

## Summary

When the `force_shutdown` policy (`max_mailbox_size` / `max_heap_size`) kills a connection, the exit reason was `{shutdown, DetailMap}`. esockd cannot count a map-shaped shutdown reason, so the event was only visible as an unreadable `connection_shutdown` supervisor report, and the per-listener shutdown counters (`emqx ctl listeners`) missed it.

This PR changes all six `emqx_utils:check_oom/1` call sites (`emqx_connection`, `emqx_socket_connection`, `emqx_ws_connection`, `emqx_gateway_conn`, `emqx_gateway_conn_ws`, `emqx_ocpp_connection`) to:

- log one readable error line (`msg: connection_shutdown_due_to_oom`) with the detail map (`reason`, `value`, `max`) via `?SLOG` from the connection process, so `clientid` / `peername` metadata is attached;
- exit with the plain reason atom: `{shutdown, mailbox_overflow}` or `{shutdown, proc_heap_too_large}`. esockd counts atom-shaped shutdown reasons and logs nothing, so the counter is bumped and the supervisor report disappears.

The `?tp(warning, check_oom_shutdown, ...)` trace points in `emqx_connection` and `emqx_socket_connection` become `?tp_ignore_side_effects_in_prod/2`: CT synchronization on the `check_oom_shutdown` kind keeps working, while a production node emits exactly one log line per OOM shutdown instead of two.

Also fixes a bug found while tracing the WebSocket paths: in `emqx_gateway_conn_ws:check_oom/1` and `emqx_ocpp_connection:check_oom/1` the `postpone/2` result was discarded and the original state returned, so the `force_shutdown` policy never actually stopped WebSocket gateway connections.

The exit-reason shape change is observable: `emqx_channel:terminate`, the `session.terminated` hook, `$SYS` disconnect events and crash dumps now see the reason atom instead of the detail map.

The listener shutdown counter only covers TCP/SSL listeners (esockd); WS/WSS listeners have no counter surface, but use the same exit reason for a consistent terminate reason.

An end-to-end CT for the esockd counter is not included: triggering a real mailbox overflow needs a suspend/flood/resume race that is too timing-sensitive for CI. Verified via `emqx_connection_SUITE:t_oom_shutdown` (exit reason is now the atom) and a manual repro.

This PR does not touch `emqx_utils.erl`; rebased on `dev-70` after the sync of #18521 landed, so the new log line carries the `label` (for example the clientid) added there.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
