### PR TITLE
feat(dashboard): split self-service out of the admin user API

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -482,8 +482,8 @@ scopes_of(Username) ->
 %%   any role      + explicit []         -> []
 %%   any role      + explicit [X, ...]   -> [X, ...]
 %%
-%% This is what RBAC checks, what `caller_has_mfa_mgmt/1' inspects,
-%% and what the /users API surfaces in responses.
+%% This is what RBAC checks and what the /users and /current_user APIs
+%% surface in responses.
 -spec effective_scopes_of(dashboard_username()) -> [binary()].
 effective_scopes_of(Username) ->
     case lookup_user(Username) of

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -30,8 +30,10 @@
     users/2,
     user_scopes/2,
     user/2,
-    change_pwd/2,
-    change_mfa/2
+    change_mfa/2,
+    current_user/2,
+    current_user_change_pwd/2,
+    current_user_mfa/2
 ]).
 -export([scopes/0]).
 
@@ -48,6 +50,7 @@
 -define(PASSWORD_LOGIN_DISABLED, 'PASSWORD_LOGIN_DISABLED').
 -define(SCRAM_CHALLENGE_INVALID, 'SCRAM_CHALLENGE_INVALID').
 -define(SERVICE_UNAVAILABLE, 'SERVICE_UNAVAILABLE').
+-define(MFA_LOCKED, 'MFA_LOCKED').
 
 namespace() -> "dashboard".
 
@@ -63,6 +66,14 @@ api_spec() ->
 %%   * /login -- pre-login (security => []).
 %%   * /logout -- any authenticated role may log itself out.
 %%   * /user_scopes -- static catalog endpoint, no tenant data.
+%%   * /current_user* -- self-service; the caller is the subject, so the
+%%     authenticated identity alone authorizes the operation. A scope
+%%     check here would let an explicit `scopes = []' lock a user out of
+%%     their own password and MFA, which is what the scope layer exists
+%%     to gate for OTHER users, not for the holder's own account. None of
+%%     these operations can widen the caller's own privileges:
+%%     change_pwd verifies `old_pwd', and the MFA routes only ever touch
+%%     the caller's own record.
 scopes() ->
     #{
         <<"/login">> => ?SCOPE_PUBLIC,
@@ -70,9 +81,11 @@ scopes() ->
         <<"/login/verify">> => ?SCOPE_PUBLIC,
         <<"/logout">> => ?SCOPE_PUBLIC,
         <<"/user_scopes">> => ?SCOPE_PUBLIC,
+        <<"/current_user">> => ?SCOPE_PUBLIC,
+        <<"/current_user/change_pwd">> => ?SCOPE_PUBLIC,
+        <<"/current_user/mfa">> => ?SCOPE_PUBLIC,
         <<"/users">> => ?SCOPE_USER_MGMT,
         <<"/users/:username">> => ?SCOPE_USER_MGMT,
-        <<"/users/:username/change_pwd">> => ?SCOPE_USER_MGMT,
         <<"/users/:username/mfa">> => ?SCOPE_MFA_MGMT
     }.
 
@@ -82,9 +95,11 @@ paths() ->
         "/login/challenge",
         "/login/verify",
         "/logout",
+        "/current_user",
+        "/current_user/change_pwd",
+        "/current_user/mfa",
         "/users",
         "/users/:username",
-        "/users/:username/change_pwd",
         "/users/:username/mfa",
         "/user_scopes"
     ].
@@ -165,6 +180,74 @@ schema("/logout") ->
             }
         }
     };
+%% Self-service routes. `/current_user' is a top-level path outside
+%% `/users/', so it cannot be shadowed by -- or shadow -- a user whose
+%% name happens to be `current_user', `self' or `me'; those are all
+%% legal usernames and there is no reserved-word check on them.
+%%
+%% Every operationId is prefixed `current_user_' because minirest
+%% requires globally unique operationIds and the admin routes already
+%% own `change_pwd' / `change_mfa'.
+schema("/current_user") ->
+    #{
+        'operationId' => current_user,
+        get => #{
+            tags => [<<"dashboard">>],
+            desc => ?DESC(current_user_api),
+            security => [#{'bearerAuth' => []}],
+            responses => #{
+                200 => current_user_fields(),
+                404 => response_schema(404)
+            }
+        }
+    };
+schema("/current_user/change_pwd") ->
+    #{
+        'operationId' => current_user_change_pwd,
+        post => #{
+            tags => [<<"dashboard">>],
+            desc => ?DESC(current_user_change_pwd_api),
+            security => [#{'bearerAuth' => []}],
+            'requestBody' => fields([old_pwd, new_pwd]),
+            responses => #{
+                204 => <<"Password is updated">>,
+                404 => response_schema(404),
+                400 => emqx_dashboard_swagger:error_codes(
+                    [?BAD_REQUEST, ?ERROR_PWD_NOT_MATCH, ?NOT_ALLOWED],
+                    ?DESC(login_failed_response400)
+                )
+            }
+        }
+    };
+schema("/current_user/mfa") ->
+    #{
+        'operationId' => current_user_mfa,
+        post => #{
+            tags => [<<"dashboard">>],
+            desc => ?DESC(current_user_mfa_api),
+            security => [#{'bearerAuth' => []}],
+            'requestBody' => emqx_dashboard_schema:mfa_fields(),
+            responses => #{
+                204 => <<"MFA setting is updated">>,
+                403 => emqx_dashboard_swagger:error_codes(
+                    [?MFA_LOCKED], ?DESC(current_user_mfa_locked)
+                ),
+                404 => response_schema(404)
+            }
+        },
+        delete => #{
+            tags => [<<"dashboard">>],
+            desc => ?DESC(delete_current_user_mfa_api),
+            security => [#{'bearerAuth' => []}],
+            responses => #{
+                204 => <<"MFA setting is disabled">>,
+                403 => emqx_dashboard_swagger:error_codes(
+                    [?MFA_LOCKED], ?DESC(current_user_mfa_locked)
+                ),
+                404 => response_schema(404)
+            }
+        }
+    };
 schema("/users") ->
     #{
         'operationId' => users,
@@ -237,24 +320,8 @@ schema("/users/:username") ->
             }
         }
     };
