### PR TITLE
fix(audit): record target namespace on audit entries for auth/bridge/connector/rule-engine/trace

### DIFF
--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
@@ -1827,6 +1827,7 @@ body_namespace(_Req) ->
 resolve_namespace(Req, _Meta) ->
     case parse_namespace(Req) of
         {ok, Namespace} ->
+            ok = log_ns(Namespace),
             {ok, Req#{resolved_ns => Namespace}};
         {error, conflicting_namespaces} ->
             ?BAD_REQUEST(
@@ -1835,6 +1836,13 @@ resolve_namespace(Req, _Meta) ->
         {error, not_authorized} ->
             ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.
+
+log_ns(?global_ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
+    ok;
+log_ns(NS) when is_binary(NS) ->
+    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+    ok.
 
 validate_managed_namespace(#{resolved_ns := ?global_ns} = Req, _Meta) ->
     {ok, Req};

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
@@ -1840,8 +1840,8 @@ resolve_namespace(Req, _Meta) ->
 log_ns(?global_ns) ->
     _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
     ok;
-log_ns(NS) when is_binary(NS) ->
-    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+log_ns(Ns) when is_binary(Ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => Ns}),
     ok.
 
 validate_managed_namespace(#{resolved_ns := ?global_ns} = Req, _Meta) ->

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
@@ -32,6 +32,11 @@ groups() ->
 init_per_testcase(t_authenticator_fail, Config) ->
     meck:expect(emqx_authn_proto_v1, lookup_from_all_nodes, 3, [{error, {exception, badarg}}]),
     init_per_testcase(default, Config);
+init_per_testcase(t_authenticator_users_audit_records_namespace, Config) ->
+    case emqx_release:edition() of
+        ee -> init_per_testcase(default, Config);
+        ce -> {skip, "audit logging is an ee-only feature"}
+    end;
 init_per_testcase(_Case, Config) ->
     emqx_authn_test_lib:delete_authenticators(
         [?CONF_NS_ATOM],
@@ -50,17 +55,40 @@ end_per_testcase(t_authenticator_fail, Config) ->
 end_per_testcase(_, Config) ->
     Config.
 
+%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
+%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
+%% unknown field, so audit logging is only enabled on the `ee' edition.
+audit_conf_spec() ->
+    case emqx_release:edition() of
+        ee ->
+            {emqx_conf, #{
+                config => "log.audit { enable = true, level = info }",
+                schema_mod => emqx_enterprise_schema
+            }};
+        ce ->
+            emqx_conf
+    end.
+
+audit_app_specs() ->
+    case emqx_release:edition() of
+        ee -> [emqx_audit];
+        ce -> []
+    end.
+
 init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
-            emqx_conf,
+            audit_conf_spec(),
             emqx,
             emqx_auth,
             %% to load schema
-            {emqx_auth_mnesia, #{start => false}},
-            emqx_management,
-            {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
-        ],
+            {emqx_auth_mnesia, #{start => false}}
+        ] ++
+            audit_app_specs() ++
+            [
+                emqx_management,
+                {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
+            ],
         #{
             work_dir => filename:join(?config(priv_dir, Config), ?MODULE)
         }
@@ -783,6 +811,104 @@ t_cache_reset(_) ->
         post,
         uri(["authentication", "node_cache", "reset"])
     ).
+
+-doc """
+Regression test for #18653/#18664's class of bug: audit records for
+`POST /authentication/:id/users` (built-in-database authenticator) must
+identify the namespace, both for a global admin's implicit-global request
+and a namespaced admin's implicit-own-namespace request (no `?ns=` in
+either case).
+""".
+t_authenticator_users_audit_records_namespace(_Config) ->
+    ok = emqx_hooks:add(
+        'namespace.resource_pre_create',
+        {?MODULE, on_namespace_resource_pre_create, []},
+        1000
+    ),
+    try
+        {ok, 200, _} = request(
+            post,
+            uri([?CONF_NS]),
+            emqx_authn_test_lib:built_in_database_example()
+        ),
+        StartAt = erlang:system_time(microsecond),
+        GlobalAuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+        GlobalUser = #{user_id => <<"audit_global_user">>, password => <<"p@ssw0rd1">>},
+        {201, _} = emqx_mgmt_api_test_util:simple_request(#{
+            method => post,
+            url => uri([?CONF_NS, "password_based:built_in_database", "users"]),
+            auth_header => GlobalAuthHeader,
+            body => GlobalUser
+        }),
+        Ns = <<"authn_audit_ns">>,
+        NsAuthHeader = create_namespaced_admin(Ns),
+        NsUser = #{user_id => <<"audit_ns_user">>, password => <<"p@ssw0rd1">>},
+        {201, _} = emqx_mgmt_api_test_util:simple_request(#{
+            method => post,
+            url => uri([?CONF_NS, "password_based:built_in_database", "users"]),
+            auth_header => NsAuthHeader,
+            body => NsUser
+        }),
+        Entries = wait_for_audit_entries(<<"/authentication/:id/users">>, StartAt, 2, 2000),
+        Namespaces = lists:sort([namespace_of(E) || E <- Entries]),
+        ?assertEqual(lists:sort([<<"global">>, Ns]), Namespaces)
+    after
+        ok = emqx_hooks:del(
+            'namespace.resource_pre_create', {?MODULE, on_namespace_resource_pre_create}
+        )
+    end.
+
+on_namespace_resource_pre_create(#{namespace := _Namespace}, ResCtx) ->
+    {stop, ResCtx#{exists := true}}.
+
+create_namespaced_admin(Namespace) ->
+    Username = <<"authn_audit_ns_admin">>,
+    Password = <<"superSecureP@ss1">>,
+    Role = <<"ns:", Namespace/binary, "::administrator">>,
+    case
+        emqx_dashboard_admin:add_user(
+            Username, Password, Role, <<"namespaced admin for audit test">>
+        )
+    of
+        {ok, _} -> ok;
+        {error, <<"username_already_exists">>} -> ok
+    end,
+    {200, #{<<"token">> := Token}} = emqx_dashboard_admin_SUITE:login(#{
+        <<"username">> => Username,
+        <<"password">> => Password
+    }),
+    {"Authorization", <<"Bearer ", Token/binary>>}.
+
+%% The audit write happens after the HTTP response is already sent (see
+%% minirest_handler:init/2), so poll for a bit rather than assume the record
+%% is there the instant the request returns.
+wait_for_audit_entries(_OperationId, _StartAt, _ExpectedCount, RemainMs) when RemainMs =< 0 ->
+    ct:fail(audit_entries_not_found_in_time);
+wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs) ->
+    Entries = audit_entries_since(OperationId, StartAt),
+    case length(Entries) >= ExpectedCount of
+        true ->
+            Entries;
+        false ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs - SleepMs)
+    end.
+
+audit_entries_since(OperationId, StartAt) ->
+    URL = uri(["audit"]),
+    QueryParams = #{
+        <<"operation_id">> => OperationId,
+        <<"gte_created_at">> => integer_to_binary(StartAt),
+        <<"limit">> => <<"100">>
+    },
+    {200, #{<<"data">> := Data}} =
+        emqx_mgmt_api_test_util:simple_request(#{
+            method => get, url => URL, query_params => QueryParams
+        }),
+    Data.
+
+namespace_of(#{<<"http_request">> := #{<<"namespace">> := Ns}}) -> Ns.
 
 %%------------------------------------------------------------------------------
 %% Helpers

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
@@ -32,11 +32,6 @@ groups() ->
 init_per_testcase(t_authenticator_fail, Config) ->
     meck:expect(emqx_authn_proto_v1, lookup_from_all_nodes, 3, [{error, {exception, badarg}}]),
     init_per_testcase(default, Config);
-init_per_testcase(t_authenticator_users_audit_records_namespace, Config) ->
-    case emqx_release:edition() of
-        ee -> init_per_testcase(default, Config);
-        ce -> {skip, "audit logging is an ee-only feature"}
-    end;
 init_per_testcase(_Case, Config) ->
     emqx_authn_test_lib:delete_authenticators(
         [?CONF_NS_ATOM],
@@ -55,40 +50,23 @@ end_per_testcase(t_authenticator_fail, Config) ->
 end_per_testcase(_, Config) ->
     Config.
 
-%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
-%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
-%% unknown field, so audit logging is only enabled on the `ee' edition.
-audit_conf_spec() ->
-    case emqx_release:edition() of
-        ee ->
-            {emqx_conf, #{
-                config => "log.audit { enable = true, level = info }",
-                schema_mod => emqx_enterprise_schema
-            }};
-        ce ->
-            emqx_conf
-    end.
-
-audit_app_specs() ->
-    case emqx_release:edition() of
-        ee -> [emqx_audit];
-        ce -> []
-    end.
-
 init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
-            audit_conf_spec(),
+            {emqx_conf, #{
+                config => "log.audit { enable = true, level = info }",
+                %% `log.audit' is declared in `emqx_enterprise_schema', not in the
+                %% bare `emqx_conf_schema' that `emqx_cth_suite' would pick by default.
+                schema_mod => emqx_enterprise_schema
+            }},
             emqx,
             emqx_auth,
             %% to load schema
-            {emqx_auth_mnesia, #{start => false}}
-        ] ++
-            audit_app_specs() ++
-            [
-                emqx_management,
-                {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
-            ],
+            {emqx_auth_mnesia, #{start => false}},
+            emqx_audit,
+            emqx_management,
+            {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
+        ],
         #{
             work_dir => filename:join(?config(priv_dir, Config), ?MODULE)
         }

--- a/apps/emqx_auth_mnesia/mix.exs
+++ b/apps/emqx_auth_mnesia/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthMnesia.MixProject do
   def project do
     [
       app: :emqx_auth_mnesia,
-      version: "6.1.2",
+      version: "6.1.3",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_mnesia/src/emqx_authz_api_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authz_api_mnesia.erl
@@ -922,10 +922,18 @@ binfmt(Fmt, Args) -> iolist_to_binary(io_lib:format(Fmt, Args)).
 resolve_namespace(Req, _Meta) ->
     case get_namespace(Req) of
         {ok, Namespace} ->
+            ok = log_ns(Namespace),
             {ok, Req#{resolved_ns => Namespace}};
         {error, not_authorized} ->
             ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.
+
+log_ns(?global_ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
+    ok;
+log_ns(NS) when is_binary(NS) ->
+    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+    ok.
 
 get_namespace(#{query_string := QueryString} = Req) ->
     ActorNamespace = emqx_dashboard:get_namespace(Req),

--- a/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
@@ -33,19 +33,46 @@ all() ->
 groups() ->
     emqx_common_test_helpers:groups_with_matrix(?MODULE).
 
+%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
+%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
+%% unknown field, so audit logging is only enabled on the `ee' edition.
+audit_conf_spec() ->
+    case emqx_release:edition() of
+        ee ->
+            {emqx_conf, #{
+                config =>
+                    "authorization.cache { enable = false },"
+                    "authorization.no_match = deny,"
+                    "authorization.sources = [{type = built_in_database, max_rules = 7}],"
+                    "log.audit { enable = true, level = info }",
+                schema_mod => emqx_enterprise_schema
+            }};
+        ce ->
+            {emqx_conf,
+                "authorization.cache { enable = false },"
+                "authorization.no_match = deny,"
+                "authorization.sources = [{type = built_in_database, max_rules = 7}]"}
+    end.
+
+audit_app_specs() ->
+    case emqx_release:edition() of
+        ee -> [emqx_audit];
+        ce -> []
+    end.
+
 init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
             emqx,
-            {emqx_conf,
-                "authorization.cache { enable = false },"
-                "authorization.no_match = deny,"
-                "authorization.sources = [{type = built_in_database, max_rules = 7}]"},
+            audit_conf_spec(),
             emqx_auth,
-            emqx_auth_mnesia,
-            emqx_management,
-            emqx_mgmt_api_test_util:emqx_dashboard()
-        ],
+            emqx_auth_mnesia
+        ] ++
+            audit_app_specs() ++
+            [
+                emqx_management,
+                emqx_mgmt_api_test_util:emqx_dashboard()
+            ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     ok = emqx_hooks:add(
@@ -105,6 +132,11 @@ init_per_group(_Group, TCConfig) ->
 end_per_group(_Group, _TCConfig) ->
     ok.
 
+init_per_testcase(t_create_rules_audit_records_namespace, TCConfig) ->
+    case emqx_release:edition() of
+        ee -> TCConfig;
+        ce -> {skip, "audit logging is an ee-only feature"}
+    end;
 init_per_testcase(_TestCase, TCConfig) ->
     AuthHeader = ?config(auth_header, TCConfig),
     put_auth_header(AuthHeader),
@@ -671,3 +703,84 @@ t_api(TCConfig) when is_list(TCConfig) ->
     }),
 
     ok.
+
+-doc """
+Regression test for #18653/#18664's class of bug: audit records for a
+built_in_database authorization-rule creation must identify the namespace,
+both when a global admin creates rules (implicit global namespace, no `?ns='
+at all) and when a namespaced admin creates its own rules (implicit
+own-namespace, no `?ns=' either).
+""".
+t_create_rules_audit_records_namespace(_TCConfig) ->
+    StartAt = erlang:system_time(microsecond),
+    GlobalAuthHeader = create_superuser(),
+    Ns = <<"authz_audit_ns">>,
+    Username = <<"authz_audit_ns_admin">>,
+    Password = <<"superSecureP@ss1">>,
+    AdminRole = <<"ns:", Ns/binary, "::administrator">>,
+    {200, _} = create_user_api(
+        #{
+            <<"username">> => Username,
+            <<"password">> => Password,
+            <<"role">> => AdminRole,
+            <<"description">> => <<"namespaced person">>
+        },
+        GlobalAuthHeader
+    ),
+    {200, #{<<"token">> := Token}} = login(#{
+        <<"username">> => Username,
+        <<"password">> => Password
+    }),
+    NsAuthHeader = bearer_auth_header(Token),
+
+    put_auth_header(GlobalAuthHeader),
+    {204, _} = create_username_rules([?USERNAME_RULES_EXAMPLE]),
+
+    put_auth_header(NsAuthHeader),
+    {204, _} = create_username_rules([?USERNAME_RULES_EXAMPLE]),
+
+    Entries = wait_for_audit_entries(
+        <<"/authorization/sources/built_in_database/rules/users">>,
+        StartAt,
+        2,
+        2000,
+        GlobalAuthHeader
+    ),
+    Namespaces = lists:sort([namespace_of(E) || E <- Entries]),
+    ?assertEqual(lists:sort([<<"global">>, Ns]), Namespaces),
+    ok.
+
+%% The audit write happens after the HTTP response is already sent (see
+%% minirest_handler:init/2), so poll for a bit rather than assume the record
+%% is there the instant the request returns.
+wait_for_audit_entries(_OperationId, _StartAt, _ExpectedCount, RemainMs, _AuthHeader) when
+    RemainMs =< 0
+->
+    ct:fail(audit_entries_not_found_in_time);
+wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs, AuthHeader) ->
+    Entries = audit_entries_since(OperationId, StartAt, AuthHeader),
+    case length(Entries) >= ExpectedCount of
+        true ->
+            Entries;
+        false ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_audit_entries(
+                OperationId, StartAt, ExpectedCount, RemainMs - SleepMs, AuthHeader
+            )
+    end.
+
+audit_entries_since(OperationId, StartAt, AuthHeader) ->
+    URL = emqx_mgmt_api_test_util:api_path(["audit"]),
+    QueryParams = #{
+        <<"operation_id">> => OperationId,
+        <<"gte_created_at">> => integer_to_binary(StartAt),
+        <<"limit">> => <<"100">>
+    },
+    {200, #{<<"data">> := Data}} =
+        emqx_mgmt_api_test_util:simple_request(#{
+            method => get, url => URL, query_params => QueryParams, auth_header => AuthHeader
+        }),
+    Data.
+
+namespace_of(#{<<"http_request">> := #{<<"namespace">> := Ns}}) -> Ns.

--- a/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
@@ -33,46 +33,26 @@ all() ->
 groups() ->
     emqx_common_test_helpers:groups_with_matrix(?MODULE).
 
-%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
-%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
-%% unknown field, so audit logging is only enabled on the `ee' edition.
-audit_conf_spec() ->
-    case emqx_release:edition() of
-        ee ->
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
             {emqx_conf, #{
                 config =>
                     "authorization.cache { enable = false },"
                     "authorization.no_match = deny,"
                     "authorization.sources = [{type = built_in_database, max_rules = 7}],"
                     "log.audit { enable = true, level = info }",
+                %% `log.audit' is declared in `emqx_enterprise_schema', not in the
+                %% bare `emqx_conf_schema' that `emqx_cth_suite' would pick by default.
                 schema_mod => emqx_enterprise_schema
-            }};
-        ce ->
-            {emqx_conf,
-                "authorization.cache { enable = false },"
-                "authorization.no_match = deny,"
-                "authorization.sources = [{type = built_in_database, max_rules = 7}]"}
-    end.
-
-audit_app_specs() ->
-    case emqx_release:edition() of
-        ee -> [emqx_audit];
-        ce -> []
-    end.
-
-init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start(
-        [
-            emqx,
-            audit_conf_spec(),
+            }},
             emqx_auth,
-            emqx_auth_mnesia
-        ] ++
-            audit_app_specs() ++
-            [
-                emqx_management,
-                emqx_mgmt_api_test_util:emqx_dashboard()
-            ],
+            emqx_auth_mnesia,
+            emqx_audit,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     ok = emqx_hooks:add(
@@ -132,11 +112,6 @@ init_per_group(_Group, TCConfig) ->
 end_per_group(_Group, _TCConfig) ->
     ok.
 
-init_per_testcase(t_create_rules_audit_records_namespace, TCConfig) ->
-    case emqx_release:edition() of
-        ee -> TCConfig;
-        ce -> {skip, "audit logging is an ee-only feature"}
-    end;
 init_per_testcase(_TestCase, TCConfig) ->
     AuthHeader = ?config(auth_header, TCConfig),
     put_auth_header(AuthHeader),

--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -1883,10 +1883,18 @@ parse_namespace(#{query_string := QueryString} = Req) ->
 resolve_namespace(Req, _Meta) ->
     case parse_namespace(Req) of
         {ok, Namespace} ->
+            ok = log_ns(Namespace),
             {ok, Req#{resolved_ns => Namespace}};
         {error, not_authorized} ->
             ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.
+
+log_ns(?global_ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
+    ok;
+log_ns(NS) when is_binary(NS) ->
+    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+    ok.
 
 validate_managed_namespace(#{resolved_ns := ?global_ns} = Req, _Meta) ->
     {ok, Req};

--- a/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
@@ -186,48 +186,31 @@ init_per_group(sources, Config) ->
 init_per_group(_Group, Config) ->
     Config.
 
-%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
-%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
-%% unknown field, so audit logging is only enabled on the `ee' edition.
-audit_conf_spec() ->
-    case emqx_release:edition() of
-        ee ->
-            {emqx_conf, #{
-                config => #{log => #{audit => #{enable => true, level => info}}},
-                schema_mod => emqx_enterprise_schema
-            }};
-        ce ->
-            emqx_conf
-    end.
-
-audit_app_specs() ->
-    case emqx_release:edition() of
-        ee -> [emqx_audit];
-        ce -> []
-    end.
-
 app_specs_without_dashboard() ->
     [
-        audit_conf_spec(),
+        {emqx_conf, #{
+            config => #{log => #{audit => #{enable => true, level => info}}},
+            %% `log.audit' is declared in `emqx_enterprise_schema', not in the
+            %% bare `emqx_conf_schema' that `emqx_cth_suite' would pick by default.
+            schema_mod => emqx_enterprise_schema
+        }},
         emqx,
-        emqx_auth
-    ] ++
-        audit_app_specs() ++
-        [
-            emqx_management,
-            emqx_connector,
-            emqx_bridge_mqtt,
-            {emqx_bridge, #{
-                after_start => fun() ->
-                    ok = emqx_hooks:add(
-                        'namespace.resource_pre_create',
-                        {?MODULE, on_namespace_resource_pre_create, []},
-                        ?HP_HIGHEST
-                    )
-                end
-            }},
-            emqx_rule_engine
-        ].
+        emqx_auth,
+        emqx_audit,
+        emqx_management,
+        emqx_connector,
+        emqx_bridge_mqtt,
+        {emqx_bridge, #{
+            after_start => fun() ->
+                ok = emqx_hooks:add(
+                    'namespace.resource_pre_create',
+                    {?MODULE, on_namespace_resource_pre_create, []},
+                    ?HP_HIGHEST
+                )
+            end
+        }},
+        emqx_rule_engine
+    ].
 
 mk_cluster(Name, Config) ->
     mk_cluster(Name, Config, #{}).
@@ -298,15 +281,7 @@ init_per_testcase(TestCase, Config) when
         BridgeConfig
         | Config
     ];
-init_per_testcase(t_source_audit_records_namespace = TestCase, Config) ->
-    case emqx_release:edition() of
-        ee -> init_per_testcase_1(TestCase, Config);
-        ce -> {skip, "audit logging is an ee-only feature"}
-    end;
 init_per_testcase(TestCase, Config) ->
-    init_per_testcase_1(TestCase, Config).
-
-init_per_testcase_1(TestCase, Config) ->
     setup_auth_header_fn(Config),
     case ?config(cluster_nodes, Config) of
         undefined ->

--- a/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
@@ -186,25 +186,48 @@ init_per_group(sources, Config) ->
 init_per_group(_Group, Config) ->
     Config.
 
+%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
+%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
+%% unknown field, so audit logging is only enabled on the `ee' edition.
+audit_conf_spec() ->
+    case emqx_release:edition() of
+        ee ->
+            {emqx_conf, #{
+                config => #{log => #{audit => #{enable => true, level => info}}},
+                schema_mod => emqx_enterprise_schema
+            }};
+        ce ->
+            emqx_conf
+    end.
+
+audit_app_specs() ->
+    case emqx_release:edition() of
+        ee -> [emqx_audit];
+        ce -> []
+    end.
+
 app_specs_without_dashboard() ->
     [
-        emqx_conf,
+        audit_conf_spec(),
         emqx,
-        emqx_auth,
-        emqx_management,
-        emqx_connector,
-        emqx_bridge_mqtt,
-        {emqx_bridge, #{
-            after_start => fun() ->
-                ok = emqx_hooks:add(
-                    'namespace.resource_pre_create',
-                    {?MODULE, on_namespace_resource_pre_create, []},
-                    ?HP_HIGHEST
-                )
-            end
-        }},
-        emqx_rule_engine
-    ].
+        emqx_auth
+    ] ++
+        audit_app_specs() ++
+        [
+            emqx_management,
+            emqx_connector,
+            emqx_bridge_mqtt,
+            {emqx_bridge, #{
+                after_start => fun() ->
+                    ok = emqx_hooks:add(
+                        'namespace.resource_pre_create',
+                        {?MODULE, on_namespace_resource_pre_create, []},
+                        ?HP_HIGHEST
+                    )
+                end
+            }},
+            emqx_rule_engine
+        ].
 
 mk_cluster(Name, Config) ->
     mk_cluster(Name, Config, #{}).
@@ -275,7 +298,15 @@ init_per_testcase(TestCase, Config) when
         BridgeConfig
         | Config
     ];
+init_per_testcase(t_source_audit_records_namespace = TestCase, Config) ->
+    case emqx_release:edition() of
+        ee -> init_per_testcase_1(TestCase, Config);
+        ce -> {skip, "audit logging is an ee-only feature"}
+    end;
 init_per_testcase(TestCase, Config) ->
+    init_per_testcase_1(TestCase, Config).
+
+init_per_testcase_1(TestCase, Config) ->
     setup_auth_header_fn(Config),
     case ?config(cluster_nodes, Config) of
         undefined ->
@@ -3121,6 +3152,111 @@ t_namespaced_crud(TCConfig0) when is_list(TCConfig0) ->
     ?assertMatch({200, []}, list(TCConfigNS2)),
 
     ok.
+
+-doc """
+Regression test for #18653/#18664's class of bug: audit records for a
+source creation must identify the namespace, both for a global admin's
+implicit-global source and a namespaced admin's implicit-own-namespace
+source (no `?ns=' in either case).
+""".
+t_source_audit_records_namespace(matrix) ->
+    [[single, sources]];
+t_source_audit_records_namespace(TCConfig0) when is_list(TCConfig0) ->
+    clear_mocks(TCConfig0),
+    Node =
+        case proplists:get_value(node, TCConfig0) of
+            undefined -> node();
+            N -> N
+        end,
+    {ok, APIKey} = erpc:call(Node, emqx_common_test_http, create_default_app, []),
+    TCConfig = [{node, Node}, {api_key, APIKey} | TCConfig0],
+    AuthHeaderGlobal = emqx_common_test_http:auth_header(APIKey),
+    TCConfigGlobal = [{auth_header, AuthHeaderGlobal} | TCConfig],
+    Ns = <<"bridge_audit_ns">>,
+    AuthHeaderNs = ensure_namespaced_api_key(Ns, TCConfig),
+    TCConfigNs = [{auth_header, AuthHeaderNs} | TCConfig],
+
+    MQTTPort = get_tcp_mqtt_port(Node),
+    Server = <<"127.0.0.1:", (integer_to_binary(MQTTPort))/binary>>,
+    ConnectorType = <<"mqtt">>,
+    ConnectorNameGlobal = <<"conn_audit_global">>,
+    ConnectorNameNs = <<"conn_audit_ns">>,
+    ConnectorConfigGlobal = source_connector_create_config(#{<<"server">> => Server}),
+    ConnectorConfigNs = source_connector_create_config(#{<<"server">> => Server}),
+    {201, #{<<"status">> := <<"connected">>}} =
+        emqx_connector_api_SUITE:create(
+            ConnectorType, ConnectorNameGlobal, ConnectorConfigGlobal, TCConfigGlobal
+        ),
+    {201, #{<<"status">> := <<"connected">>}} =
+        emqx_connector_api_SUITE:create(
+            ConnectorType, ConnectorNameNs, ConnectorConfigNs, TCConfigNs
+        ),
+
+    StartAt = erlang:system_time(microsecond),
+    SourceNameGlobal = <<"src_audit_global">>,
+    SourceConfigGlobal = source_create_config(#{
+        <<"name">> => SourceNameGlobal,
+        <<"connector">> => ConnectorNameGlobal
+    }),
+    {201, _} = ?ON(
+        Node,
+        emqx_bridge_v2_testlib:simple_request(#{
+            method => post,
+            url => emqx_mgmt_api_test_util:api_path(["sources"]),
+            body => SourceConfigGlobal,
+            auth_header => AuthHeaderGlobal
+        })
+    ),
+    SourceNameNs = <<"src_audit_ns">>,
+    SourceConfigNs = source_create_config(#{
+        <<"name">> => SourceNameNs,
+        <<"connector">> => ConnectorNameNs
+    }),
+    {201, _} = ?ON(
+        Node,
+        emqx_bridge_v2_testlib:simple_request(#{
+            method => post,
+            url => emqx_mgmt_api_test_util:api_path(["sources"]),
+            body => SourceConfigNs,
+            auth_header => AuthHeaderNs
+        })
+    ),
+
+    Entries = ?ON(Node, wait_for_audit_entries(<<"/sources">>, StartAt, 2, 2000)),
+    Namespaces = lists:sort([namespace_of(E) || E <- Entries]),
+    ?assertEqual(lists:sort([<<"global">>, Ns]), Namespaces),
+    ok.
+
+%% The audit write happens after the HTTP response is already sent (see
+%% minirest_handler:init/2), so poll for a bit rather than assume the record
+%% is there the instant the request returns.
+wait_for_audit_entries(_OperationId, _StartAt, _ExpectedCount, RemainMs) when RemainMs =< 0 ->
+    ct:fail(audit_entries_not_found_in_time);
+wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs) ->
+    Entries = audit_entries_since(OperationId, StartAt),
+    case length(Entries) >= ExpectedCount of
+        true ->
+            Entries;
+        false ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs - SleepMs)
+    end.
+
+audit_entries_since(OperationId, StartAt) ->
+    URL = emqx_mgmt_api_test_util:api_path(["audit"]),
+    QueryParams = #{
+        <<"operation_id">> => OperationId,
+        <<"gte_created_at">> => integer_to_binary(StartAt),
+        <<"limit">> => <<"100">>
+    },
+    {200, #{<<"data">> := Data}} =
+        emqx_bridge_v2_testlib:simple_request(#{
+            method => get, url => URL, query_params => QueryParams
+        }),
+    Data.
+
+namespace_of(#{<<"http_request">> := #{<<"namespace">> := Ns}}) -> Ns.
 
 -doc """
 Checks that we correctly load and unload connectors already in the config when a node

--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -1009,10 +1009,18 @@ parse_namespace(#{query_string := QueryString} = Req) ->
 resolve_namespace(Req, _Meta) ->
     case parse_namespace(Req) of
         {ok, Namespace} ->
+            ok = log_ns(Namespace),
             {ok, Req#{resolved_ns => Namespace}};
         {error, not_authorized} ->
             ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.
+
+log_ns(?global_ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
+    ok;
+log_ns(NS) when is_binary(NS) ->
+    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+    ok.
 
 validate_managed_namespace(#{resolved_ns := ?global_ns} = Req, _Meta) ->
     {ok, Req};

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -102,67 +102,49 @@
 }).
 -define(KAFKA_BRIDGE(Name), ?KAFKA_BRIDGE(Name, ?CONNECTOR_NAME)).
 
--define(APPSPECS,
-    [
-        {emqx, #{
-            before_start => fun(App, AppConfig) ->
-                %% We need this in the tests because `emqx_cth_suite` does not start apps in
-                %% the exact same way as the release works: in the release,
-                %% `emqx_enterprise_schema` is the root schema that knows all root keys.  In
-                %% CTH, we need to manually load the schema below so that when
-                %% `emqx_config:init_load` runs and encounters a namespaced root key, it knows
-                %% the schema module for it.
-                emqx_config:init_load(emqx_connector_schema, <<"">>),
-                emqx_config:add_allowed_namespaced_config_root(<<"connectors">>),
-                ok = emqx_schema_hooks:inject_from_modules([?MODULE]),
-                emqx_cth_suite:inhibit_config_loader(App, AppConfig)
-            end
-        }},
-        audit_conf_spec()
-    ] ++ audit_app_specs() ++
-        [
-            emqx_auth,
-            {emqx_connector, #{
-                after_start => fun() ->
-                    ok = emqx_hooks:add(
-                        'namespace.resource_pre_create',
-                        {?MODULE, on_namespace_resource_pre_create, []},
-                        ?HP_HIGHEST
-                    )
-                end
-            }},
-            emqx_bridge_http,
-            emqx_bridge,
-            emqx_rule_engine,
-            emqx_management
-        ]
-).
+-define(APPSPECS, [
+    {emqx, #{
+        before_start => fun(App, AppConfig) ->
+            %% We need this in the tests because `emqx_cth_suite` does not start apps in
+            %% the exact same way as the release works: in the release,
+            %% `emqx_enterprise_schema` is the root schema that knows all root keys.  In
+            %% CTH, we need to manually load the schema below so that when
+            %% `emqx_config:init_load` runs and encounters a namespaced root key, it knows
+            %% the schema module for it.
+            emqx_config:init_load(emqx_connector_schema, <<"">>),
+            emqx_config:add_allowed_namespaced_config_root(<<"connectors">>),
+            ok = emqx_schema_hooks:inject_from_modules([?MODULE]),
+            emqx_cth_suite:inhibit_config_loader(App, AppConfig)
+        end
+    }},
+    {emqx_conf, #{
+        config => #{log => #{audit => #{enable => true, level => info}}},
+        %% `log.audit' is declared in `emqx_enterprise_schema', not in the
+        %% bare `emqx_conf_schema' that `emqx_cth_suite' would pick by default.
+        schema_mod => emqx_enterprise_schema
+    }},
+    emqx_auth,
+    emqx_audit,
+    {emqx_connector, #{
+        after_start => fun() ->
+            ok = emqx_hooks:add(
+                'namespace.resource_pre_create',
+                {?MODULE, on_namespace_resource_pre_create, []},
+                ?HP_HIGHEST
+            )
+        end
+    }},
+    emqx_bridge_http,
+    emqx_bridge,
+    emqx_rule_engine,
+    emqx_management
+]).
 
 -define(APPSPEC_DASHBOARD,
     {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
 ).
 
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
-
-%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
-%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
-%% unknown field, so audit logging is only enabled on the `ee' edition.
-audit_conf_spec() ->
-    case emqx_release:edition() of
-        ee ->
-            {emqx_conf, #{
-                config => #{log => #{audit => #{enable => true, level => info}}},
-                schema_mod => emqx_enterprise_schema
-            }};
-        ce ->
-            emqx_conf
-    end.
-
-audit_app_specs() ->
-    case emqx_release:edition() of
-        ee -> [emqx_audit];
-        ce -> []
-    end.
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
@@ -228,15 +210,7 @@ end_per_group(_, Config) ->
     emqx_cth_suite:stop(?config(group_apps, Config)),
     ok.
 
-init_per_testcase(t_connector_audit_records_namespace = TestCase, Config) ->
-    case emqx_release:edition() of
-        ee -> init_per_testcase_1(TestCase, Config);
-        ce -> {skip, "audit logging is an ee-only feature"}
-    end;
 init_per_testcase(TestCase, Config) ->
-    init_per_testcase_1(TestCase, Config).
-
-init_per_testcase_1(TestCase, Config) ->
     case ?config(cluster_nodes, Config) of
         undefined ->
             init_mocks(TestCase);

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -185,7 +185,10 @@ groups() ->
         t_actions_field,
         t_update_with_failed_validation,
         t_create_with_failed_root_validation,
-        t_create_or_update_with_unexpected_error_term
+        t_create_or_update_with_unexpected_error_term,
+        %% Namespace resolution and audit logging are not cluster-specific;
+        %% no need to exercise this under the `cluster` group too.
+        t_connector_audit_records_namespace
     ],
     ClusterOnlyTests = [
         t_inconsistent_state,

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -102,43 +102,67 @@
 }).
 -define(KAFKA_BRIDGE(Name), ?KAFKA_BRIDGE(Name, ?CONNECTOR_NAME)).
 
--define(APPSPECS, [
-    {emqx, #{
-        before_start => fun(App, AppConfig) ->
-            %% We need this in the tests because `emqx_cth_suite` does not start apps in
-            %% the exact same way as the release works: in the release,
-            %% `emqx_enterprise_schema` is the root schema that knows all root keys.  In
-            %% CTH, we need to manually load the schema below so that when
-            %% `emqx_config:init_load` runs and encounters a namespaced root key, it knows
-            %% the schema module for it.
-            emqx_config:init_load(emqx_connector_schema, <<"">>),
-            emqx_config:add_allowed_namespaced_config_root(<<"connectors">>),
-            ok = emqx_schema_hooks:inject_from_modules([?MODULE]),
-            emqx_cth_suite:inhibit_config_loader(App, AppConfig)
-        end
-    }},
-    emqx_conf,
-    emqx_auth,
-    {emqx_connector, #{
-        after_start => fun() ->
-            ok = emqx_hooks:add(
-                'namespace.resource_pre_create',
-                {?MODULE, on_namespace_resource_pre_create, []},
-                ?HP_HIGHEST
-            )
-        end
-    }},
-    emqx_bridge_http,
-    emqx_bridge,
-    emqx_rule_engine,
-    emqx_management
-]).
+-define(APPSPECS,
+    [
+        {emqx, #{
+            before_start => fun(App, AppConfig) ->
+                %% We need this in the tests because `emqx_cth_suite` does not start apps in
+                %% the exact same way as the release works: in the release,
+                %% `emqx_enterprise_schema` is the root schema that knows all root keys.  In
+                %% CTH, we need to manually load the schema below so that when
+                %% `emqx_config:init_load` runs and encounters a namespaced root key, it knows
+                %% the schema module for it.
+                emqx_config:init_load(emqx_connector_schema, <<"">>),
+                emqx_config:add_allowed_namespaced_config_root(<<"connectors">>),
+                ok = emqx_schema_hooks:inject_from_modules([?MODULE]),
+                emqx_cth_suite:inhibit_config_loader(App, AppConfig)
+            end
+        }},
+        audit_conf_spec()
+    ] ++ audit_app_specs() ++
+        [
+            emqx_auth,
+            {emqx_connector, #{
+                after_start => fun() ->
+                    ok = emqx_hooks:add(
+                        'namespace.resource_pre_create',
+                        {?MODULE, on_namespace_resource_pre_create, []},
+                        ?HP_HIGHEST
+                    )
+                end
+            }},
+            emqx_bridge_http,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_management
+        ]
+).
 
 -define(APPSPEC_DASHBOARD,
     {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
 ).
 
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+
+%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
+%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
+%% unknown field, so audit logging is only enabled on the `ee' edition.
+audit_conf_spec() ->
+    case emqx_release:edition() of
+        ee ->
+            {emqx_conf, #{
+                config => #{log => #{audit => #{enable => true, level => info}}},
+                schema_mod => emqx_enterprise_schema
+            }};
+        ce ->
+            emqx_conf
+    end.
+
+audit_app_specs() ->
+    case emqx_release:edition() of
+        ee -> [emqx_audit];
+        ce -> []
+    end.
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
@@ -201,7 +225,15 @@ end_per_group(_, Config) ->
     emqx_cth_suite:stop(?config(group_apps, Config)),
     ok.
 
+init_per_testcase(t_connector_audit_records_namespace = TestCase, Config) ->
+    case emqx_release:edition() of
+        ee -> init_per_testcase_1(TestCase, Config);
+        ce -> {skip, "audit logging is an ee-only feature"}
+    end;
 init_per_testcase(TestCase, Config) ->
+    init_per_testcase_1(TestCase, Config).
+
+init_per_testcase_1(TestCase, Config) ->
     case ?config(cluster_nodes, Config) of
         undefined ->
             init_mocks(TestCase);
@@ -1862,6 +1894,69 @@ t_namespaced_crud(TCConfig) ->
     ?assertMatch({200, []}, list(TCConfigNS2)),
 
     ok.
+
+-doc """
+Regression test for #18653/#18664's class of bug: audit records for a
+connector creation must identify the namespace, both for a global admin's
+implicit-global connector and a namespaced admin's implicit-own-namespace
+connector (no `?ns=' in either case).
+""".
+t_connector_audit_records_namespace(TCConfig0) ->
+    clear_mocks(TCConfig0),
+    TCConfig =
+        case proplists:get_value(node, TCConfig0) of
+            undefined -> [{node, node()} | TCConfig0];
+            _ -> TCConfig0
+        end,
+    Ns = <<"connector_audit_ns">>,
+    AuthHeaderNs = ensure_namespaced_api_key(Ns, TCConfig),
+    TCConfigNs = [{auth_header, AuthHeaderNs} | TCConfig],
+
+    StartAt = erlang:system_time(microsecond),
+    ConnectorType = <<"http">>,
+    ConnectorNameGlobal = <<"conn_audit_global">>,
+    ConnectorNameNs = <<"conn_audit_ns">>,
+    ConnectorConfigGlobal = http_connector_config(#{<<"description">> => <<"global">>}),
+    ConnectorConfigNs = http_connector_config(#{<<"description">> => Ns}),
+
+    {201, _} = create(ConnectorType, ConnectorNameGlobal, ConnectorConfigGlobal, TCConfig),
+    {201, _} = create(ConnectorType, ConnectorNameNs, ConnectorConfigNs, TCConfigNs),
+
+    Entries = wait_for_audit_entries(<<"/connectors">>, StartAt, 2, 2000),
+    Namespaces = lists:sort([namespace_of(E) || E <- Entries]),
+    ?assertEqual(lists:sort([<<"global">>, Ns]), Namespaces),
+    ok.
+
+%% The audit write happens after the HTTP response is already sent (see
+%% minirest_handler:init/2), so poll for a bit rather than assume the record
+%% is there the instant the request returns.
+wait_for_audit_entries(_OperationId, _StartAt, _ExpectedCount, RemainMs) when RemainMs =< 0 ->
+    ct:fail(audit_entries_not_found_in_time);
+wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs) ->
+    Entries = audit_entries_since(OperationId, StartAt),
+    case length(Entries) >= ExpectedCount of
+        true ->
+            Entries;
+        false ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs - SleepMs)
+    end.
+
+audit_entries_since(OperationId, StartAt) ->
+    URL = emqx_mgmt_api_test_util:api_path(["audit"]),
+    QueryParams = #{
+        <<"operation_id">> => OperationId,
+        <<"gte_created_at">> => integer_to_binary(StartAt),
+        <<"limit">> => <<"100">>
+    },
+    {200, #{<<"data">> := Data}} =
+        emqx_bridge_v2_testlib:simple_request(#{
+            method => get, url => URL, query_params => QueryParams
+        }),
+    Data.
+
+namespace_of(#{<<"http_request">> := #{<<"namespace">> := Ns}}) -> Ns.
 
 -doc """
 Checks that we correctly load and unload connectors already in the config when a node

--- a/apps/emqx_management/src/emqx_mgmt_api_trace.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_trace.erl
@@ -1001,10 +1001,18 @@ parse_namespace(#{query_string := QueryString} = Req) ->
 resolve_namespace(Req, _Meta) ->
     case parse_namespace(Req) of
         {ok, Namespace} ->
+            ok = log_ns(Namespace),
             {ok, Req#{resolved_ns => Namespace}};
         {error, not_authorized} ->
             ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.
+
+log_ns(?global_ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
+    ok;
+log_ns(NS) when is_binary(NS) ->
+    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+    ok.
 
 validate_managed_namespace(#{resolved_ns := ?global_ns} = Req, _Meta) ->
     {ok, Req};

--- a/apps/emqx_management/src/emqx_mgmt_api_trace.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_trace.erl
@@ -1010,8 +1010,8 @@ resolve_namespace(Req, _Meta) ->
 log_ns(?global_ns) ->
     _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
     ok;
-log_ns(NS) when is_binary(NS) ->
-    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+log_ns(Ns) when is_binary(Ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => Ns}),
     ok.
 
 validate_managed_namespace(#{resolved_ns := ?global_ns} = Req, _Meta) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
@@ -25,16 +25,39 @@
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
+%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
+%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
+%% unknown field, so audit logging is only enabled on the `ee' edition.
+audit_conf_spec() ->
+    case emqx_release:edition() of
+        ee ->
+            {emqx_conf, #{
+                config => #{log => #{audit => #{enable => true, level => info}}},
+                schema_mod => emqx_enterprise_schema
+            }};
+        ce ->
+            emqx_conf
+    end.
+
+audit_app_specs() ->
+    case emqx_release:edition() of
+        ee -> [emqx_audit];
+        ce -> []
+    end.
+
 init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
             %% Needed by `emqx_modules`:
-            emqx_conf,
+            audit_conf_spec(),
             %% Manages `emqx_trace` server:
-            emqx_modules,
-            emqx_management,
-            emqx_mgmt_api_test_util:emqx_dashboard()
-        ],
+            emqx_modules
+        ] ++
+            audit_app_specs() ++
+            [
+                emqx_management,
+                emqx_mgmt_api_test_util:emqx_dashboard()
+            ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     [{apps, Apps} | Config].
@@ -42,6 +65,20 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(apps, Config)).
 
+init_per_testcase(t_create_trace_audit_records_namespace, Config) ->
+    case emqx_release:edition() of
+        ce ->
+            {skip, "audit logging is an ee-only feature"};
+        ee ->
+            ok = snabbkaffe:start_trace(),
+            emqx_trace:clear(),
+            ok = emqx_hooks:add(
+                'namespace.resource_pre_create',
+                {?MODULE, mark_ns1_managed, []},
+                1000
+            ),
+            Config
+    end;
 init_per_testcase(t_namespaced_user_cross_ns_isolation, Config) ->
     ok = snabbkaffe:start_trace(),
     emqx_trace:clear(),
@@ -64,6 +101,11 @@ init_per_testcase(_, Config) ->
     emqx_trace:clear(),
     Config.
 
+end_per_testcase(t_create_trace_audit_records_namespace, _Config) ->
+    ok = emqx_hooks:del('namespace.resource_pre_create', {?MODULE, mark_ns1_managed}),
+    snabbkaffe:stop(),
+    emqx_common_test_helpers:call_janitor(),
+    ok;
 end_per_testcase(t_namespaced_user_cross_ns_isolation, _Config) ->
     ok = emqx_hooks:del('namespace.resource_pre_create', {?MODULE, mark_ns1_managed}),
     snabbkaffe:stop(),
@@ -963,6 +1005,73 @@ t_namespaced_rule_trace(_TCConfig) ->
     ),
 
     ok.
+
+-doc """
+Regression test for #18653/#18664's class of bug: audit records for
+`POST /trace` must identify the namespace, both for a global admin's
+implicit-global trace and a namespaced admin's implicit-own-namespace
+trace (no `?ns=` in either case).
+""".
+t_create_trace_audit_records_namespace(_TCConfig) ->
+    StartAt = erlang:system_time(microsecond),
+    ?assertMatch(
+        {200, _},
+        create_trace_api(
+            #{
+                <<"name">> => <<"global_trace_for_audit">>,
+                <<"type">> => <<"clientid">>,
+                <<"clientid">> => <<"clientid_audit_global">>
+            },
+            #{}
+        )
+    ),
+    NsAdmin = namespaced_admin_headers(),
+    ?assertMatch(
+        {200, _},
+        create_trace_api(
+            #{
+                <<"name">> => <<"ns_trace_for_audit">>,
+                <<"type">> => <<"clientid">>,
+                <<"clientid">> => <<"clientid_audit_ns">>
+            },
+            #{auth_header => NsAdmin}
+        )
+    ),
+    Entries = wait_for_audit_entries(<<"/trace">>, StartAt, 2, 2000),
+    Namespaces = lists:sort([namespace_of(E) || E <- Entries]),
+    ?assertEqual(lists:sort([<<"global">>, <<"ns1">>]), Namespaces),
+    ok.
+
+%% The audit write happens after the HTTP response is already sent (see
+%% minirest_handler:init/2), so poll for a bit rather than assume the record
+%% is there the instant the request returns.
+wait_for_audit_entries(_OperationId, _StartAt, _ExpectedCount, RemainMs) when RemainMs =< 0 ->
+    ct:fail(audit_entries_not_found_in_time);
+wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs) ->
+    Entries = audit_entries_since(OperationId, StartAt),
+    case length(Entries) >= ExpectedCount of
+        true ->
+            Entries;
+        false ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs - SleepMs)
+    end.
+
+audit_entries_since(OperationId, StartAt) ->
+    URL = emqx_mgmt_api_test_util:api_path(["audit"]),
+    QueryParams = #{
+        <<"operation_id">> => OperationId,
+        <<"gte_created_at">> => integer_to_binary(StartAt),
+        <<"limit">> => <<"100">>
+    },
+    {200, #{<<"data">> := Data}} =
+        emqx_mgmt_api_test_util:simple_request(#{
+            method => get, url => URL, query_params => QueryParams
+        }),
+    Data.
+
+namespace_of(#{<<"http_request">> := #{<<"namespace">> := Ns}}) -> Ns.
 
 -doc """
 Checks the cross-namespace access boundary on per-trace operations.

--- a/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
@@ -25,39 +25,22 @@
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
-%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
-%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
-%% unknown field, so audit logging is only enabled on the `ee' edition.
-audit_conf_spec() ->
-    case emqx_release:edition() of
-        ee ->
-            {emqx_conf, #{
-                config => #{log => #{audit => #{enable => true, level => info}}},
-                schema_mod => emqx_enterprise_schema
-            }};
-        ce ->
-            emqx_conf
-    end.
-
-audit_app_specs() ->
-    case emqx_release:edition() of
-        ee -> [emqx_audit];
-        ce -> []
-    end.
-
 init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
             %% Needed by `emqx_modules`:
-            audit_conf_spec(),
+            {emqx_conf, #{
+                config => #{log => #{audit => #{enable => true, level => info}}},
+                %% `log.audit' is declared in `emqx_enterprise_schema', not in the
+                %% bare `emqx_conf_schema' that `emqx_cth_suite' would pick by default.
+                schema_mod => emqx_enterprise_schema
+            }},
             %% Manages `emqx_trace` server:
