### PR TITLE
fix(tdengine): report the action id in invalid_channel_id errors

### DIFF
--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
@@ -242,7 +242,7 @@ on_query(InstanceId, {ChannelId, Data}, #{channels := Channels} = State) ->
                     {error, {unrecoverable_error, Reason}}
             end;
         _ ->
-            {error, {unrecoverable_error, {invalid_channel_id, InstanceId}}}
+            {error, {unrecoverable_error, {invalid_channel_id, ChannelId}}}
     end.
 
 %% aggregate the batch queries to one SQL is a heavy job, we should put it in the worker process
@@ -261,7 +261,7 @@ on_batch_query(
                 State
             );
         _ ->
-            {error, {unrecoverable_error, {invalid_channel_id, InstanceId}}}
+            {error, {unrecoverable_error, {invalid_channel_id, ChannelId}}}
     end;
 on_batch_query(InstanceId, BatchReq, _State) ->
     LogMeta = #{connector => InstanceId, request => BatchReq},

--- a/changes/ee/fix-18762.en.md
+++ b/changes/ee/fix-18762.en.md
@@ -1,0 +1,1 @@
+Fixed an error reported by the TDengine action. When the action could not be found, the error named the connector's ID instead of the action's ID, which made the error read as if a valid connector ID was invalid.


### PR DESCRIPTION
Fixes: N/A
Release version: 5.8.12, 5.9.4, 5.10.5
Introduced in: N/A

## Summary

`on_query/3` and `on_batch_query/3` in the TDengine connector look the action up with `maps:find(ChannelId, Channels)`, but on a miss they return `{invalid_channel_id, InstanceId}` — the connector's ID, not the ID that was looked up.

The result is an error that names a perfectly valid connector ID as an invalid channel ID, for example `{invalid_channel_id, <<"connector:tdengine:foo">>}`, while saying nothing about the action that was actually missing. It costs real time to read past.

Reporting `ChannelId` makes the failure obvious in one read. The two sibling connectors that return the same error already do this: `emqx_bridge_iotdb_connector.erl` and `emqx_bridge_opents_connector.erl`. TDengine was the only module getting it wrong.

No behavior change beyond the error payload.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|fix|perf|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)