### PR TITLE
test(mqttsn): backport the t_auth_expire rework from dev-510

### DIFF
--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -233,26 +233,32 @@ t_auth_expire(_) ->
         emqx_access_control,
         authenticate,
         fun(_) ->
-            {ok, #{is_superuser => false, expire_at => erlang:system_time(millisecond) + 500}}
+            {ok, #{is_superuser => false, expire_at => erlang:system_time(millisecond) + 100}}
         end
     ),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
 
-    ?assertWaitEvent(
-        begin
-            {ok, Socket} = gen_udp:open(0, [binary]),
-            send_connect_msg(Socket, <<"client_id_test1">>),
-            ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
-
-            ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
-            gen_udp:close(Socket)
-        end,
+    {ok, {ok, Event}} =
+        ?wait_async_action(
+            begin
+                {ok, Socket} = gen_udp:open(0, [binary]),
+                send_connect_msg(Socket, ClientId),
+                ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+                ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+                gen_udp:close(Socket)
+            end,
+            #{?snk_kind := conn_process_terminated},
+            15_000
+        ),
+    ?assertMatch(
         #{
             ?snk_kind := conn_process_terminated,
-            clientid := <<"client_id_test1">>,
+            clientid := ClientId,
             reason := {shutdown, expired}
         },
-        5000
-    ).
+        Event
+    ),
+    meck:unload().
 
 t_first_disconnect(_) ->
     SockName = {'mqttsn:udp:default', 1884},


### PR DESCRIPTION
## Summary

`emqx_sn_protocol_SUITE:t_auth_expire` failed twice today on unrelated `dev-58` PRs:

```
Failure/Error: ?assertWaitEvent(... #{?snk_kind := conn_process_terminated,
                                      clientid := <<"client_id_test1">>,
                                      reason := {shutdown, expired}} ...)
       got: {ok,timeout}
```

- https://github.com/emqx/emqx/actions/runs/33316660894/job/99272470667
- https://github.com/emqx/emqx/actions/runs/33330791395/job/99310141301

`{ok, timeout}` means the action block passed in full — CONNACK **and** the DISCONNECT sent at
auth expiry were both received — but no `conn_process_terminated` matching *both* the clientid
and the reason arrived. Because the match is compound, the failure cannot say which field was
wrong, or whether the process terminated at all.

`dev-510` and later already carry the reworked version: wait for
`#{?snk_kind := conn_process_terminated}` alone, then assert clientid and reason in a separate
`?assertMatch` against the captured event, with a 15 s budget and the clientid derived from
`?FUNCTION_NAME`. This copies that version verbatim so the branches converge rather than
diverge — the case body is now byte-identical to `dev-510`'s.

A mismatch now reports the actual event instead of a bare timeout, so the next occurrence is
diagnosable.

`dev-59` carries the old form too and is **not** covered by the forward sync — merging this
branch into `dev-59` conflicts in this hunk (verified with a scratch merge). A matching
`dev-59` PR follows.

Local runs on this branch: the case passes 3/3 in isolation and in a full-suite run.