### PR TITLE
fix(gateway): preserve redacted NATS authn secrets

### DIFF
--- a/apps/emqx_gateway/src/emqx_gateway_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_conf.erl
@@ -404,9 +404,14 @@ pre_config_update(?GATEWAY, {update_gateway, GwName, Conf}, RawConf) ->
             badres_gateway(not_found, GwName);
         GwRawConf ->
             Conf1 = maps:without(?IGNORE_KEYS, Conf),
-            NConf = tune_gw_certs(fun convert_certs/2, GwName, Conf1),
-            NConf1 = maps:merge(GwRawConf, NConf),
-            {ok, emqx_utils_maps:deep_put([GwName], RawConf, NConf1)}
+            case emqx_gateway_schema:deobfuscate(GwName, Conf1, GwRawConf) of
+                {ok, Conf2} ->
+                    NConf = tune_gw_certs(fun convert_certs/2, GwName, Conf2),
+                    NConf1 = maps:merge(GwRawConf, NConf),
+                    {ok, emqx_utils_maps:deep_put([GwName], RawConf, NConf1)};
+                {error, _} = Error ->
+                    Error
+            end
     end;
 pre_config_update(?GATEWAY, {unload_gateway, GwName}, RawConf) ->
     {ok, maps:remove(GwName, RawConf)};

