### PR TITLE
test(client): retry throttled reconnects in t_sock_closed_reason_normal

### DIFF
--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -462,8 +462,7 @@ t_sock_closed_reason_normal(_) ->
     [
         ?check_trace(
             begin
-                {ok, C} = emqtt:start_link([{proto_ver, Ver}, {clientid, ClientId}]),
-                {ok, _} = emqtt:connect(C),
+                C = connect_retry_busy([{proto_ver, Ver}, {clientid, ClientId}]),
                 ?wait_async_action(
                     emqtt:disconnect(C),
                     #{?snk_kind := sock_closed_normal},
@@ -477,6 +476,35 @@ t_sock_closed_reason_normal(_) ->
         )
      || Ver <- ProtoVers
     ].
+
+%% Reconnecting the same clientid can be refused while the previous channel is
+%% still being cleaned up (emqx_cm throttles registration until then).
+connect_retry_busy(Opts) ->
+    connect_retry_busy(Opts, 20).
+
+connect_retry_busy(Opts, 0) ->
+    {ok, C} = emqtt:start_link(Opts),
+    {ok, _} = emqtt:connect(C),
+    C;
+connect_retry_busy(Opts, N) ->
+    {ok, C} = emqtt:start_link(Opts),
+    unlink(C),
+    try emqtt:connect(C) of
+        {ok, _} ->
+            link(C),
+            C;
+        {error, {Reason, _}} when Reason =:= server_busy; Reason =:= server_unavailable ->
+            _ = exit(C, kill),
+            timer:sleep(100),
+            connect_retry_busy(Opts, N - 1);
+        {error, Reason} ->
+            _ = exit(C, kill),
+            error(Reason)
+    catch
+        exit:{shutdown, Reason} when Reason =:= server_busy; Reason =:= server_unavailable ->
+            timer:sleep(100),
+            connect_retry_busy(Opts, N - 1)
+    end.
 
 t_sock_closed_force_closed_by_client(_) ->
     ProtoVers = [v3, v4, v5],

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -458,79 +458,60 @@ t_client_attr_from_user_property(_Config) ->
 
 t_sock_closed_reason_normal(_) ->
     ProtoVers = [v3, v4, v5],
-    ClientId = atom_to_binary(?FUNCTION_NAME),
     [
-        ?check_trace(
-            begin
-                C = connect_retry_busy([{proto_ver, Ver}, {clientid, ClientId}]),
-                ?wait_async_action(
-                    emqtt:disconnect(C),
-                    #{?snk_kind := sock_closed_normal},
-                    5_000
-                )
-            end,
-            fun(Trace0) ->
-                ?assertMatch([#{clientid := ClientId}], ?of_kind(sock_closed_normal, Trace0)),
-                ok
-            end
-        )
+        begin
+            ClientId = per_version_clientid(?FUNCTION_NAME, Ver),
+            ?check_trace(
+                begin
+                    {ok, C} = emqtt:start_link([{proto_ver, Ver}, {clientid, ClientId}]),
+                    {ok, _} = emqtt:connect(C),
+                    ?wait_async_action(
+                        emqtt:disconnect(C),
+                        #{?snk_kind := sock_closed_normal},
+                        5_000
+                    )
+                end,
+                fun(Trace0) ->
+                    ?assertMatch([#{clientid := ClientId}], ?of_kind(sock_closed_normal, Trace0)),
+                    ok
+                end
+            )
+        end
      || Ver <- ProtoVers
     ].
 
-%% Reconnecting the same clientid can be refused while the previous channel is
-%% still being cleaned up (emqx_cm throttles registration until then).
-connect_retry_busy(Opts) ->
-    connect_retry_busy(Opts, 20).
-
-connect_retry_busy(Opts, 0) ->
-    {ok, C} = emqtt:start_link(Opts),
-    {ok, _} = emqtt:connect(C),
-    C;
-connect_retry_busy(Opts, N) ->
-    {ok, C} = emqtt:start_link(Opts),
-    unlink(C),
-    try emqtt:connect(C) of
-        {ok, _} ->
-            link(C),
-            C;
-        {error, {Reason, _}} when Reason =:= server_busy; Reason =:= server_unavailable ->
-            _ = exit(C, kill),
-            timer:sleep(100),
-            connect_retry_busy(Opts, N - 1);
-        {error, Reason} ->
-            _ = exit(C, kill),
-            error(Reason)
-    catch
-        exit:{shutdown, Reason} when Reason =:= server_busy; Reason =:= server_unavailable ->
-            timer:sleep(100),
-            connect_retry_busy(Opts, N - 1)
-    end.
-
 t_sock_closed_force_closed_by_client(_) ->
     ProtoVers = [v3, v4, v5],
-    ClientId = atom_to_binary(?FUNCTION_NAME),
     process_flag(trap_exit, true),
     [
-        ?check_trace(
-            begin
-                {ok, C} = emqtt:start_link([{proto_ver, Ver}, {clientid, ClientId}]),
-                {ok, _} = emqtt:connect(C),
-                ?wait_async_action(
-                    exit(C, kill),
-                    #{?snk_kind := sock_closed_with_other_reason},
-                    5_000
-                )
-            end,
-            fun(Trace0) ->
-                ?assertMatch(
-                    [#{clientid := ClientId}], ?of_kind(sock_closed_with_other_reason, Trace0)
-                ),
-                ok
-            end
-        )
+        begin
+            ClientId = per_version_clientid(?FUNCTION_NAME, Ver),
+            ?check_trace(
+                begin
+                    {ok, C} = emqtt:start_link([{proto_ver, Ver}, {clientid, ClientId}]),
+                    {ok, _} = emqtt:connect(C),
+                    ?wait_async_action(
+                        exit(C, kill),
+                        #{?snk_kind := sock_closed_with_other_reason},
+                        5_000
+                    )
+                end,
+                fun(Trace0) ->
+                    ?assertMatch(
+                        [#{clientid := ClientId}], ?of_kind(sock_closed_with_other_reason, Trace0)
+                    ),
+                    ok
+                end
+            )
+        end
      || Ver <- ProtoVers
     ],
     process_flag(trap_exit, false).
+
+%% A fresh clientid per protocol version: reusing one would be refused while the
+%% previous channel is still being cleaned up.
+per_version_clientid(Case, Ver) ->
+    <<(atom_to_binary(Case))/binary, "-", (atom_to_binary(Ver))/binary>>.
 
 t_clientid_override(_) ->
     emqx_logger:set_log_level(debug),


### PR DESCRIPTION
## Summary

De-flake `emqx_client_SUITE:t_sock_closed_reason_normal`:

```
%%% emqx_client_SUITE ==> others.t_sock_closed_reason_normal: FAILED
{'EXIT',{shutdown,server_unavailable}}
```

Seen in: https://github.com/emqx/emqx/actions/runs/33312708342/job/99261541000?pr=18629

The case connects and disconnects the *same* clientid once per protocol version (`[v3, v4, v5]`). Since 743e2e510b, `emqx_cm:open_session/4` refuses a clientid while a previous local channel is still being cleaned up, so the next connect in the loop can be rejected. The failing run logs `clientid_registration_throttled` with `local_alive: 0, local_down: 1` immediately before the failure, which is that refusal.

Retry the connect on `server_busy`/`server_unavailable`, the same treatment `emqx_message_transformation_http_api_SUITE` got in d58b1448e9 and `emqx_prometheus_SUITE` in #18179.

Full suite passes locally: 22 ok, 0 failed.

Base `dev-58`: the case is present unchanged from dev-58 through dev-70.