### PR TITLE
test(bridge_mqtt): wait for DOWN messages instead of draining the mailbox

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_publisher_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_publisher_SUITE.erl
@@ -291,6 +291,23 @@ get_emqtt_clients(PoolName) ->
         ecpool:workers(PoolName)
     ).
 
+%% `emqx_utils:drain_down/1' returns immediately (it receives with `after 0'),
+%% so it only reports the DOWNs that already happen to be in the mailbox.
+%% Neither a 204 from the kick API nor sending `die_if_test' means the channels
+%% are down, let alone that their DOWN messages were delivered. Wait for them.
+wait_down(N, Timeout) ->
+    wait_down(N, Timeout, []).
+
+wait_down(0, _Timeout, Acc) ->
+    lists:reverse(Acc);
+wait_down(N, Timeout, Acc) ->
+    receive
+        {'DOWN', _MRef, process, Pid, _Reason} ->
+            wait_down(N - 1, Timeout, [Pid | Acc])
+    after Timeout ->
+        lists:reverse(Acc)
+    end.
+
 %%------------------------------------------------------------------------------
 %% Testcases
 %%------------------------------------------------------------------------------
@@ -791,7 +808,7 @@ t_reconnect(Config) ->
             lists:foreach(fun(Pid) -> monitor(process, Pid) end, ChanPids),
             ct:pal("kicking ~p (leaving 1 client alive)", [ClientIds]),
             {204, _} = emqx_bridge_v2_testlib:kick_clients_http(ClientIds),
-            DownPids = emqx_utils:drain_down(PoolSize - 1),
+            DownPids = wait_down(PoolSize - 1, 10_000),
             ?assertEqual(lists:sort(ChanPids), lists:sort(DownPids)),
             %% Recovery
             ct:pal("clients kicked; waiting for recovery..."),
@@ -884,7 +901,7 @@ t_publish_while_tcp_closed_concurrently(Config) ->
                         %% Forcefully kill connection processes, so we get the ellusive `tcp_closed'
                         %% error more easily from `emqtt'.
                         lists:foreach(fun(ChanPid) -> ChanPid ! die_if_test end, ChanPids),
-                        _DownPids = emqx_utils:drain_down(PoolSize),
+                        _DownPids = wait_down(PoolSize, 10_000),
 
                         ok
                     end


### PR DESCRIPTION
## Summary

De-flake `emqx_bridge_mqtt_v2_publisher_SUITE:t_reconnect`:

```
{assertEqual, [{module,emqx_bridge_mqtt_v2_publisher_SUITE}, {line,795},
               {expression,"lists : sort ( DownPids )"},
               {expected,[<0.273395.0>,<0.273398.0>]},
               {value,[<0.273398.0>]}]}
```

Seen in: https://github.com/emqx/emqx/actions/runs/33208698648/job/98978528863?pr=18599

`emqx_utils:drain_down/1` receives with `after 0`, so it is not a barrier at all — it returns only the DOWN messages that are already in the mailbox at that instant. The test calls it immediately after `kick_clients_http/1` returns 204 and then asserts the collected pids equal the monitored ones. A 204 does not mean the channels are down, and even once they are, their DOWN messages still have to be delivered, so collecting one instead of two is expected under load.

Add `wait_down/2`, which collects N DOWN messages with a timeout, and use it at both call sites. The second site (`t_publish_over_tcp_with_client_dying`, which sends `die_if_test`) discards its result but is likewise meant as a barrier before the following code, so it had the same no-op problem.

Full suite passes locally: 10 ok, 0 failed.

Base `dev-58`: this suite exists only on the v5 lines (dev-58/59/510); the blobs differ per line but this region is the same, and it syncs forward from dev-58.