### PR TITLE
test(mqttsn): backport the t_auth_expire rework from dev-510

### DIFF
--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -247,22 +247,27 @@ t_auth_expire(_) ->
     ),
     ClientId = atom_to_binary(?FUNCTION_NAME),
 
-    ?assertWaitEvent(
-        begin
-            {ok, Socket} = gen_udp:open(0, [binary]),
-            send_connect_msg(Socket, ClientId),
-            ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
-
-            ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
-            gen_udp:close(Socket)
-        end,
+    {ok, {ok, Event}} =
+        ?wait_async_action(
+            begin
+                {ok, Socket} = gen_udp:open(0, [binary]),
+                send_connect_msg(Socket, ClientId),
+                ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+                ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+                gen_udp:close(Socket)
+            end,
+            #{?snk_kind := conn_process_terminated},
+            15_000
+        ),
+    ?assertMatch(
         #{
             ?snk_kind := conn_process_terminated,
             clientid := ClientId,
             reason := {shutdown, expired}
         },
-        5000
-    ).
+        Event
+    ),
+    meck:unload().
 
 t_first_disconnect(_) ->
     SockName = {'mqttsn:udp:default', 1884},


### PR DESCRIPTION
## Summary

Companion to https://github.com/emqx/emqx/pull/18639 (same change, based on `dev-58`).

`dev-59` carries the old `?assertWaitEvent` form with the compound match and a 5 s budget, so it
has the same problem: when the assertion fails it reports `got: {ok,timeout}` and cannot say
whether the clientid was wrong, the reason was wrong, or the process never terminated.

`dev-59` already derives the clientid from `?FUNCTION_NAME` and already uses `expire_at + 100`,
so only the assertion shape and the `meck:unload()` differ from `dev-510`. After this change the
case body is byte-identical across `dev-58`, `dev-59` and `dev-510`.

This is sent separately rather than left to the forward sync: merging the `dev-58` branch into
`dev-59` conflicts in this hunk (verified with a scratch merge), and a resolution that took the
`dev-59` side would silently drop the fix. With both sides carrying identical content the sync
merges cleanly.

Local run in a `dev-59` worktree: 1 ok, 0 failed.