### PR TITLE
test(dsraft): stabilize flaky test

### DIFF
--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -1394,7 +1394,9 @@ do_kill_leader(DB, Shard, Reason, RetriesLeft) ->
         undefined when RetriesLeft =< 0 ->
             error(could_not_find_leader_to_kill);
         undefined ->
-            ct:sleep(10),
+            %% don't use `ct:sleep`; this runs on peer node, where test_server_ctrl
+            %% doesn't exist.
+            timer:sleep(10),
             do_kill_leader(DB, Shard, Reason, RetriesLeft - 1);
         Pid when is_pid(Pid) ->
             exit(Pid, Reason)


### PR DESCRIPTION
```
           {run_stage_failed,error,
               {exit,
                   {exception,
                       {noproc,
                           {gen_server,call,
                               [test_server_ctrl,get_timetrap_parameters,
                                infinity]}}}},
```

Follow up to https://github.com/emqx/emqx/pull/18553
