### PR TITLE
fix(node_dump): redact schema-sensitive values in conf.hocon

### DIFF
--- a/apps/emqx/src/emqx_node_dump.erl
+++ b/apps/emqx/src/emqx_node_dump.erl
@@ -8,7 +8,8 @@
 -export([
     sys_info/0,
     app_env_dump/0,
-    print_conf_dump/0
+    print_conf_dump/0,
+    conf_dump/0
 ]).
 
 sys_info() ->
@@ -21,9 +22,20 @@ app_env_dump() ->
     censor(ets:tab2list(ac_tab)).
 
 print_conf_dump() ->
+    io:put_chars(conf_dump()).
+
+-doc """
+Render the node's config as HOCON text with sensitive values redacted.
+
+Values marked as sensitive in the config schema are replaced with
+`"******"`; `emqx_utils:redact/1` is applied on top to cover values
+under roots the schema walk passes through unchanged.
+""".
+conf_dump() ->
     RawConf0 = emqx_config:get_raw([]),
-    RawConf = emqx_utils:redact(RawConf0),
-    io:put_chars(hocon_pp:do(RawConf, #{})).
+    RawConf1 = emqx_config:fill_defaults(RawConf0, #{obfuscate_sensitive_values => true}),
+    RawConf = emqx_utils:redact(RawConf1),
+    hocon_pp:do(RawConf, #{}).
 
 censor([]) ->
     [];

--- a/apps/emqx/test/emqx_node_dump_SUITE.erl
+++ b/apps/emqx/test/emqx_node_dump_SUITE.erl
@@ -1,0 +1,100 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_node_dump_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(DASHBOARD_PASSWORD, <<"nodedump_test_passwd_1">>).
+-define(REDACTED, <<"******">>).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_testcase(TestCase, Config0) ->
+    emqx_license_test_lib:mock_parser(),
+    {LicenseKey, Config} = license_key(TestCase, Config0),
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            {emqx_license, iolist_to_binary(["license.key = \"", LicenseKey, "\""])},
+            {emqx_dashboard,
+                iolist_to_binary([
+                    "dashboard { listeners.http.bind = 0, default_password = \"",
+                    ?DASHBOARD_PASSWORD,
+                    "\" }"
+                ])}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(TestCase, Config)}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_testcase(_TestCase, Config) ->
+    ok = emqx_cth_suite:stop(?config(apps, Config)),
+    emqx_license_test_lib:unmock_parser().
+
+license_key(t_conf_dump_license_file_key, Config) ->
+    LicenseContent = emqx_license_test_lib:make_license(#{}),
+    Path = filename:join(?config(priv_dir, Config), "node_dump_test.lic"),
+    ok = file:write_file(Path, LicenseContent),
+    Key = iolist_to_binary(["file://", Path]),
+    {Key, [{license_secret, LicenseContent} | Config]};
+license_key(_TestCase, Config) ->
+    Key = emqx_license_test_lib:make_license(#{}),
+    {Key, [{license_secret, Key} | Config]}.
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+-doc """
+Checks that the config dump keeps sensitive values out of the output:
+`dashboard.default_password` and an inline `license.key` must not occur
+in the rendered HOCON, while both keys must remain present with a
+redacted value.
+""".
+t_conf_dump_redacts_secrets(Config) ->
+    LicenseSecret = ?config(license_secret, Config),
+    Dump = conf_dump(),
+    ?assertEqual(nomatch, binary:match(Dump, ?DASHBOARD_PASSWORD)),
+    ?assertEqual(nomatch, binary:match(Dump, LicenseSecret)),
+    {ok, Conf} = hocon:binary(Dump),
+    ?assertEqual(
+        ?REDACTED,
+        emqx_utils_maps:deep_get([<<"dashboard">>, <<"default_password">>], Conf)
+    ),
+    ?assertEqual(
+        ?REDACTED,
+        emqx_utils_maps:deep_get([<<"license">>, <<"key">>], Conf)
+    ),
+    %% non-sensitive parts of the config are still dumped
+    ?assert(maps:is_key(<<"mqtt">>, Conf)).
+
+-doc """
+Checks that a `license.key` configured as a `file://` URI does not get
+the referenced file's content into the config dump, and that the key
+remains present with a redacted value.
+""".
+t_conf_dump_license_file_key(Config) ->
+    LicenseSecret = ?config(license_secret, Config),
+    Dump = conf_dump(),
+    ?assertEqual(nomatch, binary:match(Dump, LicenseSecret)),
+    ?assertEqual(nomatch, binary:match(Dump, ?DASHBOARD_PASSWORD)),
+    {ok, Conf} = hocon:binary(Dump),
+    ?assertEqual(
+        ?REDACTED,
+        emqx_utils_maps:deep_get([<<"license">>, <<"key">>], Conf)
+    ).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+conf_dump() ->
+    iolist_to_binary(emqx_node_dump:conf_dump()).

--- a/changes/ee/fix-18580.en.md
+++ b/changes/ee/fix-18580.en.md
@@ -1,0 +1,3 @@
+Redact sensitive configuration values in the `conf.hocon` file produced by the `bin/node_dump` script.
+
+Values marked as sensitive in the configuration schema, such as `dashboard.default_password` and `license.key`, are now written as `******`. Before this fix, the script redacted only a fixed list of key names, so these values were written in plain text.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/18568

Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

`bin/node_dump` writes the node config to `log/conf.hocon` (also packed into the `node_dump_*.tar.gz` archive). The dump was redacted with `emqx_utils:redact/1`, which matches an exact list of key names. `dashboard.default_password` and `license.key` are not in that list, so their values were written in plain text, although both fields are declared `sensitive => true` in their schemas.

The fix makes the dump schema-driven: `emqx_node_dump:conf_dump/0` now runs the raw config through `emqx_config:fill_defaults/2` with `obfuscate_sensitive_values => true`, the same mechanism the `GET /configs` API uses. Every field marked sensitive in the schema is written as `"******"`, including fields added in the future. `emqx_utils:redact/1` is still applied on top to cover subtrees the schema walk passes through unchanged (for example the `durable_storage` root, which `fill_defaults/3` skips).

Consequences of using `fill_defaults`:

* The dump now includes schema defaults, like `emqx ctl conf show` output. The dumped file shows the effective config rather than only the configured overrides.
* A `license.key` set as a `file://` URI is also written as `"******"`; the referenced file content never enters the raw config.

Before (values set to distinctive strings on a test node):

```
dashboard {
  default_password = DistinctSmokePw42xyz
}
license {
  key = evaluation
}
```

After, from `log/conf.hocon` produced by `bin/node_dump` on the same node:

```
dashboard {
  default_password = "******"
}
license {
  key = "******"
}
```

Note: the same module protects `log/app_env.dump` with a different predicate (`is_sensitive/1`, substring match over `passwd`/`password`/`secret`), which would have caught `default_password`. The two dump paths still use different mechanisms; this PR only changes the `conf.hocon` path.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
