### PR TITLE
fix(mgmt): enforce namespaced-role scope allowlist for API keys

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_api_keys.erl
@@ -366,21 +366,33 @@ create_scopes(Role, RawScopes) ->
 
 %% Validation of a newly written explicit scope list — POST, or PUT with
 %% a list that genuinely differs from the persisted one: the shared
-%% four-layer validation plus the namespaced-key `publish' rejection.
+%% four-layer validation plus the namespaced-role scope allowlist.
 validate_explicit_scopes(Role, Scopes) ->
     case validate_scopes(Role, Scopes, Scopes) of
-        ok -> validate_no_publish_for_namespaced(Role, Scopes);
+        ok -> validate_namespaced_scope_allowlist(Role, Scopes);
         Error -> Error
     end.
 
-%% A namespaced API key cannot hold the `publish' scope: the publish APIs
-%% are global-only, so the scope could never be exercised. Applies to any
-%% newly written explicit list; only a verbatim round-trip of a stored
-%% list that predates this rule skips it (see validate_update_scopes/3).
-validate_no_publish_for_namespaced(Role, Scopes) ->
-    case is_binary(role_namespace(Role)) andalso lists:member(?SCOPE_PUBLISH, Scopes) of
+%% A namespaced API key may only hold scopes in `?NS_ADMIN_ALLOWED_SCOPES',
+%% mirroring the dashboard login-user rule
+%% (`emqx_dashboard_api:validate_role_scope_compat/2'). `publish' is not
+%% in the allowlist, so this subsumes the former publish-only rejection.
+%% Applies to any newly written explicit list; only a verbatim round-trip
+%% of a stored list that predates this rule skips it (see
+%% `validate_update_scopes/3').
+validate_namespaced_scope_allowlist(Role, Scopes) ->
+    case is_binary(role_namespace(Role)) of
         true ->
-            {error, <<"Namespaced API keys cannot hold the 'publish' scope">>};
+            case [S || S <- Scopes, not lists:member(S, ?NS_ADMIN_ALLOWED_SCOPES)] of
+                [] ->
+                    ok;
+                Forbidden ->
+                    Names = lists:join(<<", ">>, Forbidden),
+                    {error,
+                        iolist_to_binary([
+                            <<"Namespaced API keys cannot hold scopes: ">>, Names
+                        ])}
+            end;
         false ->
             ok
     end.
@@ -470,8 +482,8 @@ update_api_key(Name, Role, Body) ->
 %% persisted scopes against the (possibly changed) role, so a role
 %% change to `publisher' cannot keep non-`publish' scopes via a partial
 %% update; `unset' clears to role default (valid by construction);
-%% `{set, L}' validates `L' with the privilege mutex applied and rejects
-%% `publish' on a namespaced key — unless `L' merely re-submits the
+%% `{set, L}' validates `L' with the privilege mutex applied and enforces
+%% the namespaced-role scope allowlist — unless `L' merely re-submits the
 %% persisted scope list for the unchanged role/namespace (a
 %% read-modify-write), which is accepted verbatim so a key stored under
 %% an older role default (e.g. a namespaced key whose materialized

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -65,7 +65,7 @@
 -export([trans/2, force_create_app/1]).
 -export([init_bootstrap_file/1]).
 %% Exported for emqx_mgmt_auth_tests.
--export([parse_bootstrap_scopes_lenient/2, group_rejected_by_reason/1]).
+-export([parse_bootstrap_scopes_lenient/3, group_rejected_by_reason/1]).
 -endif.
 
 -define(APP, emqx_app).
@@ -787,7 +787,7 @@ parse_simple_tail(ApiKey, ApiSecret, Tail) ->
             end);
         [Role, ScopesStr] ->
             with_valid_role(Role, fun(R) ->
-                {Scopes, Rejected} = parse_bootstrap_scopes_lenient(R, ScopesStr),
+                {Scopes, Rejected} = parse_bootstrap_scopes_lenient(R, ?global_ns, ScopesStr),
                 bootstrap_entry(ApiKey, ApiSecret, R, ?global_ns, Scopes, Rejected)
             end);
         _ ->
@@ -830,7 +830,7 @@ parse_role_and_scopes(ApiKey, ApiSecret, Namespace, RoleAndScopes) ->
             end);
         [Role, ScopesStr] ->
             with_valid_role(Role, fun(R) ->
-                {Scopes, Rejected} = parse_bootstrap_scopes_lenient(R, ScopesStr),
+                {Scopes, Rejected} = parse_bootstrap_scopes_lenient(R, Namespace, ScopesStr),
                 bootstrap_entry(ApiKey, ApiSecret, R, Namespace, Scopes, Rejected)
             end);
         _ ->
@@ -864,24 +864,28 @@ bootstrap_entry(ApiKey, ApiSecret, Role, Namespace, Scopes, Rejected) ->
 %%
 %% Publisher API keys can only hold the `publish' scope; other scope names
 %% are dropped (same lenient policy as unknown scopes — a typo in ops
-%% config must not abort the whole load).
+%% config must not abort the whole load). A namespaced `Role' (`Namespace'
+%% is a binary) additionally drops any scope outside
+%% `?NS_ADMIN_ALLOWED_SCOPES', mirroring the create/update-path allowlist
+%% and the dashboard login-user rule.
 %%
 %% Returns `{Valid, Rejected}'.
 %%   Valid    — list of validated scope name binaries (possibly empty).
 %%   Rejected — list of scope name binaries that were not recognised or