--- a/apps/emqx_gateway/src/emqx_gateway_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_conf.erl
@@ -530,8 +530,7 @@ pre_config_update(?GATEWAY, NewRawConf0 = #{}, OldRawConf = #{}) ->
     %% load all listeners
     NewRawConf2 = pre_load_listeners(NewRawConf1, OldRawConf),
     %% load all gateway
-    NewRawConf3 = pre_load_gateways(NewRawConf2, OldRawConf),
-    {ok, NewRawConf3};
+    pre_load_gateways(NewRawConf2, OldRawConf);
 pre_config_update(Path, UnknownReq, _RawConf) ->
     ?SLOG(error, #{
         msg => "unknown_gateway_update_request",
@@ -552,26 +551,40 @@ pre_load_gateways(NewConf, OldConf) ->
         OldConf
     ),
     %% load/update gateways
-    maps:map(
-        fun(GwName, NewGwConf) ->
-            case maps:find(GwName, OldConf) of
-                {ok, NewGwConf} ->
-                    NewGwConf;
-                {ok, _OldGwConf} ->
-                    {ok, #{GwName := NewGwConf1}} = pre_config_update(
-                        ?GATEWAY, {update_gateway, GwName, NewGwConf}, OldConf
-                    ),
-                    %% update gateway should pass through ignore keys(listener/authn)
-                    PassThroughConf = maps:with(?IGNORE_KEYS, NewGwConf),
-                    NewGwConf2 = maps:without(?IGNORE_KEYS, NewGwConf1),
-                    maps:merge(NewGwConf2, PassThroughConf);
-                error ->
-                    {ok, #{GwName := NewGwConf1}} = pre_config_update(
-                        ?GATEWAY, {load_gateway, GwName, NewGwConf}, OldConf
-                    ),
-                    NewGwConf1
-            end
+    maps:fold(
+        fun
+            (_GwName, _NewGwConf, {error, _} = Error) ->
+                Error;
+            (GwName, NewGwConf, {ok, Acc}) ->
+                case maps:find(GwName, OldConf) of
+                    {ok, NewGwConf} ->
+                        {ok, Acc#{GwName => NewGwConf}};
+                    {ok, _OldGwConf} ->
+                        case
+                            pre_config_update(
+                                ?GATEWAY, {update_gateway, GwName, NewGwConf}, OldConf
+                            )
+                        of
+                            {ok, #{GwName := NewGwConf1}} ->
+                                %% update gateway should pass through ignore keys(listener/authn)
+                                PassThroughConf = maps:with(?IGNORE_KEYS, NewGwConf),
+                                NewGwConf2 = maps:without(?IGNORE_KEYS, NewGwConf1),
+                                {ok, Acc#{GwName => maps:merge(NewGwConf2, PassThroughConf)}};
+                            {error, _} = Error ->
+                                Error
+                        end;
+                    error ->
+                        case
+                            pre_config_update(?GATEWAY, {load_gateway, GwName, NewGwConf}, OldConf)
+                        of
+                            {ok, #{GwName := NewGwConf1}} ->
+                                {ok, Acc#{GwName => NewGwConf1}};
+                            {error, _} = Error ->
+                                Error
+                        end
+                end
         end,
+        {ok, #{}},
         NewConf
     ).
 

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -39,7 +39,14 @@
 
 -export([proxy_protocol_opts/0]).
 
--export([mountpoint/0, mountpoint/1, gateway_common_options/0, gateway_schema/1, gateway_names/0]).
+-export([
+    mountpoint/0,
+    mountpoint/1,
+    gateway_common_options/0,
+    gateway_schema/1,
+    deobfuscate/3,
+    gateway_names/0
+]).
 
 -export([ws_listener/0, wss_listener/0, ws_opts/1]).
 
@@ -501,6 +508,39 @@ gateway_schema(Name) ->
         {error, _} = Error ->
             throw(Error)
     end.
+
+deobfuscate(Name0, NewRawConf, OldRawConf) ->
+    case find_gateway_definition(Name0) of
+        {ok, #{config_schema_module := SchemaMod}} ->
+            ok = emqx_utils:interactive_load(SchemaMod),
+            case erlang:function_exported(SchemaMod, deobfuscate, 2) of
+                true ->
+                    SchemaMod:deobfuscate(NewRawConf, OldRawConf);
+                false ->
+                    {ok, NewRawConf}
+            end;
+        {error, _} ->
+            {ok, NewRawConf}
+    end.
+
+find_gateway_definition(Name) when is_atom(Name) ->
+    emqx_gateway_utils:find_gateway_definition(Name);
+find_gateway_definition(Name) when is_binary(Name) ->
+    case
+        lists:search(
+            fun(#{name := GatewayName}) ->
+                atom_to_binary(GatewayName, utf8) =:= Name
+            end,
+            emqx_gateway_utils:find_gateway_definitions()
+        )
+    of
+        {value, Definition} ->
+            {ok, Definition};
+        false ->
+            {error, not_found}
+    end;
+find_gateway_definition(_Name) ->
+    {error, invalid_name}.
 
 gateway_names() ->
     [Name || #{name := Name} <- emqx_gateway_utils:find_gateway_definitions()].

--- a/apps/emqx_gateway_nats/src/emqx_nats_schema.erl
+++ b/apps/emqx_gateway_nats/src/emqx_nats_schema.erl
@@ -9,7 +9,7 @@
 -include_lib("typerefl/include/types.hrl").
 
 %% config schema provides
--export([namespace/0, fields/1, desc/1]).
+-export([namespace/0, fields/1, desc/1, deobfuscate/2]).
 
 namespace() -> "gateway".
 
@@ -236,8 +236,216 @@ desc(wss_listener) ->
 desc(websocket) ->
     ?DESC(websocket).
 
+deobfuscate(NewConf, OldConf) when is_map(NewConf), is_map(OldConf) ->
+    case map_get_any(NewConf, [internal_authn, <<"internal_authn">>], undefined) of
+        undefined ->
+            {ok, NewConf};
+        NewMethods ->
+            OldMethods = map_get_any(OldConf, [internal_authn, <<"internal_authn">>], []),
+            case deobfuscate_internal_authn(NewMethods, OldMethods) of
+                {ok, Methods} ->
+                    {ok, put_map_value(NewConf, internal_authn, Methods)};
+                {error, _} = Error ->
+                    Error
+            end
+    end;
+deobfuscate(NewConf, _OldConf) ->
+    {ok, NewConf}.
+
 %%--------------------------------------------------------------------
 %% internal functions
+
+deobfuscate_internal_authn(NewMethods, OldMethods) when
+    is_list(NewMethods), is_list(OldMethods)
+->
+    deobfuscate_internal_authn(NewMethods, OldMethods, 1, []);
+deobfuscate_internal_authn(NewMethods, _OldMethods) ->
+    {ok, NewMethods}.
+
+deobfuscate_internal_authn([], _OldMethods, _Pos, Acc) ->
+    {ok, lists:reverse(Acc)};
+deobfuscate_internal_authn([NewMethod | Rest], [OldMethod | OldRest], Pos, Acc) ->
+    NewType = method_type(NewMethod),
+    OldType = method_type(OldMethod),
+    case NewType =:= OldType andalso NewType =/= undefined of
+        true ->
+            case deobfuscate_method(NewMethod, OldMethod, NewType, Pos) of
+                {ok, Method} ->
+                    deobfuscate_internal_authn(Rest, OldRest, Pos + 1, [Method | Acc]);
+                {error, _} = Error ->
+                    Error
+            end;
+        false ->
+            case reject_redacted_method(NewMethod, Pos) of
+                ok ->
+                    deobfuscate_internal_authn(Rest, OldRest, Pos + 1, [NewMethod | Acc]);
+                {error, _} = Error ->
+                    Error
+            end
+    end;
+deobfuscate_internal_authn([NewMethod | Rest], [], Pos, Acc) ->
+    case reject_redacted_method(NewMethod, Pos) of
+        ok ->
+            deobfuscate_internal_authn(Rest, [], Pos + 1, [NewMethod | Acc]);
+        {error, _} = Error ->
+            Error
+    end.
+
+deobfuscate_method(NewMethod0, OldMethod0, token, Pos) ->
+    NewMethod = emqx_utils_maps:binary_key_map(NewMethod0),
+    OldMethod = emqx_utils_maps:binary_key_map(OldMethod0),
+    case is_redacted_field(NewMethod, token, <<"token">>) of
+        true when is_map_key(<<"token">>, OldMethod); is_map_key(token, OldMethod) ->
+            {ok, emqx_utils:deobfuscate(NewMethod, OldMethod)};
+        true ->
+            redacted_method_error(Pos, token);
+        false ->
+            {ok, NewMethod}
+    end;
+deobfuscate_method(NewMethod0, OldMethod0, jwt, Pos) ->
+    NewMethod = emqx_utils:deobfuscate(
+        emqx_utils_maps:binary_key_map(NewMethod0),
+        emqx_utils_maps:binary_key_map(OldMethod0)
+    ),
+    deobfuscate_jwt_resolver(NewMethod, OldMethod0, Pos);
+deobfuscate_method(NewMethod, _OldMethod, _Type, _Pos) ->
+    {ok, NewMethod}.
+
+deobfuscate_jwt_resolver(NewMethod, OldMethod0, Pos) ->
+    OldMethod = emqx_utils_maps:binary_key_map(OldMethod0),
+    NewResolver = map_get_any(NewMethod, [resolver, <<"resolver">>], undefined),
+    OldResolver = map_get_any(OldMethod, [resolver, <<"resolver">>], #{}),
+    case {is_map(NewResolver), is_map(OldResolver)} of
+        {true, true} ->
+            NewEntries = map_get_any(
+                NewResolver,
+                [resolver_preload, <<"resolver_preload">>],
+                []
+            ),
+            OldEntries = map_get_any(
+                OldResolver,
+                [resolver_preload, <<"resolver_preload">>],
+                []
+            ),
+            case deobfuscate_jwt_entries(NewEntries, OldEntries, Pos) of
+                {ok, Entries} ->
+                    Resolver = put_map_value(NewResolver, resolver_preload, Entries),
+                    {ok, put_map_value(NewMethod, resolver, Resolver)};
+                {error, _} = Error ->
+                    Error
+            end;
+        _ ->
+            {ok, NewMethod}
+    end.
+
+deobfuscate_jwt_entries(NewEntries, OldEntries, Pos) when
+    is_list(NewEntries), is_list(OldEntries)
+->
+    OldIndex = maps:from_list([
+        {PubKey, Entry}
+     || Entry <- OldEntries,
+        is_map(Entry),
+        PubKey <- [map_get_any(Entry, [pubkey, <<"pubkey">>], undefined)],
+        PubKey =/= undefined
+    ]),
+    deobfuscate_jwt_entries(NewEntries, OldIndex, Pos, 1, []);
+deobfuscate_jwt_entries(NewEntries, _OldEntries, _Pos) ->
+    {ok, NewEntries}.
+
+deobfuscate_jwt_entries([], _OldIndex, _MethodPos, _EntryPos, Acc) ->
+    {ok, lists:reverse(Acc)};
+deobfuscate_jwt_entries([NewEntry0 | Rest], OldIndex, MethodPos, EntryPos, Acc) ->
+    NewEntry = emqx_utils_maps:binary_key_map(NewEntry0),
+    PubKey = map_get_any(NewEntry, [pubkey, <<"pubkey">>], undefined),
+    OldEntry = maps:get(PubKey, OldIndex, #{}),
+    case is_redacted_field(NewEntry, jwt, <<"jwt">>) of
+        true when is_map_key(<<"jwt">>, OldEntry); is_map_key(jwt, OldEntry) ->
+            Entry = emqx_utils:deobfuscate(NewEntry, OldEntry),
+            deobfuscate_jwt_entries(Rest, OldIndex, MethodPos, EntryPos + 1, [Entry | Acc]);
+        true ->
+            redacted_entry_error(MethodPos, EntryPos, jwt);
+        false ->
+            deobfuscate_jwt_entries(Rest, OldIndex, MethodPos, EntryPos + 1, [NewEntry | Acc])
+    end.
+
+reject_redacted_method(Method, Pos) ->
+    case is_redacted_field(Method, token, <<"token">>) of
+        true ->
+            redacted_method_error(Pos, token);
+        false ->
+            case has_redacted_jwt(Method) of
+                true ->
+                    redacted_method_error(Pos, jwt);
+                false ->
+                    ok
+            end
+    end.
+
+has_redacted_jwt(Method) when is_map(Method) ->
+    Resolver = map_get_any(Method, [resolver, <<"resolver">>], #{}),
+    case is_map(Resolver) of
+        true ->
+            Entries = map_get_any(Resolver, [resolver_preload, <<"resolver_preload">>], []),
+            lists:any(
+                fun(Entry) ->
+                    is_map(Entry) andalso is_redacted_field(Entry, jwt, <<"jwt">>)
+                end,
+                Entries
+            );
+        false ->
+            false
+    end;
+has_redacted_jwt(_Method) ->
+    false.
+
+method_type(Method) when is_map(Method) ->
+    case map_get_any(Method, [type, <<"type">>], undefined) of
+        token -> token;
+        <<"token">> -> token;
+        nkey -> nkey;
+        <<"nkey">> -> nkey;
+        jwt -> jwt;
+        <<"jwt">> -> jwt;
+        _ -> undefined
+    end;
+method_type(_Method) ->
+    undefined.
+
+is_redacted_field(Map, AtomKey, BinaryKey) when is_map(Map) ->
+    case map_get_any(Map, [AtomKey, BinaryKey], undefined) of
+        undefined ->
+            false;
+        Value ->
+            emqx_utils:is_redacted(AtomKey, Value) orelse
+                emqx_utils:is_redacted(BinaryKey, Value)
+    end;
+is_redacted_field(_Map, _AtomKey, _BinaryKey) ->
+    false.
+
+put_map_value(Map, AtomKey, Value) ->
+    BinaryKey = atom_to_binary(AtomKey, utf8),
+    case maps:is_key(BinaryKey, Map) of
+        true -> maps:put(BinaryKey, Value, Map);
+        false -> maps:put(AtomKey, Value, Map)
+    end.
+
+redacted_method_error(Pos, Field) ->
+    {error,
+        {badconf, #{
+            key => internal_authn,
+            reason => masked_secret_without_matching_old_value,
+            position => Pos,
+            field => Field
+        }}}.
+
+redacted_entry_error(MethodPos, EntryPos, Field) ->
+    {error,
+        {badconf, #{
+            key => internal_authn,
+            reason => masked_secret_without_matching_old_value,
+            position => {MethodPos, EntryPos},
+            field => Field
+        }}}.
 
 validate_internal_authn(Methods) when is_list(Methods) ->
     validate_internal_authn(Methods, 1);

--- a/apps/emqx_gateway_nats/src/emqx_nats_schema.erl
+++ b/apps/emqx_gateway_nats/src/emqx_nats_schema.erl
@@ -258,61 +258,85 @@ deobfuscate(NewConf, _OldConf) ->
 deobfuscate_internal_authn(NewMethods, OldMethods) when
     is_list(NewMethods), is_list(OldMethods)
 ->
-    deobfuscate_internal_authn(NewMethods, OldMethods, 1, []);
+    case find_duplicate_method_type(NewMethods) of
+        none ->
+            deobfuscate_internal_authn(NewMethods, OldMethods, []);
+        {duplicate, Type} ->
+            duplicate_method_error(Type)
+    end;
 deobfuscate_internal_authn(NewMethods, _OldMethods) ->
     {ok, NewMethods}.
 
-deobfuscate_internal_authn([], _OldMethods, _Pos, Acc) ->
+deobfuscate_internal_authn([], _OldMethods, Acc) ->
     {ok, lists:reverse(Acc)};
-deobfuscate_internal_authn([NewMethod | Rest], [OldMethod | OldRest], Pos, Acc) ->
+deobfuscate_internal_authn([NewMethod | Rest], OldMethods, Acc) ->
     NewType = method_type(NewMethod),
-    OldType = method_type(OldMethod),
-    case NewType =:= OldType andalso NewType =/= undefined of
-        true ->
-            case deobfuscate_method(NewMethod, OldMethod, NewType, Pos) of
-                {ok, Method} ->
-                    deobfuscate_internal_authn(Rest, OldRest, Pos + 1, [Method | Acc]);
-                {error, _} = Error ->
-                    Error
-            end;
-        false ->
-            case reject_redacted_method(NewMethod, Pos) of
-                ok ->
-                    deobfuscate_internal_authn(Rest, OldRest, Pos + 1, [NewMethod | Acc]);
-                {error, _} = Error ->
-                    Error
-            end
-    end;
-deobfuscate_internal_authn([NewMethod | Rest], [], Pos, Acc) ->
-    case reject_redacted_method(NewMethod, Pos) of
-        ok ->
-            deobfuscate_internal_authn(Rest, [], Pos + 1, [NewMethod | Acc]);
+    case deobfuscate_method(NewMethod, OldMethods, NewType) of
+        {ok, Method} ->
+            deobfuscate_internal_authn(Rest, OldMethods, [Method | Acc]);
         {error, _} = Error ->
             Error
     end.
 
-deobfuscate_method(NewMethod0, OldMethod0, token, Pos) ->
+deobfuscate_method(NewMethod0, OldMethods, token) ->
     NewMethod = emqx_utils_maps:binary_key_map(NewMethod0),
-    OldMethod = emqx_utils_maps:binary_key_map(OldMethod0),
     case is_redacted_field(NewMethod, token, <<"token">>) of
-        true when is_map_key(<<"token">>, OldMethod); is_map_key(token, OldMethod) ->
-            {ok, emqx_utils:deobfuscate(NewMethod, OldMethod)};
         true ->
-            redacted_method_error(Pos, token);
+            case find_unique_method(token, OldMethods) of
+                {ok, OldMethod0} ->
+                    OldMethod = emqx_utils_maps:binary_key_map(OldMethod0),
+                    case has_map_key(OldMethod, token, <<"token">>) of
+                        true ->
+                            {ok, emqx_utils:deobfuscate(NewMethod, OldMethod)};
+                        false ->
+                            redacted_method_error(token)
+                    end;
+                _ ->
+                    redacted_method_error(token)
+            end;
         false ->
             {ok, NewMethod}
     end;
-deobfuscate_method(NewMethod0, OldMethod0, jwt, Pos) ->
-    NewMethod = emqx_utils:deobfuscate(
-        emqx_utils_maps:binary_key_map(NewMethod0),
-        emqx_utils_maps:binary_key_map(OldMethod0)
-    ),
-    deobfuscate_jwt_resolver(NewMethod, OldMethod0, Pos);
-deobfuscate_method(NewMethod, _OldMethod, _Type, _Pos) ->
-    {ok, NewMethod}.
+deobfuscate_method(NewMethod0, OldMethods, jwt) ->
+    NewMethod = emqx_utils_maps:binary_key_map(NewMethod0),
+    case has_redacted_jwt(NewMethod) of
+        true ->
+            case find_unique_method(jwt, OldMethods) of
+                {ok, OldMethod0} ->
+                    OldMethod = emqx_utils_maps:binary_key_map(OldMethod0),
+                    deobfuscate_jwt_method(NewMethod, OldMethod);
+                _ ->
+                    redacted_method_error(jwt)
+            end;
+        false ->
+            deobfuscate_jwt_resolver(NewMethod, #{})
+    end;
+deobfuscate_method(NewMethod, _OldMethods, _Type) ->
+    case reject_redacted_method(NewMethod) of
+        ok ->
+            {ok, NewMethod};
+        {error, _} = Error ->
+            Error
+    end.
 
-deobfuscate_jwt_resolver(NewMethod, OldMethod0, Pos) ->
-    OldMethod = emqx_utils_maps:binary_key_map(OldMethod0),
+deobfuscate_jwt_method(NewMethod, OldMethod) ->
+    NewMethod1 = emqx_utils:deobfuscate(NewMethod, OldMethod),
+    case deobfuscate_jwt_resolver(NewMethod1, OldMethod) of
+        {ok, NewMethod2} ->
+            ensure_no_redacted_jwt(NewMethod2);
+        {error, _} = Error ->
+            Error
+    end.
+
+ensure_no_redacted_jwt(Method) ->
+    case has_redacted_jwt(Method) of
+        true ->
+            redacted_method_error(jwt);
+        false ->
+            {ok, Method}
+    end.
+
+deobfuscate_jwt_resolver(NewMethod, OldMethod) ->
     NewResolver = map_get_any(NewMethod, [resolver, <<"resolver">>], undefined),
     OldResolver = map_get_any(OldMethod, [resolver, <<"resolver">>], #{}),
     case {is_map(NewResolver), is_map(OldResolver)} of
@@ -327,7 +351,7 @@ deobfuscate_jwt_resolver(NewMethod, OldMethod0, Pos) ->
                 [resolver_preload, <<"resolver_preload">>],
                 []
             ),
-            case deobfuscate_jwt_entries(NewEntries, OldEntries, Pos) of
+            case deobfuscate_jwt_entries(NewEntries, OldEntries) of
                 {ok, Entries} ->
                     Resolver = put_map_value(NewResolver, resolver_preload, Entries),
                     {ok, put_map_value(NewMethod, resolver, Resolver)};
@@ -338,44 +362,119 @@ deobfuscate_jwt_resolver(NewMethod, OldMethod0, Pos) ->
             {ok, NewMethod}
     end.
 
-deobfuscate_jwt_entries(NewEntries, OldEntries, Pos) when
+deobfuscate_jwt_entries(NewEntries, OldEntries) when
     is_list(NewEntries), is_list(OldEntries)
 ->
-    OldIndex = maps:from_list([
-        {PubKey, Entry}
-     || Entry <- OldEntries,
-        is_map(Entry),
-        PubKey <- [map_get_any(Entry, [pubkey, <<"pubkey">>], undefined)],
-        PubKey =/= undefined
-    ]),
-    deobfuscate_jwt_entries(NewEntries, OldIndex, Pos, 1, []);
-deobfuscate_jwt_entries(NewEntries, _OldEntries, _Pos) ->
+    case find_duplicate_pubkey(NewEntries) of
+        none ->
+            deobfuscate_jwt_entries(NewEntries, OldEntries, []);
+        duplicate ->
+            duplicate_entry_error()
+    end;
+deobfuscate_jwt_entries(NewEntries, _OldEntries) ->
     {ok, NewEntries}.
 
-deobfuscate_jwt_entries([], _OldIndex, _MethodPos, _EntryPos, Acc) ->
+deobfuscate_jwt_entries([], _OldEntries, Acc) ->
     {ok, lists:reverse(Acc)};
-deobfuscate_jwt_entries([NewEntry0 | Rest], OldIndex, MethodPos, EntryPos, Acc) ->
+deobfuscate_jwt_entries([NewEntry0 | Rest], OldEntries, Acc) ->
     NewEntry = emqx_utils_maps:binary_key_map(NewEntry0),
     PubKey = map_get_any(NewEntry, [pubkey, <<"pubkey">>], undefined),
-    OldEntry = maps:get(PubKey, OldIndex, #{}),
     case is_redacted_field(NewEntry, jwt, <<"jwt">>) of
-        true when is_map_key(<<"jwt">>, OldEntry); is_map_key(jwt, OldEntry) ->
-            Entry = emqx_utils:deobfuscate(NewEntry, OldEntry),
-            deobfuscate_jwt_entries(Rest, OldIndex, MethodPos, EntryPos + 1, [Entry | Acc]);
         true ->
-            redacted_entry_error(MethodPos, EntryPos, jwt);
+            case find_unique_entry(PubKey, OldEntries) of
+                {ok, OldEntry0} ->
+                    OldEntry = emqx_utils_maps:binary_key_map(OldEntry0),
+                    case has_map_key(OldEntry, jwt, <<"jwt">>) of
+                        true ->
+                            Entry = emqx_utils:deobfuscate(NewEntry, OldEntry),
+                            deobfuscate_jwt_entries(Rest, OldEntries, [Entry | Acc]);
+                        false ->
+                            redacted_entry_error(jwt)
+                    end;
+                _ ->
+                    redacted_entry_error(jwt)
+            end;
         false ->
-            deobfuscate_jwt_entries(Rest, OldIndex, MethodPos, EntryPos + 1, [NewEntry | Acc])
+            deobfuscate_jwt_entries(Rest, OldEntries, [NewEntry | Acc])
     end.
 
-reject_redacted_method(Method, Pos) ->
+find_unique_method(Type, Methods) ->
+    case [Method || Method <- Methods, method_type(Method) =:= Type] of
+        [Method] ->
+            {ok, Method};
+        [] ->
+            not_found;
+        _ ->
+            ambiguous
+    end.
+
+find_unique_entry(undefined, _Entries) ->
+    not_found;
+find_unique_entry(PubKey, Entries) ->
+    case
+        [
+            Entry
+         || Entry <- Entries,
+            is_map(Entry),
+            entry_pubkey_identity(Entry) =:= normalize_pubkey(PubKey)
+        ]
+    of
+        [Entry] ->
+            {ok, Entry};
+        [] ->
+            not_found;
+        _ ->
+            ambiguous
+    end.
+
+find_duplicate_method_type(Methods) ->
+    Types = [
+        Type
+     || Method <- Methods,
+        Type <- [method_type(Method)],
+        Type =/= undefined
+    ],
+    case Types -- lists:usort(Types) of
+        [Duplicate | _] ->
+            {duplicate, Duplicate};
+        [] ->
+            none
+    end.
+
+find_duplicate_pubkey(Entries) ->
+    PubKeys = [
+        PubKey
+     || Entry <- Entries,
+        PubKey <- [entry_pubkey_identity(Entry)],
+        PubKey =/= undefined
+    ],
+    case PubKeys -- lists:usort(PubKeys) of
+        [_Duplicate | _] ->
+            duplicate;
+        [] ->
+            none
+    end.
+
+entry_pubkey_identity(Entry) when is_map(Entry) ->
+    normalize_pubkey(map_get_any(Entry, [pubkey, <<"pubkey">>], undefined));
+entry_pubkey_identity(_Entry) ->
+    undefined.
+
+normalize_pubkey(undefined) ->
+    undefined;
+normalize_pubkey(PubKey) when is_binary(PubKey) ->
+    emqx_nats_nkey:normalize(PubKey);
+normalize_pubkey(PubKey) ->
+    PubKey.
+
+reject_redacted_method(Method) ->
     case is_redacted_field(Method, token, <<"token">>) of
         true ->
-            redacted_method_error(Pos, token);
+            redacted_method_error(token);
         false ->
             case has_redacted_jwt(Method) of
                 true ->
-                    redacted_method_error(Pos, jwt);
+                    redacted_method_error(jwt);
                 false ->
                     ok
             end
@@ -386,12 +485,17 @@ has_redacted_jwt(Method) when is_map(Method) ->
     case is_map(Resolver) of
         true ->
             Entries = map_get_any(Resolver, [resolver_preload, <<"resolver_preload">>], []),
-            lists:any(
-                fun(Entry) ->
-                    is_map(Entry) andalso is_redacted_field(Entry, jwt, <<"jwt">>)
-                end,
-                Entries
-            );
+            case is_list(Entries) of
+                true ->
+                    lists:any(
+                        fun(Entry) ->
+                            is_map(Entry) andalso is_redacted_field(Entry, jwt, <<"jwt">>)
+                        end,
+                        Entries
+                    );
+                false ->
+                    false
+            end;
         false ->
             false
     end;
@@ -422,6 +526,11 @@ is_redacted_field(Map, AtomKey, BinaryKey) when is_map(Map) ->
 is_redacted_field(_Map, _AtomKey, _BinaryKey) ->
     false.
 
+has_map_key(Map, AtomKey, BinaryKey) when is_map(Map) ->
+    is_map_key(AtomKey, Map) orelse is_map_key(BinaryKey, Map);
+has_map_key(_Map, _AtomKey, _BinaryKey) ->
+    false.
+
 put_map_value(Map, AtomKey, Value) ->
     BinaryKey = atom_to_binary(AtomKey, utf8),
     case maps:is_key(BinaryKey, Map) of
@@ -429,26 +538,51 @@ put_map_value(Map, AtomKey, Value) ->
         false -> maps:put(AtomKey, Value, Map)
     end.
 
-redacted_method_error(Pos, Field) ->
+redacted_method_error(Field) ->
     {error,
         {badconf, #{
             key => internal_authn,
-            reason => masked_secret_without_matching_old_value,
-            position => Pos,
-            field => Field
+            reason => "masked_secret_without_matching_old_value",
+            value => Field
         }}}.
 
-redacted_entry_error(MethodPos, EntryPos, Field) ->
+redacted_entry_error(Field) ->
     {error,
         {badconf, #{
             key => internal_authn,
-            reason => masked_secret_without_matching_old_value,
-            position => {MethodPos, EntryPos},
-            field => Field
+            reason => "masked_secret_without_matching_old_value",
+            value => Field
+        }}}.
+
+duplicate_method_error(Type) ->
+    {error,
+        {badconf, #{
+            key => internal_authn,
+            reason => "duplicate_authentication_method_type",
+            value => Type
+        }}}.
+
+duplicate_entry_error() ->
+    {error,
+        {badconf, #{
+            key => internal_authn,
+            reason => "duplicate_resolver_preload_pubkey",
+            value => pubkey
         }}}.
 
 validate_internal_authn(Methods) when is_list(Methods) ->
-    validate_internal_authn(Methods, 1);
+    case find_duplicate_method_type(Methods) of
+        none ->
+            validate_internal_authn(Methods, 1);
+        {duplicate, Type} ->
+            {error,
+                iolist_to_binary(
+                    io_lib:format(
+                        "duplicate authentication method type '~p'",
+                        [Type]
+                    )
+                )}
+    end;
 validate_internal_authn(_) ->
     ok.
 
@@ -493,15 +627,22 @@ validate_authn_nkeys(Config) ->
         [] ->
             {error, <<"field `nkeys` must not be empty">>};
         _ ->
-            validate_nkey_list(
-                NKeys,
-                fun emqx_nats_nkey:decode_public/1,
-                fun(Index) ->
-                    iolist_to_binary(
-                        io_lib:format("field `nkeys[~B]` must be a valid user NKey", [Index])
-                    )
-                end
-            )
+            case
+                validate_nkey_list(
+                    NKeys,
+                    fun emqx_nats_nkey:decode_public/1,
+                    fun(Index) ->
+                        iolist_to_binary(
+                            io_lib:format("field `nkeys[~B]` must be a valid user NKey", [Index])
+                        )
+                    end
+                )
+            of
+                ok ->
+                    validate_unique_nkeys(NKeys, <<"nkeys">>);
+                {error, _} = Error ->
+                    Error
+            end
     end.
 
 validate_nkey_list(Values, DecodeFun, FormatError) when is_list(Values) ->
@@ -539,15 +680,21 @@ validate_account_nkey(Value) ->
     validate_nkey_with_prefix(Value, $A).
 
 validate_resolver_preload_pubkeys(Values) when is_list(Values) ->
-    validate_resolver_preload_pubkeys(Values, 1);
+    validate_resolver_preload_pubkeys(Values, 1, #{});
 validate_resolver_preload_pubkeys(_Values) ->
     ok.
 
-validate_resolver_preload_pubkeys([Entry | Rest], Index) ->
+validate_resolver_preload_pubkeys([Entry | Rest], Index, Seen) ->
     PubKey = map_get_any(Entry, [pubkey, <<"pubkey">>], undefined),
     case validate_account_nkey(PubKey) of
         {ok, _PubKey} ->
-            validate_resolver_preload_pubkeys(Rest, Index + 1);
+            PubKey1 = normalize_pubkey(PubKey),
+            case maps:is_key(PubKey1, Seen) of
+                true ->
+                    {error, <<"field `resolver.resolver_preload.pubkey` must be unique">>};
+                false ->
+                    validate_resolver_preload_pubkeys(Rest, Index + 1, Seen#{PubKey1 => true})
+            end;
         {error, _Reason} ->
             {error,
                 iolist_to_binary(
@@ -557,7 +704,7 @@ validate_resolver_preload_pubkeys([Entry | Rest], Index) ->
                     )
                 )}
     end;
-validate_resolver_preload_pubkeys([], _Index) ->
+validate_resolver_preload_pubkeys([], _Index, _Seen) ->
     ok.
 
 validate_authn_jwt(Config) ->
@@ -594,9 +741,10 @@ validate_authn_jwt_required_fields(Config) ->
     end.
 
 validate_authn_jwt_nkey_material(Config) ->
+    TrustedOperators = map_get_any(Config, [trusted_operators, <<"trusted_operators">>], []),
     case
         validate_nkey_list(
-            map_get_any(Config, [trusted_operators, <<"trusted_operators">>], []),
+            TrustedOperators,
             fun validate_operator_nkey/1,
             fun(Index) ->
                 iolist_to_binary(
@@ -609,13 +757,40 @@ validate_authn_jwt_nkey_material(Config) ->
         )
     of
         ok ->
-            Resolver = map_get_any(Config, [resolver, <<"resolver">>], #{}),
-            validate_resolver_preload_pubkeys(
-                map_get_any(Resolver, [resolver_preload, <<"resolver_preload">>], [])
-            );
+            case validate_unique_nkeys(TrustedOperators, <<"trusted_operators">>) of
+                ok ->
+                    Resolver = map_get_any(Config, [resolver, <<"resolver">>], #{}),
+                    validate_resolver_preload_pubkeys(
+                        map_get_any(Resolver, [resolver_preload, <<"resolver_preload">>], [])
+                    );
+                {error, _} = Error ->
+                    Error
+            end;
         {error, _Reason} = Error ->
             Error
     end.
+
+validate_unique_nkeys(Values, Field) ->
+    Identities = [nkey_identity(Value) || Value <- Values],
+    case Identities -- lists:usort(Identities) of
+        [_Duplicate | _] ->
+            {error,
+                iolist_to_binary(
+                    io_lib:format("field `~ts` must be unique", [Field])
+                )};
+        [] ->
+            ok
+    end.
+
+nkey_identity(Value) when is_binary(Value) ->
+    case emqx_nats_nkey:decode_public_any(Value) of
+        {ok, PubKey} ->
+            PubKey;
+        {error, _} ->
+            Value
+    end;
+nkey_identity(Value) ->
+    Value.
 
 jwt_has_trusted_operators(Config) ->
     has_non_empty_list(map_get_any(Config, [trusted_operators, <<"trusted_operators">>], [])).

--- a/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
@@ -15,6 +15,7 @@
 -define(VALID_USER_NKEY, <<"UB4G32YJ2GVZG3KTC3Z7BLIU3PXPJC2Y4QF6SNJUN2XIF3M3E3NDEUCZ">>).
 -define(VALID_OPERATOR_NKEY, <<"OB43KVROR7TFJ6KAPCYRF2FJROTZAH4FHLTJLPWX4DRZCC5NASLGIT25">>).
 -define(VALID_ACCOUNT_NKEY, <<"ADT7CYVBBPWFLGX6UGK6JXHIJNUVNDK5FSYJMPVUI3AGQXRLC7ZPAOJZ">>).
+-define(REDACTED, <<"******">>).
 
 all() ->
     [{group, legacy}, {group, hardened}].
@@ -334,6 +335,40 @@ t_update_error_listener_in_use(_Config) ->
         _ = emqx_gateway_conf:unload_gateway(nats)
     end.
 
+t_gateway_api_preserves_redacted_internal_authn(_Config) ->
+    OriginalToken = <<"original-token">>,
+    InternalAuthn = [
+        #{
+            <<"type">> => <<"token">>,
+            <<"token">> => OriginalToken
+        }
+    ],
+    {204, _} = emqx_gateway_test_utils:request(
+        put,
+        "/gateways/nats",
+        #{<<"internal_authn">> => InternalAuthn}
+    ),
+    {200, GatewayConf} = emqx_gateway_test_utils:request(get, "/gateways/nats"),
+    [#{type := <<"token">>, token := ?REDACTED}] = maps:get(internal_authn, GatewayConf),
+
+    {204, _} = emqx_gateway_test_utils:request(
+        put,
+        "/gateways/nats",
+        #{
+            <<"server_name">> => <<"updated-server">>,
+            <<"internal_authn">> => [
+                #{
+                    <<"type">> => <<"token">>,
+                    <<"token">> => ?REDACTED
+                }
+            ]
+        }
+    ),
+    ?assertEqual(
+        InternalAuthn,
+        emqx:get_raw_config([gateway, nats, internal_authn])
+    ).
+
 t_gateway_client_management(Config) ->
     ClientOpts = maps:merge(
         ?config(client_opts, Config),
@@ -583,7 +618,8 @@ needs_gateway(TestCase) ->
             t_gateway_client_management,
             t_gateway_client_subscription_management,
             t_clientinfo_override_with_empty_clientid,
-            t_clientinfo_override_with_prefix_and_empty_clientid
+            t_clientinfo_override_with_prefix_and_empty_clientid,
+            t_gateway_api_preserves_redacted_internal_authn
         ]
     ).
 

--- a/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
@@ -282,6 +282,100 @@ t_load_badconf_partial_authn_jwt(_Config) ->
         emqx_gateway_conf:load_gateway(nats, InvalidResolverPubKeyClass)
     ).
 
+t_load_badconf_duplicate_internal_authn_type(_Config) ->
+    BaseConf = nats_conf(emqx_common_test_helpers:select_free_port(tcp)),
+    DuplicateTokenMethods = BaseConf#{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"token">>,
+                <<"token">> => <<"token-a">>
+            },
+            #{
+                <<"type">> => <<"token">>,
+                <<"token">> => <<"token-b">>
+            }
+        ]
+    },
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:load_gateway(nats, DuplicateTokenMethods)
+    ).
+
+t_load_badconf_duplicate_nkeys(_Config) ->
+    BaseConf = nats_conf(emqx_common_test_helpers:select_free_port(tcp)),
+    DuplicateNKeys = BaseConf#{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"nkey">>,
+                <<"nkeys">> => [?VALID_USER_NKEY, ?VALID_USER_NKEY]
+            }
+        ]
+    },
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:load_gateway(nats, DuplicateNKeys)
+    ).
+
+t_load_badconf_duplicate_resolver_preload_pubkey(_Config) ->
+    BaseConf = nats_conf(emqx_common_test_helpers:select_free_port(tcp)),
+    Fixture = emqx_nats_authn_SUITE:jwt_fixture(),
+    OperatorNKey = maps:get(operator_nkey, Fixture),
+    AccountNKey = maps:get(account_nkey, Fixture),
+    AccountJWT = maps:get(account_jwt, Fixture),
+    DuplicatePubKeys = BaseConf#{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"trusted_operators">> => [OperatorNKey],
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{
+                            <<"pubkey">> => AccountNKey,
+                            <<"jwt">> => AccountJWT
+                        },
+                        #{
+                            <<"pubkey">> => AccountNKey,
+                            <<"jwt">> => AccountJWT
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:load_gateway(nats, DuplicatePubKeys)
+    ).
+
+t_load_badconf_duplicate_trusted_operators(_Config) ->
+    BaseConf = nats_conf(emqx_common_test_helpers:select_free_port(tcp)),
+    Fixture = emqx_nats_authn_SUITE:jwt_fixture(),
+    OperatorNKey = maps:get(operator_nkey, Fixture),
+    AccountNKey = maps:get(account_nkey, Fixture),
+    AccountJWT = maps:get(account_jwt, Fixture),
+    DuplicateTrustedOperators = BaseConf#{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"trusted_operators">> => [OperatorNKey, OperatorNKey],
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{
+                            <<"pubkey">> => AccountNKey,
+                            <<"jwt">> => AccountJWT
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    ?assertMatch(
+        {error, #{kind := validation_error}},
+        emqx_gateway_conf:load_gateway(nats, DuplicateTrustedOperators)
+    ).
+
 t_load_badconf_authn_jwt_cache_ttl(_Config) ->
     BaseConf = nats_conf(emqx_common_test_helpers:select_free_port(tcp)),
     UnsupportedCacheTTL = BaseConf#{
@@ -351,6 +445,23 @@ t_gateway_api_preserves_redacted_internal_authn(_Config) ->
     {200, GatewayConf} = emqx_gateway_test_utils:request(get, "/gateways/nats"),
     [#{type := <<"token">>, token := ?REDACTED}] = maps:get(internal_authn, GatewayConf),
 
+    {400, _} = emqx_gateway_test_utils:request(
+        put,
+        "/gateways/nats",
+        #{
+            <<"internal_authn">> => [
+                #{
+                    <<"type">> => <<"token">>,
+                    <<"token">> => OriginalToken
+                },
+                #{
+                    <<"type">> => <<"token">>,
+                    <<"token">> => <<"another-token">>
+                }
+            ]
+        }
+    ),
+
     {204, _} = emqx_gateway_test_utils:request(
         put,
         "/gateways/nats",
@@ -367,6 +478,31 @@ t_gateway_api_preserves_redacted_internal_authn(_Config) ->
     ?assertEqual(
         InternalAuthn,
         emqx:get_raw_config([gateway, nats, internal_authn])
+    ).
+
+t_full_gateway_update_propagates_deobfuscation_error(_Config) ->
+    OldConf = #{
+        <<"nats">> => #{
+            <<"internal_authn">> => [
+                #{<<"type">> => <<"nkey">>}
+            ]
+        }
+    },
+    NewConf = #{
+        <<"nats">> => #{
+            <<"internal_authn">> => [
+                #{<<"type">> => <<"token">>, <<"token">> => <<"******">>}
+            ]
+        }
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "masked_secret_without_matching_old_value",
+                value := token
+            }}},
+        emqx_gateway_conf:pre_config_update([gateway], NewConf, OldConf)
     ).
 
 t_gateway_client_management(Config) ->

