### PR TITLE
fix(cli): do not report a shutdown failure when the node is down

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -911,18 +911,28 @@ diagnose_boot_failure_and_die() {
 }
 
 ## Only works when started in daemon mode
+## Returns non-zero when there is no pipe to shut down from.
 pipe_shutdown() {
-    if [ -d "$PIPE_DIR" ]; then
-        echo "Shutting down $NAME from to_erl pipe."
-        ## can not evaluate init:stop() or erlang:halt() because the shell is restricted
-        echo 'emqx_machine:brutal_shutdown().' | "$BINDIR/to_erl" "$PIPE_DIR"
+    ## `run_erl' creates the pipe files in PIPE_DIR. The directory is left
+    ## behind when the node exits, so check that it still holds a pipe.
+    if [ ! -d "$PIPE_DIR" ] || [ -z "$(ls -A "$PIPE_DIR" 2>/dev/null)" ]; then
+        return 1
     fi
+    echo "Shutting down $NAME from to_erl pipe."
+    ## can not evaluate init:stop() or erlang:halt() because the shell is restricted
+    echo 'emqx_machine:brutal_shutdown().' | "$BINDIR/to_erl" "$PIPE_DIR"
 }
 
 ## Call nodetool to stop EMQX
 nodetool_shutdown() {
     # Wait for the node to completely stop...
-    PID="$(relx_get_pid)"
+    ## When the node cannot be reached, nodetool has already logged the reason.
+    ## Return here so the caller can try the to_erl pipe instead. Calling
+    ## nodetool again would repeat the same message, and there is no PID to
+    ## report a graceful shutdown failure for.
+    if ! PID="$(relx_get_pid)"; then
+        return 1
+    fi
     if ! relx_nodetool "stop"; then
         die "Graceful shutdown failed PID=[$PID]"
     fi
@@ -997,7 +1007,8 @@ case "${COMMAND}" in
 
     stop)
         if ! nodetool_shutdown; then
-            pipe_shutdown
+            ## The node did not stop and there is no pipe to fall back to.
+            pipe_shutdown || exit 1
         fi
         ;;
 

--- a/changes/ee/fix-18590.en.md
+++ b/changes/ee/fix-18590.en.md
@@ -1,0 +1,5 @@
+Fixed the output of `emqx stop` when the node is not running.
+
+The command reported `Node <name> not responding to pings.` twice and then failed with
+`Graceful shutdown failed PID=[]`. It now reports the unreachable node once and does not print a
+shutdown failure for a node it could not find. The exit code is unchanged.


### PR DESCRIPTION
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

Running `emqx stop` against a node that is not running produced this:

```
$ ./bin/emqx stop
Node 'emqx@127.0.0.1' not responding to pings.
Node 'emqx@127.0.0.1' not responding to pings.
ERROR: Graceful shutdown failed PID=[]
```

`nodetool_shutdown()` in `bin/emqx` called nodetool twice: once through `relx_get_pid` to read the
PID, and once to stop the node. Both calls printed the same unreachable-node message. The first call
failed, so `PID` was empty and the reported shutdown failure named no process.

Changes:

1. `nodetool_shutdown()` returns early when the PID cannot be read. nodetool has already reported why
   the node is unreachable, so the second call and the misleading failure message are both dropped.
2. `pipe_shutdown()` returns non-zero when `PIPE_DIR` holds no pipe. `run_erl` leaves that directory
   behind when the node exits, so after a crash the fallback ran against a stale directory and printed
   a `to_erl` error. The `stop` branch now exits non-zero when neither path stopped anything, which
   keeps the previous exit code.

After:

```
$ ./bin/emqx stop
Node 'emqx@127.0.0.1' not responding to pings.
$ echo $?
1
```

Verified by hand on a 6.1 release package:

- Node running: `emqx stop` prints `ok` and exits 0.
- Node not running, stale pipe directory present: one message, exit 1.
- Node not running, no pipe directory: one message, exit 1.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
