### PR TITLE
test(dashboard): do not require exactly one sample in t_monitor_reset

### DIFF
--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -646,7 +646,9 @@ t_monitor_reset(_) ->
             infinity
         ),
     {ok, Samplers} = request(["monitor"], "latest=1"),
-    ?assertEqual(1, erlang:length(Samplers)),
+    %% `latest=1' is a 1s window and the sample interval is also 1s, so the
+    %% window holds 1 or 2 samples depending on where it falls.
+    ?assertMatch([_ | _], Samplers),
     ok = delete(["monitor"]),
     ?assertMatch({ok, []}, request(["monitor"], "latest=1")),
     ok.


### PR DESCRIPTION
## Summary

De-flake `emqx_dashboard_monitor_SUITE:t_monitor_reset`:

```
?assertEqual(1, erlang:length(Samplers))
  expected: 1
       got: 2
```

Seen in: https://github.com/emqx/emqx/actions/runs/33257954758 (r61→r62 sync PR #18615, which touches no dashboard files)

The suite sets `dashboard.sample_interval = 1s`, and the test queries `latest=1`, which `latest2time/1` turns into a one-second window. The window is therefore exactly one sample interval wide, so it holds 1 or 2 samples depending on where it falls relative to the flush boundary — "exactly 1" is not a property the test can rely on, and no timing budget makes it one.

At that point the test only needs a sample to exist (the monitor was restarted, then a flush was awaited), so assert that instead.

Full suite passes locally: 21 ok, 0 failed.

Base `dev-58`: the assert and the 1s-interval/1s-window combination are unchanged from dev-58 through dev-70, so this is the earliest affected line.