### PR TITLE
fix(mqueue): enforce max_len across the whole queue, not per priority lane

### DIFF
--- a/apps/emqx/src/emqx_mqueue.erl
+++ b/apps/emqx/src/emqx_mqueue.erl
@@ -308,15 +308,19 @@ in(
         end,
     Msg1 = with_ts(Msg),
     Q1 = emqx_pqueue:in(Msg1, Prio, Class, Q0),
-    case MaxLen =/= ?MAX_LEN_INFINITY andalso emqx_pqueue:plen(Prio, Q1) > MaxLen of
+    case MaxLen =/= ?MAX_LEN_INFINITY andalso emqx_pqueue:len(Q1) > MaxLen of
         false ->
             {_DroppedMsg = undefined, MQ#mqueue{
                 q = Q1,
                 payload_bytes = PayloadBytes + emqx_message:payload_size(Msg1)
             }};
         true ->
-            %% Reached max length: drop the oldest least important message.
-            {{value, DroppedMsg}, Q2} = emqx_pqueue:drop(Prio, Q1),
+            %% Reached max length: drop the oldest message from the lowest-priority
+            %% non-empty lane, so a lower-priority message never survives at the
+            %% expense of a higher-priority one. This may not be the lane the
+            %% incoming message was just added to.
+            DropPrio = emqx_pqueue:lowest(Q1),
+            {{value, DroppedMsg}, Q2} = emqx_pqueue:drop(DropPrio, Q1),
             PayloadBytes1 =
                 PayloadBytes - emqx_message:payload_size(DroppedMsg) +
                     emqx_message:payload_size(Msg1),

--- a/apps/emqx/src/emqx_mqueue.erl
+++ b/apps/emqx/src/emqx_mqueue.erl
@@ -319,8 +319,7 @@ in(
             %% non-empty lane, so a lower-priority message never survives at the
             %% expense of a higher-priority one. This may not be the lane the
             %% incoming message was just added to.
-            DropPrio = emqx_pqueue:lowest(Q1),
-            {{value, DroppedMsg}, Q2} = emqx_pqueue:drop(DropPrio, Q1),
+            {{value, DroppedMsg}, Q2} = emqx_pqueue:drop_lowest(Q1),
             PayloadBytes1 =
                 PayloadBytes - emqx_message:payload_size(DroppedMsg) +
                     emqx_message:payload_size(Msg1),

--- a/apps/emqx/src/emqx_pqueue.erl
+++ b/apps/emqx/src/emqx_pqueue.erl
@@ -52,6 +52,7 @@
     out/1,
     out/2,
     drop/2,
+    drop_lowest/1,
     out_p/1,
     filter/2,
     fold/3,
@@ -131,7 +132,7 @@ len({queue, _R, _F, L}) ->
 len(?cqueue(_, _, L)) ->
     L;
 len({pqueue, Queues}) ->
-    lists:sum([len(Q) || {_, Q} <- Queues]).
+    lists:foldl(fun({_P, Q}, Acc) -> Acc + len(Q) end, 0, Queues).
 
 -spec plen(priority(), pqueue()) -> non_neg_integer().
 plen(P, {pqueue, Queues}) ->
@@ -274,6 +275,31 @@ drop(Priority, {pqueue, Queues}) ->
     end;
 drop(Priority, _) ->
     erlang:error(badarg, [Priority]).
+
+-doc """
+Drop the oldest least important element from the lowest non-empty priority,
+in a single pass over the priority lanes. Equivalent to
+`drop(lowest(Q), Q)`, but without a separate lookup of the lowest priority
+followed by a second traversal to find and drop from that lane.
+""".
+-spec drop_lowest(pqueue()) -> {empty | {value, any()}, pqueue()}.
+drop_lowest({pqueue, Queues}) ->
+    {R, Queues1} = drop_lowest_lane(Queues),
+    {R, from_pqueue_list(Queues1)};
+drop_lowest(Q) ->
+    drop(0, Q).
+
+%% `Queues` is sorted highest-priority-first (see `in/4`) and never holds an
+%% emptied-out lane, so the last element is the lowest non-empty lane.
+drop_lowest_lane([{P, Q}]) ->
+    {R, Q1} = drop(0, Q),
+    case is_empty(Q1) of
+        true -> {R, []};
+        false -> {R, [{P, Q1}]}
+    end;
+drop_lowest_lane([Entry | Rest]) ->
+    {R, Rest1} = drop_lowest_lane(Rest),
+    {R, [Entry | Rest1]}.
 
 -spec shift(pqueue()) -> pqueue().
 shift({pqueue, []}) ->

--- a/apps/emqx/src/emqx_pqueue.erl
+++ b/apps/emqx/src/emqx_pqueue.erl
@@ -56,6 +56,7 @@
     filter/2,
     fold/3,
     highest/1,
+    lowest/1,
     shift/1
 ]).
 
