### PR TITLE
feat(node_dump): give bin/node_dump a formal CLI command

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -1424,6 +1424,8 @@ format_io_requests(IoRequests) ->
                 {put_chars, unicode, M, F, A} ->
                     IoDat = apply(M, F, A),
                     unicode:characters_to_binary(IoDat);
+                {put_chars, unicode, IoDat} ->
+                    unicode:characters_to_binary(IoDat);
                 _ ->
                     error({unknown_io_request, Request})
             end

--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -276,6 +276,49 @@ t_cli_redaction(_Config) ->
     {ok, _} = emqx_mgmt_auth:delete(iolist_to_binary(Name)),
     ok.
 
+-doc """
+Regression test for #18588: `bin/node_dump' used to drive the node through
+`emqx eval', which is audited as `eval_erl' carrying the raw Erlang
+expression. Running the `node_dump' CLI command must write ordinary `cli'
+audit records identifying the sub-command, and must not write any
+`eval_erl' record.
+""".
+t_node_dump(_Config) ->
+    %% Need to explicitly load the commands because they are loaded by `emqx_machine'.
+    ok = emqx_mgmt_cli:load(),
+    %% Sub-command output content is covered by `emqx_mgmt_cli_SUITE:t_node_dump/1';
+    %% this only needs each call to succeed, to trigger the audit write below.
+    lists:foreach(
+        fun(SubCmd) ->
+            ?assertEqual(ok, emqx_ctl:run_command(["node_dump", SubCmd]), SubCmd)
+        end,
+        ["sys_info", "app_env", "conf"]
+    ),
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    {ok, Res} = emqx_mgmt_api_test_util:request_api(
+        get, AuditPath, "operation_type=node_dump&limit=10", AuthHeader
+    ),
+    #{<<"data">> := Data} = emqx_utils_json:decode(Res),
+    ?assertEqual(3, length(Data)),
+    lists:foreach(
+        fun(#{<<"from">> := From, <<"operation_type">> := OpType}) ->
+            ?assertEqual(<<"cli">>, From),
+            ?assertEqual(<<"node_dump">>, OpType)
+        end,
+        Data
+    ),
+    ?assertEqual(
+        lists:sort([<<"app_env">>, <<"conf">>, <<"sys_info">>]),
+        lists:sort([Arg || #{<<"args">> := [Arg]} <- Data])
+    ),
+    %% no `eval_erl' record was written for any of the sub-commands
+    {ok, ResEval} = emqx_mgmt_api_test_util:request_api(
+        get, AuditPath, "operation_type=eval_erl", AuthHeader
+    ),
+    ?assertMatch(#{<<"data">> := []}, emqx_utils_json:decode(ResEval)),
+    ok.
+
 t_max_size(_Config) ->
     {ok, _} = emqx:update_config([log, audit, cache_size], 999),
     %% Make sure this process is using latest cache_size.

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -57,7 +57,9 @@
     ds/1,
     ds_audit_args/1,
     exclusive/1,
-    exclusive_audit_args/1
+    exclusive_audit_args/1,
+    node_dump/1,
+    node_dump_audit_args/1
 ]).
 
 -export([
@@ -75,6 +77,7 @@
     listeners,
     log,
     mnesia,
+    node_dump,
     olp,
     pem_cache,
     'session-top',
@@ -1919,3 +1922,26 @@ exclusive(_) ->
     ]).
 
 exclusive_audit_args(Args) -> Args.
+
+%%--------------------------------------------------------------------
+%% @doc node_dump Command
+%%
+%% CLI front-end for `bin/node_dump`. `sys_info/0` and `app_env_dump/0`
+%% return terms instead of printing, so render them here as `emqx eval`
+%% used to via nodetool.
+
+node_dump(["sys_info"]) ->
+    emqx_ctl:print("~p~n", [emqx_node_dump:sys_info()]);
+node_dump(["app_env"]) ->
+    emqx_ctl:print("~p~n", [emqx_node_dump:app_env_dump()]);
+node_dump(["conf"]) ->
+    emqx_node_dump:print_conf_dump();
+node_dump(_) ->
+    emqx_ctl:usage([
+        {"node_dump sys_info", "Print node release and OTP version"},
+        {"node_dump app_env", "Print the application environment (censored)"},
+        {"node_dump conf", "Print the raw configuration tree (redacted)"}
+    ]).
+
+%% No secrets among the sub-command names; pass them through unredacted.
+node_dump_audit_args(Args) -> Args.

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -834,10 +834,7 @@ t_node_dump(_Config) ->
     ?assertEqual(match, re:run(SysInfoOut, <<"otp_version">>, [{capture, none}])),
     {ok, AppEnvOut} = capture_ctl(["node_dump", "app_env"]),
     ?assert(byte_size(AppEnvOut) > 0),
-    %% `node_dump conf` prints via `io:put_chars/1` (pre-formatted text), not
-    %% `io:format/2` like the other sub-commands, so `capture_ctl` (which only
-    %% decodes deferred `io_lib:format` requests) cannot be reused here.
-    {ok, ConfOut} = capture_raw(fun() -> emqx_ctl:run_command(["node_dump", "conf"]) end),
+    {ok, ConfOut} = capture_ctl(["node_dump", "conf"]),
     ?assert(byte_size(ConfOut) > 0),
     {ok, UsageOut} = capture_ctl(["node_dump", "unknown"]),
     ?assertEqual(match, re:run(UsageOut, <<"node_dump sys_info">>, [{capture, none}])),
@@ -1014,39 +1011,6 @@ capture_ctl(Args) ->
     {Result, OutputChunks} =
         emqx_common_test_helpers:capture_io_format(fun() -> emqx_ctl:run_command(Args) end),
     {Result, iolist_to_binary(OutputChunks)}.
-
-%% Like `capture_ctl/1`, but also decodes `io:put_chars/1` `put_chars`
-%% requests, which carry pre-formatted iodata instead of a deferred
-%% `io_lib:format` call.
-capture_raw(Fun) ->
-    Owner = self(),
-    GL = spawn_link(fun() -> raw_gl_sink(Owner, []) end),
-    OldGL = group_leader(),
-    true = group_leader(GL, self()),
-    try
-        Result = Fun(),
-        GL ! {stop, self()},
-        Output =
-            receive
-                {raw_gl_output, O} -> O
-            after 1000 -> error(timeout)
-            end,
-        {Result, iolist_to_binary(Output)}
-    after
-        true = group_leader(OldGL, self())
-    end.
-
-raw_gl_sink(Owner, Acc) ->
-    receive
-        {io_request, From, ReplyAs, {put_chars, _Enc, Data}} ->
-            From ! {io_reply, ReplyAs, ok},
-            raw_gl_sink(Owner, [Data | Acc]);
-        {io_request, From, ReplyAs, {put_chars, _Enc, M, F, A}} ->
-            From ! {io_reply, ReplyAs, ok},
-            raw_gl_sink(Owner, [apply(M, F, A) | Acc]);
-        {stop, Owner} ->
-            Owner ! {raw_gl_output, lists:reverse(Acc)}
-    end.
 
 wait_session_top_status(Expected, Attempts) when Attempts > 0 ->
     {ok, Output} = capture_ctl(["session-top", "status"]),

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -822,6 +822,31 @@ t_exclusive(_Config) ->
     emqx_ctl:run_command(["exclusive", "delete", "t/1"]),
     ok.
 
+-doc """
+`node_dump' backs `bin/node_dump'. Each sub-command must print non-empty
+output and return `ok', or `collect' in the shell script falls through to
+its `|| echo "Unavailable"' branch. The command is registered visibly, so
+it must also show up in `emqx ctl help'.
+""".
+t_node_dump(_Config) ->
+    {ok, SysInfoOut} = capture_ctl(["node_dump", "sys_info"]),
+    ?assertEqual(match, re:run(SysInfoOut, <<"release">>, [{capture, none}])),
+    ?assertEqual(match, re:run(SysInfoOut, <<"otp_version">>, [{capture, none}])),
+    {ok, AppEnvOut} = capture_ctl(["node_dump", "app_env"]),
+    ?assert(byte_size(AppEnvOut) > 0),
+    %% `node_dump conf` prints via `io:put_chars/1` (pre-formatted text), not
+    %% `io:format/2` like the other sub-commands, so `capture_ctl` (which only
+    %% decodes deferred `io_lib:format` requests) cannot be reused here.
+    {ok, ConfOut} = capture_raw(fun() -> emqx_ctl:run_command(["node_dump", "conf"]) end),
+    ?assert(byte_size(ConfOut) > 0),
+    {ok, UsageOut} = capture_ctl(["node_dump", "unknown"]),
+    ?assertEqual(match, re:run(UsageOut, <<"node_dump sys_info">>, [{capture, none}])),
+    ?assertEqual(match, re:run(UsageOut, <<"node_dump app_env">>, [{capture, none}])),
+    ?assertEqual(match, re:run(UsageOut, <<"node_dump conf">>, [{capture, none}])),
+    {ok, HelpOut} = capture_ctl([]),
+    ?assertEqual(match, re:run(HelpOut, <<"node_dump sys_info">>, [{capture, none}])),
+    ok.
+
 %% Test default stats command
 t_clients_dump_stats_default(init, Config) ->
     %% Start a test client
@@ -989,6 +1014,39 @@ capture_ctl(Args) ->
     {Result, OutputChunks} =
         emqx_common_test_helpers:capture_io_format(fun() -> emqx_ctl:run_command(Args) end),
     {Result, iolist_to_binary(OutputChunks)}.
+
+%% Like `capture_ctl/1`, but also decodes `io:put_chars/1` `put_chars`
+%% requests, which carry pre-formatted iodata instead of a deferred
+%% `io_lib:format` call.
+capture_raw(Fun) ->
+    Owner = self(),
+    GL = spawn_link(fun() -> raw_gl_sink(Owner, []) end),
+    OldGL = group_leader(),
+    true = group_leader(GL, self()),
+    try
+        Result = Fun(),
+        GL ! {stop, self()},
+        Output =
+            receive
+                {raw_gl_output, O} -> O
+            after 1000 -> error(timeout)
+            end,
+        {Result, iolist_to_binary(Output)}
+    after
+        true = group_leader(OldGL, self())
+    end.
+
+raw_gl_sink(Owner, Acc) ->
+    receive
+        {io_request, From, ReplyAs, {put_chars, _Enc, Data}} ->
+            From ! {io_reply, ReplyAs, ok},
+            raw_gl_sink(Owner, [Data | Acc]);
+        {io_request, From, ReplyAs, {put_chars, _Enc, M, F, A}} ->
+            From ! {io_reply, ReplyAs, ok},
+            raw_gl_sink(Owner, [apply(M, F, A) | Acc]);
+        {stop, Owner} ->
+            Owner ! {raw_gl_output, lists:reverse(Acc)}
+    end.
 
 wait_session_top_status(Expected, Attempts) when Attempts > 0 ->
     {ok, Output} = capture_ctl(["session-top", "status"]),

--- a/bin/node_dump
+++ b/bin/node_dump
@@ -52,7 +52,7 @@ done
 # Collect system info:
 {
     collect "$RUNNER_BIN_DIR"/emqx ctl broker
-    collect "$RUNNER_BIN_DIR"/emqx eval "'emqx_node_dump:sys_info()'"
+    collect "$RUNNER_BIN_DIR"/emqx ctl node_dump sys_info
 
     collect uname -a
     collect uptime
@@ -74,11 +74,11 @@ done
 
 # Collect information about the configuration:
 {
-    collect "$RUNNER_BIN_DIR"/emqx eval "'emqx_node_dump:app_env_dump().'"
+    collect "$RUNNER_BIN_DIR"/emqx ctl node_dump app_env
 } > "${APP_ENV_DUMP}"
 
 {
-    collect "$RUNNER_BIN_DIR"/emqx eval "'emqx_node_dump:print_conf_dump().'"
+    collect "$RUNNER_BIN_DIR"/emqx ctl node_dump conf
 } > "${CONF_DUMP}"
 
 

--- a/changes/ee/feat-18592.en.md
+++ b/changes/ee/feat-18592.en.md
@@ -1,0 +1,1 @@
+`bin/node_dump` now collects node information through a dedicated `emqx ctl node_dump` command instead of `emqx eval`. Audit records for the collected system info, application environment, and configuration dump now identify the `node_dump` command instead of the raw Erlang expression that produced them.


### PR DESCRIPTION
Release version:
7.0.0

Introduced in:
N/A

## Summary

`bin/node_dump` drove the node through three `emqx eval` calls (`bin/node_dump:55,77,81`). Each one is
audited as an `eval_erl` record carrying the raw Erlang expression as its argument, while everything
else the script collects already goes through `emqx ctl`. Closes #18588.

Added `emqx ctl node_dump {sys_info,app_env,conf}` to `emqx_mgmt_cli` (`apps/emqx_management`), next to
the existing `broker`/`vm`/`listeners` commands that already cover `apps/emqx` functionality, and pointed
`bin/node_dump` at it instead of `emqx eval`. Audit records for the three collected artifacts now
identify the `node_dump` sub-command, like any other CLI command, instead of the Erlang expression that
produced them.

The bodies of `emqx_node_dump:sys_info/0`, `app_env_dump/0` and `print_conf_dump/0` are untouched — this
only adds a CLI layer in front of them, so it does not collide with the separate `print_conf_dump/0`
redaction fix for #18568 in flight on `dev-60`.

Two behavior notes:
- `sys_info/0` and `app_env_dump/0` return terms instead of printing (`emqx eval` rendered the return
  value via `nodetool`). The new command renders them with the same `~p` formatting nodetool used, so
  `sysinfo.txt`/`app_env.dump` content is unchanged.
- `print_conf_dump/0` already prints and returns `ok`. `emqx eval` printed that `ok` return value too,
  appending a stray trailing `ok` line to `conf.hocon`. Moving off `emqx eval` drops that line — an
  improvement, but a change to a collected artifact worth calling out. Nothing in the repo parses
  `conf.hocon` expecting it.

**Out of scope:** #18588 also reports that CLI audit records return `args: []` while dashboard records
return `args: ""`, and that `http_request` is `""` on non-HTTP records — a type inconsistency across
every audit producer, not something `node_dump` caused. This PR does not touch the audit schema or
`emqx_audit:to_audit/1`; that inconsistency is still open.

Also noted, not merged: `emqx ctl conf show` already exists and prints configuration, but it is not the
same as `print_conf_dump/0`, which redacts and renders the whole raw config tree through `hocon_pp`. Kept
them separate.

### Verified against a live node

Started a local node with `log.audit.enable = true`, ran `bin/node_dump`, and queried
`GET /api/v5/audit`.

Before (last records, oldest omitted):
```json
[
  {"operation_type": "conf", "args": ["show", "log"], "from": "cli"},
  {"operation_type": "status", "args": [], "from": "cli"},
  {"operation_type": "conf", "args": ["show", "log.audit"], "from": "cli"},
  {"operation_type": "status", "args": [], "from": "cli"},
  {"operation_type": "emqx", "args": ["start"], "from": "cli"}
]
```

After running `bin/node_dump`:
```json
[
  {"operation_type": "node_dump", "args": ["conf"], "from": "cli"},
  {"operation_type": "node_dump", "args": ["app_env"], "from": "cli"},
  {"operation_type": "node_dump", "args": ["sys_info"], "from": "cli"}
]
```
`GET /api/v5/audit?operation_type=eval_erl` returned zero records. The generated
`node_dump_*.tar.gz` still contained `sysinfo.txt`, `app_env.dump` and `conf.hocon` with the same
content as before, minus the trailing `ok` line in `conf.hocon` noted above.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
