### PR TITLE
perf(socket): bump esockd to 5.17.4

### DIFF
--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -78,7 +78,7 @@ maybe_start_listeners() ->
     case emqx_boot:is_enabled(listeners) of
         true ->
             %% NOTE
-            %% Disable global socket registry.
+            %% Disable socket registration by default.
             %% Having each socket saved in the registry is currently unnecessary.
             %% Registry needs few hundred extra bytes / socket, depending on the
             %% total number of sockets.

--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -77,6 +77,12 @@ maybe_load_config() ->
 maybe_start_listeners() ->
     case emqx_boot:is_enabled(listeners) of
         true ->
+            %% NOTE
+            %% Disable global socket registry.
+            %% Having each socket saved in the registry is currently unnecessary.
+            %% Registry needs few hundred extra bytes / socket, depending on the
+            %% total number of sockets.
+            ok = socket:use_registry(false),
             ok = emqx_listeners:start();
         false ->
             ok

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -234,12 +234,18 @@ t_tcp_socket_conn(_Config) ->
         <<"bind">> => format_bind({"127.0.0.1", Port}),
         <<"tcp_backend">> => <<"socket">>
     },
+    NSockets = socket:number_of(),
     with_listener(tcp, ?FUNCTION_NAME, Conf, fun() ->
         Client = emqtt_connect_tcp({127, 0, 0, 1}, Port),
         pong = emqtt:ping(Client),
         ?assertEqual(
             emqx_socket_connection,
             emqx_cth_broker:connection_info(connmod, Client)
+        ),
+        ?assertEqual(
+            NSockets,
+            socket:number_of(),
+            "Socket should skip registry by default"
         )
     end).
 

--- a/mix.exs
+++ b/mix.exs
@@ -175,7 +175,7 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.1", override: true}
-  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.3", override: true}
+  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.4", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.5", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}


### PR DESCRIPTION
Addresses: https://github.com/emqx/emqx-qa/issues/2097#issuecomment-5508105439
Release version: 6.3.0, 7.0.0
Introduced in: N/A

## Summary

This PR eliminates the cost of saving each socket used by `emqx_socket_connection` into _socket registry_.

See also https://github.com/emqx/esockd/pull/229.

### Test results

Single sample of `emqtt_bench conn -c 10000` 6.3.0 (with this PR) vs 6.2.2 run, stabilized after ~5 minutes:
```
Memory diff
left:  emqx-63-rc1/bin/emqx ('emqx-63@127.0.0.1')
right: emqx-62/bin/emqx ('emqx-622@127.0.0.1')

== OS / Erlang / Recon ==
metric                                  left           right           delta   delta%
RssAnon                            618.0 MiB       566.3 MiB       -51.7 MiB    -8.4%
VmRSS                              647.4 MiB       596.2 MiB       -51.2 MiB    -7.9%
VmData                             938.9 MiB       883.8 MiB       -55.1 MiB    -5.9%
erlang total                       452.1 MiB       409.6 MiB       -42.5 MiB    -9.4%
erlang processes                   165.9 MiB       193.5 MiB       +27.5 MiB   +16.6%
erlang binary                       53.5 MiB         3.1 MiB       -50.4 MiB   -94.2%
recon allocated                    467.3 MiB       425.6 MiB       -41.7 MiB    -8.9%
recon used                         335.2 MiB       303.4 MiB       -31.8 MiB    -9.5%
recon unused                       132.3 MiB       121.9 MiB       -10.4 MiB    -7.9%
```

^ Worth noting that results are generally not very consistent, YMMV.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible