### PR TITLE
chore(otel schema): enforce scheme and port validation for endpoint (dynatrace, 6.3)

### DIFF
--- a/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
@@ -276,12 +276,16 @@ fields("otel_exporter") ->
 fields("otel_exporter_dynatrace") ->
     [
         {endpoint,
-            ?HOCON(
-                emqx_schema:url(),
+            emqx_schema:servers_sc(
                 #{
+                    type => binary(),
                     required => true,
                     desc => ?DESC(exporter_endpoint),
                     importance => ?IMPORTANCE_HIGH
+                },
+                #{
+                    single_server => true,
+                    supported_schemes => ["http", "https"]
                 }
             )},
         {headers,

--- a/apps/emqx_opentelemetry/test/emqx_otel_api_SUITE.erl
+++ b/apps/emqx_opentelemetry/test/emqx_otel_api_SUITE.erl
@@ -364,4 +364,19 @@ t_dynatrace(_TCConfig) ->
     ?assertMatch({200, _}, update_config(ObfuscatedConf)),
     WrappedSecret = emqx_config:get([opentelemetry, exporter, auth, client_secret]),
     ?assertNotEqual(emqx_utils_redact:redacted_value(), WrappedSecret()),
+    %% endpoint validation
+    ConfInvalidEndpoint =
+        emqx_utils_maps:deep_merge(
+            Conf,
+            #{~"exporter" => #{~"endpoint" => ~"not_an_url"}}
+        ),
+    ?assertMatch(
+        {400, #{
+            ~"message" := #{
+                ~"kind" := ~"validation_error",
+                ~"path" := ~"root.exporter.endpoint"
+            }
+        }},
+        update_config(ConfInvalidEndpoint)
+    ),
     ok.


### PR DESCRIPTION
"Port" of https://github.com/emqx/emqx/pull/18528 to 6.3

Fixes https://github.com/emqx/emqx/issues/18645

Dynatrace was only introduced in 6.3, hence the "port" of the same change from 6.0

Release version:
6.3.0, 7.0.0


Introduced in:
N/A

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
