### PR TITLE
fix(dashboard): scope REST auth-error messages to what the endpoint accepts

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -293,13 +293,7 @@ authorize(Req, HandlerInfo) ->
                 false ->
                     return_unauthorized(
                         <<"AUTHORIZATION_HEADER_ERROR">>,
-                        <<
-                            "Missing authorization header. "
-                            "Use Basic auth with API key/secret, "
-                            "or Bearer token from POST /api/v5/login. "
-                            "API keys can be bootstrapped from config "
-                            "(api_key.bootstrap_file) or created via POST /api/v5/api_key"
-                        >>
+                        authorization_header_error_message(HandlerInfo)
                     )
             end
     end.
@@ -317,15 +311,45 @@ cookie_authorize(Req, HandlerInfo) ->
         _ ->
             return_unauthorized(
                 <<"AUTHORIZATION_HEADER_ERROR">>,
-                <<
-                    "Missing authorization header. "
-                    "Use Basic auth with API key/secret, "
-                    "or Bearer token from POST /api/v5/login. "
-                    "API keys can be bootstrapped from config "
-                    "(api_key.bootstrap_file) or created via POST /api/v5/api_key"
-                >>
+                authorization_header_error_message(HandlerInfo)
             )
     end.
+
+%% @doc Whether HandlerInfo's endpoint accepts API keys decides which auth-error
+%% messages may mention API keys — an endpoint that rejects them must not send a
+%% caller looking for one, and vice versa.
+with_api_key_hint(HandlerInfo, LoginOnlyMessage, ApiKeyAllowedMessage) ->
+    case emqx_mgmt_auth:is_api_key_allowed(HandlerInfo) of
+        true -> ApiKeyAllowedMessage;
+        false -> LoginOnlyMessage
+    end.
+
+authorization_header_error_message(HandlerInfo) ->
+    with_api_key_hint(
+        HandlerInfo,
+        <<"Missing authorization header. Get a bearer token from POST /api/v5/login.">>,
+        <<
+            "Missing authorization header. Use Basic auth with an API key, "
+            "or get a bearer token from POST /api/v5/login."
+        >>
+    ).
+
+token_timeout_message(HandlerInfo) ->
+    with_api_key_hint(
+        HandlerInfo,
+        <<"Token expired. Get a new token by POST /api/v5/login.">>,
+        <<"Token expired. Get a new token by POST /api/v5/login, or use an API key with Basic auth.">>
+    ).
+
+bad_token_message(HandlerInfo) ->
+    with_api_key_hint(
+        HandlerInfo,
+        <<"Invalid bearer token. Get a new token by POST /api/v5/login.">>,
+        <<
+            "Invalid bearer token. Get a new token by POST /api/v5/login, "
+            "or use an API key with Basic auth."
+        >>
+    ).
 
 return_unauthorized(Code, Message) ->
     {401,
@@ -387,20 +411,9 @@ jwt_token_bearer_authorize(Req, HandlerInfo, Token) ->
             },
             {ok, AuthnMeta};
         {error, token_timeout} ->
-            {401, 'TOKEN_TIME_OUT', <<
-                "Token expired. "
-                "Consider using API key (Basic auth) instead of bearer tokens "
-                "to avoid expiration. "
-                "Otherwise get a new token by POST /api/v5/login"
-            >>};
+            {401, 'TOKEN_TIME_OUT', token_timeout_message(HandlerInfo)};
         {error, not_found} ->
-            {401, 'BAD_TOKEN', <<
-                "Invalid bearer token. "
-                "Use API key (Basic auth) for persistent access, "
-                "or get a new bearer token by POST /api/v5/login. "
-                "API keys can be bootstrapped from config "
-                "(api_key.bootstrap_file) or created via POST /api/v5/api_key"
-            >>};
+            {401, 'BAD_TOKEN', bad_token_message(HandlerInfo)};
         {error, {unauthorized_role, Msg}} when is_binary(Msg) ->
             {403, 'UNAUTHORIZED_ROLE', Msg}
     end.

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -682,6 +682,96 @@ t_cli_redact(_Config) ->
         emqx_dashboard_cli:api_keys_audit_args(["add", "--api-secret"])
     ).
 
