### PR TITLE
ci: bump the gcp-cli emulator image past Google's retention floor

### DIFF
--- a/.ci/docker-compose-file/docker-compose-gcp-emulator.yaml
+++ b/.ci/docker-compose-file/docker-compose-gcp-emulator.yaml
@@ -1,7 +1,7 @@
 services:
   gcp_emulator:
     container_name: gcp_emulator
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:435.0.1-emulators
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators
     restart: always
     expose:
       - "8085"


### PR DESCRIPTION
## Summary

Every `emqx_bridge_gcp_pubsub` CI job fails before any test runs:

```
Image gcr.io/google.com/cloudsdktool/google-cloud-cli:435.0.1-emulators
Error failed to resolve reference "...:435.0.1-emulators": ...: not found
```

Seen on multiple unrelated PRs, e.g. https://github.com/emqx/emqx/actions/runs/33500504099.

Same root cause as #18689 (merged, `dev-58`): `gcr.io/google.com/cloudsdktool/google-cloud-cli`
only retains tags from `537.0.0` up; `435.0.1-emulators` is well below that floor and
permanently gone. `dev-59`/`dev-510` haven't picked up #18689 yet (the v5 sync chain hasn't run
since it merged), so this branch is still broken independently.

## Fix

Bump the pin in `docker-compose-gcp-emulator.yaml` to `582.0.0-emulators` — the same target
tag #18689 used on `dev-58`, so this converges with that fix instead of diverging from it once
the sync chain catches up.

## Validation

Ran the full `emqx_bridge_gcp_pubsub` suite against the new image via
`./scripts/ct/run.sh --ci --app apps/emqx_bridge_gcp_pubsub`:

```
emqx_bridge_gcp_pubsub_consumer_SUITE:      28 ok, 0 failed
emqx_bridge_v2_gcp_pubsub_consumer_SUITE:    8 ok, 0 failed
emqx_bridge_gcp_pubsub_producer_SUITE:      73 ok, 0 failed
emqx_bridge_v2_gcp_pubsub_producer_SUITE:    8 ok, 0 failed
```

117/117 pass.

## Scope

`dev-59` carries the same stale pin and is not fixed by this PR — it will self-heal once the
`dev-58 → dev-59` sync brings #18689 through, converging on the same `582.0.0-emulators` value
this PR uses, so no conflict is expected.