### PR TITLE
test(bridge_mqtt): await reconnect events from every cluster node

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
@@ -903,8 +903,11 @@ t_resubscribe_on_fast_failure(TCConfig) when is_list(TCConfig) ->
     ct:pal("Restarting source node (1)"),
     {ok, SRef0} = snabbkaffe:subscribe(
         ?match_event(#{?snk_kind := "mqtt_source_reconnected"}),
-        %% 2 sources with 3 workers each
-        2 * PoolSize,
+        %% Every cluster node runs 2 sources with PoolSize workers each, and
+        %% every worker emits the event after it resubscribed. Waiting for
+        %% fewer events lets the publishes below race the remaining
+        %% subscriptions, and the QoS 1 messages are lost.
+        NumNodes * 2 * PoolSize,
         %% Timeout
         30_000
     ),
@@ -970,8 +973,8 @@ t_resubscribe_on_fast_failure(TCConfig) when is_list(TCConfig) ->
     ct:pal("Restarting source node (2)"),
     {ok, SRef1} = snabbkaffe:subscribe(
         ?match_event(#{?snk_kind := "mqtt_source_reconnected"}),
-        %% 1 source with 3 workers each
-        1 * PoolSize,
+        %% 1 remaining source (B is deleted), PoolSize workers per node.
+        NumNodes * 1 * PoolSize,
         %% Timeout
         30_000
     ),


### PR DESCRIPTION
## Summary

De-flake `emqx_bridge_mqtt_source_SUITE:t_resubscribe_on_fast_failure`.

Seen in: https://github.com/emqx/emqx/actions/runs/33146400803/job/98770188019?pr=18576 (dev-60), and the dev-58 sibling suite on 2026-08-27 (run 33097925140).

Revised after review: `"mqtt_source_reconnected"` is emitted per worker after that worker's resubscription completes, so the event itself is a sound barrier — the bug is the awaited count. The test waited for `2 * PoolSize` events, but the cluster group runs 3 nodes with `PoolSize` workers per source on each, so the full count after the first restart is `NumNodes * 2 * PoolSize`. Proceeding after a third of the events lets the QoS 1 publishes race the remaining nodes' subscriptions, and the v3 variants (which expect one republished copy per node) then miss copies.

Correct both counts (`NumNodes * 2 * PoolSize` after restart 1; `NumNodes * PoolSize` after restart 2, where source B is deleted). The earlier subscriber-table barrier is dropped.

All four matrix variants pass locally; the only local suite failure is the toxiproxy-dependent `t_reconnect_with_session` (no toxiproxy on this host, identical on the unmodified tree).

Base `dev-60`; follows the v6 sync chain.