### PR TITLE
test(shared_sub): widen the hello2 wait in t_session_takeover

### DIFF
--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -1033,11 +1033,11 @@ t_session_takeover(Config) when is_list(Config) ->
     {ok, _} = emqtt:connect(ConnPid2),
     ?assertMatch([_], emqx:publish(Message3)),
     ?assertMatch([_], emqx:publish(Message4)),
-    {true, _} = last_message(<<"hello2">>, [ConnPid2]),
-    %% We may or may not recv dup hello2 due to QoS1 redelivery
-    _ = last_message(<<"hello2">>, [ConnPid2]),
     %% Messages published around the takeover are delivered by session
     %% redelivery, which can take longer than the default 1s under CI load.
+    {true, _} = last_message(<<"hello2">>, [ConnPid2], 5_000),
+    %% We may or may not recv dup hello2 due to QoS1 redelivery
+    _ = last_message(<<"hello2">>, [ConnPid2]),
     {true, _} = last_message(<<"hello3">>, [ConnPid2], 5_000),
     {true, _} = last_message(<<"hello4">>, [ConnPid2], 5_000),
     %% A QoS1 message delivered around the takeover may be redelivered with the


### PR DESCRIPTION
## Summary

`emqx_shared_sub_SUITE:t_session_takeover` failed on an unrelated `dev-60` PR:

```
emqx_shared_sub_SUITE:t_session_takeover failed on line 1031
Reason: {badmatch,<<"not yet?">>}
```

https://github.com/emqx/emqx/actions/runs/33377658004/job/99445579886

`<<"not yet?">>` is what `last_message/3` returns when it times out, and `last_message/2`
defaults to 1000 ms. The failing line is the required `hello2` receive.

This is the same path #18552 already widened for `hello3` and `hello4`: `hello2` is published
while the first client is down, so it lands in that client's session and only reaches the second
client through post-takeover redelivery. #18552 raised its two siblings to 5 s but left `hello2`
at the 1 s default, and that is the one that timed out here.

Raise it to 5 s and move the existing comment up to cover all three. The optional second
`hello2` receive — the possible QoS1 duplicate — keeps the 1 s default deliberately: it is a
best-effort probe, and widening it would add a 4 s dead wait on every run where no duplicate
arrives.

Base `dev-58`: the 1 s default on this call is identical on dev-58 through dev-70.

Local run: 36 ok, 0 failed.