### PR TITLE
test(mgmt): allocate free ports via select_free_port

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -21,8 +21,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
--define(PORT(Base), (Base + ?LINE)).
--define(PORT, ?PORT(20000)).
+-define(PORT, emqx_common_test_helpers:select_free_port(tcp)).
 
 all() ->
     [
@@ -167,7 +166,7 @@ t_tcp_crud_listeners_by_id(Config) when is_list(Config) ->
     MinListenerId = <<"tcp:min">>,
     BadId = <<"tcp:bad">>,
     Type = <<"tcp">>,
-    crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type, 31000).
+    crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type).
 
 t_ssl_crud_listeners_by_id(Config) when is_list(Config) ->
     ListenerId = <<"ssl:default">>,
@@ -175,7 +174,7 @@ t_ssl_crud_listeners_by_id(Config) when is_list(Config) ->
     MinListenerId = <<"ssl:min">>,
     BadId = <<"ssl:bad">>,
     Type = <<"ssl">>,
-    crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type, 32000).
+    crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type).
 
 t_ws_crud_listeners_by_id(Config) when is_list(Config) ->
     ListenerId = <<"ws:default">>,
@@ -183,7 +182,7 @@ t_ws_crud_listeners_by_id(Config) when is_list(Config) ->
     MinListenerId = <<"ws:min">>,
     BadId = <<"ws:bad">>,
     Type = <<"ws">>,
-    crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type, 33000).
+    crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type).
 
 t_wss_crud_listeners_by_id(Config) when is_list(Config) ->
     ListenerId = <<"wss:default">>,
@@ -191,7 +190,7 @@ t_wss_crud_listeners_by_id(Config) when is_list(Config) ->
     MinListenerId = <<"wss:min">>,
     BadId = <<"wss:bad">>,
     Type = <<"wss">>,
-    crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type, 34000).
+    crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type).
 
 t_api_listeners_list_not_ready(Config) when is_list(Config) ->
     ct:timetrap({seconds, 120}),
@@ -306,7 +305,7 @@ assert_config_load_not_done(Node) ->
     Prio = rpc:call(Node, emqx_app, get_config_loader, []),
     ?assertEqual(emqx, Prio, #{node => Node}).
 
-crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type, PortBase) ->
+crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type) ->
     OriginPath = emqx_mgmt_api_test_util:api_path(["listeners", ListenerId]),
     NewPath = emqx_mgmt_api_test_util:api_path(["listeners", NewListenerId]),
     OriginListener = request(get, OriginPath, [], []),
@@ -314,8 +313,8 @@ crud_listeners_by_id(ListenerId, NewListenerId, MinListenerId, BadId, Type, Port
     %% create with full options
     ?assertEqual({error, not_found}, is_running(NewListenerId)),
     ?assertMatch({error, {"HTTP/1.1", 404, _}}, request(get, NewPath, [], [])),
-    Port1 = integer_to_binary(?PORT(PortBase)),
-    Port2 = integer_to_binary(?PORT(PortBase)),
+    Port1 = integer_to_binary(?PORT),
+    Port2 = integer_to_binary(?PORT),
     NewConf = OriginListener#{
         <<"id">> => NewListenerId,
         <<"bind">> => <<"0.0.0.0:", Port1/binary>>


### PR DESCRIPTION
## Summary

Backport of `c0646b014f` (already on the v6 lines) to `dev-58`.

`emqx_mgmt_api_listeners_SUITE:t_ws_crud_listeners_by_id` failed on an unrelated PR:

```
{badmap,{error,{"HTTP/1.1",400,"Bad Request"}}}
  emqx_mgmt_api_listeners_SUITE:crud_listeners_by_id/6, line 361
```

https://github.com/emqx/emqx/actions/runs/33315255090/job/99268509759

The listener CRUD tests derive the bind port from `?LINE` plus a per-type base:
`ws` uses 33000 and `wss` uses 34000, so the ports land at 33317/33318 and
34317/34318. Those are inside the Linux ephemeral range (32768-60999), so any
outbound connection on the runner can already hold one. The bind then fails with
`eaddrinuse`, the create returns 400, and `maps:keys/1` on the error tuple crashes
the case.

Allocate the port with `emqx_common_test_helpers:select_free_port/1` instead, which
is what the v6 lines already do.

Local run: 26 ok, 0 failed.