@@ -363,6 +364,16 @@ fold(Fun, Init, Q) ->
 highest({pqueue, [{P, _} | _]}) ->
     maybe_negate_priority(P);
 highest(_Q) ->
+    0.
+
+%% Queues is sorted highest-priority-first (see `in/4`), and never holds
+%% an emptied-out lane (lanes are pruned in `out/1`, `out/2` and `drop/2`),
+%% so the last element is the lowest non-empty priority.
+-spec lowest(pqueue()) -> priority().
+lowest({pqueue, Queues}) ->
+    {P, _} = lists:last(Queues),
+    maybe_negate_priority(P);
+lowest(_Q) ->
     0.
 
 r2f([], 0) -> {queue, [], [], 0};

--- a/apps/emqx/test/emqx_mqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_mqueue_SUITE.erl
@@ -106,6 +106,7 @@ t_infinity_simple_mqueue(_) ->
     {{value, V}, _Qy} = ?Q:out(Qx),
     ?assertEqual(<<1>>, V#message.payload).
 
+-doc "max_len caps the total queue length, not each priority lane independently.".
 t_priority_mqueue(_) ->
     Opts = #{
         max_len => 3,
@@ -124,21 +125,32 @@ t_priority_mqueue(_) ->
     {_, Q2} = ?Q:in(#message{qos = 1, topic = <<"t1">>, payload = <<>>}, Q1),
     {_, Q3} = ?Q:in(#message{qos = 1, topic = <<"t3">>, payload = <<>>}, Q2),
     ?assertEqual(3, ?Q:len(Q3)),
-    {_, Q4} = ?Q:in(#message{qos = 1, topic = <<"t2">>, payload = <<>>}, Q3),
-    ?assertEqual(4, ?Q:len(Q4)),
-    {_, Q5} = ?Q:in(#message{qos = 1, topic = <<"t2">>, payload = <<>>}, Q4),
-    ?assertEqual(5, ?Q:len(Q5)),
-    {_, Q6} = ?Q:in(#message{qos = 1, topic = <<"t2">>, payload = <<>>}, Q5),
-    ?assertEqual(5, ?Q:len(Q6)),
-    {{value, _Msg}, Q7} = ?Q:out(Q6),
-    ?assertEqual(4, ?Q:len(Q7)).
+    %% Queue is at the global cap: enqueuing another t2 (prio 2) message must not
+    %% grow the total past max_len. The dropped message comes from t1 (prio 1),
+    %% the lowest non-empty lane, not from t2's own lane.
+    {Dropped4, Q4} = ?Q:in(#message{qos = 1, topic = <<"t2">>, payload = <<>>}, Q3),
+    ?assertEqual(<<"t1">>, Dropped4#message.topic),
+    ?assertEqual(3, ?Q:len(Q4)),
+    %% t1 is now empty; the lowest non-empty lane is t2, which holds the oldest
+    %% surviving message.
+    {Dropped5, Q5} = ?Q:in(#message{qos = 1, topic = <<"t2">>, payload = <<>>}, Q4),
+    ?assertEqual(<<"t2">>, Dropped5#message.topic),
+    ?assertEqual(3, ?Q:len(Q5)),
+    {{value, Msg}, Q6} = ?Q:out(Q5),
+    ?assertEqual(<<"t3">>, Msg#message.topic),
+    ?assertEqual(2, ?Q:len(Q6)).
 
 t_priority_mqueue_conservation(_) ->
     true = proper:quickcheck(conservation_prop()).
 
+-doc """
+Dequeue order across priority lanes (round-robin with priority-weighted
+credits). max_len is unbounded here so the global cap from t_priority_mqueue
+does not interact with the scheduling being tested.
+""".
 t_priority_order(_) ->
     Opts = #{
-        max_len => 5,
+        max_len => 0,
         shift_multiplier => 1,
         priorities =>
             #{
@@ -168,28 +180,47 @@ t_priority_order(_) ->
     ),
     ?assertMatch(
         [
+            {<<"t3">>, <<"1">>},
+            {<<"t3">>, <<"2">>},
+            {<<"t3">>, <<"3">>},
+
+            {<<"t2">>, <<"1">>},
+            {<<"t2">>, <<"2">>},
+
+            {<<"t1">>, <<"1">>},
+
+            {<<"t3">>, <<"4">>},
+            {<<"t3">>, <<"5">>},
             {<<"t3">>, <<"6">>},
+
+            {<<"t2">>, <<"3">>},
+            {<<"t2">>, <<"4">>},
+
+            {<<"t1">>, <<"2">>},
+
             {<<"t3">>, <<"7">>},
             {<<"t3">>, <<"8">>},
-
-            {<<"t2">>, <<"6">>},
-            {<<"t2">>, <<"7">>},
-
-            {<<"t1">>, <<"6">>},
-
             {<<"t3">>, <<"9">>},
+
+            {<<"t2">>, <<"5">>},
+            {<<"t2">>, <<"6">>},
+
+            {<<"t1">>, <<"3">>},
+
             {<<"t3">>, <<"10">>},
 
+            {<<"t2">>, <<"7">>},
             {<<"t2">>, <<"8">>},
 
-            %% Note: for performance reasons we don't reset the
-            %% counter when we run out of messages with the
-            %% current prio, so next is t1:
-            {<<"t1">>, <<"7">>},
+            {<<"t1">>, <<"4">>},
 
             {<<"t2">>, <<"9">>},
             {<<"t2">>, <<"10">>},
 
+            %% t2 and t3 are exhausted; the round-robin drains the rest of t1.
+            {<<"t1">>, <<"5">>},
+            {<<"t1">>, <<"6">>},
+            {<<"t1">>, <<"7">>},
             {<<"t1">>, <<"8">>},
             {<<"t1">>, <<"9">>},
             {<<"t1">>, <<"10">>}
@@ -197,9 +228,14 @@ t_priority_order(_) ->
         drain(Q)
     ).
 
+-doc """
+Same as t_priority_order/1, with a different shift_multiplier and negative
+priorities. max_len is unbounded so the scheduling test is not affected by
+the global cap.
+""".
 t_priority_order2(_) ->
     Opts = #{
-        max_len => 5,
+        max_len => 0,
         shift_multiplier => 2,
         priorities =>
             #{
@@ -228,16 +264,29 @@ t_priority_order2(_) ->
     ),
     ?assertMatch(
         [
+            {<<"t2">>, <<"1">>},
+            {<<"t2">>, <<"2">>},
+            {<<"t2">>, <<"3">>},
+            {<<"t2">>, <<"4">>},
+
+            {<<"t1">>, <<"1">>},
+            {<<"t1">>, <<"2">>},
+
+            {<<"t2">>, <<"5">>},
             {<<"t2">>, <<"6">>},
             {<<"t2">>, <<"7">>},
             {<<"t2">>, <<"8">>},
+
+            {<<"t1">>, <<"3">>},
+            {<<"t1">>, <<"4">>},
+
             {<<"t2">>, <<"9">>},
-
-            {<<"t1">>, <<"6">>},
-            {<<"t1">>, <<"7">>},
-
             {<<"t2">>, <<"10">>},
 
+            %% t2 is exhausted; the round-robin drains the rest of t1.
+            {<<"t1">>, <<"5">>},
+            {<<"t1">>, <<"6">>},
+            {<<"t1">>, <<"7">>},
             {<<"t1">>, <<"8">>},
             {<<"t1">>, <<"9">>},
             {<<"t1">>, <<"10">>}
@@ -288,6 +337,76 @@ t_length_priority_mqueue(_) ->
     ?assertEqual(2, ?Q:len(Q4)),
     {{value, _Val}, Q5} = ?Q:out(Q4),
     ?assertEqual(1, ?Q:len(Q5)).
+
+-doc """
+Regression test for https://github.com/emqx/emqx/issues/13409: with several
+prioritised topics, max_len bounds the total number of queued messages, not
+each priority lane independently.
+""".
+t_max_len_bounds_total_not_per_priority(_) ->
+    MaxLen = 3,
+    Topics = [<<"t1">>, <<"t2">>, <<"t3">>, <<"t4">>, <<"t5">>],
+    Priorities = maps:from_list(lists:zip(Topics, lists:seq(1, length(Topics)))),
+    Opts = #{max_len => MaxLen, priorities => Priorities, store_qos0 => false},
+    Q = lists:foldl(
+        fun(_Round, QAcc) ->
+            lists:foldl(
+                fun(Topic, QAcc1) ->
+                    {_Dropped, QAcc2} = ?Q:in(
+                        emqx_message:make(?MODULE, ?QOS_1, Topic, <<"p">>), QAcc1
+                    ),
+                    %% The regression: this must hold after every single enqueue,
+                    %% not just at the end.
+                    ?assert(?Q:len(QAcc2) =< MaxLen),
+                    QAcc2
+                end,
+                QAcc,
+                Topics
+            )
+        end,
+        ?Q:init(Opts),
+        lists:seq(1, 20)
+    ),
+    ?assertEqual(MaxLen, ?Q:len(Q)),
+    %% t5 has the highest priority: a lower-priority message must never
+    %% survive at the expense of a higher-priority one.
+    ?assert(lists:any(fun(#message{topic = T}) -> T =:= <<"t5">> end, ?Q:to_list(Q))).
+
+-doc """
+The message dropped when the queue is full comes from the lowest-priority
+non-empty lane, even when the incoming message's own lane was empty before
+this enqueue (so a naive "drop from the incoming lane" rule would have
+dropped the message just enqueued, or refused it, instead).
+""".
+t_drop_from_lowest_priority_lane(_) ->
+    Opts = #{
+        max_len => 4,
+        priorities =>
+            #{
+                <<"low">> => 1,
+                <<"mid">> => 2,
+                <<"high">> => 3
+            },
+        store_qos0 => false
+    },
+    Q0 = ?Q:init(Opts),
+    {undefined, Q1} = ?Q:in(emqx_message:make(?MODULE, ?QOS_1, <<"low">>, <<"low-1">>), Q0),
+    {undefined, Q2} = ?Q:in(emqx_message:make(?MODULE, ?QOS_1, <<"low">>, <<"low-2">>), Q1),
+    {undefined, Q3} = ?Q:in(emqx_message:make(?MODULE, ?QOS_1, <<"mid">>, <<"mid-1">>), Q2),
+    {undefined, Q4} = ?Q:in(emqx_message:make(?MODULE, ?QOS_1, <<"mid">>, <<"mid-2">>), Q3),
+    ?assertEqual(4, ?Q:len(Q4)),
+    %% "high" is a brand-new, empty lane. The oldest message in "low", the
+    %% lowest non-empty priority, is the one that must go.
+    {Dropped, Q5} = ?Q:in(emqx_message:make(?MODULE, ?QOS_1, <<"high">>, <<"high-1">>), Q4),
+    ?assertEqual(<<"low-1">>, emqx_message:payload(Dropped)),
+    ?assertEqual(4, ?Q:len(Q5)),
+    Remaining = [{T, P} || #message{topic = T, payload = P} <- ?Q:to_list(Q5)],
+    ?assertEqual(4, length(Remaining)),
+    ?assertNot(lists:member({<<"low">>, <<"low-1">>}, Remaining)),
+    ?assert(lists:member({<<"low">>, <<"low-2">>}, Remaining)),
+    ?assert(lists:member({<<"mid">>, <<"mid-1">>}, Remaining)),
+    ?assert(lists:member({<<"mid">>, <<"mid-2">>}, Remaining)),
+    ?assert(lists:member({<<"high">>, <<"high-1">>}, Remaining)).
 
 t_dropped(_) ->
     Q = ?Q:init(#{max_len => 1, store_qos0 => true}),

--- a/apps/emqx/test/emqx_mqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_mqueue_SUITE.erl
@@ -143,11 +143,7 @@ t_priority_mqueue(_) ->
 t_priority_mqueue_conservation(_) ->
     true = proper:quickcheck(conservation_prop()).
 
--doc """
-Dequeue order across priority lanes (round-robin with priority-weighted
-credits). max_len is unbounded here so the global cap from t_priority_mqueue
-does not interact with the scheduling being tested.
-""".
+-doc "Dequeue order across priority lanes (round-robin with priority-weighted credits).".
 t_priority_order(_) ->
     Opts = #{
         max_len => 0,
@@ -228,11 +224,7 @@ t_priority_order(_) ->
         drain(Q)
     ).
 
--doc """
-Same as t_priority_order/1, with a different shift_multiplier and negative
-priorities. max_len is unbounded so the scheduling test is not affected by
-the global cap.
-""".
+-doc "Dequeue order with a different shift_multiplier and negative priorities.".
 t_priority_order2(_) ->
     Opts = #{
         max_len => 0,
@@ -372,12 +364,7 @@ t_max_len_bounds_total_not_per_priority(_) ->
     %% survive at the expense of a higher-priority one.
     ?assert(lists:any(fun(#message{topic = T}) -> T =:= <<"t5">> end, ?Q:to_list(Q))).
 
--doc """
-The message dropped when the queue is full comes from the lowest-priority
-non-empty lane, even when the incoming message's own lane was empty before
-this enqueue (so a naive "drop from the incoming lane" rule would have
-dropped the message just enqueued, or refused it, instead).
-""".
+-doc "The dropped message comes from the lowest-priority non-empty lane.".
 t_drop_from_lowest_priority_lane(_) ->
     Opts = #{
         max_len => 4,

--- a/apps/emqx/test/emqx_pqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_pqueue_SUITE.erl
@@ -169,6 +169,26 @@ t_highest(_) ->
         ])
     ).
 
+-doc "lowest/1 returns the lowest non-empty priority, the mirror of highest/1.".
+t_lowest(_) ->
+    0 = ?PQ:lowest(?PQ:new()),
+    0 = ?PQ:lowest(?PQ:from_list([{0, default, a}, {0, default, b}])),
+    0 = ?PQ:lowest(
+        ?PQ:from_list([
+            {0, default, a},
+            {0, default, b},
+            {1, qos0, c},
+            {2, qos0, d},
+            {2, default, e}
+        ])
+    ),
+    %% Once the lowest lane empties out, it drops off the queue entirely.
+    PQ0 = ?PQ:from_list([{1, default, a}, {2, default, b}]),
+    ?assertEqual(1, ?PQ:lowest(PQ0)),
+    {_, PQ1} = ?PQ:drop(1, PQ0),
+    ?assertEqual(2, ?PQ:lowest(PQ1)),
+    ?assertEqual(infinity, ?PQ:lowest(?PQ:from_list([{infinity, default, a}]))).
+
 t_shift_squeue(_) ->
     %% shift on simple queue is identity
     Q = ?PQ:from_list([{0, default, a}, {0, default, b}]),

--- a/apps/emqx/test/emqx_pqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_pqueue_SUITE.erl
@@ -189,6 +189,22 @@ t_lowest(_) ->
     ?assertEqual(2, ?PQ:lowest(PQ1)),
     ?assertEqual(infinity, ?PQ:lowest(?PQ:from_list([{infinity, default, a}]))).
 
+-doc "drop_lowest/1 is equivalent to drop(lowest(Q), Q).".
+t_drop_lowest(_) ->
+    {empty, _} = ?PQ:drop_lowest(?PQ:new()),
+    %% Single-lane queue: same as an ordinary drop.
+    {{value, a}, SQ1} = ?PQ:drop_lowest(?PQ:from_list([{0, default, a}, {0, default, b}])),
+    ?assertEqual([{0, b}], ?PQ:to_list(SQ1)),
+    %% Multi-lane queue: drops from the lowest priority, leaving higher
+    %% priorities untouched, and removes the lane once it empties out.
+    PQ0 = ?PQ:from_list([{2, default, a}, {1, default, b}, {1, default, c}]),
+    {{value, b}, PQ1} = ?PQ:drop_lowest(PQ0),
+    ?assertEqual([{2, a}, {1, c}], ?PQ:to_list(PQ1)),
+    {{value, c}, PQ2} = ?PQ:drop_lowest(PQ1),
+    ?assertEqual(2, ?PQ:highest(PQ2)),
+    ?assertEqual(2, ?PQ:lowest(PQ2)),
+    ?assertEqual([{2, a}], ?PQ:to_list(PQ2)).
+
 t_shift_squeue(_) ->
     %% shift on simple queue is identity
     Q = ?PQ:from_list([{0, default, a}, {0, default, b}]),

--- a/changes/ee/fix-18620.en.md
+++ b/changes/ee/fix-18620.en.md
@@ -1,3 +1,3 @@
 Fixed `mqueue.max_len` being enforced per priority lane instead of across the whole message queue.
 
-A session with prioritised topics could hold up to (number of priorities) x `max_len` queued messages, instead of `max_len`. `mqueue.max_len` now limits the total number of queued messages, so such a session no longer holds more than the configured maximum. Deployments that relied on the old behaviour will see a smaller effective queue.
+Before this fix, a session with prioritised topics could hold up to (number of priorities) x `max_len` queued messages, instead of `max_len`. `mqueue.max_len` now limits the total number of queued messages, so such a session no longer holds more than the configured maximum. Deployments that relied on the old behaviour will see a smaller effective queue.

--- a/changes/ee/fix-18620.en.md
+++ b/changes/ee/fix-18620.en.md
@@ -1,0 +1,3 @@
+Fixed `mqueue.max_len` being enforced per priority lane instead of across the whole message queue.
+
+A session with prioritised topics could hold up to (number of priorities) x `max_len` queued messages, instead of `max_len`. `mqueue.max_len` now limits the total number of queued messages, so such a session no longer holds more than the configured maximum. Deployments that relied on the old behaviour will see a smaller effective queue.


### PR DESCRIPTION
Release version:
6.2.4, 6.3.0, 7.0.0

Introduced in:
pre-5.8

## Summary

`emqx_mqueue.max_len` was enforced per priority lane instead of across the whole
queue: `in/2` compared the incoming message's own lane length (`emqx_pqueue:plen/2`)
against `max_len`. A session with N distinct message priorities could therefore
queue up to N x `max_len` messages, contradicting both the module's own
documentation and `len/1`/`info(len, _)`, which already reported the true total.

Fixes #13409.

- `apps/emqx/src/emqx_mqueue.erl`: `in/2` now compares `emqx_pqueue:len/1` (the
  total) against `max_len`.
- `apps/emqx/src/emqx_pqueue.erl`: added `lowest/1`, mirroring the existing
  `highest/1`, returning the lowest non-empty priority.
- Dropping now targets the oldest message in the lowest non-empty priority lane
  (via `lowest/1`), not the incoming message's own lane. That lane can be empty
  (a message arriving at a brand-new priority) or hold a higher priority than
  another lane, so dropping from it could evict a more important message than
  necessary, or drop the message just enqueued when a lower-priority one was
  already queued elsewhere. A lower-priority message must never survive at the
  expense of a higher-priority one.

Test changes in `emqx_mqueue_SUITE`:
- `t_priority_mqueue` asserted the old per-lane growth (`len` reaching 5 with
  `max_len = 3`); updated to assert the new global cap and that the lowest
  non-empty lane is the one dropped from.
- `t_priority_order`/`t_priority_order2` mixed dequeue-order testing with the old
  per-lane retention (`max_len = 5` with 10 messages per topic, relying on each
  lane independently keeping its own last 5). Set `max_len` to unbounded so they
  test only the round-robin/credit dequeue order, unaffected by this change; the
  expected sequences were regenerated from the (unchanged) scheduling logic.
- Added `t_max_len_bounds_total_not_per_priority` (regression test for #13409:
  asserts total length never exceeds `max_len` across several priorities) and
  `t_drop_from_lowest_priority_lane` (asserts the dropped message comes from the
  lowest non-empty lane, including when the incoming message's own lane was
  empty).
- Added `t_lowest` to `emqx_pqueue_SUITE` for the new function.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