--- a/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
@@ -35,6 +35,91 @@ end_per_group(Profile, _Config) when Profile =:= legacy; Profile =:= hardened ->
 %% Test Cases
 %%--------------------------------------------------------------------
 
+t_deobfuscate_internal_authn(_Config) ->
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{<<"type">> => <<"token">>, <<"token">> => <<"original-token">>}
+        ]
+    },
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{<<"type">> => <<"token">>, <<"token">> => <<"******">>}
+        ]
+    },
+    {ok, Restored} = emqx_nats_schema:deobfuscate(NewConf, OldConf),
+    ?assertEqual(
+        #{
+            <<"internal_authn">> => [
+                #{<<"type">> => <<"token">>, <<"token">> => <<"original-token">>}
+            ]
+        },
+        Restored
+    ).
+
+t_deobfuscate_internal_authn_update_and_reject(_Config) ->
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{<<"type">> => <<"token">>, <<"token">> => <<"original-token">>}
+        ]
+    },
+    ChangedConf = #{
+        <<"internal_authn">> => [
+            #{<<"type">> => <<"token">>, <<"token">> => <<"new-token">>}
+        ]
+    },
+    ReorderedConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"nkey">>,
+                <<"nkeys">> => [
+                    <<"UB4G32YJ2GVZG3KTC3Z7BLIU3PXPJC2Y4QF6SNJUN2XIF3M3E3NDEUCZ">>
+                ]
+            },
+            #{<<"type">> => <<"token">>, <<"token">> => <<"******">>}
+        ]
+    },
+    {ok, Changed} = emqx_nats_schema:deobfuscate(ChangedConf, OldConf),
+    ?assertEqual(
+        <<"new-token">>,
+        maps:get(<<"token">>, hd(maps:get(<<"internal_authn">>, Changed)))
+    ),
+    ?assertMatch(
+        {error, {badconf, #{reason := masked_secret_without_matching_old_value}}},
+        emqx_nats_schema:deobfuscate(ReorderedConf, OldConf)
+    ).
+
+t_deobfuscate_internal_authn_jwt_preload(_Config) ->
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"old-jwt">>}
+                    ]
+                }
+            }
+        ]
+    },
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"******">>}
+                    ]
+                }
+            }
+        ]
+    },
+    {ok, Restored} = emqx_nats_schema:deobfuscate(NewConf, OldConf),
+    [#{<<"resolver">> := #{<<"resolver_preload">> := [Entry]}}] =
+        maps:get(<<"internal_authn">>, Restored),
+    ?assertEqual(<<"old-jwt">>, maps:get(<<"jwt">>, Entry)).
+
 t_build_authn_ctx_and_auth_required(Config) ->
     Profile = proplists:get_value(security_profile, Config),
     AuthRequiredWithoutConfig = Profile =:= hardened,

--- a/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_nats_authn_SUITE.erl
@@ -35,6 +35,27 @@ end_per_group(Profile, _Config) when Profile =:= legacy; Profile =:= hardened ->
 %% Test Cases
 %%--------------------------------------------------------------------
 
+t_deobfuscate_without_internal_authn(_Config) ->
+    NewConf = #{<<"server_name">> => <<"nats">>},
+    ?assertEqual({ok, NewConf}, emqx_nats_schema:deobfuscate(NewConf, #{})),
+    ?assertEqual({ok, false}, emqx_nats_schema:deobfuscate(false, #{})),
+    ?assertEqual(
+        {ok, #{<<"internal_authn">> => []}},
+        emqx_nats_schema:deobfuscate(#{<<"internal_authn">> => []}, #{})
+    ),
+    ?assertEqual(
+        {ok, #{<<"internal_authn">> => invalid}},
+        emqx_nats_schema:deobfuscate(#{<<"internal_authn">> => invalid}, #{})
+    ).
+
+t_deobfuscate_preserves_internal_authn_key_format(_Config) ->
+    NewConf = #{
+        internal_authn => [#{type => token, token => <<"new-token">>}]
+    },
+    {ok, Restored} = emqx_nats_schema:deobfuscate(NewConf, #{internal_authn => []}),
+    ?assert(maps:is_key(internal_authn, Restored)),
+    ?assertNot(maps:is_key(<<"internal_authn">>, Restored)).
+
 t_deobfuscate_internal_authn(_Config) ->
     OldConf = #{
         <<"internal_authn">> => [
@@ -56,7 +77,7 @@ t_deobfuscate_internal_authn(_Config) ->
         Restored
     ).
 
-t_deobfuscate_internal_authn_update_and_reject(_Config) ->
+t_deobfuscate_internal_authn_update_and_reorder(_Config) ->
     OldConf = #{
         <<"internal_authn">> => [
             #{<<"type">> => <<"token">>, <<"token">> => <<"original-token">>}
@@ -83,9 +104,280 @@ t_deobfuscate_internal_authn_update_and_reject(_Config) ->
         <<"new-token">>,
         maps:get(<<"token">>, hd(maps:get(<<"internal_authn">>, Changed)))
     ),
+    {ok, Reordered} = emqx_nats_schema:deobfuscate(ReorderedConf, OldConf),
+    ?assertEqual(
+        [
+            #{
+                <<"type">> => <<"nkey">>,
+                <<"nkeys">> => [
+                    <<"UB4G32YJ2GVZG3KTC3Z7BLIU3PXPJC2Y4QF6SNJUN2XIF3M3E3NDEUCZ">>
+                ]
+            },
+            #{<<"type">> => <<"token">>, <<"token">> => <<"original-token">>}
+        ],
+        maps:get(<<"internal_authn">>, Reordered)
+    ).
+
+t_deobfuscate_duplicate_method_type_rejected(_Config) ->
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{<<"type">> => <<"token">>, <<"token">> => <<"old-token">>}
+        ]
+    },
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{<<"type">> => <<"token">>, <<"token">> => <<"token-a">>},
+            #{<<"type">> => <<"token">>, <<"token">> => <<"token-b">>}
+        ]
+    },
     ?assertMatch(
-        {error, {badconf, #{reason := masked_secret_without_matching_old_value}}},
-        emqx_nats_schema:deobfuscate(ReorderedConf, OldConf)
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "duplicate_authentication_method_type",
+                value := token
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, OldConf)
+    ).
+
+t_deobfuscate_duplicate_old_method_rejects_masked_secret(_Config) ->
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{<<"type">> => <<"token">>, <<"token">> => <<"token-a">>},
+            #{<<"type">> => <<"token">>, <<"token">> => <<"token-b">>}
+        ]
+    },
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{<<"type">> => <<"token">>, <<"token">> => <<"******">>}
+        ]
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "masked_secret_without_matching_old_value",
+                value := token
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, OldConf)
+    ).
+
+t_deobfuscate_token_without_old_secret_rejects_masked_secret(_Config) ->
+    OldConf = #{
+        <<"internal_authn">> => [#{<<"type">> => <<"token">>}]
+    },
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{<<"type">> => <<"token">>, <<"token">> => <<"******">>}
+        ]
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "masked_secret_without_matching_old_value",
+                value := token
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, OldConf)
+    ).
+
+t_deobfuscate_jwt_without_old_method_rejects_masked_secret(_Config) ->
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"******">>}
+                    ]
+                }
+            }
+        ]
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "masked_secret_without_matching_old_value",
+                value := jwt
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, #{<<"internal_authn">> => []})
+    ).
+
+t_deobfuscate_unknown_method_rejects_masked_secret(_Config) ->
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{<<"token">> => <<"******">>}
+        ]
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "masked_secret_without_matching_old_value",
+                value := token
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, #{<<"internal_authn">> => []})
+    ).
+
+t_deobfuscate_jwt_with_unavailable_old_resolver_rejects_masked_secret(_Config) ->
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"******">>}
+                    ]
+                }
+            }
+        ]
+    },
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => invalid
+            }
+        ]
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "masked_secret_without_matching_old_value",
+                value := jwt
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, OldConf)
+    ).
+
+t_deobfuscate_jwt_entry_without_old_secret_rejects_masked_secret(_Config) ->
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"******">>}
+                    ]
+                }
+            }
+        ]
+    },
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [#{<<"pubkey">> => <<"account-a">>}]
+                }
+            }
+        ]
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "masked_secret_without_matching_old_value",
+                value := jwt
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, OldConf)
+    ).
+
+t_deobfuscate_normalizes_jwt_preload_pubkey(_Config) ->
+    PubKey = <<"ADT7CYVBBPWFLGX6UGK6JXHIJNUVNDK5FSYJMPVUI3AGQXRLC7ZPAOJZ">>,
+    LowercasePubKey = string:lowercase(PubKey),
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => PubKey, <<"jwt">> => <<"old-jwt">>}
+                    ]
+                }
+            }
+        ]
+    },
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => LowercasePubKey, <<"jwt">> => <<"******">>}
+                    ]
+                }
+            }
+        ]
+    },
+    {ok, Restored} = emqx_nats_schema:deobfuscate(NewConf, OldConf),
+    [#{<<"resolver">> := #{<<"resolver_preload">> := [Entry]}}] =
+        maps:get(<<"internal_authn">>, Restored),
+    ?assertEqual(LowercasePubKey, maps:get(<<"pubkey">>, Entry)),
+    ?assertEqual(<<"old-jwt">>, maps:get(<<"jwt">>, Entry)).
+
+t_deobfuscate_jwt_without_resolver_preserves_new(_Config) ->
+    NewMethod = #{<<"type">> => <<"jwt">>},
+    NewConf = #{<<"internal_authn">> => [NewMethod]},
+    ?assertEqual(
+        {ok, #{<<"internal_authn">> => [NewMethod]}},
+        emqx_nats_schema:deobfuscate(NewConf, #{<<"internal_authn">> => []})
+    ).
+
+t_deobfuscate_jwt_with_invalid_preload_preserves_new(_Config) ->
+    NewMethod = #{
+        <<"type">> => <<"jwt">>,
+        <<"resolver">> => #{
+            <<"type">> => <<"memory">>,
+            <<"resolver_preload">> => invalid
+        }
+    },
+    NewConf = #{<<"internal_authn">> => [NewMethod]},
+    ?assertEqual(
+        {ok, #{<<"internal_authn">> => [NewMethod]}},
+        emqx_nats_schema:deobfuscate(NewConf, #{<<"internal_authn">> => []})
+    ).
+
+t_deobfuscate_masked_jwt_without_pubkey_rejects(_Config) ->
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [#{<<"jwt">> => <<"******">>}]
+                }
+            }
+        ]
+    },
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"jwt-a">>}
+                    ]
+                }
+            }
+        ]
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "masked_secret_without_matching_old_value",
+                value := jwt
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, OldConf)
     ).
 
 t_deobfuscate_internal_authn_jwt_preload(_Config) ->
