### PR TITLE
fix(shutdown): stop listeners before stopping applications

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -338,7 +338,9 @@ stop() ->
     %% so we uninstall the config handler here.
     ok = emqx_config_handler:remove_handler(?CONF_KEY_PATH),
     ok = emqx_config_handler:remove_handler([?ROOT_KEY]),
-    foreach_listeners(fun stop_listener/3).
+    ok = foreach_listeners(fun stop_listener/3),
+    ?tp(emqx_listeners_stopped, #{}),
+    ok.
 
 -spec stop_listener(listener_id()) -> ok | {error, term()}.
 stop_listener(ListenerId) ->

--- a/apps/emqx_machine/src/emqx_machine.app.src
+++ b/apps/emqx_machine/src/emqx_machine.app.src
@@ -3,7 +3,7 @@
     {id, "emqx_machine"},
     {description, "The EMQX Machine"},
     % strict semver, bump manually!
-    {vsn, "0.3.10"},
+    {vsn, "0.3.11"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, emqx_ctl, redbug]},

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -65,10 +65,35 @@ start_autocluster() ->
 
 stop_apps() ->
     ?SLOG(notice, #{msg => "stopping_emqx_apps"}),
+    %% Shut the readiness gate first: `GET /status' reports not_running
+    %% (HTTP 503) so load balancers stop routing to this node, and
+    %% connections accepted before the listen sockets close are refused.
+    %% `ensure_apps_started/0' marks the node ready again after a reboot.
+    ok = emqx_node_readiness:mark_not_ready(),
+    %% Stop listeners next, so no client traffic reaches hook callbacks
+    %% while the apps behind them (plugins, rule engine, ...) are stopped.
+    ok = stop_listeners(),
     _ = emqx_alarm_handler:unload(),
     ok = emqx_conf_app:unset_config_loaded(),
     ok = emqx_plugins:ensure_stopped(),
     lists:foreach(fun stop_one_app/1, lists:reverse(sorted_reboot_apps())).
+
+%% Listeners are stopped again from `emqx_app:prep_stop/1' when the `emqx'
+%% app stops; `emqx_listeners:stop/0' is idempotent.
+stop_listeners() ->
+    try
+        _ = emqx_boot:is_enabled(listeners) andalso emqx_listeners:stop(),
+        ok
+    catch
+        C:E:Stacktrace ->
+            ?SLOG(error, #{
+                msg => "failed_to_stop_listeners",
+                exception => C,
+                reason => E,
+                stacktrace => Stacktrace
+            }),
+            ok
+    end.
 
 %% Those port apps are terminated after the main apps
 %% Don't need to stop when reboot.
@@ -86,6 +111,7 @@ stop_port_apps() ->
 
 stop_one_app(App) ->
     ?SLOG(debug, #{msg => "stopping_app", app => App}),
+    ?tp(machine_stopping_app, #{app => App}),
     try
         _ = application:stop(App)
     catch

--- a/apps/emqx_machine/test/emqx_machine_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_SUITE.erl
@@ -130,6 +130,52 @@ t_shutdown_reboot(Config) ->
         catch emqx_cth_cluster:stop([Node])
     end.
 
+%% Verify `emqx_machine_boot:stop_apps/0' shuts the readiness gate and stops
+%% the MQTT listeners before it stops the applications, so no client traffic
+%% reaches hook callbacks (e.g. the rule engine) while their state is torn
+%% down. Also verify a second `emqx_listeners:stop/0' (as run again from
+%% `emqx_app:prep_stop/1' when `emqx' itself stops) stays a harmless no-op.
+t_stop_apps_stops_listeners_first(Config) ->
+    [Node] = emqx_cth_cluster:start(
+        [{machine_listeners_SUITE1, #{role => core, apps => app_specs()}}],
+        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+    ),
+    try
+        Port = get_tcp_mqtt_port(Node),
+        %% The listener accepts connections before shutdown.
+        {ok, Sock0} = gen_tcp:connect("127.0.0.1", Port, [], 5000),
+        ok = gen_tcp:close(Sock0),
+        ?check_trace(
+            ok = erpc:call(Node, emqx_machine_boot, stop_apps, []),
+            fun(Trace) ->
+                %% The (first) listener stop must precede the rule engine app stop.
+                Events = [
+                    Event
+                 || #{?snk_kind := Kind} = Event <- Trace,
+                    Kind =:= emqx_listeners_stopped orelse
+                        (Kind =:= machine_stopping_app andalso
+                            maps:get(app, Event) =:= emqx_rule_engine)
+                ],
+                ?assertMatch([#{?snk_kind := emqx_listeners_stopped} | _], Events),
+                %% `emqx_listeners:stop/0' runs a second time when the `emqx'
+                %% application itself is stopped later in the same loop (from
+                %% `emqx_app:prep_stop/1'). Both stops must succeed: each only
+                %% emits `emqx_listeners_stopped' after it completes without error.
+                StoppedEvents = [E || #{?snk_kind := emqx_listeners_stopped} = E <- Trace],
+                ?assertMatch([_, _], StoppedEvents)
+            end
+        ),
+        %% The readiness gate is shut and the listener no longer accepts.
+        ?assertNot(erpc:call(Node, emqx_node_readiness, is_ready, [])),
+        ?assertEqual({error, econnrefused}, gen_tcp:connect("127.0.0.1", Port, [], 5000))
+    after
+        catch emqx_cth_cluster:stop([Node])
+    end.
+
+get_tcp_mqtt_port(Node) ->
+    {_Host, Port} = erpc:call(Node, emqx_config, get, [[listeners, tcp, default, bind]]),
+    Port.
+
 t_sorted_reboot_apps(_Config) ->
     Apps = emqx_machine_boot:sorted_reboot_apps(),
     SortApps = [App || App <- Apps, (App =:= emqx_dashboard orelse App =:= emqx_license)],

--- a/changes/ee/fix-18623.en.md
+++ b/changes/ee/fix-18623.en.md
@@ -1,0 +1,5 @@
+Stop MQTT listeners before stopping applications during node shutdown.
+
+Previously, listeners kept accepting and processing client traffic while the applications behind the publish path were already stopped. Publishing clients could then trigger a burst of `hook_callback_exception` errors in the log, for example from the rule engine, until the listeners stopped a few seconds later. Listeners now stop first, so no client traffic is processed during application shutdown.
+
+The node now also reports itself as not running in `GET /status` as soon as shutdown begins, so load balancers stop routing new connections to it.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

`stop_apps/0` stopped applications and plugins while listeners stayed open. Listeners were stopped from `emqx_app:prep_stop/1`, which runs when the `emqx` application stops, and `emqx` is last in reverse dependency order. Clients kept publishing into a hook chain whose state had already been torn down.

`stop_apps/0` now shuts the readiness gate and stops the listeners first, before `emqx_plugins:ensure_stopped/0` and the per-application stop loop. A plugin holding a hook has the same exposure as the rule engine, so listeners stop before plugins too.

Notes:

* `emqx_node_readiness:mark_not_ready/0` runs first. `GET /status` reports `not_running` (HTTP 503) as soon as shutdown begins, so load balancers stop routing to the node.
* The call in `emqx_app:prep_stop/1` stays, because the `emqx` application can be stopped without going through `stop_apps/0`. `emqx_listeners:stop/0` therefore runs twice on the normal path. It is idempotent: `emqx_config_handler:remove_handler/1` no-ops on a missing entry, and esockd/cowboy/quicer return `{error, not_found}` for an already-stopped listener, which `stop_listener/3` maps to `ok`.
* The listener stop is wrapped in try/catch, so a failure cannot abort the application shutdown loop.

This is a port of #18523 to the v5 line (`dev-58`).

Two related v6 changes were checked and need no work on `dev-58`:
* #18357 (readiness gate) is already ported as #18356, merged 2026-08-15.
* #18375 (esockd_socket gate) does not apply: `emqx_socket_connection.erl` is a v6-only module that does not exist on `dev-58`.

Out of scope: #18357 also added `emqx_cluster:is_boot_complete/0` to refuse cluster joins during boot; `emqx_cluster` does not exist on v5, and #18356 left that half unported. Whether that gap is worth closing on v5 is a separate question, not addressed here.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)