### PR TITLE
fix(sso): do not redact oidc client_jwks when it is `none`

### DIFF
--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
@@ -172,6 +172,14 @@ create_backend(Node, Params, Opts) ->
         auth_header => auth_header_lazy(Opts)
     }).
 
+get_backend(Node, Opts) ->
+    URL = url(Node, ["sso", "oidc"]),
+    simple_request(#{
+        method => get,
+        url => URL,
+        auth_header => auth_header_lazy(Opts)
+    }).
+
 delete_backend(Node, Opts) ->
     URL = url(Node, ["sso", "oidc"]),
     simple_request(#{
@@ -444,6 +452,40 @@ t_stop_cleanup(TCConfig) ->
     ?assertMatch({204, _}, delete_backend(N, #{})),
     ?assertEqual([], supervisor:which_children(emqx_dashboard_sso_oidc_sup)),
 
+    ok.
+
+-doc """
+`GET /api/v5/sso/oidc' must return `client_jwks' as `none' when no client
+JWKS is configured (the default), while a configured file JWKS and the
+client secret must stay masked in both the GET and update responses.
+""".
+t_client_jwks_redaction(TCConfig) ->
+    start_apps(?FUNCTION_NAME, TCConfig),
+    Node = node(),
+    {ok, {Port, _Pid}} = emqx_utils_http_test_server:start_link(random, "/[...]"),
+    on_exit(fun() -> ok = emqx_utils_http_test_server:stop() end),
+    ok = emqx_utils_http_test_server:set_handler(fun oidc_content_type_handler/2),
+    Issuer = host(Port) ++ ?OIDC_PATH_PREFIX,
+    ProviderParams = oidc_provider_params(Issuer),
+
+    ?assertMatch({200, _}, create_backend(Node, ProviderParams, #{})),
+    ?assertMatch(
+        {200, #{<<"client_jwks">> := <<"none">>, <<"secret">> := <<"******">>}},
+        get_backend(Node, #{})
+    ),
+
+    JwksContent = <<"{\"keys\":[{\"kty\":\"oct\",\"k\":\"c2VjcmV0\"}]}">>,
+    ParamsWithJwks = ProviderParams#{
+        <<"client_jwks">> => #{<<"type">> => <<"file">>, <<"file">> => JwksContent}
+    },
+    ?assertMatch(
+        {200, #{<<"client_jwks">> := <<"******">>}},
+        create_backend(Node, ParamsWithJwks, #{})
+    ),
+    ?assertMatch(
+        {200, #{<<"client_jwks">> := <<"******">>, <<"secret">> := <<"******">>}},
+        get_backend(Node, #{})
+    ),
     ok.
 
 t_jwks_content_type_suffix(TCConfig) ->

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -22,6 +22,10 @@
 
 -define(REDACT_VAL, "******").
 -define(IS_KEY_HEADERS(K), (K == headers orelse K == <<"headers">> orelse K == "headers")).
+-define(IS_KEY_CLIENT_JWKS(K),
+    (K == client_jwks orelse K == <<"client_jwks">> orelse K == "client_jwks")
+).
+-define(IS_VAL_NONE(V), (V == none orelse V == <<"none">> orelse V == "none")).
 
 redacted_value() -> <<?REDACT_VAL>>.
 
@@ -141,7 +145,7 @@ do_redact({Headers, Value}, _Checker) when ?IS_KEY_HEADERS(Headers) ->
 do_redact({Key, Value}, Checker) ->
     case Checker(Key) of
         true ->
-            {Key, redact_v(Value)};
+            {Key, redact_v(Key, Value)};
         false ->
             {do_redact(Key, Checker), do_redact(Value, Checker)}
     end;
@@ -162,7 +166,7 @@ do_redact(Headers, V, _Checker) when ?IS_KEY_HEADERS(Headers) ->
 do_redact(K, V, Checker) ->
     case Checker(K) of
         true ->
-            redact_v(V);
+            redact_v(K, V);
         false ->
             do_redact(V, Checker)
     end.
@@ -224,6 +228,13 @@ is_sensitive_header("x-auth-token") ->
     true;
 is_sensitive_header(_Any) ->
     false.
+
+%% `client_jwks' is a union of the atom `none' and a JWKS object; only the
+%% object holds key material. `none' (the default) must stay readable.
+redact_v(K, V) when ?IS_KEY_CLIENT_JWKS(K), ?IS_VAL_NONE(V) ->
+    V;
+redact_v(_K, V) ->
+    redact_v(V).
 
 redact_v(V) when is_binary(V) ->
     case emqx_placeholder:preproc_tmpl(V) of

--- a/apps/emqx_utils/test/emqx_utils_redact_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_redact_tests.erl
@@ -97,6 +97,40 @@ redact_common_token_aliases_test() ->
         })
     ).
 
+redact_client_jwks_configured_test() ->
+    %% A configured (file) client JWKS holds key material and must stay redacted,
+    %% in both the checked-config shape (atom keys, file already saved to a path)
+    %% and the raw-request shape (binary keys, `file' still holding the content).
+    ?assertEqual(
+        #{
+            client_jwks => "******",
+            <<"client_jwks">> => "******"
+        },
+        redact(#{
+            client_jwks => #{type => file, file => <<"/path/to/client_jwks">>},
+            <<"client_jwks">> => #{
+                <<"type">> => <<"file">>,
+                <<"file">> => <<"{\"keys\":[{\"kty\":\"oct\",\"k\":\"c2VjcmV0\"}]}">>
+            }
+        })
+    ).
+
+no_redact_client_jwks_none_test() ->
+    %% `client_jwks' is a union of `none' and a JWKS object; `none' means no
+    %% client JWKS is configured and must not be masked.
+    ?assertEqual(
+        #{
+            client_jwks => none,
+            <<"client_jwks">> => <<"none">>,
+            "client_jwks" => "none"
+        },
+        redact(#{
+            client_jwks => none,
+            <<"client_jwks">> => <<"none">>,
+            "client_jwks" => "none"
+        })
+    ).
+
 redact_secret_headers_test() ->
     ?assertEqual(
         #{

--- a/changes/ee/fix-18576.en.md
+++ b/changes/ee/fix-18576.en.md
@@ -1,0 +1,1 @@
+The OIDC SSO configuration API (`GET /api/v5/sso/oidc`) now returns `client_jwks` as `none` when no client JWKS is configured, matching the CLI output. Previously the value was masked as `******` even when nothing was configured. A configured client JWKS remains masked.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
6.1.3

## Summary

NOTE: the reveal of `none` is not considered a vulnerability.

Fixes #18569.

`GET /api/v5/sso/oidc` returned `"client_jwks": "******"` even when the value was the atom `none` (the default, meaning no client JWKS is configured). The CLI (`emqx ctl conf show dashboard`) shows `client_jwks = none`, so the API and CLI disagreed and a caller could not tell whether a client JWKS is configured.

#17739 added `client_jwks` to the sensitive keys in `emqx_utils_redact`, and redaction there is key-based: once the key matches, the value is masked whatever it is. But the schema makes `client_jwks` a union of the atom `none` and a `client_file_jwks` object; only the object holds key material.

This PR narrows the rule instead of removing it: `redact_v/2` passes the value through when the key is `client_jwks` and the value is `none` (atom, or the raw-config string forms). Any other value, including a configured file JWKS object, stays masked. The exemption is scoped to the `client_jwks` key, so redaction behaviour for every other sensitive key is unchanged.

Dropping the blanket key in favour of the inner fields was rejected: `client_file_jwks` has only `type` and `file`, neither is a sensitive key, and `file` carries the raw JWKS content in the update request body before it is written to disk, so the outer key must stay sensitive.

Relevant files:
- `apps/emqx_utils/src/emqx_utils_redact.erl` — key-scoped `none` pass-through in `redact_v/2`.
- `apps/emqx_utils/test/emqx_utils_redact_tests.erl` — `none` is not masked; a configured JWKS (checked and raw shapes) still is.
- `apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl` — API-level test: GET returns `none` for the default config; a configured file JWKS and the client secret stay masked in GET and update responses.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
