### PR TITLE
docs(mqtt): clarify client ID length vs strict_mode

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -409,6 +409,9 @@ do_parse_connect(
         PasswordFlag
     ),
     {Properties, Rest3} = parse_properties(Rest, ProtoVer, StrictMode),
+    %% `strict_mode` here only rejects an invalid UTF-8 client ID. The length limit is
+    %% applied later by emqx_packet:check_client_id/2 against `max_clientid_len`, for all
+    %% MQTT versions alike (no separate MQTT 3.1 23-byte check). See emqx/emqx#18674.
     {ClientId, Rest4} = parse_utf8_string(Rest3, StrictMode, invalid_clientid),
     ConnPacket = #mqtt_packet_connect{
         proto_name = ProtoName,

--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -381,6 +381,10 @@ check_client_id(
     _Opts
 ) ->
     ok;
+%% Client ID length is checked against `max_clientid_len` for every MQTT version.
+%% The MQTT 3.1 rule of 1..23 bytes (MQTT-3.1.3-5) is a "MAY reject", so EMQX does
+%% not enforce 23 separately for v3 clients; set `max_clientid_len` to 23 to enforce
+%% it. `strict_mode` does not affect this check. See emqx/emqx#17914 and emqx/emqx#18674.
 check_client_id(
     #mqtt_packet_connect{clientid = ClientId},
     #{max_clientid_len := MaxLen} = _Opts

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1193,7 +1193,8 @@ force_gc_count.label:
 """Process GC messages num"""
 
 mqtt_max_clientid_len.desc:
-"""Maximum allowed length of MQTT Client ID."""
+"""Maximum allowed length of MQTT Client ID.
+This limit applies to all MQTT versions (3.1, 3.1.1 and 5.0). EMQX does not enforce the MQTT 3.1 protocol limit of 23 bytes separately; set this value to 23 to enforce it. The `strict_mode` setting does not change Client ID length checking."""
 
 mqtt_max_clientid_len.label:
 """Max Client ID Length"""
@@ -1363,7 +1364,8 @@ fields_mqtt_quic_listener_maximum_mtu.label:
 mqtt_strict_mode.desc:
 """Whether to parse MQTT messages in strict mode.
 In strict mode, invalid UTF-8 strings (in client ID, topic name, etc.), reserved bits, and other malformed packet structure cause the offending client to be disconnected.
-Defaults to `true` since release 6.3 — set to `false` to restore the older lenient behavior for compatibility with nonconforming clients."""
+Defaults to `true` since release 6.3 — set to `false` to restore the older lenient behavior for compatibility with nonconforming clients.
+Strict mode checks packet well-formedness only. It does not enforce version-specific semantic limits such as the MQTT 3.1 Client ID length; Client ID length is controlled by `max_clientid_len`."""
 
 mqtt_strict_mode.label:
 """Strict Mode"""


### PR DESCRIPTION
Fixes: https://github.com/emqx/emqx/issues/18674
Release version: 6.3.0, 7.0.0
Introduced in: N/A

## Summary

Documentation-only change. It records the existing, intentional behavior around MQTT Client ID length, prompted by repeat reports (https://github.com/emqx/emqx/issues/17914, https://github.com/emqx/emqx/issues/18674).

- Client ID length is enforced against `max_clientid_len` for all MQTT versions in `emqx_packet:check_client_id/2`. EMQX does not enforce the MQTT 3.1 protocol limit of 23 bytes separately; set `max_clientid_len` to 23 to enforce it.
- `strict_mode` checks packet well-formedness only (UTF-8, reserved bits, structure). It does not enforce version-specific semantic limits such as the MQTT 3.1 Client ID length.

Notes are added at the two code sites (`emqx_packet.erl`, `emqx_frame.erl`) and in the two config descriptions (`mqtt.max_clientid_len`, `mqtt.strict_mode`), each cross-referencing the issues so future readers find the rationale.

No behavior change.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
