### PR TITLE
fix(sso): narrow client_jwks redaction to the inner secret

### DIFF
--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
@@ -457,7 +457,10 @@ t_stop_cleanup(TCConfig) ->
 -doc """
 `GET /api/v5/sso/oidc' must return `client_jwks' as `none' when no client
 JWKS is configured (the default), while a configured file JWKS and the
-client secret must stay masked in both the GET and update responses.
+client secret must stay masked in both the GET and update responses. Masking
+must only replace the `file' leaf, not the whole `client_jwks' object, or the
+value stops matching the `client_file_jwks' union member and PUT rejects it
+(see `t_client_jwks_update_roundtrip').
 """.
 t_client_jwks_redaction(TCConfig) ->
     start_apps(?FUNCTION_NAME, TCConfig),
@@ -479,12 +482,97 @@ t_client_jwks_redaction(TCConfig) ->
         <<"client_jwks">> => #{<<"type">> => <<"file">>, <<"file">> => JwksContent}
     },
     ?assertMatch(
-        {200, #{<<"client_jwks">> := <<"******">>}},
+        {200, #{<<"client_jwks">> := #{<<"type">> := <<"file">>, <<"file">> := <<"******">>}}},
         create_backend(Node, ParamsWithJwks, #{})
     ),
     ?assertMatch(
-        {200, #{<<"client_jwks">> := <<"******">>, <<"secret">> := <<"******">>}},
+        {200, #{
+            <<"client_jwks">> := #{<<"type">> := <<"file">>, <<"file">> := <<"******">>},
+            <<"secret">> := <<"******">>
+        }},
         get_backend(Node, #{})
+    ),
+    ok.
+
+-doc """
+Resubmitting the exact `GET' response as a `PUT' body must succeed and keep
+the configured JWKS. Before the fix, the redacted `client_jwks: "******"'
+failed schema validation (`matched_no_union_member') before the handler's
+de-obfuscation logic ever ran.
+""".
+t_client_jwks_update_roundtrip(TCConfig) ->
+    start_apps(?FUNCTION_NAME, TCConfig),
+    Node = node(),
+    {ok, {Port, _Pid}} = emqx_utils_http_test_server:start_link(random, "/[...]"),
+    on_exit(fun() -> ok = emqx_utils_http_test_server:stop() end),
+    ok = emqx_utils_http_test_server:set_handler(fun oidc_content_type_handler/2),
+    Issuer = host(Port) ++ ?OIDC_PATH_PREFIX,
+    ProviderParams = oidc_provider_params(Issuer),
+
+    JwksContent = <<"{\"keys\":[{\"kty\":\"oct\",\"k\":\"c2VjcmV0\"}]}">>,
+    ParamsWithJwks = ProviderParams#{
+        <<"client_jwks">> => #{<<"type">> => <<"file">>, <<"file">> => JwksContent}
+    },
+    ?assertMatch({200, _}, create_backend(Node, ParamsWithJwks, #{})),
+
+    {200, GetResp} = get_backend(Node, #{}),
+    ?assertMatch(
+        #{<<"client_jwks">> := #{<<"type">> := <<"file">>, <<"file">> := <<"******">>}},
+        GetResp
+    ),
+
+    %% Resubmit verbatim: only `enable' changes, everything else -- including
+    %% the redacted `client_jwks' -- is exactly what GET returned.
+    PutBody = GetResp#{<<"enable">> => false},
+    ?assertMatch({200, _}, create_backend(Node, PutBody, #{})),
+
+    ?assertMatch(
+        {200, #{
+            <<"enable">> := false,
+            <<"client_jwks">> := #{<<"type">> := <<"file">>, <<"file">> := <<"******">>}
+        }},
+        get_backend(Node, #{})
+    ),
+
+    %% The stored JWKS was preserved, not overwritten with the placeholder.
+    Config = ?ON(Node, emqx:get_config([dashboard, sso, oidc])),
+    ?assertMatch(#{client_jwks := #{type := file, file := _}}, Config),
+    #{client_jwks := #{file := StoredFile}} = Config,
+    ?assertEqual({ok, JwksContent}, file:read_file(StoredFile)),
+    ok.
+
+-doc """
+Explicitly setting `client_jwks' to `none' -- as opposed to resubmitting the
+redacted placeholder -- must remove the configured JWKS. The redacted
+placeholder means "unchanged"; an explicit `none' means "remove", and the two
+must stay distinguishable.
+""".
+t_client_jwks_explicit_none_removes(TCConfig) ->
+    start_apps(?FUNCTION_NAME, TCConfig),
+    Node = node(),
+    {ok, {Port, _Pid}} = emqx_utils_http_test_server:start_link(random, "/[...]"),
+    on_exit(fun() -> ok = emqx_utils_http_test_server:stop() end),
+    ok = emqx_utils_http_test_server:set_handler(fun oidc_content_type_handler/2),
+    Issuer = host(Port) ++ ?OIDC_PATH_PREFIX,
+    ProviderParams = oidc_provider_params(Issuer),
+
+    JwksContent = <<"{\"keys\":[{\"kty\":\"oct\",\"k\":\"c2VjcmV0\"}]}">>,
+    ParamsWithJwks = ProviderParams#{
+        <<"client_jwks">> => #{<<"type">> => <<"file">>, <<"file">> => JwksContent}
+    },
+    ?assertMatch({200, _}, create_backend(Node, ParamsWithJwks, #{})),
+    ?assertMatch(
+        #{client_jwks := #{type := file}},
+        ?ON(Node, emqx:get_config([dashboard, sso, oidc]))
+    ),
+
+    ?assertMatch(
+        {200, #{<<"client_jwks">> := <<"none">>}},
+        create_backend(Node, ProviderParams#{<<"client_jwks">> => <<"none">>}, #{})
+    ),
+    ?assertMatch(
+        #{client_jwks := none},
+        ?ON(Node, emqx:get_config([dashboard, sso, oidc]))
     ),
     ok.
 

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -26,6 +26,7 @@
     (K == client_jwks orelse K == <<"client_jwks">> orelse K == "client_jwks")
 ).
 -define(IS_VAL_NONE(V), (V == none orelse V == <<"none">> orelse V == "none")).
+-define(IS_KEY_CLIENT_JWKS_FILE(K), (K == file orelse K == <<"file">> orelse K == "file")).
 
 redacted_value() -> <<?REDACT_VAL>>.
 
@@ -229,10 +230,29 @@ is_sensitive_header("x-auth-token") ->
 is_sensitive_header(_Any) ->
     false.
 
+%% Scoped to the `client_jwks' object: only `file' (the JWKS content or path)
+%% holds key material, unlike the blanket `is_sensitive_key/1` check.
+is_client_jwks_file_key(K) ->
+    ?IS_KEY_CLIENT_JWKS_FILE(K).
+
 %% `client_jwks' is a union of the atom `none' and a JWKS object; only the
-%% object holds key material. `none' (the default) must stay readable.
+%% object holds key material. `none' (the default) must stay readable. A
+%% configured object stays a union member instead of collapsing to a bare
+%% string: only `file' (the key material) is masked, so the redacted value
+%% still passes schema validation on the update path and `deobfuscate/2` can
+%% restore it.
 redact_v(K, V) when ?IS_KEY_CLIENT_JWKS(K), ?IS_VAL_NONE(V) ->
     V;
+redact_v(K, V) when ?IS_KEY_CLIENT_JWKS(K), is_map(V) ->
+    maps:map(
+        fun(FK, FV) ->
+            case is_client_jwks_file_key(FK) of
+                true -> redact_v(FV);
+                false -> FV
+            end
+        end,
+        V
+    );
 redact_v(_K, V) ->
     redact_v(V).
 
@@ -287,6 +307,8 @@ deobfuscate(NewConf, OldConf, IsSensitiveFun) ->
                     end;
                 {ok, OldV} when is_map(V), is_map(OldV), ?IS_KEY_HEADERS(K) ->
                     Acc#{K => deobfuscate(V, OldV, fun check_is_sensitive_header/1)};
+                {ok, OldV} when is_map(V), is_map(OldV), ?IS_KEY_CLIENT_JWKS(K) ->
+                    Acc#{K => deobfuscate(V, OldV, fun is_client_jwks_file_key/1)};
                 {ok, OldV} when is_map(V), is_map(OldV) ->
                     Acc#{K => deobfuscate(V, OldV, IsSensitiveFun)};
                 {ok, OldV} ->

--- a/apps/emqx_utils/test/emqx_utils_redact_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_redact_tests.erl
@@ -85,7 +85,7 @@ redact_common_token_aliases_test() ->
     ?assertEqual(
         #{
             access_token => <<"******">>,
-            client_jwks => "******",
+            client_jwks => #{type => file, file => <<"******">>},
             <<"refresh_token">> => <<"******">>,
             "id_token" => "******"
         },
@@ -101,10 +101,12 @@ redact_client_jwks_configured_test() ->
     %% A configured (file) client JWKS holds key material and must stay redacted,
     %% in both the checked-config shape (atom keys, file already saved to a path)
     %% and the raw-request shape (binary keys, `file' still holding the content).
+    %% `type' is not sensitive and survives redaction unchanged, so the value
+    %% stays a valid `client_file_jwks' union member and revalidates on update.
     ?assertEqual(
         #{
-            client_jwks => "******",
-            <<"client_jwks">> => "******"
+            client_jwks => #{type => file, file => <<"******">>},
+            <<"client_jwks">> => #{<<"type">> => <<"file">>, <<"file">> => <<"******">>}
         },
         redact(#{
             client_jwks => #{type => file, file => <<"/path/to/client_jwks">>},
@@ -114,6 +116,22 @@ redact_client_jwks_configured_test() ->
             }
         })
     ).
+
+deobfuscate_client_jwks_test() ->
+    %% Resubmitting the redacted `file' leaf restores the stored JWKS; `type'
+    %% is not sensitive and passes through unchanged.
+    Old = #{
+        <<"client_jwks">> => #{<<"type">> => <<"file">>, <<"file">> => <<"/path/to/client_jwks">>}
+    },
+    New = #{
+        <<"client_jwks">> => #{<<"type">> => <<"file">>, <<"file">> => <<"******">>}
+    },
+    ?assertEqual(Old, emqx_utils_redact:deobfuscate(New, Old)),
+
+    %% An explicit `none' is a real value, not a placeholder: it must remove
+    %% the stored JWKS rather than being treated as "unchanged".
+    Removed = #{<<"client_jwks">> => <<"none">>},
+    ?assertEqual(Removed, emqx_utils_redact:deobfuscate(Removed, Old)).
 
 no_redact_client_jwks_none_test() ->
     %% `client_jwks' is a union of `none' and a JWKS object; `none' means no

--- a/changes/ee/fix-18646.en.md
+++ b/changes/ee/fix-18646.en.md
@@ -1,0 +1,1 @@
+An OIDC SSO configuration with a client JWKS file configured can now be updated from the Dashboard without re-uploading the file. This includes toggling `enable`. Previously, the Dashboard resubmitted the masked JWKS placeholder unchanged, and the server did not accept it, so no setting could be saved.

--- a/changes/ee/fix-18646.en.md
+++ b/changes/ee/fix-18646.en.md
@@ -1,1 +1,0 @@
-An OIDC SSO configuration with a client JWKS file configured can now be updated from the Dashboard without re-uploading the file. This includes toggling `enable`. Previously, the Dashboard resubmitted the masked JWKS placeholder unchanged, and the server did not accept it, so no setting could be saved.


### PR DESCRIPTION
Fixes: #18644
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: 6.1.3

## Summary

`PUT /api/v5/sso/oidc` rejected a resubmitted config once a client JWKS file
was configured: `client_jwks` is a union of `none` and a `client_file_jwks`
struct, but `emqx_utils_redact` treats `client_jwks` as a blanket sensitive
key and replaced the whole configured struct with the binary `"******"`.
That value matches neither union member, so schema validation (which runs
before the handler, in minirest) rejected the request with
`matched_no_union_member`, before the existing
`emqx_dashboard_sso_manager:update/2` de-obfuscation call was ever reached.
Once a JWKS file was configured, no OIDC setting — not even `enable` —
could be changed without re-uploading it.

This is the sibling of #18569 / #18576, which narrowed the same rule for the
`none` case. The general lesson: `emqx_utils:deobfuscate/2` only works when
the redacted field is a plain string, because `"******"` still validates
against that type. `client_jwks` is a union/struct, so replacing it wholesale
produces a value whose *type* fails validation, not just its content.

Fix: mask only the `file` leaf inside `client_jwks` (`emqx_utils_redact.erl`)
and keep the `type` tag untouched. A configured JWKS now round-trips as
`{"type": "file", "file": "******"}`, which still matches the
`client_file_jwks` union member on `PUT`, and the existing `deobfuscate/2`
call restores the real `file` value (scoped so only the nested `file` key is
treated as sensitive, mirroring the existing `headers` special case).

## Manual verification

Node started on non-default ports (`bin/emqx start` with
`EMQX_DASHBOARD__LISTENERS__HTTP__BIND=28183`). Configure OIDC with a JWKS
file:

```
$ curl -s -X PUT 'http://127.0.0.1:28183/api/v5/sso/oidc' \
    -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' \
    -d '{"enable":true,"backend":"oidc","clientid":"example-app",
         "issuer":"https://example.invalid/dex","secret":"ZXhhbXBsZS1hcHAtc2VjcmV0",
         "client_jwks":{"type":"file","file":"{\"keys\":[{\"kty\":\"oct\",\"k\":\"c2VjcmV0\"}]}"},
         "dashboard_addr":"http://127.0.0.1:28183","scopes":["openid"],
         "session_expiry":30,"require_pkce":false,
         "preferred_auth_methods":["client_secret_post","client_secret_basic","none"],
         "provider":"generic","fallback_methods":["RS256"],"name_var":"${sub}"}'
{"backend":"oidc","client_jwks":{"file":"******","type":"file"},...}
```

`GET`, then `PUT` that exact response back with only `enable` flipped to
`false`:

```
$ curl -s 'http://127.0.0.1:28183/api/v5/sso/oidc' -H "Authorization: Bearer $TOKEN" | tee get.json
{"ssl":{...},"enable":true,"secret":"******","issuer":"https://example.invalid/dex",
 "backend":"oidc","client_jwks":{"type":"file","file":"******"},...}

$ jq '.enable = false' get.json | curl -s -o /dev/null -w '%{http_code}\n' \
    -X PUT 'http://127.0.0.1:28183/api/v5/sso/oidc' \
    -H "Authorization: Bearer $TOKEN" -H 'content-type: application/json' -d @-
200
```

`200`, not `400`. The response after this `PUT` still carries
`"client_jwks":{"file":"******","type":"file"}` and `"enable":false`, and
the JWKS file on disk is byte-for-byte unchanged:

```
$ bin/emqx eval 'begin
    #{client_jwks := #{type := file, file := Path}} = emqx:get_config([dashboard, sso, oidc]),
    {ok, Content} = file:read_file(Path),
    io:format("~s~n", [Content])
  end.'
{"keys":[{"kty":"oct","k":"c2VjcmV0"}]}
```

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] This bug did not hit GA, so no changelog needed.
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

Schema itself is unchanged; only the redacted shape of a configured
`client_jwks` in `GET`/`PUT` responses changed, from a flat `"******"`
string to `{"type": "file", "file": "******"}`. This is a strictly more
informative masked representation of the same union type and does not
change the accepted request shape on create.
