### PR TITLE
fix(audit): handle bare backend atom in stringify_source/1

### DIFF
--- a/apps/emqx_audit/src/emqx_audit_api.erl
+++ b/apps/emqx_audit/src/emqx_audit_api.erl
@@ -343,11 +343,15 @@ format(Audit) ->
 
 %% SSO admin sessions carry `source' as `{Backend, Username}' (see
 %% ?SSO_USERNAME in emqx_dashboard.hrl); flatten it to a binary for the
-%% swagger schema, which declares this field as `binary()'.
+%% swagger schema, which declares this field as `binary()'. During SSO
+%% pre-authentication (before any user identity is known), `source' is
+%% instead the bare backend atom, e.g. `oidc'.
 stringify_source({Backend, Name}) when is_atom(Backend), is_binary(Name) ->
     <<(atom_to_binary(Backend))/binary, ":", Name/binary>>;
 stringify_source(Source) when is_binary(Source) ->
-    Source.
+    Source;
+stringify_source(Backend) when is_atom(Backend) ->
+    atom_to_binary(Backend).
 
 audit_log_list_example() ->
     #{

--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -57,7 +57,8 @@ init_per_suite(Config) ->
             emqx_license,
             emqx_audit,
             emqx_management,
-            emqx_mgmt_api_test_util:emqx_dashboard()
+            emqx_mgmt_api_test_util:emqx_dashboard(),
+            emqx_dashboard_sso
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
@@ -388,6 +389,37 @@ t_sso_source_json_encoding(_Config) ->
                     <<"source">> := <<"saml:jackson-http@example.com">>,
                     <<"operation_id">> := <<"/configs/global_zone">>
                 }
+            ]
+        },
+        emqx_utils_json:decode(Res, [return_maps])
+    ),
+    ok.
+
+%% GET /audit must not 500 when a page includes a record whose `source' is
+%% the bare SSO backend atom (e.g. `oidc'), which `POST /sso/login/:backend'
+%% sets as `log_source' during pre-authentication, before any user identity
+%% is known. Regression test for emqx/emqx#18711.
+t_sso_login_pre_auth_source_json_encoding(_Config) ->
+    StartAt = erlang:system_time(microsecond),
+    LoginPath = emqx_mgmt_api_test_util:api_path(["sso", "login", "oidc"]),
+    ?assertMatch(
+        {ok, 404, _},
+        emqx_mgmt_api_test_util:request_api_with_body(
+            post, LoginPath, #{<<"backend">> => <<"oidc">>}
+        )
+    ),
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Query = lists:flatten(
+        io_lib:format("from=dashboard&gte_created_at=~B&limit=1", [StartAt])
+    ),
+    %% Before the fix, this GET fails with 500 because `stringify_source/1'
+    %% has no clause for a bare atom `source'.
+    Res = wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, 2000),
+    ?assertMatch(
+        #{
+            <<"data">> := [
+                #{<<"source">> := <<"oidc">>}
             ]
         },
         emqx_utils_json:decode(Res, [return_maps])


### PR DESCRIPTION
Fixes: #18711
Release version: 5.10.5
Introduced in: N/A (regression from #18694, merged into dev-510 on 2026-09-01, not yet released)

## Summary

Port of #18725 (dev-63) to dev-510.

This branch has no shared `format_username/1`. Its sibling PR (#18694, this branch's counterpart of #18696) fixed the `GET /api/v5/audit` read path directly in `emqx_audit_api:stringify_source/1` instead of adding a shared formatter.

`POST /sso/login/:backend` sets `log_source` to the bare backend atom (e.g. `oidc`) at pre-authentication time, before any user identity is known, and that value is stored as-is. `stringify_source/1` only handled a `{Backend, Name}` SSO-identity tuple or a plain binary, so a record written by an unconfigured backend's login attempt 500s the next `GET /api/v5/audit` call that includes it.

Add a clause to `stringify_source/1` for a bare atom.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] No changelog entry — the regressed behavior was never released (#18694 merged into dev-510 the day before this was reported against its dev-63 counterpart)
- [x] Schema changes are backward compatible or intentionally breaking (N/A — no schema change)
