### PR TITLE
test(stomp): retry async client info reads

### DIFF
--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -982,6 +982,13 @@ t_rest_clientid_info(_) ->
         ?assertMatch({ok, #stomp_frame{command = <<"CONNECTED">>}}, recv_a_frame(Sock)),
 
         %% client lists
+        %% The client shows up in the clients API asynchronously to the
+        %% CONNECTED frame, so retry.
+        ?retry(
+            100,
+            20,
+            ?assertMatch({200, #{data := [_]}}, request(get, "/gateways/stomp/clients"))
+        ),
         {200, Clients} = request(get, "/gateways/stomp/clients"),
         ?assertEqual(1, length(maps:get(data, Clients))),
         StompClient = lists:nth(1, maps:get(data, Clients)),

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -7,6 +7,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/asserts.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include("emqx_stomp.hrl").
 
 -compile(export_all).
@@ -324,16 +325,15 @@ t_subscribe(_) ->
         ),
 
         %% assert subscription stats
-        [ClientInfo1] = clients(),
-        ?assertMatch(#{subscriptions_cnt := 1}, ClientInfo1),
+        %% The stats update is asynchronous to the RECEIPT, so retry.
+        ?retry(100, 20, ?assertMatch([#{subscriptions_cnt := 1}], clients())),
 
         %% Unsubscribe
         ok = send_unsubscribe_frame(Sock, 0),
         ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),
 
         %% assert subscription stats
-        [ClientInfo2] = clients(),
-        ?assertMatch(#{subscriptions_cnt := 0}, ClientInfo2),
+        ?retry(100, 20, ?assertMatch([#{subscriptions_cnt := 0}], clients())),
 
         ok = send_message_frame(Sock, <<"/queue/foo">>, <<"You will not receive this msg">>),
         ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),
@@ -452,16 +452,15 @@ t_receive_from_mqtt_publish(_) ->
         ),
 
         %% assert subscription stats
-        [ClientInfo1] = clients(),
-        ?assertMatch(#{subscriptions_cnt := 1}, ClientInfo1),
+        %% The stats update is asynchronous to the RECEIPT, so retry.
+        ?retry(100, 20, ?assertMatch([#{subscriptions_cnt := 1}], clients())),
 
         %% Unsubscribe
         ok = send_unsubscribe_frame(Sock, 0),
         ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),
 
         %% assert subscription stats
-        [ClientInfo2] = clients(),
-        ?assertMatch(#{subscriptions_cnt := 0}, ClientInfo2),
+        ?retry(100, 20, ?assertMatch([#{subscriptions_cnt := 0}], clients())),
 
         ok = send_message_frame(Sock, <<"/queue/foo">>, <<"You will not receive this msg">>),
         ?assertMatch({ok, #stomp_frame{command = <<"RECEIPT">>}}, recv_a_frame(Sock)),


### PR DESCRIPTION
## Summary

De-flake two `emqx_stomp_SUITE` cases that assert eventually-consistent client state immediately:

**`t_subscribe`** — `?assertMatch(#{subscriptions_cnt := 0}, ...)` right after the UNSUBSCRIBE RECEIPT; the stat updates asynchronously. Seen in: https://github.com/emqx/emqx/actions/runs/33145580415/job/98767532145?pr=18575. The post-SUBSCRIBE assert races identically, and a second test duplicates the block — all wrapped in `?retry(100, 20, ...)`.

**`t_rest_clientid_info`** — the gateway clients API read right after CONNECTED returned an empty list; the client registers asynchronously. Seen in: https://github.com/emqx/emqx/actions/runs/33151569866/job/98787107332?pr=18581 (dev-70; the region is identical on dev-60, so this fix syncs forward). Retry added on the clients-list read.

Full suite passes locally: 22 ok, 0 failed (both commits).

Base `dev-60` (earliest line with these blocks in identical form); follows the v6 sync chain.