@@ -119,6 +411,131 @@ t_deobfuscate_internal_authn_jwt_preload(_Config) ->
     [#{<<"resolver">> := #{<<"resolver_preload">> := [Entry]}}] =
         maps:get(<<"internal_authn">>, Restored),
     ?assertEqual(<<"old-jwt">>, maps:get(<<"jwt">>, Entry)).
+
+t_deobfuscate_reordered_jwt_preload(_Config) ->
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"jwt-a">>},
+                        #{<<"pubkey">> => <<"account-b">>, <<"jwt">> => <<"jwt-b">>}
+                    ]
+                }
+            }
+        ]
+    },
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-b">>, <<"jwt">> => <<"******">>},
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"******">>}
+                    ]
+                }
+            }
+        ]
+    },
+    {ok, Restored} = emqx_nats_schema:deobfuscate(NewConf, OldConf),
+    [#{<<"resolver">> := #{<<"resolver_preload">> := Entries}}] =
+        maps:get(<<"internal_authn">>, Restored),
+    ?assertEqual(
+        [
+            #{<<"pubkey">> => <<"account-b">>, <<"jwt">> => <<"jwt-b">>},
+            #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"jwt-a">>}
+        ],
+        Entries
+    ).
+
+t_deobfuscate_duplicate_jwt_preload_rejected(_Config) ->
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"jwt-a">>}
+                    ]
+                }
+            }
+        ]
+    },
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"jwt-a">>},
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"jwt-b">>}
+                    ]
+                }
+            }
+        ]
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "duplicate_resolver_preload_pubkey",
+                value := pubkey
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, OldConf)
+    ).
+
+t_deobfuscate_duplicate_old_jwt_preload_rejects_masked_secret(_Config) ->
+    OldConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"jwt-a">>},
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"jwt-b">>}
+                    ]
+                }
+            }
+        ]
+    },
+    NewConf = #{
+        <<"internal_authn">> => [
+            #{
+                <<"type">> => <<"jwt">>,
+                <<"resolver">> => #{
+                    <<"type">> => <<"memory">>,
+                    <<"resolver_preload">> => [
+                        #{<<"pubkey">> => <<"account-a">>, <<"jwt">> => <<"******">>}
+                    ]
+                }
+            }
+        ]
+    },
+    ?assertMatch(
+        {error,
+            {badconf, #{
+                key := internal_authn,
+                reason := "masked_secret_without_matching_old_value",
+                value := jwt
+            }}},
+        emqx_nats_schema:deobfuscate(NewConf, OldConf)
+    ).
+
+t_deobfuscate_redacted_error_is_http_400(_Config) ->
+    Reason =
+        {badconf, #{
+            key => internal_authn,
+            reason => "masked_secret_without_matching_old_value",
+            value => token
+        }},
+    ?assertMatch({400, _, _}, emqx_gateway_http:reason2resp(Reason)).
 
 t_build_authn_ctx_and_auth_required(Config) ->
     Profile = proplists:get_value(security_profile, Config),

