### PR TITLE
fix(telemetry): report the actual running edition

### DIFF
--- a/apps/emqx_telemetry/src/emqx_telemetry.app.src
+++ b/apps/emqx_telemetry/src/emqx_telemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_telemetry, [
     {description, "Report telemetry data for EMQX Opensource edition"},
-    {vsn, "0.2.2"},
+    {vsn, "0.2.3"},
     {registered, [emqx_telemetry_sup, emqx_telemetry]},
     {mod, {emqx_telemetry_app, []}},
     {applications, [

--- a/apps/emqx_telemetry/src/emqx_telemetry.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry.erl
@@ -333,7 +333,7 @@ do_get_telemetry(State0 = #state{node_uuid = NodeUUID, cluster_uuid = ClusterUUI
     } = get_rule_engine_and_bridge_info(),
     {State, [
         {emqx_version, bin(emqx_app:get_release())},
-        {license, [{edition, <<"opensource">>}]},
+        {license, [{edition, emqx_release:edition_longstr()}]},
         {os_name, bin(get_value(os_name, OSInfo))},
         {os_version, bin(get_value(os_version, OSInfo))},
         {otp_version, bin(otp_version())},

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -322,6 +322,10 @@ t_is_official_version(_) ->
 
 t_get_telemetry(_Config) ->
     {ok, TelemetryData} = emqx_telemetry:get_telemetry(),
+    ?assertEqual(
+        [{edition, emqx_release:edition_longstr()}],
+        get_value(license, TelemetryData)
+    ),
     OTPVersion = bin(erlang:system_info(otp_release)),
     ?assertEqual(OTPVersion, get_value(otp_version, TelemetryData)),
     {ok, NodeUUID} = emqx_telemetry:get_node_uuid(),


### PR DESCRIPTION
Fixes: N/A
Release version: 5.9.4, 5.10.5
Introduced in: pre-5.8

## Summary

`emqx_telemetry:do_get_telemetry/1` hardcoded the license edition as `"opensource"` in the payload sent to EMQ's telemetry server, regardless of the actual running edition. Every node running this codebase is enterprise-only, so this was factually wrong.

Fix: derive the value from `emqx_release:edition_longstr/0` instead of the hardcoded binary.

This is a backport of the same fix from #18716 (dev-70), without the accompanying doc cleanup.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eRUbp18T9rDUfC8Y42pPo
