### PR TITLE
ci: speed up app vsn check

### DIFF
--- a/scripts/apps-version-check.exs
+++ b/scripts/apps-version-check.exs
@@ -378,12 +378,16 @@ defmodule AppsVersionCheck do
 
     invalid_apps =
       apps
-      |> Enum.reject(&has_valid_app_vsn?(&1, context))
+      |> Enum.map(fn app -> Task.async(fn -> has_valid_app_vsn?(app, context) end) end)
+      |> Task.await_many(:infinity)
+      |> Enum.reject(&Function.identity/1)
       |> Enum.map(&"apps/#{&1}")
 
     invalid_plugins =
       plugins
-      |> Enum.reject(&has_valid_plugin_release_vsn?(&1, context))
+      |> Enum.map(fn app -> Task.async(fn -> has_valid_plugin_release_vsn?(app, context) end) end)
+      |> Task.await_many(:infinity)
+      |> Enum.reject(&Function.identity/1)
       |> Enum.map(&"plugins/#{&1}")
 
     (invalid_apps ++ invalid_plugins)


### PR DESCRIPTION
Before:
```sh
ͳ time scripts/apps-version-check.exs
Context: %{
  git_ref: "6.0.3",
  latest_release: %Version{major: 6, minor: 0, patch: 3},
  auto_fix: false
}
IGNORE: apps/emqx_connector_oauth2/mix.exs is newly added
IGNORE: plugins/my_emqx_plugin-5.1.0 has no VERSION
IGNORE: plugins/emqx_sync_request/VERSION is newly added
scripts/apps-version-check.exs  3.30s user 0.32s system 35% cpu 10.179 total
```

After:
```sh
ͳ time scripts/apps-version-check.exs
Context: %{
  git_ref: "6.0.3",
  latest_release: %Version{major: 6, minor: 0, patch: 3},
  auto_fix: false
}
IGNORE: apps/emqx_connector_oauth2/mix.exs is newly added
IGNORE: plugins/my_emqx_plugin-5.1.0 has no VERSION
IGNORE: plugins/emqx_sync_request/VERSION is newly added
scripts/apps-version-check.exs  2.99s user 0.32s system 114% cpu 2.904 total
```
