### PR TITLE
test(ds_shared_sub): widen the cluster ping budgets

### DIFF
--- a/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_ds_shared_sub_SUITE.erl
@@ -1096,14 +1096,16 @@ start_cluster(Config) ->
     %% down the session or the shared sub leader. In particular the retry
     %% window (`commit_retries' * `commit_retry_interval') has to outlast a
     %% DS leader re-election, which the tests trigger by killing a node.
+    %% The ping budgets must outlast a session busy with a QoS1 storm, or the
+    %% leader kicks a live borrower and redelivery misses the drain window.
     Conf = #{
         <<"durable_sessions">> => #{
             <<"commit_timeout">> => 15_000,
             <<"shared_subs">> =>
                 #{
-                    <<"heartbeat_interval">> => 100,
+                    <<"heartbeat_interval">> => 500,
                     <<"realloc_interval">> => 100,
-                    <<"leader_timeout">> => 100,
+                    <<"leader_timeout">> => 1000,
                     <<"checkpoint_interval">> => 10,
                     <<"revocation_timeout">> => 1000,
                     <<"commit_retries">> => 8,


### PR DESCRIPTION
## Summary

Port of the `emqx_ds_shared_sub_SUITE` change from #18511 (based on dev-70) to `dev-61`, the earliest branch carrying `start_cluster/1`, so the fix reaches 62 → 63 → 70 by forward sync instead of existing only on dev-70.

The leader-side ping deadline is `2 * heartbeat_interval` (`emqx_ds_shared_sub_leader:ping_deadline/0`), and the borrower sends pings from the session process. With `heartbeat_interval = 100` that is a 200 ms deadline, which a session busy with a QoS1 delivery storm can miss: the leader kicks a live borrower (`drop_invalidate_borrower(..., ping_timeout)`), the reallocated stream is redelivered after the case's drain window, and a payload reads as missing.

`heartbeat_interval` 100 → 500, `leader_timeout` 100 → 1000. The election-timing knobs (`realloc_interval`, `checkpoint_interval`) and the commit budgets are unchanged, so the election and reallocation assertions keep their timing.

Related sightings handled retry-only under the durable-session policy: `t_cluster_smoke` on dev-63 (#18557, 2026-08-27) and `declare_implicit.t_cluster_smoke` on dev-70 (#18593, 2026-08-28). dev-60 is not affected — its copy of the suite has no cluster tests.

Full suite passes locally on dev-61: 29 ok, 0 failed.

Note: the comment wording differs slightly from #18511's, so once that PR lands on dev-70 the forward sync will show a trivial conflict here (same two values). Happy to rebase then.