### PR TITLE
test(shared_sub): retry the subopts lookup in t_different_groups_update_subopts

### DIFF
--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -1182,9 +1182,14 @@ t_different_groups_update_subopts(Config) when is_list(Config) ->
 
     Fun = fun(Group, QoS) ->
         ?UPDATE_SUB_QOS(C, format_share(Group, Topic), QoS),
-        ?assertMatch(
-            #{qos := QoS},
-            emqx_broker:get_subopts(ClientId, emqx_topic:make_shared_record(Group, Topic))
+        %% The clientid is registered asynchronously, so the lookup can miss.
+        ?retry(
+            100,
+            20,
+            ?assertMatch(
+                #{qos := QoS},
+                emqx_broker:get_subopts(ClientId, emqx_topic:make_shared_record(Group, Topic))
+            )
         )
     end,
 


### PR DESCRIPTION
## Summary

De-flake `emqx_shared_sub_SUITE:t_different_groups_update_subopts`:

```
Failure/Error: ?assertMatch(#{qos := QoS}, emqx_broker:get_subopts(ClientId, ...))
  expected: = #{qos := QoS}
       got: undefined
```

https://github.com/emqx/emqx/actions/runs/33315255090/job/99268509634

The case subscribes and then reads the subopts back by clientid. `emqx_broker:get_subopts/2` resolves a clientid through `emqx_broker_helper:lookup_subpid/1`, and that table is populated by `register_sub/2` with a plain `erlang:send/2` to the helper process. The SUBACK can arrive before the helper has handled that message, so the lookup returns `undefined`.

Retry the read. The case already retries the route count a few lines below.

Local run: 36 ok, 0 failed.