### PR TITLE
test(kafka): retry the connected status after topic recreation

### DIFF
--- a/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
@@ -1493,9 +1493,14 @@ t_inexistent_topic_after_created(Config) ->
                     ensure_kafka_topic(Topic),
                     #{?snk_kind := "kafka_producer_action_connected"}
                 ),
-            ?assertMatch(
-                {200, #{<<"status">> := <<"connected">>}},
-                simplify_result(emqx_bridge_v2_testlib:get_action_api(ActionParams))
+            %% The event precedes the status the API reports.
+            ?retry(
+                200,
+                20,
+                ?assertMatch(
+                    {200, #{<<"status">> := <<"connected">>}},
+                    simplify_result(emqx_bridge_v2_testlib:get_action_api(ActionParams))
+                )
             ),
 
             ok


### PR DESCRIPTION
## Summary

De-flake `emqx_bridge_v2_kafka_producer_SUITE:t_inexistent_topic_after_created`:

```
{assertMatch, {expression, "{ 200 , # { << \"status\" >> := << \"connected\" >> } }"}}
       got: ... <<"status">> => <<"connecting">> ...
```

Seen twice, on unrelated PRs:
- https://github.com/emqx/emqx/actions/runs/33261418454/job/99124094261?pr=18617
- https://github.com/emqx/emqx/actions/runs/33314058817/job/99265234793?pr=18631

The case recreates the Kafka topic, waits for the `"kafka_producer_action_connected"` trace event, then reads the action status over the HTTP API and expects `connected`. The event fires before the status the API reports flips, so the read can still see `connecting`. Retry the read; the suite already uses `?retry` for similar reads.

Same family as the pulsar action-status fix (#18514).

Validation: the case is skipped on this host (no toxiproxy), so it rides on this PR's CI; the change compiles and the file is format/elvis clean.

Base `dev-58`: this case exists only on the v5 lines (dev-58/59/510). The sibling assert just above (`connecting` after topic deletion) has the same shape but has not been observed failing, so it is left alone.