### PR TITLE
ci: bump the gcp-cli emulator image past Google's retention floor

### DIFF
--- a/.ci/docker-compose-file/docker-compose-gcp-bigtable.yaml
+++ b/.ci/docker-compose-file/docker-compose-gcp-bigtable.yaml
@@ -12,7 +12,7 @@ services:
 
   gcp-emulator-bigtable:
     container_name: gcp-emulator-bigtable
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:533.0.0-emulators
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators
     restart: always
     expose:
       - "8086"


### PR DESCRIPTION
## Summary

Every `emqx_bridge_bigtable` CI job fails before any test runs:

```
Image gcr.io/google.com/cloudsdktool/google-cloud-cli:533.0.0-emulators
Error failed to resolve reference "...:533.0.0-emulators": ...: not found
```

Seen on https://github.com/emqx/emqx/pull/18511, run 33490591116.

Same root cause as #18692 (open, `dev-63`): `gcr.io/google.com/cloudsdktool/google-cloud-cli`
only retains tags from `537.0.0` up; `533.0.0-emulators` is below that floor and permanently
gone. `dev-70` hasn't picked up #18692 yet (it hasn't merged, and even once it does the
`dev-63 → dev-70` sync still has to run), and #18511 is blocked on it now.

## Fix

Bump the pin in `docker-compose-gcp-bigtable.yaml` to `582.0.0-emulators` — the same target tag
#18692 uses on `dev-63`, so this converges with that fix instead of diverging once the sync
chain catches up.

## Validation

Ran the full `emqx_bridge_bigtable` suite against the new image via
`./scripts/ct/run.sh --ci --app apps/emqx_bridge_bigtable`:

```
emqx_bridge_bigtable_SUITE: 34 ok, 0 failed
```