### PR TITLE
test(quic): retry client address migration with a fresh port

### DIFF
--- a/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
+++ b/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
@@ -834,18 +834,28 @@ t_conn_change_client_addr(Config) ->
         ],
         recv_pub(1)
     ),
-    NewPort = select_port(),
     {ok, OldAddr} = quicer:sockname(Conn),
-    ?assertEqual(
-        ok, quicer:setopt(Conn, local_address, "127.0.0.1:" ++ integer_to_list(NewPort))
-    ),
-
+    %% The address migration is asynchronous, and the selected port can be
+    %% taken by another socket between selection and rebind, in which case
+    %% msquic keeps the old path. Retry the whole migration with a fresh
+    %% port when the socket address does not change in time.
     ?retry(
-        _Delay = 50,
-        _attempt = 20,
+        _MigrateDelay = 200,
+        _MigrateAttempts = 10,
         begin
-            {ok, NewAddr} = quicer:sockname(Conn),
-            ?assertNotEqual(OldAddr, NewAddr)
+            NewPort = select_port(),
+            ?assertEqual(
+                ok,
+                quicer:setopt(Conn, local_address, "127.0.0.1:" ++ integer_to_list(NewPort))
+            ),
+            ?retry(
+                _Delay = 50,
+                _attempt = 20,
+                begin
+                    {ok, NewAddr} = quicer:sockname(Conn),
+                    ?assertNotEqual(OldAddr, NewAddr)
+                end
+            )
         end
     ),
     ?assert(is_list(emqtt:info(C))),


### PR DESCRIPTION
## Summary

De-flake `emqx_quic_multistreams_SUITE:t_conn_change_client_addr`:

```
Failure/Error: ?assertNotEqual({{127,0,0,1},41244}, NewAddr)
  expected not: == {{127,0,0,1},41244}
           got:    {{127,0,0,1},41244}
```

Seen in: https://github.com/emqx/emqx/actions/runs/33143324299/job/98760940707?pr=18574 (r63→r70 sync PR, no QUIC changes; two matrix variants failed in one run)

The case sets a new local address and waits 1 s (`?retry(50, 20)`) for `quicer:sockname/1` to change. Two failure modes leave the old address in place: the msquic path migration can outlast the window under CI load, and the port from `select_port()` can be taken by another socket between selection and rebind — `setopt` still returns ok, but msquic keeps the old path, so no amount of waiting helps.

Fix (test-only): wrap the migration in an outer `?retry(200, 10)` that picks a fresh port per attempt, keeping the inner verification. Issuing a second migration while an earlier one is in flight is safe: the final address is the newest port and still differs from `OldAddr`.

Case passes locally. Base `dev-60`: the case body is identical across dev-60..70, so the fix follows the sync chain.