### PR TITLE
fix(audit): record target namespace and query params on audit entries

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
@@ -138,8 +138,15 @@ operation_type(Meta) ->
     end.
 
 http_request(Meta) ->
+    %% `namespace' is the resolved target namespace, set by handlers that call
+    %% `minirest_handler:update_log_meta/1' (see emqx_topic_metrics2_api for
+    %% an example). It is not always the same as the `ns' query param: a
+    %% namespaced admin's namespace comes from their dashboard token, not
+    %% from the request, so recording it here also covers requests with no
+    %% `ns' query param at all. `maps:with/2' already omits it when absent
+    %% from `Meta', same as it does for `method'/`headers'/`bindings'/`body'.
     Request0 =
-        case maps:with([method, headers, bindings, body], Meta) of
+        case maps:with([method, headers, bindings, body, namespace], Meta) of
             #{body := Body} = Request when is_binary(Body) ->
                 Request#{body => <<"******">>};
             #{body := _} = Request ->
@@ -153,17 +160,10 @@ http_request(Meta) ->
     %% `query_string' is the parsed request query params (a map, not a raw
     %% binary), so the `emqx_utils:redact/1' call at the end of `log_meta/3'
     %% can see the keys and redact sensitive ones by name, same as it does
-    %% for `headers' and `body' above.
-    Request1 = maybe_put(
-        query_string, non_empty_map(maps:get(query_string, Meta, undefined)), Request0
-    ),
-    %% `namespace' is the resolved target namespace, set by handlers that
-    %% call `minirest_handler:update_log_meta/1' (see emqx_topic_metrics2_api
-    %% for an example). It is not always the same as the `ns' query param:
-    %% a namespaced admin's namespace comes from their dashboard token, not
-    %% from the request, so recording it here also covers requests with no
-    %% `ns' query param at all.
-    maybe_put(namespace, maps:get(namespace, Meta, undefined), Request1).
+    %% for `headers' and `body' above. Handled separately from the `with/2'
+    %% above because an empty query string must be omitted, not recorded as
+    %% `query_string => #{}'.
+    maybe_put(query_string, non_empty_map(maps:get(query_string, Meta, undefined)), Request0).
 
 maybe_put(_Key, undefined, Map) -> Map;
 maybe_put(Key, Value, Map) -> Map#{Key => Value}.

--- a/apps/emqx_dashboard/test/emqx_dashboard_audit_tests.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_audit_tests.erl
@@ -1,0 +1,75 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_dashboard_audit_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Fixed inputs to `emqx_dashboard_audit:log_meta/3' shared by every test
+%% case below: a fake cowboy request and an importance level, neither of
+%% which any test needs to vary.
+%%
+%% `log_meta/3' only needs a plain map shaped like a cowboy request (in
+%% Cowboy 2.x a request is just a map); this avoids booting the whole
+%% app just to exercise the redaction/shape logic below `log_meta/3'.
+req() ->
+    #{headers => #{}, peer => {{127, 0, 0, 1}, 0}}.
+
+%% Any importance above the "low" threshold (30) skips the
+%% `ignore_high_frequency_request/0' branch, which reads `emqx_conf'.
+-define(IMPORTANCE, 100).
+
+base_meta() ->
+    #{
+        code => 204,
+        method => put,
+        auth_type => jwt_token,
+        operation_id => <<"/mqtt/topic_metrics2/:name/reset">>,
+        bindings => #{name => <<"test">>},
+        headers => #{},
+        body => #{},
+        req_start => 0,
+        req_end => 1000
+    }.
+
+log_meta(Meta) ->
+    emqx_dashboard_audit:log_meta(?IMPORTANCE, Meta, req()).
+
+http_request(Meta) ->
+    #{http_request := Request} = log_meta(Meta),
+    Request.
+
+no_query_string_or_namespace_test() ->
+    Request = http_request(base_meta()),
+    ?assertNot(maps:is_key(query_string, Request)),
+    ?assertNot(maps:is_key(namespace, Request)).
+
+empty_query_string_omitted_test() ->
+    Request = http_request((base_meta())#{query_string => #{}}),
+    ?assertNot(maps:is_key(query_string, Request)).
+
+query_string_is_recorded_test() ->
+    Meta = (base_meta())#{query_string => #{<<"ns">> => <<"acme">>}},
+    Request = http_request(Meta),
+    ?assertEqual(#{<<"ns">> => <<"acme">>}, maps:get(query_string, Request)).
+
+%% A query parameter under a key `emqx_utils_redact' treats as sensitive
+%% (e.g. `token') is never written to the audit log in clear, same as it
+%% already is for headers and bodies.
+query_string_secret_redacted_test() ->
+    Meta = (base_meta())#{
+        query_string => #{<<"token">> => <<"super-secret">>, <<"ns">> => <<"acme">>}
+    },
+    Request = http_request(Meta),
+    #{query_string := Qs} = Request,
+    ?assertEqual(<<"******">>, maps:get(<<"token">>, Qs)),
+    ?assertEqual(<<"acme">>, maps:get(<<"ns">>, Qs)).
+
+%% Regression for #18653: a handler that resolves a target namespace and
+%% calls `minirest_handler:update_log_meta(#{namespace => Ns})' gets that
+%% namespace recorded on the audit record, independent of whether an `ns'
+%% query parameter was present at all.
+namespace_is_recorded_test() ->
+    Meta = (base_meta())#{namespace => <<"acme">>},
+    Request = http_request(Meta),
+    ?assertEqual(<<"acme">>, maps:get(namespace, Request)).

--- a/apps/emqx_topic_metrics/src/emqx_topic_metrics2_api.erl
+++ b/apps/emqx_topic_metrics/src/emqx_topic_metrics2_api.erl
@@ -213,6 +213,7 @@ collections(get, Req) ->
     ?OK([view(R) || R <- aggregated_list(OwnerNs)]);
 collections(post, #{body := Body} = Req) ->
     OwnerNs = actor_ns(Req),
+    ok = log_ns(OwnerNs),
     case parse_create(Body) of
         {ok, BinName, TopicFilter} ->
             Name = {OwnerNs, BinName},
@@ -236,6 +237,7 @@ collections(post, #{body := Body} = Req) ->
     end;
 collections(delete, Req) ->
     OwnerNs = actor_ns(Req),
+    ok = log_ns(OwnerNs),
     %% A global admin's "delete all visible" really means "delete
     %% everything"; a namespaced admin's call is scoped to their ns.
     ok = emqx_topic_metrics2:deregister_all(list_scope(OwnerNs)),
@@ -276,10 +278,25 @@ actor_ns(Req) ->
 with_ns(Req, Fun) ->
     case resolve_ns(Req) of
         {ok, OwnerNs} ->
+            ok = log_ns(OwnerNs),
             Fun(OwnerNs);
         {error, forbidden} ->
             ?FORBIDDEN(<<"not allowed to address another namespace's collection">>)
     end.
+
+%% Record the resolved target namespace on the audit log for this
+%% request (regression for #18653: `:name' alone does not distinguish
+%% `global/test' from `acme/test' in the audit trail). This is the
+%% *resolved* namespace, not the raw `ns' query param, so a namespaced
+%% admin's implicit own-namespace target (no `?ns=' at all) is also
+%% recorded, not just explicit cross-namespace targeting by a global
+%% admin. See emqx_dashboard_audit:http_request/1.
+log_ns(?global_ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
+    ok;
+log_ns(NS) when is_binary(NS) ->
+    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+    ok.
 
 %% Resolve the namespace an actor may operate on for a `:name' op.
 %% - No `ns' param  -> the actor's own namespace (unchanged behavior).

--- a/apps/emqx_topic_metrics/test/emqx_topic_metrics2_api_SUITE.erl
+++ b/apps/emqx_topic_metrics/test/emqx_topic_metrics2_api_SUITE.erl
@@ -22,6 +22,7 @@
 -define(NS_ACME_ADMIN, <<"acme_admin">>).
 -define(NS_BRAVO_ADMIN, <<"bravo_admin">>).
 -define(NS_ADMIN_PASS, <<"public123!">>).
+-define(RESET_OP_ID, <<"/mqtt/topic_metrics2/:name/reset">>).
 
 suite() -> [{timetrap, {seconds, 60}}].
 
@@ -310,6 +311,38 @@ t_namespaced_admin_own_ns_ok(Config) ->
     {204, _} = delete_one_ns(Config, ?NS_ACME, <<"n">>, ?NS_ACME),
     ?assertMatch({404, _}, get_one(Config, ?NS_ACME, <<"n">>)).
 
+-doc """
+Regression test for #18653, using the issue's exact scenario:
+resetting `global/test' and `acme/test' must produce two audit
+records that can be told apart. Before the fix, both records only
+carried the collection name `test' — the `ns' query parameter used
+to reach `acme/test' was dropped before it reached the audit log.
+""".
+t_reset_audit_records_namespace(Config) ->
+    StartAt = erlang:system_time(microsecond),
+    {201, _} = create(Config, ?global_ns, <<"test">>, <<"test/#">>),
+    {201, _} = create(Config, ?NS_ACME, <<"test">>, <<"test/#">>),
+    {204, _} = reset_one(Config, ?global_ns, <<"test">>),
+    {204, _} = reset_one_ns(Config, ?global_ns, <<"test">>, ?NS_ACME),
+    Entries = wait_for_audit_entries(?RESET_OP_ID, StartAt, 2, 2000),
+    Namespaces = lists:sort([namespace_of(E) || E <- Entries]),
+    ?assertEqual(lists:sort([<<"global">>, ?NS_ACME]), Namespaces).
+
+-doc """
+A namespaced admin resetting their own collection with no `ns' query
+parameter still gets their namespace recorded on the audit entry —
+not `global', and not absent. This is the case a fix that only
+records the raw `ns' query parameter would miss, since a namespaced
+admin's target namespace comes from their dashboard token, not from
+the request.
+""".
+t_reset_audit_no_ns_records_actor_namespace(Config) ->
+    StartAt = erlang:system_time(microsecond),
+    {201, _} = create(Config, ?NS_ACME, <<"n2">>, <<"n2/#">>),
+    {204, _} = reset_one(Config, ?NS_ACME, <<"n2">>),
+    [Entry] = wait_for_audit_entries(?RESET_OP_ID, StartAt, 1, 2000),
+    ?assertEqual(?NS_ACME, namespace_of(Entry)).
+
 %%------------------------------------------------------------------------------
 %% Helpers — real HTTP via dashboard listener
 %%------------------------------------------------------------------------------
@@ -378,3 +411,35 @@ bearer(Token) ->
 
 b2l(B) when is_binary(B) -> binary_to_list(B);
 b2l(L) when is_list(L) -> L.
+
+%%------------------------------------------------------------------------------
+%% Audit helpers
+%%------------------------------------------------------------------------------
+
+%% The audit write happens after the HTTP response is already sent
+%% (see minirest_handler:init/2), so poll for a bit rather than
+%% assume the record is there the instant the request returns.
+wait_for_audit_entries(_OperationId, _StartAt, _ExpectedCount, RemainMs) when RemainMs =< 0 ->
+    ct:fail(audit_entries_not_found_in_time);
+wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs) ->
+    Entries = audit_entries_since(OperationId, StartAt),
+    case length(Entries) >= ExpectedCount of
+        true ->
+            Entries;
+        false ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs - SleepMs)
+    end.
+
+audit_entries_since(OperationId, StartAt) ->
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Query = lists:flatten(
+        io_lib:format("operation_id=~ts&gte_created_at=~B&limit=100", [OperationId, StartAt])
+    ),
+    {ok, Res} = emqx_mgmt_api_test_util:request_api(get, AuditPath, Query, AuthHeader),
+    #{<<"data">> := Data} = emqx_utils_json:decode(Res),
+    Data.
+
+namespace_of(#{<<"http_request">> := #{<<"namespace">> := Ns}}) -> Ns.

--- a/changes/ee/fix-18664.en.md
+++ b/changes/ee/fix-18664.en.md
@@ -1,0 +1,1 @@
+Audit records for namespaced requests now identify the namespace a request targeted. Previously, resetting a topic-metrics collection with the same name in different namespaces produced audit records that looked identical, so it was not possible to tell which namespace's collection was affected. The audit log now also records any query parameters a request carried.


### PR DESCRIPTION
Fixes: #18653
Release version: 6.3.1, 7.0.0
Introduced in: 6.3.0

## Summary

`emqx_dashboard_audit:http_request/1` recorded only `method`, `headers`, `bindings` and `body`.
A namespace passed as a query parameter (`PUT /mqtt/topic_metrics2/:name/reset?ns=ns2`) was
therefore dropped before the audit record was written, so resetting `global/test` and `ns2/test`
produced indistinguishable audit entries.

Query parameters alone are not enough either: a namespaced admin's target namespace comes from
their dashboard token, not from `?ns=`, so a request with no query parameter at all still has a
definite target that a query-string-only fix would miss (see the `OwnerNs` comment in
`emqx_topic_metrics2_api.erl`).

This PR does both, and both are needed to close the issue:

- `emqx_dashboard_audit` records the parsed query string on the audit request
  (`http_request.query_string`), redacted through the same `emqx_utils:redact/1` key-based check
  already applied to headers and bodies. It's already a parsed map by the time it reaches the audit
  layer (see `minirest_handler:parse_qs/1`), not a raw query string, so redaction can see the keys.
  This is a generic, audit-layer-only change: it covers every endpoint that takes a query
  parameter, with no per-module changes.
- `emqx_topic_metrics2_api` calls `minirest_handler:update_log_meta/1` at the point it resolves the
  operation's target namespace (create, delete, delete-all, reset), so `http_request.namespace`
  records the *resolved* namespace — present whether or not `?ns=` was passed.

**Note on the diff since the last review:** the `emqx_dashboard_audit` capture logic and the two new
`emqx_audit_api:fields(http_request)` entries have since reached `dev-63` through the sync chain
(they were part of #18677 on `dev-60`), so they no longer appear here. What remains in
`emqx_dashboard_audit.erl` is only the simplification requested in review — folding `namespace` into
the existing `maps:with/2` call instead of a separate `maybe_put/3`.

**Survey of the wider issue** (the `ns` query parameter pattern is not unique to topic-metrics):
`emqx_a2a_registry_api`, `emqx_prometheus_api`, `emqx_bridge_v2_api`, `emqx_mt_api`,
`emqx_rule_engine_api` and `emqx_connector_api` all declare an `ns` query parameter the same way.
The generic `query_string` capture covers all of them — an explicit `?ns=` on any of those endpoints
is recorded. Recording the *resolved* namespace (needed for the implicit no-`?ns=` case) is
per-module; #18677 (`dev-60`, data backup) and #18678 (`dev-62`, A2A registry) cover two more.

`emqx_topic_metrics_registry`'s module doc (from #18534) says the reset request is audited "at the
REST API entrypoint like any other mutating request" — this issue is exactly that entrypoint
coverage being incomplete for namespaced resources. No per-node audit emission is re-added; the
entrypoint record is what's made sufficient.

### Manual verification (issue's exact repro)

Before: both records showed only `{"bindings":{"name":"test"}, ...}` — no way to tell `global/test`
from `ns2/test` apart. After, on a local build:

```
PUT /mqtt/topic_metrics2/test/reset            -> 204
PUT /mqtt/topic_metrics2/test/reset?ns=ns2     -> 204
GET /audit?operation_id=/mqtt/topic_metrics2/:name/reset
```

```json
{
  "http_request": {
    "bindings": {"name": "test"},
    "method": "put",
    "query_string": {"ns": "ns2"},
    "namespace": "ns2"
  }
},
{
  "http_request": {
    "bindings": {"name": "test"},
    "method": "put",
    "namespace": "global"
  }
}
```

The two records are now distinguishable, and the no-`?ns=` record correctly carries no
`query_string` key while still naming its namespace explicitly.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
