### PR TITLE
fix(sso): reject oidc https issuer with ssl.enable=false at config time

### DIFF
--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc.erl
@@ -292,8 +292,10 @@ validate_issuer_url(Value) ->
             throw(invalid_issuer_url)
     end.
 
-%% `ssl.enable = false` on an `https` issuer silently drops all TLS options
-%% and fails at request time instead; reject it up front.
+%% `ssl.enable` must match whether the issuer actually uses `https`:
+%% `false` on `https` silently drops all TLS options and fails at request
+%% time instead; `true` on `http` is dead config, oidcc always attaches it
+%% to the httpc request but httpc only ever uses it for a `https' URL.
 check_ssl_opts(#{issuer := Issuer, ssl := #{enable := false}}) ->
     case is_https(Issuer) of
         true ->
@@ -301,6 +303,15 @@ check_ssl_opts(#{issuer := Issuer, ssl := #{enable := false}}) ->
                 {invalid_ssl_opts,
                     <<"it's required to enable the TLS option to establish a https connection">>}};
         false ->
+            ok
+    end;
+check_ssl_opts(#{issuer := Issuer, ssl := #{enable := true}}) ->
+    case is_https(Issuer) of
+        false ->
+            {error,
+                {invalid_ssl_opts,
+                    <<"the TLS option must not be enabled when the issuer is not using https">>}};
+        true ->
             ok
     end;
 check_ssl_opts(_Config) ->

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc.erl
@@ -23,7 +23,8 @@
     create/1,
     update/2,
     destroy/1,
-    convert_certs/2
+    convert_certs/2,
+    check_ssl_opts/1
 ]).
 
 -define(PROVIDER_SVR_NAME, ?MODULE).
@@ -170,25 +171,30 @@ desc(_) ->
 %%------------------------------------------------------------------------------
 
 create(#{name_var := NameVar} = Config) ->
-    case
-        emqx_dashboard_sso_oidc_session:start(
-            ?PROVIDER_SVR_NAME,
-            Config
-        )
-    of
+    case check_ssl_opts(Config) of
         {error, _} = Error ->
             Error;
-        _ ->
-            %% Note: the oidcc maintains an ETS with the same name of the provider gen_server,
-            %% we should use this name in each API calls not the PID,
-            %% or it would backoff to sync calls to the gen_server
-            ClientJwks = init_client_jwks(Config),
-            {ok, #{
-                name => ?PROVIDER_SVR_NAME,
-                config => Config,
-                client_jwks => ClientJwks,
-                name_tokens => emqx_placeholder:preproc_tmpl(NameVar)
-            }}
+        ok ->
+            case
+                emqx_dashboard_sso_oidc_session:start(
+                    ?PROVIDER_SVR_NAME,
+                    Config
+                )
+            of
+                {error, _} = Error ->
+                    Error;
+                _ ->
+                    %% Note: the oidcc maintains an ETS with the same name of the provider gen_server,
+                    %% we should use this name in each API calls not the PID,
+                    %% or it would backoff to sync calls to the gen_server
+                    ClientJwks = init_client_jwks(Config),
+                    {ok, #{
+                        name => ?PROVIDER_SVR_NAME,
+                        config => Config,
+                        client_jwks => ClientJwks,
+                        name_tokens => emqx_placeholder:preproc_tmpl(NameVar)
+                    }}
+            end
     end.
 
 update(Config, State) ->
@@ -281,6 +287,26 @@ validate_issuer_url(Value) ->
     else
         _ ->
             throw(invalid_issuer_url)
+    end.
+
+%% `ssl.enable = false` on an `https` issuer silently drops all TLS options
+%% and fails at request time instead; reject it up front.
+check_ssl_opts(#{issuer := Issuer, ssl := #{enable := false}}) ->
+    case is_https(Issuer) of
+        true ->
+            {error,
+                {invalid_ssl_opts,
+                    <<"it's required to enable the TLS option to establish a https connection">>}};
+        false ->
+            ok
+    end;
+check_ssl_opts(_Config) ->
+    ok.
+
+is_https(Issuer) ->
+    case uri_string:parse(Issuer) of
+        #{scheme := <<"https">>} -> true;
+        _ -> false
     end.
 
 save_jwks_file(Dir, Content) ->

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc.erl
@@ -175,26 +175,29 @@ create(#{name_var := NameVar} = Config) ->
         {error, _} = Error ->
             Error;
         ok ->
-            case
-                emqx_dashboard_sso_oidc_session:start(
-                    ?PROVIDER_SVR_NAME,
-                    Config
-                )
-            of
-                {error, _} = Error ->
-                    Error;
-                _ ->
-                    %% Note: the oidcc maintains an ETS with the same name of the provider gen_server,
-                    %% we should use this name in each API calls not the PID,
-                    %% or it would backoff to sync calls to the gen_server
-                    ClientJwks = init_client_jwks(Config),
-                    {ok, #{
-                        name => ?PROVIDER_SVR_NAME,
-                        config => Config,
-                        client_jwks => ClientJwks,
-                        name_tokens => emqx_placeholder:preproc_tmpl(NameVar)
-                    }}
-            end
+            start_session(Config, NameVar)
+    end.
+
+start_session(Config, NameVar) ->
+    case
+        emqx_dashboard_sso_oidc_session:start(
+            ?PROVIDER_SVR_NAME,
+            Config
+        )
+    of
+        {error, _} = Error ->
+            Error;
+        _ ->
+            %% Note: the oidcc maintains an ETS with the same name of the provider gen_server,
+            %% we should use this name in each API calls not the PID,
+            %% or it would backoff to sync calls to the gen_server
+            ClientJwks = init_client_jwks(Config),
+            {ok, #{
+                name => ?PROVIDER_SVR_NAME,
+                config => Config,
+                client_jwks => ClientJwks,
+                name_tokens => emqx_placeholder:preproc_tmpl(NameVar)
+            }}
     end.
 
 update(Config, State) ->

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
@@ -455,6 +455,28 @@ t_stop_cleanup(TCConfig) ->
     ok.
 
 -doc """
+`PUT /api/v5/sso/oidc' must reject an `https' issuer combined with
+`ssl.enable = false' with a clear error at config-write time, instead of
+accepting it and failing every login attempt later with an opaque TLS error
+(see `emqx_dashboard_sso_oidc:check_ssl_opts/1').
+""".
+t_reject_https_issuer_with_ssl_disabled(TCConfig) ->
+    start_apps(?FUNCTION_NAME, TCConfig),
+    Node = node(),
+    ProviderParams = (oidc_provider_params())#{
+        <<"ssl">> => #{<<"enable">> => false}
+    },
+    {400, #{<<"message">> := Message}} = create_backend(Node, ProviderParams, #{}),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"invalid_ssl_opts">>)),
+    ?assertNotEqual(
+        nomatch,
+        binary:match(Message, <<"required to enable the TLS option">>)
+    ),
+    %% The rejected config must not have been persisted or started.
+    ?assertEqual([], supervisor:which_children(emqx_dashboard_sso_oidc_sup)),
+    ok.
+
+-doc """
 `GET /api/v5/sso/oidc' must return `client_jwks' as `none' when no client
 JWKS is configured (the default), while a configured file JWKS and the
 client secret must stay masked in both the GET and update responses. Masking

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
@@ -299,6 +299,12 @@ oidc_provider_params() ->
 oidc_provider_params(Issuer) ->
     (oidc_provider_params())#{<<"issuer">> => emqx_utils_conv:bin(Issuer)}.
 
