### PR TITLE
feat(bridge): add 'emqx ctl actions show/status' commands

### DIFF
--- a/apps/emqx_bridge/mix.exs
+++ b/apps/emqx_bridge/mix.exs
@@ -32,7 +32,8 @@ defmodule EMQXBridge.MixProject do
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
-      {:emqx_connector, in_umbrella: true}
+      {:emqx_connector, in_umbrella: true},
+      {:emqx_ctl, in_umbrella: true}
     ])
   end
 

--- a/apps/emqx_bridge/src/emqx_bridge_app.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_app.erl
@@ -11,10 +11,12 @@
 start(_StartType, _StartArgs) ->
     {ok, Sup} = emqx_bridge_sup:start_link(),
     ok = emqx_bridge_v2:load(),
+    ok = emqx_bridge_v2_cli:load(),
     ?tp(emqx_bridge_app_started, #{}),
     {ok, Sup}.
 
 stop(_State) ->
+    ok = emqx_bridge_v2_cli:unload(),
     ok = emqx_bridge_v2:unload(),
     emqx_action_info:clean_cache(),
     ok.

--- a/apps/emqx_bridge/src/emqx_bridge_v2_cli.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_cli.erl
@@ -66,11 +66,18 @@ run(Cmd, Args) ->
     case collect_opts(Args, #{}) of
         {ok, Opts} ->
             Result = query(Cmd, Opts),
-            emqx_ctl:print("~ts~n", [emqx_utils_json:encode(Result, [pretty, force_utf8])]);
+            emqx_ctl:print("~ts~n", [format_json(Result)]);
         {error, Reason} ->
             emqx_ctl:warning("~ts~n", [Reason]),
             usage()
     end.
+
+%% Pretty-printing an empty array renders as three lines (`[`, a blank line, `]`); an
+%% empty result carries no structure worth spreading out, so print it compactly.
+format_json([]) ->
+    <<"[]">>;
+format_json(Result) ->
+    emqx_utils_json:encode(Result, [pretty, force_utf8]).
 
 %%--------------------------------------------------------------------------------
 %% Option parsing

--- a/apps/emqx_bridge/src/emqx_bridge_v2_cli.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_cli.erl
@@ -1,0 +1,173 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% `emqx ctl actions ...`: inspect action status on the local node, in JSON.
+%%
+%% Unlike `GET /api/v5/actions/{id}`, this never RPCs to other nodes and never
+%% aggregates status across the cluster (see `emqx_bridge_v2_api:aggregate_status/1`).
+%% It answers "is *this* node's action usable", which is what a per-pod readiness
+%% probe needs and the cluster-aggregated REST `status` field cannot provide.
+%%
+%% Scope: actions only. Sources and connectors share the same `emqx_bridge_v2`
+%% primitives (see `?ROOT_KEY_SOURCES`), so adding `emqx ctl sources ...` later is
+%% a matter of adding another top-level clause with its own root key, not a rewrite.
+-module(emqx_bridge_v2_cli).
+
+-include_lib("emqx/include/emqx_config.hrl").
+
+-export([load/0, unload/0]).
+-export([actions/1, actions_audit_args/1]).
+
+-define(ROOT_KEY_ACTIONS, actions).
+
+%%--------------------------------------------------------------------------------
+%% Loading and unloading
+%%--------------------------------------------------------------------------------
+
+load() ->
+    emqx_ctl:register_command(actions, {?MODULE, actions}, []).
+
+unload() ->
+    emqx_ctl:unregister_command(actions).
+
+%% Arguments are a type:name selector and a namespace, never secrets.
+actions_audit_args(Args) -> Args.
+
+%%--------------------------------------------------------------------------------
+%% `emqx ctl actions ...`
+%%--------------------------------------------------------------------------------
+
+actions(["show" | Args]) ->
+    run(show, Args);
+actions(["status" | Args]) ->
+    run(status, Args);
+actions(_) ->
+    usage().
+
+usage() ->
+    emqx_ctl:usage([
+        {"actions show [--name <type:name>] [--ns <namespace>]",
+            "Show local action config (secrets redacted) and status as JSON.\n"
+            "Omit --name to show every action; omit --ns for the global namespace.\n"
+            "Always exits 0 on a successful lookup, printing `null` if --name matches\n"
+            "nothing; pipe to `jq -e` to turn that into a failing check."},
+        {"actions status [--name <type:name>] [--ns <namespace>]",
+            "Show local action status as a compact JSON array of\n"
+            "{\"<type>:<name>\": \"<status>\"} objects.\n"
+            "Omit --name to show every action; omit --ns for the global namespace.\n"
+            "Always exits 0 on a successful lookup, printing `[]` if --name matches\n"
+            "nothing; pipe to `jq -e` to turn that into a failing check."}
+    ]).
+
+run(Cmd, Args) ->
+    case collect_opts(Args, #{}) of
+        {ok, Opts} ->
+            Result = query(Cmd, Opts),
+            emqx_ctl:print("~ts~n", [emqx_utils_json:encode(Result, [pretty, force_utf8])]);
+        {error, Reason} ->
+            emqx_ctl:warning("~ts~n", [Reason]),
+            usage()
+    end.
+
+%%--------------------------------------------------------------------------------
+%% Option parsing
+%%
+%% `--name` and `--ns` are flags rather than positional arguments, which most
+%% `emqx ctl` sub-commands do not need. No dedicated flag-parsing helper exists in
+%% `emqx_ctl` or `emqx_mgmt_cli` (checked); the house pattern for the few commands
+%% that do take flags (e.g. `emqx_mgmt_cli:collect_session_top_args/2`) is a small
+%% recursive accumulator, which this follows.
+%%--------------------------------------------------------------------------------
+
+collect_opts([], Acc) ->
+    {ok, Acc};
+collect_opts(["--name", NameStr | Rest], Acc) ->
+    case parse_type_name(NameStr) of
+        {ok, TypeName} ->
+            collect_opts(Rest, Acc#{name => TypeName});
+        error ->
+            {error, "invalid --name value, expected <type>:<name>"}
+    end;
+collect_opts(["--ns", NsStr | Rest], Acc) ->
+    collect_opts(Rest, Acc#{ns => unicode:characters_to_binary(NsStr)});
+collect_opts(Args, _Acc) ->
+    {error, io_lib:format("unknown arguments: ~p", [Args])}.
+
+parse_type_name(Str) ->
+    case string:split(Str, ":", leading) of
+        [Type, Name] when Type =/= "", Name =/= "" ->
+            {ok, {unicode:characters_to_binary(Type), unicode:characters_to_binary(Name)}};
+        _ ->
+            error
+    end.
+
+%%--------------------------------------------------------------------------------
+%% Query and formatting
+%%--------------------------------------------------------------------------------
+
+query(Cmd, Opts) ->
+    Namespace = maps:get(ns, Opts, ?global_ns),
+    case maps:find(name, Opts) of
+        {ok, {Type, Name}} ->
+            case emqx_bridge_v2:lookup(Namespace, ?ROOT_KEY_ACTIONS, Type, Name) of
+                {ok, Info} -> single_result(Cmd, Info);
+                {error, not_found} -> not_found_result(Cmd)
+            end;
+        error ->
+            Infos = emqx_bridge_v2:list(Namespace, ?ROOT_KEY_ACTIONS),
+            list_result(Cmd, Infos)
+    end.
+
+%% `show --name` prints the single object, matching the REST `GET .../actions/{id}` shape.
+single_result(show, Info) ->
+    format_show(Info);
+%% `status` always prints an array, even for a single `--name`, per the issue's own examples.
+single_result(status, Info) ->
+    [format_status(Info)].
+
+%% `--name` matching nothing is not an error: it is valid, quiet input for a probe.
+%% `null`/`[]` are both falsy to `jq -e`, so a probe script does not need to special-case it.
+not_found_result(show) -> null;
+not_found_result(status) -> [].
+
+list_result(show, Infos) ->
+    [format_show(Info) || Info <- Infos];
+list_result(status, Infos) ->
+    [format_status(Info) || Info <- Infos].
+
+format_status(#{type := Type, name := Name, status := Status}) ->
+    #{<<Type/binary, ":", Name/binary>> => Status}.
+
+%% Mirrors `emqx_bridge_v2_api:format_resource/3`, minus the cluster-only fields
+%% (`node_status`, `rules`) that command reuses `aggregate_status/1` to build, and minus
+%% schema-based default-filling, which needs no local-probe justification.
+%%
+%% `resource_data` (the connector's live resource state: pids, refs, ...) is deliberately
+%% left out entirely, same as `format_resource/3` does — it is not JSON-encodable, and there
+%% is nothing in it a readiness probe needs beyond `status`/`error`, which `lookup/4` already
+%% surfaces.
+%%
+%% `raw_config` can carry connector secrets set directly on the action (e.g. an HTTP action's
+%% `parameters.headers` may hold a bearer token) alongside the action's own reference to a
+%% connector by name. Redact exactly like the REST path does before this ever reaches a
+%% terminal.
+format_show(#{
+    namespace := Namespace,
+    type := Type,
+    name := Name,
+    raw_config := RawConf,
+    status := Status,
+    error := Error
+}) ->
+    maps:merge(emqx_utils:redact(RawConf), #{
+        <<"namespace">> => namespace_out(Namespace),
+        <<"type">> => Type,
+        <<"name">> => Name,
+        <<"node">> => node(),
+        <<"status">> => Status,
+        <<"error">> => Error
+    }).
+
+namespace_out(?global_ns) -> null;
+namespace_out(Namespace) when is_binary(Namespace) -> Namespace.

--- a/apps/emqx_bridge/src/emqx_bridge_v2_cli.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_cli.erl
@@ -14,6 +14,8 @@
 %% a matter of adding another top-level clause with its own root key, not a rewrite.
 -module(emqx_bridge_v2_cli).
 
+-behaviour(emqx_ctl).
+
 -include_lib("emqx/include/emqx_config.hrl").
 
 -export([load/0, unload/0]).

--- a/apps/emqx_bridge/test/emqx_bridge_v2_cli_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_cli_SUITE.erl
@@ -67,6 +67,8 @@ t_name_selects_one_action(_Config) ->
     ok = create_connector(conn1, connected),
     ok = create_action(action1, conn1),
     ok = create_action(action2, conn1),
+    _ = force_health_check(?global_ns, action1),
+    _ = force_health_check(?global_ns, action2),
 
     {ok, AllOutput} = capture_ctl(["actions", "status"]),
     ?assertEqual(2, length(emqx_utils_json:decode(AllOutput))),
@@ -89,6 +91,7 @@ t_ns_selects_namespace(_Config) ->
     Namespace = <<"cli_test_ns">>,
     ok = create_connector(Namespace, conn_ns, connected),
     ok = create_action(Namespace, action_ns, conn_ns, #{}),
+    _ = force_health_check(Namespace, action_ns),
 
     {ok, GlobalOutput} = capture_ctl(["actions", "status"]),
     ?assertEqual([], emqx_utils_json:decode(GlobalOutput)),

--- a/apps/emqx_bridge/test/emqx_bridge_v2_cli_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_cli_SUITE.erl
@@ -1,0 +1,259 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_v2_cli_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("typerefl/include/types.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        emqx_bridge_v2_SUITE:app_specs_without_dashboard(),
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    Apps = ?config(apps, Config),
+    ok = emqx_cth_suite:stop(Apps).
+
+init_per_testcase(_TestCase, Config) ->
+    setup_mocks(),
+    ets:new(fun_table_name(), [named_table, public]),
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ets:delete(fun_table_name()),
+    emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
+    emqx_action_info:clean_cache(),
+    emqx_common_test_helpers:call_janitor(),
+    meck:unload(),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
+
+-doc "`emqx ctl actions` with no sub-command prints usage instead of crashing.".
+t_no_subcommand_prints_usage(_Config) ->
+    {ok, Output} = capture_ctl(["actions"]),
+    ?assertMatch({match, _}, re:run(Output, "actions show")),
+    ?assertMatch({match, _}, re:run(Output, "actions status")).
+
+-doc "status reports `connected` for a healthy action and something else for a down connector.".
+t_status_reports_connected_and_disconnected(_Config) ->
+    ok = create_connector(conn_up, connected),
+    ok = create_action(action_up, conn_up),
+    ok = create_connector(conn_down, disconnected),
+    ok = create_action(action_down, conn_down),
+    _ = force_health_check(?global_ns, action_up),
+    _ = force_health_check(?global_ns, action_down),
+
+    {ok, Output} = capture_ctl(["actions", "status"]),
+    Decoded = emqx_utils_json:decode(Output),
+    ?assertEqual(<<"connected">>, status_of(Decoded, action_up)),
+    ?assertNotEqual(<<"connected">>, status_of(Decoded, action_down)).
+
+-doc "`--name` selects exactly one action; omitting it lists every action.".
+t_name_selects_one_action(_Config) ->
+    ok = create_connector(conn1, connected),
+    ok = create_action(action1, conn1),
+    ok = create_action(action2, conn1),
+
+    {ok, AllOutput} = capture_ctl(["actions", "status"]),
+    ?assertEqual(2, length(emqx_utils_json:decode(AllOutput))),
+
+    {ok, OneOutput} = capture_ctl(["actions", "status", "--name", name_arg(action1)]),
+    OneDecoded = emqx_utils_json:decode(OneOutput),
+    ?assertEqual(1, length(OneDecoded)),
+    ?assertEqual(<<"connected">>, status_of(OneDecoded, action1)).
+
+-doc "A `--name` target that does not exist produces documented, non-crashing output.".
+t_missing_name_target(_Config) ->
+    {ok, StatusOutput} = capture_ctl(["actions", "status", "--name", "no_such_type:no_such_name"]),
+    ?assertEqual([], emqx_utils_json:decode(StatusOutput)),
+
+    {ok, ShowOutput} = capture_ctl(["actions", "show", "--name", "no_such_type:no_such_name"]),
+    ?assertEqual(null, emqx_utils_json:decode(ShowOutput)).
+
+-doc "`--ns` selects a namespace; omitting it uses the global namespace.".
+t_ns_selects_namespace(_Config) ->
+    Namespace = <<"cli_test_ns">>,
+    ok = create_connector(Namespace, conn_ns, connected),
+    ok = create_action(Namespace, action_ns, conn_ns, #{}),
+
+    {ok, GlobalOutput} = capture_ctl(["actions", "status"]),
+    ?assertEqual([], emqx_utils_json:decode(GlobalOutput)),
+
+    {ok, NsOutput} = capture_ctl(["actions", "status", "--ns", binary_to_list(Namespace)]),
+    NsDecoded = emqx_utils_json:decode(NsOutput),
+    ?assertEqual(<<"connected">>, status_of(NsDecoded, action_ns)).
+
+-doc "`show` output is valid JSON and never leaks a secret configured on the action.".
+t_show_output_is_json_and_redacts_secret(_Config) ->
+    Secret = <<"Bearer super-secret-token">>,
+    ok = create_connector(conn_secret, connected),
+    ok = create_action(action_secret, conn_secret, #{<<"Authorization">> => Secret}),
+    _ = force_health_check(?global_ns, action_secret),
+
+    {ok, Output} = capture_ctl([
+        "actions", "show", "--name", name_arg(action_secret)
+    ]),
+    ?assertEqual(nomatch, re:run(Output, "super-secret-token", [{capture, none}])),
+
+    Decoded = emqx_utils_json:decode(Output),
+    ?assertMatch(#{<<"status">> := <<"connected">>}, Decoded),
+    ?assertMatch(
+        #{<<"parameters">> := #{<<"headers">> := #{<<"Authorization">> := <<"******">>}}},
+        Decoded
+    ).
+
+%%------------------------------------------------------------------------------
+%% Helpers
+%%------------------------------------------------------------------------------
+
+capture_ctl(Args) ->
+    {Result, OutputChunks} =
+        emqx_common_test_helpers:capture_io_format(fun() -> emqx_ctl:run_command(Args) end),
+    {Result, iolist_to_binary(OutputChunks)}.
+
+status_of(Decoded, ActionName) when is_list(Decoded) ->
+    Key = <<(bin(action_type()))/binary, ":", (bin(ActionName))/binary>>,
+    lists:foldl(
+        fun
+            (#{Key := Status}, _Acc) -> Status;
+            (_, Acc) -> Acc
+        end,
+        undefined,
+        Decoded
+    ).
+
+name_arg(ActionName) ->
+    binary_to_list(<<(bin(action_type()))/binary, ":", (bin(ActionName))/binary>>).
+
+create_connector(Name, Status) ->
+    create_connector(?global_ns, Name, Status).
+
+create_connector(Namespace, Name, Status) ->
+    {ok, _} = emqx_connector:create(Namespace, con_type(), Name, con_config(Status)),
+    ok.
+
+create_action(Name, ConnectorName) ->
+    create_action(Name, ConnectorName, #{}).
+
+create_action(Name, ConnectorName, Headers) ->
+    create_action(?global_ns, Name, ConnectorName, Headers).
+
+create_action(Namespace, Name, ConnectorName, Headers) ->
+    {ok, _} = emqx_bridge_v2:create(
+        Namespace, actions, action_type(), Name, action_config(ConnectorName, Headers)
+    ),
+    ok.
+
+force_health_check(Namespace, Name) ->
+    emqx_bridge_v2:health_check(Namespace, actions, action_type(), Name).
+
+con_config(Status) ->
+    #{
+        <<"enable">> => true,
+        <<"status">> => atom_to_binary(Status),
+        <<"resource_opts">> => #{<<"health_check_interval">> => 100}
+    }.
+
+action_config(ConnectorName, Headers) ->
+    #{
+        <<"connector">> => bin(ConnectorName),
+        <<"enable">> => true,
+        <<"parameters">> => #{<<"headers">> => Headers},
+        <<"resource_opts">> => #{<<"health_check_interval">> => 100, <<"resume_interval">> => 100}
+    }.
+
+bin(Bin) when is_binary(Bin) -> Bin;
+bin(Str) when is_list(Str) -> list_to_binary(Str);
+bin(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8).
+
+fun_table_name() ->
+    emqx_bridge_v2_cli_SUITE_fun_table.
+
+con_type() -> cli_test_connector.
+
+con_mod() -> emqx_bridge_v2_cli_test_connector.
+
+action_type() -> cli_test_action.
+
+con_schema() ->
+    [
+        {
+            con_type(),
+            hoconsc:mk(
+                hoconsc:map(name, hoconsc:ref(?MODULE, connector_config)),
+                #{desc => <<"CLI test connector config">>, required => false}
+            )
+        }
+    ].
+
+action_schema() ->
+    [
+        {
+            action_type(),
+            hoconsc:mk(
+                hoconsc:map(name, hoconsc:ref(?MODULE, action)),
+                #{desc => <<"CLI test action config">>, required => false}
+            )
+        }
+    ].
+
+fields(connector_config) ->
+    [
+        {enable, hoconsc:mk(typerefl:boolean(), #{default => true})},
+        {status, hoconsc:mk(hoconsc:enum([connected, disconnected]), #{default => connected})},
+        {resource_opts, hoconsc:mk(typerefl:map(), #{default => #{}})}
+    ];
+fields(action) ->
+    emqx_bridge_v2_schema:make_producer_action_schema(
+        hoconsc:mk(hoconsc:ref(?MODULE, action_parameters), #{})
+    );
+fields(action_parameters) ->
+    [
+        {headers, hoconsc:mk(map(), #{default => #{}, required => false})}
+    ].
+
+setup_mocks() ->
+    MeckOpts = [passthrough, no_link, no_history],
+
+    catch meck:new(emqx_connector_schema, MeckOpts),
+    meck:expect(emqx_connector_schema, fields, 1, con_schema()),
+    meck:expect(emqx_connector_schema, connector_type_to_bridge_types, 1, [con_type()]),
+
+    catch meck:new(emqx_connector_resource, MeckOpts),
+    meck:expect(emqx_connector_resource, connector_to_resource_type, 1, con_mod()),
+
+    catch meck:new(emqx_bridge_v2_schema, MeckOpts),
+    meck:expect(emqx_bridge_v2_schema, fields, fun(Struct) ->
+        case Struct of
+            actions -> action_schema();
+            _ -> meck:passthrough([Struct])
+        end
+    end),
+    meck:expect(emqx_bridge_v2_schema, registered_action_types, 0, [action_type()]),
+
+    catch meck:new(emqx_bridge_v2, MeckOpts),
+    ActionType = action_type(),
+    ActionTypeBin = atom_to_binary(ActionType),
+    meck:expect(
+        emqx_bridge_v2,
+        bridge_v2_type_to_connector_type,
+        fun
+            (Type) when Type =:= ActionType; Type =:= ActionTypeBin -> con_type();
+            (Type) -> meck:passthrough([Type])
+        end
+    ),
+    ok.

--- a/apps/emqx_bridge/test/emqx_bridge_v2_cli_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_cli_SUITE.erl
@@ -82,6 +82,8 @@ t_name_selects_one_action(_Config) ->
 t_missing_name_target(_Config) ->
     {ok, StatusOutput} = capture_ctl(["actions", "status", "--name", "no_such_type:no_such_name"]),
     ?assertEqual([], emqx_utils_json:decode(StatusOutput)),
+    %% An empty array prints compactly on one line, not spread across three.
+    ?assertEqual(<<"[]\n">>, StatusOutput),
 
     {ok, ShowOutput} = capture_ctl(["actions", "show", "--name", "no_such_type:no_such_name"]),
     ?assertEqual(null, emqx_utils_json:decode(ShowOutput)).

--- a/apps/emqx_bridge/test/emqx_bridge_v2_cli_test_connector.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_cli_test_connector.erl
@@ -1,0 +1,49 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% Minimal connector for `emqx_bridge_v2_cli_SUITE`: its connector-level status is
+%% read directly off its own config (`status`), so tests can deterministically stand
+%% up a "connected" and a "disconnected" connector without closures or ETS plumbing.
+-module(emqx_bridge_v2_cli_test_connector).
+
+-behaviour(emqx_resource).
+
+-export([
+    resource_type/0,
+    callback_mode/0,
+    on_start/2,
+    on_stop/2,
+    on_get_status/2,
+    on_add_channel/4,
+    on_remove_channel/3,
+    on_get_channels/1,
+    on_get_channel_status/3
+]).
+
+resource_type() -> cli_test_connector.
+
+callback_mode() -> always_sync.
+
+on_start(_InstId, Config) ->
+    {ok, Config}.
+
+on_stop(_InstId, _State) ->
+    ok.
+
+on_get_status(_InstId, #{status := Status}) ->
+    Status.
+
+on_add_channel(_InstId, State, ChannelId, ChannelConfig) ->
+    Channels = maps:get(channels, State, #{}),
+    {ok, State#{channels => Channels#{ChannelId => ChannelConfig}}}.
+
+on_remove_channel(_InstId, State, ChannelId) ->
+    Channels = maps:get(channels, State, #{}),
+    {ok, State#{channels => maps:remove(ChannelId, Channels)}}.
+
+on_get_channels(ResId) ->
+    emqx_bridge_v2:get_channels_for_connector(ResId).
+
+on_get_channel_status(_ResId, _ChannelId, _State) ->
+    connected.

--- a/changes/ee/feat-18624.en.md
+++ b/changes/ee/feat-18624.en.md
@@ -1,0 +1,10 @@
+Added `emqx ctl actions show` and `emqx ctl actions status` commands. They report action
+status for the local node only, in JSON, without REST API credentials or a network call.
+
+`status` prints a compact JSON array of `{"<type>:<name>": "<status>"}` entries; `show` prints
+the same information as `GET /api/v5/actions/{id}`, with connector secrets redacted, but for the
+local node only. Both accept `--name <type:name>` to select one action and `--ns <namespace>` to
+select a namespace, defaulting to every action in the global namespace.
+
+This suits a per-node readiness probe, where the REST API's cluster-aggregated `status` field
+cannot tell whether the local node's own actions are ready to accept traffic.


### PR DESCRIPTION
Release version:
6.3.0, 7.0.0

Introduced in:


## Summary

Adds `emqx ctl actions show` and `emqx ctl actions status`, closing
[#18622](https://github.com/emqx/emqx/issues/18622). Both report action status for the
**local node only** — no RPC, no cluster aggregation — so a Kubernetes readiness probe can
check whether the local node's own actions are usable without REST credentials or an HTTP
call. This is the gap the issue describes: the REST `status` field is cluster-aggregated
(`emqx_bridge_v2_api:aggregate_status/1`) and answers "do all nodes agree", not "is this
node ready", which is the wrong question for a per-pod probe.

New module `apps/emqx_bridge/src/emqx_bridge_v2_cli.erl`, loaded from `emqx_bridge_app`
(mirrors `emqx_bridge_v2:load/0`/`unload/0`). No RPC, no new bpapi module — everything it
calls (`emqx_bridge_v2:lookup/4`, `emqx_bridge_v2:list/2`) is already local-only.

- `status` prints a compact JSON array of `{"<type>:<name>": "<status>"}` objects.
- `show` prints the same information as `GET /api/v5/actions/{id}`, minus the cluster-only
  fields (`node_status`, `rules`) that require aggregation, for the local node only.
- `--name <type:name>` selects one action; omitted, every action in the namespace is shown.
- `--ns <namespace>` selects a namespace; omitted, the global namespace is used.

**Secrets.** `lookup/4`'s `raw_config` can carry a secret set directly on the action (e.g.
an HTTP action's `parameters.headers` can hold a bearer token, independent of the
connector). `show` redacts it with `emqx_utils:redact/1`, the same function
`emqx_bridge_v2_api:format_resource/3` uses on the REST path. `resource_data` (the
connector's live resource state — pids, refs) is left out of `show` entirely, same as
`format_resource/3` does; it isn't JSON-encodable and a probe has no use for it beyond
`status`/`error`, which `lookup/4` already surfaces.

**Option parsing.** `--name`/`--ns` are flags, which most `emqx_ctl` commands don't use.
No dedicated flag-parsing helper exists in `emqx_ctl` or `emqx_mgmt_cli` (checked); this
follows the house pattern used by the few commands that do take flags — e.g.
`emqx_mgmt_cli:collect_session_top_args/2` — a small recursive accumulator.

**Exit status.** `emqx_ctl` doesn't use the process exit code for business-logic signaling
anywhere in this codebase today — `emqx_ctl:usage/1` and every command handler return `ok`
regardless of outcome, and `nodetool`'s `rpc_infinity` doesn't propagate the callee's return
value either. This command follows that convention: it always exits 0 on a successful
lookup. A `--name` that matches nothing is not an error — it's valid, quiet input for a
probe — so it prints `[]` (`status`) or `null` (`show`) instead. Both values are falsy to
`jq -e`, so `jq -e` alone distinguishes "ready" from "not ready or not found" without the
command needing a second signaling channel. Verified below.

**Scope.** Actions only, per the issue. `sources` and `connectors` share the same
`emqx_bridge_v2` primitives and are natural follow-ups, but are not in this PR. The module
takes a `ConfRootKey` internally the same way `emqx_bridge_v2` itself does, so adding
`emqx ctl sources ...` later is a new top-level clause, not a rewrite.

### Manual verification

Ran on a throwaway single node (`6.3.0-beta.3-gbae79a4c`) with two `http` actions: one on a
connector pointing at a reachable local HTTP server, one at a closed port. The healthy
action's connector has a secret (`Authorization: Bearer super-secret-token-xyz`) configured
directly on the action's `parameters.headers`, to prove redaction.

```console
$ emqx ctl actions status
[
  {
    "http:action_up" : "connected"
  },
  {
    "http:action_down" : "disconnected"
  }
]

$ emqx ctl actions show --name http:action_up
{
  "type" : "http",
  "status" : "connected",
  "parameters" : {
    "path" : "/",
    "method" : "post",
    "headers" : {
      "Authorization" : "******"
    },
    "body" : "${payload}"
  },
  "node" : "emqx1@127.0.0.1",
  "namespace" : null,
  "name" : "action_up",
  "last_modified_at" : 1788083482439,
  "error" : "",
  "enable" : true,
  "created_at" : 1788083482439,
  "connector" : "conn_up"
}

$ emqx ctl actions status --name http:no_such_action
[

]

$ emqx ctl actions show --name http:no_such_action
null
```

The `jq -e` one-liner from the issue, working against this node:

```console
$ emqx ctl actions status --name http:action_up | jq -e '.[0] | to_entries[0].value == "connected"'
true
$ echo $?
0

$ emqx ctl actions status --name http:action_down | jq -e '.[0] | to_entries[0].value == "connected"'
false
$ echo $?
1

$ emqx ctl actions status --name http:no_such_action | jq -e '.[0] | to_entries[0].value == "connected"'
jq: error (at <stdin>:3): null (null) has no keys
$ echo $?
5
```

A readiness probe using `jq -e` gets exit 0 only when the named action is actually
connected; a missing action or a down connector both fail the check, distinctly from a
connected one, without the CLI command itself needing to change its own exit code.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
