### PR TITLE
fix(audit): handle bare backend atom in format_username/1

### DIFF
--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -56,7 +56,8 @@ init_per_suite(Config) ->
             emqx_license,
             emqx_audit,
             emqx_management,
-            emqx_mgmt_api_test_util:emqx_dashboard()
+            emqx_mgmt_api_test_util:emqx_dashboard(),
+            emqx_dashboard_sso
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
@@ -149,6 +150,44 @@ t_http_api_sso_source(_) ->
                     <<"operation_id">> := <<"/configs/global_zone">>,
                     <<"source">> := <<"saml:jackson-http@example.com">>
                 }
+            ]
+        },
+        emqx_utils_json:decode(Res)
+    ),
+    ok.
+
+-doc """
+GET /audit must not 500 when a page includes a record whose `source' is the
+bare SSO backend atom (e.g. `oidc'), which `POST /sso/login/:backend' sets
+as `log_source' during pre-authentication, before any user identity is
+known. Regression test for emqx/emqx#18711.
+""".
+t_http_api_sso_login_pre_auth_source(_) ->
+    StartAt = erlang:system_time(microsecond),
+    LoginPath = emqx_mgmt_api_test_util:api_path(["sso", "login", "oidc"]),
+    ?assertMatch(
+        {ok, 404, _},
+        emqx_mgmt_api_test_util:request_api_with_body(
+            post, LoginPath, #{<<"backend">> => <<"oidc">>}
+        )
+    ),
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Query =
+        lists:flatten(
+            io_lib:format(
+                "from=dashboard&gte_created_at=~B&limit=1",
+                [StartAt]
+            )
+        ),
+    %% Before the fix, this GET fails with 500 because `format/1' passes the
+    %% bare atom `source' to `emqx_dashboard_admin:format_username/1', which
+    %% has no clause for it.
+    Res = wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, 2000),
+    ?assertMatch(
+        #{
+            <<"data">> := [
+                #{<<"source">> := <<"oidc">>}
             ]
         },
         emqx_utils_json:decode(Res)

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -1162,11 +1162,16 @@ flatten_username(#{username := ?SSO_USERNAME(Backend, Name)} = Data) ->
 flatten_username(#{username := Username} = Data) when is_binary(Username) ->
     Data#{backend => ?BACKEND_LOCAL}.
 
--spec format_username(dashboard_username()) -> binary().
+%% `Username' is normally a `dashboard_username()', but during SSO
+%% pre-authentication (before any user identity is known) the audit hook
+%% may pass the bare backend atom instead, e.g. `oidc'.
+-spec format_username(dashboard_username() | dashboard_sso_backend()) -> binary().
 format_username(?SSO_USERNAME(Backend, Name)) ->
     iolist_to_binary([atom_to_binary(Backend), <<":">>, Name]);
 format_username(Username) when is_binary(Username) ->
-    Username.
+    Username;
+format_username(Backend) when is_atom(Backend) ->
+    atom_to_binary(Backend).
 
 -spec add_sso_user(dashboard_sso_backend(), binary(), dashboard_user_role(), binary()) ->
     {ok, map()} | {error, any()}.


### PR DESCRIPTION
Fixes: #18711
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: N/A (regression from #18697, merged into dev-60 on 2026-09-01, not yet released)

## Summary

Port of #18725 (dev-63) to dev-60.

On dev-63, `POST /sso/login/:backend` crashed the request process directly, because that branch's audit write path (`emqx_dashboard_audit:source/1`) calls `format_username/1` at write time. dev-60 took a different approach in its sibling PR (#18697, this branch's counterpart of #18696): it only fixed the *read* side, `emqx_audit_api:format/1`, which calls `emqx_dashboard_admin:format_username/1` when a client fetches `GET /api/v5/audit`. The write path here stores `source` unformatted.

That means on dev-60 the crash doesn't happen on the login request itself — `log_source` is set to the bare backend atom (e.g. `oidc`) at pre-authentication time and stored as-is — but the *next* `GET /api/v5/audit` call that includes that record 500s, because `format_username/1` still only handles a `{Backend, Name}` tuple or a plain binary, not a bare atom.

The fix is the same as #18725: add a clause to `format_username/1` for a bare atom, and widen its `-spec` to match.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] No changelog entry — the regressed behavior was never released (#18697 merged into dev-60 the day before this was reported against its dev-63 counterpart)
- [x] Schema changes are backward compatible or intentionally breaking (N/A — no schema change)