-            emqx_modules
-        ] ++
-            audit_app_specs() ++
-            [
-                emqx_management,
-                emqx_mgmt_api_test_util:emqx_dashboard()
-            ],
+            emqx_modules,
+            emqx_audit,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     [{apps, Apps} | Config].
@@ -66,19 +49,14 @@ end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(apps, Config)).
 
 init_per_testcase(t_create_trace_audit_records_namespace, Config) ->
-    case emqx_release:edition() of
-        ce ->
-            {skip, "audit logging is an ee-only feature"};
-        ee ->
-            ok = snabbkaffe:start_trace(),
-            emqx_trace:clear(),
-            ok = emqx_hooks:add(
-                'namespace.resource_pre_create',
-                {?MODULE, mark_ns1_managed, []},
-                1000
-            ),
-            Config
-    end;
+    ok = snabbkaffe:start_trace(),
+    emqx_trace:clear(),
+    ok = emqx_hooks:add(
+        'namespace.resource_pre_create',
+        {?MODULE, mark_ns1_managed, []},
+        1000
+    ),
+    Config;
 init_per_testcase(t_namespaced_user_cross_ns_isolation, Config) ->
     ok = snabbkaffe:start_trace(),
     emqx_trace:clear(),

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -1007,10 +1007,18 @@ parse_namespace(#{query_string := QueryString} = Req) ->
 resolve_namespace(Req, _Meta) ->
     case parse_namespace(Req) of
         {ok, Namespace} ->
+            ok = log_ns(Namespace),
             {ok, Req#{resolved_ns => Namespace}};
         {error, not_authorized} ->
             ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end.
+
+log_ns(?global_ns) ->
+    _ = minirest_handler:update_log_meta(#{namespace => <<"global">>}),
+    ok;
+log_ns(NS) when is_binary(NS) ->
+    _ = minirest_handler:update_log_meta(#{namespace => NS}),
+    ok.
 
 validate_managed_namespace(#{resolved_ns := ?global_ns} = Req, _Meta) ->
     {ok, Req};

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -137,33 +137,16 @@ app_specs_no_dashboard() ->
                     emqx_cth_suite:inhibit_config_loader(App, AppOpts)
                 end
         }},
-        audit_conf_spec(),
-        rule_engine_app_spec()
-    ] ++
-        audit_app_specs() ++
-        [
-            emqx_management
-        ].
-
-%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
-%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
-%% unknown field, so audit logging is only enabled on the `ee' edition.
-audit_conf_spec() ->
-    case emqx_release:edition() of
-        ee ->
-            {emqx_conf, #{
-                config => #{log => #{audit => #{enable => true, level => info}}},
-                schema_mod => emqx_enterprise_schema
-            }};
-        ce ->
-            emqx_conf
-    end.
-
-audit_app_specs() ->
-    case emqx_release:edition() of
-        ee -> [emqx_audit];
-        ce -> []
-    end.
+        {emqx_conf, #{
+            config => #{log => #{audit => #{enable => true, level => info}}},
+            %% `log.audit' is declared in `emqx_enterprise_schema', not in the
+            %% bare `emqx_conf_schema' that `emqx_cth_suite' would pick by default.
+            schema_mod => emqx_enterprise_schema
+        }},
+        rule_engine_app_spec(),
+        emqx_audit,
+        emqx_management
+    ].
 
 rule_engine_app_spec() ->
     {emqx_rule_engine, #{
@@ -200,11 +183,6 @@ end_per_group(?custom_cluster, _TCConfig) ->
 end_per_group(_Group, _TCConfig) ->
     ok.
 
-init_per_testcase(t_rule_audit_records_namespace, Config) ->
-    case emqx_release:edition() of
-        ee -> Config;
-        ce -> {skip, "audit logging is an ee-only feature"}
-    end;
 init_per_testcase(_TestCase, Config) ->
     Config.
 

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -137,10 +137,33 @@ app_specs_no_dashboard() ->
                     emqx_cth_suite:inhibit_config_loader(App, AppOpts)
                 end
         }},
