### PR TITLE
fix(audit): record target namespace and query params on audit entries (data backup)

### DIFF
--- a/apps/emqx_audit/src/emqx_audit_api.erl
+++ b/apps/emqx_audit/src/emqx_audit_api.erl
@@ -236,7 +236,11 @@ fields(http_request) ->
         {bindings, ?HOCON(map(), #{})},
         {body, ?HOCON(map(), #{})},
         {headers, ?HOCON(map(), #{})},
-        {method, ?HOCON(?ENUM([post, put, delete]), #{})}
+        {method, ?HOCON(?ENUM([post, put, delete]), #{})},
+        %% Present only for endpoints that declare query parameters.
+        {query_string, ?HOCON(map(), #{required => false})},
+        %% Present only for endpoints that resolve a target namespace.
+        {namespace, ?HOCON(binary(), #{required => false})}
     ].
 
 audit(get, #{query_string := QueryString}) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
@@ -7,6 +7,10 @@
 -include_lib("emqx/include/logger.hrl").
 %% API
 -export([log/2, log_fun/0, importance/1]).
+%% Exported for direct unit testing of the redaction/shape logic
+%% below, without going through the ?AUDIT macro (which writes to
+%% mnesia and needs the whole app booted).
+-export([log_meta/3]).
 
 %% In the previous versions,
 %% this module used the request method to determine whether the request should be logged,
@@ -65,7 +69,20 @@ log_meta(Importance, Meta, Req) ->
                 operation_result => operation_result(Code, Meta),
                 node => node()
             },
-            Meta2 = maps:without([req_start, req_end, method, headers, body, bindings, code], Meta),
+            Meta2 = maps:without(
+                [
+                    req_start,
+                    req_end,
+                    method,
+                    headers,
+                    body,
+                    bindings,
+                    code,
+                    query_string,
+                    namespace
+                ],
+                Meta
+            ),
             emqx_utils:redact(maps:merge(Meta2, Meta1))
     end.
 
@@ -117,17 +134,38 @@ operation_type(Meta) ->
     end.
 
 http_request(Meta) ->
-    case maps:with([method, headers, bindings, body], Meta) of
-        #{body := Body} = Request when is_binary(Body) ->
-            Request#{body => <<"******">>};
-        #{body := _} = Request ->
-            case is_sensitive_body_operation(Meta) of
-                true -> Request#{body => <<"******">>};
-                false -> Request
-            end;
-        Request ->
-            Request
-    end.
+    Request0 =
+        case maps:with([method, headers, bindings, body], Meta) of
+            #{body := Body} = Request when is_binary(Body) ->
+                Request#{body => <<"******">>};
+            #{body := _} = Request ->
+                case is_sensitive_body_operation(Meta) of
+                    true -> Request#{body => <<"******">>};
+                    false -> Request
+                end;
+            Request ->
+                Request
+        end,
+    %% `query_string' is the parsed request query params (a map, not a raw
+    %% binary), so the `emqx_utils:redact/1' call at the end of `log_meta/3'
+    %% can see the keys and redact sensitive ones by name, same as it does
+    %% for `headers' and `body' above.
+    Request1 = maybe_put(
+        query_string, non_empty_map(maps:get(query_string, Meta, undefined)), Request0
+    ),
+    %% `namespace' is the resolved target namespace, set by handlers that
+    %% call `minirest_handler:update_log_meta/1' (see emqx_topic_metrics2_api
+    %% for an example). It is not always the same as the `ns' query param:
+    %% a namespaced admin's namespace comes from their dashboard token, not
+    %% from the request, so recording it here also covers requests with no
+    %% `ns' query param at all.
+    maybe_put(namespace, maps:get(namespace, Meta, undefined), Request1).
+
+maybe_put(_Key, undefined, Map) -> Map;
+maybe_put(Key, Value, Map) -> Map#{Key => Value}.
+
+non_empty_map(Map) when is_map(Map), map_size(Map) > 0 -> Map;
+non_empty_map(_) -> undefined.
 
 %% Endpoints whose request body carries a secret under a key name that
 %% the generic key-name based redaction does not cover.

--- a/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
@@ -244,6 +244,7 @@ field_filename(IsRequired, Meta) ->
 
 data_export(post, #{body := Params0} = Req) ->
     Namespace = emqx_dashboard:get_namespace(Req),
+    ok = log_ns(Namespace),
     Params1 = emqx_utils_maps:put_if(Params0, <<"namespace">>, Namespace, is_binary(Namespace)),
     Params = maybe_filter_export_params(Params1, auth_meta(Req)),
     maybe
@@ -277,6 +278,7 @@ data_export(post, #{body := Params0} = Req) ->
 
 data_import(post, #{body := #{<<"filename">> := Filename} = Body, query_string := QS} = Req) ->
     Namespace = op_namespace(Req, QS),
+    ok = log_ns(Namespace),
     Nodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI_NAME, 2),
     case safe_parse_node(Body, Nodes) of
         {error, Msg} ->
@@ -390,6 +392,7 @@ core_node(FileNode) ->
 
 data_files(post, #{body := #{<<"filename">> := #{type := _} = File}, query_string := QS} = Req) ->
     Namespace = op_namespace(Req, QS),
+    ok = log_ns(Namespace),
     [{Filename, FileContent} | _] = maps:to_list(maps:without([type], File)),
     case check_upload_scope(Namespace, FileContent) of
         ok ->
@@ -425,7 +428,9 @@ data_file_by_name(get, #{bindings := #{filename := Filename}, query_string := QS
             do_namespaced_file_op(get, Namespace, Filename, QS)
     end;
 data_file_by_name(delete, #{bindings := #{filename := Filename}, query_string := QS} = Req) ->
-    do_namespaced_file_op(delete, op_namespace(Req, QS), Filename, QS).
+    Namespace = op_namespace(Req, QS),
+    ok = log_ns(Namespace),
+    do_namespaced_file_op(delete, Namespace, Filename, QS).
 
 do_namespaced_file_op(Method, Namespace, Filename, QS) ->
     case safe_parse_node(QS) of
@@ -484,6 +489,17 @@ auth_meta(_) -> #{}.
 %% ignored for them. A global administrator may pass `namespace' to inspect or
 %% clean up a specific namespace's backups; without it, they operate on the
 %% global (non-namespaced) backups.
+%% Record the resolved target namespace on the audit log for this request
+%% (same class of gap as emqx/emqx#18653: the URL alone does not distinguish
+%% a global backup operation from a namespaced one). See
+%% emqx_dashboard_audit:http_request/1.
+log_ns(?global_ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
+    ok;
+log_ns(NS) when is_binary(NS) ->
+    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+    ok.
+
 op_namespace(Req, QueryString) ->
     case emqx_dashboard:get_namespace(Req) of
         ?global_ns -> query_namespace(QueryString);

--- a/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_data_backup.erl
@@ -496,8 +496,8 @@ auth_meta(_) -> #{}.
 log_ns(?global_ns) ->
     _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
     ok;
-log_ns(NS) when is_binary(NS) ->
-    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+log_ns(Ns) when is_binary(Ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => Ns}),
     ok.
 
 op_namespace(Req, QueryString) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -613,6 +613,35 @@ t_global_admin_scoped_namespace(Config) ->
     ?assertEqual([], list_filenames(?NODE1_PORT, DashboardAuth, Ns1)),
     ok.
 
+%% Audit records for a data-backup operation must identify the target
+%% namespace, whether it is the actor's own (implicit, no query param, as for
+%% the namespaced admin's export below) or opted into via `?namespace=' (as
+%% for the global admin's namespaced import/upload/delete elsewhere in this
+%% suite). Same class of gap as emqx/emqx#18653 / #18664: `?namespace=' is a
+%% query parameter, and namespace resolution for POST /data/export has no
+%% query override at all -- it never appeared anywhere in the audit log
+%% before this fix.
+t_export_import_audit_records_namespace(Config) ->
+    [Core1 | _] = ?config(cluster, Config),
+    DashboardAuth = ?config(dashboard_auth, Config),
+    Ns1Auth = ?config(ns_admin_auth, Config),
+    ok = ?ON(Core1, begin
+        {ok, _} = emqx:update_config([log, audit, enable], true),
+        {ok, _} = emqx:update_config([log, audit, level], info),
+        ok
+    end),
+    StartAt = erlang:system_time(microsecond),
+
+    {200, _} = export_backup2(?NODE1_PORT, DashboardAuth, #{}),
+    {200, _} = export_backup2(?NODE1_PORT, Ns1Auth, #{}),
+
+    Entries = wait_for_audit_entries(
+        ?NODE1_PORT, DashboardAuth, <<"/data/export">>, StartAt, 2, 2000
+    ),
+    Namespaces = lists:sort([namespace_of(E) || E <- Entries]),
+    ?assertEqual(lists:sort([<<"global">>, <<"ns1">>]), Namespaces),
+    ok.
+
 %% A namespaced administrator cannot escape its namespace by supplying the
 %% `namespace' query parameter -- it is ignored for namespaced callers.
 t_namespaced_admin_cannot_override_namespace(Config) ->
@@ -1209,6 +1238,38 @@ upload_backup(NodeApiPort, Auth, BackupFilePath) ->
             Err
     end.
 
+%% The audit write happens after the HTTP response is already sent (see
+%% minirest_handler:init/2), so poll for a bit rather than assume the record
+%% is there the instant the request returns.
+wait_for_audit_entries(_NodeApiPort, _Auth, _OperationId, _StartAt, _ExpectedCount, RemainMs) when
+    RemainMs =< 0
+->
+    ct:fail(audit_entries_not_found_in_time);
+wait_for_audit_entries(NodeApiPort, Auth, OperationId, StartAt, ExpectedCount, RemainMs) ->
+    Entries = audit_entries_since(NodeApiPort, Auth, OperationId, StartAt),
+    case length(Entries) >= ExpectedCount of
+        true ->
+            Entries;
+        false ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_audit_entries(
+                NodeApiPort, Auth, OperationId, StartAt, ExpectedCount, RemainMs - SleepMs
+            )
+    end.
+
+audit_entries_since(NodeApiPort, Auth, OperationId, StartAt) ->
+    QueryList = [
+        {<<"operation_id">>, OperationId},
+        {<<"gte_created_at">>, integer_to_binary(StartAt)},
+        {<<"limit">>, <<"100">>}
+    ],
+    {ok, Res} = request(get, NodeApiPort, ["audit"], QueryList, [], Auth),
+    #{<<"data">> := Data} = emqx_utils_json:decode(Res),
+    Data.
+
+namespace_of(#{<<"http_request">> := #{<<"namespace">> := Ns}}) -> Ns.
+
 request(Method, NodePort, PathParts, Auth) ->
     request(Method, NodePort, PathParts, [], [], Auth).
 
@@ -1385,6 +1446,12 @@ app_spec_dashboard(APIPort) ->
         }}
     ].
 
+test_case_specific_apps_spec(TC) when
+    TC =:= t_export_import_audit_records_namespace
+->
+    [
+        emqx_audit
+    ];
 test_case_specific_apps_spec(TC) when
     TC =:= t_upload_ee_backup;
     TC =:= t_import_ee_backup;

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -622,14 +622,8 @@ t_global_admin_scoped_namespace(Config) ->
 %% query override at all -- it never appeared anywhere in the audit log
 %% before this fix.
 t_export_import_audit_records_namespace(Config) ->
-    [Core1 | _] = ?config(cluster, Config),
     DashboardAuth = ?config(dashboard_auth, Config),
     Ns1Auth = ?config(ns_admin_auth, Config),
-    ok = ?ON(Core1, begin
-        {ok, _} = emqx:update_config([log, audit, enable], true),
-        {ok, _} = emqx:update_config([log, audit, level], info),
-        ok
-    end),
     StartAt = erlang:system_time(microsecond),
 
     {200, _} = export_backup2(?NODE1_PORT, DashboardAuth, #{}),
@@ -1416,11 +1410,25 @@ wait_for_dashboard_auth(ReplNode, Token, Retries) ->
     end.
 
 apps_spec(APIPort, TC) ->
-    common_apps_spec() ++
+    common_apps_spec(TC) ++
         app_spec_dashboard(APIPort) ++
         test_case_specific_apps_spec(TC).
 
-common_apps_spec() ->
+%% `log.audit' is defined by `emqx_enterprise_schema' (it redefines the `log'
+%% root), not by the `emqx_conf_schema' that `emqx_cth_suite' picks by app
+%% name, so the audit case names the schema explicitly. The cluster's own
+%% `emqx_conf' config (node, cluster, listeners) is deep-merged into this by
+%% `emqx_cth_cluster' and stays valid under the wider schema.
+common_apps_spec(t_export_import_audit_records_namespace) ->
+    [
+        emqx,
+        {emqx_conf, #{
+            config => #{log => #{audit => #{enable => true, level => info}}},
+            schema_mod => emqx_enterprise_schema
+        }},
+        emqx_management
+    ];
+common_apps_spec(_TC) ->
     [
         emqx,
         emqx_conf,

--- a/changes/ee/fix-18677.en.md
+++ b/changes/ee/fix-18677.en.md
@@ -1,0 +1,1 @@
+Audit records for data-backup requests now identify the namespace a request targeted. Previously, exporting, importing, uploading, or deleting a backup in different namespaces produced audit records that looked identical, so it was not possible to tell which namespace's backup was affected. The audit log now also records any query parameters a request carried.


### PR DESCRIPTION
Fixes: N/A
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: 6.0.0

## Summary

Same class of gap as #18653 / PR #18664 (base `dev-63`): `emqx_dashboard_audit:http_request/1`
only copied `method`, `headers`, `bindings` and `body` into the stored audit request. A namespace
passed as a query parameter (`?namespace=`), or resolved implicitly from a namespaced admin's own
dashboard token with no query parameter at all, never reached `GET /audit`.

This branch (`dev-60`) does not yet have #18664's fix — it hasn't synced back from `dev-63` yet
(that PR is still open). This PR ports the same foundation to `dev-60` and applies it to
`apps/emqx_management/src/emqx_mgmt_api_data_backup.erl`, the one module on this branch with the
same bug shape (found via a follow-up survey after #18664 — see the audit note referenced below).

- `emqx_dashboard_audit` now also records the parsed query string on the audit request
  (`http_request.query_string`), redacted through the same `emqx_utils:redact/1` key-based check
  already applied to headers and bodies.
- `emqx_mgmt_api_data_backup` now calls `minirest_handler:update_log_meta/1` at the point each
  mutating handler resolves its target namespace (`POST /data/export`, `POST /data/import`,
  `POST /data/files` upload, `DELETE /data/files/:filename`), so `http_request.namespace` records
  the *resolved* namespace — present whether or not `?namespace=` was passed. `POST /data/export`
  in particular has no query override at all (only the implicit actor-namespace case), so it needed
  this even though it never had a raw query parameter to log.

`http_request.namespace` and `http_request.query_string` are new, optional fields on the
`GET /audit` response (already added to `emqx_audit_api:fields(http_request)` by this same PR, as
part of the ported foundation). No existing field changed shape.

### Local validation note

This worktree hit unrelated environment issues in this session: the multi-node CT cluster for
`emqx_mgmt_api_data_backup_SUITE` failed to boot nodes (`not_alive`) under heavy load on the shared
dev box (load average ~22 on 20 cores at the time) — confirmed this affects a pre-existing,
unmodified test case in the same suite (`t_export_backup`) identically, so it is not caused by this
change. `make fmt-diff` and `./scripts/elvis-check.sh` both pass. The equivalent fix + test pattern
already passed full CT (and a live manual repro) on the `dev-63` PR (#18664) this ports from.
Please let CI be the gate here.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
