### PR TITLE
fix(mgmt): remove unreachable node format clause

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -299,12 +299,7 @@ format(Info = #{memory_total := Total, memory_used := Used}) ->
         memory_used := emqx_mgmt_util:kmg(Used)
     };
 format(Info) when is_map(Info) ->
-    Info;
-%% `emqx_mgmt:lookup_node/1` reaches this as `Info` when the target node
-%% becomes unreachable between the caller's liveness check and the RPC,
-%% e.g. a concurrent `cluster leave`.
-format({error, _} = Error) ->
-    Error.
+    Info.
 
 to_ok_result({error, _} = Error) ->
     Error;


### PR DESCRIPTION
Fixes: N/A
Release version: 6.3.0
Introduced in: 6.3.0

## Summary

Dialyzer reports `format({error, _})` in `emqx_mgmt_api_nodes` as unreachable because the endpoint now normalizes unreachable-node results before calling `format/1`. Remove the stale clause and its outdated comment so `make static_checks` can complete successfully.

This is a build-time/type-analysis fix only. It does not change the node API response behavior, configuration, or schema.

## PR Checklist

- [x] The changes are covered by existing tests
- [x] No user-visible behavior change; changelog is not applicable
- [x] No schema changes
