### PR TITLE
chore(mqtt): correct `mqtt_mqueue_store_qos0` description

### DIFF
--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1403,9 +1403,10 @@ shared_subscription_initial_sticky_pick_enum.desc:
  - `hash_topic`: Hash the publishing topic to select a subscriber."""
 
 mqtt_mqueue_store_qos0.desc: """~
-  Controls how QoS 0 messages are handled when the client connection is down or the inflight window (used for QoS 1 and 2) is full.
-  - When set to `true`, QoS 0 messages are buffered in the session’s message queue.
-  - When set to `false`, QoS 0 messages are dropped immediately.
+  Controls whether QoS 0 messages are buffered in a session’s message queue  while the client is disconnected or its connection is congested.
+  - When enabled, QoS 0 messages may also be queued behind QoS 1 and 2 messages to preserve delivery order when the inflight window is full.
+  - When disabled, QoS 0 messages are not stored.
+  Queue limits and message expiry still apply.
   This setting applies only to non-durable sessions.~"""
 
 mqtt_mqueue_store_qos0.label:


### PR DESCRIPTION
Release version: 6.3.0, 7.0.0

Introduced in: N/A

## Summary

This PR refines `mqtt_mqueue_store_qos0.desc` wording to follow implementation more closely: namely, inflight window being full does not generally cause message drop.

## PR Checklist

- [ ] ~~The changes are covered with new or existing tests~~
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible