### PR TITLE
test(mq): poll the received-messages rate in t_metrics

### DIFF
--- a/apps/emqx_mq/test/emqx_mq_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_SUITE.erl
@@ -1107,8 +1107,12 @@ t_metrics(_Config) ->
     ),
     ?assertEqual(10, ReceivedMessages1 - ReceivedMessages0),
     ?assertEqual(10, InsertedMessages1 - InsertedMessages0),
-    #{received_messages := #{current := Current}} = emqx_mq_metrics:get_rates(ds),
-    ?assert(Current > 0),
+    %% The rate is recomputed by the metrics worker on its sampling tick, so it
+    %% stays at 0 until a tick lands after the messages are counted.
+    ?retry(100, 30, begin
+        #{received_messages := #{current := Current}} = emqx_mq_metrics:get_rates(ds),
+        ?assert(Current > 0)
+    end),
 
     %% Verify that other accessors work
     ?assert(is_integer(emqx_mq_metrics:get_quota_buffer_inbox_size())),


### PR DESCRIPTION
## Summary

`emqx_mq_SUITE:t_metrics` failed on the r61-to-r62 sync PR #18659, which touches no files under
`apps/emqx_mq`:

```
Failure/Error: ?assert(Current > 0)
  expected: true
       got: false
      line: 1181
```

https://github.com/emqx/emqx/actions/runs/33406552609 (job 99539323633)

The two counter assertions just above it passed — only the **rate** was 0.

Rates are not updated when a counter is incremented. `emqx_metrics_worker` recomputes them on a
`ticking` timer:

```erlang
-ifndef(TEST).
-define(SAMPLING, 10).
-else.
-define(SAMPLING, 1).
-endif.
...
CurrRate = (CurrVal - LastVal) / ?SAMPLING,
```

So `received_messages.current` stays 0 until a tick lands **after** the 10 messages are counted.
The case reads it immediately after `emqtt_drain/2`, so when the publish and drain complete
inside a single tick window the rate is still 0.

Poll the rate instead of reading it once. The budget is 3 s against a 1 s test sampling
interval, which covers the tick reliably while staying well inside the window where `current`
is non-zero — the following tick, with no new traffic, returns it to 0.

The counter assertions are left as they are: those are updated synchronously and were not
implicated.

Base `dev-60`: `apps/emqx_mq` does not exist on the v5 lines, and the case is identical on
dev-60 through dev-70.

Local run: 1 ok, 0 failed.