### PR TITLE
test(ratelimiter): budget the token shortfall in t_divisible

### DIFF
--- a/apps/emqx/test/emqx_ratelimiter_SUITE.erl
+++ b/apps/emqx/test/emqx_ratelimiter_SUITE.erl
@@ -163,17 +163,22 @@ t_divisible(_) ->
     Case = fun(BucketCfg) ->
         Client = connect(BucketCfg),
         Result = emqx_htb_limiter:check(1000, Client),
+        %% Token bookkeeping is time-based: every millisecond that elapses
+        %% between connect and check refills one token, so the shortfall
+        %% shrinks below 400 under scheduling delay. Budget 5 tokens.
         ?assertMatch(
-            {partial, 400,
+            {partial, _,
                 #{
                     continuation := _,
-                    diff := 400,
+                    diff := _,
                     start := _,
                     need := 1000
                 },
                 _},
             Result
-        )
+        ),
+        {partial, Diff, #{diff := Diff}, _} = Result,
+        ?assert(Diff =< 400 andalso Diff >= 395, #{diff => Diff})
     end,
     with_per_client(Cfg, Case).
 


### PR DESCRIPTION
## Summary

De-flake `emqx_ratelimiter_SUITE:t_divisible`:

```
Failure/Error: ?assertMatch({partial, 400, #{diff := 400, need := 1000}, _}, Result)
       got: {partial, 399, #{diff => 399, ...}}
```

Seen in: https://github.com/emqx/emqx/actions/runs/33095341110/job/98601713439?pr=18552

The htb limiter computes tokens from elapsed time: every millisecond between `connect` and `check` refills one token, so the shortfall shrinks below the nominal 400 under scheduling delay. Keep the structural assertion; accept a shortfall between 395 and 400 (5 tokens of budget for slow CI).

Case passes locally.

Base `dev-58` and dev-58 only: `emqx_ratelimiter_SUITE` was removed in the 5.9 limiter refactor, so no other line carries this test.