### PR TITLE
test(ratelimiter): poll available tokens in t_try_restore_with_bucket

### DIFF
--- a/apps/emqx/test/emqx_ratelimiter_SUITE.erl
+++ b/apps/emqx/test/emqx_ratelimiter_SUITE.erl
@@ -23,6 +23,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(BASE_CONF, <<"">>).
 
@@ -240,8 +241,9 @@ t_try_restore_with_bucket(_) ->
         {_, _, Retry, L2} = emqx_htb_limiter:check(150, Client),
         timer:sleep(200),
         {ok, L3} = emqx_htb_limiter:check(Retry, L2),
-        Avaiable = emqx_htb_limiter:available(L3),
-        ?assert(Avaiable >= 50)
+        %% The bucket is refilled by a timer, which can lag behind the sleep
+        %% above; available/1 reads live state, so poll it.
+        ?retry(100, 20, ?assert(emqx_htb_limiter:available(L3) >= 50))
     end,
     with_bucket(Fun, Case).
 


### PR DESCRIPTION
## Summary

De-flake `emqx_ratelimiter_SUITE:t_try_restore_with_bucket`:

```
Failure/Error: ?assert(Avaiable >= 50)
  expected: true
       got: false
```

Seen in: https://github.com/emqx/emqx/actions/runs/33259925333/job/99121201995?pr=18616 (a dashboard test-only PR)

The case sleeps 200 ms to let the bucket refill, then reads `emqx_htb_limiter:available/1` once. The refill is driven by the limiter server's timer, which can lag behind the sleep on a loaded runner, so the single read can land before the tokens are credited. `available/1` reads live bucket state, so polling it picks the refill up as soon as it happens.

Full suite passes locally: 34 ok, 0 failed.

Base `dev-58` and dev-58 only: `emqx_ratelimiter_SUITE` was removed in the 5.9 limiter refactor. Follows #18556, which fixed the same class of timing assertion in `t_divisible`.