### PR TITLE
test(broker): retry the connected-count assert after takeover

### DIFF
--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -605,19 +605,7 @@ t_connected_client_count_transient_takeover(Config) when is_list(Config) ->
     ),
     ConnectSuccessCnt = counters:get(ConnectSuccessCntr, 1),
     ?assert(ConnectSuccessCnt > 0),
-    EventsThatShouldHaveHappened = lists:flatten(
-        lists:duplicate(
-            ConnectSuccessCnt,
-            [
-                emqx_cm_connected_client_count_inc,
-                emqx_cm_connected_client_count_dec_done
-            ]
-        )
-    ),
-    wait_for_events(fun() -> ok end, EventsThatShouldHaveHappened, 10000, infinity),
-    %% It must be 0 again because we got enough
-    %% emqx_cm_connected_client_count_dec_done events
-    ?assertEqual(0, emqx_cm:get_connected_client_count()),
+    ?retry(100, 20, ?assertEqual(0, emqx_cm:get_connected_client_count())),
     %% connecting again
     {ok, ConnPid1} = emqtt:start_link([
         {clean_start, true},


### PR DESCRIPTION
## Summary

De-flake `emqx_broker_SUITE:t_connected_client_count_transient_takeover`, seen as
`?assertEqual(0, emqx_cm:get_connected_client_count())` getting `1`
(https://github.com/emqx/emqx/actions/runs/33311519975/job/99258851159).

The case waited for `2 * ConnectSuccessCnt` events and then asserted the count is 0, on the
stated reasoning that "it must be 0 again because we got enough
`emqx_cm_connected_client_count_dec_done` events". That does not follow.

`wait_for_events/4` builds its predicate as `lists:member(K, Kinds)` and sets
`N = length(Kinds)`, so it waits for `2 * ConnectSuccessCnt` events that are **either** kind,
in any mix — not N of each, and not matched per channel pid.

And `dec_done` is not one-per-channel. `emqx_cm:mark_channel_disconnected/1` has two
independent callers:

- `emqx_channel:ensure_disconnected/2` (`emqx_channel.erl:2996`), when the channel marks itself
  disconnected, and
- `emqx_cm:handle_down_pids/1` (`emqx_cm.erl:870`), when the CM reaps the process DOWN.

So a single channel emits **two** `dec_done` events. Instrumenting the case locally confirms
it — counts collected right before the assert, one line per group:

```
inc=1 dec_done=1 success=1 fail=19 live_now=0     (tcp)
inc=2 dec_done=4 success=2 fail=18 live_now=0     (ws)
inc=2 dec_done=4 success=2 fail=18 live_now=0     (quic)
```

With `ConnectSuccessCnt = 2` the budget is 4 events, while the supply is 2 `inc` and 4
`dec_done`. If channel A's `inc` and both of its `dec_done` land before channel B's first
`dec_done`, the budget is met with B still registered — a residual count of exactly 1, which is
what CI reported.

Drop the event wait and retry the assertion instead. Keeping the wait alongside a retry would
retain a check that cannot establish what it claims.

The earlier `?retry` on `ConnectSuccessCnt + ConnectFailCnt` stays: it is a real barrier that
all 20 spawns finished, and without it a straggler could break the later `?assertEqual(1, ...)`
phase. `?assert(ConnectSuccessCnt > 0)` stays too.

Local run: the case passes in all three groups (tcp/ws/quic).