### PR TITLE
chore(changelog): drop stale SAML signature-verification fragment

### DIFF
--- a/changes/ee/feat-18002.en.md
+++ b/changes/ee/feat-18002.en.md
@@ -1,1 +1,0 @@
-Enabled SAML response and assertion signature verification by default in the hardened security profile.


### PR DESCRIPTION
\`feat-18002.en.md\` says signature verification is enabled by default only in the hardened security profile. #18627 (merged to \`dev-63\`, not yet synced into \`dev-70\`) makes it default-on in all security profiles and ships its own changelog entry (\`breaking-18627.en.md\`) describing the final behavior.

Removing this fragment now, before the next \`dev-63\` → \`dev-70\` sync, so the two don't ship as contradictory entries in the 7.0.0 release notes.