-        emqx_conf,
-        rule_engine_app_spec(),
-        emqx_management
-    ].
+        audit_conf_spec(),
+        rule_engine_app_spec()
+    ] ++
+        audit_app_specs() ++
+        [
+            emqx_management
+        ].
+
+%% `log.audit' is only declared in `emqx_enterprise_schema'; the base
+%% `emqx_conf_schema' (used e.g. on the OSS `emqx' test profile) rejects it as an
+%% unknown field, so audit logging is only enabled on the `ee' edition.
+audit_conf_spec() ->
+    case emqx_release:edition() of
+        ee ->
+            {emqx_conf, #{
+                config => #{log => #{audit => #{enable => true, level => info}}},
+                schema_mod => emqx_enterprise_schema
+            }};
+        ce ->
+            emqx_conf
+    end.
+
+audit_app_specs() ->
+    case emqx_release:edition() of
+        ee -> [emqx_audit];
+        ce -> []
+    end.
 
 rule_engine_app_spec() ->
     {emqx_rule_engine, #{
@@ -177,6 +200,11 @@ end_per_group(?custom_cluster, _TCConfig) ->
 end_per_group(_Group, _TCConfig) ->
     ok.
 
+init_per_testcase(t_rule_audit_records_namespace, Config) ->
+    case emqx_release:edition() of
+        ee -> Config;
+        ce -> {skip, "audit logging is an ee-only feature"}
+    end;
 init_per_testcase(_TestCase, Config) ->
     Config.
 
@@ -2439,6 +2467,71 @@ t_namespaced_crud(TCConfig0) when is_list(TCConfig0) ->
     ok = emqtt:stop(C),
 
     ok.
+
+-doc """
+Regression test for #18653/#18664's class of bug: audit records for a rule
+creation must identify the namespace, both for a global admin's
+implicit-global rule and a namespaced admin's implicit-own-namespace rule
+(no `?ns=' in either case).
+""".
+t_rule_audit_records_namespace(TCConfig0) when is_list(TCConfig0) ->
+    Node = node(),
+    {ok, APIKey} = erpc:call(Node, emqx_common_test_http, create_default_app, []),
+    TCConfig = [{node, Node}, {api_key, APIKey} | TCConfig0],
+    AuthHeaderGlobal = emqx_common_test_http:auth_header(APIKey),
+    TCConfigGlobal = [{auth_header, AuthHeaderGlobal} | TCConfig],
+    Ns = <<"rule_audit_ns">>,
+    AuthHeaderNs = ensure_namespaced_api_key(Ns, TCConfig),
+    TCConfigNs = [{auth_header, AuthHeaderNs} | TCConfig],
+
+    StartAt = erlang:system_time(microsecond),
+    RuleTopic = <<"t">>,
+    ConfigGlobal = rule_config(#{
+        <<"id">> => <<"audit_rule_global">>,
+        <<"sql">> => fmt(<<"select * from ${t}">>, #{t => RuleTopic})
+    }),
+    ConfigNs = rule_config(#{
+        <<"id">> => <<"audit_rule_ns">>,
+        <<"sql">> => fmt(<<"select * from ${t}">>, #{t => RuleTopic})
+    }),
+    ?assertMatch({201, #{<<"namespace">> := null}}, create(ConfigGlobal, TCConfigGlobal)),
+    ?assertMatch({201, #{<<"namespace">> := Ns}}, create(ConfigNs, TCConfigNs)),
+
+    Entries = wait_for_audit_entries(<<"/rules">>, StartAt, 2, 2000),
+    Namespaces = lists:sort([audit_namespace_of(E) || E <- Entries]),
+    ?assertEqual(lists:sort([<<"global">>, Ns]), Namespaces),
+    ok.
+
+%% The audit write happens after the HTTP response is already sent (see
+%% minirest_handler:init/2), so poll for a bit rather than assume the record
+%% is there the instant the request returns.
+wait_for_audit_entries(_OperationId, _StartAt, _ExpectedCount, RemainMs) when RemainMs =< 0 ->
+    ct:fail(audit_entries_not_found_in_time);
+wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs) ->
+    Entries = audit_entries_since(OperationId, StartAt),
+    case length(Entries) >= ExpectedCount of
+        true ->
+            Entries;
+        false ->
+            SleepMs = 100,
+            ct:sleep(SleepMs),
+            wait_for_audit_entries(OperationId, StartAt, ExpectedCount, RemainMs - SleepMs)
+    end.
+
+audit_entries_since(OperationId, StartAt) ->
+    URL = emqx_mgmt_api_test_util:api_path(["audit"]),
+    QueryParams = #{
+        <<"operation_id">> => OperationId,
+        <<"gte_created_at">> => integer_to_binary(StartAt),
+        <<"limit">> => <<"100">>
+    },
+    {200, #{<<"data">> := Data}} =
+        emqx_bridge_v2_testlib:simple_request(#{
+            method => get, url => URL, query_params => QueryParams
+        }),
+    Data.
+
+audit_namespace_of(#{<<"http_request">> := #{<<"namespace">> := Ns}}) -> Ns.
 
 -doc """
 Verifies that rules referencing actions are restricted to their namespaces.

