### PR TITLE
fix(mgmt): report a node that did not answer instead of dropping it

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -22,6 +22,7 @@
     lookup_broker/1,
     node_info/0,
     node_info/1,
+    unreachable_node_info/1,
     broker_info/0,
     broker_info/1
 ]).
@@ -132,7 +133,27 @@ list_nodes() ->
     %% all stopped core nodes
     Stopped = emqx:cluster_nodes(stopped),
     DownNodes = lists:map(fun stopped_node_info/1, Stopped),
-    [{Node, Info} || #{node := Node} = Info <- node_info(Running)] ++ DownNodes.
+    running_node_info(Running) ++ DownNodes.
+
+%% A node that was in `cluster_nodes(running)' but did not answer `node_info/0'
+%% is reported as `unreachable' rather than left out. Dropping it made a cluster
+%% view where a node stopped answering indistinguishable from one where a node
+%% was removed, which is the condition the view exists to show.
+%%
+%% `erpc:multicall/5' answers in request order and `unwrap_erpc/1' maps over
+%% that list, so zipping the two recovers which node produced which answer.
+running_node_info(Nodes) ->
+    lists:zipwith(fun node_info_entry/2, Nodes, node_info(Nodes)).
+
+node_info_entry(_Node, #{node := Node} = Info) ->
+    {Node, Info};
+%% Anything that is not a node report is treated as no answer. The list
+%% comprehension this replaced dropped every shape it did not match, so a
+%% narrower match here would turn a surprise -- an older node answering with a
+%% map that has no `node` key, say -- from a missing row into a 500 for the
+%% whole endpoint.
+node_info_entry(Node, _NotANodeReport) ->
+    {Node, unreachable_node_info(Node)}.
 
 lookup_node(Node) ->
     [Info] = node_info([Node]),
@@ -200,6 +221,14 @@ node_info(Nodes) ->
 %% The schema marks every other `node_info` field as optional.
 stopped_node_info(Node) ->
     {Node, #{node => Node, node_status => 'stopped', role => core}}.
+
+%% As above, minus `role': `cluster_nodes(stopped)' yields core nodes only, so
+%% `stopped_node_info/1' can name the role, but a running node that stopped
+%% answering may be either, and `role' comes from the node's own
+%% `mria_rlog:role()'. Reporting a guess is worse than omitting an optional
+%% field.
+unreachable_node_info(Node) ->
+    #{node => Node, node_status => 'unreachable'}.
 
 %% Hide cpu stats if os_check is not supported.
 vm_stats() ->

--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -195,7 +195,7 @@ fields(node_info) ->
             )},
         {node_status,
             mk(
-                enum(['running', 'stopped']),
+                enum(['running', 'stopped', 'unreachable']),
                 #{desc => ?DESC("node_status"), example => "running"}
             )},
         {otp_release,
@@ -281,8 +281,14 @@ list_nodes(#{}) ->
     NodesInfo = [format(NodeInfo) || {_Node, NodeInfo} <- emqx_mgmt:list_nodes()],
     {200, NodesInfo}.
 
+%% `emqx_mgmt:lookup_node/1` answers `{error, Reason}` for a node that passed
+%% the membership check but did not report. `format/1` takes a map only, so that
+%% reached the client as a 500. Report it the way `GET /nodes` does instead.
 get_node(Node) ->
-    format(emqx_mgmt:lookup_node(Node)).
+    case emqx_mgmt:lookup_node(Node) of
+        Info when is_map(Info) -> format(Info);
+        {error, _Reason} -> format(emqx_mgmt:unreachable_node_info(Node))
+    end.
 
 %%--------------------------------------------------------------------
 %% internal function

--- a/apps/emqx_management/test/emqx_mgmt_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_SUITE.erl
@@ -102,6 +102,104 @@ t_list_nodes(_) ->
         NodeInfos
     ).
 
+%% A node that `cluster_nodes(running)` reported but whose `node_info` RPC did
+%% not answer used to be filtered out by the `#{node := Node} = Info` generator
+%% in `list_nodes/0`, so it vanished from `GET /nodes` entirely. A vanished row
+%% is indistinguishable from a removed node, which is the condition the view
+%% exists to show, so it is reported as `unreachable` instead.
+t_list_nodes_reports_unreachable(init, Config) ->
+    meck:expect(
+        emqx,
+        cluster_nodes,
+        fun
+            (running) -> [node(), 'silent@node'];
+            (stopped) -> []
+        end
+    ),
+    meck:new(emqx_management_proto_v5, [passthrough, no_history]),
+    %% `erpc:multicall/5` answers in request order; the second node times out.
+    %% The first answer is synthetic: this suite starts no applications, so the
+    %% real `emqx_mgmt:node_info/0` has no ETS tables to read.
+    meck:expect(emqx_management_proto_v5, node_info, fun([Self, 'silent@node']) ->
+        [
+            {ok, #{node => Self, node_status => 'running', role => core}},
+            {error, {erpc, timeout}}
+        ]
+    end),
+    Config;
+t_list_nodes_reports_unreachable('end', _Config) ->
+    meck:unload(emqx_management_proto_v5),
+    ok.
+
+t_list_nodes_reports_unreachable(_) ->
+    Node = node(),
+    ?assertMatch(
+        [
+            {Node, #{node := Node, node_status := 'running'}},
+            {'silent@node', #{node := 'silent@node', node_status := 'unreachable'}}
+        ],
+        emqx_mgmt:list_nodes()
+    ),
+    %% `role` is the node's own `mria_rlog:role()`, so it is left out rather
+    %% than guessed. Unlike a stopped node, an unreachable one may be either.
+    [_, {_, Unreachable}] = emqx_mgmt:list_nodes(),
+    ?assertNot(maps:is_key(role, Unreachable)).
+
+%% The comprehension this replaced dropped anything it could not match, so an
+%% unexpected answer cost one row. Matching only `{error, _}` would make the
+%% same surprise a 500 for the whole endpoint instead.
+t_list_nodes_tolerates_an_unexpected_answer(init, Config) ->
+    meck:expect(
+        emqx,
+        cluster_nodes,
+        fun
+            (running) -> [node(), 'odd@node'];
+            (stopped) -> []
+        end
+    ),
+    meck:new(emqx_management_proto_v5, [passthrough, no_history]),
+    meck:expect(emqx_management_proto_v5, node_info, fun([Self, 'odd@node']) ->
+        [
+            {ok, #{node => Self, node_status => 'running', role => core}},
+            %% a map, but not a node report
+            {ok, #{unexpected => shape}}
+        ]
+    end),
+    Config;
+t_list_nodes_tolerates_an_unexpected_answer('end', _Config) ->
+    meck:unload(emqx_management_proto_v5),
+    ok.
+
+t_list_nodes_tolerates_an_unexpected_answer(_) ->
+    ?assertMatch(
+        [{_, #{node_status := 'running'}}, {'odd@node', #{node_status := 'unreachable'}}],
+        emqx_mgmt:list_nodes()
+    ).
+
+%% `GET /nodes/:node` reaches its handler for any node in `mria:running_nodes/0`,
+%% which is the same set the list endpoint fans out to, so it has the same
+%% window. `emqx_mgmt:lookup_node/1` answers `{error, Reason}` there and
+%% `format/1` takes a map only, which reached the client as a 500.
+t_get_node_reports_unreachable(init, Config) ->
+    meck:new(emqx_management_proto_v5, [passthrough, no_history]),
+    meck:expect(emqx_management_proto_v5, node_info, fun([_]) ->
+        [{error, {erpc, timeout}}]
+    end),
+    meck:new(mria, [passthrough, no_history]),
+    meck:expect(mria, running_nodes, 0, [node()]),
+    Config;
+t_get_node_reports_unreachable('end', _Config) ->
+    meck:unload(mria),
+    meck:unload(emqx_management_proto_v5),
+    ok.
+
+t_get_node_reports_unreachable(_) ->
+    Node = node(),
+    ?assertMatch(
+        {200, #{node := Node, node_status := 'unreachable'}},
+        emqx_mgmt_api_nodes:node(get, #{bindings => #{node => atom_to_binary(Node, utf8)}})
+    ).
+
 t_lookup_node(init, Config) ->
     meck:new(emqx_mgmt, [passthrough]),
     meck:expect(emqx_mgmt, os_type, 0, {win32, winME}),

--- a/changes/ee/fix-18656.en.md
+++ b/changes/ee/fix-18656.en.md
@@ -1,0 +1,7 @@
+`GET /nodes` no longer omits a node whose `node_info` RPC does not answer. Such a node was filtered out of the response entirely, so a node that was stopping, leaving, or merely slow looked the same as one that had been removed from the cluster.
+
+It is now reported with `node_status` `unreachable`, a new value alongside `running` and `stopped`. Only `node` and `node_status` are present for it; the remaining fields come from the node's own report and are omitted, as they already are for a `stopped` node.
+
+`GET /nodes/{node}` had the same gap for a node that is a running cluster member but does not report: it answered `500`. It now returns the same `unreachable` entry.
+
+Note that `/nodes` reports what each node says about itself. Automation making join or leave decisions should use `/cluster` and `/cluster/topology`, which are the cluster membership surface.

--- a/rel/i18n/emqx_mgmt_api_nodes.hocon
+++ b/rel/i18n/emqx_mgmt_api_nodes.hocon
@@ -85,7 +85,10 @@ emqx_mgmt_api_nodes {
     }
 
     node_status {
-        desc = "Node status."
+        desc = """Node status.
+`running`: the node answered with its own report.
+`stopped`: the node is a known cluster member that is not running.
+`unreachable`: the node is a running cluster member that did not answer within the timeout. Only `node` and `node_status` are reported for it."""
         label = "Node Status"
     }
 


### PR DESCRIPTION
Fixes: #18640

## Summary

`list_nodes/0` collected the multicall results with

```erlang
[{Node, Info} || #{node := Node} = Info <- node_info(Running)]
```

so a node whose `node_info` RPC failed produced `{error, Reason}`, missed the
generator pattern, and left the response entirely. In a cluster view a vanished
row is indistinguishable from a removed node, which is the condition an operator
is watching for.

`erpc:multicall/5` answers in request order and `unwrap_erpc/1` maps over that
list, so zipping the request list with the results recovers which node produced
which answer. A failure becomes an entry with `node_status` `unreachable`, a new
value in the schema. `role` is left out of it: `stopped_node_info/1` can say
`core` because `cluster_nodes(stopped)` yields core nodes only, but a running
node that stopped answering may be either, and `role` comes from the node's own
`mria_rlog:role()`. `format/1` already passes a partial map through, which is how
the `stopped` entry works today.

`node_info_entry/2` keeps a catch-all rather than matching only `{error, _}`.
The comprehension it replaces dropped every shape it did not match, so a
narrower match would turn an unexpected answer from a missing row into a 500 for
the whole endpoint.

`GET /nodes/{node}` had the same gap and is fixed with it. `with_node/2` admits
any node in `mria:running_nodes/0`, the same set the list endpoint fans out to,
and there `lookup_node/1` answers `{error, Reason}` while `format/1` takes a map
only, so it raised `function_clause` and reached the client as a 500. The fix is
in `get_node/1`, not `lookup_node/1`, because `t_lookup_node` pins the
`{error, _}` return deliberately.

The dashboard SPA is a separate artifact (`scripts/get-dashboard.sh`), so
rendering the new status is not something this PR can carry. The i18n text now
spells out all three values.

Local run: `emqx_mgmt_SUITE` 22/22, `emqx_mgmt_api_nodes_SUITE` 6/6,
`emqx_mgmt_api_cluster_SUITE` 5/5, `emqx_mgmt_api_status_SUITE` 10/10. Reverting
only `emqx_mgmt.erl` fails the new case with the silent node absent from the list.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (new `node_status` value, additive)
