### PR TITLE
fix(session): end an expiry-interval-0 session at takeover

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1559,6 +1559,28 @@ handle_call(discard, Channel) ->
         []
     );
 %% Session Takeover
+handle_call(
+    {takeover, 'begin'},
+    Channel = #channel{conninfo = #{expiry_interval := 0}}
+) ->
+    %% MQTT 5.0 3.1.2.11.2: with Session Expiry Interval 0 the session ends
+    %% when the network connection is closed. The takeover closes it, so
+    %% there is no session to hand over: publish the will message because
+    %% the session ends now, then shut down like a takeover kick.
+    %% `noreply' makes the connection process shut down without answering
+    %% the call; the caller observes the `{shutdown, _}' exit, classifies
+    %% it as `noproc', and falls back to creating a fresh session. Peer
+    %% nodes running older code handle this the same way.
+    ?EXT_TRACE_BROKER_DISCONNECT(
+        ?EXT_TRACE_ATTR(
+            maps:merge(basic_attrs(Channel), disconnect_attrs(takeover, Channel))
+        ),
+        fun() ->
+            Channel0 = maybe_publish_will_msg(expired, Channel),
+            disconnect_and_shutdown(takenover, noreply, Channel0)
+        end,
+        []
+    );
 handle_call({takeover, 'begin'}, Channel = #channel{session = Session}) ->
     reply(Session, Channel#channel{takeover = true});
 handle_call(
@@ -3108,6 +3130,9 @@ maybe_publish_will_msg(
     %% because the Session ends.
     %% """"
     %% NOTE, above clean start=1 is `discard' scenarios not `takeover' scenario.
+    %% NOTE: a session with expiry interval 0 never reaches here from the
+    %% takeover-begin path: that path publishes its will message with reason
+    %% `expired' before shutting down.
     case will_delay_interval(WillMsg) of
         0 ->
             ?tp(debug, maybe_publish_willmsg_takenover_pub, #{clientid => ClientId}),

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -559,6 +559,9 @@ handle_msg({'$gen_call', From, Req}, State) ->
         {reply, Reply, NState} ->
             gen_server:reply(From, Reply),
             {ok, NState};
+        {stop, Reason, noreply, NState} ->
+            %% The caller learns about the shutdown from the process exit.
+            stop(Reason, NState);
         {stop, Reason, Reply, NState} ->
             gen_server:reply(From, Reply),
             stop(Reason, NState)

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -531,13 +531,20 @@ handle_call(From, Req, State = #state{channel = Channel}) ->
             gen_server:reply(From, Reply),
             return(State#state{channel = NChannel});
         {shutdown, Reason, Reply, NChannel} ->
-            gen_server:reply(From, Reply),
+            ok = maybe_reply(From, Reply),
             shutdown(Reason, State#state{channel = NChannel});
         {shutdown, Reason, Reply, Packet, NChannel} ->
-            gen_server:reply(From, Reply),
+            ok = maybe_reply(From, Reply),
             NState = State#state{channel = NChannel},
             shutdown(Reason, enqueue(Packet, NState))
     end.
+
+%% A `noreply' reply means the channel shuts down without answering the
+%% call; the caller learns about the shutdown from the process exit.
+maybe_reply(_From, noreply) ->
+    ok;
+maybe_reply(From, Reply) ->
+    gen_server:reply(From, Reply).
 
 %%--------------------------------------------------------------------
 %% Handle Info

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -768,7 +768,18 @@ t_handle_call_discard(_) ->
         emqx_channel:handle_call(discard, channel()).
 
 t_handle_call_takeover_begin(_) ->
