### PR TITLE
test(dsraft): attempt to stabilize flaky test

### DIFF
--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -591,6 +591,7 @@ t_rebalance_chaotic_converges(Config) ->
     %% allocation will converge to the target state.
     NMsgs = 400,
     Nodes = [N1, N2, N3] = ?config(nodes, Config),
+    NodeStream = emqx_utils_stream:repeat(emqx_utils_stream:list(Nodes)),
     Sites = [S1, S2, S3] = [ds_repl_meta(N, this_site) || N <- Nodes],
     NClients = 5,
     {Stream0, TopicStreams} = emqx_ds_test_helpers:interleaved_topic_messages(
@@ -650,7 +651,14 @@ t_rebalance_chaotic_converges(Config) ->
             ),
 
             %% Store the messages + chaotically change the membership.
-            emqx_ds_raft_test_helpers:apply_stream(?DB, Nodes, Stream),
+            emqx_ds_raft_test_helpers:apply_stream(?DB, NodeStream, Stream, 0, #{
+                %% race condition flakiness: since the membership is changing during this
+                %% test, it may happen that the otx leader changes just as we attempt to
+                %% dirty append a message.  this is classified as an unrecoverable error
+                %% which is usually not retried by the test helpers, hence this option to
+                %% avoid retrying all the application's test suites in CI.
+                should_retry_not_the_leader => true
+            }),
 
             %% Wait for the last transition to complete.
             ?ON(N1, emqx_ds_raft_test_helpers:wait_db_transitions_done(?DB)),

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_raft_test_helpers.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_raft_test_helpers.erl
@@ -64,6 +64,9 @@ apply_stream(DB, Nodes, Stream) ->
     ).
 
 apply_stream(DB, NodeStream0, Stream0, N) ->
+    apply_stream(DB, NodeStream0, Stream0, N, _Opts = #{}).
+
+apply_stream(DB, NodeStream0, Stream0, N, Opts) ->
     case emqx_utils_stream:next(Stream0) of
         [] ->
             ?tp(all_done, #{});
@@ -77,14 +80,15 @@ apply_stream(DB, NodeStream0, Stream0, N) ->
                 )
             ),
             ?assertMatch(
-                ok, ?ON(Node, emqx_ds_test_helpers:dirty_append(#{db => DB, retries => 30}, [Msg]))
+                ok,
+                ?ON(Node, emqx_ds_test_helpers:dirty_append(Opts#{db => DB, retries => 30}, [Msg]))
             ),
-            apply_stream(DB, NodeStream, Stream, N + 1);
+            apply_stream(DB, NodeStream, Stream, N + 1, Opts);
         [add_generation | Stream] ->
             ?tp(notice, test_add_generation, #{}),
             [Node | NodeStream] = emqx_utils_stream:next(NodeStream0),
             ?ON(Node, emqx_ds:add_generation(DB)),
-            apply_stream(DB, NodeStream, Stream, N);
+            apply_stream(DB, NodeStream, Stream, N, Opts);
         [{Node, Operation, Arg} | Stream] when
             Operation =:= join_db_site;
             Operation =:= leave_db_site;
@@ -99,10 +103,10 @@ apply_stream(DB, NodeStream0, Stream0, N) ->
                     ?ON(Node, emqx_ds_builtin_raft_meta:Operation(DB, Arg))
                 )
             ),
-            apply_stream(DB, NodeStream0, Stream, N);
+            apply_stream(DB, NodeStream0, Stream, N, Opts);
         [Fun | Stream] when is_function(Fun) ->
             Fun(),
-            apply_stream(DB, NodeStream0, Stream, N)
+            apply_stream(DB, NodeStream0, Stream, N, Opts)
     end.
 
 %% Consuming streams and iterators

--- a/apps/emqx_durable_storage/test/emqx_ds_test_helpers.erl
+++ b/apps/emqx_durable_storage/test/emqx_ds_test_helpers.erl
@@ -308,10 +308,16 @@ retry_dirty_append(Shard, Opts, TTVs, Retries) ->
             %% We've entered unknown territory, do not retry:
             {error, unrecoverable, timeout}
         end,
+    ShouldRetryNotTheLeader = maps:get(should_retry_not_the_leader, Opts, false),
     case Result of
         ok ->
             ok;
         {error, recoverable, _} when Retries > 0 ->
+            timer:sleep(500),
+            retry_dirty_append(Shard, Opts, TTVs, Retries - 1);
+        {error, unrecoverable, {not_the_leader, _}} when
+            Retries > 0 andalso ShouldRetryNotTheLeader
+        ->
             timer:sleep(500),
             retry_dirty_append(Shard, Opts, TTVs, Retries - 1);
         _ ->


### PR DESCRIPTION
```
%%% emqx_ds_builtin_raft_SUITE ==> t_rebalance_chaotic_converges: FAILED
%%% emqx_ds_builtin_raft_SUITE ==> {{panic,
     #{msg => "Unexpected result",
       result =>
           {run_stage_failed,error,
               {assertMatch,
                   [{module,emqx_ds_raft_test_helpers},
                    {line,80},
                    {expression,
                        "? ON ( Node , emqx_ds_test_helpers : dirty_append ( # { db => DB , retries => 30 } , [ Msg ] ) )"},
                    {pattern,"ok"},
                    {value,
                        {error,unrecoverable,
                            {not_the_leader,
                                #{got => <139017.1552.0>,
                                  expect => <139016.1949.0>}}}}]},
               [{emqx_ds_raft_test_helpers,apply_stream,4,
                    [{file,"test/emqx_ds_raft_test_helpers.erl"},{line,80}]},
                {emqx_ds_builtin_raft_SUITE,
                    '-t_rebalance_chaotic_converges/1-fun-20-',9,
                    [{file,"test/emqx_ds_builtin_raft_SUITE.erl"},{line,726}]},
                {emqx_ds_builtin_raft_SUITE,t_rebalance_chaotic_converges,1,
                    [{file,"test/emqx_ds_builtin_raft_SUITE.erl"},
                     {line,692}]}]}}},
 [{emqx_ds_builtin_raft_SUITE,t_rebalance_chaotic_converges,1,
      [{file,"test/emqx_ds_builtin_raft_SUITE.erl"},{line,755}]},
```
