### PR TITLE
test(dsraft): attempt to stabilize flaky test

### DIFF
--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -110,7 +110,7 @@ t_leader_otx_supervion(Config) ->
             ?wait_async_action(
                 ?ON(
                     Leader0,
-                    exit(emqx_ds_optimistic_tx:where(DB, Shard), shutdown)
+                    kill_leader(DB, Shard, shutdown)
                 ),
                 #{?snk_kind := ds_otx_up, db := DB, shard := Shard}
             ),
@@ -118,7 +118,7 @@ t_leader_otx_supervion(Config) ->
             ?wait_async_action(
                 ?ON(
                     Leader0,
-                    exit(emqx_ds_optimistic_tx:where(DB, Shard), shutdown)
+                    kill_leader(DB, Shard, shutdown)
                 ),
                 #{?snk_kind := ds_otx_up, db := DB, shard := Shard}
             ),
@@ -167,7 +167,7 @@ t_leader_otx_supervion(Config) ->
                             exit(mocked)
                         end
                     ),
-                    exit(emqx_ds_optimistic_tx:where(DB, Shard), shutdown)
+                    kill_leader(DB, Shard, shutdown)
                 end
             ),
             %% Wait for at least two attempts:
@@ -1384,4 +1384,18 @@ open_db(DB, Opts) ->
     maybe
         ok ?= emqx_ds:open_db(DB, Opts),
         ok ?= emqx_ds:wait_db(DB, all, infinity)
+    end.
+
+kill_leader(DB, Shard, Reason) ->
+    do_kill_leader(DB, Shard, Reason, 5).
+
+do_kill_leader(DB, Shard, Reason, RetriesLeft) ->
+    case emqx_ds_optimistic_tx:where(DB, Shard) of
+        undefined when RetriesLeft =< 0 ->
+            error(could_not_find_leader_to_kill);
+        undefined ->
+            ct:sleep(10),
+            do_kill_leader(DB, Shard, Reason, RetriesLeft - 1);
+        Pid when is_pid(Pid) ->
+            exit(Pid, Reason)
     end.


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/33084519265/job/98596136814#step:5:783

```
%%% emqx_ds_builtin_raft_SUITE ==> t_leader_otx_supervion: FAILED
%%% emqx_ds_builtin_raft_SUITE ==> {{panic,
     #{msg => "Unexpected result",
       result =>
           {run_stage_failed,error,
               {failed_call_to_node,
                   #{node => 't_leader_otx_supervion2@127.0.0.1',
                     reason => badarg,
                     remote_stacktrace =>
                         [{erlang,exit,
                              [undefined,shutdown],
                              [{error_info,#{module => erl_erts_errors}}]},
                          {emqx_ds_builtin_raft_SUITE,
                              '-t_leader_otx_supervion/1-fun-9-',0,
                              [{file,"test/emqx_ds_builtin_raft_SUITE.erl"},
                               {line,112}]},
                          {erlang,apply,2,[]}]}},
```
