### PR TITLE
test(ps ds): increase cluster readiness timeout

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -1620,7 +1620,10 @@ start_cluster_ds(Config, ClusterSpec0, Opts) when is_list(ClusterSpec0) ->
     NodeSpecs = emqx_cth_cluster:mk_nodespecs(ClusterSpec, ClusterOpts),
     Nodes = emqx_cth_cluster:start(ClusterSpec, ClusterOpts),
     ExpectedOk = lists:duplicate(length(Nodes), {ok, ok}),
-    ExpectedOk = erpc:multicall(Nodes, emqx_persistent_message, wait_readiness, [15_000], infinity),
+    WaitReadinessTimeout = maps:get(wait_readiness_timeout, Opts, 15_000),
+    ExpectedOk = erpc:multicall(
+        Nodes, emqx_persistent_message, wait_readiness, [WaitReadinessTimeout], infinity
+    ),
     [{cluster_nodes, Nodes}, {node_specs, NodeSpecs}, {work_dir, WorkDir} | Config].
 
 stop_cluster_ds(Config) ->

--- a/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
@@ -1595,6 +1595,7 @@ start_cluster(TestCase, Config0, ClusterOpts) ->
     },
     Opts = emqx_utils_maps:deep_merge(ClusterOpts, #{
         durable_sessions_opts => DurableSessionsOpts,
+        wait_readiness_timeout => 30_000,
         work_dir => emqx_cth_suite:work_dir(TestCase, Config0)
     }),
     ClusterSpec = cluster(Opts),


### PR DESCRIPTION
```
*** emqx_cth_suite 2026-09-02T20:05:49.247+00:00 @ 'ds_SUITE1@127.0.0.1' ***
Started applications: [os_mon,esockd,runtime_tools,lc,bcrypt,recon,quicer,emqx]

*** emqx_cth_suite 2026-09-02T20:05:50.856+00:00 @ 'ds_SUITE3@127.0.0.1' ***
Started applications: [os_mon,esockd,runtime_tools,lc,bcrypt,recon,quicer,emqx]

*** emqx_cth_suite 2026-09-02T20:05:51.106+00:00 @ 'ds_SUITE2@127.0.0.1' ***
Started applications: [os_mon,esockd,runtime_tools,lc,bcrypt,recon,quicer,emqx]

=== ERROR! init_per_testcase crashed!
	Location: [{emqx_common_test_helpers,start_cluster_ds,1623},
              {emqx_persistent_session_ds_SUITE,start_cluster,1601},
              {test_server,do_init_per_testcase,1564},
              {test_server,run_test_case_eval1,1265},
              {test_server,run_test_case_eval,1235}]
	Reason: {{badmatch,[{ok,timeout},{ok,timeout},{ok,timeout}]},
 [{emqx_common_test_helpers,start_cluster_ds,3,
      [{file,"test/emqx_common_test_helpers.erl"},{line,1623}]},
  {emqx_persistent_session_ds_SUITE,start_cluster,3,
      [{file,"test/emqx_persistent_session_ds_SUITE.erl"},{line,1601}]},
  {test_server,do_init_per_testcase,2,[{file,"test_server.erl"},{line,1564}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1265}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1235}]}]}
```

