### PR TITLE
chore(bpapi): deprecate proto versions unreachable from 5.8

### DIFF
--- a/apps/emqx/src/proto/emqx_cm_proto_v1.erl
+++ b/apps/emqx/src/proto/emqx_cm_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     lookup_client/2,
     kickout_client/2,
@@ -25,6 +26,9 @@
 
 introduced_in() ->
     "5.0.0".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec kickout_client(node(), emqx_types:clientid()) -> ok | {badrpc, _}.
 kickout_client(Node, ClientId) ->

--- a/apps/emqx/src/proto/emqx_proto_v1.erl
+++ b/apps/emqx/src/proto/emqx_proto_v1.erl
@@ -10,6 +10,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     is_running/1,
 
@@ -27,6 +28,9 @@
 
 introduced_in() ->
     "5.0.0".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec is_running(node()) -> boolean() | {badrpc, term()}.
 is_running(Node) ->

--- a/apps/emqx_conf/src/proto/emqx_conf_proto_v1.erl
+++ b/apps/emqx_conf/src/proto/emqx_conf_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     get_config/2,
     get_config/3,
@@ -30,6 +31,9 @@
 
 introduced_in() ->
     "5.0.0".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec get_config(node(), emqx_utils_maps:config_key_path()) ->
     term() | emqx_rpc:badrpc().

--- a/apps/emqx_conf/src/proto/emqx_conf_proto_v2.erl
+++ b/apps/emqx_conf/src/proto/emqx_conf_proto_v2.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
     sync_data_from_node/1,
     get_config/2,
     get_config/3,
@@ -28,6 +29,9 @@
 
 introduced_in() ->
     "5.0.1".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec sync_data_from_node(node()) -> {ok, binary()} | emqx_rpc:badrpc().
 sync_data_from_node(Node) ->

--- a/apps/emqx_eviction_agent/src/proto/emqx_eviction_agent_proto_v1.erl
+++ b/apps/emqx_eviction_agent/src/proto/emqx_eviction_agent_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     evict_session_channel/4
 ]).
@@ -16,6 +17,9 @@
 
 introduced_in() ->
     "5.0.22".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec evict_session_channel(
     node(),

--- a/apps/emqx_management/src/proto/emqx_management_proto_v1.erl
+++ b/apps/emqx_management/src/proto/emqx_management_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     node_info/1,
     broker_info/1,
@@ -26,6 +27,9 @@
 
 introduced_in() ->
     "5.0.0".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec node_info(node()) -> map() | {badrpc, _}.
 node_info(Node) ->

--- a/apps/emqx_management/src/proto/emqx_management_proto_v2.erl
+++ b/apps/emqx_management/src/proto/emqx_management_proto_v2.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     node_info/1,
     broker_info/1,
@@ -27,6 +28,9 @@
 
 introduced_in() ->
     "5.0.1".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec unsubscribe_batch(node(), emqx_types:clientid(), [emqx_types:topic()]) ->
     {unsubscribe, _} | {error, _} | {badrpc, _}.

--- a/apps/emqx_management/src/proto/emqx_management_proto_v3.erl
+++ b/apps/emqx_management/src/proto/emqx_management_proto_v3.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     node_info/1,
     broker_info/1,
@@ -27,6 +28,9 @@
 
 introduced_in() ->
     "5.0.9".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec unsubscribe_batch(node(), emqx_types:clientid(), [emqx_types:topic()]) ->
     {unsubscribe, _} | {error, _} | {badrpc, _}.

--- a/apps/emqx_management/src/proto/emqx_management_proto_v4.erl
+++ b/apps/emqx_management/src/proto/emqx_management_proto_v4.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     node_info/1,
     broker_info/1,
@@ -29,6 +30,9 @@
 
 introduced_in() ->
     "5.1.0".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec unsubscribe_batch(node(), emqx_types:clientid(), [emqx_types:topic()]) ->
     {unsubscribe, _} | {error, _} | {badrpc, _}.

--- a/apps/emqx_management/src/proto/emqx_mgmt_api_plugins_proto_v2.erl
+++ b/apps/emqx_management/src/proto/emqx_mgmt_api_plugins_proto_v2.erl
@@ -7,6 +7,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
     get_plugins/1,
     install_package/3,
     describe_package/2,
@@ -18,6 +19,9 @@
 
 introduced_in() ->
     "5.1.0".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec get_plugins([node()]) -> emqx_rpc:multicall_result().
 get_plugins(Nodes) ->

--- a/apps/emqx_management/src/proto/emqx_mgmt_cluster_proto_v1.erl
+++ b/apps/emqx_management/src/proto/emqx_mgmt_cluster_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
     invite_node/2
 ]).
 
