### PR TITLE
test(smoke): wait for the api-docs route to be installed

### DIFF
--- a/scripts/test/emqx-smoke-test.sh
+++ b/scripts/test/emqx-smoke-test.sh
@@ -35,15 +35,25 @@ json_status() {
     fi
 }
 
-## Check if the API docs are available
+## Check if the API docs are available.
+## The dashboard serves /status from the initial dispatch and installs the
+## API routes later, so /api-docs can still return 404 here.
 check_api_docs() {
     local url="$BASE_URL/api-docs/index.html"
+    local attempts=30
     local status
-    status="$(curl -s -o /dev/null -w "%{http_code}" "$url")"
-    if [ "$status" != "200" ]; then
-        echo "emqx return non-200 responses($status) on $url"
-        exit 1
-    fi
+    while true; do
+        status="$(curl -s -o /dev/null -w "%{http_code}" "$url")"
+        if [ "$status" = "200" ]; then
+            return 0
+        fi
+        if [ $attempts -eq 0 ]; then
+            echo "emqx return non-200 responses($status) on $url"
+            exit 1
+        fi
+        sleep 1
+        attempts=$((attempts-1))
+    done
 }
 
 ## Check if the swagger.json contains hidden fields


### PR DESCRIPTION
## Summary

The docker smoke test failed on an unrelated PR:

```
EMQX 5.8.11-gbd708da2 is started successfully!
+ /emqx/scripts/test/emqx-smoke-test.sh 127.0.0.1 18083
emqx return non-200 responses(404) on http://127.0.0.1:18083/api-docs/index.html
```

https://github.com/emqx/emqx/actions/runs/33318087631/job/99275309034

`emqx_dashboard:start_listeners/1` deliberately starts minirest with a small initial
dispatch and installs the full dispatch afterwards:

```erlang
InitDispatch = init_dispatch(),   %% static files + /status + '_' -> emqx_dashboard_not_found
... minirest:start(Name, RanchOptions, Minirest) ...
ok = emqx_dashboard_dispatch:regenerate_dispatch(OkListeners).
```

`/status` is in the initial dispatch, so it answers as soon as the listener accepts.
`/api-docs/index.html` is not, and until `regenerate_dispatch/1` finishes it falls
through to the `'_'` catch-all and returns 404. The smoke test waited only for
`/status` and then issued a single `curl` for the docs, so it could land inside that
window.

Retry the docs check until it returns 200, with a 30 s budget. This also acts as the
barrier for the `swagger.json` and schema checks that follow.