### PR TITLE
fix(listener): clamp tcp_options active_n and buffer to safe ranges

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -1614,7 +1614,9 @@ get_state(Pid) ->
 get_active_n(quic, _Listener) ->
     ?ACTIVE_N;
 get_active_n(Type, Listener) ->
-    emqx_config:get_listener_conf(Type, Listener, [tcp_options, active_n]).
+    emqx_listeners:clamp_active_n(
+        emqx_config:get_listener_conf(Type, Listener, [tcp_options, active_n])
+    ).
 
 get_high_watermark(quic, _Listener) ->
     0;

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -23,7 +23,8 @@
     default_max_conn/0,
     shutdown_count/2,
     tcp_opts/1,
-    ip_port/1
+    ip_port/1,
+    clamp_active_n/1
 ]).
 
 -export([
@@ -86,6 +87,22 @@
 
 -define(ESOCKD_LISTENER(T), (T == tcp orelse T == ssl)).
 -define(COWBOY_LISTENER(T), (T == ws orelse T == wss)).
+
+%% `tcp_options.active_n' and `tcp_options.buffer' are clamped at the point of
+%% use. Out-of-range values are not rejected, so existing configs keep working.
+%%
+%% `active_n': `emqx_connection' passes it as `{active, N}', and N = 0 leaves
+%% the socket passive forever. `emqx_socket_connection' uses it only as the
+%% `#deliver{}' batch size and as the number of sent packets between OOM checks.
+%% The cap bounds how many packets either backend handles between OOM checks.
+-define(MIN_ACTIVE_N, 1).
+-define(MAX_ACTIVE_N, 1000).
+%% `buffer': the inet driver floors it at 1 byte (INET_BUFFER_MIN), while the
+%% `socket' module rejects `{otp, rcvbuf}' = 0 and esockd then drops the
+%% accepted connection. Floor it at the largest MQTT fixed header (1 type byte
+%% + up to 4 remaining-length bytes) on both backends, so a single read can
+%% hold a complete fixed header.
+-define(MIN_TCP_BUFFER, 5).
 
 -define(ROOT_KEY, listeners).
 -define(CONF_KEY_PATH, [?ROOT_KEY, '?', '?']).
@@ -1048,8 +1065,15 @@ tcp_opt({nolinger, Bool}) ->
             %% but also be able to revert it on the fly
             {linger, {false, 0}}
     end;
+tcp_opt({buffer, Bytes}) when is_integer(Bytes) andalso Bytes < ?MIN_TCP_BUFFER ->
+    {buffer, ?MIN_TCP_BUFFER};
 tcp_opt(Opt) ->
     Opt.
+
+%% Used by emqx_connection, emqx_socket_connection and emqx_ws_connection.
+-spec clamp_active_n(integer()) -> pos_integer().
+clamp_active_n(N) when is_integer(N) ->
+    max(?MIN_ACTIVE_N, min(?MAX_ACTIVE_N, N)).
 
 foreach_listeners(Do) ->
     lists:foreach(

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1582,7 +1582,9 @@ init_parser_and_serializer(FrameOpts0) ->
     {Parser0, Serialize0}.
 
 get_active_n(#conf{listener = {Type, Listener}}) ->
-    emqx_config:get_listener_conf(Type, Listener, [tcp_options, active_n]).
+    emqx_listeners:clamp_active_n(
+        emqx_config:get_listener_conf(Type, Listener, [tcp_options, active_n])
+    ).
 
 get_send_timeout(#conf{listener = {Type, Listener}}) ->
     emqx_config:get_listener_conf(Type, Listener, [tcp_options, send_timeout], 15_000).

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -1008,4 +1008,6 @@ get_ws_opt(Type, Listener, Key) ->
     emqx_config:get_listener_conf(Type, Listener, [websocket, Key]).
 
 get_active_n(Type, Listener) ->
-    emqx_config:get_listener_conf(Type, Listener, [tcp_options, active_n]).
+    emqx_listeners:clamp_active_n(
+        emqx_config:get_listener_conf(Type, Listener, [tcp_options, active_n])
+    ).

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -243,6 +243,52 @@ t_tcp_socket_conn(_Config) ->
         )
     end).
 
+-doc """
+`active_n=0` is clamped to 1 on the `socket` backend, so a client connects normally.
+""".
+t_tcp_socket_conn_active_n_zero(_Config) ->
+    Port = emqx_common_test_helpers:select_free_port(tcp),
+    Conf = #{
+        <<"bind">> => format_bind({"127.0.0.1", Port}),
+        <<"tcp_backend">> => <<"socket">>,
+        <<"tcp_options">> => #{<<"active_n">> => 0}
+    },
+    with_listener(tcp, ?FUNCTION_NAME, Conf, fun() ->
+        Client = emqtt_connect_tcp({127, 0, 0, 1}, Port),
+        pong = emqtt:ping(Client)
+    end).
+
+-doc """
+`active_n=0` is clamped to 1 on the `gen_tcp` backend too, so a client connects
+normally, consistent with the `socket` backend.
+""".
+t_tcp_gen_tcp_conn_active_n_zero(_Config) ->
+    Port = emqx_common_test_helpers:select_free_port(tcp),
+    Conf = #{
+        <<"bind">> => format_bind({"127.0.0.1", Port}),
+        <<"tcp_backend">> => <<"gen_tcp">>,
+        <<"tcp_options">> => #{<<"active_n">> => 0}
+    },
+    with_listener(tcp, ?FUNCTION_NAME, Conf, fun() ->
+        Client = emqtt_connect_tcp({127, 0, 0, 1}, Port),
+        pong = emqtt:ping(Client)
+    end).
+
+-doc """
+`buffer=0` is floored to 5 bytes on the `socket` backend, so a client connects normally.
+""".
+t_tcp_socket_conn_buffer_zero(_Config) ->
+    Port = emqx_common_test_helpers:select_free_port(tcp),
+    Conf = #{
+        <<"bind">> => format_bind({"127.0.0.1", Port}),
+        <<"tcp_backend">> => <<"socket">>,
+        <<"tcp_options">> => #{<<"buffer">> => <<"0KB">>}
+    },
+    with_listener(tcp, ?FUNCTION_NAME, Conf, fun() ->
+        Client = emqtt_connect_tcp({127, 0, 0, 1}, Port),
+        pong = emqtt:ping(Client)
+    end).
+
 t_ssl_chunk_parsing_conn(Config) ->
     PrivDir = ?config(priv_dir, Config),
     Port = emqx_common_test_helpers:select_free_port(ssl),

