### PR TITLE
fix(cli): do not print the Erlang cookie in debug trace

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -494,7 +494,7 @@ if [ -n "${EMQX_NODE_COOKIE:-}" ]; then
 fi
 
 PS_LINE="$(find_emqx_process)"
-logdebug "PS_LINE=$(echo -e "$PS_LINE" | sed -E 's/(-setcookie) +[^ ]+/\1 ******/g')"
+logdebug "PS_LINE=$(printf '%s' "$PS_LINE" | sed -E 's/(-setcookie) +[^ ]+/\1 ******/g')"
 RUNNING_NODES_COUNT="$(echo -e "$PS_LINE" | sed '/^\s*$/d' | wc -l)"
 [ "$RUNNING_NODES_COUNT" -gt 1 ] && logdebug "More than one running node found: count=$RUNNING_NODES_COUNT"
 
@@ -566,7 +566,10 @@ else
         EMQX_BOOT_CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get "${CONF_KEYS[@]}")"
     fi
 fi
-logdebug "EMQX_BOOT_CONFIGS: $(echo -e "$EMQX_BOOT_CONFIGS" | sed -E 's/^(node\.cookie|license\.key)=.*/\1=******/')"
+# Redact the raw serialized string before any escape expansion, so an
+# embedded escape cannot split a secret across lines. Values may be
+# quoted (from hocon multi_get) or bare (parsed from ps output).
+logdebug "EMQX_BOOT_CONFIGS: $(printf '%s' "$EMQX_BOOT_CONFIGS" | sed -E 's/(node\.cookie|license\.key)=("(\\.|[^"\\])*"|[^\\ ]*)/\1=******/g')"
 [[ "$DEBUG" -gt 0 ]] && set -x
 
 # Subshell body with trace off: EMQX_BOOT_CONFIGS may contain secrets
@@ -922,11 +925,11 @@ diagnose_boot_failure_and_die() {
     # Turn off debug: the ps output contains the '-setcookie' argument.
     set +x
     ps_line="$(find_emqx_process)"
-    if [ "$DEBUG" -gt 0 ]; then set -x; fi
     if [ -z "$ps_line" ]; then
         echo "Find more information in the latest log file: ${EMQX_LOG_DIR}/erlang.log.*"
         exit 1
     fi
+    if [ "$DEBUG" -gt 0 ]; then set -x; fi
     if ! relx_nodetool "ping" > /dev/null; then
         logerr "$NAME seems to be running, but not responding to pings."
         echo "Make sure '$HOST_NAME' is a resolvable and reachable hostname."

--- a/bin/emqx
+++ b/bin/emqx
@@ -384,6 +384,10 @@ remsh() {
     # transparently
     id="remsh$(gen_node_id)-${NAME}"
 
+    # Turn off debug (and keep it off through the exec below) so the
+    # cookie in the command arguments isn't traced by 'set -x'.
+    set +x
+
     # shellcheck disable=SC2086
     # Setup remote shell command to control node
     if [ "${EMQX_CONSOLE_FLAVOR:-erl}" = 'erl' ] ; then
@@ -427,9 +431,14 @@ call_nodetool() {
 
 # Control a node
 relx_nodetool() {
+    local ret=0
     command="$1"; shift
+    # Turn off debug so the cookie value isn't traced by 'set -x'.
+    set +x
     ERL_FLAGS="${ERL_FLAGS:-} $EPMD_ARGS -setcookie $COOKIE" \
-             call_nodetool "$NAME_TYPE" "$NAME" "$command" "$@"
+             call_nodetool "$NAME_TYPE" "$NAME" "$command" "$@" || ret=$?
+    if [ "$DEBUG" -gt 0 ]; then set -x; fi
+    return $ret
 }
 
 call_hocon() {
@@ -473,6 +482,10 @@ if [ -n "${EMQX_NODE_NAME:-}" ]; then
     unset EMQX_NODE_NAME
 fi
 
+# Turn off debug: the cookie value must not be traced by 'set -x',
+# and the ps output below can be quite noisy.
+set +x
+
 ## Resolve Erlang cookie.
 if [ -n "${EMQX_NODE_COOKIE:-}" ]; then
     ## To be backward compatible, read and unset EMQX_NODE_COOKIE
@@ -480,11 +493,8 @@ if [ -n "${EMQX_NODE_COOKIE:-}" ]; then
     unset EMQX_NODE_COOKIE
 fi
 
-# Turn off debug as the ps output can be quite noisy
-set +x
-
 PS_LINE="$(find_emqx_process)"
-logdebug "PS_LINE=$PS_LINE"
+logdebug "PS_LINE=$(echo -e "$PS_LINE" | sed -E 's/(-setcookie) +[^ ]+/\1 ******/g')"
 RUNNING_NODES_COUNT="$(echo -e "$PS_LINE" | sed '/^\s*$/d' | wc -l)"
 [ "$RUNNING_NODES_COUNT" -gt 1 ] && logdebug "More than one running node found: count=$RUNNING_NODES_COUNT"
 
@@ -556,13 +566,16 @@ else
         EMQX_BOOT_CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get "${CONF_KEYS[@]}")"
     fi
 fi
-logdebug "EMQX_BOOT_CONFIGS: $EMQX_BOOT_CONFIGS"
+logdebug "EMQX_BOOT_CONFIGS: $(echo -e "$EMQX_BOOT_CONFIGS" | sed -E 's/^(node\.cookie|license\.key)=.*/\1=******/')"
 [[ "$DEBUG" -gt 0 ]] && set -x
 
-get_boot_config() {
+# Subshell body with trace off: EMQX_BOOT_CONFIGS may contain secrets
+# (node.cookie, license.key) which must not be traced by 'set -x'.
+get_boot_config() (
+    set +x
     path_to_value="$1"
     echo -e "$EMQX_BOOT_CONFIGS" | $GREP "$path_to_value=" | sed -e "s/$path_to_value=//g" | tr -d \"
-}
+)
 
 EPMD_ARGS="${EPMD_ARGS:-"-start_epmd false -epmd_module ekka_epmd -proto_dist ekka"}"
 PROTO_DIST="$(get_boot_config 'cluster.proto_dist' || true)"
@@ -607,10 +620,15 @@ check_license() {
         return 0
     fi
 
+    # Turn off debug so the license key isn't traced by 'set -x'.
+    set +x
     key_license="${EMQX_LICENSE__KEY:-$(get_boot_config 'license.key' || echo '')}"
 
     if [[ -n "$key_license" && ("$key_license" != "undefined") ]]; then
-      call_nodetool check_license_key "$key_license"
+      local ret=0
+      call_nodetool check_license_key "$key_license" || ret=$?
+      if [ "$DEBUG" -gt 0 ]; then set -x; fi
+      return $ret
     else
       set +x
       logerr "License not found."
@@ -684,6 +702,9 @@ generate_config() {
     ## read lines from generated vm.<time>.args file
     ## drop comment lines, and empty lines using sed
     ## pipe the lines to a while loop
+    ## Turn off debug: the generated args contain the '-setcookie' line,
+    ## which must not be traced by 'set -x'.
+    set +x
     sed '/^#/d' "$ARGS_FILE" | sed '/^$/d' | while IFS='' read -r ARG_LINE || [ -n "$ARG_LINE" ]; do
         ## in the loop, split the 'key[:space:]value' pair
         ARG_KEY=$(echo "$ARG_LINE" | awk '{$NF="";print}')
@@ -702,6 +723,7 @@ generate_config() {
             fi
         fi
     done
+    if [ "$DEBUG" -gt 0 ]; then set -x; fi
     echo "$name_type $node_name" >> "$TMP_ARG_FILE"
     echo "-mnesia dir '\"$DATA_DIR/mnesia/$NAME\"'" >> "$TMP_ARG_FILE"
     ## rename the generated vm.<time>.args file
@@ -862,6 +884,8 @@ export ESCRIPT_NAME="$SHORT_NAME"
 
 PIPE_DIR="${PIPE_DIR:-/$DATA_DIR/${WHOAMI}_erl_pipes/$NAME/}"
 
+# Turn off debug so the cookie value isn't traced by 'set -x' below.
+set +x
 COOKIE="${EMQX_NODE__COOKIE:-}"
 COOKIE_IN_USE="$(get_boot_config 'node.cookie')"
 if [ "$IS_BOOT_COMMAND" != 'yes' ] && [ -n "$COOKIE_IN_USE" ] && [ -n "$COOKIE" ] && [ "$COOKIE" != "$COOKIE_IN_USE" ]; then
@@ -869,13 +893,17 @@ if [ "$IS_BOOT_COMMAND" != 'yes' ] && [ -n "$COOKIE_IN_USE" ] && [ -n "$COOKIE" 
 fi
 [ -z "$COOKIE" ] && COOKIE="$COOKIE_IN_USE"
 [ -z "$COOKIE" ] && COOKIE="$EMQX_DEFAULT_ERLANG_COOKIE"
+[[ "$DEBUG" -gt 0 ]] && set -x
 
 maybe_warn_default_cookie() {
+    # Turn off debug so the cookie value isn't traced by 'set -x'.
+    set +x
     if [ $IS_BOOT_COMMAND = 'yes' ] && [ "$COOKIE" = "$EMQX_DEFAULT_ERLANG_COOKIE" ]; then
         logwarn "Default (insecure) Erlang cookie is in use."
         logwarn "Configure node.cookie in $EMQX_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE__COOKIE"
         logwarn "NOTE: Use the same cookie for all nodes in the cluster."
     fi
+    if [ "$DEBUG" -gt 0 ]; then set -x; fi
 }
 
 ## check if OTP version has mnesia_hook feature; if not, fallback to
@@ -891,7 +919,10 @@ fi
 diagnose_boot_failure_and_die() {
     local ps_line
     local app_status
+    # Turn off debug: the ps output contains the '-setcookie' argument.
+    set +x
     ps_line="$(find_emqx_process)"
+    if [ "$DEBUG" -gt 0 ]; then set -x; fi
     if [ -z "$ps_line" ]; then
         echo "Find more information in the latest log file: ${EMQX_LOG_DIR}/erlang.log.*"
         exit 1
@@ -1205,6 +1236,8 @@ case "${COMMAND}" in
         assert_node_alive
 
         shift
+        # Turn off debug so the cookie value isn't traced by 'set -x'.
+        set +x
         "$REL_DIR/elixir" \
             --hidden \
             --name "rand-$(gen_node_id)-$NAME" \

--- a/bin/emqx
+++ b/bin/emqx
@@ -223,6 +223,9 @@ if [ -f "$RELUP_PATH/current" ]; then
     exec "$RELUP_PATH/$TARGET_VSN"/bin/emqx "$@"
 fi
 
+# Turn off debug: the sourced file may set secrets such as
+# EMQX_NODE_COOKIE, which must not be traced by 'set -x'.
+set +x
 # shellcheck disable=SC1090,SC1091
 . "$RUNNER_ROOT_DIR"/releases/emqx_vars
 
@@ -232,6 +235,7 @@ export EMQX_ETC_DIR
 export REL_VSN
 export SCHEMA_MOD
 export IS_ENTERPRISE
+[[ "$DEBUG" -gt 0 ]] && set -x
 
 RUNNER_SCRIPT="$RUNNER_BIN_DIR/$REL_NAME"
 CODE_LOADING_MODE="${CODE_LOADING_MODE:-embedded}"

--- a/changes/ee/fix-18708.en.md
+++ b/changes/ee/fix-18708.en.md
@@ -1,0 +1,3 @@
+Avoid logging sensitive information in debug mode.
+
+Running `bin/emqx` commands with `DEBUG=1` or `DEBUG=2` no longer prints the Erlang cookie or the license key in the shell trace output.

--- a/scripts/pkg-tests.sh
+++ b/scripts/pkg-tests.sh
@@ -103,6 +103,10 @@ emqx_test(){
 
             run_test "${PACKAGE_PATH}/emqx/bin" "${PACKAGE_PATH}/emqx/log" "${PACKAGE_PATH}/emqx/releases/emqx_vars"
 
+            ## Only for the tgz flow: the deb/rpm flow re-execs through
+            ## 'su - emqx', which resets the DEBUG environment variable.
+            "$SCRIPTS/test/emqx-debug-trace-smoke.sh" "${PACKAGE_PATH}/emqx"
+
             rm -rf "${PACKAGE_PATH}"/emqx
         ;;
         "deb")

--- a/scripts/test/emqx-debug-trace-smoke.sh
+++ b/scripts/test/emqx-debug-trace-smoke.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+## Regression test: running bin/emqx with DEBUG=1 or DEBUG=2 must not
+## print the Erlang cookie in the shell trace output. The cookie is set
+## both in the environment and via etc/emqx.env, so on releases that
+## source the env file this also covers the file sourcing path (the
+## file is ignored on releases that do not source it).
+##
+## Usage: emqx-debug-trace-smoke.sh <emqx-root-dir>
+## The directory must hold an installed release (bin/, etc/, log/) with
+## no node running from it.
+
+set -euo pipefail
+
+[ $# -ne 1 ] && { echo "Usage: $0 <emqx-root-dir>"; exit 1; }
+
+ROOT="$1"
+SECRET='debugtracesmokesecret'
+ENV_FILE="$ROOT/etc/emqx.env"
+
+cleanup() {
+    rm -f "$ENV_FILE"
+}
+trap cleanup EXIT
+
+echo "EMQX_NODE__COOKIE=$SECRET" > "$ENV_FILE"
+
+## Drop logs from earlier runs so the erlang.log check below only sees
+## output produced by this run.
+rm -f "$ROOT"/log/erlang.log.*
+
+assert_no_secret() {
+    local phase="$1"
+    local out="$2"
+    if grep -qF "$SECRET" <<< "$out"; then
+        echo "ERROR: cookie leaked in '$phase' output:"
+        grep -nF "$SECRET" <<< "$out" | head -5
+        exit 1
+    fi
+}
+
+run_and_check() {
+    local debug="$1"
+    shift
+    local out
+    if ! out="$(env DEBUG="$debug" EMQX_NODE__COOKIE="$SECRET" "$ROOT/bin/emqx" "$@" 2>&1)"; then
+        echo "$out"
+        echo "ERROR: 'emqx $*' failed with DEBUG=$debug"
+        exit 1
+    fi
+    assert_no_secret "DEBUG=$debug emqx $*" "$out"
+}
+
+run_and_check 2 start
+run_and_check 2 ping
+run_and_check 1 ctl status
+run_and_check 2 stop
+
+## The console process spawned by 'start' (via run_erl) writes its
+## output, including its shell trace, to erlang.log.*.
+if grep -qF "$SECRET" "$ROOT"/log/erlang.log.* 2>/dev/null; then
+    echo "ERROR: cookie leaked in erlang.log"
+    exit 1
+fi
+
+echo "emqx-debug-trace-smoke: OK"

--- a/scripts/test/emqx-debug-trace-smoke.sh
+++ b/scripts/test/emqx-debug-trace-smoke.sh
@@ -2,13 +2,16 @@
 
 ## Regression test: running bin/emqx with DEBUG=1 or DEBUG=2 must not
 ## print the Erlang cookie in the shell trace output. The cookie is set
-## both in the environment and via etc/emqx.env, so on releases that
-## source the env file this also covers the file sourcing path (the
-## file is ignored on releases that do not source it).
+## in the environment, appended to releases/emqx_vars (the persisted
+## override location the file itself suggests for EMQX_NODE_COOKIE),
+## and written to etc/emqx.env, so on releases that source the env file
+## this also covers that path (the file is ignored on releases that do
+## not source it).
 ##
 ## Usage: emqx-debug-trace-smoke.sh <emqx-root-dir>
 ## The directory must hold an installed release (bin/, etc/, log/) with
-## no node running from it.
+## no node running from it. Pre-existing etc/emqx.env, emqx_vars, and
+## erlang.log.* files are restored when the test finishes.
 
 set -euo pipefail
 
@@ -17,17 +20,53 @@ set -euo pipefail
 ROOT="$1"
 SECRET='debugtracesmokesecret'
 ENV_FILE="$ROOT/etc/emqx.env"
+VARS_FILE="$ROOT/releases/emqx_vars"
+
+# shellcheck disable=SC2009 # match the node by its '-root <dir>' argument, like bin/emqx does
+if ps -efww | grep -qE "[-]root ${ROOT}( |$)"; then
+    echo "ERROR: a node is already running from $ROOT"
+    exit 1
+fi
+
+BACKUP_DIR="$(mktemp -d)"
+mkdir -p "$BACKUP_DIR/logs"
+TEST_OK=0
 
 cleanup() {
-    rm -f "$ENV_FILE"
+    ## Stop the node in case an assertion failed while it was running.
+    env DEBUG=0 EMQX_NODE__COOKIE="$SECRET" "$ROOT/bin/emqx" stop >/dev/null 2>&1 || true
+    ## Restore the pre-existing configuration.
+    if [ -f "$BACKUP_DIR/emqx.env" ]; then
+        cp "$BACKUP_DIR/emqx.env" "$ENV_FILE"
+    else
+        rm -f "$ENV_FILE"
+    fi
+    cp "$BACKUP_DIR/emqx_vars" "$VARS_FILE"
+    ## Restore the pre-existing logs. Keep this run's logs on failure,
+    ## moved aside so they cannot collide with the restored ones.
+    if [ "$TEST_OK" = 1 ]; then
+        rm -f "$ROOT"/log/erlang.log.*
+    else
+        local failed_dir="$ROOT/log/debug-trace-smoke-failed.$$"
+        mkdir -p "$failed_dir"
+        mv "$ROOT"/log/erlang.log.* "$failed_dir/" 2>/dev/null || true
+        echo "logs from the failed run are kept in $failed_dir"
+    fi
+    mv "$BACKUP_DIR"/logs/erlang.log.* "$ROOT/log/" 2>/dev/null || true
+    rm -rf "$BACKUP_DIR"
 }
 trap cleanup EXIT
 
+## Back up the files this test modifies, then plant the secret in every
+## persisted location an operator may use for the cookie.
+[ -f "$ENV_FILE" ] && cp "$ENV_FILE" "$BACKUP_DIR/emqx.env"
+cp "$VARS_FILE" "$BACKUP_DIR/emqx_vars"
 echo "EMQX_NODE__COOKIE=$SECRET" > "$ENV_FILE"
+echo "EMQX_NODE_COOKIE=\"$SECRET\"" >> "$VARS_FILE"
 
-## Drop logs from earlier runs so the erlang.log check below only sees
-## output produced by this run.
-rm -f "$ROOT"/log/erlang.log.*
+## Move logs from earlier runs aside so the erlang.log check below only
+## sees output produced by this run.
+mv "$ROOT"/log/erlang.log.* "$BACKUP_DIR/logs/" 2>/dev/null || true
 
 assert_no_secret() {
     local phase="$1"
@@ -63,4 +102,5 @@ if grep -qF "$SECRET" "$ROOT"/log/erlang.log.* 2>/dev/null; then
     exit 1
 fi
 
+TEST_OK=1
 echo "emqx-debug-trace-smoke: OK"


### PR DESCRIPTION
Fixes:
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: pre-5.8

## Summary

The `bin/emqx` script enables shell xtrace (`set -x`) when `DEBUG=1` or `DEBUG=2` is set. The trace output printed the Erlang distribution cookie at every point where the cookie flows through a shell variable:

- the cookie resolution block (`EMQX_NODE__COOKIE`, `node.cookie`);
- the `remsh` command building block (`-setcookie` / `--cookie` arguments);
- `relx_nodetool` (`ERL_FLAGS` assignment);
- the `generate_config` vm.args merge loop (on this branch the generated args carry the `-setcookie` line);
- the `eval-ex` command;
- `get_boot_config`, which echoes the whole `EMQX_BOOT_CONFIGS` string (it carries `node.cookie` and `license.key`);
- `maybe_warn_default_cookie` and `diagnose_boot_failure_and_die` (cookie in the test expression and `ps` output);
- `check_license` (license key in the `key_license` assignment and the nodetool argument).

The `DEBUG=1` `logdebug` lines also printed `PS_LINE` and `EMQX_BOOT_CONFIGS`, which carry the cookie.

The fix turns tracing off around each secret-bearing region and re-arms it after, following the `set +x` / `set -x` pattern already used in the script. The `logdebug` lines now mask the cookie and license key values as `******`. Tracing everywhere else is unchanged; in particular the main boot command building block stays traced, because on this branch the boot command line does not carry the cookie (it goes through the generated vm.args file).

The dev-63 counterpart is #18706 (the script diverged there: the cookie moved to the boot command line, which adds sites this branch does not have).

Manual validation (all print 0 cookie occurrences after the fix, nonzero before):

```sh
DEBUG=1 EMQX_NODE__COOKIE=secret ./bin/emqx console 2>&1 | grep -c secret
```

Verified with both `DEBUG=1` and `DEBUG=2` for the `console`, `start`, `stop`, `ctl`, `ping`, and `remote_console` commands, including non-boot commands reading the cookie back from the running node's `ps` output. Verified a normal (non-DEBUG) `start`/`ctl status`/`stop` cycle still works and that tracing is re-armed after each masked region.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
