### PR TITLE
test(broker): widen the reconnect inc-event timeout, no look-back

### DIFF
--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -559,12 +559,15 @@ t_connected_client_count_transient_takeover(Config) when is_list(Config) ->
     %% emqx_cm_connected_client_count_dec events
     ?assertEqual(0, emqx_cm:get_connected_client_count()),
     %% connecting again, this time, retry until server is not busy
+    %% BackInTime must stay 0 here: this clientid was just reused by the
+    %% takeover storm, so a look-back window can match a stale inc event from
+    %% one of those discarded channels instead of this reconnect's own event.
+    %% Only the forward timeout needs widening.
     {{ok, _}, {ok, [_]}} =
         wait_for_events(
             fun() -> start_connect_client(Opts, ConnFun) end,
             [emqx_cm_connected_client_count_inc],
-            1000,
-            1000
+            5000
         ),
     ?assertEqual(1, emqx_cm:get_connected_client_count()),
     %% abnormal exit of channel process


### PR DESCRIPTION
## Summary

`emqx_broker_SUITE:t_connected_client_count_transient_takeover`'s reconnect step waits for a
`emqx_cm_connected_client_count_inc` event with `BackInTime = 1000` — a 1-second look-back
window in addition to the forward wait. This pattern comes from `411795d6ea` ("test: fix flaky
tc in emqx_broker_SUITE", 2025-05-21, "snabbkaffe should look back for the events") and has
since spread to every branch that carries this test (`dev-510`, all of `dev-60` through
`dev-70`).

The look-back is wrong for this call. The clientid was just reused by a 20-way takeover storm
a few lines above (that's the point of the test — clients fighting over one clientid), so the
look-back window can match a stale `inc` event from one of those discarded channels instead of
waiting for *this* reconnect's own event.

Confirmed empirically, not just by reading the code: instrumented the test to compare the
matched event's `chan_pid` against the channel actually registered for the clientid right
after. **In 3/3 local runs (tcp/ws/quic), they did not match** — the wait was satisfied by a
stale event every single time. The test still passes because the following
`?assertEqual(1, emqx_cm:get_connected_client_count())` is an independent, unguarded state read
that happens to succeed once the connect call returns synchronously — the `wait_for_events`
call was never actually acting as a barrier, on any branch carrying this pattern since it was
introduced.

## How this was found

Backporting this call to `dev-59` (#18723, missing entirely there, causing a hard timeout)
copied this exact pattern verbatim as "the established fix." [A reviewer questioned the
look-back semantics on that
PR](https://github.com/emqx/emqx/pull/18723#discussion_r3914548417) and was right — which
surfaced that the pattern being copied was itself flawed everywhere it already existed.

## Fix

Widen the forward timeout instead, leaving `BackInTime` at its default of `0` so the wait only
matches a genuinely new event:

```erlang
wait_for_events(
    fun() -> start_connect_client(Opts, ConnFun) end,
    [emqx_cm_connected_client_count_inc],
    5000
),
```

## Validation

Full suite: 27 ok, 0 failed (both before removing look-back, confirming the mismatch, and
after the fix).

## Scope

Base `dev-60`: earliest branch in the v6/v7 chain (`60 → 61 → 62 → 63 → 70`) carrying this
exact call; expected to reach the rest via the normal forward sync. Not sent to `dev-510`
(v5) in this PR, since that's a separate chain — worth a follow-up there too, since it carries
the identical pattern and is where `411795d6ea` originated.