### PR TITLE
fix(mgmt): remove dead error clause and fix stale unreachable-node test

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -299,12 +299,7 @@ format(Info = #{memory_total := Total, memory_used := Used}) ->
         memory_used := emqx_mgmt_util:kmg(Used)
     };
 format(Info) when is_map(Info) ->
-    Info;
-%% `emqx_mgmt:lookup_node/1` reaches this as `Info` when the target node
-%% becomes unreachable between the caller's liveness check and the RPC,
-%% e.g. a concurrent `cluster leave`.
-format({error, _} = Error) ->
-    Error.
+    Info.
 
 to_ok_result({error, _} = Error) ->
     Error;

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -79,16 +79,18 @@ t_nodes_api(_) ->
 -doc """
 A node can pass the running-nodes liveness check and still fail the RPC right
 after, e.g. a concurrent `cluster leave`. `emqx_mgmt:lookup_node/1` then
-returns `{error, _}` instead of a node info map.
+returns `{error, _}`, and the API reports the node as unreachable instead of
+failing the request.
 """.
 t_node_api_unreachable_node(_) ->
     meck:new(emqx_mgmt, [passthrough, no_history]),
     meck:expect(emqx_mgmt, lookup_node, fun(_Node) -> {error, badarg} end),
     try
         NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
+        {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),
         ?assertMatch(
-            {error, {_, 400, _}},
-            emqx_mgmt_api_test_util:request_api(get, NodePath)
+            #{<<"node">> := _, <<"node_status">> := <<"unreachable">>},
+            emqx_utils_json:decode(NodeInfo)
         )
     after
         meck:unload(emqx_mgmt)


### PR DESCRIPTION
## Summary

Cleanup follow-up to #18656 (`fix(mgmt): report a node that did not answer instead of dropping it`), which rewrote `get_node/1` in `emqx_mgmt_api_nodes.erl` so both branches produce a map before calling `format/1`. That left the old `format({error, _}) -> Error.` clause unreachable — dialyzer now reports `pattern can never match type map()` at that clause — and left `t_node_api_unreachable_node/1` asserting the pre-#18656 400 response instead of the 200/`node_status => unreachable` response #18656 introduced.

- Remove the dead `format({error, _})` clause and its stale explanatory comment.
- Update `t_node_api_unreachable_node/1` to assert the current 200 response shape.

No behavior change: the REST API response was already changed by #18656, not by this PR.

Note: both the dialyzer warning and the stale test passed on #18656's own CI run and on the next PR merged on top of it, then started failing deterministically on later PRs against otherwise-unchanged code — points at a CI reliability gap (e.g. dialyzer PLT caching) rather than anything about this code. Not investigated further here; out of scope.

## Test plan

- [x] `make fmt-diff`
- [x] `./scripts/elvis-check.sh $(git merge-base origin/dev-70 HEAD)`
- [x] `make dialyzer` — confirmed the `pattern can never match type map()` warning at this location is gone
- [x] `emqx_mgmt_api_nodes_SUITE:t_node_api_unreachable_node` passes against current code