### PR TITLE
fix(audit): stringify SSO source in GET /audit response

### DIFF
--- a/apps/emqx_audit/src/emqx_audit.app.src
+++ b/apps/emqx_audit/src/emqx_audit.app.src
@@ -1,6 +1,6 @@
 {application, emqx_audit, [
     {description, "Audit log for EMQX"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {mod, {emqx_audit_app, []}},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_audit/src/emqx_audit_api.erl
+++ b/apps/emqx_audit/src/emqx_audit_api.erl
@@ -328,7 +328,7 @@ format(Audit) ->
         created_at => emqx_utils_calendar:epoch_to_rfc3339(CreatedAt, microsecond),
         node => Node,
         from => From,
-        source => Source,
+        source => stringify_source(Source),
         source_ip => SourceIp,
         operation_id => OperationId,
         operation_type => OperationType,
@@ -340,6 +340,14 @@ format(Audit) ->
         failure => Failure,
         http_request => HttpRequest
     }.
+
+%% SSO admin sessions carry `source' as `{Backend, Username}' (see
+%% ?SSO_USERNAME in emqx_dashboard.hrl); flatten it to a binary for the
+%% swagger schema, which declares this field as `binary()'.
+stringify_source({Backend, Name}) when is_atom(Backend), is_binary(Name) ->
+    <<(atom_to_binary(Backend))/binary, ":", Name/binary>>;
+stringify_source(Source) when is_binary(Source) ->
+    Source.
 
 audit_log_list_example() ->
     #{

--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -8,7 +8,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
--include("../../emqx_dashboard/include/emqx_dashboard.hrl").
+-include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
 
 all() ->
     [

--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -8,6 +8,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include("../../emqx_dashboard/include/emqx_dashboard.hrl").
 
 all() ->
     [
@@ -353,6 +354,48 @@ t_license_key_redacted(_) ->
     ?assertEqual(nomatch, binary:match(AuditBody, <<"default">>), AuditBody),
     ?assertNotEqual(nomatch, binary:match(AuditBody, <<"******">>), AuditBody),
     ok.
+
+%% `GET /audit' must not 500 when a page contains a record created by an
+%% SSO-authenticated admin: `source' is `{Backend, Username}' (see
+%% ?SSO_USERNAME), not a plain binary. See emqx/emqx#18687.
+t_sso_source_json_encoding(_Config) ->
+    SsoBackend = saml,
+    SsoUser = <<"jackson-http@example.com">>,
+    SsoUsername = ?SSO_USERNAME(SsoBackend, SsoUser),
+    {ok, _} = emqx_dashboard_admin:add_sso_user(SsoBackend, SsoUser, ?ROLE_SUPERUSER, <<>>),
+    {ok, #{role := ?ROLE_SUPERUSER, token := SsoToken}} =
+        emqx_dashboard_admin:sign_token(SsoUsername, <<>>),
+    SsoAuthHeader = bearer_auth_header(SsoToken),
+
+    StartAt = erlang:system_time(microsecond),
+    {ok, Zones} = emqx_mgmt_api_configs_SUITE:get_global_zone(),
+    NewZones = emqx_utils_maps:deep_put([<<"mqtt">>, <<"max_qos_allowed">>], Zones, 2),
+    ConfigsPath = emqx_mgmt_api_test_util:api_path(["configs", "global_zone"]),
+    {ok, 200, _} = emqx_mgmt_api_test_util:request_api_with_body(
+        put, ConfigsPath, SsoAuthHeader, NewZones
+    ),
+
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Query = lists:flatten(
+        io_lib:format("operation_id=/configs/global_zone&gte_created_at=~B&limit=1", [StartAt])
+    ),
+    Res = wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, 2000),
+    ?assertMatch(
+        #{
+            <<"data">> := [
+                #{
+                    <<"source">> := <<"saml:jackson-http@example.com">>,
+                    <<"operation_id">> := <<"/configs/global_zone">>
+                }
+            ]
+        },
+        emqx_utils_json:decode(Res, [return_maps])
+    ),
+    ok.
+
+bearer_auth_header(Token) ->
+    {"Authorization", "Bearer " ++ binary_to_list(Token)}.
 
 wait_for_matching_audit_entry(_AuditPath, _Query, _AuthHeader, RemainMs) when RemainMs =< 0 ->
     ct:fail(audit_entry_not_found_in_time);

--- a/changes/ee/fix-18694.en.md
+++ b/changes/ee/fix-18694.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where querying the audit log could return an error for records created by SSO-authenticated users.


### PR DESCRIPTION
Release versions:
5.10.5

Introduced in:
5.10.4

## Summary

`GET /api/v5/audit` returned HTTP 500 (`invalid json term`) whenever a page contained an audit record created by an SSO-authenticated admin. The `source` field for such records is `{Backend, Username}` (see `?SSO_USERNAME` in `emqx_dashboard.hrl`), not a binary, and the audit API passed it straight into the JSON response without stringifying it. One bad record failed the whole page for every caller, not just the SSO user.

The fix stringifies the tuple at the audit-record → JSON-response boundary only, as `"<backend>:<username>"` (e.g. `"saml:jackson-http@example.com"`). `auth_meta.source` stays a tuple everywhere else, since other code (e.g. `emqx_dashboard_api:caller_admin/1`) depends on that shape.

Fixes emqx/emqx#18687.

This is the v5 (dev-510) follow-up to the same fix landing on dev-63 (flagged as a 6.3.0 release blocker) and dev-60. dev-58 was investigated and deliberately excluded — it doesn't have the vulnerable tuple-shaped `source` code path.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