@@ -15,6 +16,9 @@
 
 introduced_in() ->
     "5.0.0".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec invite_node(node(), node()) -> ok | ignore | {error, term()} | emqx_rpc:badrpc().
 invite_node(Node, Self) ->

--- a/apps/emqx_management/src/proto/emqx_mgmt_cluster_proto_v2.erl
+++ b/apps/emqx_management/src/proto/emqx_mgmt_cluster_proto_v2.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
     invite_node/2,
     connected_replicants/1
 ]).
@@ -16,6 +17,9 @@
 
 introduced_in() ->
     "5.1.1".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec invite_node(node(), node()) -> ok | ignore | {error, term()} | emqx_rpc:badrpc().
 invite_node(Node, Self) ->

--- a/apps/emqx_modules/src/proto/emqx_delayed_proto_v1.erl
+++ b/apps/emqx_modules/src/proto/emqx_delayed_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
     get_delayed_message/2,
     delete_delayed_message/2
 ]).
@@ -16,6 +17,9 @@
 
 introduced_in() ->
     "5.0.0".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec get_delayed_message(node(), binary()) ->
     emqx_delayed:with_id_return(map()) | emqx_rpc:badrpc().

--- a/apps/emqx_modules/src/proto/emqx_delayed_proto_v2.erl
+++ b/apps/emqx_modules/src/proto/emqx_delayed_proto_v2.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
     get_delayed_message/2,
     delete_delayed_message/2,
 
@@ -19,6 +20,9 @@
 
 introduced_in() ->
     "5.2.1".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec get_delayed_message(node(), binary()) ->
     emqx_delayed:with_id_return(map()) | emqx_rpc:badrpc().

--- a/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_api_proto_v1.erl
+++ b/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_api_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     node_rebalance_evacuation_start/2,
     node_rebalance_evacuation_stop/1,
@@ -21,6 +22,9 @@
 
 introduced_in() ->
     "5.0.22".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec node_rebalance_evacuation_start(node(), emqx_node_rebalance_evacuation:start_opts()) ->
     emqx_rpc:badrpc() | ok_or_error(emqx_node_rebalance_evacuation:start_error()).

--- a/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_proto_v1.erl
+++ b/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     available_nodes/1,
     evict_connections/2,
@@ -24,6 +25,9 @@
 
 introduced_in() ->
     "5.0.22".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec available_nodes([node()]) -> emqx_rpc:multicall_result(node()).
 available_nodes(Nodes) ->

--- a/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_proto_v2.erl
+++ b/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_proto_v2.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     available_nodes/1,
     evict_connections/2,
@@ -29,6 +30,9 @@
 
 introduced_in() ->
     "5.2.1".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec available_nodes([node()]) -> emqx_rpc:multicall_result(node()).
 available_nodes(Nodes) ->

--- a/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_status_proto_v1.erl
+++ b/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_status_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
 
     local_status/1,
     rebalance_status/1,
@@ -19,6 +20,9 @@
 
 introduced_in() ->
     "5.0.22".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec local_status(node()) ->
     emqx_rpc:badrpc() | disabled | {evacuation, map()} | {rebalance, map()}.

--- a/apps/emqx_plugins/src/proto/emqx_plugins_proto_v1.erl
+++ b/apps/emqx_plugins/src/proto/emqx_plugins_proto_v1.erl
@@ -8,6 +8,7 @@
 
 -export([
     introduced_in/0,
+    deprecated_since/0,
     get_tar/3
 ]).
 
@@ -17,6 +18,9 @@
 
 introduced_in() ->
     "5.0.21".
+
+deprecated_since() ->
+    "6.3.0".
 
 -spec get_tar(node(), name_vsn(), timeout()) -> {ok, binary()} | {error, any}.
 get_tar(Node, NameVsn, Timeout) ->


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:
N/A

## Summary

`apps/emqx_bpapi/README.md` states the rule: an API deprecated in release `maj.min.0` can be
removed in release `maj.min+1.0`. This PR is phase 1 of a three-phase cleanup: mark
`deprecated_since() -> "6.3.0"` on proto modules that no supported rolling-upgrade source can
still call. It deletes nothing.

