### PR TITLE
fix(mqttsn): handle asleep channel lifecycle

### DIFF
--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -118,6 +118,7 @@
 -define(REGISTER_INFLIGHT(TopicId, TopicName), #channel{register_inflight = {TopicId, _, TopicName}}).
 
 -define(MAX_RETRY_TIMES, 3).
+-define(CLIENT_DISCONNECT, client_disconnect).
 
 % 5s
 -define(REGISTER_TIMEOUT, 5000).
@@ -596,10 +597,13 @@ handle_in(
         previous_state => ConnState,
         clientid => ClientId
     }),
+    %% A keepalive timeout may fire while asleep without removing its timer entry.
+    %% Clear it so CONNACK can arm fresh keepalive supervision.
+    Channel1 = cancel_timer(keepalive, cancel_timer(expire_asleep, Channel)),
     handle_out(
         connack,
         ?SN_RC_ACCEPTED,
-        Channel#channel{conn_state = connected}
+        Channel1#channel{conn_state = connected}
     );
 %% new connection
 handle_in(
@@ -1594,6 +1598,11 @@ handle_out(
             }),
             {ok, Channel#channel{register_awaiting_queue = NRAQueue}}
     end;
+handle_out(disconnect, normal, Channel = #channel{conn_state = ConnState}) when
+    ConnState =:= connected; ConnState =:= asleep; ConnState =:= awake
+->
+    DisPkt = ?SN_DISCONNECT_MSG(undefined),
+    {ok, [{outgoing, DisPkt}, {close, ?CLIENT_DISCONNECT}], Channel};
 handle_out(disconnect, RC, Channel) ->
     DisPkt = ?SN_DISCONNECT_MSG(undefined),
     Reason =
@@ -1845,6 +1854,15 @@ handle_info(
 ) ->
     shutdown(Reason, Channel);
 handle_info(
+    {sock_closed, ?CLIENT_DISCONNECT},
+    Channel = #channel{conn_state = ConnState}
+) when
+    ConnState =:= connected;
+    ConnState =:= asleep;
+    ConnState =:= awake
+->
+    handle_client_disconnect(Channel);
+handle_info(
     {sock_closed, Reason},
     Channel = #channel{
         conn_state = connected,
@@ -1855,19 +1873,30 @@ handle_info(
     %% How to get the flapping detect policy ???
     %emqx_zone:enable_flapping_detect(Zone)
     %    andalso emqx_flapping:detect(ClientInfo),
-    NChannel = ensure_disconnected(Reason, mabye_publish_will_msg(Channel)),
-    case maybe_shutdown(Reason, NChannel) of
-        {ok, NChannel1} -> {ok, {event, disconnected}, NChannel1};
-        Shutdown -> Shutdown
-    end;
+    handle_connection_lost(Reason, Channel);
 handle_info(
     {sock_closed, Reason},
-    Channel = #channel{conn_state = disconnected}
+    Channel = #channel{conn_state = awake}
 ) ->
-    ?SLOG(error, #{
-        msg => "unexpected_sock_closed",
+    handle_connection_lost(Reason, Channel);
+handle_info(
+    {sock_closed, Reason},
+    Channel = #channel{
+        conn_state = asleep,
+        clientinfo = #{clientid := ClientId}
+    }
+) ->
+    %% A sleeping MQTT-SN client has no live transport to lose.
+    %% Preserve its session until it wakes up or the sleep timer expires.
+    ?tp(debug, mqttsn_asleep_sock_closed_ignored, #{
+        clientid => ClientId,
         reason => Reason
     }),
+    {ok, Channel};
+handle_info(
+    {sock_closed, _Reason},
+    Channel = #channel{conn_state = disconnected}
+) ->
     {ok, Channel};
 handle_info(clean_authz_cache, Channel) ->
     ok = emqx_authz_cache:empty_authz_cache(),
@@ -1894,6 +1923,20 @@ handle_info(Info, Channel) ->
         info => Info
     }),
     {ok, Channel}.
+
+handle_client_disconnect(Channel) ->
+    NChannel = ensure_disconnected(normal, cancel_timer(expire_asleep, Channel)),
+    case maybe_shutdown(normal, NChannel) of
+        {ok, NChannel1} -> {ok, {event, disconnected}, NChannel1};
+        Shutdown -> Shutdown
+    end.
+
+handle_connection_lost(Reason, Channel) ->
+    NChannel = ensure_disconnected(Reason, mabye_publish_will_msg(Channel)),
+    case maybe_shutdown(Reason, NChannel) of
+        {ok, NChannel1} -> {ok, {event, disconnected}, NChannel1};
+        Shutdown -> Shutdown
+    end.
 
 maybe_shutdown(Reason, Channel = #channel{conninfo = ConnInfo}) ->
     case maps:get(expiry_interval, ConnInfo) of
@@ -2052,6 +2095,9 @@ handle_timeout(
     ConnState =:= disconnected;
     ConnState =:= asleep
 ->
+    ?tp(debug, mqttsn_keepalive_timeout_ignored, #{
+        conn_state => ConnState
+    }),
     {ok, Channel};
 handle_timeout(
     _TRef,
@@ -2126,8 +2172,14 @@ handle_timeout(
     end;
 handle_timeout(_TRef, expire_session, Channel) ->
     shutdown(expired, Channel);
+handle_timeout(
+    _TRef,
+    expire_asleep,
+    Channel = #channel{conn_state = asleep}
+) ->
+    handle_connection_lost(asleep_timeout, clean_timer(expire_asleep, Channel));
 handle_timeout(_TRef, expire_asleep, Channel) ->
-    shutdown(asleep_timeout, Channel);
+    {ok, clean_timer(expire_asleep, Channel)};
 handle_timeout(_TRef, connection_expire, Channel) ->
     NChannel = clean_timer(connection_expire, Channel),
     handle_out(disconnect, expired, NChannel);

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -1477,22 +1477,29 @@ t_asleep_test01_timeout(_) ->
     {ok, Socket} = gen_udp:open(0, [binary]),
 
     ClientId = ?CLIENTID,
-    send_connect_msg_with_will(Socket, Duration, ClientId),
-    ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
-    send_willtopic_msg(Socket, WillTopic, QoS),
-    ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
-    send_willmsg_msg(Socket, WillPayload),
-    ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+    ok = emqx_broker:subscribe(WillTopic),
+    try
+        send_connect_msg_with_will(Socket, Duration, ClientId),
+        ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+        send_willtopic_msg(Socket, WillTopic, QoS),
+        ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
+        send_willmsg_msg(Socket, WillPayload),
+        ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
 
-    send_disconnect_msg(Socket, 1),
-    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+        send_disconnect_msg(Socket, 1),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
 
-    %% asleep timer should get timeout, and device is lost
-    timer:sleep(3000),
-
-    ?assertEqual([], emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId)),
-
-    gen_udp:close(Socket).
+        %% asleep timer should get timeout, and device is lost
+        ?assertReceive({deliver, WillTopic, #message{payload = WillPayload}}, 4000),
+        ?retry(
+            50,
+            20,
+            ?assertEqual([], emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId))
+        )
+    after
+        ok = emqx_broker:unsubscribe(WillTopic),
+        gen_udp:close(Socket)
+    end.
 
 t_asleep_test02_to_awake_and_back(_) ->
     QoS = 1,
@@ -1855,46 +1862,58 @@ t_asleep_test07_to_connected(_) ->
     WillPayload = <<10, 11, 12, 13, 14>>,
     {ok, Socket} = gen_udp:open(0, [binary]),
     ClientId = ?CLIENTID,
-    send_connect_msg_with_will(Socket, Keepalive_Duration, ClientId),
-    ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
-    send_willtopic_msg(Socket, WillTopic, QoS),
-    ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
-    send_willmsg_msg(Socket, WillPayload),
-    ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+    ok = emqx_broker:subscribe(WillTopic),
+    try
+        send_connect_msg_with_will(Socket, Keepalive_Duration, ClientId),
+        ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+        send_willtopic_msg(Socket, WillTopic, QoS),
+        ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
+        send_willmsg_msg(Socket, WillPayload),
+        ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
 
-    % subscribe
-    TopicName_tom = <<"tom">>,
-    MsgId1 = 25,
-    WillBit = 0,
-    Dup = 0,
-    Retain = 0,
-    CleanSession = 0,
-    ReturnCode = 0,
-    send_register_msg(Socket, TopicName_tom, MsgId1),
-    TopicId_tom = check_regack_msg_on_udp(MsgId1, receive_response(Socket)),
-    send_subscribe_msg_predefined_topic(Socket, QoS, TopicId_tom, MsgId1),
-    ?assertEqual(
-        <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
-            TopicId_tom:16, MsgId1:16, ReturnCode>>,
-        receive_response(Socket)
-    ),
+        % subscribe
+        TopicName_tom = <<"tom">>,
+        MsgId1 = 25,
+        WillBit = 0,
+        Dup = 0,
+        Retain = 0,
+        CleanSession = 0,
+        ReturnCode = 0,
+        send_register_msg(Socket, TopicName_tom, MsgId1),
+        TopicId_tom = check_regack_msg_on_udp(MsgId1, receive_response(Socket)),
+        send_subscribe_msg_predefined_topic(Socket, QoS, TopicId_tom, MsgId1),
+        ?assertEqual(
+            <<8, ?SN_SUBACK, Dup:1, QoS:2, Retain:1, WillBit:1, CleanSession:1, ?SN_NORMAL_TOPIC:2,
+                TopicId_tom:16, MsgId1:16, ReturnCode>>,
+            receive_response(Socket)
+        ),
 
-    % goto asleep state
-    send_disconnect_msg(Socket, SleepDuration),
-    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+        % goto asleep state
+        send_disconnect_msg(Socket, SleepDuration),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
 
-    timer:sleep(100),
+        timer:sleep(100),
 
-    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    %% send connect message, and goto connected state
-    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    send_connect_msg(Socket, ClientId),
-    ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        %% send connect message, and goto connected state
+        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        send_connect_msg(Socket, ClientId),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
 
-    timer:sleep(1500),
-    % asleep timer should get timeout, without any effect
-    ?assertEqual([], emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId)),
-    gen_udp:close(Socket).
+        timer:sleep(1500),
+        %% The old asleep timer must not terminate the resumed connection.
+        ?assertMatch(
+            #{conn_state := connected},
+            emqx_gateway_cm:get_chan_info(mqttsn, ClientId)
+        ),
+
+        send_disconnect_msg(Socket, undefined),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+        ?assertNotReceive({deliver, WillTopic, #message{payload = WillPayload}}, 1000)
+    after
+        ok = emqx_broker:unsubscribe(WillTopic),
+        gen_udp:close(Socket)
+    end.
 
 t_asleep_test08_to_disconnected(_) ->
     QoS = 1,
@@ -1928,6 +1947,202 @@ t_asleep_test08_to_disconnected(_) ->
     ?assertEqual([], emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId)),
 
     gen_udp:close(Socket).
+
+t_asleep_test10_client_disconnect(_) ->
+    QoS = 1,
+    Keepalive_Duration = 10,
+    SleepDuration = 1,
+    WillTopic = <<"asleep/client-disconnect/will">>,
+    WillPayload = <<10, 11, 12, 13, 14>>,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    ClientId = ?CLIENTID,
+    ok = emqx_broker:subscribe(WillTopic),
+    try
+        send_connect_msg_with_will1(Socket, Keepalive_Duration, ClientId),
+        ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+        send_willtopic_msg(Socket, WillTopic, QoS),
+        ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
+        send_willmsg_msg(Socket, WillPayload),
+        ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+
+        send_disconnect_msg(Socket, SleepDuration),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+        timer:sleep(100),
+
+        send_disconnect_msg(Socket, undefined),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+        ?retry(
+            50,
+            20,
+            #{conn_state := disconnected} = emqx_gateway_cm:get_chan_info(mqttsn, ClientId)
+        ),
+        %% Wait past the original asleep deadline to prove its timer was cancelled.
+        timer:sleep(1500),
+        ?assertMatch(
+            #{conn_state := disconnected},
+            emqx_gateway_cm:get_chan_info(mqttsn, ClientId)
+        ),
+        ?assertNotReceive({deliver, WillTopic, #message{payload = WillPayload}}, 1000)
+    after
+        ok = emqx_broker:unsubscribe(WillTopic),
+        _ = emqx_gateway_cm:discard_session(mqttsn, ClientId),
+        gen_udp:close(Socket)
+    end.
+
+t_asleep_transport_close_preserves_session(_) ->
+    QoS = 1,
+    KeepaliveDuration = 10,
+    SleepDuration = 10,
+    WillTopic = <<"asleep/transport-close/will">>,
+    WillPayload = <<10, 11, 12, 13, 14>>,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    ClientId = ?CLIENTID,
+    ok = emqx_broker:subscribe(WillTopic),
+    try
+        send_connect_msg_with_will(Socket, KeepaliveDuration, ClientId),
+        ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+        send_willtopic_msg(Socket, WillTopic, QoS),
+        ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
+        send_willmsg_msg(Socket, WillPayload),
+        ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+
+        send_disconnect_msg(Socket, SleepDuration),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+        [ConnPid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
+
+        ?check_trace(
+            begin
+                ConnPid ! udp_proxy_closed,
+                {ok, _} = ?block_until(
+                    #{
+                        ?snk_kind := mqttsn_asleep_sock_closed_ignored,
+                        clientid := ClientId
+                    },
+                    2000
+                ),
+                ?assertMatch(
+                    #{conn_state := asleep},
+                    emqx_gateway_cm:get_chan_info(mqttsn, ClientId)
+                ),
+                ?assertNotReceive(
+                    {deliver, WillTopic, #message{payload = WillPayload}},
+                    1000
+                )
+            end,
+            fun(Trace) ->
+                ?assertMatch(
+                    [#{reason := normal}],
+                    ?of_kind(mqttsn_asleep_sock_closed_ignored, Trace)
+                )
+            end
+        )
+    after
+        ok = emqx_broker:unsubscribe(WillTopic),
+        _ = emqx_gateway_cm:discard_session(mqttsn, ClientId),
+        gen_udp:close(Socket)
+    end.
+
+t_awake_transport_close_publishes_will(_) ->
+    QoS = 1,
+    KeepaliveDuration = 10,
+    SleepDuration = 10,
+    WillTopic = <<"awake/transport-close/will">>,
+    WillPayload = <<10, 11, 12, 13, 14>>,
+    TopicId = ?PREDEF_TOPIC_ID1,
+    TopicName = ?PREDEF_TOPIC_NAME1,
+    Payload = <<55, 66, 77, 88, 99>>,
+    MsgId = 1000,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    ClientId = ?CLIENTID,
+    ok = emqx_broker:subscribe(WillTopic),
+    try
+        send_connect_msg_with_will(Socket, KeepaliveDuration, ClientId),
+        ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+        send_willtopic_msg(Socket, WillTopic, QoS),
+        ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
+        send_willmsg_msg(Socket, WillPayload),
+        ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+
+        send_subscribe_msg_predefined_topic(Socket, QoS, TopicId, MsgId),
+        ?assertMatch(
+            <<8, ?SN_SUBACK, _Flags:8, TopicId:16, MsgId:16, ?SN_RC_ACCEPTED>>,
+            receive_response(Socket)
+        ),
+        send_disconnect_msg(Socket, SleepDuration),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+
+        _ = emqx:publish(emqx_message:make(<<"ct">>, QoS, TopicName, Payload)),
+        send_pingreq_msg(Socket, ClientId),
+        Publish = receive_response(Socket),
+        _ = check_publish_msg_on_udp(
+            {0, QoS, 0, 0, 0, ?SN_PREDEFINED_TOPIC, TopicId, Payload},
+            Publish
+        ),
+        ?assertMatch(
+            #{conn_state := awake},
+            emqx_gateway_cm:get_chan_info(mqttsn, ClientId)
+        ),
+
+        [ConnPid] = emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId),
+        ConnPid ! udp_proxy_closed,
+        ?assertReceive({deliver, WillTopic, #message{payload = WillPayload}}, 2000),
+        ?retry(
+            50,
+            20,
+            ?assertEqual([], emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId))
+        )
+    after
+        ok = emqx_broker:unsubscribe(WillTopic),
+        _ = emqx_gateway_cm:discard_session(mqttsn, ClientId),
+        gen_udp:close(Socket)
+    end.
+
+t_connect_from_asleep_restarts_keepalive(_) ->
+    QoS = 1,
+    KeepaliveDuration = 1,
+    SleepDuration = 10,
+    WillTopic = <<"asleep/reconnect/keepalive/will">>,
+    WillPayload = <<10, 11, 12, 13, 14>>,
+    {ok, Socket} = gen_udp:open(0, [binary]),
+    ClientId = ?CLIENTID,
+    ok = emqx_broker:subscribe(WillTopic),
+    try
+        send_connect_msg_with_will(Socket, KeepaliveDuration, ClientId),
+        ?assertEqual(<<2, ?SN_WILLTOPICREQ>>, receive_response(Socket)),
+        send_willtopic_msg(Socket, WillTopic, QoS),
+        ?assertEqual(<<2, ?SN_WILLMSGREQ>>, receive_response(Socket)),
+        send_willmsg_msg(Socket, WillPayload),
+        ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
+
+        send_disconnect_msg(Socket, SleepDuration),
+        ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
+
+        %% Let the original keepalive timer expire while the client is asleep.
+        {ok, _} = ?block_until(
+            #{
+                ?snk_kind := mqttsn_keepalive_timeout_ignored,
+                conn_state := asleep
+            },
+            3000
+        ),
+        send_connect_msg(Socket, ClientId, 0, KeepaliveDuration),
+        ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
+        ?assertMatch(
+            #{conn_state := connected},
+            emqx_gateway_cm:get_chan_info(mqttsn, ClientId)
+        ),
+
+        ?assertReceive({deliver, WillTopic, #message{payload = WillPayload}}, 5000),
+        ?retry(
+            50,
+            20,
+            ?assertEqual([], emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId))
+        )
+    after
+        ok = emqx_broker:unsubscribe(WillTopic),
+        _ = emqx_gateway_cm:discard_session(mqttsn, ClientId),
+        gen_udp:close(Socket)
+    end.
 
 t_asleep_test09_to_awake_again_qos1_dl_msg(_) ->
     QoS = 1,
@@ -2062,8 +2277,13 @@ t_awake_test01_to_connected(_) ->
     ?assertEqual(<<3, ?SN_CONNACK, ?SN_RC_ACCEPTED>>, receive_response(Socket)),
 
     timer:sleep(1500),
-    % asleep timer should get timeout
-    ?assertEqual([], emqx_gateway_cm:lookup_by_clientid(mqttsn, ClientId)),
+    %% Reconnecting from asleep cancels the old sleep timer.
+    ?assertMatch(
+        #{conn_state := connected},
+        emqx_gateway_cm:get_chan_info(mqttsn, ClientId)
+    ),
+    send_disconnect_msg(Socket, undefined),
+    ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
     gen_udp:close(Socket).
 
 t_awake_test02_to_disconnected(_) ->
@@ -2545,7 +2765,10 @@ send_searchgw_msg(Socket) ->
     Radius = 0,
     ok = gen_udp:send(Socket, ?HOST, ?PORT, <<Length:8, MsgType:8, Radius:8>>).
 
-make_connect_msg(ClientId, CleanSession) when
+make_connect_msg(ClientId, CleanSession) ->
+    make_connect_msg(ClientId, CleanSession, 10).
+
+make_connect_msg(ClientId, CleanSession, Duration) when
     CleanSession == 0;
     CleanSession == 1
 ->
@@ -2557,7 +2780,6 @@ make_connect_msg(ClientId, CleanSession) when
     Will = 0,
     TopicIdType = 0,
     ProtocolId = 1,
-    Duration = 10,
     <<Length:8, MsgType:8, Dup:1, QoS:2, Retain:1, Will:1, CleanSession:1, TopicIdType:2,
         ProtocolId:8, Duration:16, ClientId/binary>>.
 
@@ -2565,7 +2787,10 @@ send_connect_msg(Socket, ClientId) ->
     send_connect_msg(Socket, ClientId, 1).
 
 send_connect_msg(Socket, ClientId, CleanSession) ->
-    Packet = make_connect_msg(ClientId, CleanSession),
+    send_connect_msg(Socket, ClientId, CleanSession, 10).
+
+send_connect_msg(Socket, ClientId, CleanSession, Duration) ->
+    Packet = make_connect_msg(ClientId, CleanSession, Duration),
     ok = gen_udp:send(Socket, ?HOST, ?PORT, Packet).
 
 send_connect_msg_with_will(Socket, Duration, ClientId) ->

--- a/changes/ee/fix-18652.en.md
+++ b/changes/ee/fix-18652.en.md
@@ -1,0 +1,1 @@
+MQTT-SN now publishes configured Will messages when sleeping clients exceed their sleep duration and no longer publishes Will messages when clients disconnect normally.


### PR DESCRIPTION
Fixes: #18638
Release version: 5.8.12, 5.9.4, 5.10.5
Introduced in: pre-5.8

## Summary

Fix MQTT-SN channel lifecycle handling around the `asleep` state.

The channel now distinguishes a client-initiated normal `DISCONNECT` from transport and UDP proxy close notifications. Normal disconnects from `connected`, `asleep`, or `awake` move the channel to `disconnected` without publishing the Will. Transport or proxy closes during `asleep` preserve the sleeping session, while connection loss during `connected` or `awake` performs lost-client cleanup and publishes the Will. Sleep timeout also performs lost-client cleanup and publishes the Will before applying session expiry. Reconnecting from `asleep` cancels stale sleep and keepalive timers so keepalive supervision restarts.

This keeps the behavior compatible with both the ownerless UDP proxy callbacks used by this release line and the owner-aware callbacks used by newer branches.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)