### PR TITLE
test(dashboard): accept einval as a client TLS rejection shape

### DIFF
--- a/apps/emqx_dashboard/test/emqx_dashboard_https_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_https_SUITE.erl
@@ -268,6 +268,11 @@ t_verify_cacertfile(Config) ->
             ok;
         closed ->
             ok;
+        %% The server tears the connection down when the client sends no
+        %% certificate. When the teardown lands while the client still writes,
+        %% the client reports a socket-level einval instead of closed.
+        einval ->
+            ok;
         Other ->
             throw({unexpected, Other})
     end.


### PR DESCRIPTION
## Summary

De-flake `emqx_dashboard_https_SUITE:t_verify_cacertfile`:

```
%%% emqx_dashboard_https_SUITE ==> hardened.t_verify_cacertfile: FAILED
{thrown, {{unexpected, einval}, ...}}
```

Seen in: https://github.com/emqx/emqx/actions/runs/33075361078/job/98531926856?pr=18542 (a topic_metrics PR that does not touch dashboard code)

The test already documents the race: the `verify_peer` server tears down the connection of a client that sends no certificate, and the client-side error shape depends on where the client's socket operation is when the teardown lands. The accepted set was `socket_closed_remotely`, `{tls_alert, {certificate_required, _}}`, and `closed`. When the client is still writing, it reports `einval` — same variance family as the ws `einval` fixed in #18490.

Add `einval` to the accepted set; the case remains an explicit allowlist and a successful request still fails the test. Full suite passes locally.

Base `dev-60`: the suite differs across lines, but this case block is byte-identical in all variants, so the hunk merges cleanly up the sync chain.