The README's "Rolling Upgrade Paths" matrix shows 5.8 is the oldest release that can roll into
6.x or 7.0. So for each API, every version a 5.8 node can still be asked to speak must stay, and
every version below that is unreachable and safe to mark deprecated.

The baseline is **5.8.0, not 5.8.9**. `emqx_bpapi:supported_version/2` returns the remote node's
max version for an API, so a 6.3 node talking to a 5.8.0 node calls whatever 5.8.0 supports — not
whatever the latest 5.8.x patch supports. Two successors that landed mid-5.8 are excluded from
this list for exactly this reason: `emqx_dashboard_proto_v2` (5.8.4) and `emqx_plugins_proto_v3`
(5.8.6) mean `emqx_dashboard_proto_v1` and `emqx_plugins_proto_v2` are still reachable from an
early 5.8 patch.

The list was derived by comparing `git show v5.8.0:apps/emqx/priv/bpapi.versions` against the
current `apps/emqx/priv/bpapi.versions`: any local `<api>_proto_vN` whose N is strictly below the
5.8.0 maximum for that API. 25 modules matched; 19 needed the callback added (this PR), 6 already
carry a `deprecated_since` from an earlier release and are left unchanged:
`emqx_cm_proto_v2` (5.7.0), `emqx_conf_proto_v3` (5.7.1), `emqx_eviction_agent_proto_v2` (5.7.0),
`emqx_metrics_proto_v1` (5.7.0), `emqx_mgmt_api_plugins_proto_v1` (5.1.0),
`emqx_resource_proto_v1` (5.6.0).

Modules touched in this PR:

- `emqx_proto_v1`
- `emqx_cm_proto_v1`
- `emqx_conf_proto_v1`
- `emqx_conf_proto_v2`
- `emqx_delayed_proto_v1`
- `emqx_delayed_proto_v2`
- `emqx_eviction_agent_proto_v1`
- `emqx_management_proto_v1`
- `emqx_management_proto_v2`
- `emqx_management_proto_v3`
- `emqx_management_proto_v4`
- `emqx_mgmt_api_plugins_proto_v2`
- `emqx_mgmt_cluster_proto_v1`
- `emqx_mgmt_cluster_proto_v2`
- `emqx_node_rebalance_proto_v1`
- `emqx_node_rebalance_proto_v2`
- `emqx_node_rebalance_api_proto_v1`
- `emqx_node_rebalance_status_proto_v1`
- `emqx_plugins_proto_v1`

Deprecated does not mean droppable: `emqx_conf_proto_v4` is deprecated since 6.0.0 but is 5.8.0's
maximum for `emqx_conf`, so phase 3 must use the upgrade matrix, not the presence of
`deprecated_since`, to decide what to delete.

Plan:

1. This PR — mark deprecated on `dev-63`.
2. Sync forward `dev-63` → `dev-70` carries the markers automatically.
3. After 6.3.0 GA, delete from `dev-70` in a separate PR.

Safety checks performed before writing these changes:

- `deprecated_since/0` is inert at runtime. It is declared only as an optional callback in
  `apps/emqx_bpapi/src/emqx_bpapi.erl`; nothing reads it, and nothing filters version negotiation
  or the announced version set on it.
- Adding the callback does not trip the immutability check.
  `apps/emqx_utils/src/bpapi/emqx_bpapi_trans.erl` explicitly skips `introduced_in/0` and
  `deprecated_since/0` in its parse transform, so neither is added to the frozen call-signature
  set. The six modules that already carry a `deprecated_since` from an earlier release are the
  working precedent.

No changelog: nothing user-facing changes.

Two things worth noting for phase 3, not fixed here:

- `apps/emqx_bpapi/test/emqx_bpapi_static_checks.erl` gates deletion on the hardcoded
  `?FORCE_DELETED_APIS` / `?FORCE_DELETED_MODULES` lists, while its error message says a module
  "was removed in release ~p without being deprecated." The check never consults
  `deprecated_since/0`. Phase 3 will need entries added to those lists.
- Deleting a `_proto_vN` module removes this node's ability to *call* vN. It does not remove its
  ability to *answer* a vN call from an older node, because the target function is referenced by
  MFA and lives in an ordinary module. Phase 3 must delete only the caller wrappers and must not
  treat the target functions as newly-dead code.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
