### PR TITLE
fix(agent): handle special characters in dashboard identifiers

### DIFF
--- a/changes/ee/fix-18595.en.md
+++ b/changes/ee/fix-18595.en.md
@@ -1,0 +1,1 @@
+Fixed an issue in the EMQX Agent Dashboard where connections, tools, and pipelines with identifiers containing quotes or other special characters could not be managed.

--- a/plugins/emqx_agent/priv/ui/connections.js
+++ b/plugins/emqx_agent/priv/ui/connections.js
@@ -20,8 +20,8 @@ export async function loadConnections() {
       : '<span class="tag draft">○ disabled</span>';
     const runtimeStatus = renderRuntimeStatus(statuses?.[c.id]);
     const action = c.enable === true
-      ? `<button class="btn sm" onclick="stopConnection('${esc(c.id)}')">stop</button>`
-      : `<button class="btn sm" onclick="startConnection('${esc(c.id)}')">start</button>`;
+      ? `<button class="btn sm" data-id="${esc(c.id)}" onclick="stopConnection(this.dataset.id)">stop</button>`
+      : `<button class="btn sm" data-id="${esc(c.id)}" onclick="startConnection(this.dataset.id)">start</button>`;
     return `<tr>
       <td><code>${esc(c.id)}</code></td>
       <td><span class="tag ch">${esc(c.type)}</span></td>
@@ -29,8 +29,8 @@ export async function loadConnections() {
       <td style="color:var(--muted)">${esc(c.config?.server ?? '')}</td>
       <td><div style="display:flex;gap:4px">
         ${action}
-        <button class="btn sm" onclick="editConnection('${esc(c.id)}')">edit</button>
-        <button class="btn sm danger" onclick="deleteConnection('${esc(c.id)}')">delete</button>
+        <button class="btn sm" data-id="${esc(c.id)}" onclick="editConnection(this.dataset.id)">edit</button>
+        <button class="btn sm danger" data-id="${esc(c.id)}" onclick="deleteConnection(this.dataset.id)">delete</button>
       </div></td>
     </tr>`;
   }).join('');

--- a/plugins/emqx_agent/priv/ui/pipelines.js
+++ b/plugins/emqx_agent/priv/ui/pipelines.js
@@ -30,9 +30,9 @@ export async function loadPipelines() {
       <td>${steps}</td>
       <td>${statusBadge}</td>
       <td><div style="display:flex;gap:4px">
-        <button class="btn sm" onclick="togglePipelineActive('${esc(p.pipeline_id)}')">${toggleLabel}</button>
-        <button class="btn sm" onclick="editPipeline('${esc(p.pipeline_id)}')">edit</button>
-        <button class="btn sm danger" onclick="deletePipeline('${esc(p.pipeline_id)}')">delete</button>
+        <button class="btn sm" data-id="${esc(p.pipeline_id)}" onclick="togglePipelineActive(this.dataset.id)">${toggleLabel}</button>
+        <button class="btn sm" data-id="${esc(p.pipeline_id)}" onclick="editPipeline(this.dataset.id)">edit</button>
+        <button class="btn sm danger" data-id="${esc(p.pipeline_id)}" onclick="deletePipeline(this.dataset.id)">delete</button>
       </div></td>
     </tr>`;
   }).join('');

--- a/plugins/emqx_agent/priv/ui/tools.js
+++ b/plugins/emqx_agent/priv/ui/tools.js
@@ -20,8 +20,8 @@ export async function loadTools() {
       <td><span class="tag ${typeClass(s.type)}">${esc(s.type)}</span></td>
       <td style="color:var(--muted)">${esc(s.desc ?? '')}</td>
       <td><div style="display:flex;gap:6px">
-        <button class="btn sm" onclick="editTool('${esc(s.type)}','${esc(s.id)}')">edit</button>
-        <button class="btn sm danger" onclick="deleteTool('${esc(s.type)}','${esc(s.id)}')">delete</button>
+        <button class="btn sm" data-type="${esc(s.type)}" data-id="${esc(s.id)}" onclick="editTool(this.dataset.type,this.dataset.id)">edit</button>
+        <button class="btn sm danger" data-type="${esc(s.type)}" data-id="${esc(s.id)}" onclick="deleteTool(this.dataset.type,this.dataset.id)">delete</button>
       </div></td>
     </tr>`).join('');
 }


### PR DESCRIPTION
Release version: 7.0.0

Introduced in: 6.3.0

Fixes #18541

## Summary

Pass connection, tool, and pipeline identifiers through escaped data attributes instead of embedding them in JavaScript strings.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