--- a/changes/ee/fix-18700.en.md
+++ b/changes/ee/fix-18700.en.md
@@ -1,3 +1,5 @@
-Fixed NATS Gateway token authentication being overwritten by the masked value `******` during a Dashboard configuration update.
+Fixed an issue where saving an existing NATS Gateway configuration from the Dashboard could replace its authentication credentials with the masked value displayed in the form, causing NATS clients to fail authentication.
 
-When a Gateway configuration is read and submitted again without changing the token, the original token is now preserved. Masked secrets that cannot be matched to an existing authentication method are rejected instead of being persisted.
+Authentication credentials are now preserved when users update other Gateway settings without changing the authentication configuration.
+
+NATS Gateway authentication settings now reject duplicate authentication methods and credential entries, including duplicate NKeys and JWT account entries, to prevent ambiguous authentication behavior.

--- a/changes/ee/fix-18700.en.md
+++ b/changes/ee/fix-18700.en.md
@@ -1,0 +1,3 @@
+Fixed NATS Gateway token authentication being overwritten by the masked value `******` during a Dashboard configuration update.
+
+When a Gateway configuration is read and submitted again without changing the token, the original token is now preserved. Masked secrets that cannot be matched to an existing authentication method are rejected instead of being persisted.


### PR DESCRIPTION
Fixes: #18691
Release version: 6.3.0
Introduced in: 6.3.0

## Summary

Fixed an issue where saving an existing NATS Gateway configuration from the Dashboard could replace its authentication credentials with the masked value displayed in the form, causing NATS clients to fail authentication.

Authentication credentials are now preserved when users update other Gateway settings without changing the authentication configuration. NATS Gateway authentication settings also reject duplicate authentication methods and credential entries, including duplicate NKeys and JWT account entries, to prevent ambiguous authentication behavior.

Gateway-specific configuration validation errors are propagated without persisting an invalid configuration.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (duplicate authentication entries are rejected to keep authentication configuration unambiguous)