### PR TITLE
test(ds ps): mark flaky test as such

### DIFF
--- a/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
@@ -28,6 +28,14 @@
 %% CT boilerplate
 %%------------------------------------------------------------------------------
 
+suite() ->
+    [{ct_hooks, [emqx_cth_ct_hook_flaky]}].
+
+flaky_tests() ->
+    #{
+        t_session_replay_retry => 3
+    }.
+
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 


### PR DESCRIPTION
While the reason for the flakiness is unknown, mark it as flaky so we don't waste 15+ minutes in CI for each run.

```
%%% emqx_persistent_session_ds_SUITE ==> t_session_replay_retry: FAILED
%%% emqx_persistent_session_ds_SUITE ==> {{panic,
     #{msg => "Unexpected result",
       result =>
           {run_stage_failed,error,
               {assertEqual,
                   [{module,emqx_persistent_session_ds_SUITE},
                    {line,1309},
                    {comment,[]},
                    {expression,"NPubs"},
                    {expected,10},
                    {value,9}]},
```
