### PR TITLE
ci: bump the gcp-cli emulator image past Google's retention floor

### DIFF
--- a/.ci/docker-compose-file/docker-compose-gcp-bigtable.yaml
+++ b/.ci/docker-compose-file/docker-compose-gcp-bigtable.yaml
@@ -12,7 +12,7 @@ services:
 
   gcp-emulator-bigtable:
     container_name: gcp-emulator-bigtable
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:533.0.0-emulators
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators
     restart: always
     expose:
       - "8086"


### PR DESCRIPTION
## Summary

Every `emqx_bridge_bigtable` CI job fails before any test runs:

```
Image gcr.io/google.com/cloudsdktool/google-cloud-cli:533.0.0-emulators
Error failed to resolve reference "...:533.0.0-emulators": ...: not found
```

Seen on multiple unrelated PRs, e.g. https://github.com/emqx/emqx/actions/runs/33477860297.

Queried `gcr.io/google.com/cloudsdktool/google-cloud-cli` anonymously (2034 tags currently
listed): the registry only retains tags from `537.0.0` up, of any variant. `533.0.0-emulators`
is just below that floor and is permanently gone — not a transient registry issue, retrying
does not help.

## Fix

Bump the pin in `docker-compose-gcp-bigtable.yaml` to `582.0.0-emulators`, the newest tag at
the time of this fix (confirmed it resolves: `docker pull` succeeds, multi-arch OCI index,
`linux/amd64` + `linux/arm64`). Same tag `docker-compose-gcp-emulator.yaml` already uses on
dev-60 and later.

## Validation

Ran the full `emqx_bridge_bigtable` suite against the new image via
`./scripts/ct/run.sh --ci --app apps/emqx_bridge_bigtable`:

```
emqx_bridge_bigtable_SUITE: 34 ok, 0 failed
```

Base `dev-63`: `docker-compose-gcp-bigtable.yaml` exists only on `dev-63` and `dev-70` (the
`emqx_bridge_bigtable` app doesn't exist on earlier branches); `dev-63` forward-syncs into
`dev-70`.