--- a/changes/ee/fix-18686.en.md
+++ b/changes/ee/fix-18686.en.md
@@ -1,0 +1,1 @@
+Audit records for authorization, authentication, connector, bridge, rule-engine and trace requests now identify the namespace a request targeted. Previously, these audit records looked identical across namespaces, so it was not possible to tell which namespace's resources a request affected. The audit log now also records any query parameters a request carried.


### PR DESCRIPTION
Fixes: <!-- github issue number if applicable -->
Release version: 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: 6.1.0

## Summary

Part of the same class of fix as #18664 (issue #18653): audit records for a namespaced
request never identified the namespace the request targeted, whether it came from an
explicit `?ns=` query parameter or was resolved implicitly from a namespaced admin's own
dashboard token. #18664 fixed this generically at the audit layer and fixed the one
reported instance (`emqx_topic_metrics2_api`) on `dev-63`.

This PR ports the same foundation fix to `dev-61` and extends it to six more modules that
share the exact same bug shape (confirmed via source inspection, not yet synced from
`dev-63`):

- `apps/emqx_auth_mnesia/src/emqx_authz_api_mnesia.erl`
- `apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl`
- `apps/emqx_bridge/src/emqx_bridge_v2_api.erl`
- `apps/emqx_connector/src/emqx_connector_api.erl`
- `apps/emqx_rule_engine/src/emqx_rule_engine_api.erl`
- `apps/emqx_management/src/emqx_mgmt_api_trace.erl`

