### PR TITLE
test(audit): retry the clients list after bulk kickout

### DIFF
--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -19,6 +19,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 all() ->
     [
@@ -322,9 +323,12 @@ kickout_clients() ->
     KickoutBody = [ClientId1, ClientId2, ClientId3],
     {ok, 204, _} = emqx_mgmt_api_test_util:request_api_with_body(post, KickoutPath, KickoutBody),
 
-    {ok, Clients2} = emqx_mgmt_api_test_util:request_api(get, ClientsPath),
-    ClientsResponse2 = emqx_utils_json:decode(Clients2, [return_maps]),
-    ?assertMatch(#{<<"data">> := []}, ClientsResponse2).
+    %% The kick call is answered before emqx_cm reaps the channel DOWN and
+    %% cleans its tables, so the clients API can still list the kicked clients.
+    ?retry(100, 20, begin
+        {ok, Clients2} = emqx_mgmt_api_test_util:request_api(get, ClientsPath),
+        ?assertMatch(#{<<"data">> := []}, emqx_utils_json:decode(Clients2, [return_maps]))
+    end).
 
 %% The audit log records the `POST /license` request body as `******`
 %% so the license key does not appear in cleartext in `GET /audit`.


### PR DESCRIPTION
## Summary

De-flake `emqx_audit_api_SUITE:t_kickout_clients_without_log`:

```
Failure/Error: ?assertMatch(#{<<"data">> := []}, ClientsResponse2)
       got: #{<<"data">> => [#{<<"ip_address">> => <<"127.0.0.1">>, ...}]}
```

Seen in: https://github.com/emqx/emqx/actions/runs/33273821437/job/99158136052?pr=18619 (a mgmt Nodes-API PR)

`POST /clients/kickout/bulk` returns 204 once the kick is dispatched; the channels are deregistered asynchronously, so the immediately following `GET /clients` can still list them. Retry the read.

Same class as the mgmt-clients and stomp-stats fixes.

Full suite passes locally: 6 ok, 0 failed.

Base `dev-58`: the assert is present unchanged from dev-58 through dev-70.