+-doc """
+Regression test: an invalid bearer token on a login-only endpoint (POST
+/api/v5/logout, which rejects API keys) must not tell the caller to use one.
+""".
+t_bad_token_message_login_only_endpoint(_Config) ->
+    {ok, 401, Body} = post_logout(bearer_header(<<"not-a-real-token">>)),
+    #{<<"code">> := <<"BAD_TOKEN">>, <<"message">> := Message} = json(Body),
+    ?assertNot(has_substring(Message, "API key")),
+    assert_no_bootstrap_file_mention(Message),
+    ok.
+
+-doc "An invalid bearer token on an endpoint that accepts API keys still gets the API-key hint.".
+t_bad_token_message_api_key_endpoint(_Config) ->
+    {ok, 401, Body} = request_api(get, api_path(["nodes"]), bearer_header(<<"not-a-real-token">>)),
+    #{<<"code">> := <<"BAD_TOKEN">>, <<"message">> := Message} = json(Body),
+    ?assert(has_substring(Message, "API key")),
+    assert_no_bootstrap_file_mention(Message),
+    ok.
+
+-doc "An expired bearer token on a login-only endpoint must not recommend an API key.".
+t_token_timeout_message_login_only_endpoint(_Config) ->
+    Token = sign_expired_token(bin(["expired-user-", integer_to_list(random_num())])),
+    {ok, 401, Body} = post_logout(bearer_header(Token)),
+    #{<<"code">> := <<"TOKEN_TIME_OUT">>, <<"message">> := Message} = json(Body),
+    ?assertNot(has_substring(Message, "API key")),
+    assert_no_bootstrap_file_mention(Message),
+    ok.
+
+-doc "An expired bearer token on an endpoint that accepts API keys still gets the API-key hint.".
+t_token_timeout_message_api_key_endpoint(_Config) ->
+    Token = sign_expired_token(bin(["expired-user-", integer_to_list(random_num())])),
+    {ok, 401, Body} = request_api(get, api_path(["nodes"]), bearer_header(Token)),
+    #{<<"code">> := <<"TOKEN_TIME_OUT">>, <<"message">> := Message} = json(Body),
+    ?assert(has_substring(Message, "API key")),
+    assert_no_bootstrap_file_mention(Message),
+    ok.
+
+-doc """
+No authorization header at all: the message is gated by endpoint the same
+way as an invalid token.
+""".
+t_missing_auth_header_message_scope(_Config) ->
+    {ok, 401, LoginOnlyBody} = post_logout(undefined),
+    #{<<"code">> := <<"AUTHORIZATION_HEADER_ERROR">>, <<"message">> := LoginOnlyMessage} =
+        json(LoginOnlyBody),
+    ?assertNot(has_substring(LoginOnlyMessage, "API key")),
+    assert_no_bootstrap_file_mention(LoginOnlyMessage),
+
+    {ok, 401, ApiKeyBody} = request_api(get, api_path(["nodes"]), undefined),
+    #{<<"code">> := <<"AUTHORIZATION_HEADER_ERROR">>, <<"message">> := ApiKeyMessage} =
+        json(ApiKeyBody),
+    ?assert(has_substring(ApiKeyMessage, "API key")),
+    assert_no_bootstrap_file_mention(ApiKeyMessage),
+    ok.
+
+-doc """
+Baseline that must not regress: Basic auth (API key) on a login-only endpoint
+is still rejected outright, with the unchanged API_KEY_NOT_ALLOW code.
+""".
+t_basic_auth_on_login_only_endpoint_still_rejected(_Config) ->
+    {ok, _} = emqx_common_test_http:create_default_app(),
+    BasicHeader = emqx_common_test_http:default_auth_header(),
+    {ok, 401, Body} = post_logout(BasicHeader),
+    ?assertMatch(#{<<"code">> := <<"API_KEY_NOT_ALLOW">>}, json(Body)),
+    _ = emqx_common_test_http:delete_default_app(),
+    ok.
+
+bearer_header(Token) ->
+    {"Authorization", "Bearer " ++ binary_to_list(Token)}.
+
+%% httpc rejects a bodyless POST request tuple; send an empty JSON body so
+%% the auth check (which runs before the handler) is exercised the same way
+%% a real client's POST /logout would hit it.
+post_logout(Auth) ->
+    request_api(post, api_path(["logout"]), [], Auth, #{}).
+
+has_substring(Bin, SubStr) when is_binary(Bin) ->
+    binary:match(Bin, list_to_binary(SubStr)) =/= nomatch.
+
+assert_no_bootstrap_file_mention(Message) ->
+    ?assertNot(has_substring(Message, "bootstrap_file")).
+
+sign_expired_token(Username) ->
+    {ok, _Role, Token, _Namespace} = emqx_dashboard_token:sign(#?ADMIN{username = Username}),
+    [JWT] = emqx_dashboard_token:lookup_by_username(Username),
+    _ = mria:sync_transaction(?DASHBOARD_SHARD, fun mnesia:write/1, [
+        JWT#?ADMIN_JWT{exptime = erlang:system_time(millisecond) - 1000}
+    ]),
+    Token.
+
 t_lookup_by_username_jwt(_Config) ->
     User = bin(["user-", integer_to_list(random_num())]),
     emqx_dashboard_token:sign(#?ADMIN{username = User}),

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -690,7 +690,6 @@ t_bad_token_message_login_only_endpoint(_Config) ->
     {ok, 401, Body} = post_logout(bearer_header(<<"not-a-real-token">>)),
     #{<<"code">> := <<"BAD_TOKEN">>, <<"message">> := Message} = json(Body),
     ?assertNot(has_substring(Message, "API key")),
-    assert_no_bootstrap_file_mention(Message),
     ok.
 
 -doc "An invalid bearer token on an endpoint that accepts API keys still gets the API-key hint.".
@@ -698,7 +697,6 @@ t_bad_token_message_api_key_endpoint(_Config) ->
     {ok, 401, Body} = request_api(get, api_path(["nodes"]), bearer_header(<<"not-a-real-token">>)),
     #{<<"code">> := <<"BAD_TOKEN">>, <<"message">> := Message} = json(Body),
     ?assert(has_substring(Message, "API key")),
-    assert_no_bootstrap_file_mention(Message),
     ok.
 
 -doc "An expired bearer token on a login-only endpoint must not recommend an API key.".
@@ -707,7 +705,6 @@ t_token_timeout_message_login_only_endpoint(_Config) ->
     {ok, 401, Body} = post_logout(bearer_header(Token)),
     #{<<"code">> := <<"TOKEN_TIME_OUT">>, <<"message">> := Message} = json(Body),
     ?assertNot(has_substring(Message, "API key")),
-    assert_no_bootstrap_file_mention(Message),
     ok.
 
 -doc "An expired bearer token on an endpoint that accepts API keys still gets the API-key hint.".
@@ -716,7 +713,6 @@ t_token_timeout_message_api_key_endpoint(_Config) ->
     {ok, 401, Body} = request_api(get, api_path(["nodes"]), bearer_header(Token)),
     #{<<"code">> := <<"TOKEN_TIME_OUT">>, <<"message">> := Message} = json(Body),
     ?assert(has_substring(Message, "API key")),
-    assert_no_bootstrap_file_mention(Message),
     ok.
 
 -doc """
@@ -728,13 +724,11 @@ t_missing_auth_header_message_scope(_Config) ->
     #{<<"code">> := <<"AUTHORIZATION_HEADER_ERROR">>, <<"message">> := LoginOnlyMessage} =
         json(LoginOnlyBody),
     ?assertNot(has_substring(LoginOnlyMessage, "API key")),
-    assert_no_bootstrap_file_mention(LoginOnlyMessage),
 
     {ok, 401, ApiKeyBody} = request_api(get, api_path(["nodes"]), undefined),
     #{<<"code">> := <<"AUTHORIZATION_HEADER_ERROR">>, <<"message">> := ApiKeyMessage} =
         json(ApiKeyBody),
     ?assert(has_substring(ApiKeyMessage, "API key")),
-    assert_no_bootstrap_file_mention(ApiKeyMessage),
     ok.
 
 -doc """
@@ -760,9 +754,6 @@ post_logout(Auth) ->
 
 has_substring(Bin, SubStr) when is_binary(Bin) ->
     binary:match(Bin, list_to_binary(SubStr)) =/= nomatch.
-
-assert_no_bootstrap_file_mention(Message) ->
-    ?assertNot(has_substring(Message, "bootstrap_file")).
 
 sign_expired_token(Username) ->
     {ok, _Role, Token, _Namespace} = emqx_dashboard_token:sign(#?ADMIN{username = Username}),

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -43,7 +43,7 @@
     check_scopes/3
 ]).
 
--export([authorize/4]).
+-export([authorize/4, is_api_key_allowed/1]).
 -export([post_config_update/5]).
 
 -export([backup_tables/0, validate_mnesia_backup/1]).
@@ -259,19 +259,15 @@ format_epoch(Epoch) ->
 list() ->
     to_map(ets:match_object(?APP, #?APP{_ = '_'})).
 
-authorize(#{module := emqx_dashboard_api, function := user}, _Req, _ApiKey, _ApiSecret) ->
-    {error, <<"not_allowed">>, <<"users">>};
-authorize(#{module := emqx_dashboard_api, function := users}, _Req, _ApiKey, _ApiSecret) ->
-    {error, <<"not_allowed">>, <<"users">>};
-authorize(#{module := emqx_dashboard_api, function := logout}, _Req, _ApiKey, _ApiSecret) ->
-    {error, <<"not_allowed">>, <<"logout">>};
-authorize(#{module := emqx_dashboard_api, function := change_pwd}, _Req, _ApiKey, _ApiSecret) ->
-    {error, <<"not_allowed">>, <<"users">>};
-authorize(#{module := emqx_dashboard_api, function := change_mfa}, _Req, _ApiKey, _ApiSecret) ->
-    {error, <<"not_allowed">>, <<"users">>};
-authorize(#{module := emqx_mgmt_api_api_keys}, _Req, _ApiKey, _ApiSecret) ->
-    {error, <<"not_allowed">>, <<"api_key">>};
 authorize(HandlerInfo, Req, ApiKey, ApiSecret) ->
+    case not_allowed_resource(HandlerInfo) of
+        {true, Resource} ->
+            {error, <<"not_allowed">>, Resource};
+        false ->
+            do_authorize(HandlerInfo, Req, ApiKey, ApiSecret)
+    end.
+
+do_authorize(HandlerInfo, Req, ApiKey, ApiSecret) ->
     Now = erlang:system_time(second),
     case find_by_api_key(ApiKey) of
         {ok, true, ExpiredAt, SecretHash, Role, Namespace, Extra} when ExpiredAt >= Now ->
@@ -288,6 +284,27 @@ authorize(HandlerInfo, Req, ApiKey, ApiSecret) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+%% @doc Whether HandlerInfo's endpoint accepts API key (Basic auth) credentials at all.
+%% Shared by authorize/4 so the set of API-key-rejecting endpoints has one definition.
+-spec is_api_key_allowed(map()) -> boolean().
+is_api_key_allowed(HandlerInfo) ->
+    not_allowed_resource(HandlerInfo) =:= false.
+
+not_allowed_resource(#{module := emqx_dashboard_api, function := user}) ->
+    {true, <<"users">>};
+not_allowed_resource(#{module := emqx_dashboard_api, function := users}) ->
+    {true, <<"users">>};
+not_allowed_resource(#{module := emqx_dashboard_api, function := logout}) ->
+    {true, <<"logout">>};
+not_allowed_resource(#{module := emqx_dashboard_api, function := change_pwd}) ->
+    {true, <<"users">>};
+not_allowed_resource(#{module := emqx_dashboard_api, function := change_mfa}) ->
+    {true, <<"users">>};
+not_allowed_resource(#{module := emqx_mgmt_api_api_keys}) ->
+    {true, <<"api_key">>};
+not_allowed_resource(_HandlerInfo) ->
+    false.
 
 check_rbac_and_scopes(Req, HandlerInfo, ApiKey, Role, Namespace, Extra) ->
     case check_rbac(Req, HandlerInfo, ApiKey, Role, Namespace) of

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -19,6 +19,7 @@
     t_ee_authorize_admin,
     t_ee_authorize_admin_cannot_manage_mfa,
     t_ee_authorize_admin_cannot_manage_mfa_module_level,
+    t_is_api_key_allowed,
     t_ee_authorize_publisher,
     %% Schema validation: publisher role can only hold publish scope
     t_ee_publisher_only_publish_scope,
@@ -1179,6 +1180,32 @@ t_ee_authorize_admin_cannot_manage_mfa_module_level(_Config) ->
     ?assertEqual(
         {error, <<"not_allowed">>, <<"users">>},
         emqx_mgmt_auth:authorize(ChangePwdHandler, FakeReq, ApiKey, ApiSecret)
+    ),
+    ok.
+
+-doc """
+`emqx_mgmt_auth:is_api_key_allowed/1` is the single predicate the auth-error
+message code (emqx_dashboard.erl) consults to decide whether to hint at API
+keys. It must agree with authorize/4's own denylist for every handler shape
+on the list, and allow anything else.
+""".
+t_is_api_key_allowed(_Config) ->
+    NotAllowed = [
+        #{module => emqx_dashboard_api, function => user},
+        #{module => emqx_dashboard_api, function => users},
+        #{module => emqx_dashboard_api, function => logout},
+        #{module => emqx_dashboard_api, function => change_pwd},
+        #{module => emqx_dashboard_api, function => change_mfa},
+        #{module => emqx_mgmt_api_api_keys, function => list}
+    ],
+    lists:foreach(
+        fun(HandlerInfo) ->
+            ?assertNot(emqx_mgmt_auth:is_api_key_allowed(HandlerInfo), HandlerInfo)
+        end,
+        NotAllowed
+    ),
+    ?assert(
+        emqx_mgmt_auth:is_api_key_allowed(#{module => emqx_mgmt_api_nodes, function => nodes})
     ),
     ok.
 

--- a/changes/ee/fix-18681.en.md
+++ b/changes/ee/fix-18681.en.md
@@ -1,0 +1,1 @@
+Fixed REST API authentication error messages to match what the target endpoint accepts. A rejected bearer token or missing authorization header on an endpoint that rejects API keys, such as `POST /api/v5/logout`, no longer suggests using one. The message also no longer names the `api_key.bootstrap_file` configuration key.


### PR DESCRIPTION
Fixes: N/A
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: 6.0.3

## Summary

A rejected bearer token or a missing authorization header always told the caller to use an API key, even on the endpoints that reject API keys (`POST /api/v5/logout`, `/users*`, `change_pwd`, `change_mfa`, `/api_key*`). Following that advice fails: those endpoints answer a Basic-auth request with `API_KEY_NOT_ALLOW`. This was introduced by #16868 (shipped in 6.0.3).

`emqx_mgmt_auth:is_api_key_allowed/1` is now the single predicate for "does this endpoint accept API keys", used by both `authorize/4` (which already enforced the denylist) and the four `emqx_dashboard.erl` auth-error messages (`AUTHORIZATION_HEADER_ERROR` ×2, `TOKEN_TIME_OUT`, `BAD_TOKEN`), so the two cannot drift apart again. The two duplicated `AUTHORIZATION_HEADER_ERROR` message sites are collapsed into one function.

Separately, every message dropped the `api_key.bootstrap_file` config-key reference — a 401 body has no reason to name a server-side file path.

Error `code` values are unchanged; only `message` text differs. Manual verification (non-default port, see below) and new tests cover both endpoint classes.

Before / after example, `POST /api/v5/logout` with an invalid bearer token:

```
before: {"code":"BAD_TOKEN","message":"Invalid bearer token. Use API key (Basic auth) for persistent access, or get a new bearer token by POST /api/v5/login. API keys can be bootstrapped from config (api_key.bootstrap_file) or created via POST /api/v5/api_key"}
after:  {"code":"BAD_TOKEN","message":"Invalid bearer token. Get a new token by POST /api/v5/login."}
```

`GET /api/v5/nodes` (accepts API keys) with an invalid bearer token is unaffected in substance, only trimmed:

```
before: {"code":"BAD_TOKEN","message":"Invalid bearer token. Use API key (Basic auth) for persistent access, or get a new bearer token by POST /api/v5/login. API keys can be bootstrapped from config (api_key.bootstrap_file) or created via POST /api/v5/api_key"}
after:  {"code":"BAD_TOKEN","message":"Invalid bearer token. Get a new token by POST /api/v5/login, or use an API key with Basic auth."}
```

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-18681.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)