### PR TITLE
test(authn_jwt): stop snabbkaffe in teardown

### DIFF
--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -48,6 +48,13 @@ end_per_suite(Config) ->
 
 end_per_testcase(_TestCase, _Config) ->
     emqx_common_test_helpers:call_janitor(),
+    %% Cases start and stop the snabbkaffe trace themselves. A case that
+    %% exits between the two leaves the supervision tree linked to its dead
+    %% process; the tree then dies asynchronously and can take the
+    %% registered collector with it while a later case is attached, whose
+    %% flush_trace then fails with noproc. Stop it here so every case starts
+    %% from a clean slate.
+    ok = snabbkaffe:stop(),
     ok.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

De-flake `emqx_authn_jwt_SUITE:t_invalid_signature_trace_redacts_hmac_jwks`:

```
%%% emqx_authn_jwt_SUITE ==> t_invalid_signature_trace_redacts_hmac_jwks: FAILED
{noproc,{gen_server,call,[snabbkaffe_collector,flush_trace,infinity]}}
```

Seen in: https://github.com/emqx/emqx/actions/runs/33175461188/job/98865505011?pr=18591

Same class as #18551 (`emqx_bridge_http_SUITE`) and the precedent 9ffea5eba8 (`emqx_authn_mongodb_tls_SUITE`). Here the cases call `snabbkaffe:start_trace/0` and `snabbkaffe:stop/0` themselves, so a case that exits between the two leaves the supervision tree linked to its dead process. The tree then dies asynchronously and can take the registered collector with it while a later case is already attached, whose `flush_trace` hits `noproc`.

Stop the trace in `end_per_testcase` so every case starts from a clean slate regardless of which path the previous one took.

Validation: the target case passes locally. Two JWKS cases (`t_jwks_config_update`, `t_jwks_renewal`) fail on this host from a stale `ecpool` (`undef ecpool:check_pool_integrity/1`); the unmodified baseline fails those two identically.

Base `dev-58`.