-schema("/users/:username/change_pwd") ->
-    #{
-        'operationId' => change_pwd,
-        post => #{
-            tags => [<<"dashboard">>],
-            desc => ?DESC(change_pwd_api),
-            parameters => fields([username_in_path]),
-            'requestBody' => fields([old_pwd, new_pwd]),
-            responses => #{
-                204 => <<"Update user password successfully">>,
-                404 => response_schema(404),
-                400 => emqx_dashboard_swagger:error_codes(
-                    [?BAD_REQUEST, ?ERROR_PWD_NOT_MATCH],
-                    ?DESC(login_failed_response400)
-                )
-            }
-        }
-    };
+%% Administrator-only: the target is always another user. A caller
+%% managing its own MFA uses `/current_user/mfa'.
 schema("/users/:username/mfa") ->
     #{
         'operationId' => change_mfa,
@@ -265,6 +332,9 @@ schema("/users/:username/mfa") ->
             'requestBody' => emqx_dashboard_schema:mfa_fields(),
             responses => #{
                 204 => <<"MFA setting is updated">>,
+                400 => emqx_dashboard_swagger:error_codes(
+                    [?NOT_ALLOWED], ?DESC(login_failed_response400)
+                ),
                 404 => response_schema(404)
             }
         },
@@ -274,6 +344,9 @@ schema("/users/:username/mfa") ->
             parameters => sso_parameters(fields([username_in_path])),
             responses => #{
                 204 => <<"MFA setting is disabled">>,
+                400 => emqx_dashboard_swagger:error_codes(
+                    [?NOT_ALLOWED], ?DESC(login_failed_response400)
+                ),
                 404 => response_schema(404)
             }
         }
@@ -295,6 +368,15 @@ fields(List) ->
 
 user_fields() ->
     fields([username, role, description, backend, scopes_response]) ++ ee_user_fields().
+
+%% Same shape as `user_fields/0', but `scopes' carries the EFFECTIVE
+%% list rather than the raw tri-state one. The admin routes report the
+%% raw value so that a read-modify-write of `PUT /users/:username' does
+%% not sediment the role default into an explicit list; this endpoint
+%% has no write counterpart, and its caller is asking what it may
+%% actually do, so the expanded list is the useful answer.
+current_user_fields() ->
+    fields([username, role, description, backend, effective_scopes_response]) ++ ee_user_fields().
 
 ee_user_fields() ->
     [
@@ -373,6 +455,15 @@ field(scopes_response) ->
             desc => ?DESC(user_scopes_response),
             required => false,
             example => [?SCOPE_USER_MGMT, ?SCOPE_MFA_MGMT]
+        })};
+field(effective_scopes_response) ->
+    %% Always a concrete list -- the role default is expanded, so the
+    %% `unset' sentinel of `scopes_response' cannot appear here.
+    {scopes,
+        mk(hoconsc:array(binary()), #{
+            desc => ?DESC(effective_user_scopes_response),
+            required => true,
+            example => [?SCOPE_MONITORING, ?SCOPE_CONNECTIONS]
         })};
 field(backend) ->
     {backend, mk(binary(), #{desc => ?DESC(backend), example => <<"local">>})};
@@ -758,9 +849,15 @@ is_default_admin(_NonLocalTarget) ->
     %% `dashboard.default_username'.
     false.
 
-handle_delete_user(#{bindings := #{username := Username0}, headers := Headers} = Req) ->
+handle_delete_user(#{bindings := #{username := Username0}} = Req) ->
     Username = username(Req, Username0),
-    case is_self_auth(Username0, Headers) of
+    %% The caller is identified by the authenticated token, not by
+    %% re-parsing the `Authorization' header: the header form varies
+    %% (basic / bearer, either capitalisation) and only the token
+    %% resolution knows the SSO key. `caller_key/1' returns the same
+    %% admin-record key `username/2' produces, so the two are directly
+    %% comparable for both local and SSO targets.
+    case caller_key(Req) =:= Username of
         true ->
             {400, ?NOT_ALLOWED, <<"Cannot delete self">>};
         false ->
@@ -775,40 +872,47 @@ handle_delete_user(#{bindings := #{username := Username0}, headers := Headers} =
             end
     end.
 
-is_self_auth(?SSO_USERNAME(_, _), _) ->
-    false;
-is_self_auth(Username, #{<<"authorization">> := Token}) ->
-    is_self_auth(Username, Token);
-is_self_auth(Username, #{<<"Authorization">> := Token}) ->
-    is_self_auth(Username, Token);
-is_self_auth(Username, <<"basic ", Token/binary>>) ->
-    is_self_auth_basic(Username, Token);
-is_self_auth(Username, <<"Basic ", Token/binary>>) ->
-    is_self_auth_basic(Username, Token);
-is_self_auth(Username, <<"bearer ", Token/binary>>) ->
-    is_self_auth_token(Username, Token);
-is_self_auth(Username, <<"Bearer ", Token/binary>>) ->
-    is_self_auth_token(Username, Token).
+%%--------------------------------------------------------------------
+%% Self-service handlers (`/current_user/*')
+%%
+%% The subject is the authenticated identity itself. There is no
+%% `:username' in the path, so there is nothing to spoof and nothing to
+%% compare: `caller_key/1' IS the target. Authorization is therefore
+%% complete once the request is authenticated -- RBAC lets any
+%% authenticated dashboard user through, and the scope layer treats
+%% these paths as public.
+%%--------------------------------------------------------------------
 
-is_self_auth_basic(Username, Token) ->
-    UP = base64:decode(Token),
-    case binary:match(UP, Username) of
-        {0, N} ->
-            binary:part(UP, {N, 1}) == <<":">>;
-        _ ->
-            false
-    end.
+current_user(get, Req) ->
+    with_caller(Req, fun(#?ADMIN{username = Username} = Admin) ->
+        Profile = emqx_dashboard_admin:to_external_user(Admin),
+        {200, Profile#{scopes => emqx_dashboard_admin:effective_scopes_of(Username)}}
+    end).
 
-is_self_auth_token(Username, Token) ->
-    case emqx_dashboard_token:owner(Token) of
-        {ok, Owner} ->
-            Owner == Username;
-        {error, _NotFound} ->
-            false
-    end.
+current_user_change_pwd(post, #{body := Params} = Req) ->
+    with_caller(Req, fun(#?ADMIN{username = Username}) ->
+        do_change_pwd(Username, Params)
+    end).
 
-change_pwd(post, #{bindings := #{username := Username}, body := Params}) ->
-    LogMeta = #{msg => "dashboard_change_password", username => binary_to_list(Username)},
+%% An SSO user has no local password -- the identity provider owns the
+%% credential -- so there is nothing here to change. Reject explicitly:
+%% `emqx_dashboard_admin:change_password/3' is guarded on a binary
+%% username and would otherwise raise a function_clause on the
+%% `?SSO_USERNAME' tuple, turning this into a 500.
+do_change_pwd(?SSO_USERNAME(Backend, Name), _Params) ->
+    ?SLOG(warning, #{
+        msg => "dashboard_change_password",
+        username => Name,
+        backend => Backend,
+        result => denied,
+        reason => "sso_user_has_no_local_password"
+    }),
+    {400, ?NOT_ALLOWED, <<
+        "This account signs in through an SSO backend and has no local "
+        "password. Change it with the identity provider instead."
+    >>};
+do_change_pwd(Username, Params) when is_binary(Username) ->
+    LogMeta = #{msg => "dashboard_change_password", username => Username},
     OldPwd = maps:get(<<"old_pwd">>, Params),
     NewPwd = maps:get(<<"new_pwd">>, Params),
     case ?EMPTY(OldPwd) orelse ?EMPTY(NewPwd) of
@@ -832,23 +936,99 @@ change_pwd(post, #{bindings := #{username := Username}, body := Params}) ->
             end
     end.
 
+current_user_mfa(post, #{body := Settings} = Req) ->
+    Mechanism = maps:get(<<"mechanism">>, Settings),
+    with_caller(Req, fun(#?ADMIN{username = Username}) ->
+        LogMeta = #{msg => "dashboard_user_mfa_setup", username => Username},
+        case authorize_self_mfa(Username, setup) of
+            ok ->
+                %% Never `ByAdmin': a self-initiated (re)init must not
+                %% touch the admin_override decision.
+                mfa_result(emqx_dashboard_admin:reinit_mfa(Username, Mechanism, false), LogMeta);
+            {deny, Code, ErrCode, Msg} ->
+                ?SLOG(warning, LogMeta#{result => denied, reason => ErrCode}),
+                {Code, ErrCode, Msg}
+        end
+    end);
+current_user_mfa(delete, Req) ->
+    with_caller(Req, fun(#?ADMIN{username = Username}) ->
+        LogMeta = #{msg => "dashboard_user_mfa_disable", username => Username},
+        case authorize_self_mfa(Username, disable) of
+            ok ->
+                mfa_result(emqx_dashboard_admin:disable_mfa(Username, false), LogMeta);
+            {deny, Code, ErrCode, Msg} ->
+                ?SLOG(warning, LogMeta#{result => denied, reason => ErrCode}),
+                {Code, ErrCode, Msg}
+        end
+    end).
+
+mfa_result(ok, LogMeta) ->
+    ?SLOG(info, LogMeta#{result => success}),
+    {204};
+mfa_result({error, <<"username_not_found">>}, LogMeta) ->
+    ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
+    {404, ?USER_NOT_FOUND, <<"User not found">>};
+mfa_result({error, Reason}, LogMeta) ->
+    ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
+    {400, ?BAD_REQUEST, Reason}.
+
+%% Self-MFA policy, in full:
+%%
+%%   first-time setup           => allow  (deadlock prevention: a user
+%%                                         that has never enrolled must
+%%                                         always be able to)
+%%   admin_override = required  => deny   (an administrator reset this
+%%                                         account's MFA; only another
+%%                                         administrator or the CLI can
+%%                                         lift it)
+%%   otherwise                  => allow
+%%
+%% `admin_override' is only ever written when an administrator acts on
+%% ANOTHER user (`emqx_dashboard_api:change_mfa/2' passes ByAdmin), so a
+%% user cannot lock themselves out by rotating their own MFA.
+authorize_self_mfa(Username, Op) ->
+    case is_first_time_setup(Username, Op) orelse not self_mfa_locked(Username) of
+        true ->
+            ok;
+        false ->
+            {deny, 403, ?MFA_LOCKED, <<
+                "MFA for this account was set by an administrator and "
+                "cannot be changed here. Ask an administrator to reset it."
+            >>}
+    end.
+
+self_mfa_locked(Username) ->
+    emqx_dashboard_admin:admin_override_of(Username) =:= ?ADMIN_MFA_REQUIRED.
+
+is_first_time_setup(_Username, disable) ->
+    false;
+is_first_time_setup(Username, setup) ->
+    case emqx_dashboard_admin:get_mfa_state(Username) of
+        {ok, _} -> false;
+        _ -> true
+    end.
+
+%% Resolve the caller's own admin record from the bearer token's
+%% `source' -- the key `emqx_dashboard:authorize/2' already resolved
+%% (a `?SSO_USERNAME' tuple for SSO users, a plain binary otherwise).
+with_caller(Req, Fun) ->
+    case caller_admin(Req) of
+        #?ADMIN{} = Admin ->
+            Fun(Admin);
+        undefined ->
+            %% Unreachable in practice: these routes are bearer-only and
+            %% API keys are refused for them in `emqx_mgmt_auth:authorize/4'.
+            %% Reachable only if the account is deleted between login and
+            %% this request.
+            {404, ?USER_NOT_FOUND, <<"User not found">>}
+    end.
+
 change_mfa(delete, #{bindings := #{username := Username0}} = Req) ->
     Username = username(Req, Username0),
     LogMeta = #{msg => "dashboard_user_mfa_disable", username => Username},
-    case authorize_mfa_change(Req, Username, disable) of
+    case reject_self_target(Req, Username) of
         ok ->
-            ByAdmin = caller_is_admin_acting_on_other(Req, Username),
-            case emqx_dashboard_admin:disable_mfa(Username, ByAdmin) of
-                ok ->
-                    ?SLOG(info, LogMeta#{result => success}),
-                    {204};
-                {error, <<"username_not_found">>} ->
-                    ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
-                    {404, ?USER_NOT_FOUND, <<"User not found">>};
-                {error, Reason} ->
-                    ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
-                    {400, ?BAD_REQUEST, Reason}
-            end;
+            mfa_result(emqx_dashboard_admin:disable_mfa(Username, true), LogMeta);
         {deny, Code, ErrCode, Msg} ->
             ?SLOG(warning, LogMeta#{result => denied, reason => ErrCode}),
             {Code, ErrCode, Msg}
@@ -857,23 +1037,28 @@ change_mfa(post, #{bindings := #{username := Username0}, body := Settings} = Req
     Username = username(Req, Username0),
     Mechanism = maps:get(<<"mechanism">>, Settings),
     LogMeta = #{msg => "dashboard_user_mfa_setup", username => Username},
-    case authorize_mfa_change(Req, Username, setup) of
+    case reject_self_target(Req, Username) of
         ok ->
-            ByAdmin = caller_is_admin_acting_on_other(Req, Username),
-            case emqx_dashboard_admin:reinit_mfa(Username, Mechanism, ByAdmin) of
-                ok ->
-                    ?SLOG(info, LogMeta#{result => success}),
-                    {204};
-                {error, <<"username_not_found">>} ->
-                    ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
-                    {404, ?USER_NOT_FOUND, <<"User not found">>};
-                {error, Reason} ->
-                    ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
-                    {400, ?BAD_REQUEST, Reason}
-            end;
+            mfa_result(emqx_dashboard_admin:reinit_mfa(Username, Mechanism, true), LogMeta);
         {deny, Code, ErrCode, Msg} ->
             ?SLOG(warning, LogMeta#{result => denied, reason => ErrCode}),
             {Code, ErrCode, Msg}
+    end.
+
+%% The admin MFA routes act on other users only; the caller's own
+%% account is served by `/current_user/mfa'. Without this guard an
+%% administrator could route a self-change through the admin path,
+%% where it would be recorded as an administrator decision
+%% (`admin_override') and would skip the self policy entirely.
+reject_self_target(Req, TargetUsername) ->
+    case caller_key(Req) =:= TargetUsername of
+        false ->
+            ok;
+        true ->
+            {deny, 400, ?NOT_ALLOWED, <<
+                "This endpoint manages other users' MFA. "
+                "Use /current_user/mfa to manage your own."
+            >>}
     end.
 
 register_unsuccessful_login(Username, <<"password_error">>) ->
@@ -1098,94 +1283,6 @@ reload_external_user(Username, Fallback) ->
         _ -> Fallback
     end.
 
-%% --- MFA self-lock authorization ---
-%%
-%% Decision matrix:
-%%
-%%   IsFirstSetup = (Op == setup) AND (target.mfa_state == not_configured)
-%%   IsSelf       = (caller.username == target)
-%%   HasMfaMgmt   = caller.scopes contains mfa_management
-%%   Locked       = target.admin_override == mfa_required
-%%
-%%   IsFirstSetup => allow                                  (deadlock prevention)
-%%   IsSelf       AND HasMfaMgmt           => allow         (self-exempt)
-%%   IsSelf       AND NOT HasMfaMgmt AND NOT Locked => allow
-%%   IsSelf       AND NOT HasMfaMgmt AND Locked     => deny mfa_locked
-%%   NOT IsSelf   AND HasMfaMgmt AND administrator   => allow (admin reset)
-%%   NOT IsSelf   AND HasMfaMgmt AND non-admin       => deny self_only
-%%   NOT IsSelf   AND NOT HasMfaMgmt                 => deny missing_mfa_mgmt
-%%
-%% Returns:
-%%   ok                                          allow
-%%   {deny, HttpCode, ErrorCode, BinaryMessage}  deny with HTTP response
-authorize_mfa_change(Req, TargetUsername, Op) ->
-    Caller = caller_admin(Req),
-    case Caller of
-        undefined ->
-            %% No bearer token caller (shouldn't happen — bearer-only
-            %% endpoint, but guard anyway).
-            {deny, 401, 'UNAUTHORIZED', <<"Bearer auth required">>};
-        _ ->
-            authorize_mfa_change_with_caller(Caller, TargetUsername, Op)
-    end.
-
-authorize_mfa_change_with_caller(Caller, TargetUsername, Op) ->
-    IsSelf = (Caller#?ADMIN.username =:= TargetUsername),
-    CallerRole = Caller#?ADMIN.role,
-    HasMfaMgmt = caller_has_mfa_mgmt(Caller),
-    IsFirstSetup = is_first_time_setup(TargetUsername, Op),
-    Locked = target_self_locked(TargetUsername),
-    case {IsFirstSetup, IsSelf, HasMfaMgmt, Locked, CallerRole} of
-        {true, _, _, _, _} ->
-            ok;
-        {false, true, true, _, _} ->
-            ok;
-        {false, true, false, false, _} ->
-            ok;
-        {false, true, false, true, _} ->
-            {deny, 403, 'MFA_LOCKED', <<
-                "MFA changes for this account are restricted; "
-                "the mfa_management scope is required to override."
-            >>};
-        {false, false, true, _, ?ROLE_SUPERUSER} ->
-            ok;
-        {false, false, true, _, _NonAdmin} ->
-            {deny, 403, 'MFA_SELF_ONLY', <<
-                "Non-administrator users with mfa_management scope can "
-                "only manage their own MFA, not other users'."
-            >>};
-        {false, false, false, _, _} ->
-            {deny, 403, 'MFA_MGMT_REQUIRED', <<
-                "The mfa_management scope is required to manage other "
-                "users' MFA."
-            >>}
-    end.
-
-is_first_time_setup(_TargetUsername, disable) ->
-    false;
-is_first_time_setup(TargetUsername, setup) ->
-    case emqx_dashboard_admin:get_mfa_state(TargetUsername) of
-        {ok, _} -> false;
-        _ -> true
-    end.
-
-%% Compute the "self locked" boolean used by authorize_mfa_change/3.
-%% Only admin_override == mfa_required locks self-disable/rotate.
-%% undefined means "no admin decision" — self may always disable an
-%% already-configured MFA. The decision whether a user must SET UP
-%% MFA in the first place lives in the login flow (consults backend
-%% live force_mfa), not here.
-target_self_locked(TargetUsername) ->
-    emqx_dashboard_admin:admin_override_of(TargetUsername) =:= ?ADMIN_MFA_REQUIRED.
-
-caller_has_mfa_mgmt(#?ADMIN{} = Caller) ->
-    %% Use effective scopes so the role-default fallback (admin -> all
-    %% 14, viewer -> common scopes only) applies. Viewer with no explicit
-    %% scopes therefore does NOT carry mfa_management; admin always
-    %% does.
-    Scopes = emqx_dashboard_admin:effective_scopes_of_admin(Caller),
-    lists:member(?SCOPE_MFA_MGMT, Scopes).
-
 %% Look up the caller's #?ADMIN{} record using the bearer token's
 %% `source' field (set by emqx_dashboard:authorize/2). Returns
 %% undefined if not a bearer-token request or the user has been
@@ -1203,10 +1300,15 @@ caller_admin(#{auth_meta := #{auth_type := jwt_token, source := Username}}) ->
 caller_admin(_) ->
     undefined.
 
-caller_is_admin_acting_on_other(Req, TargetUsername) ->
+%% The caller's own admin-record key, in the same shape `username/2'
+%% builds for a path target, so the two compare directly. `undefined'
+%% for a non-bearer caller or a deleted account; it never equals a real
+%% target key, so a self-check against it is false, which is the safe
+%% answer for both call sites (delete and the admin MFA routes).
+caller_key(Req) ->
     case caller_admin(Req) of
-        #?ADMIN{username = Caller} when Caller =/= TargetUsername -> true;
-        _ -> false
+        #?ADMIN{username = Username} -> Username;
+        undefined -> undefined
     end.
 
 mk(Type, Props) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -68,19 +68,12 @@ api_spec() ->
 %%   * /logout -- any authenticated role may log itself out.
 %%   * /user_scopes -- static catalog endpoint, no tenant data.
 %%   * /current_user* -- self-service; the caller is the subject, so the
-%%     authenticated identity alone authorizes the operation. A scope
-%%     check here would let an explicit `scopes = []' lock a user out of
-%%     their own password and MFA, which is what the scope layer exists
-%%     to gate for OTHER users, not for the holder's own account. None of
-%%     these operations can widen the caller's own privileges:
-%%     change_pwd verifies `old_pwd', and the MFA routes only ever touch
+%%     authenticated identity alone authorizes the operation. These routes only ever touch
 %%     the caller's own record.
 %%   * /users/:username/change_pwd -- the deprecated self-only shim. It
 %%     carries no scope for the same reason as `/current_user/change_pwd':
 %%     the handler asserts the target is the caller and then acts on the
 %%     caller's own record, so there is nothing here to gate per-scope.
-%%     Dropping `user_management' is what lets a viewer keep using its
-%%     old password-change call.
 scopes() ->
     #{
         <<"/login">> => ?SCOPE_PUBLIC,
@@ -189,14 +182,6 @@ schema("/logout") ->
             }
         }
     };
-%% Self-service routes. `/current_user' is a top-level path outside
-%% `/users/', so it cannot be shadowed by -- or shadow -- a user whose
-%% name happens to be `current_user', `self' or `me'; those are all
-%% legal usernames and there is no reserved-word check on them.
-%%
-%% Every operationId is prefixed `current_user_' because minirest
-%% requires globally unique operationIds and the admin routes already
-%% own `change_pwd' / `change_mfa'.
 schema("/current_user") ->
     #{
         'operationId' => current_user,
@@ -326,15 +311,10 @@ schema("/users/:username") ->
             }
         }
     };
-%% Deprecated self-only shim for `/current_user/change_pwd'. Kept so the
-%% heavily-integrated password-change call keeps working; scheduled for
-%% removal a release later.
-%%
-%% This is not the old endpoint with a new name. The old one was reachable
-%% for any target and merely failed on the `old_pwd' check, so a cross-user
-%% call was refused by accident. The shim asserts the target is the caller
-%% and answers 403 otherwise, which also makes the namespaced-administrator
-%% invariant deliberate rather than incidental.
+%% Deprecated self-only shim for `/current_user/change_pwd', kept for
+%% clients that still call this path; scheduled for removal a release
+%% later. The handler answers 403 unless the path target is the caller
+%% itself.
 schema("/users/:username/change_pwd") ->
     #{
         'operationId' => change_pwd,
@@ -407,12 +387,11 @@ fields(List) ->
 user_fields() ->
     fields([username, role, description, backend, scopes_response]) ++ ee_user_fields().
 
-%% Same shape as `user_fields/0', but `scopes' carries the EFFECTIVE
-%% list rather than the raw tri-state one. The admin routes report the
-%% raw value so that a read-modify-write of `PUT /users/:username' does
-%% not sediment the role default into an explicit list; this endpoint
-%% has no write counterpart, and its caller is asking what it may
-%% actually do, so the expanded list is the useful answer.
+%% Same fields as `user_fields/0', except `scopes' contains the effective
+%% scope list. Admin endpoints return the stored value so a `PUT
+%% /users/:username' round-trip does not replace implicit role defaults
+%% with an explicit list. This endpoint is read-only and reports the
+%% permissions the current user actually has.
 current_user_fields() ->
     fields([username, role, description, backend, effective_scopes_response]) ++ ee_user_fields().
 
@@ -889,7 +868,7 @@ is_default_admin(_NonLocalTarget) ->
 
 handle_delete_user(#{bindings := #{username := Username0}} = Req) ->
     Username = username(Req, Username0),
-    case caller_key(Req) =:= Username of
+    case is_caller(Req, Username) of
         true ->
             {400, ?NOT_ALLOWED, <<"Cannot delete self">>};
         false ->
@@ -918,10 +897,8 @@ handle_delete_user(#{bindings := #{username := Username0}} = Req) ->
 current_user(get, Req) ->
     with_caller(Req, fun(#?ADMIN{username = Username} = Admin) ->
         Profile = emqx_dashboard_admin:to_external_user(Admin),
-        %% `to_json_out/1' like every other emitter of this shape: it maps
-        %% `?global_ns' to `null', and without it a global user reports
-        %% `"namespace": "global"' here while `GET /users' reports `null'
-        %% for the same account.
+        %% `to_json_out/1' maps `?global_ns' to `null', so a global user
+        %% reports the same `"namespace": null' as `GET /users' does.
         {200, to_json_out(Profile#{scopes => emqx_dashboard_admin:effective_scopes_of(Username)})}
     end).
 
@@ -930,10 +907,10 @@ current_user_change_pwd(post, #{body := Params} = Req) ->
         do_change_pwd(Username, Params)
     end).
 
-%% Deprecated shim: assert the path target is the caller, then run the
-%% canonical self operation. It always acts on `Username', the caller's
-%% own resolved key, never on the path segment, so the path cannot steer
-%% the write even if the match below were ever loosened.
+%% Deprecated self-only shim for `/current_user/change_pwd'. Kept so the
+%% heavily-integrated password-change call keeps working; scheduled for
+%% removal a release later.
+%% The shim asserts the target is the caller and answers 403 otherwise.
 change_pwd(post, #{bindings := #{username := Target}, body := Params} = Req) ->
     with_caller(Req, fun(#?ADMIN{username = Username}) ->
         case is_self_target(Username, Target) of
@@ -1036,12 +1013,10 @@ mfa_result({error, Reason}, LogMeta) ->
 
 %% Self-MFA policy, in full:
 %%
-%%   setup / rotate             => always allowed. Rotation keeps MFA
-%%                                 enabled, so it cannot weaken the
-%%                                 requirement the override protects, and a
-%%                                 first enrolment has to stay open or an
-%%                                 account under a mandate could never
-%%                                 comply. Hence no check on this route.
+%%   setup / rotate             => always allowed. Rotation leaves MFA
+%%                                 enabled, and a first enrolment must
+%%                                 stay open, so this route runs no
+%%                                 check.
 %%   disable, override=required => denied. An administrator requires MFA on
 %%                                 this account; only another administrator
 %%                                 or the CLI can lift it.
@@ -1104,7 +1079,7 @@ change_mfa(post, #{bindings := #{username := Username0}, body := Settings} = Req
 %% where it would be recorded as an administrator decision
 %% (`admin_override') and would skip the self policy entirely.
 reject_self_target(Req, TargetUsername) ->
-    case caller_key(Req) =:= TargetUsername of
+    case is_caller(Req, TargetUsername) of
         false ->
             ok;
         true ->
@@ -1355,14 +1330,23 @@ caller_admin(_) ->
     undefined.
 
 %% The caller's own admin-record key, in the same shape `username/2'
-%% builds for a path target, so the two compare directly. `undefined'
-%% for a non-bearer caller or a deleted account; it never equals a real
-%% target key, so a self-check against it is false, which is the safe
-%% answer for both call sites (delete and the admin MFA routes).
+%% builds for a path target. `undefined' for a non-bearer caller or an
+%% account that no longer exists.
 caller_key(Req) ->
     case caller_admin(Req) of
         #?ADMIN{username = Username} -> Username;
         undefined -> undefined
+    end.
+
+%% Whether `Target' names the caller's own account. Every key shape is
+%% listed so that an unexpected one raises here rather than answering
+%% `false', which the callers read as "acting on somebody else" and act
+%% upon.
+is_caller(Req, Target) ->
+    case caller_key(Req) of
+        undefined -> false;
+        Name when is_binary(Name) -> Name =:= Target;
+        ?SSO_USERNAME(_Backend, Name) = Key when is_binary(Name) -> Key =:= Target
     end.
 
 mk(Type, Props) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -51,7 +51,7 @@
 -define(PASSWORD_LOGIN_DISABLED, 'PASSWORD_LOGIN_DISABLED').
 -define(SCRAM_CHALLENGE_INVALID, 'SCRAM_CHALLENGE_INVALID').
 -define(SERVICE_UNAVAILABLE, 'SERVICE_UNAVAILABLE').
--define(MFA_LOCKED, 'MFA_LOCKED').
+-define(MFA_ADMIN_REQUIRED, 'MFA_ADMIN_REQUIRED').
 
 namespace() -> "dashboard".
 
@@ -238,9 +238,6 @@ schema("/current_user/mfa") ->
             'requestBody' => emqx_dashboard_schema:mfa_fields(),
             responses => #{
                 204 => <<"MFA setting is updated">>,
-                403 => emqx_dashboard_swagger:error_codes(
-                    [?MFA_LOCKED], ?DESC(current_user_mfa_locked)
-                ),
                 404 => response_schema(404)
             }
         },
@@ -251,7 +248,7 @@ schema("/current_user/mfa") ->
             responses => #{
                 204 => <<"MFA setting is disabled">>,
                 403 => emqx_dashboard_swagger:error_codes(
-                    [?MFA_LOCKED], ?DESC(current_user_mfa_locked)
+                    [?MFA_ADMIN_REQUIRED], ?DESC(current_user_mfa_admin_required)
                 ),
                 404 => response_schema(404)
             }
@@ -1016,20 +1013,14 @@ current_user_mfa(post, #{body := Settings} = Req) ->
     Mechanism = maps:get(<<"mechanism">>, Settings),
     with_caller(Req, fun(#?ADMIN{username = Username}) ->
         LogMeta = #{msg => "dashboard_user_mfa_setup", username => Username},
-        case authorize_self_mfa(Username, setup) of
-            ok ->
-                %% Never `ByAdmin': a self-initiated (re)init must not
-                %% touch the admin_override decision.
-                mfa_result(emqx_dashboard_admin:reinit_mfa(Username, Mechanism, false), LogMeta);
-            {deny, Code, ErrCode, Msg} ->
-                ?SLOG(warning, LogMeta#{result => denied, reason => ErrCode}),
-                {Code, ErrCode, Msg}
-        end
+        %% Never `ByAdmin': a self-initiated (re)init must not touch the
+        %% admin_override decision.
+        mfa_result(emqx_dashboard_admin:reinit_mfa(Username, Mechanism, false), LogMeta)
     end);
 current_user_mfa(delete, Req) ->
     with_caller(Req, fun(#?ADMIN{username = Username}) ->
         LogMeta = #{msg => "dashboard_user_mfa_disable", username => Username},
-        case authorize_self_mfa(Username, disable) of
+        case authorize_self_mfa_disable(Username) of
             ok ->
                 mfa_result(emqx_dashboard_admin:disable_mfa(Username, false), LogMeta);
             {deny, Code, ErrCode, Msg} ->
@@ -1050,38 +1041,29 @@ mfa_result({error, Reason}, LogMeta) ->
 
 %% Self-MFA policy, in full:
 %%
-%%   first-time setup           => allow  (deadlock prevention: a user
-%%                                         that has never enrolled must
-%%                                         always be able to)
-%%   admin_override = required  => deny   (an administrator reset this
-%%                                         account's MFA; only another
-%%                                         administrator or the CLI can
-%%                                         lift it)
-%%   otherwise                  => allow
+%%   setup / rotate             => always allowed. Rotation keeps MFA
+%%                                 enabled, so it cannot weaken the
+%%                                 requirement the override protects, and a
+%%                                 first enrolment has to stay open or an
+%%                                 account under a mandate could never
+%%                                 comply. Hence no check on this route.
+%%   disable, override=required => denied. An administrator requires MFA on
+%%                                 this account; only another administrator
+%%                                 or the CLI can lift it.
+%%   disable, otherwise         => allowed.
 %%
 %% `admin_override' is only ever written when an administrator acts on
 %% ANOTHER user (`emqx_dashboard_api:change_mfa/2' passes ByAdmin), so a
 %% user cannot lock themselves out by rotating their own MFA.
-authorize_self_mfa(Username, Op) ->
-    case is_first_time_setup(Username, Op) orelse not self_mfa_locked(Username) of
-        true ->
-            ok;
-        false ->
-            {deny, 403, ?MFA_LOCKED, <<
-                "MFA for this account was set by an administrator and "
-                "cannot be changed here. Ask an administrator to reset it."
-            >>}
-    end.
-
-self_mfa_locked(Username) ->
-    emqx_dashboard_admin:admin_override_of(Username) =:= ?ADMIN_MFA_REQUIRED.
-
-is_first_time_setup(_Username, disable) ->
-    false;
-is_first_time_setup(Username, setup) ->
-    case emqx_dashboard_admin:get_mfa_state(Username) of
-        {ok, _} -> false;
-        _ -> true
+authorize_self_mfa_disable(Username) ->
+    case emqx_dashboard_admin:admin_override_of(Username) of
+        ?ADMIN_MFA_REQUIRED ->
+            {deny, 403, ?MFA_ADMIN_REQUIRED, <<
+                "An administrator requires MFA on this account, so it "
+                "cannot be turned off here. It can still be re-keyed."
+            >>};
+        _ ->
+            ok
     end.
 
 %% Resolve the caller's own admin record from the bearer token's

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -927,7 +927,11 @@ handle_delete_user(#{bindings := #{username := Username0}} = Req) ->
 current_user(get, Req) ->
     with_caller(Req, fun(#?ADMIN{username = Username} = Admin) ->
         Profile = emqx_dashboard_admin:to_external_user(Admin),
-        {200, Profile#{scopes => emqx_dashboard_admin:effective_scopes_of(Username)}}
+        %% `to_json_out/1' like every other emitter of this shape: it maps
+        %% `?global_ns' to `null', and without it a global user reports
+        %% `"namespace": "global"' here while `GET /users' reports `null'
+        %% for the same account.
+        {200, to_json_out(Profile#{scopes => emqx_dashboard_admin:effective_scopes_of(Username)})}
     end).
 
 current_user_change_pwd(post, #{body := Params} = Req) ->
@@ -1143,10 +1147,11 @@ register_unsuccessful_login(_, _) ->
 %% Two-layer rule:
 %%   * Any unknown scope name is rejected.
 %%   * Non-administrator role users cannot hold any of the admin-only
-%%     subset (user_management, sso_management, api_key_management).
-%%     mfa_management is intentionally allowed for any role — non-
-%%     admin holders can self-exempt their own MFA but cannot manage
-%%     other users' MFA (handler-level enforcement).
+%%     subset, which is all four login-only scopes: user_management,
+%%     mfa_management, sso_management, api_key_management.
+%%     `mfa_management' means "manage OTHER users' MFA"; managing one's
+%%     own MFA is identity-authorized on /current_user/mfa and needs no
+%%     scope.
 %% @doc Normalize a `scopes' request value to a storage intent:
 %%   * `keep'       - field omitted (`undefined'): leave persisted scopes
 %%                    unchanged (PUT read-modify-write of another field).

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -30,6 +30,7 @@
     users/2,
     user_scopes/2,
     user/2,
+    change_pwd/2,
     change_mfa/2,
     current_user/2,
     current_user_change_pwd/2,
@@ -74,6 +75,12 @@ api_spec() ->
 %%     these operations can widen the caller's own privileges:
 %%     change_pwd verifies `old_pwd', and the MFA routes only ever touch
 %%     the caller's own record.
+%%   * /users/:username/change_pwd -- the deprecated self-only shim. It
+%%     carries no scope for the same reason as `/current_user/change_pwd':
+%%     the handler asserts the target is the caller and then acts on the
+%%     caller's own record, so there is nothing here to gate per-scope.
+%%     Dropping `user_management' is what lets a viewer keep using its
+%%     old password-change call.
 scopes() ->
     #{
         <<"/login">> => ?SCOPE_PUBLIC,
@@ -86,6 +93,7 @@ scopes() ->
         <<"/current_user/mfa">> => ?SCOPE_PUBLIC,
         <<"/users">> => ?SCOPE_USER_MGMT,
         <<"/users/:username">> => ?SCOPE_USER_MGMT,
+        <<"/users/:username/change_pwd">> => ?SCOPE_PUBLIC,
         <<"/users/:username/mfa">> => ?SCOPE_MFA_MGMT
     }.
 
@@ -100,6 +108,7 @@ paths() ->
         "/current_user/mfa",
         "/users",
         "/users/:username",
+        "/users/:username/change_pwd",
         "/users/:username/mfa",
         "/user_scopes"
     ].
@@ -317,6 +326,38 @@ schema("/users/:username") ->
                     [?BAD_REQUEST, ?NOT_ALLOWED], ?DESC(login_failed_response400)
                 ),
                 404 => response_schema(404)
+            }
+        }
+    };
+%% Deprecated self-only shim for `/current_user/change_pwd'. Kept so the
+%% heavily-integrated password-change call keeps working; scheduled for
+%% removal a release later.
+%%
+%% This is not the old endpoint with a new name. The old one was reachable
+%% for any target and merely failed on the `old_pwd' check, so a cross-user
+%% call was refused by accident. The shim asserts the target is the caller
+%% and answers 403 otherwise, which also makes the namespaced-administrator
+%% invariant deliberate rather than incidental.
+schema("/users/:username/change_pwd") ->
+    #{
+        'operationId' => change_pwd,
+        post => #{
+            tags => [<<"dashboard">>],
+            desc => ?DESC(change_pwd_api),
+            deprecated => true,
+            security => [#{'bearerAuth' => []}],
+            parameters => fields([username_in_path]),
+            'requestBody' => fields([old_pwd, new_pwd]),
+            responses => #{
+                204 => <<"Update user password successfully">>,
+                403 => emqx_dashboard_swagger:error_codes(
+                    [?NOT_ALLOWED], ?DESC(change_pwd_self_only)
+                ),
+                404 => response_schema(404),
+                400 => emqx_dashboard_swagger:error_codes(
+                    [?BAD_REQUEST, ?ERROR_PWD_NOT_MATCH, ?NOT_ALLOWED],
+                    ?DESC(login_failed_response400)
+                )
             }
         }
     };
@@ -893,6 +934,37 @@ current_user_change_pwd(post, #{body := Params} = Req) ->
     with_caller(Req, fun(#?ADMIN{username = Username}) ->
         do_change_pwd(Username, Params)
     end).
+
+%% Deprecated shim: assert the path target is the caller, then run the
+%% canonical self operation. It always acts on `Username', the caller's
+%% own resolved key, never on the path segment, so the path cannot steer
+%% the write even if the match below were ever loosened.
+change_pwd(post, #{bindings := #{username := Target}, body := Params} = Req) ->
+    with_caller(Req, fun(#?ADMIN{username = Username}) ->
+        case is_self_target(Username, Target) of
+            true ->
+                do_change_pwd(Username, Params);
+            false ->
+                ?SLOG(warning, #{
+                    msg => "dashboard_change_password",
+                    username => Target,
+                    result => denied,
+                    reason => "not_the_authenticated_user"
+                }),
+                {403, ?NOT_ALLOWED, <<
+                    "This endpoint only changes your own password. "
+                    "Use /current_user/change_pwd."
+                >>}
+        end
+    end).
+
+%% The route carries no `?backend' parameter, so an SSO caller's key
+%% (`{Backend, Name}') never equals the bare path segment. Match on the
+%% name part as well, so an SSO user reaches `do_change_pwd/2' and gets
+%% the "no local password" answer rather than a misleading 403.
+is_self_target(Username, Username) -> true;
+is_self_target(?SSO_USERNAME(_Backend, Name), Name) -> true;
+is_self_target(_Caller, _Target) -> false.
 
 %% An SSO user has no local password -- the identity provider owns the
 %% credential -- so there is nothing here to change. Reject explicitly:

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -889,12 +889,6 @@ is_default_admin(_NonLocalTarget) ->
 
 handle_delete_user(#{bindings := #{username := Username0}} = Req) ->
     Username = username(Req, Username0),
-    %% The caller is identified by the authenticated token, not by
-    %% re-parsing the `Authorization' header: the header form varies
-    %% (basic / bearer, either capitalisation) and only the token
-    %% resolution knows the SSO key. `caller_key/1' returns the same
-    %% admin-record key `username/2' produces, so the two are directly
-    %% comparable for both local and SSO targets.
     case caller_key(Req) =:= Username of
         true ->
             {400, ?NOT_ALLOWED, <<"Cannot delete self">>};

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -949,6 +949,7 @@ change_pwd(post, #{bindings := #{username := Target}, body := Params} = Req) ->
                 ?SLOG(warning, #{
                     msg => "dashboard_change_password",
                     username => Target,
+                    attempted_by => Username,
                     result => denied,
                     reason => "not_the_authenticated_user"
                 }),

--- a/apps/emqx_dashboard/src/emqx_dashboard_token.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_token.erl
@@ -66,7 +66,7 @@ destroy(#?ADMIN_JWT{token = Token}) ->
 destroy(Token) when is_binary(Token) ->
     do_destroy(Token).
 
--spec destroy_by_username(Username :: term()) -> ok.
+-spec destroy_by_username(dashboard_username()) -> ok.
 destroy_by_username(Username) ->
     do_destroy_by_username(Username).
 
@@ -147,14 +147,12 @@ do_destroy(Token) ->
     ok.
 
 do_destroy_by_username(Username) ->
-    Spec = jwt_by_username_spec(Username),
     Fun = fun() ->
-        Tokens = mnesia:select(?TAB, Spec),
         lists:foreach(
             fun(#?ADMIN_JWT{token = Token}) ->
                 mnesia:delete({?TAB, Token})
             end,
-            Tokens
+            select_by_username(Username)
         ),
         ok
     end,
@@ -172,8 +170,7 @@ lookup(Token) ->
     end.
 
 lookup_by_username(Username) ->
-    Spec = jwt_by_username_spec(Username),
-    Fun = fun() -> mnesia:select(?TAB, Spec) end,
+    Fun = fun() -> select_by_username(Username) end,
     {atomic, List} = mria:ro_transaction(?DASHBOARD_SHARD, Fun),
     List.
 
@@ -217,8 +214,25 @@ format(Token, Backend, Username, Role, ExpTime, Namespace) ->
         extra = Extra
     }.
 
-jwt_by_username_spec(Username) ->
-    [{jwt_pat([{#?ADMIN_JWT.username, Username}]), [], ['$_']}].
+%% A row keeps the bare name in `username' and the backend in `extra',
+%% so an SSO key matches nothing on its own.  Select on the name and
+%% keep the rows whose backend belongs to the same account, so that a
+%% local user and an SSO user of the same name stay isolated.
+select_by_username(Username) ->
+    Rows = mnesia:select(?TAB, jwt_by_username_spec(name_of(Username))),
+    [
+        JWT
+     || #?ADMIN_JWT{username = Name, extra = Extra} = JWT <- Rows,
+        full_admin_key(Name, Extra) =:= Username
+    ].
+
+name_of(?SSO_USERNAME(_Backend, Name)) ->
+    Name;
+name_of(Username) ->
+    Username.
+
+jwt_by_username_spec(Name) ->
+    [{jwt_pat([{#?ADMIN_JWT.username, Name}]), [], ['$_']}].
 
 jwt_pat(Overrides) ->
     erlang:make_tuple(

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -297,8 +297,10 @@ t_rest_api(_Config) ->
     ),
     {ok, 204, _} = http_delete(["users", "usera"]),
     {ok, 404, _} = http_delete(["users", "usera"]),
+    %% Changing one's own password is self-service: the caller is the
+    %% subject, so there is no username in the path.
     {ok, 204, _} = http_post(
-        ["users", "admin", "change_pwd"],
+        ["current_user", "change_pwd"],
         #{
             <<"old_pwd">> => Password,
             <<"new_pwd">> => <<"newpwd_lkdfki1">>

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -758,6 +758,31 @@ t_lookup_by_username_jwt(_Config) ->
     ?assertMatch([], emqx_dashboard_token:lookup_by_username(User)),
     ok.
 
+t_lookup_by_username_jwt_sso(_Config) ->
+    Name = bin(["user-", integer_to_list(random_num())]),
+    Sso = ?SSO_USERNAME(ldap, Name),
+    emqx_dashboard_token:sign(#?ADMIN{username = Sso}),
+    ?assertMatch(
+        [#?ADMIN_JWT{username = Name}],
+        emqx_dashboard_token:lookup_by_username(Sso)
+    ),
+    ok = emqx_dashboard_token:destroy_by_username(Sso),
+    ok = gen_server:call(emqx_dashboard_token, dummy, infinity),
+    ?assertMatch([], emqx_dashboard_token:lookup_by_username(Sso)),
+    ok.
+
+t_lookup_by_username_jwt_backend_isolation(_Config) ->
+    Name = bin(["user-", integer_to_list(random_num())]),
+    emqx_dashboard_token:sign(#?ADMIN{username = Name}),
+    emqx_dashboard_token:sign(#?ADMIN{username = ?SSO_USERNAME(ldap, Name)}),
+    ?assertMatch([_], emqx_dashboard_token:lookup_by_username(Name)),
+    ?assertMatch([_], emqx_dashboard_token:lookup_by_username(?SSO_USERNAME(ldap, Name))),
+    ok = emqx_dashboard_token:destroy_by_username(?SSO_USERNAME(ldap, Name)),
+    ok = gen_server:call(emqx_dashboard_token, dummy, infinity),
+    ?assertMatch([], emqx_dashboard_token:lookup_by_username(?SSO_USERNAME(ldap, Name))),
+    ?assertMatch([_], emqx_dashboard_token:lookup_by_username(Name)),
+    ok.
+
 t_clean_expired_jwt(_Config) ->
     User = bin(["user-", integer_to_list(random_num())]),
     emqx_dashboard_token:sign(#?ADMIN{username = User}),

--- a/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
@@ -93,9 +93,27 @@ t_get_own_profile(_Config) ->
             <<"username">> := <<"viewer">>,
             <<"role">> := ?ROLE_VIEWER,
             <<"backend">> := <<"local">>,
-            <<"mfa">> := <<"none">>
+            <<"mfa">> := <<"none">>,
+            %% `null', not the string "global": the profile goes through
+            %% `to_json_out/1' like every other emitter of this shape.
+            <<"namespace">> := null
         },
         json(Body)
+    ).
+
+%% The profile is the same object `GET /users' reports for the same
+%% account, so the two must not disagree field by field. Only `scopes'
+%% differs by design: the self endpoint expands the role default.
+t_own_profile_matches_admin_view(_Config) ->
+    ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
+    Token = token(<<"boss">>),
+    {ok, 200, SelfBody} = get_current_user(Token),
+    {ok, 200, ListBody} = request_api(get, api_path(["users"]), auth_header(Token)),
+    Self = json(SelfBody),
+    [Admin] = [U || U <- json(ListBody), maps:get(<<"username">>, U) =:= <<"boss">>],
+    ?assertEqual(
+        maps:remove(<<"scopes">>, Admin),
+        maps:remove(<<"scopes">>, Self)
     ).
 
 %% `scopes' is the EFFECTIVE list: the role default is expanded, so the

--- a/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
@@ -1,0 +1,430 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+%%
+%% HTTP coverage for the self-service / administrator split:
+%%
+%%   /current_user            GET     own profile
+%%   /current_user/change_pwd POST    own password
+%%   /current_user/mfa        POST    own MFA setup / rotate
+%%                            DELETE  own MFA disable
+%%
+%% Self endpoints are authorized by the authenticated identity alone --
+%% no scope, no role, no `:username' in the path. The administrator
+%% routes under `/users/:username/*' are the mirror image: scope plus
+%% global-administrator role, target is always another user.
+%%
+%% The MFA lock policy itself (first-time setup, admin_override) lives
+%% in emqx_dashboard_user_scopes_SUITE; this suite covers the routing,
+%% the identity binding, the password rules and the SSO case.
+%%--------------------------------------------------------------------
+
+-module(emqx_dashboard_current_user_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
+-include("emqx_dashboard.hrl").
+
+-define(HOST, "http://127.0.0.1:18083").
+-define(BASE_PATH, "/api/v5").
+
+-define(PASSWORD, <<"P@ssw0rd_1">>).
+-define(NEW_PASSWORD, <<"P@ssw0rd_2">>).
+
+-define(EE_ONLY(EXPR, NON_EE),
+    case emqx_release:edition() of
+        ee -> EXPR;
+        _ -> NON_EE
+    end
+).
+
+all() ->
+    ?EE_ONLY(emqx_common_test_helpers:all(?MODULE), []).
+
+init_per_suite(Config) ->
+    ?EE_ONLY(
+        begin
+            Apps = emqx_cth_suite:start(
+                [
+                    emqx,
+                    emqx_conf,
+                    emqx_management,
+                    emqx_mgmt_api_test_util:emqx_dashboard()
+                ],
+                #{work_dir => emqx_cth_suite:work_dir(Config)}
+            ),
+            [{apps, Apps} | Config]
+        end,
+        Config
+    ).
+
+end_per_suite(Config) ->
+    ?EE_ONLY(emqx_cth_suite:stop(?config(apps, Config)), ok),
+    ok.
+
+end_per_testcase(_Case, _Config) ->
+    lists:foreach(
+        fun(User) -> emqx_dashboard_admin:remove_user(admin_key(User)) end,
+        emqx_dashboard_admin:all_users()
+    ).
+
+%% `to_external_user/1' flattens an SSO key `{Backend, Name}' into a bare
+%% `username' plus a `backend' field; `remove_user/1' wants the key back.
+admin_key(#{username := Name, backend := ?BACKEND_LOCAL}) ->
+    Name;
+admin_key(#{username := Name, backend := Backend}) when is_atom(Backend) ->
+    ?SSO_USERNAME(Backend, Name).
+
+%%--------------------------------------------------------------------
+%% GET /current_user
+%%--------------------------------------------------------------------
+
+%% The profile describes the caller, resolved from the bearer token --
+%% there is no path parameter to point it at anybody else.
+t_get_own_profile(_Config) ->
+    ok = add_user(<<"viewer">>, ?ROLE_VIEWER),
+    {ok, 200, Body} = get_current_user(token(<<"viewer">>)),
+    ?assertMatch(
+        #{
+            <<"username">> := <<"viewer">>,
+            <<"role">> := ?ROLE_VIEWER,
+            <<"backend">> := <<"local">>,
+            <<"mfa">> := <<"none">>
+        },
+        json(Body)
+    ).
+
+%% `scopes' is the EFFECTIVE list: the role default is expanded, so the
+%% `unset' sentinel that `GET /users' may report never appears here.
+%% A viewer that has never been given an explicit list still learns
+%% what it holds.
+t_get_own_profile_reports_effective_scopes(_Config) ->
+    ok = add_user(<<"viewer">>, ?ROLE_VIEWER),
+    ?assertEqual(undefined, emqx_dashboard_admin:scopes_of(<<"viewer">>)),
+    {ok, 200, Body} = get_current_user(token(<<"viewer">>)),
+    #{<<"scopes">> := Scopes} = json(Body),
+    ?assert(is_list(Scopes), Scopes),
+    ?assertEqual(
+        lists:sort(emqx_dashboard_admin:effective_scopes_of(<<"viewer">>)),
+        lists:sort(Scopes)
+    ),
+    %% An explicit list is reported verbatim.
+    {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"viewer">>, [?SCOPE_MONITORING]),
+    {ok, 200, Body1} = get_current_user(token(<<"viewer">>)),
+    ?assertMatch(#{<<"scopes">> := [?SCOPE_MONITORING]}, json(Body1)).
+
+%%--------------------------------------------------------------------
+%% Self-service is not gated by role or scope
+%%--------------------------------------------------------------------
+
+%% Requirement: a viewer with no explicit scopes manages its own
+%% account fully, and an explicitly emptied scope list does not lock it
+%% out of its own password or MFA.
+t_viewer_self_service_allowed(_Config) ->
+    lists:foreach(
+        fun(Scopes) ->
+            ok = add_user(<<"viewer">>, ?ROLE_VIEWER),
+            case Scopes of
+                undefined -> ok;
+                _ -> {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"viewer">>, Scopes)
+            end,
+            ?assertMatch({ok, 200, _}, get_current_user(token(<<"viewer">>)), Scopes),
+            ?assertMatch({ok, 204, _}, setup_own_mfa(token(<<"viewer">>)), Scopes),
+            %% A second POST is a rotate, not a first-time setup.
+            ?assertMatch({ok, 204, _}, setup_own_mfa(token(<<"viewer">>)), Scopes),
+            ?assertMatch({ok, 204, _}, delete_own_mfa(token(<<"viewer">>)), Scopes),
+            ?assertMatch(
+                {ok, 204, _},
+                change_own_pwd(token(<<"viewer">>), ?PASSWORD, ?NEW_PASSWORD),
+                Scopes
+            ),
+            {ok, _} = emqx_dashboard_admin:remove_user(<<"viewer">>)
+        end,
+        [undefined, []]
+    ).
+
+%% The mirror image: a viewer is refused on every administrator route,
+%% for every target -- another user and itself alike. Deleting the
+%% viewer-self RBAC clauses is what closes the "itself" half.
+t_viewer_denied_on_admin_routes(_Config) ->
+    ok = add_user(<<"viewer">>, ?ROLE_VIEWER),
+    ok = add_user(<<"other">>, ?ROLE_VIEWER),
+    Token = token(<<"viewer">>),
+    lists:foreach(
+        fun(Target) ->
+            ?assertMatch({ok, 403, _}, admin_setup_mfa(Token, Target), Target),
+            ?assertMatch({ok, 403, _}, admin_delete_mfa(Token, Target), Target),
+            ?assertMatch({ok, 403, _}, update_user(Token, Target), Target),
+            ?assertMatch({ok, 403, _}, delete_user(Token, Target), Target)
+        end,
+        [<<"other">>, <<"viewer">>]
+    ).
+
+%%--------------------------------------------------------------------
+%% Administrator side
+%%--------------------------------------------------------------------
+
+%% An administrator manages other users through the admin routes and
+%% its own account through the self routes -- and the admin routes
+%% refuse a self target rather than quietly doing the wrong thing.
+t_admin_manages_others_and_self_separately(_Config) ->
+    ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
+    ok = add_user(<<"other">>, ?ROLE_VIEWER),
+    Token = token(<<"boss">>),
+    ?assertMatch({ok, 204, _}, admin_setup_mfa(Token, <<"other">>)),
+    ?assertMatch({ok, 204, _}, admin_delete_mfa(Token, <<"other">>)),
+    ?assertMatch({ok, 200, _}, update_user(Token, <<"other">>)),
+    %% Own account: refused on the admin route, served on the self route.
+    ?assertMatch({ok, 400, _}, admin_setup_mfa(Token, <<"boss">>)),
+    ?assertMatch({ok, 400, _}, admin_delete_mfa(Token, <<"boss">>)),
+    %% A successful MFA write invalidates the caller's own sessions, so
+    %% the second call needs a fresh token -- see t_own_mfa_write_ends_session.
+    ?assertMatch({ok, 204, _}, setup_own_mfa(token(<<"boss">>))),
+    ?assertMatch({ok, 204, _}, delete_own_mfa(token(<<"boss">>))).
+
+%% The "cannot delete self" guard now compares the authenticated
+%% identity with the target instead of re-parsing the Authorization
+%% header. Deleting somebody else still works.
+t_admin_cannot_delete_self(_Config) ->
+    ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
+    ok = add_user(<<"other">>, ?ROLE_VIEWER),
+    Token = token(<<"boss">>),
+    {ok, 400, Body} = delete_user(Token, <<"boss">>),
+    ?assertEqual(<<"NOT_ALLOWED">>, error_code(Body)),
+    ?assertMatch([_], emqx_dashboard_admin:lookup_user(<<"boss">>)),
+    ?assertMatch({ok, 204, _}, delete_user(Token, <<"other">>)).
+
+%% A namespaced administrator is confined to its own account: denied on
+%% another user's MFA even inside its own namespace (the cross-user
+%% reset vector), allowed on `/current_user/*'.
+t_namespaced_admin_is_self_only(_Config) ->
+    ok = add_user(<<"nsadmin">>, <<"ns:ns1::", ?ROLE_SUPERUSER/binary>>),
+    ok = add_user(<<"victim">>, ?ROLE_VIEWER),
+    Token = token(<<"nsadmin">>),
+    ?assertMatch({ok, 403, _}, admin_setup_mfa(Token, <<"victim">>)),
+    ?assertMatch({ok, 403, _}, admin_delete_mfa(Token, <<"victim">>)),
+    ?assertMatch({ok, 200, _}, get_current_user(Token)),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(token(<<"nsadmin">>))),
+    ?assertMatch({ok, 204, _}, delete_own_mfa(token(<<"nsadmin">>))),
+    ?assertMatch(
+        {ok, 204, _}, change_own_pwd(token(<<"nsadmin">>), ?PASSWORD, ?NEW_PASSWORD)
+    ).
+
+%%--------------------------------------------------------------------
+%% POST /current_user/change_pwd
+%%--------------------------------------------------------------------
+
+%% `old_pwd' is always verified: there is no administrator HTTP path
+%% that resets a password without it.
+t_change_own_pwd(_Config) ->
+    ok = add_user(<<"viewer">>, ?ROLE_VIEWER),
+    Token = token(<<"viewer">>),
+    {ok, 400, Wrong} = change_own_pwd(Token, <<"not-the-password">>, ?NEW_PASSWORD),
+    ?assertEqual(<<"ERROR_PWD_NOT_MATCH">>, error_code(Wrong)),
+    {ok, 400, EmptyOld} = change_own_pwd(Token, <<>>, ?NEW_PASSWORD),
+    ?assertEqual(<<"BAD_REQUEST">>, error_code(EmptyOld)),
+    {ok, 400, EmptyNew} = change_own_pwd(Token, ?PASSWORD, <<>>),
+    ?assertEqual(<<"BAD_REQUEST">>, error_code(EmptyNew)),
+    %% The failed attempts left the password alone.
+    ?assertMatch({ok, 204, _}, change_own_pwd(Token, ?PASSWORD, ?NEW_PASSWORD)),
+    ?assertMatch({ok, _}, emqx_dashboard_admin:check(<<"viewer">>, ?NEW_PASSWORD)).
+
+%% An SSO account has no local password -- the identity provider owns
+%% the credential. The endpoint must say so rather than crash:
+%% `emqx_dashboard_admin:change_password/3' is guarded on a binary
+%% username and would raise a function_clause on the SSO key.
+t_change_own_pwd_sso_user_rejected(_Config) ->
+    Backend = saml,
+    SsoUser = <<"sso-user@example.com">>,
+    {ok, _} = emqx_dashboard_admin:add_sso_user(Backend, SsoUser, ?ROLE_VIEWER, <<"d">>),
+    SsoKey = ?SSO_USERNAME(Backend, SsoUser),
+    {ok, 400, Body} = change_own_pwd(sso_token(SsoKey), ?PASSWORD, ?NEW_PASSWORD),
+    ?assertEqual(<<"NOT_ALLOWED">>, error_code(Body)),
+    %% The rest of the namespace still works for an SSO caller.
+    {ok, 200, Profile} = get_current_user(sso_token(SsoKey)),
+    ?assertMatch(
+        #{<<"username">> := SsoUser, <<"backend">> := <<"saml">>},
+        json(Profile)
+    ),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(sso_token(SsoKey))),
+    ?assertMatch({ok, 204, _}, delete_own_mfa(sso_token(SsoKey))).
+
+%% Re-keying MFA invalidates the account's sessions
+%% (`emqx_dashboard_admin:reinit_mfa/3' destroys its tokens), so the
+%% bearer token that authorized the change is dead immediately after
+%% it. Pinned here because every other self-MFA test has to work around
+%% it, and a caller has to log in again with the new secret.
+t_own_mfa_write_ends_session(_Config) ->
+    ok = add_user(<<"viewer">>, ?ROLE_VIEWER),
+    Token = token(<<"viewer">>),
+    ?assertMatch({ok, 200, _}, get_current_user(Token)),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(Token)),
+    {ok, 401, Body} = get_current_user(Token),
+    ?assertEqual(<<"BAD_TOKEN">>, error_code(Body)),
+    %% A fresh login is all it takes.
+    ?assertMatch({ok, 200, _}, get_current_user(token(<<"viewer">>))).
+
+%%--------------------------------------------------------------------
+%% Routing
+%%--------------------------------------------------------------------
+
+%% `current_user', `self' and `me' are all legal usernames and there is
+%% no reserved-word check on them. `/current_user' is a top-level path
+%% outside `/users/', so such a user neither shadows nor is shadowed by
+%% the self-service routes, and an administrator still manages it by
+%% name.
+t_username_colliding_with_self_route(_Config) ->
+    ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
+    AdminToken = token(<<"boss">>),
+    lists:foreach(
+        fun(Name) ->
+            ok = add_user(Name, ?ROLE_VIEWER),
+            Token = token(Name),
+            %% The self route serves the caller, whatever it is called.
+            {ok, 200, Body} = get_current_user(Token),
+            ?assertMatch(#{<<"username">> := Name}, json(Body), Name),
+            ?assertMatch({ok, 204, _}, setup_own_mfa(Token), Name),
+            %% ... and the administrator still reaches the account by name.
+            ?assertMatch({ok, 204, _}, admin_delete_mfa(AdminToken, Name), Name),
+            ?assertMatch({ok, 200, _}, get_current_user(token(Name)), Name),
+            ?assertMatch({ok, 200, _}, update_user(AdminToken, Name), Name),
+            ?assertMatch({ok, 204, _}, delete_user(AdminToken, Name), Name)
+        end,
+        [<<"current_user">>, <<"self">>, <<"me">>]
+    ).
+
+%% The administrator password-reset route is gone: self password change
+%% is `/current_user/change_pwd' and resetting another user's password
+%% stays CLI-only (`emqx ctl admins passwd'). A stale client hitting the
+%% old path gets a 404 from the router, not a silent success.
+t_old_change_pwd_route_is_gone(_Config) ->
+    ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
+    Token = token(<<"boss">>),
+    Url = api_path(["users", "boss", "change_pwd"]),
+    ?assertMatch(
+        {ok, 404, _},
+        request_api(
+            post, Url, auth_header(Token), #{old_pwd => ?PASSWORD, new_pwd => ?NEW_PASSWORD}
+        )
+    ),
+    %% The password is untouched: the route did not silently succeed.
+    ?assertMatch({ok, _}, emqx_dashboard_admin:check(<<"boss">>, ?PASSWORD)).
+
+%% The Dashboard SPA and emqx-docs are generated from the OpenAPI spec,
+%% so the split is only really shipped once the spec carries it: the
+%% three self routes present, the administrator password-reset route
+%% gone.
+t_openapi_spec_carries_the_split(_Config) ->
+    ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
+    Url = ?HOST ++ "/api-docs/swagger.json",
+    {ok, {{_, 200, _}, _Headers, Body}} =
+        httpc:request(
+            get, {Url, [auth_header(token(<<"boss">>))]}, [], [{body_format, binary}]
+        ),
+    #{<<"paths">> := Paths} = json(Body),
+    ?assertMatch(#{<<"get">> := _}, maps:get(<<"/current_user">>, Paths)),
+    ?assertMatch(
+        #{<<"post">> := _}, maps:get(<<"/current_user/change_pwd">>, Paths)
+    ),
+    ?assertMatch(
+        #{<<"post">> := _, <<"delete">> := _}, maps:get(<<"/current_user/mfa">>, Paths)
+    ),
+    ?assertEqual(
+        error,
+        maps:find(<<"/users/{username}/change_pwd">>, Paths),
+        {stale_admin_password_reset_route, maps:keys(Paths)}
+    ),
+    %% The administrator MFA route stays.
+    ?assertMatch(
+        #{<<"post">> := _, <<"delete">> := _}, maps:get(<<"/users/{username}/mfa">>, Paths)
+    ).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+sso_token(SsoKey) ->
+    {ok, #{token := Token}} = emqx_dashboard_admin:sign_token(
+        SsoKey, <<>>, ?TRUSTED_MFA_TOKEN
+    ),
+    Token.
+
+add_user(Username, Role) ->
+    {ok, _} = emqx_dashboard_admin:add_user(Username, ?PASSWORD, Role, <<"desc">>),
+    ok.
+
+token(Username) ->
+    {ok, #{token := Token}} = emqx_dashboard_admin:sign_token(
+        Username, ?PASSWORD, ?TRUSTED_MFA_TOKEN
+    ),
+    Token.
+
+get_current_user(Token) ->
+    request_api(get, api_path(["current_user"]), auth_header(Token)).
+
+change_own_pwd(Token, OldPwd, NewPwd) ->
+    request_api(
+        post,
+        api_path(["current_user", "change_pwd"]),
+        auth_header(Token),
+        #{<<"old_pwd">> => OldPwd, <<"new_pwd">> => NewPwd}
+    ).
+
+setup_own_mfa(Token) ->
+    request_api(
+        post,
+        api_path(["current_user", "mfa"]),
+        auth_header(Token),
+        #{<<"mechanism">> => <<"totp">>}
+    ).
+
+delete_own_mfa(Token) ->
+    request_api(delete, api_path(["current_user", "mfa"]), auth_header(Token), #{}).
+
+admin_setup_mfa(Token, Target) ->
+    request_api(
+        post,
+        api_path(["users", binary_to_list(Target), "mfa"]),
+        auth_header(Token),
+        #{<<"mechanism">> => <<"totp">>}
+    ).
+
+admin_delete_mfa(Token, Target) ->
+    request_api(
+        delete, api_path(["users", binary_to_list(Target), "mfa"]), auth_header(Token), #{}
+    ).
+
+update_user(Token, Target) ->
+    request_api(
+        put,
+        api_path(["users", binary_to_list(Target)]),
+        auth_header(Token),
+        #{<<"description">> => <<"touched">>}
+    ).
+
+delete_user(Token, Target) ->
+    request_api(
+        delete, api_path(["users", binary_to_list(Target)]), auth_header(Token), #{}
+    ).
+
+auth_header(Token) ->
+    {"Authorization", "Bearer " ++ binary_to_list(Token)}.
+
+api_path(Parts) ->
+    ?HOST ++ filename:join([?BASE_PATH | Parts]).
+
+request_api(Method, Url, Auth) ->
+    emqx_common_test_http:request_api(Method, Url, _QueryParams = [], Auth).
+
+request_api(Method, Url, Auth, Body) ->
+    emqx_common_test_http:request_api(Method, Url, _QueryParams = [], Auth, Body).
+
+json(Body) ->
+    emqx_utils_json:decode(Body).
+
+error_code(Body) ->
+    maps:get(<<"code">>, json(Body)).

--- a/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
@@ -14,9 +14,9 @@
 %% routes under `/users/:username/*' are the mirror image: scope plus
 %% global-administrator role, target is always another user.
 %%
-%% The MFA lock policy itself (first-time setup, admin_override) lives
-%% in emqx_dashboard_user_scopes_SUITE; this suite covers the routing,
-%% the identity binding, the password rules and the SSO case.
+%% The self-MFA policy itself (admin_override blocking a self-disable)
+%% lives in emqx_dashboard_user_scopes_SUITE; this suite covers the
+%% routing, the identity binding, the password rules and the SSO case.
 %%--------------------------------------------------------------------
 
 -module(emqx_dashboard_current_user_SUITE).

--- a/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
@@ -11,8 +11,8 @@
 %%
 %% Self endpoints are authorized by the authenticated identity alone --
 %% no scope, no role, no `:username' in the path. The administrator
-%% routes under `/users/:username/*' are the mirror image: scope plus
-%% global-administrator role, target is always another user.
+%% routes under `/users/:username/*' require both a scope and the
+%% global-administrator role, and always target another user.
 %%
 %% The self-MFA policy itself (admin_override blocking a self-disable)
 %% lives in emqx_dashboard_user_scopes_SUITE; this suite covers the
@@ -35,35 +35,23 @@
 -define(PASSWORD, <<"P@ssw0rd_1">>).
 -define(NEW_PASSWORD, <<"P@ssw0rd_2">>).
 
--define(EE_ONLY(EXPR, NON_EE),
-    case emqx_release:edition() of
-        ee -> EXPR;
-        _ -> NON_EE
-    end
-).
-
 all() ->
-    ?EE_ONLY(emqx_common_test_helpers:all(?MODULE), []).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ?EE_ONLY(
-        begin
-            Apps = emqx_cth_suite:start(
-                [
-                    emqx,
-                    emqx_conf,
-                    emqx_management,
-                    emqx_mgmt_api_test_util:emqx_dashboard()
-                ],
-                #{work_dir => emqx_cth_suite:work_dir(Config)}
-            ),
-            [{apps, Apps} | Config]
-        end,
-        Config
-    ).
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
-    ?EE_ONLY(emqx_cth_suite:stop(?config(apps, Config)), ok),
+    emqx_cth_suite:stop(?config(apps, Config)),
     ok.
 
 end_per_testcase(_Case, _Config) ->
@@ -165,9 +153,9 @@ t_viewer_self_service_allowed(_Config) ->
         [undefined, []]
     ).
 
-%% The mirror image: a viewer is refused on every administrator route,
-%% for every target -- another user and itself alike. Deleting the
-%% viewer-self RBAC clauses is what closes the "itself" half.
+%% A viewer is refused on every administrator route, for every target --
+%% another user and itself alike. There is no self-exemption in the
+%% RBAC check on those routes.
 t_viewer_denied_on_admin_routes(_Config) ->
     ok = add_user(<<"viewer">>, ?ROLE_VIEWER),
     ok = add_user(<<"other">>, ?ROLE_VIEWER),
@@ -187,8 +175,8 @@ t_viewer_denied_on_admin_routes(_Config) ->
 %%--------------------------------------------------------------------
 
 %% An administrator manages other users through the admin routes and
-%% its own account through the self routes -- and the admin routes
-%% refuse a self target rather than quietly doing the wrong thing.
+%% its own account through the self routes; the admin routes refuse a
+%% self target with 400.
 t_admin_manages_others_and_self_separately(_Config) ->
     ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
     ok = add_user(<<"other">>, ?ROLE_VIEWER),
@@ -204,9 +192,8 @@ t_admin_manages_others_and_self_separately(_Config) ->
     ?assertMatch({ok, 204, _}, setup_own_mfa(token(<<"boss">>))),
     ?assertMatch({ok, 204, _}, delete_own_mfa(token(<<"boss">>))).
 
-%% The "cannot delete self" guard now compares the authenticated
-%% identity with the target instead of re-parsing the Authorization
-%% header. Deleting somebody else still works.
+%% The "cannot delete self" guard compares the authenticated identity
+%% with the target. Deleting another user is allowed.
 t_admin_cannot_delete_self(_Config) ->
     ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
     ok = add_user(<<"other">>, ?ROLE_VIEWER),
@@ -316,41 +303,11 @@ t_own_mfa_write_keeps_other_backend_session(_Config) ->
     ?assertMatch({ok, 200, _}, get_current_user(LocalToken)).
 
 %%--------------------------------------------------------------------
-%% Routing
-%%--------------------------------------------------------------------
-
-%% `current_user', `self' and `me' are all legal usernames and there is
-%% no reserved-word check on them. `/current_user' is a top-level path
-%% outside `/users/', so such a user neither shadows nor is shadowed by
-%% the self-service routes, and an administrator still manages it by
-%% name.
-t_username_colliding_with_self_route(_Config) ->
-    ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
-    AdminToken = token(<<"boss">>),
-    lists:foreach(
-        fun(Name) ->
-            ok = add_user(Name, ?ROLE_VIEWER),
-            Token = token(Name),
-            %% The self route serves the caller, whatever it is called.
-            {ok, 200, Body} = get_current_user(Token),
-            ?assertMatch(#{<<"username">> := Name}, json(Body), Name),
-            ?assertMatch({ok, 204, _}, setup_own_mfa(Token), Name),
-            %% ... and the administrator still reaches the account by name.
-            ?assertMatch({ok, 204, _}, admin_delete_mfa(AdminToken, Name), Name),
-            ?assertMatch({ok, 200, _}, get_current_user(token(Name)), Name),
-            ?assertMatch({ok, 200, _}, update_user(AdminToken, Name), Name),
-            ?assertMatch({ok, 204, _}, delete_user(AdminToken, Name), Name)
-        end,
-        [<<"current_user">>, <<"self">>, <<"me">>]
-    ).
-
-%%--------------------------------------------------------------------
 %% Deprecated shim: POST /users/:username/change_pwd
 %%--------------------------------------------------------------------
 
-%% The shim keeps working for the caller's own account, at any role and
-%% with an explicitly emptied scope list -- dropping `user_management'
-%% from the route is what lets a viewer keep its old call.
+%% The shim serves the caller's own account at any role and with an
+%% explicitly emptied scope list: the route requires no scope.
 t_shim_changes_own_password(_Config) ->
     lists:foreach(
         fun(Role) ->
@@ -368,10 +325,8 @@ t_shim_changes_own_password(_Config) ->
     ).
 
 %% Pointing the shim at somebody else is refused with 403, for every
-%% role. Before the split this was allowed through RBAC for an
-%% administrator and merely failed the `old_pwd' check, so a cross-user
-%% call was blocked by accident; now it is blocked on purpose, and the
-%% namespaced-administrator invariant holds by the same single check.
+%% role: the route serves only the caller's own account, which is also
+%% what confines a namespaced administrator to itself.
 t_shim_rejects_other_user(_Config) ->
     ok = add_user(<<"victim">>, ?ROLE_VIEWER),
     lists:foreach(
@@ -426,32 +381,6 @@ t_shim_is_marked_deprecated(_Config) ->
     ?assertEqual(true, maps:get(<<"deprecated">>, Shim, false)),
     Canonical = maps:get(<<"post">>, maps:get(<<"/current_user/change_pwd">>, Paths)),
     ?assertEqual(false, maps:get(<<"deprecated">>, Canonical, false)).
-
-%% The Dashboard SPA and emqx-docs are generated from the OpenAPI spec,
-%% so the split is only really shipped once the spec carries it: the
-%% three self routes present, the administrator password-reset route
-%% gone.
-t_openapi_spec_carries_the_split(_Config) ->
-    ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
-    Url = ?HOST ++ "/api-docs/swagger.json",
-    {ok, {{_, 200, _}, _Headers, Body}} =
-        httpc:request(
-            get, {Url, [auth_header(token(<<"boss">>))]}, [], [{body_format, binary}]
-        ),
-    #{<<"paths">> := Paths} = json(Body),
-    ?assertMatch(#{<<"get">> := _}, maps:get(<<"/current_user">>, Paths)),
-    ?assertMatch(
-        #{<<"post">> := _}, maps:get(<<"/current_user/change_pwd">>, Paths)
-    ),
-    ?assertMatch(
-        #{<<"post">> := _, <<"delete">> := _}, maps:get(<<"/current_user/mfa">>, Paths)
-    ),
-    %% The administrator MFA route stays, and so does the deprecated
-    %% change_pwd shim (see t_shim_is_marked_deprecated).
-    ?assertMatch(
-        #{<<"post">> := _, <<"delete">> := _}, maps:get(<<"/users/{username}/mfa">>, Paths)
-    ),
-    ?assertMatch(#{<<"post">> := _}, maps:get(<<"/users/{username}/change_pwd">>, Paths)).
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
@@ -297,22 +297,88 @@ t_username_colliding_with_self_route(_Config) ->
         [<<"current_user">>, <<"self">>, <<"me">>]
     ).
 
-%% The administrator password-reset route is gone: self password change
-%% is `/current_user/change_pwd' and resetting another user's password
-%% stays CLI-only (`emqx ctl admins passwd'). A stale client hitting the
-%% old path gets a 404 from the router, not a silent success.
-t_old_change_pwd_route_is_gone(_Config) ->
+%%--------------------------------------------------------------------
+%% Deprecated shim: POST /users/:username/change_pwd
+%%--------------------------------------------------------------------
+
+%% The shim keeps working for the caller's own account, at any role and
+%% with an explicitly emptied scope list -- dropping `user_management'
+%% from the route is what lets a viewer keep its old call.
+t_shim_changes_own_password(_Config) ->
+    lists:foreach(
+        fun(Role) ->
+            ok = add_user(<<"u">>, Role),
+            {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"u">>, []),
+            ?assertMatch(
+                {ok, 204, _},
+                shim_change_pwd(token(<<"u">>), <<"u">>, ?PASSWORD, ?NEW_PASSWORD),
+                Role
+            ),
+            ?assertMatch({ok, _}, emqx_dashboard_admin:check(<<"u">>, ?NEW_PASSWORD), Role),
+            {ok, _} = emqx_dashboard_admin:remove_user(<<"u">>)
+        end,
+        [?ROLE_VIEWER, ?ROLE_SUPERUSER, <<"ns:ns1::", ?ROLE_SUPERUSER/binary>>]
+    ).
+
+%% Pointing the shim at somebody else is refused with 403, for every
+%% role. Before the split this was allowed through RBAC for an
+%% administrator and merely failed the `old_pwd' check, so a cross-user
+%% call was blocked by accident; now it is blocked on purpose, and the
+%% namespaced-administrator invariant holds by the same single check.
+t_shim_rejects_other_user(_Config) ->
+    ok = add_user(<<"victim">>, ?ROLE_VIEWER),
+    lists:foreach(
+        fun(Role) ->
+            ok = add_user(<<"u">>, Role),
+            {ok, 403, Body} = shim_change_pwd(
+                token(<<"u">>), <<"victim">>, ?PASSWORD, ?NEW_PASSWORD
+            ),
+            ?assertEqual(<<"NOT_ALLOWED">>, error_code(Body), Role),
+            %% The refusal is real: the target's password is untouched
+            %% and so is the caller's.
+            ?assertMatch({ok, _}, emqx_dashboard_admin:check(<<"victim">>, ?PASSWORD), Role),
+            ?assertMatch({ok, _}, emqx_dashboard_admin:check(<<"u">>, ?PASSWORD), Role),
+            {ok, _} = emqx_dashboard_admin:remove_user(<<"u">>)
+        end,
+        [?ROLE_VIEWER, ?ROLE_SUPERUSER, <<"ns:ns1::", ?ROLE_SUPERUSER/binary>>]
+    ).
+
+%% The shim runs the same checks as the canonical route, because it
+%% delegates to it rather than reimplementing anything.
+t_shim_verifies_old_password(_Config) ->
+    ok = add_user(<<"u">>, ?ROLE_VIEWER),
+    Token = token(<<"u">>),
+    {ok, 400, Wrong} = shim_change_pwd(Token, <<"u">>, <<"not-the-password">>, ?NEW_PASSWORD),
+    ?assertEqual(<<"ERROR_PWD_NOT_MATCH">>, error_code(Wrong)),
+    {ok, 400, Empty} = shim_change_pwd(Token, <<"u">>, <<>>, ?NEW_PASSWORD),
+    ?assertEqual(<<"BAD_REQUEST">>, error_code(Empty)),
+    ?assertMatch({ok, _}, emqx_dashboard_admin:check(<<"u">>, ?PASSWORD)).
+
+%% An SSO caller reaches the delegate and gets the "no local password"
+%% answer. The route has no `?backend' parameter, so without matching on
+%% the name part of the SSO key this would be a misleading 403 instead.
+t_shim_sso_user_gets_no_local_password(_Config) ->
+    Backend = saml,
+    SsoUser = <<"sso-shim@example.com">>,
+    {ok, _} = emqx_dashboard_admin:add_sso_user(Backend, SsoUser, ?ROLE_VIEWER, <<"d">>),
+    SsoKey = ?SSO_USERNAME(Backend, SsoUser),
+    {ok, 400, Body} = shim_change_pwd(sso_token(SsoKey), SsoUser, ?PASSWORD, ?NEW_PASSWORD),
+    ?assertEqual(<<"NOT_ALLOWED">>, error_code(Body)).
+
+%% The shim is advertised as deprecated so clients can see it is on the
+%% way out, and the canonical route is not.
+t_shim_is_marked_deprecated(_Config) ->
     ok = add_user(<<"boss">>, ?ROLE_SUPERUSER),
-    Token = token(<<"boss">>),
-    Url = api_path(["users", "boss", "change_pwd"]),
-    ?assertMatch(
-        {ok, 404, _},
-        request_api(
-            post, Url, auth_header(Token), #{old_pwd => ?PASSWORD, new_pwd => ?NEW_PASSWORD}
-        )
-    ),
-    %% The password is untouched: the route did not silently succeed.
-    ?assertMatch({ok, _}, emqx_dashboard_admin:check(<<"boss">>, ?PASSWORD)).
+    Url = ?HOST ++ "/api-docs/swagger.json",
+    {ok, {{_, 200, _}, _Headers, Body}} =
+        httpc:request(
+            get, {Url, [auth_header(token(<<"boss">>))]}, [], [{body_format, binary}]
+        ),
+    #{<<"paths">> := Paths} = json(Body),
+    Shim = maps:get(<<"post">>, maps:get(<<"/users/{username}/change_pwd">>, Paths)),
+    ?assertEqual(true, maps:get(<<"deprecated">>, Shim, false)),
+    Canonical = maps:get(<<"post">>, maps:get(<<"/current_user/change_pwd">>, Paths)),
+    ?assertEqual(false, maps:get(<<"deprecated">>, Canonical, false)).
 
 %% The Dashboard SPA and emqx-docs are generated from the OpenAPI spec,
 %% so the split is only really shipped once the spec carries it: the
@@ -333,15 +399,12 @@ t_openapi_spec_carries_the_split(_Config) ->
     ?assertMatch(
         #{<<"post">> := _, <<"delete">> := _}, maps:get(<<"/current_user/mfa">>, Paths)
     ),
-    ?assertEqual(
-        error,
-        maps:find(<<"/users/{username}/change_pwd">>, Paths),
-        {stale_admin_password_reset_route, maps:keys(Paths)}
-    ),
-    %% The administrator MFA route stays.
+    %% The administrator MFA route stays, and so does the deprecated
+    %% change_pwd shim (see t_shim_is_marked_deprecated).
     ?assertMatch(
         #{<<"post">> := _, <<"delete">> := _}, maps:get(<<"/users/{username}/mfa">>, Paths)
-    ).
+    ),
+    ?assertMatch(#{<<"post">> := _}, maps:get(<<"/users/{username}/change_pwd">>, Paths)).
 
 %%--------------------------------------------------------------------
 %% Helpers
@@ -365,6 +428,14 @@ token(Username) ->
 
 get_current_user(Token) ->
     request_api(get, api_path(["current_user"]), auth_header(Token)).
+
+shim_change_pwd(Token, Target, OldPwd, NewPwd) ->
+    request_api(
+        post,
+        api_path(["users", binary_to_list(Target), "change_pwd"]),
+        auth_header(Token),
+        #{<<"old_pwd">> => OldPwd, <<"new_pwd">> => NewPwd}
+    ).
 
 change_own_pwd(Token, OldPwd, NewPwd) ->
     request_api(

--- a/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_current_user_SUITE.erl
@@ -286,6 +286,35 @@ t_own_mfa_write_ends_session(_Config) ->
     %% A fresh login is all it takes.
     ?assertMatch({ok, 200, _}, get_current_user(token(<<"viewer">>))).
 
+%% An SSO account's sessions end on a self MFA re-key just as a local
+%% account's do. A JWT row keeps the bare name and the backend in
+%% separate fields, so token invalidation has to match on the resolved
+%% key rather than on the name alone.
+t_own_mfa_write_ends_sso_session(_Config) ->
+    Backend = saml,
+    SsoUser = <<"sso-mfa@example.com">>,
+    {ok, _} = emqx_dashboard_admin:add_sso_user(Backend, SsoUser, ?ROLE_VIEWER, <<"d">>),
+    SsoKey = ?SSO_USERNAME(Backend, SsoUser),
+    Token = sso_token(SsoKey),
+    ?assertMatch({ok, 200, _}, get_current_user(Token)),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(Token)),
+    {ok, 401, Body} = get_current_user(Token),
+    ?assertEqual(<<"BAD_TOKEN">>, error_code(Body)),
+    ?assertMatch({ok, 200, _}, get_current_user(sso_token(SsoKey))).
+
+%% A local account and an SSO account may carry the same name. Ending
+%% one account's sessions leaves the other's alone.
+t_own_mfa_write_keeps_other_backend_session(_Config) ->
+    Name = <<"twin_user">>,
+    Backend = saml,
+    ok = add_user(Name, ?ROLE_VIEWER),
+    {ok, _} = emqx_dashboard_admin:add_sso_user(Backend, Name, ?ROLE_VIEWER, <<"d">>),
+    LocalToken = token(Name),
+    SsoToken = sso_token(?SSO_USERNAME(Backend, Name)),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(SsoToken)),
+    ?assertMatch({ok, 401, _}, get_current_user(SsoToken)),
+    ?assertMatch({ok, 200, _}, get_current_user(LocalToken)).
+
 %%--------------------------------------------------------------------
 %% Routing
 %%--------------------------------------------------------------------

--- a/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
@@ -246,11 +246,14 @@ t_disable_mfa(_Config) ->
     ?assertMatch({ok, 204, _}, enable_mfa(<<"viewer2">>), AdminJwtToken),
     {ok, 200, RspBody} = login(LoginBody),
     #{<<"token">> := JwtToken} = json_map(RspBody),
-    %% viewer1 cannot disable own admin-enforced MFA
+    %% viewer1 cannot disable own admin-enforced MFA (MFA_LOCKED on
+    %% its own route -- admin_override = mfa_required).
+    ?assertMatch({ok, 403, _}, disable_own_mfa(JwtToken)),
+    %% a viewer may not reach the administrator routes at all, for any
+    %% target -- including itself.
+    ?assertMatch({ok, 403, _}, enable_mfa(<<"viewer1">>, JwtToken)),
     ?assertMatch({ok, 403, _}, disable_mfa(<<"viewer1">>, JwtToken)),
-    %% viewer is not allow to enable other user's MFA
     ?assertMatch({ok, 403, _}, enable_mfa(<<"viewer2">>, JwtToken)),
-    %% viewer is not allow to disable other user's MFA
     ?assertMatch({ok, 403, _}, disable_mfa(<<"viewer2">>, JwtToken)),
     %% admin can disable any user's MFA (overrides admin_required)
     ?assertMatch({ok, 204, _}, disable_mfa(<<"viewer1">>, AdminJwtToken)),
@@ -307,15 +310,17 @@ t_enable_by_config(_Config) ->
     ),
     {ok, 200, LoginRsp} = login(LoginBody#{<<"mfa_token">> => ?GOOD_TOTP}),
     #{<<"token">> := JwtToken} = json_map(LoginRsp),
-    %% mark MFA disalbed for this user
-    ?assertMatch({ok, 204, _}, disable_mfa(<<"viewer1">>, JwtToken)),
+    %% mark MFA disabled for this user (self-service: no administrator
+    %% decision recorded against the account, so it is not locked)
+    ?assertMatch({ok, 204, _}, disable_own_mfa(JwtToken)),
     ?assertMatch(#{<<"mfa">> := <<"disabled">>}, get_user(<<"viewer1">>)),
     %% should be able to login without TOTP even though default MFA is configured
     {ok, 200, _} = login(LoginBody),
     ok.
 
 %% DELETE MFA ignores the historical reset query parameter.
-%% Resetting/re-keying MFA should be done with POST /users/:username/mfa.
+%% Resetting/re-keying another user's MFA is POST /users/:username/mfa;
+%% for one's own account it is POST /current_user/mfa.
 t_reset_mfa({init, Config}) ->
     ok = mock_totp(),
     _ = emqx_dashboard_admin:clear_mfa_state(<<"viewer1">>),
@@ -373,9 +378,9 @@ t_reset_mfa_reinit_error(_Config) ->
         body => #{<<"mechanism">> => <<"totp">>},
         query_string => #{<<"backend">> => <<"local">>},
         %% Simulate authn metadata that minirest injects after a
-        %% successful bearer token verification (admin1 lookup
-        %% succeeds on the existing fixture, granting mfa_management
-        %% via the role-default fallback in caller_has_mfa_mgmt/1).
+        %% successful bearer token verification. admin1 is not the
+        %% target, so `reject_self_target/2' lets the call through to
+        %% the mecked `reinit_mfa/3'.
         auth_meta => #{auth_type => jwt_token, source => <<"admin1">>}
     },
     ?assertMatch({400, 'BAD_REQUEST', <<"boom">>}, emqx_dashboard_api:change_mfa(post, Req)),
@@ -412,6 +417,9 @@ enable_mfa(User, JwtToken) ->
 
 disable_mfa(User, JwtToken) ->
     request_api(delete, api_path(["users", User, mfa]), auth_header(JwtToken), #{}).
+
+disable_own_mfa(JwtToken) ->
+    request_api(delete, api_path(["current_user", "mfa"]), auth_header(JwtToken), #{}).
 
 delete_mfa_with_reset_query(User, JwtToken) ->
     Url = binary_to_list(iolist_to_binary(api_path(["users", User, "mfa"]))),

--- a/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
@@ -246,8 +246,8 @@ t_disable_mfa(_Config) ->
     ?assertMatch({ok, 204, _}, enable_mfa(<<"viewer2">>), AdminJwtToken),
     {ok, 200, RspBody} = login(LoginBody),
     #{<<"token">> := JwtToken} = json_map(RspBody),
-    %% viewer1 cannot disable own admin-enforced MFA (MFA_LOCKED on
-    %% its own route -- admin_override = mfa_required).
+    %% viewer1 cannot disable own admin-enforced MFA (MFA_ADMIN_REQUIRED
+    %% on its own route -- admin_override = mfa_required).
     ?assertMatch({ok, 403, _}, disable_own_mfa(JwtToken)),
     %% a viewer may not reach the administrator routes at all, for any
     %% target -- including itself.

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -4,23 +4,16 @@
 %%
 %% Coverage for dashboard login user scope checking
 %% (emqx_dashboard_rbac:check_login_user_scopes/2) and the MFA
-%% self-lock matrix (emqx_dashboard_api:authorize_mfa_change/3).
+%% authorization rules on both sides of the self/admin split.
 %%
-%% MFA self-lock decision matrix:
+%% Self-MFA (`/current_user/mfa', emqx_dashboard_api:authorize_self_mfa/2):
 %%
-%%   IsFirstSetup = (Op == setup) AND (target.mfa_state == not_configured)
-%%   IsSelf       = (caller.username == target)
-%%   HasMfaMgmt   = caller effective scopes contain mfa_management
-%%   Locked       = target.admin_override == mfa_required
-%%                  (admin_override == mfa_exempted or undefined => unlocked)
+%%   first-time setup          => allow (deadlock prevention)
+%%   admin_override = required => deny  MFA_LOCKED
+%%   otherwise                 => allow
 %%
-%%   IsFirstSetup                                    => allow (deadlock prevention)
-%%   IsSelf       AND HasMfaMgmt                     => allow (self-exempt)
-%%   IsSelf       AND NOT HasMfaMgmt AND NOT Locked  => allow
-%%   IsSelf       AND NOT HasMfaMgmt AND Locked      => deny  mfa_locked
-%%   NOT IsSelf   AND HasMfaMgmt AND administrator   => allow (admin reset)
-%%   NOT IsSelf   AND HasMfaMgmt AND non-admin       => deny  self_only
-%%   NOT IsSelf   AND NOT HasMfaMgmt                 => deny  missing_mfa_mgmt
+%% Administrator MFA (`/users/:username/mfa'): global administrator
+%% holding `mfa_management', target must be another user.
 %%
 %% Field-write tests verify the admin_override write rules:
 %% admin reinit writes mfa_required; admin disable writes mfa_exempted;
@@ -1040,49 +1033,35 @@ t_role_demotion_with_compatible_persisted_scopes_succeeds(_Config) ->
     ?assertEqual(?ROLE_VIEWER, Admin#?ADMIN.role).
 
 %%--------------------------------------------------------------------
-%% MFA self-lock matrix (the 7-line decision table)
+%% Self-MFA policy (`/current_user/mfa')
+%%
+%% What used to be a seven-row matrix over {IsFirstSetup, IsSelf,
+%% HasMfaMgmt, Locked, CallerRole} is now two rules, because the caller
+%% and the subject are the same identity on these routes:
+%%
+%%   first-time setup          => allow  (deadlock prevention)
+%%   admin_override = required => deny   (MFA_LOCKED)
+%%   otherwise                 => allow
+%%
+%% `mfa_management' no longer acts as a self-exemption key: it is an
+%% administrator-only scope meaning "manage OTHER users' MFA". The exits
+%% from a locked account are an administrator exemption and the CLI.
 %%--------------------------------------------------------------------
 
-%% Row 1: First-time setup is always allowed, regardless of locks.
-%% Without this, a user with force_mfa=true would be unable to
-%% complete initial MFA setup (deadlock).
+%% First-time setup is always allowed, regardless of the lock. Without
+%% this a user under an active mandate could never enrol (deadlock).
 t_first_time_setup_always_allowed(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
         <<"u">>, test_password(), ?ROLE_VIEWER, "u"
     ),
-    %% Force the lock state — would normally block a non-first-time
-    %% rotate. mfa_state is absent (not_configured), so the matrix
-    %% short-circuits to allow.
+    %% Force the lock state -- it would block a rotate, but mfa_state is
+    %% absent (not_configured), so first-time setup short-circuits it.
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
     Token = jwt(<<"u">>, test_password()),
-    Body = #{<<"mechanism">> => <<"totp">>},
-    ?assertMatch(
-        {ok, 204, _},
-        request_api(post, api_path(["users", "u", "mfa"]), auth_header(Token), Body)
-    ).
+    ?assertMatch({ok, 204, _}, setup_own_mfa(Token)).
 
-%% Row 2: Self with mfa_management scope, locked — allowed.
-t_self_with_mfa_mgmt_can_rotate_under_force_mfa_lock(_Config) ->
-    add_admin(<<"admin">>),
-    {ok, _} = emqx_dashboard_admin:add_user(
-        <<"u">>, test_password(), ?ROLE_VIEWER, "u"
-    ),
-    {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"u">>, [?SCOPE_MFA_MGMT]),
-    %% First setup MFA so subsequent POST is a rotate, not first-setup
-    {ok, ok} = emqx_dashboard_admin:set_mfa_state(
-        <<"u">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
-    ),
-    %% Now lock the user
-    {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
-    Token = jwt(<<"u">>, test_password()),
-    Body = #{<<"mechanism">> => <<"totp">>},
-    ?assertMatch(
-        {ok, 204, _},
-        request_api(post, api_path(["users", "u", "mfa"]), auth_header(Token), Body)
-    ).
-
-%% Row 3: Self without mfa_management, NOT locked — allowed.
+%% Not locked: a user may rotate its own MFA.
 t_self_can_rotate_when_not_locked(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -1092,31 +1071,9 @@ t_self_can_rotate_when_not_locked(_Config) ->
         <<"u">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
     ),
     Token = jwt(<<"u">>, test_password()),
-    Body = #{<<"mechanism">> => <<"totp">>},
-    ?assertMatch(
-        {ok, 204, _},
-        request_api(post, api_path(["users", "u", "mfa"]), auth_header(Token), Body)
-    ).
+    ?assertMatch({ok, 204, _}, setup_own_mfa(Token)).
 
-%% Row 4: Self without mfa_management, force_mfa locked — denied.
-t_self_cannot_rotate_when_force_mfa_locked(_Config) ->
-    add_admin(<<"admin">>),
-    {ok, _} = emqx_dashboard_admin:add_user(
-        <<"u">>, test_password(), ?ROLE_VIEWER, "u"
-    ),
-    {ok, ok} = emqx_dashboard_admin:set_mfa_state(
-        <<"u">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
-    ),
-    {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
-    Token = jwt(<<"u">>, test_password()),
-    Body = #{<<"mechanism">> => <<"totp">>},
-    {ok, 403, RespBody} = request_api(
-        post, api_path(["users", "u", "mfa"]), auth_header(Token), Body
-    ),
-    Json = emqx_utils_json:decode(RespBody),
-    ?assertEqual(<<"MFA_LOCKED">>, maps:get(<<"code">>, Json)).
-
-%% Row 4 variant: admin override mfa_required instead of force_mfa.
+%% Locked by an administrator decision: rotate is denied.
 t_self_cannot_rotate_when_admin_override_required_locked(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -1127,33 +1084,10 @@ t_self_cannot_rotate_when_admin_override_required_locked(_Config) ->
     ),
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
     Token = jwt(<<"u">>, test_password()),
-    Body = #{<<"mechanism">> => <<"totp">>},
-    {ok, 403, RespBody} = request_api(
-        post, api_path(["users", "u", "mfa"]), auth_header(Token), Body
-    ),
-    Json = emqx_utils_json:decode(RespBody),
-    ?assertEqual(<<"MFA_LOCKED">>, maps:get(<<"code">>, Json)).
+    {ok, 403, RespBody} = setup_own_mfa(Token),
+    ?assertEqual(<<"MFA_LOCKED">>, error_code(RespBody)).
 
-%% admin_override = mfa_required locks self changes: holding
-%% mfa_management scope self-exempts from both.
-t_self_with_mfa_mgmt_can_rotate_under_admin_override_required_lock(_Config) ->
-    add_admin(<<"admin">>),
-    {ok, _} = emqx_dashboard_admin:add_user(
-        <<"u">>, test_password(), ?ROLE_VIEWER, "u"
-    ),
-    {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"u">>, [?SCOPE_MFA_MGMT]),
-    {ok, ok} = emqx_dashboard_admin:set_mfa_state(
-        <<"u">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
-    ),
-    {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
-    Token = jwt(<<"u">>, test_password()),
-    Body = #{<<"mechanism">> => <<"totp">>},
-    ?assertMatch(
-        {ok, 204, _},
-        request_api(post, api_path(["users", "u", "mfa"]), auth_header(Token), Body)
-    ).
-
-%% Self-DELETE under admin_override=mfa_required without mfa_management — denied.
+%% Locked by an administrator decision: self-disable is denied too.
 t_self_cannot_delete_when_admin_override_required_locked(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -1164,18 +1098,17 @@ t_self_cannot_delete_when_admin_override_required_locked(_Config) ->
     ),
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
     Token = jwt(<<"u">>, test_password()),
-    {ok, 403, RespBody} = request_api(
-        delete, api_path(["users", "u", "mfa"]), auth_header(Token), #{}
-    ),
-    Json = emqx_utils_json:decode(RespBody),
-    ?assertEqual(<<"MFA_LOCKED">>, maps:get(<<"code">>, Json)).
+    {ok, 403, RespBody} = delete_own_mfa(Token),
+    ?assertEqual(<<"MFA_LOCKED">>, error_code(RespBody)).
 
-%% Self-DELETE under admin_override=mfa_required WITH mfa_management — allowed
-%% (self-exemption applies to DELETE too, not just POST/rotate).
-t_self_with_mfa_mgmt_can_delete_under_admin_override_required_lock(_Config) ->
+%% `mfa_management' is no longer a self-exemption key. It is now an
+%% administrator-only scope, so the holder must be an administrator --
+%% and even then it does not unlock their own account. Replaces the two
+%% former "self with mfa_management can rotate/delete under lock" rows.
+t_self_with_mfa_mgmt_still_locked(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
-        <<"u">>, test_password(), ?ROLE_VIEWER, "u"
+        <<"u">>, test_password(), ?ROLE_SUPERUSER, "u"
     ),
     {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"u">>, [?SCOPE_MFA_MGMT]),
     {ok, ok} = emqx_dashboard_admin:set_mfa_state(
@@ -1183,13 +1116,30 @@ t_self_with_mfa_mgmt_can_delete_under_admin_override_required_lock(_Config) ->
     ),
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
     Token = jwt(<<"u">>, test_password()),
-    ?assertMatch(
-        {ok, 204, _},
-        request_api(delete, api_path(["users", "u", "mfa"]), auth_header(Token), #{})
-    ).
+    {ok, 403, RotateBody} = setup_own_mfa(Token),
+    ?assertEqual(<<"MFA_LOCKED">>, error_code(RotateBody)),
+    {ok, 403, DeleteBody} = delete_own_mfa(Token),
+    ?assertEqual(<<"MFA_LOCKED">>, error_code(DeleteBody)).
 
-%% Row 5: Admin can reset another user's MFA — admin has implicit
-%% mfa_management via role-default fallback.
+%% A viewer with an explicitly emptied scope list still reaches its own
+%% MFA: self-service is not scope-gated.
+t_self_mfa_not_gated_by_scopes(_Config) ->
+    add_admin(<<"admin">>),
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"u">>, test_password(), ?ROLE_VIEWER, "u"
+    ),
+    {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"u">>, []),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(jwt(<<"u">>, test_password()))),
+    %% Re-keying MFA invalidates the account's sessions, so the disable
+    %% needs a fresh token.
+    ?assertMatch({ok, 204, _}, delete_own_mfa(jwt(<<"u">>, test_password()))).
+
+%%--------------------------------------------------------------------
+%% Administrator MFA routes (`/users/:username/mfa')
+%%--------------------------------------------------------------------
+
+%% An administrator resets another user's MFA. The role default gives
+%% an administrator `mfa_management' implicitly.
 t_admin_can_reset_others_mfa(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -1199,17 +1149,25 @@ t_admin_can_reset_others_mfa(_Config) ->
         <<"u">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
     ),
     Token = jwt(<<"admin">>, test_password()),
-    ?assertMatch(
-        {ok, 204, _},
-        request_api(
-            delete, api_path(["users", "u", "mfa"]), auth_header(Token), #{}
-        )
-    ).
+    ?assertMatch({ok, 204, _}, admin_delete_mfa(Token, <<"u">>)).
 
-%% End-to-end: admin disables a policy-locked user's MFA, then the
-%% user can self-setup MFA again (admin_override=mfa_exempted unlocks
-%% them despite snapshot=true). This exercises the full HTTP path
-%% across admin disable → self POST.
+%% The admin routes manage OTHER users only. An administrator aiming
+%% them at its own account is refused and pointed at /current_user/mfa,
+%% so a self-change cannot be laundered into an `admin_override' write.
+t_admin_cannot_target_self_on_admin_route(_Config) ->
+    add_admin(<<"admin">>),
+    Token = jwt(<<"admin">>, test_password()),
+    {ok, 400, PostBody} = admin_setup_mfa(Token, <<"admin">>),
+    ?assertEqual(<<"NOT_ALLOWED">>, error_code(PostBody)),
+    {ok, 400, DeleteBody} = admin_delete_mfa(Token, <<"admin">>),
+    ?assertEqual(<<"NOT_ALLOWED">>, error_code(DeleteBody)),
+    %% The refusal is a guard, not a side effect: no administrator
+    %% decision was recorded against the account.
+    ?assertEqual(undefined, emqx_dashboard_admin:admin_override_of(<<"admin">>)).
+
+%% End-to-end: an administrator exemption is the way out of a locked
+%% account. Admin disables (writes mfa_exempted), the user may then
+%% enrol again through its own route.
 t_admin_disable_unlocks_user_for_self_setup(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -1220,30 +1178,13 @@ t_admin_disable_unlocks_user_for_self_setup(_Config) ->
         <<"u">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
     ),
     AdminToken = jwt(<<"admin">>, test_password()),
-    %% Admin disables MFA — writes admin_override=mfa_exempted.
-    ?assertMatch(
-        {ok, 204, _},
-        request_api(
-            delete, api_path(["users", "u", "mfa"]), auth_header(AdminToken), #{}
-        )
-    ),
+    ?assertMatch({ok, 204, _}, admin_delete_mfa(AdminToken, <<"u">>)),
     ?assertEqual(?ADMIN_MFA_EXEMPTED, emqx_dashboard_admin:admin_override_of(<<"u">>)),
-    %% User self-setup MFA — would be locked by snapshot=true, but
-    %% admin_override=mfa_exempted overrides.
     UserToken = jwt(<<"u">>, test_password()),
-    ?assertMatch(
-        {ok, 204, _},
-        request_api(
-            post,
-            api_path(["users", "u", "mfa"]),
-            auth_header(UserToken),
-            #{<<"mechanism">> => <<"totp">>}
-        )
-    ).
+    ?assertMatch({ok, 204, _}, setup_own_mfa(UserToken)).
 
-%% End-to-end: admin forces MFA on a previously unlocked user
-%% (snapshot=false). User cannot self-disable afterwards even though
-%% snapshot says no lock — admin_override=mfa_required overrides.
+%% End-to-end: an administrator reset locks the account against
+%% self-disable, which is what `default_mfa' enforcement rests on.
 t_admin_force_locks_user_against_self_disable(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -1251,16 +1192,7 @@ t_admin_force_locks_user_against_self_disable(_Config) ->
     ),
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, undefined),
     AdminToken = jwt(<<"admin">>, test_password()),
-    %% Admin forces MFA setup — writes admin_override=mfa_required.
-    ?assertMatch(
-        {ok, 204, _},
-        request_api(
-            post,
-            api_path(["users", "u", "mfa"]),
-            auth_header(AdminToken),
-            #{<<"mechanism">> => <<"totp">>}
-        )
-    ),
+    ?assertMatch({ok, 204, _}, admin_setup_mfa(AdminToken, <<"u">>)),
     ?assertEqual(?ADMIN_MFA_REQUIRED, emqx_dashboard_admin:admin_override_of(<<"u">>)),
     %% Make MFA actually enabled (post-verify); set state directly to
     %% bypass the verify step.
@@ -1268,44 +1200,12 @@ t_admin_force_locks_user_against_self_disable(_Config) ->
         <<"u">>, #{mechanism => totp, secret => <<"S2">>, first_verify_ts => 1}
     ),
     UserToken = jwt(<<"u">>, test_password()),
-    %% User self-disable denied — admin_override=mfa_required locks
-    %% even with snapshot=false.
-    {ok, 403, RespBody} = request_api(
-        delete, api_path(["users", "u", "mfa"]), auth_header(UserToken), #{}
-    ),
-    Json = emqx_utils_json:decode(RespBody),
-    ?assertEqual(<<"MFA_LOCKED">>, maps:get(<<"code">>, Json)).
+    {ok, 403, RespBody} = delete_own_mfa(UserToken),
+    ?assertEqual(<<"MFA_LOCKED">>, error_code(RespBody)).
 
-%% Row 6: Non-admin with mfa_management cannot manage other users' MFA.
-%%
-%% Note: in the current code path the request is rejected by the
-%% existing RBAC layer (PR #16943, preserved unchanged) BEFORE the
-%% MFA self-lock check has a chance to run — the RBAC clause for
-%% ?ROLE_VIEWER POST /users/<other>/mfa returns false. So the
-%% expected error code is UNAUTHORIZED_ROLE, not MFA_SELF_ONLY.
-%%
-%% This is the correct RBAC × scope stacking behaviour. MFA_SELF_ONLY
-%% would only be reachable if a future change ever loosens the RBAC
-%% viewer rule for cross-user MFA paths; the scope check serves as
-%% defense-in-depth for that scenario.
-t_non_admin_with_mfa_mgmt_cannot_reset_others(_Config) ->
-    add_admin(<<"admin">>),
-    {ok, _} = emqx_dashboard_admin:add_user(
-        <<"v1">>, test_password(), ?ROLE_VIEWER, "v1"
-    ),
-    {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"v1">>, [?SCOPE_MFA_MGMT]),
-    {ok, _} = emqx_dashboard_admin:add_user(
-        <<"v2">>, test_password(), ?ROLE_VIEWER, "v2"
-    ),
-    {ok, ok} = emqx_dashboard_admin:set_mfa_state(
-        <<"v2">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
-    ),
-    Token = jwt(<<"v1">>, test_password()),
-    {ok, 403, _RespBody} = request_api(
-        delete, api_path(["users", "v2", "mfa"]), auth_header(Token), #{}
-    ).
-
-%% Row 7: Non-admin without mfa_management cannot manage other users' MFA.
+%% A non-administrator cannot reach the admin MFA route at all, with or
+%% without an explicit scope list. RBAC rejects it before any policy
+%% check runs, so the assertion is on the status, not the error code.
 t_viewer_cannot_reset_other_users_mfa(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -1314,15 +1214,32 @@ t_viewer_cannot_reset_other_users_mfa(_Config) ->
     {ok, _} = emqx_dashboard_admin:add_user(
         <<"v2">>, test_password(), ?ROLE_VIEWER, "v2"
     ),
-    Token = jwt(<<"v1">>, test_password()),
-    {ok, 403, RespBody} = request_api(
-        delete, api_path(["users", "v2", "mfa"]), auth_header(Token), #{}
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(
+        <<"v2">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
     ),
-    Json = emqx_utils_json:decode(RespBody),
-    %% RBAC layer rejects this BEFORE the scope check kicks in (viewer
-    %% cannot DELETE on /users/<other>/mfa). The exact error code
-    %% depends on which layer rejects first, but it must be 403.
-    ?assert(maps:is_key(<<"code">>, Json)).
+    Token = jwt(<<"v1">>, test_password()),
+    ?assertMatch({ok, 403, _}, admin_delete_mfa(Token, <<"v2">>)),
+    ?assertMatch({ok, 403, _}, admin_setup_mfa(Token, <<"v2">>)).
+
+%% A namespaced administrator is denied on another user's MFA even
+%% inside its own namespace -- the cross-user reset vector stays closed.
+t_ns_admin_cannot_reset_other_users_mfa(_Config) ->
+    add_admin(<<"admin">>),
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"nsadmin">>, test_password(), <<"ns:ns1::", ?ROLE_SUPERUSER/binary>>, "ns"
+    ),
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"victim">>, test_password(), ?ROLE_VIEWER, "victim"
+    ),
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(
+        <<"victim">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
+    ),
+    Token = jwt(<<"nsadmin">>, test_password()),
+    ?assertMatch({ok, 403, _}, admin_delete_mfa(Token, <<"victim">>)),
+    ?assertMatch({ok, 403, _}, admin_setup_mfa(Token, <<"victim">>)),
+    %% ... and its own account is reachable only through /current_user.
+    ?assertMatch({ok, 403, _}, admin_delete_mfa(Token, <<"nsadmin">>)),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(Token)).
 
 %%--------------------------------------------------------------------
 %% Field-write triggers (admin_override write rules)
@@ -1454,3 +1371,36 @@ request_api(Method, Url, Auth, Body) ->
     emqx_common_test_http:request_api(
         Method, Url, _QueryParams = [], Auth, Body
     ).
+
+%% Self-service requests: no username in the path, the bearer token is
+%% the whole subject.
+setup_own_mfa(Token) ->
+    request_api(
+        post,
+        api_path(["current_user", "mfa"]),
+        auth_header(Token),
+        #{<<"mechanism">> => <<"totp">>}
+    ).
+
+delete_own_mfa(Token) ->
+    request_api(delete, api_path(["current_user", "mfa"]), auth_header(Token), #{}).
+
+%% Administrator requests against another user's account.
+admin_setup_mfa(Token, TargetUsername) ->
+    request_api(
+        post,
+        api_path(["users", binary_to_list(TargetUsername), "mfa"]),
+        auth_header(Token),
+        #{<<"mechanism">> => <<"totp">>}
+    ).
+
+admin_delete_mfa(Token, TargetUsername) ->
+    request_api(
+        delete,
+        api_path(["users", binary_to_list(TargetUsername), "mfa"]),
+        auth_header(Token),
+        #{}
+    ).
+
+error_code(RespBody) ->
+    maps:get(<<"code">>, emqx_utils_json:decode(RespBody)).

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -476,10 +476,7 @@ t_viewer_cannot_hold_user_management(_Config) ->
     ).
 
 %% Viewer cannot hold mfa_management: the scope means "manage another
-%% user's MFA" and is administrator-only. Its former non-administrator
-%% meaning (a self-exemption key) is gone -- managing one's own MFA is
-%% an identity-authorized operation on /current_user/mfa and needs no
-%% scope.
+%% user's MFA" and is administrator-only.
 t_viewer_cannot_hold_mfa_management(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
@@ -1042,9 +1039,8 @@ t_role_demotion_with_compatible_persisted_scopes_succeeds(_Config) ->
 %%--------------------------------------------------------------------
 %% Self-MFA policy (`/current_user/mfa')
 %%
-%% What used to be a seven-row matrix over {IsFirstSetup, IsSelf,
-%% HasMfaMgmt, Locked, CallerRole} is now one rule, because the caller
-%% and the subject are the same identity on these routes:
+%% One rule covers these routes, because the caller and the subject are
+%% the same identity:
 %%
 %%   setup / rotate             => allow  (never gated)
 %%   disable, override=required => deny   (MFA_ADMIN_REQUIRED)
@@ -1053,9 +1049,9 @@ t_role_demotion_with_compatible_persisted_scopes_succeeds(_Config) ->
 %% Rotation stays open under the requirement: it keeps MFA enabled, so it
 %% cannot weaken what the override protects.
 %%
-%% `mfa_management' no longer acts as a self-exemption key: it is an
-%% administrator-only scope meaning "manage OTHER users' MFA". The exits
-%% from a locked account are an administrator exemption and the CLI.
+%% `mfa_management' is an administrator-only scope meaning "manage OTHER
+%% users' MFA"; it does not exempt its holder on their own account. The
+%% exits from a locked account are an administrator exemption and the CLI.
 %%--------------------------------------------------------------------
 
 %% First-time setup is always allowed, regardless of the lock. Without
@@ -1115,11 +1111,9 @@ t_self_cannot_delete_when_admin_override_required(_Config) ->
     {ok, 403, RespBody} = delete_own_mfa(Token),
     ?assertEqual(<<"MFA_ADMIN_REQUIRED">>, error_code(RespBody)).
 
-%% `mfa_management' is no longer a self-exemption key. It is now an
-%% administrator-only scope, so the holder must be an administrator --
-%% and even then it does not lift the requirement on their own account.
-%% Replaces the two former "self with mfa_management can rotate/delete
-%% under lock" rows.
+%% `mfa_management' does not lift the requirement on its holder's own
+%% account. It is an administrator-only scope, so the holder must be an
+%% administrator, and the self route still denies the disable.
 t_self_with_mfa_mgmt_still_required(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -1167,7 +1161,7 @@ t_admin_can_reset_others_mfa(_Config) ->
 
 %% The admin routes manage OTHER users only. An administrator aiming
 %% them at its own account is refused and pointed at /current_user/mfa,
-%% so a self-change cannot be laundered into an `admin_override' write.
+%% so a self-change cannot write `admin_override'.
 t_admin_cannot_target_self_on_admin_route(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
@@ -1236,7 +1230,8 @@ t_viewer_cannot_reset_other_users_mfa(_Config) ->
     ?assertMatch({ok, 403, _}, admin_setup_mfa(Token, <<"v2">>)).
 
 %% A namespaced administrator is denied on another user's MFA even
-%% inside its own namespace -- the cross-user reset vector stays closed.
+%% inside its own namespace, and reaches its own account only through
+%% /current_user/mfa.
 t_ns_admin_cannot_reset_other_users_mfa(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -6,11 +6,12 @@
 %% (emqx_dashboard_rbac:check_login_user_scopes/2) and the MFA
 %% authorization rules on both sides of the self/admin split.
 %%
-%% Self-MFA (`/current_user/mfa', emqx_dashboard_api:authorize_self_mfa/2):
+%% Self-MFA (`/current_user/mfa',
+%% emqx_dashboard_api:authorize_self_mfa_disable/1):
 %%
-%%   first-time setup          => allow (deadlock prevention)
-%%   admin_override = required => deny  MFA_LOCKED
-%%   otherwise                 => allow
+%%   setup / rotate             => allow (never gated)
+%%   disable, override=required => deny  MFA_ADMIN_REQUIRED
+%%   disable, otherwise         => allow
 %%
 %% Administrator MFA (`/users/:username/mfa'): global administrator
 %% holding `mfa_management', target must be another user.
@@ -1042,12 +1043,15 @@ t_role_demotion_with_compatible_persisted_scopes_succeeds(_Config) ->
 %% Self-MFA policy (`/current_user/mfa')
 %%
 %% What used to be a seven-row matrix over {IsFirstSetup, IsSelf,
-%% HasMfaMgmt, Locked, CallerRole} is now two rules, because the caller
+%% HasMfaMgmt, Locked, CallerRole} is now one rule, because the caller
 %% and the subject are the same identity on these routes:
 %%
-%%   first-time setup          => allow  (deadlock prevention)
-%%   admin_override = required => deny   (MFA_LOCKED)
-%%   otherwise                 => allow
+%%   setup / rotate             => allow  (never gated)
+%%   disable, override=required => deny   (MFA_ADMIN_REQUIRED)
+%%   disable, otherwise         => allow
+%%
+%% Rotation stays open under the requirement: it keeps MFA enabled, so it
+%% cannot weaken what the override protects.
 %%
 %% `mfa_management' no longer acts as a self-exemption key: it is an
 %% administrator-only scope meaning "manage OTHER users' MFA". The exits
@@ -1061,8 +1065,7 @@ t_first_time_setup_always_allowed(_Config) ->
     {ok, _} = emqx_dashboard_admin:add_user(
         <<"u">>, test_password(), ?ROLE_VIEWER, "u"
     ),
-    %% Force the lock state -- it would block a rotate, but mfa_state is
-    %% absent (not_configured), so first-time setup short-circuits it.
+    %% Force the requirement: it blocks a self-disable, never an enrolment.
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
     Token = jwt(<<"u">>, test_password()),
     ?assertMatch({ok, 204, _}, setup_own_mfa(Token)).
@@ -1079,8 +1082,9 @@ t_self_can_rotate_when_not_locked(_Config) ->
     Token = jwt(<<"u">>, test_password()),
     ?assertMatch({ok, 204, _}, setup_own_mfa(Token)).
 
-%% Locked by an administrator decision: rotate is denied.
-t_self_cannot_rotate_when_admin_override_required_locked(_Config) ->
+%% Required by an administrator: rotate stays available. Re-keying keeps
+%% MFA on, so it does not weaken the requirement.
+t_self_can_rotate_when_admin_override_required(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
         <<"u">>, test_password(), ?ROLE_VIEWER, "u"
@@ -1090,11 +1094,14 @@ t_self_cannot_rotate_when_admin_override_required_locked(_Config) ->
     ),
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
     Token = jwt(<<"u">>, test_password()),
-    {ok, 403, RespBody} = setup_own_mfa(Token),
-    ?assertEqual(<<"MFA_LOCKED">>, error_code(RespBody)).
+    ?assertMatch({ok, 204, _}, setup_own_mfa(Token)),
+    %% The rotate must not have cleared the requirement.
+    ?assertEqual(?ADMIN_MFA_REQUIRED, emqx_dashboard_admin:admin_override_of(<<"u">>)),
+    {ok, 403, RespBody} = delete_own_mfa(Token),
+    ?assertEqual(<<"MFA_ADMIN_REQUIRED">>, error_code(RespBody)).
 
-%% Locked by an administrator decision: self-disable is denied too.
-t_self_cannot_delete_when_admin_override_required_locked(_Config) ->
+%% Required by an administrator: self-disable is denied.
+t_self_cannot_delete_when_admin_override_required(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
         <<"u">>, test_password(), ?ROLE_VIEWER, "u"
@@ -1105,13 +1112,14 @@ t_self_cannot_delete_when_admin_override_required_locked(_Config) ->
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
     Token = jwt(<<"u">>, test_password()),
     {ok, 403, RespBody} = delete_own_mfa(Token),
-    ?assertEqual(<<"MFA_LOCKED">>, error_code(RespBody)).
+    ?assertEqual(<<"MFA_ADMIN_REQUIRED">>, error_code(RespBody)).
 
 %% `mfa_management' is no longer a self-exemption key. It is now an
 %% administrator-only scope, so the holder must be an administrator --
-%% and even then it does not unlock their own account. Replaces the two
-%% former "self with mfa_management can rotate/delete under lock" rows.
-t_self_with_mfa_mgmt_still_locked(_Config) ->
+%% and even then it does not lift the requirement on their own account.
+%% Replaces the two former "self with mfa_management can rotate/delete
+%% under lock" rows.
+t_self_with_mfa_mgmt_still_required(_Config) ->
     add_admin(<<"admin">>),
     {ok, _} = emqx_dashboard_admin:add_user(
         <<"u">>, test_password(), ?ROLE_SUPERUSER, "u"
@@ -1122,10 +1130,9 @@ t_self_with_mfa_mgmt_still_locked(_Config) ->
     ),
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
     Token = jwt(<<"u">>, test_password()),
-    {ok, 403, RotateBody} = setup_own_mfa(Token),
-    ?assertEqual(<<"MFA_LOCKED">>, error_code(RotateBody)),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(Token)),
     {ok, 403, DeleteBody} = delete_own_mfa(Token),
-    ?assertEqual(<<"MFA_LOCKED">>, error_code(DeleteBody)).
+    ?assertEqual(<<"MFA_ADMIN_REQUIRED">>, error_code(DeleteBody)).
 
 %% A viewer with an explicitly emptied scope list still reaches its own
 %% MFA: self-service is not scope-gated.
@@ -1207,7 +1214,7 @@ t_admin_force_locks_user_against_self_disable(_Config) ->
     ),
     UserToken = jwt(<<"u">>, test_password()),
     {ok, 403, RespBody} = delete_own_mfa(UserToken),
-    ?assertEqual(<<"MFA_LOCKED">>, error_code(RespBody)).
+    ?assertEqual(<<"MFA_ADMIN_REQUIRED">>, error_code(RespBody)).
 
 %% A non-administrator cannot reach the admin MFA route at all, with or
 %% without an explicit scope list. RBAC rejects it before any policy

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -1093,11 +1093,12 @@ t_self_can_rotate_when_admin_override_required(_Config) ->
         <<"u">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
     ),
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
-    Token = jwt(<<"u">>, test_password()),
-    ?assertMatch({ok, 204, _}, setup_own_mfa(Token)),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(jwt(<<"u">>, test_password()))),
     %% The rotate must not have cleared the requirement.
     ?assertEqual(?ADMIN_MFA_REQUIRED, emqx_dashboard_admin:admin_override_of(<<"u">>)),
-    {ok, 403, RespBody} = delete_own_mfa(Token),
+    %% Re-keying MFA invalidates the account's sessions, so the disable needs a
+    %% fresh token; reusing the one that authorized the rotate answers 401.
+    {ok, 403, RespBody} = delete_own_mfa(jwt(<<"u">>, test_password())),
     ?assertEqual(<<"MFA_ADMIN_REQUIRED">>, error_code(RespBody)).
 
 %% Required by an administrator: self-disable is denied.
@@ -1129,9 +1130,9 @@ t_self_with_mfa_mgmt_still_required(_Config) ->
         <<"u">>, #{mechanism => totp, secret => <<"S1">>, first_verify_ts => 1}
     ),
     {ok, ok} = emqx_dashboard_admin:set_admin_override(<<"u">>, ?ADMIN_MFA_REQUIRED),
-    Token = jwt(<<"u">>, test_password()),
-    ?assertMatch({ok, 204, _}, setup_own_mfa(Token)),
-    {ok, 403, DeleteBody} = delete_own_mfa(Token),
+    ?assertMatch({ok, 204, _}, setup_own_mfa(jwt(<<"u">>, test_password()))),
+    %% Fresh token: the rotate above invalidated the account's sessions.
+    {ok, 403, DeleteBody} = delete_own_mfa(jwt(<<"u">>, test_password())),
     ?assertEqual(<<"MFA_ADMIN_REQUIRED">>, error_code(DeleteBody)).
 
 %% A viewer with an explicitly emptied scope list still reaches its own

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -112,15 +112,15 @@ end_per_testcase(_Case, _Config) ->
 %% role x scope schema validation (POST /users)
 %%--------------------------------------------------------------------
 
-%% Administrator can hold the three admin-only login scopes together
-%% (they are all privilege scopes, so a privilege-only list is allowed).
-%% mfa_management is a non-privilege scope and so cannot share an
-%% explicit list with the privilege scopes; it is exercised separately
-%% below and in t_user_mfa_mgmt_not_privilege/1.
+%% Administrator can hold the three privilege login scopes together
+%% (a privilege-only list is allowed). mfa_management is admin-only too
+%% but is NOT a privilege scope, so it cannot share an explicit list
+%% with them; it is exercised separately below and in
+%% t_user_mfa_mgmt_not_privilege/1.
 t_admin_can_hold_all_4_new_scopes(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
-    PrivLoginScopes = ?ADMIN_ONLY_SCOPES,
+    PrivLoginScopes = ?ADMIN_ONLY_SCOPES -- [?SCOPE_MFA_MGMT],
     Body = #{
         <<"username">> => <<"admin2">>,
         <<"password">> => test_password(),
@@ -474,9 +474,12 @@ t_viewer_cannot_hold_user_management(_Config) ->
         request_api(post, api_path(["users"]), auth_header(Token), Body)
     ).
 
-%% Viewer CAN hold mfa_management — non-admin self-exemption rule
-%% (viewer self-exemption rule).
-t_viewer_can_hold_mfa_management(_Config) ->
+%% Viewer cannot hold mfa_management: the scope means "manage another
+%% user's MFA" and is administrator-only. Its former non-administrator
+%% meaning (a self-exemption key) is gone -- managing one's own MFA is
+%% an identity-authorized operation on /current_user/mfa and needs no
+%% scope.
+t_viewer_cannot_hold_mfa_management(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
     Body = #{
@@ -486,9 +489,12 @@ t_viewer_can_hold_mfa_management(_Config) ->
         <<"description">> => <<"test">>,
         <<"scopes">> => [?SCOPE_MFA_MGMT]
     },
+    {ok, 400, RespBody} = request_api(
+        post, api_path(["users"]), auth_header(Token), Body
+    ),
     ?assertMatch(
-        {ok, 200, _},
-        request_api(post, api_path(["users"]), auth_header(Token), Body)
+        #{<<"message">> := <<"Non-administrator users cannot hold admin-only scopes:", _/binary>>},
+        emqx_utils_json:decode(RespBody)
     ).
 
 %% Viewer cannot hold sso_management.
@@ -1020,9 +1026,9 @@ t_role_demotion_with_compatible_persisted_scopes_succeeds(_Config) ->
     {ok, _} = emqx_dashboard_admin:add_user(
         <<"u">>, test_password(), ?ROLE_SUPERUSER, "demote-target"
     ),
-    %% mfa_management is allowed for any role, so the persisted
-    %% scope remains compatible after demotion.
-    {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"u">>, [?SCOPE_MFA_MGMT]),
+    %% A generic scope is allowed for any role, so the persisted scope
+    %% remains compatible after demotion.
+    {ok, ok} = emqx_dashboard_admin:set_user_scopes(<<"u">>, [?SCOPE_CONNECTIONS]),
     PutBody = #{
         <<"role">> => ?ROLE_VIEWER,
         <<"description">> => <<"demoted">>

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -117,24 +117,13 @@ check_login_user_scopes(Username, Req) when is_map(Req) ->
 check_login_user_scopes(Username, Path) when is_binary(Path) ->
     check_login_user_scopes_for_path(Username, Path).
 
+%% Self-service no longer needs a path-parsing exception here: it lives
+%% on `/current_user/*', which `emqx_dashboard_api:scopes/0' declares
+%% ?SCOPE_PUBLIC, so `check_login_user_scopes_strict/2' allows it
+%% through the `public' branch. Everything under `/users/' is now
+%% management of ANOTHER user and is scope-checked without exception.
 check_login_user_scopes_for_path(Username, Path) ->
-    %% Self-service endpoints — the user's own change_pwd / mfa —
-    %% bypass the scope check: they are gated by RBAC's self rule
-    %% and, for MFA, by emqx_dashboard_api:authorize_mfa_change/3
-    %% (admin_override decision, mfa_management self-exemption).
-    %% Locking viewers out of changing their own password / setting
-    %% up their own MFA via the scope check would defeat the
-    %% scope's purpose, which is to gate management of OTHER users.
-    %%
-    %% The bypass is intentionally restricted to those two actions.
-    %% PUT/DELETE on /users/<self> itself MUST still be scope-
-    %% checked — otherwise an admin who explicitly set
-    %% `scopes = []' could PUT their own record to add admin-only
-    %% scopes back, defeating the explicit self-restriction.
-    case is_self_service_endpoint(Path, Username) of
-        true -> true;
-        false -> check_login_user_scopes_strict(Username, Path)
-    end.
+    check_login_user_scopes_strict(Username, Path).
 
 parse_api_role(Role) ->
     parse_role(api, Role).
@@ -166,34 +155,6 @@ check_login_user_scopes_strict(Username, Path) ->
             Scopes = emqx_dashboard_admin:effective_scopes_of(Username),
             lists:member(PathScope, Scopes)
     end.
-
-%% Whitelist of self-service paths that may skip the login-user
-%% scope check. Currently only the own password and MFA endpoints —
-%% extending this whitelist requires careful thought because it
-%% creates a hole where an admin who self-restricted via explicit
-%% scopes can no longer be reliably restricted.
-%%
-%% Match /users/<self>/change_pwd or /users/<self>/mfa (with
-%% %-encoded segments) regardless of whether Username is a bare
-%% binary (local) or a ?SSO_USERNAME(Backend, Name) tuple (SSO;
-%% the sub-path uses just Name).
-is_self_service_endpoint(<<"/users/", SubPath/binary>>, Username) ->
-    case binary:split(SubPath, <<"/">>, [global]) of
-        [SelfSeg, Action] when
-            Action =:= <<"change_pwd">>;
-            Action =:= <<"mfa">>
-        ->
-            Decoded = uri_string:percent_decode(SelfSeg),
-            is_same_user(Decoded, Username);
-        _ ->
-            false
-    end;
-is_self_service_endpoint(_Path, _Username) ->
-    false.
-
-is_same_user(Decoded, Decoded) -> true;
-is_same_user(Decoded, {_Backend, Decoded}) -> true;
-is_same_user(_, _) -> false.
 
 parse_role(Type, Role0) ->
     maybe
@@ -309,63 +270,40 @@ do_check_rbac(
 do_check_rbac(#{}, _, ?DASHBOARD_API(post, logout)) ->
     %% emqx_dashboard_api:logout
     true;
-%% viewer should allow to change self password and (re)setup multi-factor auth for self,
-%% superuser should allow to change any user
-do_check_rbac(
-    #{?role := ?ROLE_VIEWER, ?actor := Username},
-    Req,
-    ?DASHBOARD_API(post, Fn)
-) when Fn == change_pwd; Fn == change_mfa ->
-    %% emqx_dashboard_api:change_pwd
-    %% emqx_dashboard_api:change_mfa
-    case Req of
-        #{bindings := #{username := Username}} ->
-            true;
-        _ ->
-            {error, <<"Viewers may only change their own password or MFA">>}
-    end;
-do_check_rbac(
-    #{?role := ?ROLE_VIEWER, ?actor := Username},
-    Req,
-    ?DASHBOARD_API(delete, change_mfa)
-) ->
-    %% RBAC decides only that viewer may DELETE its OWN mfa endpoint.
-    %% Policy state (admin_override lock and mfa_management self-
-    %% exemption) is decided in emqx_dashboard_api:authorize_mfa_change/3.
-    %% RBAC must not consult the live backend force_mfa flag here —
-    %% doing so would bypass admin_override and prevent mfa_management
-    %% scope holders from self-exempting.
-    case Req of
-        #{bindings := #{username := Username}} -> true;
-        _ -> {error, <<"Viewers may only delete their own MFA">>}
-    end;
-do_check_rbac(
-    #{?role := ?ROLE_SUPERUSER, ?namespace := Namespace, ?actor := Username},
-    Req,
-    ?DASHBOARD_API(post, Fn)
-) when
-    is_binary(Namespace) andalso (Fn == change_pwd orelse Fn == change_mfa)
+%% Self-service: the caller IS the subject, so the authenticated
+%% identity alone authorizes the operation. There is no `:username' in
+%% these paths to compare the actor against, hence no `IsSelf' rule and
+%% nothing to spoof. Any authenticated dashboard user is allowed --
+%% including a viewer and a namespaced administrator, who each manage
+%% their own account here and nothing else. API keys never reach these
+%% functions: `emqx_mgmt_auth:authorize/4' refuses them by handler name
+%% before RBAC runs.
+do_check_rbac(#{}, _, ?DASHBOARD_API(_, Fn)) when
+    Fn == current_user;
+    Fn == current_user_change_pwd;
+    Fn == current_user_mfa
 ->
-    %% Namespaced administrators may manage their own password and MFA
-    %% only -- never another user's, even within their namespace.  The
-    %% `change_pwd` handler validates the supplied `old_pwd`, so it is
-    %% not a real admin-reset path; and `change_mfa` reset by a tenant
-    %% admin is a known social-engineering vector.
-    case Req of
-        #{bindings := #{username := Username}} -> true;
-        _ -> {error, <<"Namespaced administrators may only change their own password or MFA">>}
-    end;
+    %% emqx_dashboard_api:current_user
+    %% emqx_dashboard_api:current_user_change_pwd
+    %% emqx_dashboard_api:current_user_mfa
+    true;
+%% Managing another user's MFA is a global-administrator operation. A
+%% namespaced administrator must not reach it even inside its own
+%% namespace: resetting a tenant user's MFA is a known social-
+%% engineering vector. Their own MFA is at `/current_user/mfa'.
+%%
+%% Viewers and other non-administrator roles fall through to the
+%% catch-all deny below; only GET is granted to them earlier, and these
+%% routes have no GET.
 do_check_rbac(
-    #{?role := ?ROLE_SUPERUSER, ?namespace := Namespace, ?actor := Username},
-    Req,
-    ?DASHBOARD_API(delete, change_mfa)
+    #{?role := ?ROLE_SUPERUSER, ?namespace := Namespace},
+    _Req,
+    ?DASHBOARD_API(_, change_mfa)
 ) when is_binary(Namespace) ->
-    %% Namespaced administrators: same handler-decides policy as viewer.
-    %% Self only -- see the post change_mfa clause above for rationale.
-    case Req of
-        #{bindings := #{username := Username}} -> true;
-        _ -> {error, <<"Namespaced administrators may only delete their own MFA">>}
-    end;
+    {error, <<
+        "Namespaced administrators may not manage another user's MFA. "
+        "Use /current_user/mfa for your own account."
+    >>};
 do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := Namespace}, _Req, ?CONNECTOR_API(_, _)) when
     is_binary(Namespace)
 ->

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -117,11 +117,11 @@ check_login_user_scopes(Username, Req) when is_map(Req) ->
 check_login_user_scopes(Username, Path) when is_binary(Path) ->
     check_login_user_scopes_for_path(Username, Path).
 
-%% Self-service no longer needs a path-parsing exception here: it lives
-%% on `/current_user/*', which `emqx_dashboard_api:scopes/0' declares
-%% ?SCOPE_PUBLIC, so `check_login_user_scopes_strict/2' allows it
-%% through the `public' branch. Everything under `/users/' is now
-%% management of ANOTHER user and is scope-checked without exception.
+%% Self-service lives on `/current_user/*', which
+%% `emqx_dashboard_api:scopes/0' declares ?SCOPE_PUBLIC, so
+%% `check_login_user_scopes_strict/2' allows it through the `public'
+%% branch. Everything under `/users/' is management of another user and
+%% is scope-checked without exception.
 check_login_user_scopes_for_path(Username, Path) ->
     check_login_user_scopes_strict(Username, Path).
 
@@ -271,23 +271,21 @@ do_check_rbac(#{}, _, ?DASHBOARD_API(post, logout)) ->
     %% emqx_dashboard_api:logout
     true;
 %% Self-service: the caller IS the subject, so the authenticated
-%% identity alone authorizes the operation. There is no `:username' in
-%% these paths to compare the actor against, hence no `IsSelf' rule and
-%% nothing to spoof. Any authenticated dashboard user is allowed --
-%% including a viewer and a namespaced administrator, who each manage
-%% their own account here and nothing else. API keys never reach these
-%% functions: `emqx_mgmt_auth:authorize/4' refuses them by handler name
-%% before RBAC runs.
+%% identity alone authorizes the operation. These paths carry no
+%% `:username' binding, so there is no target to compare the actor
+%% against and nothing to spoof. Any authenticated dashboard user is
+%% allowed -- including a viewer and a namespaced administrator, who
+%% each manage their own account here and nothing else. API keys never
+%% reach these functions: `emqx_mgmt_auth:authorize/4' refuses them by
+%% handler name before RBAC runs.
 do_check_rbac(#{}, _, ?DASHBOARD_API(_, Fn)) when
     Fn == current_user;
     Fn == current_user_change_pwd;
     Fn == current_user_mfa;
-    %% The deprecated `/users/:username/change_pwd' shim belongs here
-    %% too: it is a self operation wearing an admin-shaped path. RBAC
-    %% lets any authenticated user through and the handler asserts the
-    %% target is the caller, answering 403 otherwise. Keeping the check
-    %% in one place is the point -- an RBAC-level `IsSelf' clause here
-    %% is exactly the machinery this split removes.
+    %% `/users/:username/change_pwd' is a deprecated self-only shim on
+    %% an admin-style path. RBAC lets any authenticated user through and
+    %% the handler asserts the target is the caller, answering 403
+    %% otherwise.
     Fn == change_pwd
 ->
     %% emqx_dashboard_api:current_user

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -281,11 +281,19 @@ do_check_rbac(#{}, _, ?DASHBOARD_API(post, logout)) ->
 do_check_rbac(#{}, _, ?DASHBOARD_API(_, Fn)) when
     Fn == current_user;
     Fn == current_user_change_pwd;
-    Fn == current_user_mfa
+    Fn == current_user_mfa;
+    %% The deprecated `/users/:username/change_pwd' shim belongs here
+    %% too: it is a self operation wearing an admin-shaped path. RBAC
+    %% lets any authenticated user through and the handler asserts the
+    %% target is the caller, answering 403 otherwise. Keeping the check
+    %% in one place is the point -- an RBAC-level `IsSelf' clause here
+    %% is exactly the machinery this split removes.
+    Fn == change_pwd
 ->
     %% emqx_dashboard_api:current_user
     %% emqx_dashboard_api:current_user_change_pwd
     %% emqx_dashboard_api:current_user_mfa
+    %% emqx_dashboard_api:change_pwd
     true;
 %% Managing another user's MFA is a global-administrator operation. A
 %% namespaced administrator must not reach it even inside its own

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -256,12 +256,11 @@ t_logout(TCConfig) when is_list(TCConfig) ->
     {ok, #{actor := Username}} = emqx_dashboard_admin:verify_token(FakeReq, FakeHandlerInfo, Token),
     ok.
 
-%% Self-service moved to `/current_user/*'. RBAC's rule for those routes
-%% is "any authenticated dashboard user", with no `:username' binding to
-%% compare the actor against — so every role passes, and a viewer with an
-%% explicitly emptied scope list still passes (the scope layer treats the
-%% paths as public). Replaces the old viewer-self / namespaced-self
-%% clauses, which are deleted along with `is_self_service_endpoint/2'.
+%% RBAC's rule for `/current_user/*' is "any authenticated dashboard
+%% user": those routes carry no `:username' binding to compare the actor
+%% against, so every role passes, and a viewer with an explicitly
+%% emptied scope list passes too (the scope layer treats the paths as
+%% public).
 t_current_user_allowed_for_every_role(_) ->
     Password = <<"public_www1">>,
     Desc = <<"desc">>,
@@ -310,16 +309,12 @@ t_setup_mfa(_) ->
 t_delete_mfa(_) ->
     test_mfa(fun delete_mfa/2).
 
-%% Descendant of the #17122 regression (SSO usernames may contain `@`,
-%% which the HTTP layer percent-encodes as `%40`, and RBAC used to match
-%% the decoded path segment against the logged-in actor).
-%%
-%% `/current_user/mfa' carries no username segment at all, so there is
-%% nothing to encode, decode or compare -- the class of bug is gone
-%% rather than fixed. What this test still pins is the part that
-%% survives: the self-MFA lock is driven by the per-user
+%% `/current_user/mfa' carries no username path segment, so an SSO
+%% username containing `@' (percent-encoded as `%40' by the HTTP layer)
+%% needs no decoding or comparison here. Over the full HTTP path this
+%% pins the contract: the self-MFA lock is driven by the per-user
 %% `admin_override' field, not by the SSO backend's live `force_mfa'
-%% flag, and it applies to an SSO identity whose name needs escaping.
+%% flag, and it holds for an SSO identity whose name needs escaping.
 t_delete_own_mfa_sso_admin_override_http(_) ->
     SsoBackend = saml,
     SsoUser = <<"jackson-http@example.com">>,
@@ -395,10 +390,9 @@ test_mfa(VerifyFn) ->
     ),
     {ok, #{role := ?ROLE_SUPERUSER, token := NamespacedSuperToken}} =
         emqx_dashboard_admin:sign_token(NamespacedSuperUser, Password),
-    %% `/users/:username/mfa' is now purely administrative: it manages
-    %% ANOTHER user, and the self case lives at `/current_user/mfa'.
-    %% A viewer is denied on every target, its own account included --
-    %% there is no longer a viewer-self clause to fall into.
+    %% `/users/:username/mfa' is purely administrative: it manages
+    %% another user, and the self case lives at `/current_user/mfa'.
+    %% A viewer is denied on every target, its own account included.
     ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, Viewer1)),
     ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, Viewer2)),
     ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, SuperUser)),
@@ -451,9 +445,8 @@ t_check_login_user_scopes_undefined_falls_back(_) ->
     ).
 
 %% Self-service is unscoped because `/current_user/*' is declared
-%% ?SCOPE_PUBLIC, not because of a path-parsing exception -- the old
-%% `is_self_service_endpoint/2' whitelist is deleted. A user with an
-%% explicit empty scope list still reaches its own account.
+%% ?SCOPE_PUBLIC. A user with an explicit empty scope list still reaches
+%% its own account.
 t_check_login_user_scopes_current_user_is_public(_) ->
     Username = <<"login_user_scopes_self">>,
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -479,8 +472,8 @@ t_check_login_user_scopes_current_user_is_public(_) ->
             <<"/users/somebody_else/change_pwd">>
         ]
     ),
-    %% Nothing under /users/ is exempt any more, not even a path that
-    %% names the caller: those routes manage OTHER users now.
+    %% Every other path under /users/ is scope-checked, even one that
+    %% names the caller: those routes manage other users.
     lists:foreach(
         fun(Path) ->
             ?assertEqual(
@@ -495,29 +488,6 @@ t_check_login_user_scopes_current_user_is_public(_) ->
             <<"/users/", Username/binary>>,
             <<"/users">>
         ]
-    ).
-
-%% A user literally named `current_user' does not gain the self-service
-%% exemption for its own record: `/users/current_user' is still scope-
-%% checked. Guards against a prefix/segment confusion between the
-%% top-level `/current_user' route and a username of the same text.
-t_check_login_user_scopes_username_named_current_user(_) ->
-    Username = <<"current_user">>,
-    {ok, _} = emqx_dashboard_admin:add_user(
-        Username, <<"P@ssw0rd">>, ?ROLE_SUPERUSER, <<>>
-    ),
-    {ok, ok} = emqx_dashboard_admin:set_user_scopes(Username, []),
-    ?assertEqual(
-        true,
-        emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/current_user">>)
-    ),
-    ?assertEqual(
-        false,
-        emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/users/current_user">>)
-    ),
-    ?assertEqual(
-        false,
-        emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/users/current_user/mfa">>)
     ).
 
 %% scopes=[] denies every mapped path (semantically: "explicitly no

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -256,38 +256,52 @@ t_logout(TCConfig) when is_list(TCConfig) ->
     {ok, #{actor := Username}} = emqx_dashboard_admin:verify_token(FakeReq, FakeHandlerInfo, Token),
     ok.
 
-t_change_pwd(_) ->
-    Viewer1 = <<"viewer1">>,
-    Viewer2 = <<"viewer2">>,
-    SuperUser = <<"super_user">>,
+%% Self-service moved to `/current_user/*'. RBAC's rule for those routes
+%% is "any authenticated dashboard user", with no `:username' binding to
+%% compare the actor against — so every role passes, and a viewer with an
+%% explicitly emptied scope list still passes (the scope layer treats the
+%% paths as public). Replaces the old viewer-self / namespaced-self
+%% clauses, which are deleted along with `is_self_service_endpoint/2'.
+t_current_user_allowed_for_every_role(_) ->
     Password = <<"public_www1">>,
     Desc = <<"desc">>,
-    {ok, _} = emqx_dashboard_admin:add_user(Viewer1, Password, ?ROLE_VIEWER, Desc),
-    {ok, _} = emqx_dashboard_admin:add_user(Viewer2, Password, ?ROLE_VIEWER, Desc),
-    {ok, _} = emqx_dashboard_admin:add_user(SuperUser, Password, ?ROLE_SUPERUSER, Desc),
-    {ok, #{role := ?ROLE_VIEWER, token := Viewer1Token}} = emqx_dashboard_admin:sign_token(
-        Viewer1, Password
+    Users = [
+        {<<"cu_viewer">>, ?ROLE_VIEWER},
+        {<<"cu_admin">>, ?ROLE_SUPERUSER},
+        {<<"cu_ns_admin">>, <<"ns:ns1::", ?ROLE_SUPERUSER/binary>>},
+        {<<"cu_ns_viewer">>, <<"ns:ns1::", ?ROLE_VIEWER/binary>>}
+    ],
+    lists:foreach(
+        fun({Username, Role}) ->
+            {ok, _} = emqx_dashboard_admin:add_user(Username, Password, Role, Desc),
+            %% Deliberately restricted to "no permissions" — self-service
+            %% must not be gated by the scope list.
+            {ok, ok} = emqx_dashboard_admin:set_user_scopes(Username, []),
+            {ok, #{token := Token}} = emqx_dashboard_admin:sign_token(Username, Password),
+            lists:foreach(
+                fun({Method, Fn, Path}) ->
+                    ?assertMatch(
+                        {ok, #{actor := Username}},
+                        current_user_req(Token, Method, Fn, Path),
+                        #{username => Username, role => Role, function => Fn}
+                    )
+                end,
+                [
+                    {get, current_user, <<"/api/v5/current_user">>},
+                    {post, current_user_change_pwd, <<"/api/v5/current_user/change_pwd">>},
+                    {post, current_user_mfa, <<"/api/v5/current_user/mfa">>},
+                    {delete, current_user_mfa, <<"/api/v5/current_user/mfa">>}
+                ]
+            )
+        end,
+        Users
     ),
-    {ok, #{role := ?ROLE_SUPERUSER, token := SuperToken}} = emqx_dashboard_admin:sign_token(
-        SuperUser, Password
-    ),
-    %% viewer can change own password
-    ?assertMatch({ok, #{actor := Viewer1}}, change_pwd(Viewer1Token, Viewer1)),
-    %% viewer can't change other's password
-    ?assertMatch({error, {unauthorized_role, _}}, change_pwd(Viewer1Token, Viewer2)),
-    ?assertMatch({error, {unauthorized_role, _}}, change_pwd(Viewer1Token, SuperUser)),
-    %% superuser can change other's password
-    ?assertMatch({ok, #{actor := SuperUser}}, change_pwd(SuperToken, Viewer1)),
-    ?assertMatch({ok, #{actor := SuperUser}}, change_pwd(SuperToken, Viewer2)),
-    ?assertMatch({ok, #{actor := SuperUser}}, change_pwd(SuperToken, SuperUser)),
     ok.
 
-change_pwd(Token, Username) ->
-    Req = #{
-        bindings => #{username => Username},
-        path => <<"/api/v5/users/", Username/binary, "/change_pwd">>
-    },
-    HandlerInfo = #{method => post, function => change_pwd, module => emqx_dashboard_api},
+current_user_req(Token, Method, Fn, Path) ->
+    %% No `bindings' at all — these routes carry no path parameter.
+    Req = #{bindings => #{}, path => Path},
+    HandlerInfo = #{method => Method, function => Fn, module => emqx_dashboard_api},
     emqx_dashboard_admin:verify_token(Req, HandlerInfo, Token).
 
 t_setup_mfa(_) ->
@@ -296,19 +310,17 @@ t_setup_mfa(_) ->
 t_delete_mfa(_) ->
     test_mfa(fun delete_mfa/2).
 
-%% Port from release-510 #17122 c4ab6b15: SSO usernames may contain `@`
-%% (e.g. email addresses). The HTTP layer URL-encodes them as `%40`.
-%% On release-60, cowboy_router automatically URL-decodes path segments
-%% before populating `bindings`, so the RBAC binding match against the
-%% logged-in actor still works. This is the end-to-end equivalent of the
-%% release-510 path-string regression: it exercises cowboy + minirest +
-%% RBAC + the MFA handler with `backend=saml` and `force_mfa = false`/`true`.
-t_delete_mfa_sso_force_mfa_urlencoded_username_http(_) ->
-    %% Full HTTP path: RBAC + emqx_dashboard_api:authorize_mfa_change/3.
-    %% Lock state is derived from the per-user `admin_override' field,
-    %% so the test pins the contract: override=mfa_required denies
-    %% self-DELETE, override=undefined (or mfa_exempted) allows it,
-    %% regardless of the backend's live force_mfa flag.
+%% Descendant of the #17122 regression (SSO usernames may contain `@`,
+%% which the HTTP layer percent-encodes as `%40`, and RBAC used to match
+%% the decoded path segment against the logged-in actor).
+%%
+%% `/current_user/mfa' carries no username segment at all, so there is
+%% nothing to encode, decode or compare -- the class of bug is gone
+%% rather than fixed. What this test still pins is the part that
+%% survives: the self-MFA lock is driven by the per-user
+%% `admin_override' field, not by the SSO backend's live `force_mfa'
+%% flag, and it applies to an SSO identity whose name needs escaping.
+t_delete_own_mfa_sso_admin_override_http(_) ->
     SsoBackend = saml,
     SsoUser = <<"jackson-http@example.com">>,
     Desc = <<"desc">>,
@@ -319,26 +331,18 @@ t_delete_mfa_sso_force_mfa_urlencoded_username_http(_) ->
     ),
     %% override=undefined (no admin decision): self-DELETE succeeds.
     {ok, ok} = emqx_dashboard_admin:set_admin_override(SsoUsername, undefined),
-    ?assertMatch(
-        {ok, 204, _},
-        delete_mfa_urlencoded_username_http(SsoToken, SsoBackend, SsoUser)
-    ),
+    ?assertMatch({ok, 204, _}, delete_own_mfa_http(SsoToken)),
     %% override=mfa_required: self-DELETE denied with MFA_LOCKED.
     {ok, ok} = emqx_dashboard_admin:set_admin_override(SsoUsername, ?ADMIN_MFA_REQUIRED),
-    ?assertMatch(
-        {ok, 403, _},
-        delete_mfa_urlencoded_username_http(SsoToken, SsoBackend, SsoUser)
-    ),
+    ?assertMatch({ok, 403, _}, delete_own_mfa_http(SsoToken)),
     ok.
 
-t_delete_mfa_sso_force_mfa(_) ->
-    %% RBAC layer no longer consults the live SSO backend `force_mfa'
-    %% flag for self-DELETE on /users/:self/mfa. Policy state (the
-    %% admin_override decision) is decided in
-    %% emqx_dashboard_api:authorize_mfa_change/3. This RBAC-only test
-    %% therefore asserts that self-DELETE always passes the RBAC
-    %% layer; admin_override enforcement is covered by the full-HTTP
-    %% test below and by emqx_dashboard_user_scopes_SUITE.
+t_delete_own_mfa_sso_force_mfa(_) ->
+    %% RBAC does not consult the SSO backend's live `force_mfa' flag for
+    %% self-MFA: `/current_user/mfa' is allowed for any authenticated
+    %% user and the lock decision belongs to the handler
+    %% (`authorize_self_mfa/2', driven by `admin_override'). Assert RBAC
+    %% stays policy-independent across both values of the flag.
     SsoBackend = saml,
     SsoUser = <<"sso_viewermfa">>,
     LocalUser = <<"local_viewermfa">>,
@@ -353,14 +357,15 @@ t_delete_mfa_sso_force_mfa(_) ->
     {ok, #{role := ?ROLE_VIEWER, token := LocalToken}} = emqx_dashboard_admin:sign_token(
         LocalUser, Password
     ),
+    Delete = fun(Token) ->
+        current_user_req(Token, delete, current_user_mfa, <<"/api/v5/current_user/mfa">>)
+    end,
     try
-        %% RBAC is policy-independent for self-DELETE: passes regardless
-        %% of the backend's current force_mfa value.
         ok = emqx_config:put([dashboard, sso, SsoBackend], SsoConfig#{force_mfa => false}),
-        ?assertMatch({ok, #{actor := SsoUser}}, delete_mfa(SsoToken, SsoUser)),
+        ?assertMatch({ok, #{actor := SsoUser}}, Delete(SsoToken)),
         ok = emqx_config:put([dashboard, sso, SsoBackend], SsoConfig#{force_mfa => true}),
-        ?assertMatch({ok, #{actor := SsoUser}}, delete_mfa(SsoToken, SsoUser)),
-        ?assertMatch({ok, #{actor := LocalUser}}, delete_mfa(LocalToken, LocalUser))
+        ?assertMatch({ok, #{actor := SsoUser}}, Delete(SsoToken)),
+        ?assertMatch({ok, #{actor := LocalUser}}, Delete(LocalToken))
     after
         ok = emqx_config:put([dashboard, sso, SsoBackend], SsoConfig)
     end,
@@ -390,18 +395,25 @@ test_mfa(VerifyFn) ->
     ),
     {ok, #{role := ?ROLE_SUPERUSER, token := NamespacedSuperToken}} =
         emqx_dashboard_admin:sign_token(NamespacedSuperUser, Password),
-    %% viewer can change own MFA
-    ?assertMatch({ok, #{actor := Viewer1}}, VerifyFn(Viewer1Token, Viewer1)),
-    %% viewer can't change other's MFA
+    %% `/users/:username/mfa' is now purely administrative: it manages
+    %% ANOTHER user, and the self case lives at `/current_user/mfa'.
+    %% A viewer is denied on every target, its own account included --
+    %% there is no longer a viewer-self clause to fall into.
+    ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, Viewer1)),
     ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, Viewer2)),
     ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, SuperUser)),
-    %% superuser can change other's MFA
+    %% A global administrator reaches every target. (The handler then
+    %% refuses the self target and points at /current_user/mfa; that is a
+    %% handler decision, not an RBAC one, and is asserted over HTTP in
+    %% emqx_dashboard_current_user_SUITE.)
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, Viewer1)),
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, Viewer2)),
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, SuperUser)),
-    %% namespaced superuser can change own MFA, but not other dashboard users' MFA
+    %% A namespaced administrator is denied on every target, its own
+    %% account included. Resetting a tenant user's MFA is the vector this
+    %% keeps closed; the namespaced admin's own MFA is at /current_user/mfa.
     ?assertMatch(
-        {ok, #{actor := NamespacedSuperUser}},
+        {error, {unauthorized_role, _}},
         VerifyFn(NamespacedSuperToken, NamespacedSuperUser)
     ),
     ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(NamespacedSuperToken, Viewer1)),
@@ -418,8 +430,8 @@ test_mfa(VerifyFn) ->
 %% scopes=undefined uses the role-default fallback (admin -> common + login-only,
 %% viewer -> common scopes only). A viewer with no explicit scopes therefore
 %% holds only generic scopes and is denied on /users (user_management
-%% scope). Self-targeted user endpoints are an exception (see
-%% t_check_login_user_scopes_self_user_endpoints_bypass below).
+%% scope). Self-service lives on /current_user/* and is unscoped (see
+%% t_check_login_user_scopes_current_user_is_public below).
 t_check_login_user_scopes_undefined_falls_back(_) ->
     Username = <<"login_user_scopes_undef">>,
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -438,66 +450,69 @@ t_check_login_user_scopes_undefined_falls_back(_) ->
         emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/clients">>)
     ).
 
-%% Self-targeted user endpoints (own change_pwd, own MFA) bypass the
-%% scope check — they are gated by RBAC's self-check and, for MFA, by
-%% emqx_dashboard_api:authorize_mfa_change/3.
-t_check_login_user_scopes_self_user_endpoints_bypass(_) ->
+%% Self-service is unscoped because `/current_user/*' is declared
+%% ?SCOPE_PUBLIC, not because of a path-parsing exception -- the old
+%% `is_self_service_endpoint/2' whitelist is deleted. A user with an
+%% explicit empty scope list still reaches its own account.
+t_check_login_user_scopes_current_user_is_public(_) ->
     Username = <<"login_user_scopes_self">>,
     {ok, _} = emqx_dashboard_admin:add_user(
         Username, <<"P@ssw0rd">>, ?ROLE_VIEWER, <<>>
     ),
-    %% Viewer default does NOT contain user_management/mfa_management,
-    %% but self-targeted paths are still allowed.
-    ?assertEqual(
-        true,
-        emqx_dashboard_rbac:check_login_user_scopes(
-            Username, <<"/users/", Username/binary, "/change_pwd">>
-        )
+    {ok, ok} = emqx_dashboard_admin:set_user_scopes(Username, []),
+    lists:foreach(
+        fun(Path) ->
+            ?assertEqual(
+                true,
+                emqx_dashboard_rbac:check_login_user_scopes(Username, Path),
+                #{path => Path}
+            )
+        end,
+        [
+            <<"/current_user">>,
+            <<"/current_user/change_pwd">>,
+            <<"/current_user/mfa">>
+        ]
     ),
-    ?assertEqual(
-        true,
-        emqx_dashboard_rbac:check_login_user_scopes(
-            Username, <<"/users/", Username/binary, "/mfa">>
-        )
-    ),
-    %% Other users' endpoints still respect scope rules.
-    ?assertEqual(
-        false,
-        emqx_dashboard_rbac:check_login_user_scopes(
-            Username, <<"/users/somebody_else/mfa">>
-        )
+    %% Nothing under /users/ is exempt any more, not even a path that
+    %% names the caller: those routes manage OTHER users now.
+    lists:foreach(
+        fun(Path) ->
+            ?assertEqual(
+                false,
+                emqx_dashboard_rbac:check_login_user_scopes(Username, Path),
+                #{path => Path}
+            )
+        end,
+        [
+            <<"/users/", Username/binary, "/mfa">>,
+            <<"/users/somebody_else/mfa">>,
+            <<"/users/", Username/binary>>,
+            <<"/users">>
+        ]
     ).
 
-%% Self-bypass is restricted to change_pwd and mfa. PUT /users/<self>
-%% (modifying one's own record) MUST still be subject to the scope
-%% check — otherwise a user with explicit `scopes = []' could PUT
-%% itself to add scopes back, defeating the self-restriction.
-t_check_login_user_scopes_self_user_record_not_bypassed(_) ->
-    Username = <<"login_user_scopes_self_put">>,
+%% A user literally named `current_user' does not gain the self-service
+%% exemption for its own record: `/users/current_user' is still scope-
+%% checked. Guards against a prefix/segment confusion between the
+%% top-level `/current_user' route and a username of the same text.
+t_check_login_user_scopes_username_named_current_user(_) ->
+    Username = <<"current_user">>,
     {ok, _} = emqx_dashboard_admin:add_user(
         Username, <<"P@ssw0rd">>, ?ROLE_SUPERUSER, <<>>
     ),
     {ok, ok} = emqx_dashboard_admin:set_user_scopes(Username, []),
-    %% Self change_pwd / mfa still allowed.
     ?assertEqual(
         true,
-        emqx_dashboard_rbac:check_login_user_scopes(
-            Username, <<"/users/", Username/binary, "/change_pwd">>
-        )
+        emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/current_user">>)
     ),
-    %% But PUT /users/<self> (the record itself) is NOT bypassed —
-    %% the user record path maps to user_management which the user
-    %% explicitly does not hold.
     ?assertEqual(
         false,
-        emqx_dashboard_rbac:check_login_user_scopes(
-            Username, <<"/users/", Username/binary>>
-        )
+        emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/users/current_user">>)
     ),
-    %% Likewise GET /users (list) is not bypassed.
     ?assertEqual(
         false,
-        emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/users">>)
+        emqx_dashboard_rbac:check_login_user_scopes(Username, <<"/users/current_user/mfa">>)
     ).
 
 %% scopes=[] denies every mapped path (semantically: "explicitly no
@@ -546,7 +561,7 @@ t_check_login_user_scopes_user_mgmt_grants_users(_) ->
         )
     ).
 
-%% scopes=[mfa_management] grants MFA paths but not /users.
+%% scopes=[mfa_management] grants the other-user MFA path but not /users.
 t_check_login_user_scopes_mfa_mgmt_grants_only_mfa(_) ->
     Username = <<"login_user_scopes_mm">>,
     {ok, _} = emqx_dashboard_admin:add_user(
@@ -558,7 +573,7 @@ t_check_login_user_scopes_mfa_mgmt_grants_only_mfa(_) ->
     ?assertEqual(
         true,
         emqx_dashboard_rbac:check_login_user_scopes(
-            Username, <<"/users/", Username/binary, "/mfa">>
+            Username, <<"/users/somebody_else/mfa">>
         )
     ),
     ?assertEqual(
@@ -894,14 +909,12 @@ delete_mfa(Token, Username) ->
     HandlerInfo = #{method => delete, module => emqx_dashboard_api, function => change_mfa},
     emqx_dashboard_admin:verify_token(Req, HandlerInfo, Token).
 
-delete_mfa_urlencoded_username_http(Token, Backend, Username) ->
-    Url = emqx_mgmt_api_test_util:api_path([
-        "users", uri_string:quote(binary_to_list(Username)), "mfa"
-    ]),
+delete_own_mfa_http(Token) ->
+    Url = emqx_mgmt_api_test_util:api_path(["current_user", "mfa"]),
     emqx_mgmt_api_test_util:request_api(
         delete,
         Url,
-        [{backend, atom_to_binary(Backend)}],
+        [],
         [bearer_auth_header(Token)],
         [],
         #{compatible_mode => true}

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -332,7 +332,7 @@ t_delete_own_mfa_sso_admin_override_http(_) ->
     %% override=undefined (no admin decision): self-DELETE succeeds.
     {ok, ok} = emqx_dashboard_admin:set_admin_override(SsoUsername, undefined),
     ?assertMatch({ok, 204, _}, delete_own_mfa_http(SsoToken)),
-    %% override=mfa_required: self-DELETE denied with MFA_LOCKED.
+    %% override=mfa_required: self-DELETE denied with MFA_ADMIN_REQUIRED.
     {ok, ok} = emqx_dashboard_admin:set_admin_override(SsoUsername, ?ADMIN_MFA_REQUIRED),
     ?assertMatch({ok, 403, _}, delete_own_mfa_http(SsoToken)),
     ok.
@@ -340,9 +340,9 @@ t_delete_own_mfa_sso_admin_override_http(_) ->
 t_delete_own_mfa_sso_force_mfa(_) ->
     %% RBAC does not consult the SSO backend's live `force_mfa' flag for
     %% self-MFA: `/current_user/mfa' is allowed for any authenticated
-    %% user and the lock decision belongs to the handler
-    %% (`authorize_self_mfa/2', driven by `admin_override'). Assert RBAC
-    %% stays policy-independent across both values of the flag.
+    %% user and the decision belongs to the handler
+    %% (`authorize_self_mfa_disable/1', driven by `admin_override').
+    %% Assert RBAC stays policy-independent across both values of the flag.
     SsoBackend = saml,
     SsoUser = <<"sso_viewermfa">>,
     LocalUser = <<"local_viewermfa">>,

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -471,7 +471,12 @@ t_check_login_user_scopes_current_user_is_public(_) ->
         [
             <<"/current_user">>,
             <<"/current_user/change_pwd">>,
-            <<"/current_user/mfa">>
+            <<"/current_user/mfa">>,
+            %% The deprecated shim is unscoped for the same reason. It is
+            %% a templated ?SCOPE_PUBLIC entry, so it only classifies as
+            %% public through segment matching, not exact lookup.
+            <<"/users/", Username/binary, "/change_pwd">>,
+            <<"/users/somebody_else/change_pwd">>
         ]
     ),
     %% Nothing under /users/ is exempt any more, not even a path that

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
@@ -418,11 +418,11 @@ t_check_sso_mfa_admin_disabled(_Config) ->
 
 %% Regression for PR #17361 P1 review (HJianBo):
 %% An SSO viewer on a `force_mfa = true' backend completes MFA once,
-%% then self-DELETE /current_user/mfa. Before the fix, the next login
-%% returned `{ok, login}' because `classify_mfa_state({ok, disabled})'
-%% mapped to `admin_disabled' regardless of WHO disabled it. Now,
-%% self-disable (admin_override = undefined) must still honour the
-%% live `force_mfa', forcing re-setup on the next login.
+%% then self-DELETE /current_user/mfa. That leaves `mfa_state' as
+%% `disabled' while `admin_override' stays `undefined', which marks a
+%% self-disable rather than an admin exemption, so the live
+%% `force_mfa' still applies and the next login must go through MFA
+%% setup again.
 t_check_sso_mfa_self_disabled_still_forced({init, Config}) ->
     mock_force_mfa(?SSO_BACKEND, true),
     SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
@@ -418,7 +418,7 @@ t_check_sso_mfa_admin_disabled(_Config) ->
 
 %% Regression for PR #17361 P1 review (HJianBo):
 %% An SSO viewer on a `force_mfa = true' backend completes MFA once,
-%% then self-DELETE /users/:self/mfa. Before the fix, the next login
+%% then self-DELETE /current_user/mfa. Before the fix, the next login
 %% returned `{ok, login}' because `classify_mfa_state({ok, disabled})'
 %% mapped to `admin_disabled' regardless of WHO disabled it. Now,
 %% self-disable (admin_override = undefined) must still honour the

--- a/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
@@ -107,6 +107,7 @@ classify(Path, PathMap) ->
         undefined ->
             case match_template(Path, PathMap) of
                 undefined -> not_found;
+                ?SCOPE_PUBLIC -> public;
                 Scope -> {scope, Scope}
             end;
         ?SCOPE_PUBLIC ->
@@ -116,37 +117,43 @@ classify(Path, PathMap) ->
             {scope, Scope}
     end.
 
-%% Iterate templates and return the scope for the first one whose
-%% segments match the request path. Concrete path segments must equal
-%% template segments verbatim except where the template segment starts
-%% with `:' (path parameter), which matches any single segment.
+%% Return the scope of the template whose segments match the request
+%% path. Concrete path segments must equal template segments verbatim
+%% except where the template segment starts with `:' (path parameter),
+%% which matches any single segment.
 %%
-%% Entries whose value is ?SCOPE_PUBLIC are skipped: they are kept in
-%% the cache as sentinels (so exact-match lookup can distinguish
-%% "intentionally public" from "genuinely unmapped"), but they must
-%% not claim a sibling concrete path via wildcard segment match.
-%% Without this skip, e.g. `/sso/running' (public) would be claimed
-%% by the sibling template `/sso/:backend' (sso_management).
+%% Scoped templates are tried first and ?SCOPE_PUBLIC ones only if none
+%% matched, so a scoped template always wins over a public one. That
+%% ordering is what the previous unconditional skip of public entries
+%% was protecting (a public template must not claim a path some other
+%% template scopes), and making it explicit lets a genuinely public
+%% template match its own paths, which the skip made impossible.
+%% `/sso/login/:backend' and `/users/:username/change_pwd' are declared
+%% public and are unreachable through an exact-match lookup, so without
+%% this they classified as `not_found' and fell to the fail-closed
+%% branch for any user carrying an explicit scope list.
 %%
-%% Match cost is O(n*m) where n is the number of templates and m is
-%% the average path depth. The cache is small (~250 entries) and this
-%% function is called once per authorised request, so the cost is
-%% acceptable.
+%% Two passes cost one extra traversal in the no-match case. The cache
+%% is small (~250 entries) and this runs once per authorised request.
 match_template(Path, PathMap) ->
     PathSegs = normalize_segments(split_segments(Path)),
-    Iter = maps:iterator(PathMap),
-    match_template_iter(PathSegs, Iter).
+    case match_template_iter(PathSegs, maps:iterator(PathMap), scoped) of
+        undefined -> match_template_iter(PathSegs, maps:iterator(PathMap), public);
+        Scope -> Scope
+    end.
 
-match_template_iter(PathSegs, Iter) ->
+match_template_iter(PathSegs, Iter, Pass) ->
     case maps:next(Iter) of
         none ->
             undefined;
-        {_Tmpl, ?SCOPE_PUBLIC, Iter1} ->
-            match_template_iter(PathSegs, Iter1);
+        {_Tmpl, ?SCOPE_PUBLIC, Iter1} when Pass =:= scoped ->
+            match_template_iter(PathSegs, Iter1, Pass);
+        {_Tmpl, Scope, Iter1} when Pass =:= public, Scope =/= ?SCOPE_PUBLIC ->
+            match_template_iter(PathSegs, Iter1, Pass);
         {Tmpl, Scope, Iter1} ->
             case segments_match(PathSegs, split_segments(Tmpl)) of
                 true -> Scope;
-                false -> match_template_iter(PathSegs, Iter1)
+                false -> match_template_iter(PathSegs, Iter1, Pass)
             end
     end.
 

--- a/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
@@ -123,19 +123,11 @@ classify(Path, PathMap) ->
 %% which matches any single segment.
 %%
 %% Scoped templates are tried first and ?SCOPE_PUBLIC ones only if none
-%% matched, so a scoped template always wins over a public one. That
-%% ordering is what the previous unconditional skip of public entries
-%% was protecting (a public template must not claim a path some other
-%% template scopes), and making it explicit lets a genuinely public
-%% template match its own paths, which the skip made impossible.
-%% Three declarations in the umbrella are public templates and so were
-%% unreachable through an exact-match lookup: `/sso/login/:backend',
-%% `/users/:username/change_pwd', and `/schemas/:name' (declared by the
-%% whole-module form `scopes() -> ?SCOPE_PUBLIC'). All three classified
-%% as `not_found' and fell to the fail-closed branch for any user
-%% carrying an explicit scope list; they now classify as `public', which
-%% is what each module declared. API keys are unaffected either way:
-%% `path_to_scope/1' collapses `public' and `not_found' to `undefined'.
+%% matched, so a scoped template always wins over a public one: a
+%% public template's wildcard segment must not claim a path that
+%% another template scopes. The public pass exists because public
+%% declarations can carry path parameters, such as
+%% `/sso/login/:backend', which no exact-match lookup can reach.
 %%
 %% Two passes cost one extra traversal in the no-match case. The cache
 %% is small (~250 entries) and this runs once per authorised request.

--- a/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
@@ -128,10 +128,14 @@ classify(Path, PathMap) ->
 %% was protecting (a public template must not claim a path some other
 %% template scopes), and making it explicit lets a genuinely public
 %% template match its own paths, which the skip made impossible.
-%% `/sso/login/:backend' and `/users/:username/change_pwd' are declared
-%% public and are unreachable through an exact-match lookup, so without
-%% this they classified as `not_found' and fell to the fail-closed
-%% branch for any user carrying an explicit scope list.
+%% Three declarations in the umbrella are public templates and so were
+%% unreachable through an exact-match lookup: `/sso/login/:backend',
+%% `/users/:username/change_pwd', and `/schemas/:name' (declared by the
+%% whole-module form `scopes() -> ?SCOPE_PUBLIC'). All three classified
+%% as `not_found' and fell to the fail-closed branch for any user
+%% carrying an explicit scope list; they now classify as `public', which
+%% is what each module declared. API keys are unaffected either way:
+%% `path_to_scope/1' collapses `public' and `not_found' to `undefined'.
 %%
 %% Two passes cost one extra traversal in the no-match case. The cache
 %% is small (~250 entries) and this runs once per authorised request.

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -275,7 +275,12 @@ authorize(#{module := emqx_dashboard_api, function := change_mfa}, _Req, _ApiKey
 authorize(#{module := emqx_dashboard_api, function := Fn}, _Req, _ApiKey, _ApiSecret) when
     Fn == current_user;
     Fn == current_user_change_pwd;
-    Fn == current_user_mfa
+    Fn == current_user_mfa;
+    %% Same reasoning for the deprecated `/users/:username/change_pwd'
+    %% shim, which is a self operation and so equally meaningless for a
+    %% machine credential. It also no longer carries a scope, so the
+    %% scope layer would not stop an API key either.
+    Fn == change_pwd
 ->
     {error, <<"not_allowed">>, <<"users">>};
 authorize(#{module := emqx_mgmt_api_api_keys}, _Req, _ApiKey, _ApiSecret) ->

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -265,9 +265,18 @@ authorize(#{module := emqx_dashboard_api, function := users}, _Req, _ApiKey, _Ap
     {error, <<"not_allowed">>, <<"users">>};
 authorize(#{module := emqx_dashboard_api, function := logout}, _Req, _ApiKey, _ApiSecret) ->
     {error, <<"not_allowed">>, <<"logout">>};
-authorize(#{module := emqx_dashboard_api, function := change_pwd}, _Req, _ApiKey, _ApiSecret) ->
-    {error, <<"not_allowed">>, <<"users">>};
 authorize(#{module := emqx_dashboard_api, function := change_mfa}, _Req, _ApiKey, _ApiSecret) ->
+    {error, <<"not_allowed">>, <<"users">>};
+%% Self-service endpoints authorize on "the caller IS the subject". An
+%% API key has no such subject -- it is a machine credential, not a
+%% dashboard account -- so there is no account for it to act on here.
+%% Refusing by handler name keeps the check independent of the scope
+%% layer, where these paths are ?SCOPE_PUBLIC and would otherwise pass.
+authorize(#{module := emqx_dashboard_api, function := Fn}, _Req, _ApiKey, _ApiSecret) when
+    Fn == current_user;
+    Fn == current_user_change_pwd;
+    Fn == current_user_mfa
+->
     {error, <<"not_allowed">>, <<"users">>};
 authorize(#{module := emqx_mgmt_api_api_keys}, _Req, _ApiKey, _ApiSecret) ->
     {error, <<"not_allowed">>, <<"api_key">>};

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -270,16 +270,16 @@ authorize(#{module := emqx_dashboard_api, function := change_mfa}, _Req, _ApiKey
 %% Self-service endpoints authorize on "the caller IS the subject". An
 %% API key has no such subject -- it is a machine credential, not a
 %% dashboard account -- so there is no account for it to act on here.
-%% Refusing by handler name keeps the check independent of the scope
-%% layer, where these paths are ?SCOPE_PUBLIC and would otherwise pass.
+%% These paths are ?SCOPE_PUBLIC, so the scope check lets an API key
+%% through; this clause is what rejects it.
 authorize(#{module := emqx_dashboard_api, function := Fn}, _Req, _ApiKey, _ApiSecret) when
     Fn == current_user;
     Fn == current_user_change_pwd;
     Fn == current_user_mfa;
     %% Same reasoning for the deprecated `/users/:username/change_pwd'
     %% shim, which is a self operation and so equally meaningless for a
-    %% machine credential. It also no longer carries a scope, so the
-    %% scope layer would not stop an API key either.
+    %% machine credential. It is ?SCOPE_PUBLIC as well, so the scope
+    %% layer would not stop an API key either.
     Fn == change_pwd
 ->
     {error, <<"not_allowed">>, <<"users">>};

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -1122,10 +1122,9 @@ any of the self-service `/current_user/*' routes. These endpoints belong
 to the human-facing dashboard surface and are intended only for
 bearer-token (JWT) callers.
 
-Before the fix, DELETE /api/v5/users/:username/mfa via API key Basic auth
-returned HTTP 204 and silently disabled the target user's MFA. After the
-fix it must return HTTP 401 with body code API_KEY_NOT_ALLOW, matching
-the policy already enforced on /users and /users/:username.
+DELETE and POST /api/v5/users/:username/mfa via API key Basic auth must
+return HTTP 401 with body code API_KEY_NOT_ALLOW, matching the policy
+already enforced on /users and /users/:username.
 
 The `/current_user/*' routes need the same guard for a different reason:
 they are declared ?SCOPE_PUBLIC (self-service is authorized by identity,
@@ -1190,11 +1189,10 @@ t_ee_authorize_admin_cannot_manage_mfa(_Config) ->
 -doc """
 Lower-level companion to t_ee_authorize_admin_cannot_manage_mfa:
 call emqx_mgmt_auth:authorize/4 directly with a HandlerInfo map that
-names the dashboard change_mfa and current_user_* handlers. This pins
-the contract at the exact clauses, independent of any HTTP / minirest
-plumbing -- the denial keys off the handler function name, so adding a
-dashboard route without adding it here would silently open it to API
-keys.
+names the dashboard change_mfa and current_user_* handlers. It checks
+the rule directly in emqx_mgmt_auth, independent of any HTTP / minirest
+plumbing. The denial matches on the handler function name, so a
+dashboard route is covered only once it appears in this list.
 """.
 t_ee_authorize_admin_cannot_manage_mfa_module_level(_Config) ->
     Name = <<"EMQX-EE-API-AUTH-MFA-MODULE">>,

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -1117,14 +1117,20 @@ t_ee_authorize_admin(_Config) ->
 
 -doc """
 An admin-role API key must NOT be able to reach the dashboard user-account
-management endpoints change_mfa and change_pwd via HTTP Basic auth. These
-endpoints belong to the human-facing dashboard surface and are intended
-only for bearer-token (JWT) callers.
+endpoints via HTTP Basic auth -- neither the administrator MFA route nor
+any of the self-service `/current_user/*' routes. These endpoints belong
+to the human-facing dashboard surface and are intended only for
+bearer-token (JWT) callers.
 
 Before the fix, DELETE /api/v5/users/:username/mfa via API key Basic auth
 returned HTTP 204 and silently disabled the target user's MFA. After the
 fix it must return HTTP 401 with body code API_KEY_NOT_ALLOW, matching
 the policy already enforced on /users and /users/:username.
+
+The `/current_user/*' routes need the same guard for a different reason:
+they are declared ?SCOPE_PUBLIC (self-service is authorized by identity,
+not by scope), so the scope layer would let an API key through. An API
+key has no dashboard account to be the subject of a self-service call.
 """.
 t_ee_authorize_admin_cannot_manage_mfa(_Config) ->
     Name = <<"EMQX-EE-API-AUTHORIZE-KEY-ADMIN-MFA">>,
@@ -1139,7 +1145,9 @@ t_ee_authorize_admin_cannot_manage_mfa(_Config) ->
     ok = ensure_victim_user(Victim),
     DeleteMfa = emqx_mgmt_api_test_util:api_path(["users", Victim, "mfa"]),
     PostMfa = DeleteMfa,
-    ChangePwd = emqx_mgmt_api_test_util:api_path(["users", Victim, "change_pwd"]),
+    CurrentUser = emqx_mgmt_api_test_util:api_path(["current_user"]),
+    CurrentUserMfa = emqx_mgmt_api_test_util:api_path(["current_user", "mfa"]),
+    CurrentUserPwd = emqx_mgmt_api_test_util:api_path(["current_user", "change_pwd"]),
 
     ok = assert_api_key_not_allow(
         delete, DeleteMfa, [], BasicHeader, []
@@ -1147,9 +1155,15 @@ t_ee_authorize_admin_cannot_manage_mfa(_Config) ->
     ok = assert_api_key_not_allow(
         post, PostMfa, [], BasicHeader, #{mechanism => totp}
     ),
+    %% Self-service routes are equally out of reach for an API key.
+    ok = assert_api_key_not_allow(get, CurrentUser, [], BasicHeader, []),
+    ok = assert_api_key_not_allow(delete, CurrentUserMfa, [], BasicHeader, []),
+    ok = assert_api_key_not_allow(
+        post, CurrentUserMfa, [], BasicHeader, #{mechanism => totp}
+    ),
     ok = assert_api_key_not_allow(
         post,
-        ChangePwd,
+        CurrentUserPwd,
         [],
         BasicHeader,
         #{old_pwd => <<"mfa_victim_pass">>, new_pwd => <<"new_pass_123">>}
@@ -1166,9 +1180,11 @@ t_ee_authorize_admin_cannot_manage_mfa(_Config) ->
 -doc """
 Lower-level companion to t_ee_authorize_admin_cannot_manage_mfa:
 call emqx_mgmt_auth:authorize/4 directly with a HandlerInfo map that
-names the dashboard change_mfa / change_pwd handlers. This pins the
-contract at the exact clause being added in the fix, independent of
-any HTTP / minirest plumbing.
+names the dashboard change_mfa and current_user_* handlers. This pins
+the contract at the exact clauses, independent of any HTTP / minirest
+plumbing -- the denial keys off the handler function name, so adding a
+dashboard route without adding it here would silently open it to API
+keys.
 """.
 t_ee_authorize_admin_cannot_manage_mfa_module_level(_Config) ->
     Name = <<"EMQX-EE-API-AUTH-MFA-MODULE">>,
@@ -1186,23 +1202,27 @@ t_ee_authorize_admin_cannot_manage_mfa_module_level(_Config) ->
         path => "/users/:username/mfa"
     },
     PostMfaHandler = DeleteMfaHandler#{method => post},
-    ChangePwdHandler = #{
-        method => post,
-        module => emqx_dashboard_api,
-        function => change_pwd,
-        path => "/users/:username/change_pwd"
-    },
-    ?assertEqual(
-        {error, <<"not_allowed">>, <<"users">>},
-        emqx_mgmt_auth:authorize(DeleteMfaHandler, FakeReq, ApiKey, ApiSecret)
-    ),
-    ?assertEqual(
-        {error, <<"not_allowed">>, <<"users">>},
-        emqx_mgmt_auth:authorize(PostMfaHandler, FakeReq, ApiKey, ApiSecret)
-    ),
-    ?assertEqual(
-        {error, <<"not_allowed">>, <<"users">>},
-        emqx_mgmt_auth:authorize(ChangePwdHandler, FakeReq, ApiKey, ApiSecret)
+    SelfHandlers = [
+        #{method => get, function => current_user, path => "/current_user"},
+        #{
+            method => post,
+            function => current_user_change_pwd,
+            path => "/current_user/change_pwd"
+        },
+        #{method => post, function => current_user_mfa, path => "/current_user/mfa"},
+        #{method => delete, function => current_user_mfa, path => "/current_user/mfa"}
+    ],
+    lists:foreach(
+        fun(Handler) ->
+            ?assertEqual(
+                {error, <<"not_allowed">>, <<"users">>},
+                emqx_mgmt_auth:authorize(
+                    Handler#{module => emqx_dashboard_api}, FakeReq, ApiKey, ApiSecret
+                ),
+                Handler
+            )
+        end,
+        [DeleteMfaHandler, PostMfaHandler | SelfHandlers]
     ),
     ok.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -1145,6 +1145,7 @@ t_ee_authorize_admin_cannot_manage_mfa(_Config) ->
     ok = ensure_victim_user(Victim),
     DeleteMfa = emqx_mgmt_api_test_util:api_path(["users", Victim, "mfa"]),
     PostMfa = DeleteMfa,
+    ShimPwd = emqx_mgmt_api_test_util:api_path(["users", Victim, "change_pwd"]),
     CurrentUser = emqx_mgmt_api_test_util:api_path(["current_user"]),
     CurrentUserMfa = emqx_mgmt_api_test_util:api_path(["current_user", "mfa"]),
     CurrentUserPwd = emqx_mgmt_api_test_util:api_path(["current_user", "change_pwd"]),
@@ -1154,6 +1155,15 @@ t_ee_authorize_admin_cannot_manage_mfa(_Config) ->
     ),
     ok = assert_api_key_not_allow(
         post, PostMfa, [], BasicHeader, #{mechanism => totp}
+    ),
+    %% The deprecated self-only shim is a self operation too, and it
+    %% carries no scope, so only the handler-name denial stops an API key.
+    ok = assert_api_key_not_allow(
+        post,
+        ShimPwd,
+        [],
+        BasicHeader,
+        #{old_pwd => <<"mfa_victim_pass">>, new_pwd => <<"new_pass_123">>}
     ),
     %% Self-service routes are equally out of reach for an API key.
     ok = assert_api_key_not_allow(get, CurrentUser, [], BasicHeader, []),
@@ -1203,6 +1213,11 @@ t_ee_authorize_admin_cannot_manage_mfa_module_level(_Config) ->
     },
     PostMfaHandler = DeleteMfaHandler#{method => post},
     SelfHandlers = [
+        #{
+            method => post,
+            function => change_pwd,
+            path => "/users/:username/change_pwd"
+        },
         #{method => get, function => current_user, path => "/current_user"},
         #{
             method => post,

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -479,9 +479,8 @@ collect_public_paths(Modules) ->
                         [path_to_binary(P) || {P, ?SCOPE_PUBLIC} <- maps:to_list(Map)];
                     %% Whole-module form: `scopes() -> ?SCOPE_PUBLIC'
                     %% makes every path the module declares public.
-                    %% Missing this clause hid `/schemas/:name' from every
-                    %% test that consumes this helper, including the
-                    %% safety half of the wildcard invariant.
+                    %% `emqx_dashboard_schema_api' uses this form, so
+                    %% `/schemas/:name' is public.
                     ?SCOPE_PUBLIC ->
                         [path_to_binary(P) || P <- apply(M, paths, [])];
                     _ ->
@@ -744,18 +743,15 @@ A ?SCOPE_PUBLIC entry that is itself a TEMPLATE must classify the
 concrete paths it covers as `public', not `not_found'.
 
 `classify_path/1' answers an exact-match lookup first, so a public
-template is only ever reached through segment matching. Public entries
-used to be skipped there unconditionally, which made a public template
-unreachable: every concrete path under it fell through to `not_found',
-and `emqx_dashboard_rbac:check_login_user_scopes_strict/2' fails that
-branch closed for any user carrying an explicit scope list. Both
+template is only ever reached through segment matching. Both
 `/sso/login/:backend' and `/users/:username/change_pwd' are declared
-public and are templates.
+public and are templates, and
+`emqx_dashboard_rbac:check_login_user_scopes_strict/2' denies a
+`not_found' path to any user carrying an explicit scope list.
 
-A scoped template still wins over a public one, which is what the old
-skip was really protecting; that is asserted by
-`t_wildcard_does_not_claim_public_path' above (`/sso/oidc' keeps
-resolving to sso_management).
+`t_wildcard_does_not_claim_public_path' above covers the opposite
+direction: a scoped template wins over a public one, so `/sso/oidc'
+resolves to sso_management.
 """.
 t_public_template_classifies_concrete_path_as_public(_Config) ->
     emqx_mgmt_api_key_scopes:init_cache(),

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -42,7 +42,8 @@ groups() ->
             t_all_endpoints_covered_by_scopes,
             t_init_cache_no_missing_path_warnings,
             t_public_paths_not_in_cache,
-            t_wildcard_does_not_claim_public_path
+            t_wildcard_does_not_claim_public_path,
+            t_public_template_classifies_concrete_path_as_public
         ]},
         {integration_tests, [parallel], [
             t_authorize_with_scopes,
@@ -730,6 +731,50 @@ create_app(Name, Extra) ->
         {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
+
+-doc """
+A ?SCOPE_PUBLIC entry that is itself a TEMPLATE must classify the
+concrete paths it covers as `public', not `not_found'.
+
+`classify_path/1' answers an exact-match lookup first, so a public
+template is only ever reached through segment matching. Public entries
+used to be skipped there unconditionally, which made a public template
+unreachable: every concrete path under it fell through to `not_found',
+and `emqx_dashboard_rbac:check_login_user_scopes_strict/2' fails that
+branch closed for any user carrying an explicit scope list. Both
+`/sso/login/:backend' and `/users/:username/change_pwd' are declared
+public and are templates.
+
+A scoped template still wins over a public one, which is what the old
+skip was really protecting; that is asserted by
+`t_wildcard_does_not_claim_public_path' above (`/sso/oidc' keeps
+resolving to sso_management).
+""".
+t_public_template_classifies_concrete_path_as_public(_Config) ->
+    emqx_mgmt_api_key_scopes:init_cache(),
+    Modules = emqx_mgmt_api_key_scopes:find_api_modules(),
+    PublicPaths = collect_public_paths(Modules),
+    Templates = [P || P <- PublicPaths, binary:match(P, <<"/:">>) =/= nomatch],
+    ?assert(
+        Templates =/= [],
+        "no templated ?SCOPE_PUBLIC path declared -- test now vacuous"
+    ),
+    lists:foreach(
+        fun(Template) ->
+            Concrete = binary:replace(Template, <<":">>, <<>>, [global]),
+            ?assertEqual(
+                public,
+                emqx_mgmt_api_key_scopes:classify_path(Concrete),
+                lists:flatten(
+                    io_lib:format(
+                        "public template ~s did not cover ~s", [Template, Concrete]
+                    )
+                )
+            )
+        end,
+        Templates
+    ),
+    emqx_mgmt_api_key_scopes:clear_cache().
 
 read_app(Name) ->
     AuthHeader = emqx_common_test_http:default_user_auth_header(),

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -477,6 +477,13 @@ collect_public_paths(Modules) ->
                 try apply(M, scopes, []) of
                     Map when is_map(Map) ->
                         [path_to_binary(P) || {P, ?SCOPE_PUBLIC} <- maps:to_list(Map)];
+                    %% Whole-module form: `scopes() -> ?SCOPE_PUBLIC'
+                    %% makes every path the module declares public.
+                    %% Missing this clause hid `/schemas/:name' from every
+                    %% test that consumes this helper, including the
+                    %% safety half of the wildcard invariant.
+                    ?SCOPE_PUBLIC ->
+                        [path_to_binary(P) || P <- apply(M, paths, [])];
                     _ ->
                         []
                 catch

--- a/apps/emqx_utils/include/emqx_api_key_scopes.hrl
+++ b/apps/emqx_utils/include/emqx_api_key_scopes.hrl
@@ -47,16 +47,15 @@
 %% keys whose scope list includes any login-only scope; bootstrap-file
 %% loader filters them with a warning.
 %%
-%% Among the four:
-%%   * `user_management`, `sso_management`, `api_key_management` are
-%%     ADMIN-ONLY — only login users with role=administrator may hold
-%%     them. Schema validation enforces this in POST /users / PUT
-%%     /users/:name handlers.
-%%   * `mfa_management` is available to ANY login user role (including
-%%     viewer / SSO viewer). For non-admin holders it acts as a
-%%     "self-exemption key" — the user may bypass force_mfa /
-%%     admin_required locks on THEIR OWN MFA only. Non-admins with
-%%     mfa_management still cannot manage other users' MFA.
+%% All four are ADMIN-ONLY: only login users with role=administrator may
+%% hold them. Schema validation enforces this in POST /users / PUT
+%% /users/:name handlers.
+%%
+%% `mfa_management` means "manage OTHER users' MFA" and nothing else.
+%% It was previously holdable by any role, where for a non-administrator
+%% it acted as a self-exemption key over that user's own MFA. Self-MFA is
+%% now an identity-authorized operation on `/current_user/mfa', so the
+%% scope has no self meaning left to carry.
 
 -define(SCOPE_USER_MGMT, <<"user_management">>).
 -define(SCOPE_MFA_MGMT, <<"mfa_management">>).
@@ -75,9 +74,13 @@
 ]).
 
 %% Subset of login-only scopes that require role=administrator.
-%% mfa_management is intentionally NOT in this list — see comment above.
+%% Currently all of them, but kept as its own list: this is the
+%% role-compatibility rule, which is a different question from
+%% "is this scope administrator-EQUIVALENT" (?PRIVILEGE_SCOPES).
+%% `mfa_management' is admin-only and NOT a privilege scope.
 -define(ADMIN_ONLY_SCOPES, [
     ?SCOPE_USER_MGMT,
+    ?SCOPE_MFA_MGMT,
     ?SCOPE_SSO_MGMT,
     ?SCOPE_API_KEY_MGMT
 ]).

--- a/apps/emqx_utils/include/emqx_api_key_scopes.hrl
+++ b/apps/emqx_utils/include/emqx_api_key_scopes.hrl
@@ -144,8 +144,11 @@
 %% scope cannot meaningfully restrict the account, so schema validation
 %% refuses that combination at write time: an explicit, non-empty scope
 %% list must be either entirely privilege or entirely non-privilege.
-%% `mfa_management' is intentionally excluded — any login user role may
-%% hold it and it is not administrator-equivalent.
+%% `mfa_management' is intentionally excluded: it is administrator-only
+%% like the other three, but it is not administrator-equivalent — it
+%% resets another user's MFA and cannot provision users, mint keys or
+%% rewrite configuration. So it may share an explicit list with
+%% restricted scopes while the other three may not.
 -define(PRIVILEGE_SCOPES, [
     ?SCOPE_SYSTEM,
     ?SCOPE_USER_MGMT,

--- a/apps/emqx_utils/src/emqx_scope_catalog.erl
+++ b/apps/emqx_utils/src/emqx_scope_catalog.erl
@@ -68,12 +68,11 @@ creation or update if the scope list contains any login-only scope,
 and the bootstrap-file loader filters such names with a warning.
 
 The `admin_only` flag indicates whether the scope is restricted to
-administrator role. `mfa_management` is the only login-only scope
-non-administrators may hold; for non-admins it acts as a self-
-exemption key allowing the holder to bypass force_mfa and
-admin_override locks on their OWN MFA — they still cannot manage
-other users' MFA (enforced by RBAC and by
-`emqx_dashboard_api:authorize_mfa_change/3').
+administrator role. All four login-only scopes are administrator-only:
+each one manages something about OTHER users. `mfa_management` in
+particular means "reset or disable another user's MFA" — managing
+one's own MFA is an identity-authorized operation on
+`/current_user/mfa' and needs no scope at all.
 """.
 -spec admin_only_scope_catalog() ->
     [#{name := binary(), desc := term(), admin_only := boolean()}].
@@ -86,7 +85,7 @@ admin_only_scope_catalog() ->
         },
         #{
             name => ?SCOPE_MFA_MGMT,
-            admin_only => false,
+            admin_only => true,
             desc => ?DESC(scope_mfa_management)
         },
         #{

--- a/apps/emqx_utils/src/emqx_scope_catalog.erl
+++ b/apps/emqx_utils/src/emqx_scope_catalog.erl
@@ -68,11 +68,10 @@ creation or update if the scope list contains any login-only scope,
 and the bootstrap-file loader filters such names with a warning.
 
 The `admin_only` flag indicates whether the scope is restricted to
-administrator role. All four login-only scopes are administrator-only:
-each one manages something about OTHER users. `mfa_management` in
-particular means "reset or disable another user's MFA" — managing
-one's own MFA is an identity-authorized operation on
-`/current_user/mfa' and needs no scope at all.
+administrator role. Every login-only scope is administrator-only: each one acts on
+other users' accounts. `mfa_management` covers resetting or
+disabling another user's MFA; a user's own MFA is managed through
+`/current_user/mfa', which requires no scope.
 """.
 -spec admin_only_scope_catalog() ->
     [#{name := binary(), desc := term(), admin_only := boolean()}].

--- a/changes/ee/breaking-18608.en.md
+++ b/changes/ee/breaking-18608.en.md
@@ -1,16 +1,16 @@
-Split the Dashboard self-service APIs out of the administrator user-management APIs. A user managing their own account now uses `/current_user/*`; the endpoints under `/users/:username/*` manage other users.
+Dashboard account APIs are now separate from user administration APIs.
 
-New self-service endpoints, authorized by the signed-in identity alone and requiring no permission scope:
+Users manage their own accounts through `/current_user`:
 
-- `GET /current_user`: own username, role, effective scopes and MFA status.
-- `POST /current_user/change_pwd`: change own password (`old_pwd` + `new_pwd`).
-- `POST /current_user/mfa`: set up or rotate own MFA.
-- `DELETE /current_user/mfa`: disable own MFA.
+- `GET /current_user` returns the signed-in user's username, role, effective scopes, and MFA status.
+- `POST /current_user/change_pwd` changes the signed-in user's password. The request must include `old_pwd` and `new_pwd`.
+- `POST /current_user/mfa` sets up or rotates the signed-in user's MFA.
+- `DELETE /current_user/mfa` disables the signed-in user's MFA.
 
-This is a breaking change:
+Breaking changes:
 
-- `POST /users/:username/change_pwd` is deprecated and now self-only: the `username` in the path must be the signed-in user, otherwise the request is rejected with `403`. It previously accepted any target and merely failed the `old_pwd` check, so a cross-user call was refused by accident rather than by rule. Use `POST /current_user/change_pwd` instead; the deprecated path will be removed in a later release. Resetting another user's password remains available only from the node console (`emqx ctl admins passwd`).
-- `POST` and `DELETE /users/:username/mfa` now require the administrator role and manage other users only. Use `/current_user/mfa` for your own account. A namespaced (multi-tenant) administrator can no longer reach another user's MFA, not even within its own namespace.
-- The `mfa_management` scope becomes administrator-only and means "manage other users' MFA". It previously also acted as a self-exemption key that let a non-administrator bypass an MFA lock on their own account. That meaning is gone, and assigning the scope to a non-administrator is now rejected with `400`. An account whose MFA an administrator has reset can be unlocked by another administrator or from the node console.
+- `POST /users/:username/change_pwd` is deprecated and restricted to the signed-in user. EMQX returns `403` when the path identifies another user. Use `POST /current_user/change_pwd` instead. Administrators can reset another local user's password only with `emqx ctl admins passwd`.
+- `POST` and `DELETE /users/:username/mfa` now manage other users and require the administrator role. Use `/current_user/mfa` to manage your own MFA. Namespaced administrators cannot manage another user's MFA.
+- The `mfa_management` scope is now administrator-only and grants permission to manage another user's MFA. It no longer lets non-administrators override an MFA requirement on their own accounts. EMQX returns `400` when this scope is assigned to a non-administrator. Another administrator or the node console must remove an administrator-set MFA requirement.
 
-Dashboard clients and any scripts calling the removed or narrowed endpoints must be updated.
+Operations that end a Dashboard session now also end the sessions of SSO accounts: rotating or disabling MFA, changing a password, changing a role, and deleting a user. An SSO account previously kept its bearer tokens through all of these. Ending one account's sessions no longer ends those of an account with the same name on a different backend.

--- a/changes/ee/breaking-18608.en.md
+++ b/changes/ee/breaking-18608.en.md
@@ -9,7 +9,7 @@ New self-service endpoints, authorized by the signed-in identity alone and requi
 
 This is a breaking change:
 
-- `POST /users/:username/change_pwd` is removed. Use `POST /current_user/change_pwd` to change your own password. This endpoint always verified `old_pwd`, so it was never an administrator reset; resetting another user's password remains available only from the node console (`emqx ctl admins passwd`).
+- `POST /users/:username/change_pwd` is deprecated and now self-only: the `username` in the path must be the signed-in user, otherwise the request is rejected with `403`. It previously accepted any target and merely failed the `old_pwd` check, so a cross-user call was refused by accident rather than by rule. Use `POST /current_user/change_pwd` instead; the deprecated path will be removed in a later release. Resetting another user's password remains available only from the node console (`emqx ctl admins passwd`).
 - `POST` and `DELETE /users/:username/mfa` now require the administrator role and manage other users only. Use `/current_user/mfa` for your own account. A namespaced (multi-tenant) administrator can no longer reach another user's MFA, not even within its own namespace.
 - The `mfa_management` scope becomes administrator-only and means "manage other users' MFA". It previously also acted as a self-exemption key that let a non-administrator bypass an MFA lock on their own account. That meaning is gone, and assigning the scope to a non-administrator is now rejected with `400`. An account whose MFA an administrator has reset can be unlocked by another administrator or from the node console.
 

--- a/changes/ee/breaking-18608.en.md
+++ b/changes/ee/breaking-18608.en.md
@@ -1,0 +1,16 @@
+Split the Dashboard self-service APIs out of the administrator user-management APIs. A user managing their own account now uses `/current_user/*`; the endpoints under `/users/:username/*` manage other users.
+
+New self-service endpoints, authorized by the signed-in identity alone and requiring no permission scope:
+
+- `GET /current_user`: own username, role, effective scopes and MFA status.
+- `POST /current_user/change_pwd`: change own password (`old_pwd` + `new_pwd`).
+- `POST /current_user/mfa`: set up or rotate own MFA.
+- `DELETE /current_user/mfa`: disable own MFA.
+
+This is a breaking change:
+
+- `POST /users/:username/change_pwd` is removed. Use `POST /current_user/change_pwd` to change your own password. This endpoint always verified `old_pwd`, so it was never an administrator reset; resetting another user's password remains available only from the node console (`emqx ctl admins passwd`).
+- `POST` and `DELETE /users/:username/mfa` now require the administrator role and manage other users only. Use `/current_user/mfa` for your own account. A namespaced (multi-tenant) administrator can no longer reach another user's MFA, not even within its own namespace.
+- The `mfa_management` scope becomes administrator-only and means "manage other users' MFA". It previously also acted as a self-exemption key that let a non-administrator bypass an MFA lock on their own account. That meaning is gone, and assigning the scope to a non-administrator is now rejected with `400`. An account whose MFA an administrator has reset can be unlocked by another administrator or from the node console.
+
+Dashboard clients and any scripts calling the removed or narrowed endpoints must be updated.

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -163,8 +163,8 @@ delete_current_user_mfa_api.desc:
 delete_current_user_mfa_api.label:
 """Delete own MFA"""
 
-current_user_mfa_locked.desc:
-"""MFA for this account was configured by an administrator and cannot be changed by the account holder. An administrator must reset it."""
+current_user_mfa_admin_required.desc:
+"""MFA is required on this account by an administrator, so the account holder cannot turn it off. Re-keying it is still allowed."""
 
 effective_user_scopes_response.desc:
 """The permission scopes the user effectively holds. Unlike the `scopes` field of the user management endpoints, the role default is already expanded here, so this is always a concrete list."""

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -140,6 +140,14 @@ current_user_api.desc:
 current_user_api.label:
 """Get own account"""
 
+change_pwd_api.desc:
+"""Deprecated. Change the signed-in user's own password; the `username` in the path must be the signed-in user, otherwise the request is rejected. Use `/current_user/change_pwd` instead, which takes no username."""
+change_pwd_api.label:
+"""Change own password (deprecated)"""
+
+change_pwd_self_only.desc:
+"""The `username` in the path is not the signed-in user. This endpoint changes your own password only."""
+
 current_user_change_pwd_api.desc:
 """Change the signed-in user's own password. The current password must be supplied as `old_pwd`. Accounts that sign in through an SSO backend have no local password and are rejected."""
 current_user_change_pwd_api.label:

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -1,10 +1,5 @@
 emqx_dashboard_api {
 
-change_pwd_api.desc:
-"""Change Dashboard user password"""
-change_pwd_api.label:
-"""Change Dashboard user password"""
-
 create_user_api.desc:
 """Create Dashboard user"""
 create_user_api.label:
@@ -120,10 +115,10 @@ password_expire_in_seconds.desc:
 """Time in seconds until the password expires."""
 
 change_mfa.desc:
-"""Set up or reset MFA for a Dashboard user. Calling this endpoint generates a fresh TOTP secret."""
+"""Set up or reset MFA for another Dashboard user. Calling this endpoint generates a fresh TOTP secret. Requires the `mfa_management` scope and the administrator role. To manage your own MFA, use `/current_user/mfa`."""
 
 delete_mfa.desc:
-"""Disable MFA for a Dashboard user. To reset or re-key TOTP, call the `POST` method."""
+"""Disable MFA for another Dashboard user. To reset or re-key TOTP, call the `POST` method. Requires the `mfa_management` scope and the administrator role. To manage your own MFA, use `/current_user/mfa`."""
 
 mfa_token.desc:
 """Multifactor authentication token."""
@@ -139,5 +134,31 @@ change_mfa.label:
 
 delete_mfa.label:
 """Delete MFA"""
+
+current_user_api.desc:
+"""Return the signed-in user's own account: username, role, effective permission scopes and MFA status."""
+current_user_api.label:
+"""Get own account"""
+
+current_user_change_pwd_api.desc:
+"""Change the signed-in user's own password. The current password must be supplied as `old_pwd`. Accounts that sign in through an SSO backend have no local password and are rejected."""
+current_user_change_pwd_api.label:
+"""Change own password"""
+
+current_user_mfa_api.desc:
+"""Set up or rotate MFA for the signed-in user's own account. Calling this endpoint generates a fresh TOTP secret."""
+current_user_mfa_api.label:
+"""Change own MFA"""
+
+delete_current_user_mfa_api.desc:
+"""Disable MFA for the signed-in user's own account. To reset or re-key TOTP, call the `POST` method."""
+delete_current_user_mfa_api.label:
+"""Delete own MFA"""
+
+current_user_mfa_locked.desc:
+"""MFA for this account was configured by an administrator and cannot be changed by the account holder. An administrator must reset it."""
+
+effective_user_scopes_response.desc:
+"""The permission scopes the user effectively holds. Unlike the `scopes` field of the user management endpoints, the role default is already expanded here, so this is always a concrete list."""
 
 }

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -99,14 +99,14 @@ If this field is omitted when a user is created, the server applies the default 
 
 On write (create or update) this field also accepts the literal string `unset`, and a scope list that matches the role's implicit default set is treated the same way: both are stored as \"no explicit scopes\", so the user keeps the forward-compatible role default instead of a frozen list. This lets a read-modify-write (for example editing only the description) round-trip the `unset` value or the expanded scope list returned by a `GET` without error.
 
-Login users may be assigned any API key catalog scope plus the four login-only scopes: `user_management`, `mfa_management`, `sso_management`, and `api_key_management`. Among these four scopes, `user_management`, `sso_management`, and `api_key_management` are administrator-only. `mfa_management` may also be assigned to non-administrator users. For non-administrator users, it acts only as a self-exemption key that allows the user to bypass `force_mfa` and `admin_required` locks for their own MFA."""
+Login users may be assigned any API key catalog scope plus the four login-only scopes: `user_management`, `mfa_management`, `sso_management`, and `api_key_management`. All four are administrator-only; assigning any of them to a non-administrator is rejected. `mfa_management` means "manage other users' MFA": managing your own MFA is done through `/current_user/mfa` and needs no scope at all."""
 
 user_scopes_response.desc:
 """Dashboard user scopes: a fine-grained access list applied in addition to the user's role.
 
 The literal string `unset` is a legacy-only sentinel for records upgraded from a release that did not support Dashboard user scopes. At runtime, such records fall back to the default scopes for the role. Clients should treat `unset` as \"no explicit scope policy has been set yet\". An empty list `[]` means deny-all; only anonymous endpoints such as `/status` remain reachable.
 
-Login users may be assigned any API key catalog scope plus the four login-only scopes: `user_management`, `mfa_management`, `sso_management`, and `api_key_management`. Among these four scopes, `user_management`, `sso_management`, and `api_key_management` are administrator-only. `mfa_management` may also be assigned to non-administrator users. For non-administrator users, it acts only as a self-exemption key that allows the user to bypass `force_mfa` and `admin_required` locks for their own MFA."""
+Login users may be assigned any API key catalog scope plus the four login-only scopes: `user_management`, `mfa_management`, `sso_management`, and `api_key_management`. All four are administrator-only; assigning any of them to a non-administrator is rejected. `mfa_management` means "manage other users' MFA": managing your own MFA is done through `/current_user/mfa` and needs no scope at all."""
 
 backend.desc:
 """User account source"""

--- a/rel/i18n/emqx_scope_catalog.hocon
+++ b/rel/i18n/emqx_scope_catalog.hocon
@@ -31,10 +31,10 @@ scope_license.desc:
 """License management"""
 
 scope_user_management.desc:
-"""Manage dashboard users (create, update, delete, change other users' password)"""
+"""Manage dashboard users (create, update, delete)"""
 
 scope_mfa_management.desc:
-"""Manage MFA. For administrators: reset and re-key any user's MFA, override force_mfa and admin_override locks. For non-administrators: self-exemption only — bypass force_mfa / admin_override locks on the holder's own MFA"""
+"""Reset, re-key or disable another dashboard user's MFA. Administrator role only. Managing your own MFA needs no scope: use `/current_user/mfa`"""
 
 scope_sso_management.desc:
 """Configure SSO backends (LDAP, OIDC, SAML)"""


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/18607

Self-service and administration shared `/users/:username/*` and were told apart by an "is this me?" test spread across four layers: the viewer-self and namespaced-self RBAC clauses plus `is_self_service_endpoint/2`, a seven-row MFA matrix, an `Authorization` header re-parser (`is_self_auth/2`), and a separate caller-resolution path. Self-service moves to `/current_user/*`, where the caller is the subject, so each side gets one rule.

**New**

| | |
|---|---|
| `GET /current_user` | own profile: username, role, effective scopes, MFA status |
| `POST /current_user/change_pwd` | own password |
| `POST`/`DELETE /current_user/mfa` | own MFA |

Authorized by the authenticated identity alone: RBAC allows any authenticated dashboard user, and the paths are `?SCOPE_PUBLIC`, so a viewer with `scopes = []` still reaches its own account.

**Removed / narrowed**

* `POST /users/:username/change_pwd` stays as a **deprecated self-only shim** (per the [refinement](https://github.com/emqx/emqx/issues/18607#issuecomment-5461632246)): it asserts the path target is the caller, then delegates to the canonical route, and answers `403` otherwise. The old route accepted any target and merely failed the `old_pwd` check, so a cross-user call was refused by accident; now it is refused by rule. Resetting another user's password stays CLI-only.
* `/users/:username/mfa` is administrator-only, target is always another user. The handler refuses a self target so a self-change cannot be recorded as an `admin_override` decision.
* `mfa_management` becomes administrator-only. Its non-admin meaning was a self-exemption key over the holder's own MFA, and self-MFA now needs no scope at all.
* The seven-row matrix collapses to two rules: first-time setup always allowed, administrator-set MFA not changeable by the account holder.

**Three points the issue does not mention**

1. `emqx_mgmt_auth:authorize/4` denies API keys **by handler function name**, not by path. The new routes are `?SCOPE_PUBLIC`, so the scope layer would have let an API key through. Clauses added, and pinned in `emqx_mgmt_api_api_keys_SUITE`. This now covers the shim too, which no longer carries a scope either.
2. `change_password/3` is guarded on a binary username. The caller identity now comes from the token, which for SSO is a `{Backend, Name}` tuple, so this would have been a `function_clause` and a 500. `/current_user/change_pwd` returns 400 for SSO accounts instead.
3. Replacing `is_self_auth/2` with a comparison against the resolved admin key incidentally fixes the delete-self guard for SSO: the old header parser returned `false` for every SSO caller, so an SSO administrator could delete its own account.

`/current_user` is top-level, outside `/users/`, so a user named `current_user`, `self` or `me` neither shadows nor is shadowed by it (asserted).

**One fix outside the issue's scope**

Dropping `user_management` from the shim's route was not sufficient on its own. `classify_path/1` matches exact paths first, so a `?SCOPE_PUBLIC` entry that is a *template* was reachable only through segment matching, and `match_template_iter/2` skipped public entries there. `/users/:username/change_pwd` therefore classified as `not_found`, which `check_login_user_scopes_strict/2` fails closed for any user carrying an explicit scope list, so a viewer with `scopes = []` got a 403 from the scope layer before the handler ran. `/sso/login/:backend` has the same shape and is public too; it never surfaced because it is a pre-login route the scope layer does not run for.

`fix(mgmt): let a ?SCOPE_PUBLIC path template cover its concrete paths` makes scoped templates a first pass and public ones a second, so a scoped template still wins over a public one (`/sso/oidc` keeps resolving to `sso_management`, already asserted by `t_wildcard_does_not_claim_public_path`). Happy to split it out if you'd rather it did not ride along.

The umbrella has exactly **three** public templates, and all three move from `not_found` to `public`: `/users/:username/change_pwd`, `/sso/login/:backend`, and `/schemas/:name` (declared through the whole-module form `scopes() -> ?SCOPE_PUBLIC`). The third means a login user pinned to an explicit scope list can now read the static hocon/OpenAPI schema text that `emqx_dashboard_schema_api` already meant to serve "any authenticated Dashboard user". No scoped path is downgraded, and API keys are unaffected in either direction because `path_to_scope/1` collapses `public` and `not_found` to `undefined`.

**Tests**

New `emqx_dashboard_current_user_SUITE` (17 cases) covers all eight rows of the issue's coverage table, including the username-collision case and an assertion that the generated OpenAPI spec carries the split. Five of them are the shim: self-change works for viewer, global admin and namespaced admin (including with `scopes = []`); a non-self target is `403` for all three and leaves both passwords untouched; `old_pwd` is still verified; an SSO caller gets the "no local password" `400`; and the shim is marked `deprecated` in the spec while the canonical route is not. The old viewer-self / `is_self_service_endpoint` RBAC cases are deleted, not edited.

Green in `ghcr.io/emqx/emqx-builder/6.1-8:1.19.1-28.4.1-4-ubuntu24.04`: `current_user` 18/18, `user_scopes` 62/62, `rbac` 32/32, `mfa` 8/8, `sso_mfa` 41/41, `api_keys` 26/26, `key_scopes` 31/31, `api_spec` 19/19.

Four failures on this checkout are environmental, not from this branch:

* `emqx_dashboard_SUITE:t_security_response_headers` needs `priv/www/index.html` (downloaded by `make`).
* `emqx_swagger_parameter_SUITE:t_summary_i18n` needs `priv/desc.zh.hocon` (downloaded by `pre-compile.sh`).
* `sso_oidc` 4/13 and `sso_ldap` 6/10 need the compose-file Dex and LDAP servers. Both produce identical counts on an untouched `dev-70` tree.

The full CT run needs the compose stack and was not attempted locally.

**Follow-up outside this repo:** the Dashboard SPA and emqx-docs call the removed and narrowed routes and need to migrate with the cutover.
