### PR TITLE
test(broker): look back for the reconnect inc event in t_connected_client_count_transient_takeover

### DIFF
--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -591,10 +591,15 @@ t_connected_client_count_transient_takeover(Config) when is_list(Config) ->
     %% asserting once right after the event wait.
     ?retry(100, 20, ?assertEqual(0, emqx_cm:get_connected_client_count())),
     %% connecting again, this time, retry until server is not busy
+    %% BackInTime must stay 0 here: this clientid was just reused by the
+    %% takeover storm, so a look-back window can match a stale inc event from
+    %% one of those discarded channels instead of this reconnect's own event.
+    %% Only the forward timeout needs widening.
     {{ok, _}, {ok, [_]}} =
         wait_for_events(
             fun() -> start_connect_client(Opts, ConnFun) end,
-            [emqx_cm_connected_client_count_inc]
+            [emqx_cm_connected_client_count_inc],
+            5000
         ),
     ?assertEqual(1, emqx_cm:get_connected_client_count()),
     %% abnormal exit of channel process


### PR DESCRIPTION
## Summary

`emqx_broker_SUITE:connected_client_count_group.quic.t_connected_client_count_transient_takeover`
failed on an unrelated PR:

```
{badmatch,{{ok,<0.255510.0>},timeout}}
  emqx_broker_SUITE:t_connected_client_count_transient_takeover/1, line 594
```

https://github.com/emqx/emqx/actions/runs/33598200243/job/100147967240

`{ok, Pid}` (the connect succeeded) paired with `timeout` (the `wait_for_events` call never
saw the `emqx_cm_connected_client_count_inc` trace event) — a race, not the counter mismatch
`?assertEqual(0, ...)` fixed by #18629 a few lines above this one.

`dev-59` is the only branch carrying an unfixed version of this specific `wait_for_events`
call. Every other branch — `dev-510` and all of `dev-60` through `dev-70` — already has a fix
from `411795d6ea` ("test: fix flaky tc in emqx_broker_SUITE", 2025-05-21), which was apparently
never backported to `dev-59`.

## Fix (revised after review)

The first version of this PR copied `dev-510`'s form verbatim — adding `BackInTime = 1000` so
`wait_for_events` also looks back over the last second of trace history, not just forward.
[@thalesmg pointed out](https://github.com/emqx/emqx/pull/18723#discussion_r3914548417) that
this doesn't wait for *this* reconnect's own event, and he was right: this clientid was just
reused by the 20-way takeover storm a few lines above, so the look-back window matches a stale
`inc` event from one of those discarded channels instead. Confirmed by instrumenting the test:
in 3/3 local runs, the matched event's `chan_pid` did not match the channel actually registered
for this clientid afterwards. The test still passed only because the following count assertion
is an independent, unguarded state read that happens to succeed once the connect call returns —
the wait itself wasn't a real barrier.

Fixed by widening the forward timeout instead, leaving `BackInTime` at its default of `0` so the
wait only matches a genuinely new event:

```erlang
wait_for_events(
    fun() -> start_connect_client(Opts, ConnFun) end,
    [emqx_cm_connected_client_count_inc],
    5000
),
```

## Validation

`connected_client_count_group`: 12 ok, 0 failed (both the original and the revised fix).