-%%              not allowed for the given role.
+%%              not allowed for the given role/namespace.
 %%
 %% An empty input (`<<>>') returns `{[], []}' — explicit deny-all marker.
-parse_bootstrap_scopes_lenient(Role, <<>>) ->
+parse_bootstrap_scopes_lenient(Role, _Namespace, <<>>) ->
     filter_publisher_scopes(Role, [], []);
-parse_bootstrap_scopes_lenient(Role, ScopesStr) ->
+parse_bootstrap_scopes_lenient(Role, Namespace, ScopesStr) ->
     Candidates = binary:split(ScopesStr, <<",">>, [global, trim_all]),
     Raw = [string:lowercase(string:trim(S)) || S <- Candidates, string:trim(S) =/= <<>>],
     Available = [Name || #{name := Name} <- emqx_scope_catalog:scope_catalog()],
     {Valid0, Unknown0} = lists:partition(fun(S) -> lists:member(S, Available) end, Raw),
     Rejected0 = [{S, unknown_scope} || S <- Unknown0],
     {Valid1, Rejected1} = filter_publisher_scopes(Role, Valid0, Rejected0),
-    drop_mixed_privilege_scopes(Valid1, Rejected1).
+    {Valid2, Rejected2} = drop_mixed_privilege_scopes(Valid1, Rejected1),
+    drop_disallowed_namespaced_scopes(Namespace, Valid2, Rejected2).
 
 %% A privilege scope is administrator-equivalent, so it must not be
 %% combined with restricted scopes in the same list. In the strict HTTP
@@ -895,6 +899,18 @@ drop_mixed_privilege_scopes(Valid, Rejected) ->
         {_, []} -> {Valid, Rejected};
         {Priv, Other} -> {Other, Rejected ++ [{S, privilege_scope_conflict} || S <- Priv]}
     end.
+
+%% A namespaced bootstrap key (`Namespace' is a binary) may only hold
+%% scopes in `?NS_ADMIN_ALLOWED_SCOPES'; a global line (`Namespace' is
+%% `?global_ns') is unaffected. Returns updated `{Valid, Rejected}'.
+drop_disallowed_namespaced_scopes(Namespace, Valid, Rejected) when is_binary(Namespace) ->
+    {Keep, Drop} = lists:partition(
+        fun(S) -> lists:member(S, ?NS_ADMIN_ALLOWED_SCOPES) end,
+        Valid
+    ),
+    {Keep, Rejected ++ [{S, namespaced_scope_not_allowed} || S <- Drop]};
+drop_disallowed_namespaced_scopes(_Namespace, Valid, Rejected) ->
+    {Valid, Rejected}.
 
 %% Restrict publisher role to the `publish' scope only. Other roles
 %% pass through unchanged. Returns updated {Valid, Rejected}.
@@ -923,7 +939,9 @@ maybe_warn_rejected_scopes(File, Line, ApiKey, Rejected) ->
             "dropped: `unknown_scope' (not a known scope name, likely a typo), "
             "`not_allowed_for_publisher_role' (publisher keys may only hold `publish'), "
             "`privilege_scope_conflict' (a privilege/administrator-equivalent scope cannot be "
-            "combined with other scopes; the non-privilege scopes were kept)."
+            "combined with other scopes; the non-privilege scopes were kept), "
+            "`namespaced_scope_not_allowed' (a namespaced key may only hold scopes in the "
+            "namespaced-administrator allowlist)."
         >>,
         dropped => group_rejected_by_reason(Rejected),
         file => File,

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -909,7 +909,7 @@ drop_disallowed_namespaced_scopes(Namespace, Valid, Rejected) when is_binary(Nam
         Valid
     ),
     {Keep, Rejected ++ [{S, namespaced_scope_not_allowed} || S <- Drop]};
-drop_disallowed_namespaced_scopes(_Namespace, Valid, Rejected) ->
+drop_disallowed_namespaced_scopes(?global_ns, Valid, Rejected) ->
     {Valid, Rejected}.
 
 %% Restrict publisher role to the `publish' scope only. Other roles

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -51,7 +51,10 @@
     t_ee_ns_key_create_rejects_publish_scope,
     t_ee_ns_key_update_rejects_publish_in_changed_scopes,
     t_ee_ns_admin_legacy_publish_scopes_roundtrip,
-    t_ee_ns_admin_legacy_publish_only_scopes_stay_set
+    t_ee_ns_admin_legacy_publish_only_scopes_stay_set,
+    %% Namespaced-key scope allowlist parity with the dashboard user rule (#412)
+    t_ee_ns_key_create_rejects_out_of_allowlist_scopes,
+    t_ee_ns_key_update_rejects_out_of_allowlist_scopes
 ]).
 
 -define(APP, emqx_app).
@@ -88,6 +91,7 @@ groups() ->
             t_bootstrap_file_2_segment_seeds_default_scopes,
             t_bootstrap_file_3_segment_publisher_seeds_publish_scope,
             t_bootstrap_file_ns_admin_seeds_ns_default_scopes,
+            t_bootstrap_file_ns_admin_drops_out_of_allowlist_scopes,
             t_create_failed
         ]}
     ].
@@ -879,6 +883,32 @@ t_bootstrap_file_ns_admin_seeds_ns_default_scopes(_) ->
     ?assertEqual(
         ?NS_ADMIN_COMMON_SCOPES,
         read_bootstrap_scopes(<<"from_bootstrap_file_ns_admin">>)
+    ),
+    ok.
+
+-doc """
+A namespaced bootstrap line granting scopes outside `?NS_ADMIN_ALLOWED_SCOPES'
+(`audit`, `gateways`, `publish`) has those scopes dropped; an allowlisted
+scope in the same line is kept (emqx-dev-team-tasks#412).
+""".
+t_bootstrap_file_ns_admin_drops_out_of_allowlist_scopes(_) ->
+    File = "./bootstrap_api_keys.txt",
+    Bin = iolist_to_binary([
+        "from_bootstrap_file_ns_over_grant:secret-ns-over-grant:ns:nsboot2::administrator:",
+        ?SCOPE_AUDIT,
+        ",",
+        ?SCOPE_GATEWAYS,
+        ",",
+        ?SCOPE_PUBLISH,
+        ",",
+        ?SCOPE_CONNECTIONS,
+        "\n"
+    ]),
+    ok = file:write_file(File, Bin),
+    update_file(File),
+    ?assertEqual(
+        [?SCOPE_CONNECTIONS],
+        read_bootstrap_scopes(<<"from_bootstrap_file_ns_over_grant">>)
     ),
     ok.
 
@@ -1735,6 +1765,68 @@ t_ee_ns_admin_legacy_publish_only_scopes_stay_set(_Config) ->
     ?assertMatch({ok, #{<<"scopes">> := [?SCOPE_PUBLISH]}}, read_app(Name)),
     ?assertEqual(unset, emqx_mgmt_auth:write_scope_intent(NsRole, ?NS_ADMIN_COMMON_SCOPES)),
     delete_app(Name).
+
+-doc """
+POST with an explicit scope list containing `gateways` or `audit` for a
+namespaced role is rejected with 400, mirroring the dashboard login-user
+rule (`?NS_ADMIN_ALLOWED_SCOPES`, emqx-dev-team-tasks#412). An allowlisted
+scope is still accepted.
+""".
+t_ee_ns_key_create_rejects_out_of_allowlist_scopes(_Config) ->
+    NsAdmin = <<"ns:scopes_ns6::administrator">>,
+    assert_400(
+        create_app(<<"EE-NS-GATEWAYS-REJECT">>, #{role => NsAdmin, scopes => [?SCOPE_GATEWAYS]})
+    ),
+    assert_400(
+        create_app(<<"EE-NS-AUDIT-REJECT">>, #{role => NsAdmin, scopes => [?SCOPE_AUDIT]})
+    ),
+    assert_400(
+        create_app(<<"EE-NS-MIXED-REJECT">>, #{
+            role => NsAdmin, scopes => [?SCOPE_CONNECTIONS, ?SCOPE_AUDIT]
+        })
+    ),
+    Name = <<"EE-NS-ALLOWLISTED-OK">>,
+    ?assertMatch(
+        {ok, _},
+        create_app(Name, #{role => NsAdmin, scopes => [?SCOPE_CONNECTIONS]})
+    ),
+    delete_app(Name).
+
+-doc """
+PUT with a changed scope list adding `gateways` or `audit` on a namespaced
+key is rejected with 400 and leaves the record unchanged, even when the
+persisted list already carries the disallowed scope from before this
+allowlist existed (grandfathered legacy record) — changing the list is
+the opportunity to shed the disallowed scopes. A verbatim round-trip of
+the legacy list is still accepted (backward compat).
+""".
+t_ee_ns_key_update_rejects_out_of_allowlist_scopes(_Config) ->
+    Name = <<"EE-NS-UPDATE-NEW-AUDIT">>,
+    NsRole = <<"ns:scopes_ns7::administrator">>,
+    {ok, _} = create_app(Name, #{role => NsRole, scopes => [?SCOPE_CONNECTIONS]}),
+    assert_400(
+        update_app(Name, #{role => NsRole, scopes => [?SCOPE_CONNECTIONS, ?SCOPE_AUDIT]})
+    ),
+    ?assertMatch({ok, #{<<"scopes">> := [?SCOPE_CONNECTIONS]}}, read_app(Name)),
+    %% A legacy key whose persisted list already carries `audit`/`gateways`
+    %% (minted before this allowlist existed) must shed them when changing
+    %% the list, but a verbatim round-trip is grandfathered.
+    Legacy = <<"EE-NS-UPDATE-LEGACY-AUDIT">>,
+    LegacyScopes = [?SCOPE_AUDIT, ?SCOPE_GATEWAYS, ?SCOPE_CONNECTIONS],
+    {ok, _} = emqx_mgmt_auth:create(Legacy, true, infinity, <<"legacy">>, NsRole, LegacyScopes),
+    ?assertMatch({ok, #{<<"scopes">> := LegacyScopes}}, read_app(Legacy)),
+    {ok, RoundTripped} = update_app(Legacy, #{role => NsRole, scopes => LegacyScopes}),
+    ?assertEqual(LegacyScopes, maps:get(<<"scopes">>, RoundTripped)),
+    assert_400(
+        update_app(Legacy, #{
+            role => NsRole, scopes => [?SCOPE_AUDIT, ?SCOPE_GATEWAYS, ?SCOPE_MONITORING]
+        })
+    ),
+    ?assertMatch({ok, #{<<"scopes">> := LegacyScopes}}, read_app(Legacy)),
+    {ok, Updated} = update_app(Legacy, #{role => NsRole, scopes => [?SCOPE_CONNECTIONS]}),
+    ?assertEqual([?SCOPE_CONNECTIONS], maps:get(<<"scopes">>, Updated)),
+    delete_app(Name),
+    delete_app(Legacy).
 
 assert_400_publisher_only(Result) ->
     %% request_api/5 returns {error, {"HTTP/1.1", 400, "Bad Request"}}

--- a/apps/emqx_management/test/emqx_mgmt_auth_tests.erl
+++ b/apps/emqx_management/test/emqx_mgmt_auth_tests.erl
@@ -7,6 +7,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
 -include_lib("emqx_dashboard/include/emqx_dashboard_rbac.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 bootstrap_scopes_drop_reasons_test() ->
     %% An administrator line mixing a privilege scope, a valid non-privilege
@@ -14,7 +15,7 @@ bootstrap_scopes_drop_reasons_test() ->
     %% distinct reasons.
     {AdminValid, AdminRejected} =
         emqx_mgmt_auth:parse_bootstrap_scopes_lenient(
-            ?ROLE_API_SUPERUSER, <<"system,connections,bogus_scope">>
+            ?ROLE_API_SUPERUSER, ?global_ns, <<"system,connections,bogus_scope">>
         ),
     ?assertEqual([?SCOPE_CONNECTIONS], AdminValid),
     ?assertEqual(
@@ -28,10 +29,26 @@ bootstrap_scopes_drop_reasons_test() ->
     %% publisher-role reason.
     {PubValid, PubRejected} =
         emqx_mgmt_auth:parse_bootstrap_scopes_lenient(
-            ?ROLE_API_PUBLISHER, <<"publish,connections">>
+            ?ROLE_API_PUBLISHER, ?global_ns, <<"publish,connections">>
         ),
     ?assertEqual([?SCOPE_PUBLISH], PubValid),
     ?assertEqual(
         #{not_allowed_for_publisher_role => [?SCOPE_CONNECTIONS]},
         emqx_mgmt_auth:group_rejected_by_reason(PubRejected)
+    ).
+
+bootstrap_scopes_namespaced_allowlist_test() ->
+    %% A namespaced administrator line: scopes outside
+    %% `?NS_ADMIN_ALLOWED_SCOPES' (here `audit', `gateways', `publish') are
+    %% dropped; the allowlisted scope is kept.
+    {Valid, Rejected} =
+        emqx_mgmt_auth:parse_bootstrap_scopes_lenient(
+            ?ROLE_API_SUPERUSER, <<"ns1">>, <<"audit,gateways,publish,connections">>
+        ),
+    ?assertEqual([?SCOPE_CONNECTIONS], Valid),
+    ?assertEqual(
+        #{
+            namespaced_scope_not_allowed => [?SCOPE_AUDIT, ?SCOPE_GATEWAYS, ?SCOPE_PUBLISH]
+        },
+        emqx_mgmt_auth:group_rejected_by_reason(Rejected)
     ).

--- a/apps/emqx_utils/include/emqx_api_key_scopes.hrl
+++ b/apps/emqx_utils/include/emqx_api_key_scopes.hrl
@@ -103,8 +103,11 @@
 %% Namespaced-administrator scope defaults — a restricted subset of
 %% scopes that are actually useful for a namespaced admin. RBAC blocks
 %% namespaced admins from mutating most system endpoints, but
-%% explicitly allows data_backup (export/import/list).  RBAC is the
-%% primary authorization gate — the scope layer is defense-in-depth.
+%% explicitly allows data_backup (export/import/list). RBAC is the
+%% primary authorization gate for mutating endpoints, where the scope
+%% layer is defense-in-depth; for GET endpoints RBAC's catch-all grants
+%% namespaced admins blanket read access, so there the scope layer is
+%% the sole gate, not a second layer.
 -define(NS_ADMIN_COMMON_SCOPES, [
     ?SCOPE_CONNECTIONS,
     ?SCOPE_MONITORING,

--- a/changes/ee/fix-18630.en.md
+++ b/changes/ee/fix-18630.en.md
@@ -1,0 +1,3 @@
+Namespaced administrator API keys can no longer be created, updated, or bootstrapped with scopes the namespaced role is not allowed to hold (such as `gateways` or `audit`), matching the existing dashboard user rule.
+
+Rotate any existing namespaced API key that was granted such scopes, since keys already minted with them keep working until rotated.


### PR DESCRIPTION
Fixes: https://github.com/emqx/emqx-dev-team-tasks/issues/412
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: 6.0.3

## Summary

A namespaced administrator (`ns:<ns>::administrator`) could mint, update, or bootstrap an API key carrying scopes outside `?NS_ADMIN_ALLOWED_SCOPES` — notably `gateways` and, worse, `audit`, which reaches the **global** audit log. The dashboard login-user path already rejects this via `emqx_dashboard_api:validate_role_scope_compat/2`. https://github.com/emqx/emqx/pull/18222 closed only the `publish` leg of this gap on the API-key side; `gateways`, `audit`, and any other out-of-allowlist scope remained mintable.

This PR enforces the same `?NS_ADMIN_ALLOWED_SCOPES` allowlist across all three API-key scope-granting paths in `apps/emqx_management/src/emqx_mgmt_api_api_keys.erl` and `apps/emqx_management/src/emqx_mgmt_auth.erl`:

- **Create** (`validate_explicit_scopes/2` → new `validate_namespaced_scope_allowlist/2`): rejects any scope outside the allowlist for a namespaced role with a 400 naming the disallowed scopes. This subsumes the old publish-only check.
- **Update**: the `{set, Scopes}` leg routes through the same validation whenever the requested list genuinely differs from the persisted one. A verbatim round-trip of an already-persisted list is still accepted without re-validation (see design note below).
- **Bootstrap**: `parse_bootstrap_scopes_lenient/2` is now `/3` — the namespace is threaded through from both bootstrap-tail parsers so a namespaced line can drop disallowed scopes with a new `namespaced_scope_not_allowed` reason, consistent with the existing lenient drop-and-warn style (`unknown_scope`, `not_allowed_for_publisher_role`, `privilege_scope_conflict`).

Also corrected a stale comment in `emqx_utils/include/emqx_api_key_scopes.hrl` claiming the scope layer is only "defense-in-depth" behind RBAC. That is not true for GET endpoints: RBAC's catch-all grants a namespaced administrator blanket read access, so there the scope list is the sole gate.

### Design decision: grandfathered keys (please confirm)

This is create/update/bootstrap-time validation only. It stops new over-grants but does **not** retroactively strip scopes from API keys already minted through the gap — an existing namespaced key still holding `audit`/`gateways` keeps working until rotated, matching the "existing records untouched" precedent from #18222. The changelog tells operators to rotate such keys.

A more thorough alternative would additionally intersect a namespaced principal's effective scopes with `?NS_ADMIN_ALLOWED_SCOPES` at the single runtime choke point (`emqx_mgmt_auth:check_rbac_and_scopes/6`, which already has the key's `Namespace` in scope), neutering already-minted over-granted keys immediately instead of only on rotation. That changes runtime behavior for existing keys, so it leans `breaking`. The linked issue's fix direction did not ask for it, so I left it out of this PR — flagging it here as a follow-up candidate if the grandfathering window is a concern.

### Out of scope (tracked separately)

`GET /api/v5/audit` itself returns the global log with no namespace filter (`emqx_audit_api.erl`). Namespace-scoping that endpoint is a separate defense-in-depth follow-up, not implemented here.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
