### PR TITLE
feat(readiness): let applications register readiness checks

### DIFF
--- a/apps/emqx/src/emqx_node_readiness.erl
+++ b/apps/emqx/src/emqx_node_readiness.erl
@@ -12,24 +12,22 @@ refuse to serve until the node is ready, so no client can connect
 before authentication, authorization and plugin hooks are installed.
 The `GET /status` REST API and cluster join checks read it too.
 
-The gate is closed while the node is booting and re-opened by the
-managed boot sequence (`emqx_machine_boot:ensure_apps_started/0`) once
-all applications (including plugins) are started.  Contexts that do
-not boot through `emqx_machine` (test suites) are therefore always
-ready.
+The readiness flag defaults to `true`.  The managed boot sequence
+(`emqx_machine_boot:ensure_apps_started/0`) clears it while the node
+boots and sets it back once all applications (including plugins) are
+started.  Contexts that do not boot through `emqx_machine` (test
+suites) never clear it and are therefore always ready.
 
-"All applications started" is not always the same as "this node can
-serve traffic", so applications can narrow the gate further by
-registering a predicate with `register_check/2`.  `is_ready/0` returns
-`true` only once boot has completed *and* every registered check
-returns `true`.
+An application can add a further condition by registering a predicate
+with `register_check/2`.  `is_ready/0` returns `true` only once boot
+has completed and every registered check returns `true`.
 
 Registered checks are evaluated on every `is_ready/0` call, and that
 happens once per incoming connection.  A check must therefore be
 cheap: poll in your own process and let the predicate read the cached
 answer.  A check that raises, or returns anything other than a
-boolean, holds the gate closed and is reported through a throttled
-`readiness_check_failed` log.
+boolean, makes `is_ready/0` return `false` and is reported through a
+throttled `readiness_check_failed` log.
 
 The registry is kept in a `persistent_term` and is updated with a
 read-modify-write, so registration is only safe from a serialized

--- a/apps/emqx/src/emqx_node_readiness.erl
+++ b/apps/emqx/src/emqx_node_readiness.erl
@@ -5,29 +5,59 @@
 -module(emqx_node_readiness).
 
 -moduledoc """
-Node readiness flag.
+Node readiness gate.
 
-Connection processes (MQTT and gateway) check this flag at init and
-refuse to serve until the node has finished booting, so no client can
-connect before authentication, authorization and plugin hooks are
-installed.  The `GET /status` REST API and cluster join checks read it
-too.
+Connection processes (MQTT and gateway) check this gate at init and
+refuse to serve until the node is ready, so no client can connect
+before authentication, authorization and plugin hooks are installed.
+The `GET /status` REST API and cluster join checks read it too.
 
-The flag defaults to `true`: only the managed boot sequence
-(`emqx_machine_boot:ensure_apps_started/0`) clears it and sets it back
-once all applications (including plugins) are started.  Contexts that
-do not boot through `emqx_machine` (test suites) are therefore always
+The gate is closed while the node is booting and re-opened by the
+managed boot sequence (`emqx_machine_boot:ensure_apps_started/0`) once
+all applications (including plugins) are started.  Contexts that do
+not boot through `emqx_machine` (test suites) are therefore always
 ready.
+
+"All applications started" is not always the same as "this node can
+serve traffic", so applications can narrow the gate further by
+registering a predicate with `register_check/2`.  `is_ready/0` returns
+`true` only once boot has completed *and* every registered check
+returns `true`.
+
+Registered checks are evaluated on every `is_ready/0` call, and that
+happens once per incoming connection.  A check must therefore be
+cheap: poll in your own process and let the predicate read the cached
+answer.  A check that raises, or returns anything other than a
+boolean, holds the gate closed and is reported through a throttled
+`readiness_check_failed` log.
+
+The registry is kept in a `persistent_term` and is updated with a
+read-modify-write, so registration is only safe from a serialized
+context — an application's `start/2` and `stop/1` callbacks, or a
+single owning process.  Deregister a check before purging the module
+that defines its fun.
 """.
 