--- a/apps/emqx/test/emqx_listeners_tests.erl
+++ b/apps/emqx/test/emqx_listeners_tests.erl
@@ -1,0 +1,18 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2018-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_listeners_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+clamp_active_n_test_() ->
+    [
+        ?_assertEqual(1, emqx_listeners:clamp_active_n(0)),
+        ?_assertEqual(1, emqx_listeners:clamp_active_n(-10)),
+        ?_assertEqual(1, emqx_listeners:clamp_active_n(1)),
+        ?_assertEqual(10, emqx_listeners:clamp_active_n(10)),
+        ?_assertEqual(1000, emqx_listeners:clamp_active_n(1000)),
+        ?_assertEqual(1000, emqx_listeners:clamp_active_n(1001)),
+        ?_assertEqual(1000, emqx_listeners:clamp_active_n(100000))
+    ].

--- a/changes/ee/fix-18734.en.md
+++ b/changes/ee/fix-18734.en.md
@@ -1,0 +1,3 @@
+Fixed a TCP listener issue where `tcp_options.buffer = 0` made every new connection fail on the default `socket` backend.
+
+`tcp_options.active_n` is now clamped to the 1..1000 range and `tcp_options.buffer` to at least 5 bytes (the largest MQTT fixed header), on all listener types. Out-of-range values are still accepted and are silently adjusted.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -642,7 +642,9 @@ sysmon_vm_process_high_watermark.label:
 """Process high watermark"""
 
 fields_tcp_opts_buffer.desc:
-"""The size of the user-space buffer used by the driver."""
+"""The size of the user-space buffer used by the driver.
+
+Values below 5 bytes (the largest MQTT fixed header) are not rejected; the effective buffer size is silently raised to 5 bytes for compatibility with existing configurations."""
 
 fields_tcp_opts_buffer.label:
 """TCP user-space buffer"""
@@ -1260,7 +1262,11 @@ server_ssl_opts_schema_ocsp_issuer_pem.label:
 
 fields_tcp_opts_active_n.desc:
 """Specify the {active, N} option for this Socket.<br/>
-See: https://erlang.org/doc/man/inet.html#setopts-2"""
+See: https://erlang.org/doc/man/inet.html#setopts-2
+
+With the `socket` TCP backend, this value only sets the message delivery batch size and the number of sent packets between memory checks.
+
+Values outside the 1-1000 range are not rejected; the effective value is silently clamped to that range for compatibility with existing configurations."""
 
 fields_tcp_opts_active_n.label:
 """active_n"""


### PR DESCRIPTION
Fixes: #18727
Release version: 6.2.4, 6.3.0, 7.0.0
Introduced in: N/A (pre-release; the underlying gap has existed since `emqx_socket_connection.erl` was added, but only became reachable once #17854 switched the TCP listener default to the `socket` backend, which has not GA'd yet)

## Summary

Two `tcp_options` combinations made a plain TCP listener unusable on the `socket` backend (default on Linux since #17854):

- `buffer=0`: maps to `socket:setopt(Sock, {otp, rcvbuf}, 0)`, and OTP's `socket` module rejects `rcvbuf=0` outright (`{error,{invalid,{socket_option,{otp,rcvbuf},0}}}`, `esock_decode_bufsz` fails on `val == 0`), so `esockd` resets the connection right after accept, before it reaches the MQTT protocol handler. The `inet` driver instead floors `buffer` at 1 byte on its own (`INET_BUFFER_MIN`), which is why `gen_tcp` never had this problem.
- `active_n=0`: on `gen_tcp` this is `{active, 0}` and the socket stays passive forever; on the `socket` backend `active_n` is only the `#deliver{}` batch size and the number of sent packets between `check_oom` calls, so 0 does something else entirely. The two backends disagreed on the same setting.

Both reproduced independently (raw TCP client, A/B against `tcp_backend=gen_tcp` on the same binary) and root-caused; full analysis, the alternatives considered, and the buffer-floor study: `/mnt/data/emqx/_out/260902-tcp-listener-active-n-buffer-rca.md` (internal, not part of this diff).

Fix: clamp both values, silently, at the single point each connection module reads them from config — no config value is rejected, so `GET` on a listener still round-trips the value exactly as configured.

- `active_n` is clamped to `[1, 1000]` (`emqx_listeners:clamp_active_n/1`, used by `emqx_connection` for `tcp`/`ssl`, `emqx_socket_connection` for the `tcp` `socket` backend, and `emqx_ws_connection` for `ws`/`wss`). The cap bounds how many packets either backend handles between OOM checks.
- `buffer` is floored to 5 bytes, the largest MQTT fixed header (1 type byte + up to 4 remaining-length bytes), in `emqx_listeners:tcp_opt/1` — the single point where `tcp_options` becomes the option list handed to `esockd` (`tcp`/`ssl`) and `ranch` (`ws`/`wss`). Nothing in OTP or the kernel requires more than 1 byte (`buffer` is a user-space read chunk size; the kernel only bounds `recbuf`/`SO_RCVBUF`, which it clamps itself), so this is a parser-motivated floor, not a driver one.

This was chosen over implementing real `gen_tcp`-style passive mode in the `socket` backend's recv loop, and over a floor in `esockd` (a separate git-dependency repo): neither `active_n=0` passive mode nor sub-5-byte read buffers have a realistic use, so clamping at the config-read site is the smaller change. One consequence: `active_n=0` on `ssl` listeners (unaffected by the original regression) also loses real passive-mode support, for consistency across listener types that share the same `tcp_options` schema struct.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-18734.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AD34QW2ZJGJMRwuxho9mxy