### PR TITLE
fix(mqtt): handle non-map frame-error reason in idle conn_state

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1312,6 +1312,17 @@ handle_frame_error(
         _ ->
             shutdown(ShutdownCount, NChannel)
     end;
+%% Frame error before CONNECT is parsed, with a reason that is not a map
+%% (e.g. malformed_properties). No protocol version is known yet, so no
+%% CONNACK is sent.
+handle_frame_error(
+    Reason,
+    Channel = #channel{conn_state = idle}
+) ->
+    shutdown(
+        shutdown_count(frame_error, Reason, Channel),
+        Channel
+    );
 handle_frame_error(
     Reason,
     Channel = #channel{conn_state = connecting}

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -511,6 +511,24 @@ t_handle_in_frame_error(_) ->
     {ok, DisconnectedChan} =
         emqx_channel:handle_in({frame_error, #{cause => frame_too_large}}, DisconnectedChan).
 
+%% A bare-atom frame-error reason (e.g. malformed_properties) in conn_state=idle
+%% must close the connection, not crash the connection process.
+t_handle_in_frame_error_idle_atom_reason(_) ->
+    IdleChan = channel(#{conn_state => idle}),
+    ?assertMatch(
+        {shutdown, #{shutdown_count := frame_error, reason := malformed_properties}, _Chan},
+        emqx_channel:handle_in({frame_error, malformed_properties}, IdleChan)
+    ),
+
+    %% conn_state=connecting with an atom reason was already safe; keep it that way.
+    ConnackPacket = ?CONNACK_PACKET(?RC_MALFORMED_PACKET),
+    ConnectingChan = channel(#{conn_state => connecting}),
+    ?assertMatch(
+        {shutdown, #{shutdown_count := frame_error, reason := malformed_properties}, ConnackPacket,
+            _Chan},
+        emqx_channel:handle_in({frame_error, malformed_properties}, ConnectingChan)
+    ).
+
 t_handle_in_expected_packet(_) ->
     Packet = ?DISCONNECT_PACKET(?RC_PROTOCOL_ERROR),
     {ok, [{outgoing, Packet}, {close, protocol_error}], _Chan} =

--- a/changes/ee/fix-18676.en.md
+++ b/changes/ee/fix-18676.en.md
@@ -1,0 +1,1 @@
+A malformed packet received before the CONNECT packet now closes the connection instead of crashing the connection process.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

A malformed MQTT packet received before the CONNECT packet crashes the connection process instead of closing the connection.

`handle_frame_error/2`'s clause for `conn_state = idle` only matches when the frame-error reason is a map. `emqx_frame` raises several parse errors as bare atoms (e.g. `malformed_properties`, `bad_subqos`, `invalid_packet_id`). In the `idle` state, an atom reason falls through every remaining clause and crashes with `function_clause`. The `connecting` state is unaffected, because its clause has no map guard.

This fix adds an unguarded `idle` clause, mirroring the structure v6 already has (`a2579f3ac5`, PR #16779). It does not port that commit's `invalid_connect_packet` shutdown-count reason or the first-packet protocol-guessing changes (`emqx_connection.erl`, `emqx_frame.erl`, `emqx_socket_connection.erl` — the last does not exist on v5), which go beyond this maintenance-branch fix. The shutdown reason stays `frame_error`, already used elsewhere in this function on v5.

v6 (`dev-60` and later) already has this clause and is unaffected.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