-    {reply, _Session, _Chan} = emqx_channel:handle_call({takeover, 'begin'}, channel()).
+    %% The default test channel has session expiry interval 0: its session
+    %% ends at the takeover, so the channel shuts down without replying.
+    Packet = ?DISCONNECT_PACKET(?RC_SESSION_TAKEN_OVER),
+    {shutdown, takenover, noreply, Packet, _Chan0} =
+        emqx_channel:handle_call({takeover, 'begin'}, channel()),
+    %% With a nonzero expiry interval the session is handed over.
+    Channel = channel(),
+    ConnInfo = emqx_channel:info(conninfo, Channel),
+    NChannel = emqx_channel:set_field(
+        conninfo, ConnInfo#{expiry_interval => 60000}, Channel
+    ),
+    {reply, _Session, _Chan} = emqx_channel:handle_call({takeover, 'begin'}, NChannel).
 
 t_handle_call_takeover_end(_) ->
     ok = meck:expect(emqx_broker, unsubscribe, fun(_) -> ok end),

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -180,7 +180,12 @@ t_connect_clean_start(Config) ->
     {ok, Client1} = emqtt:start_link([
         {clientid, <<"t_connect_clean_start">>},
         {proto_ver, v5},
-        {clean_start, true}
+        {clean_start, true},
+        %% Nonzero session expiry interval, so the session survives the
+        %% takeover below. With interval 0 the session ends when the taken-over
+        %% network connection closes (MQTT 5.0 3.1.2.11.2) and the new
+        %% connection would get a fresh session (Session Present 0).
+        {properties, #{'Session-Expiry-Interval' => 30}}
         | Config
     ]),
     {ok, _} = emqtt:ConnFun(Client1),

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -53,6 +53,8 @@ tc_v5_only() ->
         t_takeover_before_session_expire,
         t_takeover_before_willmsg_expire,
         t_takeover_before_session_expire_willdelay0,
+        t_takeover_delayed_willmsg_session_expiry0,
+        t_takeover_delayed_willmsg_session_expiry_absent,
         t_takeover_session_then_normal_disconnect,
         t_takeover_session_then_abnormal_disconnect,
         t_takeover_session_then_abnormal_disconnect_2
@@ -599,6 +601,9 @@ t_takeover_before_session_expire(Config) ->
     #{client := [CPid2, CPidSub, CPid1]} = FCtx,
     ct:pal("FCtx: ~p", [FCtx]),
     assert_client_exit(CPid1, ?config(mqtt_vsn, Config), takenover),
+    %% THEN: the session survives (expiry interval > 0): the new connection
+    %% resumes it.
+    ?assertEqual(1, proplists:get_value(session_present, emqtt:info(CPid2))),
 
     Received = [Msg || {publish, Msg} <- ?drainMailbox(1000)],
     ct:pal("received: ~p", [[P || #{payload := P} <- Received]]),
@@ -606,6 +611,72 @@ t_takeover_before_session_expire(Config) ->
     %% THEN: No Willmsg is published
     ?assertNot(IsWill),
     ?assertNotEqual([], ReceivedNoWill),
+    emqtt:stop(CPidSub),
+    emqtt:stop(CPid2),
+    ?assert(not is_process_alive(CPid1)),
+    ok.
+
+%% Regression test for emqx/emqx#18565: a session with Session Expiry Interval 0
+%% ends when its network connection closes, so a takeover must publish the will
+%% message even when the Will Delay Interval is greater than zero, and the new
+%% connection must start a fresh session (Session Present 0, no inherited
+%% subscriptions) (MQTT 5.0 3.1.3.2.2 and 3.1.2.11.2).
+t_takeover_delayed_willmsg_session_expiry0(Config) ->
+    takeover_delayed_willmsg_no_session(
+        ?FUNCTION_NAME, Config, #{'Session-Expiry-Interval' => 0}
+    ).
+
+%% Same as t_takeover_delayed_willmsg_session_expiry0, but with the
+%% Session Expiry Interval property absent from CONNECT. The spec treats an
+%% absent Session Expiry Interval as 0 (MQTT 5.0 3.1.2.11.2).
+t_takeover_delayed_willmsg_session_expiry_absent(Config) ->
+    takeover_delayed_willmsg_no_session(?FUNCTION_NAME, Config, #{}).
+
+takeover_delayed_willmsg_no_session(Case, Config, ConnProps) ->
+    case ?config(persistence_enabled, Config) of
+        true ->
+            {skip, "Durable sessions are out of scope; see emqx/emqx#18585"};
+        false ->
+            do_takeover_delayed_willmsg_no_session(Case, Config, ConnProps)
+    end.
+
+do_takeover_delayed_willmsg_no_session(Case, Config, ConnProps) ->
+    ?config(mqtt_vsn, Config) =:= v5 orelse ct:fail("MQTTv5 Only"),
+    process_flag(trap_exit, true),
+    ClientId = make_client_id(Case, Config),
+    ClientIdSub = <<ClientId/binary, "_willsub">>,
+    WillTopic = <<ClientId/binary, "willtopic">>,
+    SubTopic = <<ClientId/binary, "subtopic">>,
+    ClientOpts = [
+        {proto_ver, ?config(mqtt_vsn, Config)},
+        {clean_start, false},
+        {will_topic, WillTopic},
+        {will_payload, <<"willpayload_delay10_sei0">>},
+        {will_qos, 1},
+        {will_props, #{'Will-Delay-Interval' => 10}},
+        {properties, ConnProps}
+    ],
+    %% GIVEN: client connects with will-delay-interval 10s
+    %%        and session expiry interval 0 (or absent), and subscribes.
+    CPid1 = start_connect_client(ClientId, ClientOpts),
+    {ok, _, [?QOS_1]} = emqtt:subscribe(CPid1, SubTopic, ?QOS_1),
+    CPidSub = start_connect_client(ClientIdSub, []),
+    {ok, _, [?QOS_1]} = emqtt:subscribe(CPidSub, WillTopic, ?QOS_1),
+    %% WHEN: the session is taken over.
+    CPid2 = start_connect_client(ClientId, ClientOpts),
+    assert_client_exit(CPid1, ?config(mqtt_vsn, Config), takenover),
+    %% THEN: the old session ended at the takeover, so the new connection
+    %% starts a fresh session.
+    ?assertEqual(0, proplists:get_value(session_present, emqtt:info(CPid2))),
+    %% THEN: the will message is published without waiting for the will
+    %% delay interval.
+    ?assertReceive(
+        {publish, #{payload := <<"willpayload_delay10_sei0">>}}, timer:seconds(5)
+    ),
+    %% THEN: the fresh session did not inherit the old session's subscription.
+    Marker = <<"no_inherited_sub">>,
+    _ = emqx:publish(emqx_message:make(ct, ?QOS_1, SubTopic, Marker)),
+    ?assertNotReceive({publish, #{payload := Marker}}, 1000),
     emqtt:stop(CPidSub),
     emqtt:stop(CPid2),
     ?assert(not is_process_alive(CPid1)),
@@ -1105,6 +1176,23 @@ payload(I) ->
             emqx_utils_calendar:now_to_rfc3339(millisecond)
         ])
     ).
+
+%% @doc Start an emqtt client and connect it, retrying while the server is busy
+%%      taking over the previous connection with the same client ID.
+start_connect_client(ClientId, Opts) ->
+    {ok, CPid} = emqtt:start_link([{clientid, ClientId} | Opts]),
+    unlink(CPid),
+    case emqtt:connect(CPid) of
+        {ok, _} ->
+            link(CPid),
+            CPid;
+        {error, {server_busy, _}} ->
+            timer:sleep(10),
+            ct:pal("server busy, clientid=~s retry connect after delay", [ClientId]),
+            start_connect_client(ClientId, Opts);
+        {error, Reason} ->
+            error(Reason)
+    end.
 
 %% @doc Filter out the message with matching target payload from the list of messages.
 %%      return '{IsTargetFound, ListOfOtherMessages}'

--- a/changes/ee/fix-18599.en.md
+++ b/changes/ee/fix-18599.en.md
@@ -1,0 +1,5 @@
+End a session that does not outlive its connection when a new connection takes over the same client ID, as the MQTT specification requires. This covers MQTT 5.0 clients connecting with Session Expiry Interval 0 and MQTT 3.1.1 clients connecting with Clean Session 1.
+
+Before this fix, the new connection could inherit the old session's subscriptions and queued messages, and a will message with a Will Delay Interval greater than zero was silently dropped. Now the new connection starts a fresh session (CONNACK Session Present 0), the old connection receives DISCONNECT with reason code 0x8E (Session taken over), and its will message, if any, is published at the takeover.
+
+This applies to in-memory sessions. Takeover of durable sessions (`durable_sessions.enable = true`) is unchanged.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

Ports the in-memory session half of #18585 (dev-60) to this line. Fixes #18565.

A session with expiry interval 0 ends when its network connection closes
(MQTT 5.0 3.1.2.11.2). A takeover closes that connection, so there is
nothing to hand over. `emqx_channel` now refuses the takeover for such a
session: it publishes the will message (the session ends now, so the will
delay interval does not apply) and shuts down without replying. The new
connection then creates a fresh session and gets CONNACK Session Present 0.

Expiry interval 0 covers MQTT 5.0 CONNECT with Session Expiry Interval 0 or
absent, and MQTT 3.1.1 CONNECT with Clean Session 1.

Durable sessions are deliberately out of scope on this line: the
`emqx_persistent_session_ds:open/4` change from #18585 is not ported, and
`handle_call(takeover_kick, ...)` is left alone because its only caller is
that durable-session path. The two new test cases therefore skip in the
`persistence_enabled` group. Draft until #18585 merges, so late review
changes there can be mirrored here.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