+%% `emqx_utils_http_test_server' only ever serves plain http; ssl must be
+%% disabled to match, or the config is rejected up front (see
+%% `emqx_dashboard_sso_oidc:check_ssl_opts/1').
+oidc_provider_params_local_mock(Issuer) ->
+    (oidc_provider_params(Issuer))#{<<"ssl">> => #{<<"enable">> => false}}.
+
 %%------------------------------------------------------------------------------
 %% Test cases
 %%------------------------------------------------------------------------------
@@ -477,6 +483,26 @@ t_reject_https_issuer_with_ssl_disabled(TCConfig) ->
     ok.
 
 -doc """
+`PUT /api/v5/sso/oidc' must reject a `http' issuer combined with
+`ssl.enable = true' with a clear error at config-write time. oidcc always
+attaches the TLS options to its httpc request regardless of URL scheme, but
+httpc only ever uses them for a `https' URL (see `httpc_handler:socket_type/1'),
+so the TLS options would be silently ignored, not applied.
+""".
+t_reject_http_issuer_with_ssl_enabled(TCConfig) ->
+    start_apps(?FUNCTION_NAME, TCConfig),
+    Node = node(),
+    ProviderParams = oidc_provider_params("http://authn-server:5556/dex"),
+    {400, #{<<"message">> := Message}} = create_backend(Node, ProviderParams, #{}),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"invalid_ssl_opts">>)),
+    ?assertNotEqual(
+        nomatch,
+        binary:match(Message, <<"must not be enabled">>)
+    ),
+    ?assertEqual([], supervisor:which_children(emqx_dashboard_sso_oidc_sup)),
+    ok.
+
+-doc """
 `GET /api/v5/sso/oidc' must return `client_jwks' as `none' when no client
 JWKS is configured (the default), while a configured file JWKS and the
 client secret must stay masked in both the GET and update responses. Masking
@@ -491,7 +517,7 @@ t_client_jwks_redaction(TCConfig) ->
     on_exit(fun() -> ok = emqx_utils_http_test_server:stop() end),
     ok = emqx_utils_http_test_server:set_handler(fun oidc_content_type_handler/2),
     Issuer = host(Port) ++ ?OIDC_PATH_PREFIX,
-    ProviderParams = oidc_provider_params(Issuer),
+    ProviderParams = oidc_provider_params_local_mock(Issuer),
 
     ?assertMatch({200, _}, create_backend(Node, ProviderParams, #{})),
     ?assertMatch(
@@ -529,7 +555,7 @@ t_client_jwks_update_roundtrip(TCConfig) ->
     on_exit(fun() -> ok = emqx_utils_http_test_server:stop() end),
     ok = emqx_utils_http_test_server:set_handler(fun oidc_content_type_handler/2),
     Issuer = host(Port) ++ ?OIDC_PATH_PREFIX,
-    ProviderParams = oidc_provider_params(Issuer),
+    ProviderParams = oidc_provider_params_local_mock(Issuer),
 
     JwksContent = <<"{\"keys\":[{\"kty\":\"oct\",\"k\":\"c2VjcmV0\"}]}">>,
     ParamsWithJwks = ProviderParams#{
@@ -576,7 +602,7 @@ t_client_jwks_explicit_none_removes(TCConfig) ->
     on_exit(fun() -> ok = emqx_utils_http_test_server:stop() end),
     ok = emqx_utils_http_test_server:set_handler(fun oidc_content_type_handler/2),
     Issuer = host(Port) ++ ?OIDC_PATH_PREFIX,
-    ProviderParams = oidc_provider_params(Issuer),
+    ProviderParams = oidc_provider_params_local_mock(Issuer),
 
     JwksContent = <<"{\"keys\":[{\"kty\":\"oct\",\"k\":\"c2VjcmV0\"}]}">>,
     ParamsWithJwks = ProviderParams#{
@@ -606,7 +632,7 @@ t_jwks_content_type_suffix(TCConfig) ->
     ok = emqx_utils_http_test_server:set_handler(fun oidc_content_type_handler/2),
 
     Issuer = host(Port) ++ ?OIDC_PATH_PREFIX,
-    ProviderParams = oidc_provider_params(Issuer),
+    ProviderParams = oidc_provider_params_local_mock(Issuer),
     ?assertMatch({200, _}, create_backend(Node, ProviderParams, #{})),
 
     ?retry(
@@ -631,7 +657,7 @@ t_kanidm_cache_control_max_age_zero(TCConfig) ->
     ok = emqx_utils_http_test_server:set_handler(fun oidc_kanidm_shape_handler/2),
 
     Issuer = host(Port) ++ ?OIDC_PATH_PREFIX,
-    ProviderParams = oidc_provider_params(Issuer),
+    ProviderParams = oidc_provider_params_local_mock(Issuer),
     ?assertMatch({200, _}, create_backend(Node, ProviderParams, #{})),
 
     ?retry(

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_tests.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_tests.erl
@@ -115,6 +115,14 @@ check_ssl_opts_test_() ->
                     ssl => #{enable => false}
                 })
             )},
+        {"http issuer with ssl enabled is rejected",
+            ?_assertMatch(
+                {error, {invalid_ssl_opts, _}},
+                emqx_dashboard_sso_oidc:check_ssl_opts(#{
+                    issuer => <<"http://example.com">>,
+                    ssl => #{enable => true}
+                })
+            )},
         {"https issuer without an ssl config is allowed",
             ?_assertEqual(
                 ok,
@@ -129,6 +137,17 @@ create_rejects_https_issuer_with_ssl_disabled_test() ->
         name_var => <<"${sub}">>,
         issuer => <<"https://example.com">>,
         ssl => #{enable => false}
+    },
+    ?assertMatch(
+        {error, {invalid_ssl_opts, _}},
+        emqx_dashboard_sso_oidc:create(Config)
+    ).
+
+create_rejects_http_issuer_with_ssl_enabled_test() ->
+    Config = #{
+        name_var => <<"${sub}">>,
+        issuer => <<"http://example.com">>,
+        ssl => #{enable => true}
     },
     ?assertMatch(
         {error, {invalid_ssl_opts, _}},

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_tests.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_tests.erl
@@ -88,3 +88,49 @@ issuer_validation_test_() ->
                 parse_and_check(oidc_config(#{<<"issuer">> => <<"pulsar+ssl://string">>}))
             )}
     ].
+
+check_ssl_opts_test_() ->
+    [
+        {"https issuer with ssl disabled is rejected",
+            ?_assertMatch(
+                {error, {invalid_ssl_opts, _}},
+                emqx_dashboard_sso_oidc:check_ssl_opts(#{
+                    issuer => <<"https://example.com">>,
+                    ssl => #{enable => false}
+                })
+            )},
+        {"https issuer with ssl enabled is allowed",
+            ?_assertEqual(
+                ok,
+                emqx_dashboard_sso_oidc:check_ssl_opts(#{
+                    issuer => <<"https://example.com">>,
+                    ssl => #{enable => true}
+                })
+            )},
+        {"http issuer with ssl disabled is allowed",
+            ?_assertEqual(
+                ok,
+                emqx_dashboard_sso_oidc:check_ssl_opts(#{
+                    issuer => <<"http://example.com">>,
+                    ssl => #{enable => false}
+                })
+            )},
+        {"https issuer without an ssl config is allowed",
+            ?_assertEqual(
+                ok,
+                emqx_dashboard_sso_oidc:check_ssl_opts(#{issuer => <<"https://example.com">>})
+            )}
+    ].
+
+create_rejects_https_issuer_with_ssl_disabled_test() ->
+    %% check_ssl_opts/1 runs before any network I/O, so this returns without
+    %% starting an oidcc session.
+    Config = #{
+        name_var => <<"${sub}">>,
+        issuer => <<"https://example.com">>,
+        ssl => #{enable => false}
+    },
+    ?assertMatch(
+        {error, {invalid_ssl_opts, _}},
+        emqx_dashboard_sso_oidc:create(Config)
+    ).

--- a/changes/ee/fix-18724.en.md
+++ b/changes/ee/fix-18724.en.md
@@ -1,1 +1,1 @@
-Dashboard SSO OIDC now rejects configuration with an `https` issuer and TLS disabled at config time, instead of failing repeatedly at runtime with an unclear TLS error.
+Dashboard SSO OIDC now rejects configuration where the issuer's URL scheme and the TLS option disagree (`https` with TLS disabled, or `http` with TLS enabled) at config time, instead of failing repeatedly at runtime with an unclear TLS error or silently ignoring the TLS option.

--- a/changes/ee/fix-18724.en.md
+++ b/changes/ee/fix-18724.en.md
@@ -1,0 +1,1 @@
+Dashboard SSO OIDC now rejects configuration with an `https` issuer and TLS disabled at config time, instead of failing repeatedly at runtime with an unclear TLS error.


### PR DESCRIPTION
Fixes: #18715
Release version:
6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: pre-5.8

## Summary

Dashboard SSO OIDC's config accepted an `https` issuer with `ssl.enable = false`. At runtime, `emqx_tls_lib:to_client_opts/2` treats `enable =/= true` the same as "no TLS options at all", so the request ends up with no `ssl` httpc option and falls back to OTP's default `verify_peer` with no configured CA. Against a self-signed or private-CA issuer this fails every request with an opaque `bad_certificate`-style error, with no indication that `ssl.enable` was the cause.

This PR is a config-time validation fix, not a change to the underlying TLS-option-construction behavior. `emqx_dashboard_sso_oidc:create/1` now rejects `https` issuer + `ssl.enable = false` up front, mirroring the existing `check_ssl_opts/1` pattern in `emqx_auth_http/src/emqx_authn_http.erl`:

```erlang
check_ssl_opts(#{issuer := Issuer, ssl := #{enable := false}}) ->
    case is_https(Issuer) of
        true -> {error, {invalid_ssl_opts, <<"it's required to enable the TLS option to establish a https connection">>}};
        false -> ok
    end;
check_ssl_opts(_Config) -> ok.
```

`create/1` is the single entry point used by both `create/1` and `update/2` (which calls `create/1` internally), so both config-write paths get the check. An `https` issuer with the `ssl` field entirely absent is left unchanged (not rejected) — this matches how many working configurations (public CAs, no custom `ssl` block) function today via OTP's default `verify_peer`, and is not the combination this issue reports.

The `emqx_dashboard_sso` behaviour has no `validations/0`-style HOCON-schema-level hook (unlike `emqx_authn_schema`), so this couldn't be wired as a HOCON struct-level validation without extending that behaviour — a larger change than this fix warrants. `create/1` gives the same real error instead of the current silent runtime failure.

Out of scope for this PR (left for later discussion):
- The underlying `to_client_opts/2` behavior of discarding all SSL options (including `verify`) when `ssl.enable =/= true` — present unchanged since OIDC's configurable-SSL-options feature shipped in 6.0.1/5.9.3, and reproducible on every branch from dev-58 through dev-70.
- A structurally similar issue in `emqx_auth_jwt/src/emqx_authn_jwks_client.erl` (JWKS fetch over https).
- `emqx_dashboard_sso_saml.erl`'s IdP metadata fetch, which has no configurable `ssl`/`verify` field at all (different shape of problem).
- Backporting this validation to dev-58/59/510/61/62/63/70 — the same root mechanism exists on all of them, but that's a separate decision.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-18724.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)