### PR TITLE
fix(cluster): bump ekka to 1.0.2

### DIFF
--- a/changes/ee/fix-18733.en.md
+++ b/changes/ee/fix-18733.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where an EMQX node would not reconnect to etcd-based cluster discovery after a transient etcd outage, requiring a manual restart to rejoin the cluster.

--- a/mix.exs
+++ b/mix.exs
@@ -174,7 +174,7 @@ defmodule EMQXUmbrella.MixProject do
     end
   end
 
-  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.1", override: true}
+  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.2", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.3", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.5", override: true}


### PR DESCRIPTION
Fixes: emqx/emqx#12743
Release version: 6.2.4, 6.3.0, 7.0.0
Introduced in: N/A

## Summary

Bumps the `ekka` dependency from `1.0.1` to `1.0.2` in `mix.exs`.

`ekka_cluster_etcd` used to crash its supervisor (`reached_max_restart_intensity`) when the etcd
connection process exited after a successful `init` — for example, when etcd went down briefly and
came back. Once that happened, the node never reconnected to etcd or re-registered its cluster
membership key, even after etcd recovered, and required a manual restart to rejoin the cluster.

The fix lives entirely in `ekka` and is already merged and released upstream:
[emqx/ekka#276](https://github.com/emqx/ekka/pull/276), tag `1.0.2`. `ekka_cluster_etcd` now
tolerates an `EXIT` from the etcd connection post-init with a delay-retry loop instead of treating
it as fatal.

This PR is a dependency-version bump only; no code changes on the `emqx` side. Verified locally that
`mix deps.update ekka` resolves the dependency to the exact expected commit
(`1e44121478f90bc7269158b2c035d52729966fb8`, tag `1.0.2`) and that `make emqx-enterprise` compiles
cleanly with it.

## PR Checklist

- [x] The changes are covered with new or existing tests (fix lives in `ekka`; no emqx-side test needed)
- [x] Change log for changes visible by users has been added to `changes/ee/fix-18733.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)