### PR TITLE
fix(session): publish will message when a takenover session has expiry interval 0

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -3175,25 +3175,24 @@ maybe_publish_will_msg(
     takenover,
     Channel0 = #channel{
         will_msg = WillMsg,
-        conninfo = #{clientid := ClientId}
+        conninfo = #{clientid := ClientId, expiry_interval := ExpiryInterval}
     }
 ) ->
     %% TAKEOVER [MQTT-3.1.4-3]
-    %% MQTT 5, Non-normative comment:
-    %% """"
-    %% If a Network Connection uses a Client Identifier of an existing Network Connection to the Server,
-    %% the Will Message for the exiting connection is sent unless the new connection specifies Clean Start
-    %% of 0 and the Will Delay is greater than zero. If the Will Delay is 0 the Will Message is sent at
-    %% the close of the existing Network Connection, and if Clean Start is 1 the Will Message is sent
-    %% because the Session ends.
-    %% """"
-    %% NOTE, above clean start=1 is `discard' scenarios not `takeover' scenario.
-    case will_delay_interval(WillMsg) of
-        0 ->
+    %% MQTT 5.0, normative:
+    %% - 3.1.3.2.2: "The Server delays publishing the Client's Will Message until
+    %%   the Will Delay Interval has passed or the Session ends, whichever happens first."
+    %% - 3.1.2.11.2: "If it [Session Expiry Interval] is set to 0, or is absent,
+    %%   the Session ends when the Network Connection is closed."
+    %% So skip publishing only when the session outlives the taken-over connection:
+    %% Will Delay Interval > 0 AND session expiry interval > 0.
+    %% NOTE: `ExpiryInterval' is in milliseconds, `will_delay_interval/1' returns
+    %% seconds; only compare either against 0.
+    case will_delay_interval(WillMsg) > 0 andalso ExpiryInterval > 0 of
+        false ->
             ?tp(debug, maybe_publish_willmsg_takenover_pub, #{clientid => ClientId}),
-            Channel = publish_will_msg(Channel0),
-            ok;
-        I when I > 0 ->
+            Channel = publish_will_msg(Channel0);
+        true ->
             %% @NOTE Non-normative comment in MQTT 5.0 spec
             %% """
             %% One use of this is to avoid publishing Will Messages if there is a temporary network
@@ -3201,9 +3200,10 @@ maybe_publish_will_msg(
             %% before the Will Message is published.
             %% """
             ?tp(debug, maybe_publish_willmsg_takenover_skip, #{clientid => ClientId}),
-            Channel = Channel0,
-            skip
+            Channel = Channel0
     end,
+    %% The will message belongs to the taken-over connection; the new connection
+    %% carries its own will message, so drop it here on both branches.
     remove_willmsg(Channel);
 maybe_publish_will_msg(
     Reason,

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -49,6 +49,8 @@ tc_v5_only() ->
         t_takeover_before_session_expire,
         t_takeover_before_willmsg_expire,
         t_takeover_before_session_expire_willdelay0,
+        t_takeover_delayed_willmsg_session_expiry0,
+        t_takeover_delayed_willmsg_session_expiry_absent,
         t_takeover_session_then_normal_disconnect,
         t_takeover_session_then_abnormal_disconnect,
         t_takeover_session_then_abnormal_disconnect_2,
@@ -600,6 +602,70 @@ t_takeover_before_session_expire(Config) ->
     %% THEN: No Willmsg is published
     ?assertNot(IsWill),
     ?assertNotEqual([], ReceivedNoWill),
+    emqtt:stop(CPidSub),
+    emqtt:stop(CPid2),
+    ?assert(not is_process_alive(CPid1)),
+    ok.
+
+-doc """
+Regression test for emqx/emqx#18565: a session with Session Expiry Interval 0
+ends when its network connection closes, so a takeover must publish the will
+message even when the Will Delay Interval is greater than zero
+(MQTT 5.0 3.1.3.2.2 and 3.1.2.11.2).
+""".
+t_takeover_delayed_willmsg_session_expiry0(Config) ->
+    takeover_delayed_willmsg_no_session(
+        ?FUNCTION_NAME, Config, #{'Session-Expiry-Interval' => 0}
+    ).
+
+-doc """
+Same as t_takeover_delayed_willmsg_session_expiry0, but with the
+Session Expiry Interval property absent from CONNECT. The spec treats an
+absent Session Expiry Interval as 0 (MQTT 5.0 3.1.2.11.2).
+""".
+t_takeover_delayed_willmsg_session_expiry_absent(Config) ->
+    takeover_delayed_willmsg_no_session(?FUNCTION_NAME, Config, #{}).
+
+takeover_delayed_willmsg_no_session(Case, Config, ConnProps) ->
+    ?config(mqtt_vsn, Config) =:= v5 orelse ct:fail("MQTTv5 Only"),
+    case ?config(persistence_enabled, Config) of
+        true ->
+            %% force_persistence makes even a session with expiry interval 0
+            %% durable. Taking such a session over crashes the new connection
+            %% with failed_to_commit_session (pre-existing, unrelated to the
+            %% will-message fix this case covers; see emqx/emqx#18565).
+            {skip, "Durable takeover with session expiry interval 0 crashes"};
+        false ->
+            do_takeover_delayed_willmsg_no_session(Case, Config, ConnProps)
+    end.
+
+do_takeover_delayed_willmsg_no_session(Case, Config, ConnProps) ->
+    process_flag(trap_exit, true),
+    ClientId = atom_to_binary(Case),
+    ClientIdSub = <<ClientId/binary, "_willsub">>,
+    WillTopic = <<ClientId/binary, "willtopic">>,
+    ClientOpts = [
+        {proto_ver, ?config(mqtt_vsn, Config)},
+        {clean_start, false},
+        {will_topic, WillTopic},
+        {will_payload, <<"willpayload_delay10_sei0">>},
+        {will_qos, 1},
+        {will_props, #{'Will-Delay-Interval' => 10}},
+        {properties, ConnProps}
+    ],
+    %% GIVEN: client connects with will-delay-interval 10s
+    %%        and session expiry interval 0 (or absent).
+    CPid1 = start_connect_client(ClientId, ClientOpts),
+    CPidSub = start_connect_client(ClientIdSub, []),
+    {ok, _, [?QOS_1]} = emqtt:subscribe(CPidSub, WillTopic, ?QOS_1),
+    %% WHEN: the session is taken over.
+    CPid2 = start_connect_client(ClientId, ClientOpts),
+    assert_client_exit(CPid1, ?config(mqtt_vsn, Config), takenover),
+    %% THEN: the session ended at the takeover, so the will message is
+    %% published without waiting for the will delay interval.
+    ?assertReceive(
+        {publish, #{payload := <<"willpayload_delay10_sei0">>}}, timer:seconds(5)
+    ),
     emqtt:stop(CPidSub),
     emqtt:stop(CPid2),
     ?assert(not is_process_alive(CPid1)),

--- a/changes/ee/fix-18582.en.md
+++ b/changes/ee/fix-18582.en.md
@@ -1,0 +1,3 @@
+Publish the will message when a session with Session Expiry Interval 0 is taken over, even if the Will Delay Interval is greater than zero.
+
+Before this fix, when an MQTT 5.0 client connected with Session Expiry Interval 0 and a Will Delay Interval greater than zero, a session takeover silently dropped the will message. Per the MQTT 5.0 specification, such a session ends when its network connection closes, so the will message must be published at that point.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
pre-5.8 (e5.6.0)

## Summary

Fixes #18565.

An MQTT 5.0 client connects with Session Expiry Interval 0 and a will message with Will Delay Interval > 0. When another connection takes the session over, the will message is silently dropped: it is neither published nor kept for later publishing.

### Root cause

The `takenover` clause of `emqx_channel:maybe_publish_will_msg/2` branches only on the Will Delay Interval. When the delay is greater than zero it skips publishing, and the unconditional `remove_willmsg/1` after the `case` then deletes the will message from the channel state, so no later path can publish it.

The code comment quotes a non-normative comment from MQTT 5.0 section 3.1.4, which says nothing about the Session Expiry Interval. The normative text governs:

- Section 3.1.3.2.2 (Will Delay Interval): "The Server delays publishing the Client's Will Message until the Will Delay Interval has passed or the Session ends, whichever happens first."
- Section 3.1.2.11.2 (Session Expiry Interval): "If it is set to 0, or is absent, the Session ends when the Network Connection is closed."

With Session Expiry Interval 0, the session ends when the takeover closes the old network connection. "The Session ends" happens first, so the will message must be published at that point. The spec's own takeover paragraph in section 3.1.4 confirms this in a non-normative comment: "If the Session Expiry Interval of the existing Network Connection is 0, or the new Network Connection has Clean Start set to 1 then if the existing Network Connection has a Will Message it will be sent because the original Session is ended on the takeover."

### Change

The `takenover` clause now skips publishing only when the session outlives the taken-over connection: Will Delay Interval > 0 **and** the session expiry interval (from `conninfo`, milliseconds) is non-zero. Otherwise it publishes immediately. Behaviour is unchanged when the session survives (Session Expiry Interval > 0), when the Will Delay Interval is 0, and for MQTT 3.x (its clause publishes unconditionally before this one).

`remove_willmsg/1` still runs on both branches: the will message belongs to the taken-over connection, and the new connection carries its own will message.

Regression tests in `emqx_takeover_SUITE`: takeover with Will Delay Interval > 0 and Session Expiry Interval 0, with the property both explicitly 0 and absent (the spec treats them identically). Both fail on unmodified code. The existing `t_no_takeover_with_delayed_willmsg` and `t_takeover_before_session_expire` cases guard the surviving-session behaviour and pass unchanged.

The new cases skip in the `persistence_enabled` group; see the second finding below. Durable sessions are otherwise unaffected by this change: `emqx_persistent_session_ds:publish_will_message_now/2` ignores the channel's request and will messages go through `emqx_durable_will`, and without `force_persistence` a session with expiry interval 0 uses `emqx_session_mem`.

### Pre-existing durable-session crash, not fixed here

The new test combination exposed a separate bug in the durable backend, reproducible on unmodified code: with `force_persistence` enabled, taking over a session whose expiry interval is 0 crashes the **new** connection in `emqx_persistent_session_ds:open/4` → `create_session/7` with `failed_to_commit_session` / `{precondition_failed, ...}` — the session guard record (`[<<"g">>, ClientId]`) the takeover commit expects is deleted concurrently, presumably by the expiry-interval-0 cleanup of the kicked channel. The client sees `tcp_closed` instead of CONNACK. The new test cases therefore skip in the `persistence_enabled` (force_persistence) group.

### Adjacent spec gap, not fixed here

Per section 3.1.2.11.2 the old session (Session Expiry Interval 0) ended when its network connection closed, so the new Clean Start 0 connection should get a fresh session and CONNACK Session Present 0. EMQX instead decides takeover-vs-discard from the new connection's `clean_start` alone: `emqx_cm:open_session/4` never consults the existing session's expiry interval, and `emqx_session_mem:open/4` hands the whole live session state (subscriptions, inflight, mqueue) to the new connection and reports Session Present 1. The taken-over session's state is therefore inherited by a connection that, per the spec, addresses a session that no longer exists. Changing that touches the takeover protocol, the Session Present flag, and message-loss expectations, so it is reported here rather than fixed.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
