### PR TITLE
test(session): wait for route teardown before publishing after unsubscribe

### DIFF
--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -1089,6 +1089,9 @@ do_t_unsubscribe_replay(UnackedQoS, Config) ->
     ),
     %% 3. Unsubscribe from the topic and disconnect:
     ?assertMatch({ok, _, _}, emqtt:unsubscribe(Sub, Topic1)),
+    %% UNSUBACK precedes the route teardown, so without this the "5"/"6"
+    %% publishes below can still reach the session and replay on reconnect.
+    ?retry(100, 20, ?assertEqual([], emqx_router:match_routes(Topic1))),
     ok = emqtt:disconnect(Sub),
     %% 5. Publish more messages to the disconnected topic:
     ok = publish(Topic1, <<"5">>, ?QOS_1),


### PR DESCRIPTION
## Summary

De-flake `emqx_persistent_session_SUITE:t_unsubscribe_replay_qos1` / `_qos2`:

```
?assertMatch(#{Topic1 := [<<"1">>], Topic2 := [<<"2">>]}, ...)
  expected: #{Topic1 := [<<"1">>], Topic2 := [<<"2">>]}
       got: #{".../foo/sub" => [<<"2">>], ".../foo/unsub" => [<<"5">>,<<"1">>]}
```

Seen twice, on different transports: 2026-08-04 in `persistence_disabled.tcp` (run 30942729938, PR #18244) and 2026-08-29 in `persistence_disabled.quic` (https://github.com/emqx/emqx/actions/runs/33247090360/job/99087695327?pr=18609). Neither PR touches session code.

`emqtt:unsubscribe/2` returns on UNSUBACK, but the broker removes the route asynchronously. The `"5"`/`"6"` publishes that immediately follow can therefore still be routed to the just-disconnected session, get queued in its mqueue, and replay on reconnect — which is exactly the extra `"5"` in the failure.

Wait until `emqx_router:match_routes/1` reports no route for the topic before disconnecting. Both cases share `do_t_unsubscribe_replay/2`, so both are covered.

Full suite passes locally: 152 ok, 0 failed.

Base `dev-60`: the helper exists only on the v6 lines (dev-60 through dev-70), so this is the earliest affected branch and it syncs forward.