### PR TITLE
fix(authz): separate rule render failure policy

### DIFF
--- a/apps/emqx/src/emqx_security_profile.erl
+++ b/apps/emqx/src/emqx_security_profile.erl
@@ -53,6 +53,7 @@ Returns policy depending on the current security profile.
     (authn_not_configured) -> allow | deny;
     (authn_backend_failure) -> ignore | deny;
     (authz_backend_failure) -> ignore | deny;
+    (authz_rule_render_failure) -> ignore | deny;
     (dashboard_unchanged_default_credentials) -> allow | deny;
     (access_control_hook_failure) -> ignore | interrupt;
     (outbound_tls_verify) -> verify_none | verify_peer;
@@ -89,6 +90,11 @@ policy(authn_backend_failure) ->
         hardened -> deny
     end;
 policy(authz_backend_failure) ->
+    case profile() of
+        legacy -> ignore;
+        hardened -> deny
+    end;
+policy(authz_rule_render_failure) ->
     case profile() of
         legacy -> ignore;
         hardened -> deny

--- a/apps/emqx/test/emqx_security_profile_SUITE.erl
+++ b/apps/emqx/test/emqx_security_profile_SUITE.erl
@@ -86,6 +86,7 @@ t_uppercase_profile_rejected(_) ->
 assert_policies(legacy) ->
     ?assertEqual(ignore, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(ignore, emqx_security_profile:policy(authz_backend_failure)),
+    ?assertEqual(ignore, emqx_security_profile:policy(authz_rule_render_failure)),
     ?assertEqual(verify_none, emqx_security_profile:policy(outbound_tls_verify)),
     ?assertEqual(ignore, emqx_security_profile:policy(authn_jwt_missing)),
     ?assertEqual(false, emqx_security_profile:policy(saml_signature_verification)),
@@ -107,6 +108,7 @@ assert_policies(legacy) ->
 assert_policies(hardened) ->
     ?assertEqual(deny, emqx_security_profile:policy(authn_backend_failure)),
     ?assertEqual(deny, emqx_security_profile:policy(authz_backend_failure)),
+    ?assertEqual(deny, emqx_security_profile:policy(authz_rule_render_failure)),
     ?assertEqual(verify_peer, emqx_security_profile:policy(outbound_tls_verify)),
     ?assertEqual(deny, emqx_security_profile:policy(authn_jwt_missing)),
     ?assertEqual(true, emqx_security_profile:policy(saml_signature_verification)),

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_rule.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_rule.erl
@@ -502,7 +502,7 @@ render_topic(Topic, AuthzContext) ->
                 template => Topic,
                 reason => Reason
             }),
-            case emqx_security_profile:policy(authz_backend_failure) of
+            case emqx_security_profile:policy(authz_rule_render_failure) of
                 ignore -> error;
                 deny -> throw({cannot_render_topic_template, Reason})
             end


### PR DESCRIPTION
Release version: 7.0.0
Introduced in: 6.3.0

## Summary

Add a dedicated security profile policy for authorization rule rendering failures.
This is a refactoring to decouple policies, not a change in behaviour.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
