### PR TITLE
fix(mgmt): apply client list filters to disconnected durable sessions

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1036,7 +1036,10 @@ parse_qstring(QString) ->
     end.
 
 run_filters(Rows, QString0) ->
-    {_NClauses, {QString1, FuzzyQString1}} = emqx_mgmt_api:parse_qstring(QString0, ?CLIENT_QSCHEMA),
+    {_NClauses, ParsedQString} = emqx_mgmt_api:parse_qstring(QString0, ?CLIENT_QSCHEMA),
+    run_parsed_filters(Rows, ParsedQString).
+
+run_parsed_filters(Rows, {QString1, FuzzyQString1}) ->
     {QString, FuzzyQString} = adapt_custom_filters(QString1, FuzzyQString1),
     FuzzyFilterFn = fuzzy_filter_fun(FuzzyQString),
     lists:filter(
@@ -1444,7 +1447,9 @@ do_list_clients_cluster_query(
                         Tail, QueryState1
                     ),
                     QueryState = add_persistent_session_count(QueryState2),
-                    Complete = Complete0 andalso Tail =:= [] andalso no_persistent_sessions(),
+                    Complete =
+                        Complete0 andalso Tail =:= [] andalso
+                            no_matching_persistent_sessions(QueryState),
                     emqx_mgmt_api:finalize_query(
                         NResultAcc, emqx_mgmt_api:mark_complete(QueryState, Complete)
                     );
@@ -1475,9 +1480,9 @@ list_clients_node_query(Node, QString, Options) ->
             emqx_mgmt_api:format_query_result(fun ?MODULE:format_channel_info/3, Meta, Res, Opts)
     end.
 
-add_persistent_session_count(QueryState0 = #{total := Totals0}) ->
-    case emqx_persistent_message:is_persistence_enabled() of
-        true ->
+add_persistent_session_count(QueryState0 = #{total := Totals0, qs := Qs}) ->
+    case emqx_persistent_message:is_persistence_enabled() andalso may_durable_session_match(Qs) of
+        true when Qs =:= {[], []} ->
             %% TODO: currently, counting persistent sessions can be not only costly (needs
             %% to traverse the whole table), but also hard to deduplicate live connections
             %% from it...  So this count will possibly overshoot the true count of
@@ -1486,6 +1491,14 @@ add_persistent_session_count(QueryState0 = #{total := Totals0}) ->
                 emqx_persistent_session_bookkeeper:get_disconnected_session_count(),
             Totals = Totals0#{undefined => DisconnectedSessionCount},
             QueryState0#{total := Totals};
+        true ->
+            %% Counting the durable sessions that match the filters needs a full table
+            %% traversal. Drop the total instead of reporting a wrong count, like
+            %% fuzzy searches do.
+            case no_persistent_sessions() of
+                true -> QueryState0;
+                false -> maps:remove(total, QueryState0)
+            end;
         false ->
             QueryState0
     end;
@@ -1504,7 +1517,7 @@ do_list_clients_node_query(
         {Rows, NQueryState = #{complete := Complete}} ->
             case emqx_mgmt_api:accumulate_query_rows(Node, Rows, NQueryState, ResultAcc) of
                 {enough, NResultAcc} ->
-                    FComplete = Complete andalso no_persistent_sessions(),
+                    FComplete = Complete andalso no_matching_persistent_sessions(NQueryState),
                     emqx_mgmt_api:finalize_query(
                         NResultAcc, emqx_mgmt_api:mark_complete(NQueryState, FComplete)
                     );
@@ -1517,6 +1530,21 @@ do_list_clients_node_query(
 
 init_persistent_session_iterator() ->
     emqx_persistent_session_ds_state:make_session_iterator().
+
+no_matching_persistent_sessions(#{qs := Qs}) ->
+    not may_durable_session_match(Qs) orelse no_persistent_sessions().
+
+-doc """
+The durable sessions listed by the persistent-session tail query are all
+disconnected. When the query filters on another connection state, no durable
+session can match and the tail query can be skipped.
+""".
+may_durable_session_match({Qs, _Fuzzy}) ->
+    case lists:keyfind(conn_state, 1, Qs) of
+        false -> true;
+        {conn_state, '=:=', disconnected} -> true;
+        {conn_state, '=:=', _} -> false
+    end.
 
 no_persistent_sessions() ->
     case emqx_persistent_message:is_persistence_enabled() of
@@ -1532,8 +1560,8 @@ no_persistent_sessions() ->
             true
     end.
 
-do_persistent_session_query(ResultAcc, QueryState) ->
-    case emqx_persistent_message:is_persistence_enabled() of
+do_persistent_session_query(ResultAcc, QueryState = #{qs := Qs}) ->
+    case emqx_persistent_message:is_persistence_enabled() andalso may_durable_session_match(Qs) of
         true ->
             do_persistent_session_query1(
                 ResultAcc,
@@ -1547,9 +1575,9 @@ do_persistent_session_query(ResultAcc, QueryState) ->
 do_persistent_session_query1(ResultAcc, QueryState, Iter0) ->
     %% Since persistent session data is accessible from all nodes, there's no need to go
     %% through all the nodes.
-    #{limit := Limit} = QueryState,
+    #{limit := Limit, qs := Qs} = QueryState,
     {Rows0, Iter} = emqx_persistent_session_ds_state:session_iterator_next(Iter0, Limit),
-    Rows = check_for_live_and_expired(Rows0),
+    Rows = run_parsed_filters(check_for_live_and_expired(Rows0), Qs),
     case emqx_mgmt_api:accumulate_query_rows(undefined, Rows, QueryState, ResultAcc) of
         {enough, NResultAcc} ->
             emqx_mgmt_api:finalize_query(NResultAcc, emqx_mgmt_api:mark_complete(QueryState, true));
@@ -1758,6 +1786,11 @@ does_offline_chan_info_match({created_at, '=<', CreatedAtTo}, #{
     CreatedAt =< CreatedAtTo
 ->
     true;
+%% A `gte_' + `lte_' pair of query parameters produces one clause with both
+%% bounds; check each bound separately.
+does_offline_chan_info_match({Key, Op1, V1, Op2, V2}, ChanInfo) ->
+    does_offline_chan_info_match({Key, Op1, V1}, ChanInfo) andalso
+        does_offline_chan_info_match({Key, Op2, V2}, ChanInfo);
 does_offline_chan_info_match(_, _) ->
     false.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -56,6 +56,7 @@ persistent_session_testcases() ->
         t_persistent_sessions3,
         t_persistent_sessions4,
         t_persistent_sessions5,
+        t_persistent_sessions_filters,
         t_persistent_sessions_subscriptions1,
         t_list_clients_v2,
         t_list_clients_v2_limit,
@@ -556,6 +557,77 @@ t_persistent_sessions5(Config) ->
     ),
     ok.
 
+-doc """
+Tests that `GET /clients` filters also apply to disconnected durable sessions,
+which are appended to the result after the ETS scan (#15682).
+""".
+t_persistent_sessions_filters(Config) ->
+    [N1, _N2] = ?config(cluster_nodes, Config),
+    Port1 = get_mqtt_port(N1, tcp),
+    Auth = ?config(api_auth_header, Config),
+
+    ?assertMatch({ok, {?HTTP200, _, #{<<"data">> := []}}}, list_request(Config)),
+
+    ?check_trace(
+        begin
+            ConnectedId = ?CLIENTID(<<"connected">>),
+            DisconnectedId = ?CLIENTID(<<"disconnected">>),
+            C1 = connect_client(#{
+                port => Port1, clientid => ConnectedId, username => <<"u-connected">>
+            }),
+            C2 = connect_client(#{
+                port => Port1, clientid => DisconnectedId, username => <<"u-disconnected">>
+            }),
+            ok = stop_and_commit(C2),
+            %% Wait until the disconnected durable session is listed.
+            ?retry(
+                100,
+                20,
+                ?assertMatch(
+                    {ok, {?HTTP200, _, #{<<"data">> := [_, _]}}},
+                    list_request(Config)
+                )
+            ),
+            %% The reported bug: `conn_state=connected` returned disconnected
+            %% durable sessions too.
+            ?assertEqual([ConnectedId], get_clients(Auth, "conn_state=connected")),
+            ?assertEqual([DisconnectedId], get_clients(Auth, "conn_state=disconnected")),
+            %% The other filters share the same code path: disconnected durable
+            %% sessions were appended to the result regardless of any filter.
+            ?assertEqual([ConnectedId], get_clients(Auth, "clientid=" ++ b2l(ConnectedId))),
+            ?assertEqual(
+                [DisconnectedId], get_clients(Auth, "clientid=" ++ b2l(DisconnectedId))
+            ),
+            ?assertEqual([ConnectedId], get_clients(Auth, "username=u-connected")),
+            ?assertEqual([DisconnectedId], get_clients(Auth, "username=u-disconnected")),
+            ?assertEqual([ConnectedId], get_clients(Auth, "like_username=u-conn")),
+            ?assertEqual([DisconnectedId], get_clients(Auth, "like_username=u-disconn")),
+            ?assertEqual([], get_clients(Auth, "username=no-such-user")),
+            ?assertEqual([], get_clients(Auth, "ip_address=1.2.3.4")),
+            %% A `gte_' + `lte_' pair produces one query clause with both bounds.
+            FutureMs = integer_to_list(erlang:system_time(millisecond) + 60_000),
+            ?assertEqual(
+                lists:sort([ConnectedId, DisconnectedId]),
+                lists:sort(
+                    get_clients(Auth, "gte_created_at=0&lte_created_at=" ++ FutureMs)
+                )
+            ),
+            ?assertEqual([], get_clients(Auth, "gte_created_at=1&lte_created_at=2")),
+            %% `conn_state=connected` skips the durable-session tail query, so the
+            %% count stays exact.
+            ?assertMatch(
+                {ok, {?HTTP200, _, #{<<"meta">> := #{<<"count">> := 1}}}},
+                list_request("conn_state=connected", Config)
+            ),
+            ok = disconnect_and_destroy_session(C1),
+            ok = erpc:call(N1, emqx_persistent_session_ds, destroy_session, [DisconnectedId])
+        end,
+        []
+    ),
+    ok.
+
+b2l(B) -> binary_to_list(B).
+
 %% Check that the output of `/clients/:clientid/subscriptions' has the expected keys.
 t_persistent_sessions_subscriptions1(Config) ->
     [N1, _N2] = ?config(cluster_nodes, Config),
@@ -968,6 +1040,76 @@ t_query_multiple_clients_urlencode(Config) ->
     ExpectedClients = lists:sort([C || {C, _} <- ClientIdsUsers]),
     ?assertEqual(ExpectedClients, lists:sort(get_clients(Auth, ClientsQs))),
     ?assertEqual(ExpectedClients, lists:sort(get_clients(Auth, UsersQs))).
+
+-doc """
+Tests that `GET /clients?conn_state=...` filters clients by connection state (#15682).
+""".
+t_query_clients_conn_state(Config) ->
+    ConnectedId = ?CLIENTID(<<"connected">>),
+    DisconnectedId = ?CLIENTID(<<"disconnected">>),
+    C1 = connect_client(#{port => 1883, clientid => ConnectedId, expiry => 120}),
+    C2 = connect_client(#{port => 1883, clientid => DisconnectedId, expiry => 120}),
+    ok = emqtt:disconnect(C2),
+    Auth = ?config(api_auth_header, Config),
+    %% Wait until the disconnected client is listed as disconnected.
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            {ok,
+                {?HTTP200, _, #{
+                    <<"data">> := [_, _],
+                    <<"meta">> := #{<<"count">> := 2}
+                }}},
+            list_request(Config)
+        )
+    ),
+    ?assertEqual([ConnectedId], get_clients(Auth, "conn_state=connected")),
+    ?assertEqual([DisconnectedId], get_clients(Auth, "conn_state=disconnected")),
+    %% The count metadata must reflect the filter.
+    ?assertMatch(
+        {ok, {?HTTP200, _, #{<<"meta">> := #{<<"count">> := 1}}}},
+        list_request("conn_state=connected", Config)
+    ),
+    ok = disconnect_and_destroy_session(C1),
+    DisconnectedPath = emqx_mgmt_api_test_util:api_path(["clients", DisconnectedId]),
+    {ok, {?HTTP204, _, _}} = request(delete, DisconnectedPath, [], Config),
+    ok.
+
+-doc """
+Tests that `GET /clients` filters clients by `clean_start`, `proto_ver` and
+`ip_address`.  Regression coverage for the query-string parsing path shared
+with `conn_state` (#15682).
+""".
+t_query_clients_more_filters(Config) ->
+    V5Id = ?CLIENTID(<<"v5">>),
+    V4Id = ?CLIENTID(<<"v4">>),
+    C1 = connect_client(#{port => 1883, clientid => V5Id, clean_start => true}),
+    {ok, C2} = emqtt:start_link(#{clientid => V4Id, proto_ver => v4, clean_start => false}),
+    {ok, _} = emqtt:connect(C2),
+    Auth = ?config(api_auth_header, Config),
+    ?retry(
+        100,
+        20,
+        ?assertMatch(
+            {ok, {?HTTP200, _, #{<<"meta">> := #{<<"count">> := 2}}}},
+            list_request(Config)
+        )
+    ),
+    ?assertEqual([V5Id], get_clients(Auth, "clean_start=true")),
+    ?assertEqual([V4Id], get_clients(Auth, "clean_start=false")),
+    ?assertEqual([V5Id], get_clients(Auth, "proto_ver=5")),
+    ?assertEqual([V4Id], get_clients(Auth, "proto_ver=4")),
+    ?assertEqual(
+        lists:sort([V5Id, V4Id]),
+        lists:sort(get_clients(Auth, "ip_address=127.0.0.1"))
+    ),
+    ?assertEqual([], get_clients(Auth, "ip_address=1.2.3.4")),
+    ok = disconnect_and_destroy_session(C1),
+    ok = emqtt:disconnect(C2),
+    V4Path = emqx_mgmt_api_test_util:api_path(["clients", V4Id]),
+    {ok, {?HTTP204, _, _}} = request(delete, V4Path, [], Config),
+    ok.
 
 t_query_clients_with_fields(Config) ->
     TCBin = atom_to_binary(?FUNCTION_NAME),

--- a/changes/ee/fix-18600.en.md
+++ b/changes/ee/fix-18600.en.md
@@ -1,0 +1,5 @@
+Fixed client list API filtering when durable sessions are enabled.
+
+`GET /api/v5/clients` appended all disconnected durable sessions to the result, ignoring query-string filters such as `conn_state`, `username`, and `clientid`. For example, `conn_state=connected` also returned disconnected durable sessions. Now the filters apply to disconnected durable sessions as well.
+
+When filters are applied and disconnected durable sessions exist, the response omits the `meta.count` field instead of reporting a wrong number. Queries that filter with `conn_state=connected` keep an exact `meta.count`.


### PR DESCRIPTION
Fixes: #15682
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: pre-5.8

## Summary

`GET /api/v5/clients` filters live channels with an ETS match spec, then appends disconnected durable sessions to the result without applying any filter. With `durable_sessions.enable=true`, `conn_state=connected` therefore returned disconnected sessions too, and every other filter — `username`, `clientid`, `ip_address`, `clean_start`, `proto_ver`, the time ranges and the fuzzy `like_*` filters — leaked non-matching disconnected durable sessions into the result. The reported symptom is the most visible case, not the whole bug.

The filters themselves are fine: the query string reaches the handler intact and the match spec is built correctly. Only the durable-session rows appended after the ETS scan escape filtering. With durable sessions disabled, every filter works. Commit 796eab30e5 fixed the same defect for the `clients_v2` API and left the v1 listing unfixed.

Changes in `emqx_mgmt_api_clients`:

* `do_persistent_session_query1/3` runs the appended durable rows through the parsed query string, reusing the `clients_v2` filter functions (`does_offline_row_match_query/2` plus the fuzzy filters) via a new `run_parsed_filters/2`.
* When the `conn_state` filter excludes disconnected sessions, the durable-session tail query is skipped: the sessions listed there are all disconnected, so none can match.
* `meta.count`: counting the durable sessions that match arbitrary filters needs a full table scan. When filters are active and disconnected durable sessions exist, the response omits `meta.count` instead of reporting a wrong number, which is what fuzzy searches already do. `conn_state=connected` keeps an exact count because it skips the tail query.
* `does_offline_chan_info_match/2` gets a clause for the combined `gte_` + `lte_` bound pairs, which arrive as a single 5-tuple. Without it a `gte_created_at` + `lte_created_at` query dropped every durable row. This clause also serves the `clients_v2` filters.

The fix keeps filtering out of the response-assembly path, so paging and the count metadata stay intact.

Manual check on a single node with `durable_sessions.enable=true`, one connected client (`demo-connected`, username `u-conn`) and one disconnected durable session (`demo-disconnected`, username `u-disc`).

Before:

```
GET /clients?conn_state=connected
{"clients":["demo-connected","demo-disconnected"],"meta":{"count":2,"limit":100,"page":1,"hasnext":false}}
GET /clients?username=u-conn
{"clients":["demo-connected","demo-disconnected"],"meta":{"count":2,"limit":100,"page":1,"hasnext":false}}
```

After:

```
GET /clients?conn_state=connected
{"clients":["demo-connected"],"meta":{"count":1,"limit":100,"page":1,"hasnext":false}}
GET /clients?conn_state=disconnected
{"clients":["demo-disconnected"],"meta":{"limit":100,"page":1,"hasnext":false}}
GET /clients?username=u-conn
{"clients":["demo-connected"],"meta":{"limit":100,"page":1,"hasnext":false}}
GET /clients?username=u-disc
{"clients":["demo-disconnected"],"meta":{"limit":100,"page":1,"hasnext":false}}
GET /clients
{"clients":["demo-connected","demo-disconnected"],"meta":{"count":2,"limit":100,"page":1,"hasnext":false}}
```

Three test cases were added to `emqx_mgmt_api_clients_SUITE`. `t_query_clients_conn_state` and `t_query_clients_more_filters` cover the in-memory path and pass without the fix, which confirms the defect is confined to durable sessions. `t_persistent_sessions_filters` fails without the fix with the reported symptom.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
