### PR TITLE
docs: drop stale Community/Enterprise edition mentions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,9 +84,8 @@ The footer should contain any information about **Breaking Changes** and is also
 
 Changes affecting EMQX functionality shall be described in a separate markdown file under `changes` directory.
 
-File name pattern: `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md`, where:
+File name pattern: `changes/ee/(feat|fix|perf|breaking)-<PR-id>.en.md`, where:
 
-- `ce,ee`: Indicates whether given change affects community and enterprise edition (`ce`), or enterprise edition only (`ee`); for any change only one file is needed as enterprise edition absorbs all changes from the community edition automatically. When in doubts, one could consult [documentation](https://www.emqx.io/docs/en/latest/). Enterprise features have a corresponding "Tip" banner, see for example [here](https://www.emqx.io/docs/en/v5.1/data-integration/data-bridge-influxdb.html).
-- `feat|perf|fix`: Whether the change is a new functionality (`feat`), performance improvement (`perf`), or a bug fix (`fix`).
+- `feat|fix|perf|breaking`: Whether the change is a new functionality (`feat`), a bug fix (`fix`), a performance improvement (`perf`), or a breaking change (`breaking`).
 - `PR-id`: Github pull request id. Since pull request id cannot be known before the PR is actually created, it's common to add change log entry in a separate commit.
 - `en`: ISO 639-1 language code indicating the language the change log entry is written in. Right now we are only accepting entries in English.

--- a/apps/emqx/src/emqx_release.erl
+++ b/apps/emqx/src/emqx_release.erl
@@ -47,7 +47,7 @@ edition() ->
 edition_vsn_prefix() ->
     ?EMQX_REL_VSN_PREFIX.
 
-%% @doc Return EMQX edition name, ee => Enterprise ce => Opensource.
+%% @doc Return EMQX edition name.
 edition_longstr() -> ?EMQX_REL_NAME.
 
 %% @doc Return the release version with prefix.

--- a/apps/emqx_license/src/emqx_license.erl
+++ b/apps/emqx_license/src/emqx_license.erl
@@ -32,8 +32,8 @@
 -define(CONF_KEY_PATH, [license]).
 
 %% Give the license app the highest priority.
-%% We don't define it in the emqx_hooks.hrl becasue that is an opensource code
-%% and can be changed by the communitiy.
+%% We don't define it in emqx_hooks.hrl because that header is part of the
+%% core emqx app, not the license app.
 -define(HP_LICENSE, 2000).
 
 -define(IS_CLIENTID_TO_BE_ASSIGENED(X), (X =:= <<>> orelse X =:= undefined)).

--- a/apps/emqx_mt/README.md
+++ b/apps/emqx_mt/README.md
@@ -7,7 +7,7 @@ The 'users' or 'tenants' here can be a group of MQTT clients with a shared names
 or a group of admins with different access scopes.
 This app (so far) implements MQTT client multi-tenancy but not yet admin multi-tenancy.
 
-## Tenant Namespace Extraction (available in Open-Source Edition)
+## Tenant Namespace Extraction
 
 Starting from **EMQX 5.9**, MQTT clients with a client attribute named `tns`
 will be considered a client belonging to the corresponding tenant.
@@ -28,7 +28,7 @@ More examples are:
 - `user_property.foobar`: Use `foobar` field from User-Property of the CONNECT packet.
 - `peersni`: Use the server name indication sent by TLS client.
 
-## Tenant Client ID Isolation (available in Open-Source Edition)
+## Tenant Client ID Isolation
 
 Ideally, if well planed, MQTT clients should be pre-assigned to avoid ID clashes between
 different tenants.
@@ -41,7 +41,7 @@ to assign a prefix for all clients so to avoid client ID clashing between the te
 For example this config `mqtt.clientid_override = "concat([username, '-', clientid])"`
 should add `username-` as prefix to the client ID internally in EMQX.
 
-## Tenant Topic Isolation (available in Open-Source Edition)
+## Tenant Topic Isolation
 
 This can be done by making use of the MQTT listener's `mountpoint` config.
 For example: `listeners.tcp.default.mountpoint = "${client_attrs.tns}/"`.

--- a/apps/emqx_telemetry/README.md
+++ b/apps/emqx_telemetry/README.md
@@ -1,6 +1,6 @@
 # emqx_telemetry
 
-In order for EMQ to understand how EMQX opensource edition is being used,
+In order for EMQ to understand how EMQX is being used,
 this app reports some telemetry data to [EMQ's telemetry server](https://telemetry.emqx.io/api/telemetry)
 
 To turn it off, you can set `telemetry.enable = false` in emqx.conf,
@@ -8,7 +8,6 @@ or start EMQX with environment variable `EMQX_TELEMETRY__ENABLE=false`.
 
 ## Reported Data
 
-This application is only relesaed in EMQX opensource edition.
 There is nothing in the reported data which can back-track the origin.
 The report interval is 7 days, so there is no performance impact.
 
@@ -17,7 +16,7 @@ Here is the full catalog of the reported data.
 ### Installation
 
 - EMQX version string
-- License (always stubed with "opensource")
+- License edition
 - VM Stats (number of cores, total memory)
 - Operating system name
 - Operating system version

--- a/apps/emqx_telemetry/src/emqx_telemetry.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry.erl
@@ -333,7 +333,7 @@ do_get_telemetry(State0 = #state{node_uuid = NodeUUID, cluster_uuid = ClusterUUI
     } = get_rule_engine_and_bridge_info(),
     {State, [
         {emqx_version, bin(emqx_app:get_release())},
-        {license, [{edition, <<"opensource">>}]},
+        {license, [{edition, emqx_release:edition_longstr()}]},
         {os_name, bin(get_value(os_name, OSInfo))},
         {os_version, bin(get_value(os_version, OSInfo))},
         {otp_version, bin(otp_version())},

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -342,6 +342,10 @@ t_is_official_version(_) ->
 
 t_get_telemetry(_Config) ->
     {ok, TelemetryData} = emqx_telemetry:get_telemetry(),
+    ?assertEqual(
+        [{edition, emqx_release:edition_longstr()}],
+        get_value(license, TelemetryData)
+    ),
     OTPVersion = bin(erlang:system_info(otp_release)),
     ?assertEqual(OTPVersion, get_value(otp_version, TelemetryData)),
     {ok, NodeUUID} = emqx_telemetry:get_node_uuid(),

--- a/changes/ee/fix-18716.en.md
+++ b/changes/ee/fix-18716.en.md
@@ -1,0 +1,1 @@
+Fixed the telemetry report sent to EMQ's telemetry server always stating the running edition as `opensource`, regardless of the actual build.

--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -21,9 +21,6 @@ help() {
 
 # PROFILE is no longer in use, TODO: clean up
 case ${1:-} in
-    opensource)
-        shift
-        ;;
     enterprise)
         shift
         ;;

--- a/scripts/merge-config.escript
+++ b/scripts/merge-config.escript
@@ -5,8 +5,8 @@
 %% Sections are grouped between CONFIG_SECTION_BGN and
 %% CONFIG_SECTION_END pairs
 %%
-%% NOTE: this feature is so far not used in opensource
-%% edition due to backward-compatibility reasons.
+%% NOTE: this feature is so far not used, due to
+%% backward-compatibility reasons.
 
 -mode(compile).
 -define(APPS, ["emqx", "emqx_dashboard", "emqx_auth"]).

--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## cut a new 5.x release for EMQX (opensource or enterprise).
+## cut a new 5.x release for EMQX.
 
 set -euo pipefail
 


### PR DESCRIPTION
Fixes: N/A
Release version: 7.0.0
Introduced in: N/A

## Summary

EMQX unified Community and Enterprise editions into a single BSL-licensed offering at 5.9.0. This PR cleans up leftover stale text and one dead code branch from before that unification, plus a real bug:

- Remove stale "Community Edition"/"opensource edition" wording from `README.md`-adjacent docs (`apps/emqx_mt/README.md`, `apps/emqx_telemetry/README.md`), code comments (`emqx_release.erl`, `emqx_license.erl`), and build scripts (`pkg-vsn.sh`, `scripts/merge-config.escript`, `scripts/rel/cut.sh`).
- Correct `CONTRIBUTING.md`'s documented changelog file-suffix convention (`ce`/`ee`) to match this repo's actual current convention (`changes/ee/(feat|fix|perf|breaking)-<PR-id>.en.md`).
- Remove `pkg-vsn.sh`'s dead `opensource)` case-arm, per its own `TODO: clean up` comment. Verified no caller (`Makefile`, CI workflows, `scripts/*.sh`) passes `opensource` as an argument.
- Fix `emqx_telemetry:do_get_telemetry/1` hardcoding `{edition, <<"opensource">>}` in the payload sent to EMQ's telemetry server, regardless of the actual running edition. Every node running this codebase is enterprise-only, so this was factually wrong. Now derived from `emqx_release:edition_longstr/0`.

Out of scope, left untouched by design: the REST API `edition` field/enum (`emqx_dashboard_api.erl`, `emqx_mgmt_api_nodes.erl`), and the backup-format `check_edition/1` compatibility check (`emqx_mgmt_data_backup.erl`). Narrowing that documented API schema is a separate API-contract change requiring Dashboard-team coordination.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-18716.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eRUbp18T9rDUfC8Y42pPo
