### PR TITLE
test(authz): wait for the publish authz result before draining

### DIFF
--- a/apps/emqx/test/emqx_authz_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_authz_cache_SUITE.erl
@@ -53,6 +53,10 @@ t_clean_authz_cache(_) ->
     {ok, _, _} = emqtt:subscribe(Client, <<"t2">>, 0),
     emqtt:publish(Client, <<"t1">>, <<"{\"x\":1}">>, 0),
     ClientPid = find_client_pid(ClientId),
+    %% Same race as in t_drain_authz_cache: wait until the fire-and-forget
+    %% publish has been authorized, otherwise its cache entry can be written
+    %% after the channel handled `clean_authz_cache'.
+    ?retry(100, 20, ?assert(is_publish_cached(ClientPid))),
     Caches = list_cache(ClientPid),
     ct:log("authz caches: ~p", [Caches]),
     ?assert(length(Caches) > 0),
@@ -67,6 +71,12 @@ t_drain_authz_cache(_) ->
     {ok, _, _} = emqtt:subscribe(Client, <<"t2">>, 0),
     emqtt:publish(Client, <<"t1">>, <<"{\"x\":1}">>, 0),
     ClientPid = find_client_pid(ClientId),
+    %% The publish is fire-and-forget, so the channel can cache its authz
+    %% result after drain_cache/0 recorded the eviction cutoff, and an entry
+    %% cached after the cutoff survives the drain. Wait for it. The
+    %% subscribe above is SUBACK-confirmed, so `length(Caches) > 0' alone
+    %% does not prove the publish was authorized yet.
+    ?retry(100, 20, ?assert(is_publish_cached(ClientPid))),
     Caches = list_cache(ClientPid),
     ct:log("authz caches: ~p", [Caches]),
     ?assert(length(Caches) > 0),
@@ -76,6 +86,15 @@ t_drain_authz_cache(_) ->
     {ok, _, _} = emqtt:subscribe(Client, <<"t2">>, 0),
     ?assert(length(list_cache(ClientPid)) > 0),
     emqtt:stop(Client).
+
+is_publish_cached(ClientPid) ->
+    lists:any(
+        fun
+            ({{#{action_type := publish}, <<"t1">>}, _}) -> true;
+            (_) -> false
+        end,
+        list_cache(ClientPid)
+    ).
 
 list_cache(ClientId) when is_binary(ClientId) ->
     ClientPid = find_client_pid(ClientId),


### PR DESCRIPTION
## Summary

De-flake `emqx_authz_cache_SUITE:t_drain_authz_cache`:

```
Failure/Error: ?assertEqual([], list_cache ( ClientPid ))
       got: [{{#{qos => 0,retain => false,action_type => publish},<<"t1">>}, {allow,1787919410755}}]
```

Seen in: https://github.com/emqx/emqx/actions/runs/33169601426/job/98845119619?pr=18556

`drain_cache/0` is synchronous: it records an eviction cutoff in a persistent term, and `list_authz_cache/0` → `cleanup_authz_cache/0` evicts entries whose `CachedAt =< cutoff`. So the race is not in the drain, it is in *what has been cached* when the drain runs. The QoS 0 publish is fire-and-forget, so the channel can authorize `t1` **after** the cutoff was recorded; that entry is newer than the cutoff and survives — which matches the failure, where the surviving entry's timestamp is later than the drain.

The preceding `emqtt:subscribe/3` is SUBACK-confirmed and caches its own entry, so the existing `length(Caches) > 0` check passes without proving the publish was authorized yet.

Fix: wait for the publish's cache entry before draining. `t_clean_authz_cache` races identically (the `clean_authz_cache` message can be handled before the publish is processed), so it gets the same barrier.

Full suite passes locally: 3 ok, 0 failed.

Base `dev-58`: the case bodies are identical through dev-60; dev-63+ carry a diverged variant with the same exposure.