### PR TITLE
test(bridge_http): stop snabbkaffe deterministically in teardown

### DIFF
--- a/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
@@ -145,6 +145,13 @@ end_per_testcase(TestCase, _Config) when
     emqx_bridge_v2_testlib:delete_all_bridges(),
     emqx_bridge_v2_testlib:delete_all_connectors(),
     emqx_common_test_helpers:call_janitor(),
+    %% Stop the snabbkaffe supervision tree deterministically.
+    %% snabbkaffe:start_trace() calls snabbkaffe_sup:start_link() from the
+    %% calling process, so the tree is linked to whichever case process
+    %% started it first and dies with it asynchronously. A later case's
+    %% ?check_trace can attach to the still-registered old collector and
+    %% lose it mid-case; flush_trace then fails with noproc.
+    ok = snabbkaffe:stop(),
     ok;
 end_per_testcase(_TestCase, Config) ->
     case ?config(http_server, Config) of
@@ -154,6 +161,7 @@ end_per_testcase(_TestCase, Config) ->
     emqx_bridge_v2_testlib:delete_all_bridges(),
     emqx_bridge_v2_testlib:delete_all_connectors(),
     emqx_common_test_helpers:call_janitor(),
+    ok = snabbkaffe:stop(),
     ok.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

De-flake `emqx_bridge_http_SUITE:t_empty_path`:

```
%%% emqx_bridge_http_SUITE ==> t_empty_path: FAILED
{noproc,{gen_server,call,[snabbkaffe_collector,flush_trace,infinity]}}
```

Seen in: https://github.com/emqx/emqx/actions/runs/33089569523/job/98582743519?pr=18549 (r59→r510 sync PR; it touches no bridge_http files)

The snabbkaffe collector is linked to the test-case process that started the trace. The suite never calls `snabbkaffe:stop()` in `end_per_testcase`, so a previous case's collector can die asynchronously while the next case's `?check_trace` is attached to it, and the flush then hits `noproc`. Same class and same fix as 9ffea5eba8 (`emqx_authn_mongodb_tls_SUITE`, Nov 2024): stop the collector deterministically in both `end_per_testcase` clauses so each `?check_trace` starts a fresh one.

Validation: full build with the change compiles clean. A local suite run is blocked on this host by an ehttpc option mismatch that equally fails the unmodified baseline (resource start rejected with `{options,{tcp_opts,[]}}`), so the behavioral run rides on this PR's CI.

Base `dev-58`: the `end_per_testcase` region is identical across dev-58/59/510, so the fix follows the v5 sync chain. The v6 suite variants share the missing-stop pattern and can get the same treatment if observed there.