### PR TITLE
test(authz cache): attempt to fix flaky drain authz cache test

### DIFF
--- a/apps/emqx/src/emqx_authz_cache.erl
+++ b/apps/emqx/src/emqx_authz_cache.erl
@@ -275,6 +275,7 @@ keys_queue_remove(Key, KeysQ) ->
 keys_queue_set(KeysQ) ->
     erlang:put(authz_keys_q, KeysQ),
     ok.
+
 keys_queue_get() ->
     case erlang:get(authz_keys_q) of
         undefined -> queue:new();

--- a/apps/emqx/test/emqx_authz_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_authz_cache_SUITE.erl
@@ -41,11 +41,17 @@ t_clean_authz_cache(_) ->
     {ok, _, _} = emqtt:subscribe(Client, <<"t2">>, 0),
     emqtt:publish(Client, <<"t1">>, <<"{\"x\":1}">>, 0),
     ClientPid = find_client_pid(ClientId),
-    Caches = list_cache(ClientPid),
-    ct:log("authz caches: ~p", [Caches]),
-    ?assert(length(Caches) > 0),
+    ?retry(
+        20,
+        100,
+        begin
+            Caches = list_cache(ClientPid),
+            ct:log("authz caches: ~p", [Caches]),
+            ?assert(length(Caches) > 0)
+        end
+    ),
     erlang:send(ClientPid, clean_authz_cache),
-    ?assertEqual([], list_cache(ClientPid)),
+    ?retry(20, 100, ?assertEqual([], list_cache(ClientPid))),
     emqtt:stop(Client).
 
 t_drain_authz_cache(_) ->


### PR DESCRIPTION
```
%%% emqx_authz_cache_SUITE ==> t_drain_authz_cache: FAILED
%%% emqx_authz_cache_SUITE ==>
Failure/Error: ?assertEqual([], list_cache ( ClientPid ))
  expected: []
       got: [{{#{retain => false,qos => 0,action_type => publish},<<"t1">>},
              {allow,1788382227403}}]
      line: 62
```