+-include("logger.hrl").
+
 -export([is_ready/0, mark_ready/0, mark_not_ready/0]).
+-export([register_check/2, deregister_check/1]).
 
 -define(KEY, {?MODULE, ready}).
+-define(CHECKS, {?MODULE, checks}).
 
--doc "Return `true` once this node has finished booting.".
+-type check_name() :: atom() | binary() | {atom(), term()}.
+-type check() :: fun(() -> boolean()).
+
+-export_type([check_name/0, check/0]).
+
+-doc """
+Return `true` once this node has finished booting and every registered
+readiness check returns `true`.
+""".
 -spec is_ready() -> boolean().
 is_ready() ->
-    persistent_term:get(?KEY, true).
+    persistent_term:get(?KEY, true) andalso checks_pass().
 
 -doc "Mark the node as fully booted.".
 -spec mark_ready() -> ok.
@@ -38,3 +68,67 @@ mark_ready() ->
 -spec mark_not_ready() -> ok.
 mark_not_ready() ->
     persistent_term:put(?KEY, false).
+
+-doc """
+Register a readiness check under `Name`, replacing any check already
+registered under it.  While the check returns anything but `true` the
+node reports itself as not ready.
+""".
+-spec register_check(check_name(), check()) -> ok.
+register_check(Name, Check) when is_function(Check, 0) ->
+    persistent_term:put(?CHECKS, maps:put(Name, Check, checks())).
+
+-doc "Remove the readiness check registered under `Name`, if any.".
+-spec deregister_check(check_name()) -> ok.
+deregister_check(Name) ->
+    case checks() of
+        #{Name := _} = Checks ->
+            persistent_term:put(?CHECKS, maps:remove(Name, Checks));
+        _ ->
+            ok
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+checks() ->
+    persistent_term:get(?CHECKS, #{}).
+
+checks_pass() ->
+    case checks() of
+        Checks when map_size(Checks) =:= 0 ->
+            %% Common case: nothing registered, no iteration.
+            true;
+        Checks ->
+            checks_pass(maps:next(maps:iterator(Checks)))
+    end.
+
+checks_pass(none) ->
+    true;
+checks_pass({Name, Check, Iter}) ->
+    run_check(Name, Check) andalso checks_pass(maps:next(Iter)).
+
+run_check(Name, Check) ->
+    try Check() of
+        true ->
+            true;
+        false ->
+            false;
+        Other ->
+            log_failed(Name, #{reason => unexpected_return, returned => Other}),
+            false
+    catch
+        Class:Reason:Stacktrace ->
+            log_failed(Name, #{
+                reason => Class, details => Reason, stacktrace => Stacktrace
+            }),
+            false
+    end.
+
+log_failed(Name, Details) ->
+    ?SLOG_THROTTLE(
+        error,
+        Details#{msg => readiness_check_failed, check => Name},
+        #{}
+    ).

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -59,6 +59,8 @@ init_per_testcase(_Case, Config) ->
     Config.
 
 end_per_testcase(_Case, _Config) ->
+    _ = persistent_term:erase({emqx_node_readiness, checks}),
+    _ = [persistent_term:erase(K) || {{?MODULE, _} = K, _} <- persistent_term:get()],
     ok = emqx_node_readiness:mark_ready().
 
 -doc "The readiness flag defaults to true and toggles with mark_not_ready/mark_ready.".
@@ -142,6 +144,87 @@ t_gate_cluster_join(_Config) ->
     ),
     ok = emqx_node_readiness:mark_ready(),
     ?assertEqual(ok, emqx_cluster:can_i_join(node())).