Each module's `resolve_namespace/2` now calls a small `log_ns/1` helper right after
resolving the namespace, which records it via `minirest_handler:update_log_meta/1` for
the audit layer to pick up. The namespace-resolution logic itself is untouched.

**Why bundled into one PR**: the foundation diff
(`emqx_dashboard_audit.erl` + `emqx_audit_api.erl`) is a prerequisite every one of these
six module fixes needs, and it hasn't synced from `dev-63` back to `dev-61` yet (#18664
is still open). Six separate PRs would each carry their own copy of the foundation diff,
and whichever merged first would make the other five conflict on those two files. One PR
avoids that.

**Duplication across dev-60 / dev-61 / dev-62 (expected)**: sibling PRs from the same
initiative land around the same time on `dev-60` (`emqx_mgmt_api_data_backup.erl`) and
`dev-62` (`emqx_a2a_registry_api.erl`), each carrying its own copy of the same foundation
diff. Once all of these plus #18664 land and the normal sync chain catches up, the
duplicate diffs should reconcile as no-ops.

**Test harness note**: enabling `log.audit` via `emqx_cth_suite:start/2` needs
`schema_mod => emqx_enterprise_schema` on the `emqx_conf` app spec. The harness's default
`app_schema(emqx_conf)` resolves to the bare `emqx_conf_schema`, which does not declare
`log.audit` (only `emqx_enterprise_schema` does, matching what the release actually uses).
Same pattern as `emqx_audit_api_SUITE`.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)


