### PR TITLE
ci: bump the gcp-cli emulator image past Google's retention floor

### DIFF
--- a/.ci/docker-compose-file/docker-compose-gcp-emulator.yaml
+++ b/.ci/docker-compose-file/docker-compose-gcp-emulator.yaml
@@ -3,7 +3,7 @@ version: '3.9'
 services:
   gcp_emulator:
     container_name: gcp_emulator
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:435.0.1-emulators
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators
     restart: always
     expose:
       - "8085"


### PR DESCRIPTION
## Summary

Every `emqx_bridge_gcp_pubsub` CI job fails before any test runs:

```
Image gcr.io/google.com/cloudsdktool/google-cloud-cli:435.0.1-emulators
Error failed to resolve reference "...:435.0.1-emulators": ...: not found
```

Seen on multiple unrelated PRs, e.g. https://github.com/emqx/emqx/actions/runs/33476604750.

Queried `gcr.io/google.com/cloudsdktool/google-cloud-cli` anonymously (2034 tags currently
listed): the registry only retains tags from `537.0.0` up, of any variant. `435.0.1-emulators`
is well below that floor and is permanently gone — this is not a transient registry issue and
retrying does not help.

## Fix

Bump the pin in `docker-compose-gcp-emulator.yaml` to `582.0.0-emulators`, the newest tag at
the time of this fix (confirmed it resolves: `docker pull` succeeds, multi-arch OCI index,
`linux/amd64` + `linux/arm64`).

## Validation

Ran the full `emqx_bridge_gcp_pubsub` suite against the new image via
`./scripts/ct/run.sh --ci --app apps/emqx_bridge_gcp_pubsub`:

```
emqx_bridge_gcp_pubsub_consumer_SUITE:      28 ok, 0 failed
emqx_bridge_gcp_pubsub_producer_SUITE:      73 ok, 0 failed
emqx_bridge_v2_gcp_pubsub_consumer_SUITE:    7 ok, 0 failed
emqx_bridge_v2_gcp_pubsub_producer_SUITE:    8 ok, 0 failed
```

All 116 cases pass — the newer emulator is a drop-in replacement.

Base `dev-58`: this compose file is also pinned to `435.0.1-emulators` on `dev-59`/`dev-510`
(same value, will reach them via the v5 sync chain). `dev-60` and later already pin
`576.0.0-emulators`, which is still within the current retention floor and does not need this
change.