### PR TITLE
fix(mgmt): return 400 instead of 500 for an unreachable node in Nodes API

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -283,7 +283,12 @@ format(Info = #{memory_total := Total, memory_used := Used}) ->
         memory_used := emqx_mgmt_util:kmg(Used)
     };
 format(Info) when is_map(Info) ->
-    Info.
+    Info;
+%% `emqx_mgmt:lookup_node/1` reaches this as `Info` when the target node
+%% becomes unreachable between the caller's liveness check and the RPC,
+%% e.g. a concurrent `cluster leave`.
+format({error, _} = Error) ->
+    Error.
 
 to_ok_result({error, _} = Error) ->
     Error;

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -73,6 +73,24 @@ t_nodes_api(_) ->
         emqx_mgmt_api_test_util:request_api(get, BadNodePath)
     ).
 
+-doc """
+A node can pass the running-nodes liveness check and still fail the RPC right
+after, e.g. a concurrent `cluster leave`. `emqx_mgmt:lookup_node/1` then
+returns `{error, _}` instead of a node info map.
+""".
+t_node_api_unreachable_node(_) ->
+    meck:new(emqx_mgmt, [passthrough, no_history]),
+    meck:expect(emqx_mgmt, lookup_node, fun(_Node) -> {error, badarg} end),
+    try
+        NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
+        ?assertMatch(
+            {error, {_, 400, _}},
+            emqx_mgmt_api_test_util:request_api(get, NodePath)
+        )
+    after
+        meck:unload(emqx_mgmt)
+    end.
+
 t_log_path(_) ->
     NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
     {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),

--- a/changes/ee/fix-18619.en.md
+++ b/changes/ee/fix-18619.en.md
@@ -1,0 +1,1 @@
+Fixed `GET /nodes/{node}` returning a 500 Internal Server Error instead of a 400 Bad Request when the target node becomes unreachable between the API's liveness check and the RPC that fetches its info, for example when the node concurrently leaves the cluster.


### PR DESCRIPTION
Fixes: #17896
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: pre-5.8

## Summary

`GET /nodes/{node}` (and the `/metrics`, `/stats` sub-paths) returned a 500
Internal Server Error instead of a 400 Bad Request when the target node
became unreachable between `emqx_mgmt_api_lib:with_node/2`'s liveness check
(`lists:member(Node, mria:running_nodes())`) and the RPC that fetches its
info. The most common trigger is a concurrent `cluster leave`: the node
still shows up as running in the caller's cached membership view, but the
`erpc` call to it fails.

`emqx_mgmt:lookup_node/1` already surfaces that failure as `{error, Reason}`
(via `emqx_rpc:unwrap_erpc/1`), and `to_ok_result/1` already knows how to
turn `{error, _}` into a proper `400 Bad Request` — the sibling
`node_metrics`/`node_stats` handlers rely on exactly this path today.
`emqx_mgmt_api_nodes:format/1` was the one place that didn't: it only had
clauses for a map, so an `{error, Reason}` tuple raised a `function_clause`.

The fix adds one clause: `format({error, _} = Error) -> Error.` No other
behavior changes; a successful lookup is unaffected.

Reproduced with a real 2-node cluster: `emqx1` executing `cluster leave`
while `emqx2`'s Nodes API was concurrently queried for `emqx1`'s info
produced the exact crash reported in the issue (`{error,badarg}` reaching
`format/1`). With the fix, the same race returns a normal 400 response.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)