### PR TITLE
fix(audit): stringify SSO source in GET /audit responses

### DIFF
--- a/apps/emqx_audit/mix.exs
+++ b/apps/emqx_audit/mix.exs
@@ -25,6 +25,7 @@ defmodule EMQXAudit.MixProject do
     UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
+      {:emqx_dashboard, in_umbrella: true, runtime: false},
       :minirest
     ])
   end

--- a/apps/emqx_audit/src/emqx_audit_api.erl
+++ b/apps/emqx_audit/src/emqx_audit_api.erl
@@ -326,7 +326,7 @@ format(Audit) ->
         created_at => emqx_utils_calendar:epoch_to_rfc3339(CreatedAt, microsecond),
         node => Node,
         from => From,
-        source => Source,
+        source => emqx_dashboard_admin:format_username(Source),
         source_ip => SourceIp,
         operation_id => OperationId,
         operation_type => OperationType,

--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -5,7 +5,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include("../../emqx_dashboard/include/emqx_dashboard.hrl").
+-include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 

--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -5,6 +5,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+-include("../../emqx_dashboard/include/emqx_dashboard.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
@@ -104,6 +105,53 @@ t_http_api(_) ->
             ]
         },
         emqx_utils_json:decode(Res1)
+    ),
+    ok.
+
+-doc """
+GET /audit must not 500 when a page includes a record written by an
+SSO-authenticated user, whose `auth_meta.source` is `{Backend, Name}`
+instead of a plain binary.
+""".
+t_http_api_sso_source(_) ->
+    process_flag(trap_exit, true),
+    SsoBackend = saml,
+    SsoUser = <<"jackson-http@example.com">>,
+    Desc = <<"desc">>,
+    SsoUsername = ?SSO_USERNAME(SsoBackend, SsoUser),
+    {ok, _} = emqx_dashboard_admin:add_sso_user(SsoBackend, SsoUser, ?ROLE_SUPERUSER, Desc),
+    {ok, #{role := ?ROLE_SUPERUSER, token := SsoToken}} =
+        emqx_dashboard_admin:sign_token(SsoUsername, <<>>),
+    SsoAuthHeader = {"Authorization", "Bearer " ++ binary_to_list(SsoToken)},
+    StartAt = erlang:system_time(microsecond),
+    {ok, Zones} = emqx_mgmt_api_configs_SUITE:get_global_zone(),
+    NewZones = emqx_utils_maps:deep_put([<<"mqtt">>, <<"max_qos_allowed">>], Zones, 1),
+    ConfigsPath = emqx_mgmt_api_test_util:api_path(["configs", "global_zone"]),
+    {ok, _} = emqx_mgmt_api_test_util:request_api(
+        put, ConfigsPath, "", SsoAuthHeader, NewZones
+    ),
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Query =
+        lists:flatten(
+            io_lib:format(
+                "from=dashboard&operation_id=/configs/global_zone&gte_created_at=~B&limit=1",
+                [StartAt]
+            )
+        ),
+    %% Before the fix, this GET fails with 500 (invalid json term) because
+    %% `format/1` passed the tuple `source` straight to the JSON encoder.
+    Res = wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, 2000),
+    ?assertMatch(
+        #{
+            <<"data">> := [
+                #{
+                    <<"operation_id">> := <<"/configs/global_zone">>,
+                    <<"source">> := <<"saml:jackson-http@example.com">>
+                }
+            ]
+        },
+        emqx_utils_json:decode(Res)
     ),
     ok.
 

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -27,6 +27,7 @@
 -export([get_namespace/1]).
 
 -include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
 -include_lib("emqx_dashboard/include/emqx_dashboard_rbac.hrl").
 -include_lib("emqx_utils/include/emqx_http_api.hrl").
 -include_lib("emqx/include/emqx_release.hrl").
@@ -49,7 +50,7 @@
 
 -type auth_meta() :: #{
     auth_type := jwt_token | api_key,
-    source := binary(),
+    source := dashboard_username(),
     namespace := ?global_ns | binary(),
     actor := emqx_dashboard_rbac:actor_context()
 }.

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -75,6 +75,8 @@
 
 -export([role/1, namespace_of/1]).
 
+-export([format_username/1]).
+
 -export([to_external_user/1]).
 
 -export([backup_tables/0]).
@@ -1159,6 +1161,12 @@ flatten_username(#{username := ?SSO_USERNAME(Backend, Name)} = Data) ->
     };
 flatten_username(#{username := Username} = Data) when is_binary(Username) ->
     Data#{backend => ?BACKEND_LOCAL}.
+
+-spec format_username(dashboard_username()) -> binary().
+format_username(?SSO_USERNAME(Backend, Name)) ->
+    iolist_to_binary([atom_to_binary(Backend), <<":">>, Name]);
+format_username(Username) when is_binary(Username) ->
+    Username.
 
 -spec add_sso_user(dashboard_sso_backend(), binary(), dashboard_user_role(), binary()) ->
     {ok, map()} | {error, any()}.

--- a/changes/ee/fix-18697.en.md
+++ b/changes/ee/fix-18697.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where querying the audit log could return an error for records created by SSO-authenticated users.


### PR DESCRIPTION
Fixes: #18687
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: 6.0.3

## Summary

`GET /api/v5/audit` returned HTTP 500 (`invalid json term`) whenever a page included an audit record created by an SSO-authenticated dashboard user. For such users, `auth_meta.source` is the tuple `{Backend, Name}` instead of a binary, and `emqx_audit_api:format/1` passed it straight into the response map even though the swagger schema for that field already declares `binary()`. A single such record failed the whole page for every caller.

Fix:
- Add `emqx_dashboard_admin:format_username/1`, which folds `{Backend, Name}` into the binary `"Backend:Name"` and passes plain binaries through unchanged.
- Call it from `emqx_audit_api:format/1` at the audit-record-to-JSON boundary, replacing `source => Source` with `source => emqx_dashboard_admin:format_username(Source)`.

`auth_meta.source` keeps its tuple shape everywhere else — other code (e.g. admin lookup in `emqx_dashboard_api:caller_admin/1`) depends on that shape.

This is the dev-60 follow-up to the same fix landing on dev-63 (flagged as a 6.3.0 release blocker) and dev-510.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