+
+-doc "A registered check that does not return true holds the gate closed.".
+t_registered_check_holds_gate(_Config) ->
+    ?assert(emqx_node_readiness:is_ready()),
+    ok = set_check(actions, false),
+    ?assertNot(emqx_node_readiness:is_ready()),
+    ok = set_check(actions, true),
+    ?assert(emqx_node_readiness:is_ready()),
+    ok = set_check(actions, false),
+    ?assertNot(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:deregister_check(actions),
+    ?assert(emqx_node_readiness:is_ready()).
+
+-doc "Boot completion and every registered check must hold for the node to be ready.".
+t_boot_flag_and_checks_both_apply(_Config) ->
+    ok = set_check(actions, true),
+    ok = emqx_node_readiness:mark_not_ready(),
+    ?assertNot(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:mark_ready(),
+    ?assert(emqx_node_readiness:is_ready()),
+    ok = set_check(other, false),
+    ?assertNot(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:deregister_check(other),
+    ?assert(emqx_node_readiness:is_ready()).
+
+-doc "Registering the same name twice replaces the check rather than adding one.".
+t_register_check_replaces(_Config) ->
+    ok = set_check(actions, false),
+    ?assertNot(emqx_node_readiness:is_ready()),
+    ok = set_check(actions, true),
+    ?assert(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:deregister_check(actions),
+    ?assert(emqx_node_readiness:is_ready()).
+
+-doc "Deregistering a name that was never registered is a no-op.".
+t_deregister_unknown_check(_Config) ->
+    ?assertEqual(ok, emqx_node_readiness:deregister_check(never_registered)),
+    ?assert(emqx_node_readiness:is_ready()),
+    ok = set_check(actions, true),
+    ?assertEqual(ok, emqx_node_readiness:deregister_check(never_registered)),
+    ?assert(emqx_node_readiness:is_ready()).
+
+-doc """
+A check that raises, or returns a non-boolean, holds the gate closed and is
+reported through the throttled readiness_check_failed log.
+""".
+t_broken_check_holds_gate(_Config) ->
+    ok = emqx_node_readiness:register_check(raising, fun() -> error(badcheck) end),
+    ?assertNot(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:deregister_check(raising),
+    ?assert(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:register_check(bad_return, fun() -> maybe_ready end),
+    ?assertNot(emqx_node_readiness:is_ready()),
+    ok = emqx_node_readiness:deregister_check(bad_return),
+    ?assert(emqx_node_readiness:is_ready()).
+
+-doc "A registered check that does not pass refuses a TCP MQTT connection.".
+t_check_gates_tcp_connection(_Config) ->
+    ok = set_check(actions, false),
+    ?assertMatch({error, _}, try_connect(fun emqtt:connect/1, #{port => ?TCP_PORT})),
+    Bind = emqx_config:get([listeners, tcp, default, bind]),
+    ?retry(
+        100,
+        10,
+        ?assertMatch(
+            {node_not_ready, _},
+            lists:keyfind(
+                node_not_ready, 1, emqx_listeners:shutdown_count(<<"tcp:default">>, Bind)
+            )
+        )
+    ),
+    ok = set_check(actions, true),
+    ?assertEqual(ok, try_connect(fun emqtt:connect/1, #{port => ?TCP_PORT})).
+
+%% Register a check under `Name` that answers `Answer`, the way a real consumer
+%% would: the predicate reads a cached value rather than doing work per call.
+set_check(Name, Answer) ->
+    persistent_term:put({?MODULE, Name}, Answer),
+    emqx_node_readiness:register_check(Name, fun() ->
+        persistent_term:get({?MODULE, Name})
+    end).
 
 try_connect(ConnFun, Opts0) ->
     Opts = maps:merge(#{host => "127.0.0.1", connect_timeout => 5}, Opts0),

--- a/apps/emqx/test/emqx_node_readiness_SUITE.erl
+++ b/apps/emqx/test/emqx_node_readiness_SUITE.erl
@@ -145,7 +145,7 @@ t_gate_cluster_join(_Config) ->
     ok = emqx_node_readiness:mark_ready(),
     ?assertEqual(ok, emqx_cluster:can_i_join(node())).
 
--doc "A registered check that does not return true holds the gate closed.".
+-doc "A registered check that does not return true makes `is_ready/0` return false.".
 t_registered_check_holds_gate(_Config) ->
     ?assert(emqx_node_readiness:is_ready()),
     ok = set_check(actions, false),
@@ -187,8 +187,8 @@ t_deregister_unknown_check(_Config) ->
     ?assert(emqx_node_readiness:is_ready()).
 
 -doc """
-A check that raises, or returns a non-boolean, holds the gate closed and is
-reported through the throttled readiness_check_failed log.
+A check that raises, or returns a non-boolean, makes is_ready/0 return false
+and is reported through the throttled readiness_check_failed log.
 """.
 t_broken_check_holds_gate(_Config) ->
     ok = emqx_node_readiness:register_check(raising, fun() -> error(badcheck) end),
@@ -218,8 +218,8 @@ t_check_gates_tcp_connection(_Config) ->
     ok = set_check(actions, true),
     ?assertEqual(ok, try_connect(fun emqtt:connect/1, #{port => ?TCP_PORT})).
 
-%% Register a check under `Name` that answers `Answer`, the way a real consumer
-%% would: the predicate reads a cached value rather than doing work per call.
+%% Register a check under `Name` that returns `Answer`.  The answer is kept in
+%% a persistent_term, so the check itself only reads a cached value.
 set_check(Name, Answer) ->
     persistent_term:put({?MODULE, Name}, Answer),
     emqx_node_readiness:register_check(Name, fun() ->

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -133,6 +133,7 @@
     gcp_pubsub_consumer_worker_pull_error,
     handle_resource_metrics_failed,
     mq_message_db_key_expression_error,
+    readiness_check_failed,
     resource_exception,
     retain_failed_for_payload_size_exceeded_limit,
     retain_failed_for_rate_exceeded_limit,


### PR DESCRIPTION
Release version: 7.0.0

Introduced in: N/A

## Summary

Part 1 of https://github.com/emqx/emqx/issues/18626 — the readiness-check registry
only. `emqx_node_readiness:register_check/2` and `deregister_check/1`; `is_ready/0`
returns true only once boot has completed and every registered check returns true.

The registry lives in the same `persistent_term` the flag already uses, so `is_ready/0`
stays lock-free. It is read once per incoming connection — `emqx_connection`,
`emqx_ws_connection`, `emqx_quic_connection`, `emqx_socket_connection` and
`emqx_gateway_conn` all call it at init — so an empty registry short-circuits on
`map_size/1`, and the moduledoc says a check has to be cheap. Registration is a
read-modify-write, so it is documented as safe only from a serialized context (an
application's `start/2`/`stop/1`); adding a process to serialize it looked heavier than
the problem.

A check that raises, or returns a non-boolean, holds the gate closed — it did not
"return true". That is the opposite of the module's existing
`persistent_term:get(?KEY, true)` default, so say the word if you would rather have it
fail open. Either way it is reported through a throttled `readiness_check_failed`, which
is the one atom added to `?LOG_THROTTLING_MSGS`.

No consumer here, so nothing user-visible changes and there is no changelog entry; that
belongs with part 2.

Part 2 is not in this PR: it needs the three open questions answered, and @keynslug's
objection on the thread is unanswered. One thing from the query path that bears on it —
`is_channel_apt_for_queries/1` already passes `connecting`, and a channel is
`disconnected` only until `on_add_channel/4` returns, so the loss window is "channel not
installed" rather than "action not connected". Gating on installed closes the same window
without deriving readiness from external reachability.

Tests: `emqx_node_readiness_SUITE` 12/12 (6 new), `emqx_log_throttler_SUITE` 6/6,
`emqx_machine_SUITE` 6/6, `emqx_conf_schema_tests` 50/50.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log — none; no user-visible behaviour without a consumer
- [x] Schema changes are backward compatible or intentionally breaking (additive: one atom added to the `log.throttling.msgs` enum and its default)
