### PR TITLE
test(shared_sub): tolerate slow redelivery and DUP in t_session_takeover

### DIFF
--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -1036,9 +1036,14 @@ t_session_takeover(Config) when is_list(Config) ->
     {true, _} = last_message(<<"hello2">>, [ConnPid2]),
     %% We may or may not recv dup hello2 due to QoS1 redelivery
     _ = last_message(<<"hello2">>, [ConnPid2]),
-    {true, _} = last_message(<<"hello3">>, [ConnPid2]),
-    {true, _} = last_message(<<"hello4">>, [ConnPid2]),
-    ?assertEqual([], collect_msgs(timer:seconds(2))),
+    %% Messages published around the takeover are delivered by session
+    %% redelivery, which can take longer than the default 1s under CI load.
+    {true, _} = last_message(<<"hello3">>, [ConnPid2], 5_000),
+    {true, _} = last_message(<<"hello4">>, [ConnPid2], 5_000),
+    %% A QoS1 message delivered around the takeover may be redelivered with the
+    %% DUP flag set; such redeliveries are expected and must be ignored here.
+    Remaining = [Msg || {publish, #{dup := false}} = Msg <- collect_msgs(timer:seconds(2))],
+    ?assertEqual([], Remaining),
     emqtt:unsubscribe(ConnPid2, SharedTopic),
     emqtt:stop(ConnPid2),
     ok.


### PR DESCRIPTION
## Summary

De-flake `emqx_shared_sub_SUITE:t_session_takeover`:

```
{badmatch,<<"not yet?">>}   %% line 1026: {true, _} = last_message(<<"hello3">>, [ConnPid2])
```

Seen in: https://github.com/emqx/emqx/actions/runs/33092651895/job/98592891196?pr=18549 (r59→r510 sync PR)

`hello3`/`hello4` are published around the session takeover and reach the client through session redelivery, which can take longer than `last_message/2`'s default 1s timeout under CI load. The final `collect_msgs` assert can also see an expected QoS1 DUP redelivery — the second known flake mode of this test.

Port the two master fixes the v5 lines never got:

- `9e2f3b4382` — wait 5s for `hello3`/`hello4`.
- `66a62d0c39` — filter DUP redeliveries out of the final assert.

Full suite passes locally: 36 ok, 0 failed.

Base `dev-58`: the `t_session_takeover` body is identical across dev-58/59/510, so the fix follows the v5 sync chain. dev-60+ already carry both fixes.