### PR TITLE
chore: bump `esockd` to 5.17.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -175,7 +175,7 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.1", override: true}
-  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.2", override: true}
+  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.3", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.5", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}


### PR DESCRIPTION
Release version: 6.3.0, 7.0.0

## Summary

https://github.com/emqx/esockd/pull/209

NOTE: changes made in 5.17.3 (vs 5.17.2) has no impact to EMQX v6. The hidden config added in 5.17.3 will be benchmarked in the 6.3 line before made configurable from EMQX configs.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible