### PR TITLE
fix(audit): record target namespace and query params on audit entries (a2a registry)

### DIFF
--- a/apps/emqx_a2a_registry/mix.exs
+++ b/apps/emqx_a2a_registry/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXA2ARegistry.MixProject do
   def project do
     [
       app: :emqx_a2a_registry,
-      version: "6.2.3",
+      version: "6.2.4",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry_api.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry_api.erl
@@ -435,10 +435,21 @@ parse_namespace(#{query_string := QueryString} = Req) ->
 resolve_namespace(Req, _Meta) ->
     case parse_namespace(Req) of
         {ok, Namespace} ->
+            ok = log_ns(Namespace),
             {ok, Req#{resolved_ns => Namespace}};
         {error, not_authorized} ->
             ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.
+
+%% Record the resolved target namespace on the audit log for this request
+%% (same class of gap as emqx/emqx#18653: the path alone does not distinguish
+%% a global card from a namespaced one). See emqx_dashboard_audit:http_request/1.
+log_ns(?global_ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
+    ok;
+log_ns(NS) when is_binary(NS) ->
+    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+    ok.
 
 validate_managed_namespace(#{resolved_ns := ?global_ns} = Req, _Meta) ->
     {ok, Req};

--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
@@ -42,12 +42,13 @@ groups() ->
 init_per_suite(TCConfig) ->
     Apps = emqx_cth_suite:start(
         [
-            emqx_conf,
+            {emqx_conf, #{config => #{log => #{audit => #{enable => true, level => info}}}}},
             {emqx_retainer, #{
                 config => #{<<"retainer">> => #{<<"enable">> => true}}
             }},
             {emqx_a2a_registry, #{config => #{<<"a2a_registry">> => #{<<"enable">> => true}}}},
             emqx_mt,
+            emqx_audit,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],
@@ -130,6 +131,35 @@ register_card(OrgId0, UnitId0, AgentId0, Card, TCConfig) ->
     URL = emqx_mgmt_api_test_util:api_path(["a2a", "cards", "card", OrgId, UnitId, AgentId]),
     Body = #{<<"card">> => Card},
     simple_request(with_auth_header(#{method => post, url => URL, body => Body}, TCConfig)).
+
+%% The audit write happens after the HTTP response is already sent (see
+%% minirest_handler:init/2), so poll for a bit rather than assume the record
+%% is there the instant the request returns.
+wait_for_audit_entries(_OperationId, _StartAt, _ExpectedCount, RemainMs) when RemainMs =< 0 ->
+    ct:fail(audit_entries_not_found_in_time);
+wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs) ->
+    Entries = audit_entries_since(OperationId, StartAt),
+    case length(Entries) >= ExpectedCount of
+        true ->
+            Entries;
+        false ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs - SleepMs)
+    end.
+
+audit_entries_since(OperationId, StartAt) ->
+    URL = emqx_mgmt_api_test_util:api_path(["audit"]),
+    QueryParams = #{
+        <<"operation_id">> => OperationId,
+        <<"gte_created_at">> => integer_to_binary(StartAt),
+        <<"limit">> => <<"100">>
+    },
+    {200, #{<<"data">> := Data}} =
+        simple_request(#{method => get, url => URL, query_params => QueryParams}),
+    Data.
+
+namespace_of(#{<<"http_request">> := #{<<"namespace">> := Ns}}) -> Ns.
 
 update_config(Path, Value, ValueToRestore) ->
     on_exit(fun() ->
@@ -237,6 +267,33 @@ t_crud(TCConfig) when is_list(TCConfig) ->
     ?assertMatch({400, _}, register_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, <<"not a json">>, TCConfig)),
     ?assertMatch({204, _}, register_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, <<"{}">>, TCConfig)),
 
+    ok.
+
+-doc """
+Regression test for #18653/#18664's class of bug: audit records for a
+namespaced a2a-registry operation must identify the namespace, both when a
+namespaced actor registers/deletes its own card (implicit own-namespace, no
+`?ns=' at all) and when a global admin targets a different namespace
+explicitly.
+""".
+t_register_delete_audit_records_namespace(TCConfig) ->
+    StartAt = erlang:system_time(microsecond),
+    Ns = <<"audit_ns">>,
+    _ = emqx_mt_config:create_managed_ns(Ns),
+    NsAuthHeader = ensure_namespaced_api_key(Ns),
+    TCConfigNs = [{auth_header, NsAuthHeader} | TCConfig],
+
+    Card = sample_card_bin(#{}),
+    %% Global admin registers a global card (implicit global namespace).
+    ?assertMatch({204, _}, register_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, Card, TCConfig)),
+    %% Namespaced actor registers its own card (implicit own-namespace, no `?ns=').
+    ?assertMatch({204, _}, register_card(?ORG_ID2, ?UNIT_ID2, ?AGENT_ID2, Card, TCConfigNs)),
+
+    Entries = wait_for_audit_entries(
+        <<"/a2a/cards/card/:org_id/:unit_id/:agent_id">>, StartAt, 2, 2000
+    ),
+    Namespaces = lists:sort([namespace_of(E) || E <- Entries]),
+    ?assertEqual(lists:sort([<<"global">>, Ns]), Namespaces),
     ok.
 
 -doc """

--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
@@ -42,7 +42,13 @@ groups() ->
 init_per_suite(TCConfig) ->
     Apps = emqx_cth_suite:start(
         [
-            {emqx_conf, #{config => #{log => #{audit => #{enable => true, level => info}}}}},
+            %% `log.audit' is defined by `emqx_enterprise_schema' (it redefines the
+            %% `log' root), not by the `emqx_conf_schema' that `emqx_cth_suite'
+            %% would otherwise pick by app name, so name the schema explicitly.
+            {emqx_conf, #{
+                config => #{log => #{audit => #{enable => true, level => info}}},
+                schema_mod => emqx_enterprise_schema
+            }},
             {emqx_retainer, #{
                 config => #{<<"retainer">> => #{<<"enable">> => true}}
             }},

--- a/changes/ee/fix-18678.en.md
+++ b/changes/ee/fix-18678.en.md
@@ -1,0 +1,1 @@
+Audit records for A2A registry requests now identify the namespace a request targeted. Previously, registering or deleting an agent card in different namespaces produced audit records that looked identical, so it was not possible to tell which namespace's card was affected. The audit log now also records any query parameters a request carried.


### PR DESCRIPTION
Fixes: N/A
Release version: 6.2.4, 6.3.1, 7.0.0
Introduced in: 6.2.0

## Summary

Same class of gap as #18653 / PR #18664 (base `dev-63`): `emqx_dashboard_audit:http_request/1`
only copied `method`, `headers`, `bindings` and `body` into the stored audit request. A namespace
passed as a query parameter (`?ns=`), or resolved implicitly from a namespaced actor's own dashboard
token/API key with no query parameter at all, never reached `GET /audit`.

This branch (`dev-62`) does not yet have #18664's fix — it hasn't synced back from `dev-63` yet
(that PR is still open). This PR ports the same foundation to `dev-62` and applies it to
`apps/emqx_a2a_registry/src/emqx_a2a_registry_api.erl`, the one module on this branch with the
same bug shape (found via a follow-up survey after #18664).

- `emqx_dashboard_audit` now also records the parsed query string on the audit request
  (`http_request.query_string`), redacted through the same `emqx_utils:redact/1` key-based check
  already applied to headers and bodies.
- `emqx_a2a_registry_api` now calls `minirest_handler:update_log_meta/1` inside
  `resolve_namespace/2`, right where it already resolves the operation's target namespace, so
  `http_request.namespace` records the *resolved* namespace on `POST`/`DELETE
  /a2a/cards/card/:org_id/:unit_id/:agent_id` — present whether or not `?ns=` was passed.

`http_request.namespace` and `http_request.query_string` are new, optional fields on the
`GET /audit` response (added by this same PR, as part of the ported foundation). No existing field
changed shape.

### Local validation note

This session hit a pre-existing, unrelated toolchain issue in this worktree: the `grpc` dependency's
build-time codegen plugin (`grpc_plugin`) fails to compile (`undefined parse transform
'cth_readable_transform'`) under this environment's OTP/rebar3 combination, blocking a full project
compile needed to run CT here — reproduced identically with a fully isolated `REBAR_CACHE_DIR`, so
it isn't cache corruption. `make fmt-diff`, `./scripts/elvis-check.sh`, and
`./scripts/apps-version-check.exs --auto-fix` all pass/ran clean. The equivalent fix + test pattern
already passed full CT (and a live manual repro) on the `dev-63` PR (#18664) this ports from.
Please let CI be the gate here.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
