### PR TITLE
fix(durable_timer): log a failing timer callback

### DIFF
--- a/apps/emqx_durable_timer/mix.exs
+++ b/apps/emqx_durable_timer/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDurableTimer.MixProject do
   def project do
     [
       app: :emqx_durable_timer,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.strict_erlc_options(),

--- a/apps/emqx_durable_timer/src/emqx_durable_timer_worker.erl
+++ b/apps/emqx_durable_timer/src/emqx_durable_timer_worker.erl
@@ -472,7 +472,19 @@ handle_timeout(Type, CBM, Time, Key, Value) ->
         emqx_durable_timer:handle_durable_timeout(CBM, Key, Value),
         ok
     catch
-        _:_ ->
+        Class:Reason:Stacktrace ->
+            %% The timer is still treated as fired and is not retried, so this
+            %% log is the only trace the failure leaves. The value is left out:
+            %% it is opaque callback data, and for `emqx_durable_will' it is a
+            %% will message payload.
+            ?tp(error, ?tp_callback_failed, #{
+                type => Type,
+                cbm => CBM,
+                key => Key,
+                exception => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
             ok
     end.
 

--- a/apps/emqx_durable_timer/src/emqx_durable_timer_worker.erl
+++ b/apps/emqx_durable_timer/src/emqx_durable_timer_worker.erl
@@ -473,10 +473,10 @@ handle_timeout(Type, CBM, Time, Key, Value) ->
         ok
     catch
         Class:Reason:Stacktrace ->
-            %% The timer is still treated as fired and is not retried, so this
-            %% log is the only trace the failure leaves. The value is left out:
-            %% it is opaque callback data, and for `emqx_durable_will' it is a
-            %% will message payload.
+            %% A failing callback does not prevent the timer from being
+            %% consumed: it is not retried. The value is not logged, because it
+            %% is opaque callback data and may hold user payload, such as an
+            %% `emqx_durable_will' will message.
             ?tp(error, ?tp_callback_failed, #{
                 type => Type,
                 cbm => CBM,

--- a/apps/emqx_durable_timer/src/internals.hrl
+++ b/apps/emqx_durable_timer/src/internals.hrl
@@ -36,6 +36,7 @@
 -define(tp_new_dead_hand, emqx_durable_timer_dead_hand).
 -define(tp_delete, emqx_durable_timer_delete).
 -define(tp_fire, emqx_durable_timer_fire).
+-define(tp_callback_failed, emqx_durable_timer_callback_failed).
 -define(tp_unknown_event, emqx_durable_timer_unknown_event).
 -define(tp_app_activation, emqx_durable_timer_app_activated).
 -define(tp_state_change, emqx_durable_timer_state_change).

--- a/apps/emqx_durable_timer/test/emqx_durable_test_timer.erl
+++ b/apps/emqx_durable_timer/test/emqx_durable_test_timer.erl
@@ -4,7 +4,7 @@
 -module(emqx_durable_test_timer).
 
 %% API:
--export([init/0, apply_after/3, dead_hand/3, cancel/1]).
+-export([init/0, apply_after/3, dead_hand/3, cancel/1, raising_value/0]).
 
 %% behavior callbacks:
 -export([durable_timer_type/0, timer_introduced_in/0, handle_durable_timeout/2]).
@@ -31,6 +31,11 @@ dead_hand(Key, Val, Delay) ->
 cancel(Key) ->
     emqx_durable_timer:cancel(durable_timer_type(), Key).
 
+%% @doc A timer carrying this value makes the callback raise, so a test can
+%% drive the worker's handling of a failing callback.
+raising_value() ->
+    <<"raise">>.
+
 %%================================================================================
 %% behavior callbacks
 %%================================================================================
@@ -39,6 +44,8 @@ durable_timer_type() -> 16#fffffffe.
 
 timer_introduced_in() -> "6.0.0".
 
+handle_durable_timeout(_Key, <<"raise">>) ->
+    error(deliberate_callback_failure);
 handle_durable_timeout(Key, Value) ->
     ?tp(info, ?tp_test_fire, #{key => Key, val => Value, type => durable_timer_type()}).
 

--- a/apps/emqx_durable_timer/test/emqx_durable_timer_SUITE.erl
+++ b/apps/emqx_durable_timer/test/emqx_durable_timer_SUITE.erl
@@ -913,6 +913,59 @@ db_dump(Node) ->
 
 suite() -> [{timetrap, {minutes, 1}}].
 
+%% A callback that raises must leave a trace: the timer is treated as fired and
+%% is not retried, so without a log the work is lost silently. The worker has to
+%% survive it and keep firing later timers.
+t_080_callback_failure({init, Config}) ->
+    Cluster = cluster(?FUNCTION_NAME, Config, 1, #{}),
+    [{cluster, Cluster} | Config];
+t_080_callback_failure({stop, Config}) ->
+    Config;
+t_080_callback_failure(Config) ->
+    Cluster = proplists:get_value(cluster, Config),
+    Type = emqx_durable_test_timer:durable_timer_type(),
+    Raising = emqx_durable_test_timer:raising_value(),
+    ?check_trace(
+        #{timetrap => 15_000},
+        begin
+            [Node] = emqx_cth_cluster:start(Cluster),
+            ?assertMatch(ok, ?ON(Node, emqx_durable_test_timer:init())),
+            ?wait_async_action(
+                ?assertMatch(
+                    ok,
+                    ?ON(Node, emqx_durable_test_timer:apply_after(<<"boom">>, Raising, 0))
+                ),
+                #{?snk_kind := ?tp_callback_failed, key := <<"boom">>},
+                infinity
+            ),
+            %% the worker is still there and still firing
+            ?wait_async_action(
+                ?assertMatch(
+                    ok,
+                    ?ON(Node, emqx_durable_test_timer:apply_after(<<"after">>, <<>>, 0))
+                ),
+                #{?snk_kind := ?tp_fire, key := <<"after">>},
+                infinity
+            ),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [
+                    #{
+                        type := Type,
+                        key := <<"boom">>,
+                        exception := error,
+                        reason := deliberate_callback_failure,
+                        stacktrace := [_ | _]
+                    }
+                    | _
+                ],
+                ?of_kind(?tp_callback_failed, Trace)
+            )
+        end
+    ).
+
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 

--- a/apps/emqx_durable_timer/test/emqx_durable_timer_SUITE.erl
+++ b/apps/emqx_durable_timer/test/emqx_durable_timer_SUITE.erl
@@ -913,9 +913,9 @@ db_dump(Node) ->
 
 suite() -> [{timetrap, {minutes, 1}}].
 
-%% A callback that raises must leave a trace: the timer is treated as fired and
-%% is not retried, so without a log the work is lost silently. The worker has to
-%% survive it and keep firing later timers.
+%% A callback that raises is reported with its exception, and the timer is
+%% consumed rather than retried. The worker survives the failure and keeps
+%% firing later timers.
 t_080_callback_failure({init, Config}) ->
     Cluster = cluster(?FUNCTION_NAME, Config, 1, #{}),
     [{cluster, Cluster} | Config];

--- a/changes/ce/fix-18606.en.md
+++ b/changes/ce/fix-18606.en.md
@@ -1,0 +1,3 @@
+A durable timer callback that raises is now logged with the exception and its stacktrace, along with the timer type and key.
+
+The failure was previously discarded in full: the worker survived, the timer counted as fired and was not retried, and nothing was written to the log at any level. A delayed will message that failed to publish, or an expired durable session that failed to be deleted, left no trace an operator could find.


### PR DESCRIPTION
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.2, 7.0.0

Introduced in: pre-6.0

## Summary

Fixes https://github.com/emqx/emqx/issues/18601

`handle_timeout/5` caught every exception from a durable-timer callback with `_:_ -> ok`,
discarding the class, the reason and the stacktrace. The worker survived, the timer counted
as fired and was not retried, and nothing was written to the log at any level, so the lost
work left no trace at all.

The failure is now reported at error level with the timer type, the callback module, the key,
and the exception with its stacktrace. The value is deliberately left out: it is opaque
callback data, and for `emqx_durable_will` it is a will message payload.

Whether the timer should then be retried or dropped is a separate decision and is unchanged
here, as the issue asks.

Worth knowing for review: this app logs through `?tp/3` and has no `?SLOG` at all. Only the
three-argument form reaches the log in a release build, since snabbkaffe's `trace_prod.hrl`
compiles `?tp/2` down to `begin _ = EVT, ok end`. A two-argument trace point would have
produced nothing outside tests.

`t_080_callback_failure` asserts the event carries the type, key, exception and stacktrace,
and that the worker keeps firing later timers. With `emqx_durable_timer_worker.erl` reverted
and the case kept, it fails: the trace point never arrives.

Commits touching this app have not carried a changelog before, so say the word if you would
rather drop `changes/ce/fix-18606.en.md`.

Tests: `emqx_durable_timer_SUITE` 8/8, run in
ghcr.io/emqx/emqx-builder/6.1-8:1.18.3-27.3.4.2-8-ubuntu24.04.

Unrelated, but seen while running the suite: `t_030_cancellation` failed once in four runs
at the `emqx_ds:dirty_read` assertion on line 392, finding the dead hand record still there.
It passed in the other three, including with this change reverted, so it looks like the read
racing the delete rather than anything here.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log added: `changes/ce/fix-18606.en.md`
- [x] Schema changes are backward compatible
