### PR TITLE
feat(influxdb): templatable bucket and raw line protocol writes

### DIFF
--- a/apps/emqx_bridge_influxdb/mix.exs
+++ b/apps/emqx_bridge_influxdb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeInfluxdb.MixProject do
   def project do
     [
       app: :emqx_bridge_influxdb,
-      version: "6.1.1",
+      version: "6.1.2",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.erl
@@ -140,6 +140,11 @@ fields(influxdb_action) ->
 fields(action_parameters) ->
     [
         {write_syntax, fun write_syntax/1},
+        {bucket,
+            mk(binary(), #{
+                required => false,
+                desc => ?DESC("bucket")
+            })},
         emqx_bridge_influxdb_connector:precision_field()
     ];
 fields(action_resource_opts) ->
@@ -235,22 +240,67 @@ influx_lines(RawLines, Acc) ->
 influx_line([], Acc) ->
     {Acc, []};
 influx_line(Line, Acc) ->
-    {?NON_EMPTY = Measurement, Line1} = measurement(Line),
-    {Tags, Line2} = tags(Line1),
-    {?NON_EMPTY = Fields, Line3} = influx_fields(Line2),
-    {Timestamp, Line4} = timestamp(Line3),
-    {
-        [
-            #{
-                measurement => Measurement,
-                tags => Tags,
-                fields => Fields,
-                timestamp => Timestamp
+    case raw_line_tmpl(Line) of
+        {ok, Tmpl, Rest} ->
+            {[#{line => Tmpl} | Acc], Rest};
+        error ->
+            {?NON_EMPTY = Measurement, Line1} = measurement(Line),
+            {Tags, Line2} = tags(Line1),
+            {?NON_EMPTY = Fields, Line3} = influx_fields(Line2),
+            {Timestamp, Line4} = timestamp(Line3),
+            {
+                [
+                    #{
+                        measurement => Measurement,
+                        tags => Tags,
+                        fields => Fields,
+                        timestamp => Timestamp
+                    }
+                    | Acc
+                ],
+                Line4
             }
-            | Acc
-        ],
-        Line4
-    }.
+    end.
+
+%% A whole line that is exactly one placeholder is treated as a raw line
+%% protocol template. The rendered value is written verbatim, which makes
+%% it possible to write a select result that is already a formatted line.
+raw_line_tmpl(Line) ->
+    {Line0, Rest} = split_line(Line, []),
+    Unescaped = unescape_raw_line(string:trim(Line0), []),
+    case single_placeholder(Unescaped) of
+        true -> {ok, Unescaped, Rest};
+        false -> error
+    end.
+
+split_line([$\n | _] = Line, Acc) ->
+    {lists:reverse(Acc), Line};
+split_line([], Acc) ->
+    {lists:reverse(Acc), []};
+split_line([Ch | Rest], Acc) ->
+    split_line(Rest, [Ch | Acc]).
+
+%% unescape a whole line the same way as other templates, but do not stop at
+%% any separator, e.g. `${payload.line\ 1}` is a single placeholder
+unescape_raw_line([$\\, Char | T], Acc) ->
+    IsEscapeChar = lists:member(Char, ?TAG_FIELD_KEY_ESC_CHARS),
+    Acc1 =
+        case IsEscapeChar of
+            true -> [Char | Acc];
+            false -> [Char, $\\ | Acc]
+        end,
+    unescape_raw_line(T, Acc1);
+unescape_raw_line([Char | T], Acc) ->
+    unescape_raw_line(T, [Char | Acc]);
+unescape_raw_line([], Acc) ->
+    lists:reverse(Acc).
+
+single_placeholder(Line) ->
+    Subject = unicode:characters_to_binary(Line),
+    case re:run(Subject, "^\\$\\{[^{}]*\\}$", [{capture, none}]) of
+        match -> true;
+        nomatch -> false
+    end.
 
 measurement(Line) ->
     unescape(?MEASUREMENT_ESC_CHARS, [?MEASUREMENT_TAG_SEP, ?SEP], Line, []).

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -33,6 +33,7 @@
     on_format_query_result/1
 ]).
 -export([reply_callback/2]).
+-export([coordinated_reply_callback/2]).
 
 -export([
     roots/0,
@@ -44,7 +45,7 @@
 -export([precision_field/0]).
 
 %% only for test
--export([client_config/2, is_unrecoverable_error/1]).
+-export([client_config/2, is_unrecoverable_error/1, data_to_points/2, render_bucket/2]).
 
 -type ts_precision() :: ns | us | ms | s.
 
@@ -88,7 +89,8 @@ on_add_channel(
         Parameters,
         ChannelConfig0#{
             channel_client => influxdb:update_precision(Client, Precision),
-            write_syntax => to_config(WriteSytaxTmpl, Precision)
+            write_syntax => to_config(WriteSytaxTmpl, Precision),
+            bucket_tmpl => preproc_bucket_tmpl(Parameters)
         }
     ),
     {ok, OldState#{
@@ -127,15 +129,16 @@ on_stop(InstId, _State) ->
     end.
 
 on_query(InstId, {Channel, Message}, #{channels := ChannelConf}) ->
-    #{write_syntax := SyntaxLines} = maps:get(Channel, ChannelConf),
-    #{channel_client := Client} = maps:get(Channel, ChannelConf),
+    ChannelConfig = maps:get(Channel, ChannelConf),
+    #{write_syntax := SyntaxLines, channel_client := Client} = ChannelConfig,
     case data_to_points(Message, SyntaxLines) of
         {ok, Points} ->
+            Client1 = render_bucket_client(Message, Client, ChannelConfig),
             ?tp(
                 influxdb_connector_send_query,
-                #{points => Points, batch => false, mode => sync}
+                #{points => Points, batch => false, mode => sync, path => path(Client1)}
             ),
-            do_query(InstId, Channel, Client, Points);
+            do_query(InstId, Channel, Client1, Points);
         {error, ErrorPoints} ->
             ?tp(
                 influxdb_connector_send_query_error,
@@ -149,21 +152,28 @@ on_query(InstId, {Channel, Message}, #{channels := ChannelConf}) ->
 %% This batch query failed
 on_batch_query(InstId, BatchData, #{channels := ChannelConf}) ->
     [{Channel, _} | _] = BatchData,
-    #{write_syntax := SyntaxLines} = maps:get(Channel, ChannelConf),
-    #{channel_client := Client} = maps:get(Channel, ChannelConf),
-    case parse_batch_data(InstId, BatchData, SyntaxLines) of
-        {ok, Points} ->
-            ?tp(
-                influxdb_connector_send_query,
-                #{points => Points, batch => true, mode => sync}
-            ),
-            do_query(InstId, Channel, Client, Points);
-        {error, Reason} ->
-            ?tp(
-                influxdb_connector_send_query_error,
-                #{batch => true, mode => sync, error => Reason}
-            ),
-            {error, {unrecoverable_error, Reason}}
+    ChannelConfig = maps:get(Channel, ChannelConf),
+    #{write_syntax := SyntaxLines} = ChannelConfig,
+    case group_batch_by_bucket(BatchData, ChannelConfig) of
+        [{Client, Data}] ->
+            case parse_batch_data(InstId, Data, SyntaxLines) of
+                {ok, Points} ->
+                    ?tp(
+                        influxdb_connector_send_query,
+                        #{
+                            points => Points, batch => true, mode => sync, path => path(Client)
+                        }
+                    ),
+                    do_query(InstId, Channel, Client, Points);
+                {error, Reason} ->
+                    ?tp(
+                        influxdb_connector_send_query_error,
+                        #{batch => true, mode => sync, error => Reason}
+                    ),
+                    {error, {unrecoverable_error, Reason}}
+            end;
+        Groups ->
+            do_grouped_batch_query(InstId, Channel, Groups, SyntaxLines)
     end.
 
 on_query_async(
@@ -172,15 +182,16 @@ on_query_async(
     {ReplyFun, Args},
     #{channels := ChannelConf}
 ) ->
-    #{write_syntax := SyntaxLines} = maps:get(Channel, ChannelConf),
-    #{channel_client := Client} = maps:get(Channel, ChannelConf),
+    ChannelConfig = maps:get(Channel, ChannelConf),
+    #{write_syntax := SyntaxLines, channel_client := Client} = ChannelConfig,
     case data_to_points(Message, SyntaxLines) of
         {ok, Points} ->
+            Client1 = render_bucket_client(Message, Client, ChannelConfig),
             ?tp(
                 influxdb_connector_send_query,
-                #{points => Points, batch => false, mode => async}
+                #{points => Points, batch => false, mode => async, path => path(Client1)}
             ),
-            do_async_query(InstId, Channel, Client, Points, {ReplyFun, Args});
+            do_async_query(InstId, Channel, Client1, Points, {ReplyFun, Args});
         {error, ErrorPoints} = Err ->
             ?tp(
                 influxdb_connector_send_query_error,
@@ -193,25 +204,34 @@ on_query_async(
 on_batch_query_async(
     InstId,
     BatchData,
-    {ReplyFun, Args},
+    ReplyFunAndArgs,
     #{channels := ChannelConf}
 ) ->
     [{Channel, _} | _] = BatchData,
-    #{write_syntax := SyntaxLines} = maps:get(Channel, ChannelConf),
-    #{channel_client := Client} = maps:get(Channel, ChannelConf),
-    case parse_batch_data(InstId, BatchData, SyntaxLines) of
-        {ok, Points} ->
-            ?tp(
-                influxdb_connector_send_query,
-                #{points => Points, batch => true, mode => async}
-            ),
-            do_async_query(InstId, Channel, Client, Points, {ReplyFun, Args});
-        {error, Reason} ->
-            ?tp(
-                influxdb_connector_send_query_error,
-                #{batch => true, mode => async, error => Reason}
-            ),
-            {error, {unrecoverable_error, Reason}}
+    ChannelConfig = maps:get(Channel, ChannelConf),
+    #{write_syntax := SyntaxLines} = ChannelConfig,
+    case group_batch_by_bucket(BatchData, ChannelConfig) of
+        [{Client, Data}] ->
+            case parse_batch_data(InstId, Data, SyntaxLines) of
+                {ok, Points} ->
+                    ?tp(
+                        influxdb_connector_send_query,
+                        #{
+                            points => Points, batch => true, mode => async, path => path(Client)
+                        }
+                    ),
+                    do_async_query(InstId, Channel, Client, Points, ReplyFunAndArgs);
+                {error, Reason} ->
+                    ?tp(
+                        influxdb_connector_send_query_error,
+                        #{batch => true, mode => async, error => Reason}
+                    ),
+                    {error, {unrecoverable_error, Reason}}
+            end;
+        Groups ->
+            do_grouped_async_batch_query(
+                InstId, Channel, Groups, SyntaxLines, ReplyFunAndArgs
+            )
     end.
 
 on_format_query_result(Result) ->
@@ -224,6 +244,179 @@ on_get_status(_InstId, #{client := Client}) ->
         false ->
             ?status_disconnected
     end.
+
+%% -------------------------------------------------------------------------------------------------
+%% Dynamic bucket
+
+preproc_bucket_tmpl(#{bucket := Bucket}) when is_binary(Bucket) ->
+    emqx_placeholder:preproc_tmpl(Bucket);
+preproc_bucket_tmpl(_) ->
+    undefined.
+
+render_bucket_client(Data, Client, ChannelConfig) ->
+    case render_bucket(Data, maps:get(bucket_tmpl, ChannelConfig, undefined)) of
+        {ok, Bucket} ->
+            influxdb:update_bucket(Client, Bucket);
+        undefined ->
+            Client
+    end.
+
+render_bucket(_Data, undefined) ->
+    undefined;
+render_bucket(Data, Tmpl) ->
+    TransOptions = #{return => rawlist, var_trans => fun data_filter/1},
+    case emqx_placeholder:proc_tmpl(Tmpl, Data, TransOptions) of
+        Parts when is_list(Parts) ->
+            %% a template may render to several parts (static text mixed with
+            %% placeholders, e.g. `tenant-${payload.tenant}`); concatenate them
+            %% into the bucket name. A missing part falls back to the static
+            %% bucket from the connector config.
+            case lists:member(undefined, Parts) of
+                true ->
+                    undefined;
+                false ->
+                    case iolist_to_binary([bin(Part) || Part <- Parts]) of
+                        <<>> ->
+                            undefined;
+                        Bucket ->
+                            {ok, Bucket}
+                    end
+            end;
+        _ ->
+            undefined
+    end.
+
+%% Group batch messages by their rendered bucket so that each group can be
+%% written to its own bucket with a single write request.
+%% Batch items are kept as {Channel, Message} pairs, as expected by parse_batch_data/3.
+group_batch_by_bucket(BatchData, ChannelConfig) ->
+    #{channel_client := Client, bucket_tmpl := BucketTmpl} = ChannelConfig,
+    Groups0 = lists:foldl(
+        fun(Item = {_Channel, Message}, Acc) ->
+            case render_bucket(Message, BucketTmpl) of
+                {ok, Bucket} ->
+                    Client1 = influxdb:update_bucket(Client, Bucket),
+                    maps:update_with(
+                        {ok, Bucket},
+                        fun({C, Items}) -> {C, [Item | Items]} end,
+                        {Client1, [Item]},
+                        Acc
+                    );
+                undefined ->
+                    maps:update_with(
+                        static,
+                        fun({C, Items}) -> {C, [Item | Items]} end,
+                        {Client, [Item]},
+                        Acc
+                    )
+            end
+        end,
+        #{},
+        BatchData
+    ),
+    [{C, lists:reverse(Items)} || {_, {C, Items}} <- maps:to_list(Groups0)].
+
+do_grouped_batch_query(InstId, Channel, Groups, SyntaxLines) ->
+    lists:foldl(
+        fun
+            ({Client, Data}, ok) ->
+                case parse_batch_data(InstId, Data, SyntaxLines) of
+                    {ok, Points} ->
+                        ?tp(
+                            influxdb_connector_send_query,
+                            #{
+                                points => Points, batch => true, mode => sync, path => path(Client)
+                            }
+                        ),
+                        do_query(InstId, Channel, Client, Points);
+                    {error, Reason} ->
+                        ?tp(
+                            influxdb_connector_send_query_error,
+                            #{batch => true, mode => sync, error => Reason}
+                        ),
+                        {error, {unrecoverable_error, Reason}}
+                end;
+            (_, Error) ->
+                Error
+        end,
+        ok,
+        Groups
+    ).
+
+%% When a batch is split into multiple bucket groups, each group write replies
+%% asynchronously. The batch reply fun must be called exactly once, after all
+%% group writes are done. An ets table is used to coordinate the replies.
+do_grouped_async_batch_query(InstId, _Channel, Groups, SyntaxLines, ReplyFunAndArgs) ->
+    TID = ets:new(?MODULE, [public, set]),
+    true = ets:insert(TID, {remaining, length(Groups)}),
+    CoordArgs = #{tid => TID, reply => ReplyFunAndArgs},
+    lists:foreach(
+        fun({Client, Data}) ->
+            case parse_batch_data(InstId, Data, SyntaxLines) of
+                {ok, Points} ->
+                    ?tp(
+                        influxdb_connector_send_query,
+                        #{
+                            points => Points, batch => true, mode => async, path => path(Client)
+                        }
+                    ),
+                    WrappedReplyFunAndArgs = {
+                        fun ?MODULE:coordinated_reply_callback/2,
+                        [CoordArgs]
+                    },
+                    case influxdb:write_async(Client, Points, WrappedReplyFunAndArgs) of
+                        {ok, _WorkerPid} ->
+                            ok;
+                        {error, Reason} ->
+                            coordinated_reply_callback(CoordArgs, {error, Reason})
+                    end;
+                {error, Reason} ->
+                    ?tp(
+                        influxdb_connector_send_query_error,
+                        #{batch => true, mode => async, error => Reason}
+                    ),
+                    coordinated_reply_callback(
+                        CoordArgs, {error, {unrecoverable_error, Reason}}
+                    )
+            end
+        end,
+        Groups
+    ),
+    ok.
+
+coordinated_reply_callback(#{tid := TID, reply := ReplyFunAndArgs}, Result) ->
+    Result1 = classify_result(Result),
+    case Result1 of
+        ok ->
+            ok;
+        _ ->
+            %% record the first error atomically: later errors must not
+            %% overwrite an earlier one
+            _ = ets:insert_new(TID, {first_error, Result1}),
+            ok
+    end,
+    Remaining = ets:update_counter(TID, remaining, -1, {remaining, 0}),
+    case Remaining of
+        0 ->
+            FirstError =
+                case ets:lookup(TID, first_error) of
+                    [{first_error, Err}] -> Err;
+                    [] -> undefined
+                end,
+            true = ets:delete(TID),
+            case FirstError of
+                undefined ->
+                    emqx_resource:apply_reply_fun(ReplyFunAndArgs, ok);
+                _ ->
+                    emqx_resource:apply_reply_fun(ReplyFunAndArgs, FirstError)
+            end,
+            ok;
+        _ ->
+            ok
+    end.
+
+path(Client) ->
+    maps:get(path, Client, undefined).
 
 %% -------------------------------------------------------------------------------------------------
 %% schema
@@ -553,7 +746,9 @@ is_auth_key(_) ->
 %% -------------------------------------------------------------------------------------------------
 %% Query
 do_query(InstId, Channel, Client, Points) ->
-    emqx_trace:rendered_action_template(Channel, #{points => Points, is_async => false}),
+    emqx_trace:rendered_action_template(
+        Channel, #{points => Points, is_async => false}
+    ),
     case influxdb:write(Client, Points) of
         ok ->
             ?SLOG(debug, #{
@@ -594,36 +789,39 @@ do_async_query(InstId, Channel, Client, Points, ReplyFunAndArgs) ->
     WrappedReplyFunAndArgs = {fun ?MODULE:reply_callback/2, [ReplyFunAndArgs]},
     {ok, _WorkerPid} = influxdb:write_async(Client, Points, WrappedReplyFunAndArgs).
 
-reply_callback(ReplyFunAndArgs, {error, Reason} = Error) ->
+reply_callback(ReplyFunAndArgs, Result) ->
+    emqx_resource:apply_reply_fun(ReplyFunAndArgs, classify_result(Result)).
+
+classify_result({error, {unrecoverable_error, _}} = Error) ->
+    %% already classified, e.g. a parse failure reported by the coordinated
+    %% batch callback; do not wrap it again
+    Error;
+classify_result({error, {recoverable_error, _}} = Error) ->
+    Error;
+classify_result({error, Reason} = Error) ->
     case is_unrecoverable_error(Error) of
         true ->
-            Result = {error, {unrecoverable_error, Reason}},
-            emqx_resource:apply_reply_fun(ReplyFunAndArgs, Result);
+            {error, {unrecoverable_error, Reason}};
         false ->
-            Result = {error, {recoverable_error, Reason}},
-            emqx_resource:apply_reply_fun(ReplyFunAndArgs, Result)
+            {error, {recoverable_error, Reason}}
     end;
-reply_callback(ReplyFunAndArgs, {ok, 401, _, _}) ->
+classify_result({ok, 401, _, _}) ->
     ?tp(influxdb_connector_do_query_failure, #{error => <<"authorization failure">>}),
-    Result = {error, {unrecoverable_error, <<"authorization failure">>}},
-    emqx_resource:apply_reply_fun(ReplyFunAndArgs, Result);
-reply_callback(ReplyFunAndArgs, {ok, 401, _}) ->
+    {error, {unrecoverable_error, <<"authorization failure">>}};
+classify_result({ok, 401, _}) ->
     ?tp(influxdb_connector_do_query_failure, #{error => <<"authorization failure">>}),
-    Result = {error, {unrecoverable_error, <<"authorization failure">>}},
-    emqx_resource:apply_reply_fun(ReplyFunAndArgs, Result);
-reply_callback(ReplyFunAndArgs, {ok, Code, _, Body}) when ?IS_HTTP_ERROR(Code) ->
+    {error, {unrecoverable_error, <<"authorization failure">>}};
+classify_result({ok, Code, _, Body}) when ?IS_HTTP_ERROR(Code) ->
     Error = #{code => Code, body => Body},
     ?tp(influxdb_connector_do_query_failure, #{error => Error}),
-    Result = {error, {unrecoverable_error, Error}},
-    emqx_resource:apply_reply_fun(ReplyFunAndArgs, Result);
-reply_callback(ReplyFunAndArgs, {ok, Code, _}) when ?IS_HTTP_ERROR(Code) ->
+    {error, {unrecoverable_error, Error}};
+classify_result({ok, Code, _}) when ?IS_HTTP_ERROR(Code) ->
     Error = #{code => Code, body => <<"">>},
     ?tp(influxdb_connector_do_query_failure, #{error => Error}),
-    Result = {error, {unrecoverable_error, Error}},
-    emqx_resource:apply_reply_fun(ReplyFunAndArgs, Result);
-reply_callback(ReplyFunAndArgs, Result) ->
+    {error, {unrecoverable_error, Error}};
+classify_result(Result) ->
     ?tp(influxdb_connector_do_query_ok, #{result => Result}),
-    emqx_resource:apply_reply_fun(ReplyFunAndArgs, Result).
+    Result.
 
 %% -------------------------------------------------------------------------------------------------
 %% Tags & Fields Config Trans
@@ -633,6 +831,8 @@ to_config(Lines, Precision) ->
 
 to_config([], Acc, _Precision) ->
     lists:reverse(Acc);
+to_config([#{line := Line0} | Rest], Acc, Precision) ->
+    to_config(Rest, [#{line => emqx_placeholder:preproc_tmpl(Line0)} | Acc], Precision);
 to_config([Item0 | Rest], Acc, Precision) ->
     Ts0 = maps:get(timestamp, Item0, undefined),
     {Ts, FromPrecision, ToPrecision} = preproc_tmpl_timestamp(Ts0, Precision),
@@ -719,7 +919,8 @@ parse_batch_data(InstId, BatchData, SyntaxLines) ->
         timestamp := emqx_placeholder:tmpl_token() | integer(),
         precision := {From :: ts_precision(), To :: ts_precision()}
     }
-]) -> {ok, [map()]} | {error, term()}.
+    | #{line := emqx_placeholder:tmpl_token()}
+]) -> {ok, [map() | binary()]} | {error, term()}.
 data_to_points(Data, SyntaxLines) ->
     lines_to_points(Data, SyntaxLines, [], []).
 
@@ -732,6 +933,28 @@ lines_to_points(_, [], Points, ErrorPoints) ->
         _ ->
             %% ignore trans succeeded points
             {error, ErrorPoints}
+    end;
+%% a raw line protocol template, the rendered value is written verbatim
+lines_to_points(Data, [#{line := Tmpl} | Rest], PointsAcc, ErrorPointsAcc) ->
+    TransOptions = #{return => rawlist, var_trans => fun data_filter/1},
+    case emqx_placeholder:proc_tmpl(Tmpl, Data, TransOptions) of
+        [undefined] ->
+            lines_to_points(Data, Rest, PointsAcc, ErrorPointsAcc);
+        [RawLine0] ->
+            case raw_line_to_bin(RawLine0) of
+                {ok, RawLine1} ->
+                    RawLine = string:trim(RawLine1, trailing, "\n"),
+                    case RawLine of
+                        <<>> ->
+                            lines_to_points(Data, Rest, PointsAcc, ErrorPointsAcc);
+                        _ ->
+                            lines_to_points(Data, Rest, [RawLine | PointsAcc], ErrorPointsAcc)
+                    end;
+                skip ->
+                    lines_to_points(Data, Rest, PointsAcc, ErrorPointsAcc)
+            end;
+        _ ->
+            lines_to_points(Data, Rest, PointsAcc, ErrorPointsAcc)
     end;
 lines_to_points(
     Data,
@@ -949,6 +1172,15 @@ data_filter(Number) when is_number(Number) -> Number;
 data_filter(Bool) when is_boolean(Bool) -> Bool;
 data_filter(Data) -> bin(Data).
 
+%% a raw line protocol line must be actual text; values that cannot be text
+%% (numbers, booleans, ...) are skipped just like an empty render
+raw_line_to_bin(<<_/binary>> = Raw) ->
+    {ok, Raw};
+raw_line_to_bin(Raw) when is_list(Raw) ->
+    {ok, bin(Raw)};
+raw_line_to_bin(_) ->
+    skip.
+
 bin(Data) when is_list(Data) ->
     case io_lib:printable_unicode_list(Data) of
         true -> unicode:characters_to_binary(Data);
@@ -1006,6 +1238,140 @@ is_auth_key_test_() ->
         ?_assert(is_auth_key(<<"Authorization">>)),
         ?_assertNot(is_auth_key(<<"Something">>)),
         ?_assertNot(is_auth_key(89))
+    ].
+
+render_bucket_test_() ->
+    Tmpl = emqx_placeholder:preproc_tmpl(<<"${payload.bucket}">>),
+    Data = #{payload => #{bucket => <<"mqtt2">>}},
+    [
+        {"renders the bucket from the data",
+            ?_assertEqual({ok, <<"mqtt2">>}, render_bucket(Data, Tmpl))},
+        {"no template renders undefined", ?_assertEqual(undefined, render_bucket(Data, undefined))},
+        {"missing field falls back to the connector bucket",
+            ?_assertEqual(undefined, render_bucket(#{payload => #{}}, Tmpl))},
+        {"empty bucket falls back to the connector bucket",
+            ?_assertEqual(
+                undefined,
+                render_bucket(#{payload => #{bucket => <<>>}}, Tmpl)
+            )},
+        {"bucket without template still overrides",
+            ?_assertEqual(
+                {ok, <<"fixed_bucket">>},
+                render_bucket(Data, emqx_placeholder:preproc_tmpl(<<"fixed_bucket">>))
+            )},
+        {"static text and placeholder are concatenated",
+            ?_assertEqual(
+                {ok, <<"tenant-mqtt2">>},
+                render_bucket(
+                    Data,
+                    emqx_placeholder:preproc_tmpl(<<"tenant-${payload.bucket}">>)
+                )
+            )},
+        {"concatenated template with a missing part falls back",
+            ?_assertEqual(
+                undefined,
+                render_bucket(
+                    #{payload => #{}},
+                    emqx_placeholder:preproc_tmpl(<<"tenant-${payload.bucket}">>)
+                )
+            )}
+    ].
+
+data_to_points_test_() ->
+    SyntaxLines = [
+        #{line => emqx_placeholder:preproc_tmpl(<<"${payload.line}">>)}
+    ],
+    [
+        {"renders a raw line protocol string",
+            ?_assertEqual(
+                {ok, [
+                    <<"weather,location=us-midwest temperature=82 1465839830100400200">>
+                ]},
+                data_to_points(
+                    #{
+                        payload => #{
+                            line => <<
+                                "weather,location=us-midwest "
+                                "temperature=82 1465839830100400200"
+                            >>
+                        }
+                    },
+                    SyntaxLines
+                )
+            )},
+        {"raw line with trailing newline is trimmed",
+            ?_assertEqual(
+                {ok, [<<"weather temperature=82 1">>]},
+                data_to_points(
+                    #{payload => #{line => <<"weather temperature=82 1\n">>}},
+                    SyntaxLines
+                )
+            )},
+        {"missing field skips the raw line",
+            ?_assertEqual(
+                {ok, []},
+                data_to_points(#{payload => #{}}, SyntaxLines)
+            )},
+        {"empty rendered line is skipped",
+            ?_assertEqual(
+                {ok, []},
+                data_to_points(#{payload => #{line => <<>>}}, SyntaxLines)
+            )},
+        {"non-text rendered values are skipped, not crashing",
+            ?_assertEqual(
+                {ok, []},
+                data_to_points(#{payload => #{line => true}}, SyntaxLines)
+            )},
+        {"integer rendered values are skipped",
+            ?_assertEqual(
+                {ok, []},
+                data_to_points(#{payload => #{line => 123}}, SyntaxLines)
+            )},
+        {"raw lines and structured points are mixed",
+            ?_assertEqual(
+                {ok, [
+                    #{
+                        measurement => <<"m">>,
+                        tags => #{<<"tag">> => <<"1">>},
+                        fields => #{<<"f">> => {int, 2}},
+                        timestamp => 1
+                    },
+                    <<"weather temperature=82 1">>
+                ]},
+                data_to_points(
+                    #{payload => #{line => <<"weather temperature=82 1">>}},
+                    [
+                        #{line => emqx_placeholder:preproc_tmpl(<<"${payload.line}">>)},
+                        #{
+                            measurement => emqx_placeholder:preproc_tmpl(<<"m">>),
+                            tags => #{
+                                emqx_placeholder:preproc_tmpl(<<"tag">>) =>
+                                    emqx_placeholder:preproc_tmpl(<<"1">>)
+                            },
+                            fields => #{
+                                emqx_placeholder:preproc_tmpl(<<"f">>) =>
+                                    emqx_placeholder:preproc_tmpl(<<"2i">>)
+                            },
+                            timestamp => emqx_placeholder:preproc_tmpl(<<"1">>),
+                            precision => {ms, ms}
+                        }
+                    ]
+                )
+            )}
+    ].
+
+classify_result_test_() ->
+    [
+        {"already classified errors are not wrapped again",
+            ?_assertEqual(
+                {error, {unrecoverable_error, boom}},
+                classify_result({error, {unrecoverable_error, boom}})
+            )},
+        {"already classified recoverable errors are not wrapped again",
+            ?_assertEqual(
+                {error, {recoverable_error, boom}},
+                classify_result({error, {recoverable_error, boom}})
+            )}
     ].
 
 %% for coverage

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -290,7 +290,8 @@ render_bucket(Data, Tmpl) ->
 %% written to its own bucket with a single write request.
 %% Batch items are kept as {Channel, Message} pairs, as expected by parse_batch_data/3.
 group_batch_by_bucket(BatchData, ChannelConfig) ->
-    #{channel_client := Client, bucket_tmpl := BucketTmpl} = ChannelConfig,
+    #{channel_client := Client} = ChannelConfig,
+    BucketTmpl = maps:get(bucket_tmpl, ChannelConfig, undefined),
     Groups0 = lists:foldl(
         fun(Item = {_Channel, Message}, Acc) ->
             case render_bucket(Message, BucketTmpl) of
@@ -331,6 +332,9 @@ do_grouped_batch_query(InstId, Channel, Groups, SyntaxLines) ->
                                 points => Points, batch => true, mode => sync, path => path(Client)
                             }
                         ),
+                        emqx_trace:rendered_action_template(
+                            Channel, #{points => Points, is_async => false}
+                        ),
                         do_query(InstId, Channel, Client, Points);
                     {error, Reason} ->
                         ?tp(
@@ -349,7 +353,7 @@ do_grouped_batch_query(InstId, Channel, Groups, SyntaxLines) ->
 %% When a batch is split into multiple bucket groups, each group write replies
 %% asynchronously. The batch reply fun must be called exactly once, after all
 %% group writes are done. An ets table is used to coordinate the replies.
-do_grouped_async_batch_query(InstId, _Channel, Groups, SyntaxLines, ReplyFunAndArgs) ->
+do_grouped_async_batch_query(InstId, Channel, Groups, SyntaxLines, ReplyFunAndArgs) ->
     TID = ets:new(?MODULE, [public, set]),
     true = ets:insert(TID, {remaining, length(Groups)}),
     CoordArgs = #{tid => TID, reply => ReplyFunAndArgs},
@@ -362,6 +366,9 @@ do_grouped_async_batch_query(InstId, _Channel, Groups, SyntaxLines, ReplyFunAndA
                         #{
                             points => Points, batch => true, mode => async, path => path(Client)
                         }
+                    ),
+                    emqx_trace:rendered_action_template(
+                        Channel, #{points => Points, is_async => true}
                     ),
                     WrappedReplyFunAndArgs = {
                         fun ?MODULE:coordinated_reply_callback/2,
@@ -388,34 +395,46 @@ do_grouped_async_batch_query(InstId, _Channel, Groups, SyntaxLines, ReplyFunAndA
     ok.
 
 coordinated_reply_callback(#{tid := TID, reply := ReplyFunAndArgs}, Result) ->
-    Result1 = classify_result(Result),
-    case Result1 of
-        ok ->
-            ok;
-        _ ->
-            %% record the first error atomically: later errors must not
-            %% overwrite an earlier one
-            _ = ets:insert_new(TID, {first_error, Result1}),
+    case coordinated_reply(TID, Result) of
+        {reply, ReplyResult} ->
+            emqx_resource:apply_reply_fun(ReplyFunAndArgs, ReplyResult);
+        noreply ->
             ok
-    end,
-    Remaining = ets:update_counter(TID, remaining, -1, {remaining, 0}),
-    case Remaining of
-        0 ->
-            FirstError =
-                case ets:lookup(TID, first_error) of
-                    [{first_error, Err}] -> Err;
-                    [] -> undefined
-                end,
-            true = ets:delete(TID),
-            case FirstError of
-                undefined ->
-                    emqx_resource:apply_reply_fun(ReplyFunAndArgs, ok);
-                _ ->
-                    emqx_resource:apply_reply_fun(ReplyFunAndArgs, FirstError)
-            end,
-            ok;
-        _ ->
-            ok
+    end.
+
+%% Collect the outcome of one group write. Only errors are remembered, so a
+%% successful group can never shadow a failing one. The group that completes
+%% the batch removes the table and reports the first error (or `ok`).
+coordinated_reply(TID, Result) ->
+    try
+        case classify_result(Result) of
+            {error, _} = Error ->
+                %% record the first error atomically: later errors must not
+                %% overwrite an earlier one
+                _ = ets:insert_new(TID, {first_error, Error});
+            _ ->
+                ok
+        end,
+        case ets:update_counter(TID, remaining, -1) of
+            0 ->
+                FirstError =
+                    case ets:lookup(TID, first_error) of
+                        [{first_error, Err}] -> Err;
+                        [] -> undefined
+                    end,
+                true = ets:delete(TID),
+                case FirstError of
+                    undefined -> {reply, ok};
+                    _ -> {reply, FirstError}
+                end;
+            _ ->
+                noreply
+        end
+    catch
+        error:badarg ->
+            %% The coordination table was already removed, e.g. the owning
+            %% resource worker stopped. There is nothing left to reply to.
+            noreply
     end.
 
 path(Client) ->
@@ -953,8 +972,10 @@ lines_to_points(Data, [#{line := Tmpl} | Rest], PointsAcc, ErrorPointsAcc) ->
                         _ ->
                             lines_to_points(Data, Rest, [RawLine | PointsAcc], ErrorPointsAcc)
                     end;
-                skip ->
-                    lines_to_points(Data, Rest, PointsAcc, ErrorPointsAcc)
+                {error, BadRawLine} ->
+                    lines_to_points(Data, Rest, PointsAcc, [
+                        {error, {non_textual_raw_line, BadRawLine}} | ErrorPointsAcc
+                    ])
             end;
         _ ->
             lines_to_points(Data, Rest, PointsAcc, ErrorPointsAcc)
@@ -1175,14 +1196,15 @@ data_filter(Number) when is_number(Number) -> Number;
 data_filter(Bool) when is_boolean(Bool) -> Bool;
 data_filter(Data) -> bin(Data).
 
-%% a raw line protocol line must be actual text; values that cannot be text
-%% (numbers, booleans, ...) are skipped just like an empty render
+%% a raw line protocol line must be actual text; a value that cannot be
+%% text (a number, boolean, ...) is a conversion error, so the write is not
+%% silently turned into a no-op.
 raw_line_to_bin(<<_/binary>> = Raw) ->
     {ok, Raw};
 raw_line_to_bin(Raw) when is_list(Raw) ->
     {ok, bin(Raw)};
-raw_line_to_bin(_) ->
-    skip.
+raw_line_to_bin(Raw) ->
+    {error, Raw}.
 
 bin(Data) when is_list(Data) ->
     case io_lib:printable_unicode_list(Data) of
@@ -1309,6 +1331,16 @@ group_batch_by_bucket_test_() ->
             ]
         end}.
 
+group_batch_without_bucket_tmpl_test_() ->
+    BatchData = [{c1, #{payload => #{bucket => <<"b1">>}}}],
+    [
+        {"a channel config without bucket_tmpl groups everything to the static client",
+            ?_assertEqual(
+                [{client, BatchData}],
+                group_batch_by_bucket(BatchData, #{channel_client => client})
+            )}
+    ].
+
 data_to_points_test_() ->
     SyntaxLines = [
         #{line => emqx_placeholder:preproc_tmpl(<<"${payload.line}">>)}
@@ -1349,14 +1381,14 @@ data_to_points_test_() ->
                 {ok, []},
                 data_to_points(#{payload => #{line => <<>>}}, SyntaxLines)
             )},
-        {"non-text rendered values are skipped, not crashing",
-            ?_assertEqual(
-                {ok, []},
+        {"non-text rendered values fail the batch instead of silently succeeding",
+            ?_assertMatch(
+                {error, _},
                 data_to_points(#{payload => #{line => true}}, SyntaxLines)
             )},
-        {"integer rendered values are skipped",
-            ?_assertEqual(
-                {ok, []},
+        {"integer rendered values fail the batch instead of silently succeeding",
+            ?_assertMatch(
+                {error, _},
                 data_to_points(#{payload => #{line => 123}}, SyntaxLines)
             )},
         {"raw lines and structured points are mixed",
@@ -1405,6 +1437,65 @@ classify_result_test_() ->
                 classify_result({error, {recoverable_error, boom}})
             )}
     ].
+
+coordinated_reply_callback_test_() ->
+    [
+        {"a failing group is reported even when a success replies first",
+            ?_assertEqual(
+                [{error, {unrecoverable_error, #{code => 500, body => <<"boom">>}}}],
+                run_coordinated([
+                    {ok, 204, [], <<>>},
+                    {ok, 500, [], <<"boom">>}
+                ])
+            )},
+        {"a failing group is reported when it replies first",
+            ?_assertEqual(
+                [{error, {unrecoverable_error, #{code => 500, body => <<"boom">>}}}],
+                run_coordinated([
+                    {ok, 500, [], <<"boom">>},
+                    {ok, 204, [], <<>>}
+                ])
+            )},
+        {"a recoverable connection error is reported",
+            ?_assertEqual(
+                [{error, {recoverable_error, timeout}}],
+                run_coordinated([{ok, 204, [], <<>>}, {error, timeout}])
+            )},
+        {"only ok is replied when every group succeeds",
+            ?_assertEqual(
+                [ok],
+                run_coordinated([{ok, 204, [], <<>>}, {ok, 204, [], <<>>}])
+            )},
+        {"a callback over a removed coordination table is ignored", fun() ->
+            TID = ets:new(?MODULE, [public, set]),
+            true = ets:insert(TID, {remaining, 1}),
+            true = ets:delete(TID),
+            ReplyFunAndArgs = {fun(Result) -> self() ! {unexpected, Result} end, []},
+            ?assertEqual(
+                ok,
+                coordinated_reply_callback(
+                    #{tid => TID, reply => ReplyFunAndArgs},
+                    {ok, 204, [], <<>>}
+                )
+            )
+        end}
+    ].
+
+run_coordinated(Results) ->
+    TID = ets:new(?MODULE, [public, set]),
+    true = ets:insert(TID, {remaining, length(Results)}),
+    Self = self(),
+    ReplyFunAndArgs = {fun(Result) -> Self ! {coordinated_reply, Result} end, []},
+    CoordArgs = #{tid => TID, reply => ReplyFunAndArgs},
+    lists:foreach(fun(Result) -> coordinated_reply_callback(CoordArgs, Result) end, Results),
+    collect_coordinated([]).
+
+collect_coordinated(Acc) ->
+    receive
+        {coordinated_reply, Result} -> collect_coordinated([Result | Acc])
+    after 0 ->
+        lists:reverse(Acc)
+    end.
 
 %% for coverage
 desc_test_() ->

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -295,13 +295,16 @@ group_batch_by_bucket(BatchData, ChannelConfig) ->
         fun(Item = {_Channel, Message}, Acc) ->
             case render_bucket(Message, BucketTmpl) of
                 {ok, Bucket} ->
-                    Client1 = influxdb:update_bucket(Client, Bucket),
-                    maps:update_with(
-                        {ok, Bucket},
-                        fun({C, Items}) -> {C, [Item | Items]} end,
-                        {Client1, [Item]},
-                        Acc
-                    );
+                    %% Rebuild the write path at most once per distinct bucket:
+                    %% reuse the already updated client for repeated buckets.
+                    Key = {ok, Bucket},
+                    case maps:find(Key, Acc) of
+                        {ok, {Client1, Items}} ->
+                            Acc#{Key := {Client1, [Item | Items]}};
+                        error ->
+                            Client1 = influxdb:update_bucket(Client, Bucket),
+                            Acc#{Key => {Client1, [Item]}}
+                    end;
                 undefined ->
                     maps:update_with(
                         static,
@@ -1276,6 +1279,35 @@ render_bucket_test_() ->
                 )
             )}
     ].
+
+group_batch_by_bucket_test_() ->
+    Tmpl = emqx_placeholder:preproc_tmpl(<<"${payload.bucket}">>),
+    ChannelConfig = #{channel_client => client, bucket_tmpl => Tmpl},
+    BatchData =
+        [
+            {c1, #{payload => #{bucket => Bucket}}}
+         || Bucket <- [<<"b1">>, <<"b1">>, <<"b2">>, <<"b1">>, <<>>]
+        ],
+    {setup,
+        fun() ->
+            ok = meck:new(influxdb, [passthrough, no_link]),
+            ok = meck:expect(influxdb, update_bucket, fun(_Client, Bucket) -> Bucket end),
+            group_batch_by_bucket(BatchData, ChannelConfig)
+        end,
+        fun(_Groups) ->
+            meck:unload(influxdb)
+        end,
+        fun(Groups) ->
+            [
+                {"the write path is rebuilt once per distinct bucket",
+                    ?_assertEqual(2, meck:num_calls(influxdb, update_bucket, ['_', '_']))},
+                {"batch items are grouped by rendered bucket; empty/missing falls back",
+                    ?_assertEqual(
+                        [{client, 1}, {<<"b1">>, 3}, {<<"b2">>, 1}],
+                        lists:sort([{C, length(Items)} || {C, Items} <- Groups])
+                    )}
+            ]
+        end}.
 
 data_to_points_test_() ->
     SyntaxLines = [

--- a/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_SUITE.erl
+++ b/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_SUITE.erl
@@ -338,6 +338,9 @@ authn_header_value(TCConfig) ->
     end.
 
 query_by_clientid(RuleTopic, ClientId, TCConfig) ->
+    query_in_bucket(<<"mqtt">>, RuleTopic, ClientId, TCConfig).
+
+query_in_bucket(Bucket, RuleTopic, ClientId, TCConfig) ->
     APIType = get_config(api_type, TCConfig, ?api_v2),
     RawBody0 =
         case APIType of
@@ -346,14 +349,16 @@ query_by_clientid(RuleTopic, ClientId, TCConfig) ->
                     c => ClientId,
                     t => RuleTopic
                 }),
-                Body = #{db => <<"mqtt">>, q => Query, format => <<"csv">>},
+                Body = #{db => Bucket, q => Query, format => <<"csv">>},
                 Path = <<"/api/v3/query_influxql">>,
                 Method = post,
                 Opts = #{method => Method, body => Body, path => Path},
                 query_v3(Opts, TCConfig);
             _ ->
                 Query = <<
-                    "from(bucket: \"mqtt\")\n"
+                    "from(bucket: \"",
+                    Bucket/binary,
+                    "\")\n"
                     "  |> range(start: -12h)\n"
                     "  |> filter(fn: (r) => r.clientid == \"",
                     ClientId/binary,
@@ -558,6 +563,70 @@ clear_table(RuleTopic, TCConfig) ->
             }
         },
         query_v3(Opts, TCConfig)
+    end.
+
+create_bucket(TCConfig) ->
+    {Host, Port} = server_tuple(TCConfig),
+    BaseURI = iolist_to_binary([
+        "http://",
+        Host,
+        ":",
+        integer_to_binary(Port)
+    ]),
+    Headers = [{"Authorization", "Token abcdefg"}],
+    {ok, 200, _, OrgBody} =
+        ehttpc:request(
+            ?HELPER_POOL,
+            get,
+            {<<BaseURI/binary, "/api/v2/orgs">>, Headers},
+            10_000,
+            0
+        ),
+    #{<<"orgs">> := [#{<<"id">> := OrgId} | _]} = emqx_utils_json:decode(OrgBody),
+    %% the matrix runs this test case several times against the same influxdb
+    %% container, so the bucket may already exist; only create it once
+    {ok, 200, _, BucketsBody} =
+        ehttpc:request(
+            ?HELPER_POOL,
+            get,
+            {<<BaseURI/binary, "/api/v2/buckets?orgID=", OrgId/binary>>, Headers},
+            10_000,
+            0
+        ),
+    Buckets = maps:get(<<"buckets">>, emqx_utils_json:decode(BucketsBody)),
+    case
+        lists:any(
+            fun
+                (#{<<"name">> := <<"mqtt2">>}) -> true;
+                (_) -> false
+            end,
+            Buckets
+        )
+    of
+        true ->
+            ok;
+        false ->
+            Body = emqx_utils_json:encode(#{
+                <<"name">> => <<"mqtt2">>,
+                <<"orgID">> => OrgId,
+                <<"retentionRules">> => []
+            }),
+            {ok, 201, _, _} =
+                ehttpc:request(
+                    ?HELPER_POOL,
+                    post,
+                    {
+                        <<BaseURI/binary, "/api/v2/buckets">>,
+                        [
+                            {"Authorization", "Token abcdefg"},
+                            {"Content-Type", "application/json"}
+                        ],
+                        Body
+                    },
+                    10_000,
+                    0
+                ),
+            ok
     end.
 
 proxy_name(TCConfig) ->
@@ -1243,6 +1312,73 @@ t_missing_field(TCConfig) when is_list(TCConfig) ->
             ok
         end
     ),
+    ok.
+
+t_dynamic_bucket() ->
+    [{matrix, true}].
+t_dynamic_bucket(matrix) ->
+    [
+        [?api_v2, ?tcp, Sync, Batch]
+     || Sync <- [?sync, ?async], Batch <- [?without_batch, ?with_batch]
+    ];
+t_dynamic_bucket(TCConfig) when is_list(TCConfig) ->
+    create_bucket(TCConfig),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{
+            <<"bucket">> => <<"${payload.bucket}">>,
+            <<"write_syntax">> => <<"${topic},clientid=${clientid} foo=${payload.foo}i">>
+        }
+    }),
+    #{topic := RuleTopic} = simple_create_rule_api(TCConfig),
+    ClientId0 = emqx_guid:to_hexstr(emqx_guid:gen()),
+    ClientId1 = emqx_guid:to_hexstr(emqx_guid:gen()),
+    C0 = start_client(#{clientid => ClientId0}),
+    C1 = start_client(#{clientid => ClientId1}),
+    ct:timetrap({seconds, 30}),
+    Payload0 = emqx_utils_json:encode(#{<<"foo">> => 123, <<"bucket">> => <<"mqtt2">>}),
+    %% payload without the bucket field, the connector bucket is used as fallback
+    Payload1 = emqx_utils_json:encode(#{<<"foo">> => 456}),
+    emqtt:publish(C0, RuleTopic, Payload0, [{qos, 1}]),
+    emqtt:publish(C1, RuleTopic, Payload1, [{qos, 1}]),
+    ?retry(200, 10, begin
+        PersistedData0 = query_in_bucket(<<"mqtt2">>, RuleTopic, ClientId0, TCConfig),
+        PersistedData1 = query_in_bucket(<<"mqtt">>, RuleTopic, ClientId1, TCConfig),
+        assert_persisted_data(ClientId0, #{foo => {<<"123">>, <<"long">>}}, PersistedData0),
+        assert_persisted_data(ClientId1, #{foo => {<<"456">>, <<"long">>}}, PersistedData1),
+        ok
+    end),
+    ok.
+
+t_raw_line_write_syntax() ->
+    [{matrix, true}].
+t_raw_line_write_syntax(matrix) ->
+    [
+        [?api_v2, ?tcp, Sync, Batch]
+     || Sync <- [?sync, ?async], Batch <- [?without_batch, ?with_batch]
+    ];
+t_raw_line_write_syntax(TCConfig) when is_list(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{<<"write_syntax">> => <<"${line_protocol}">>}
+    }),
+    SQL = <<
+        "select clientid, topic, "
+        "concat(concat(concat(concat('mqtt,clientid=', clientid), ' foo='), payload.foo), 'i') "
+        "as line_protocol "
+        "from \"${t}\" "
+    >>,
+    #{topic := RuleTopic} = simple_create_rule_api(SQL, TCConfig),
+    ClientId = emqx_guid:to_hexstr(emqx_guid:gen()),
+    C = start_client(#{clientid => ClientId}),
+    ct:timetrap({seconds, 30}),
+    Payload = emqx_utils_json:encode(#{<<"foo">> => 123}),
+    emqtt:publish(C, RuleTopic, Payload, [{qos, 1}]),
+    ?retry(200, 10, begin
+        PersistedData = query_by_clientid(RuleTopic, ClientId, TCConfig),
+        Expected = #{foo => {<<"123">>, <<"long">>}},
+        assert_persisted_data(ClientId, Expected, PersistedData)
+    end),
     ok.
 
 t_authentication_error() ->

--- a/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_tests.erl
+++ b/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_tests.erl
@@ -51,10 +51,10 @@
     "measurement,t= a f=a,f1=b ${timestamp}",
     "measurement,t= a f=a,f1 =b ${timestamp}",
     "measurement, t = a f = a,f1 = b ${timestamp}",
-    "measurement,t=a f=a,f1=b \n ${timestamp}",
-    "measurement,t=a \n f=a,f1=b \n ${timestamp}",
+    "measurement,t=a f=a,f1=b \n ${t}${s}",
+    "measurement,t=a \n f=a,f1=b \n ${t}${s}",
     "measurement,t=a \n f=a,f1=b \n ",
-    "\n measurement,t=a \n f=a,f1=b \n ${timestamp}",
+    "\n measurement,t=a \n f=a,f1=b \n ${t}${s}",
     "\n measurement,t=a \n f=a,f1=b \n",
     %% not escaped backslash in a quoted field value is invalid
     "measurement,tag=1 field=\"val\\1\""
@@ -431,6 +431,48 @@ unicode_write_syntax_test_() ->
             [Expected],
             to_influx_lines(<<"m,tag=标签 f=\"固定中文\""/utf8>>)
         )
+    ].
+
+raw_line_write_syntax_test_() ->
+    [
+        {"a single placeholder line is a raw line template",
+            ?_assertEqual(
+                [#{line => "${payload.line}"}],
+                to_influx_lines(<<"${payload.line}">>)
+            )},
+        {"raw line template with trailing newline",
+            ?_assertEqual(
+                [#{line => "${payload.line}"}],
+                to_influx_lines(<<"${payload.line}\n">>)
+            )},
+        {"multiple raw line templates",
+            ?_assertEqual(
+                [#{line => "${payload.l1}"}, #{line => "${payload.l2}"}],
+                to_influx_lines(<<"${payload.l1}\n${payload.l2}">>)
+            )},
+        {"raw line template mixed with structured lines",
+            ?_assertEqual(
+                [
+                    #{line => "${payload.line}"},
+                    #{
+                        measurement => "m",
+                        tags => [{"tag", "1"}],
+                        fields => [{"f", "2"}],
+                        timestamp => undefined
+                    }
+                ],
+                to_influx_lines(<<"${payload.line}\nm,tag=1 f=2">>)
+            )},
+        {"escaped chars in a placeholder are unescaped",
+            ?_assertEqual(
+                [#{line => "${payload.line 1}"}],
+                to_influx_lines(<<"${payload.line\\ 1}">>)
+            )},
+        {"a line with two placeholders is not a raw line template",
+            ?_assertMatch(
+                {error, _},
+                to_influx_lines(<<"${payload.a}${payload.b}">>)
+            )}
     ].
 
 influxdb_api_v1_connector_ping_with_auth_test_() ->

--- a/changes/ee/feat-18766.en.md
+++ b/changes/ee/feat-18766.en.md
@@ -1,0 +1,13 @@
+## Summary
+
+Support templating of the InfluxDB bucket name in the InfluxDB action.
+
+The bucket (or database for InfluxDB v1/v3) is now an optional, templatable
+parameter of the action. It overrides the bucket configured in the connector
+per message, which allows dynamic bucket selection from the rule SQL result,
+e.g. `bucket = "${payload.bucket_name}"`. If the rendered value is empty or the
+referenced field is missing, the bucket configured in the connector is used.
+
+A `write_syntax` line that consists of exactly one placeholder is now written
+verbatim as a line protocol, which makes it possible to write a rule SQL select
+result that is already a formatted line, e.g. `write_syntax = "${payload.line}"`.

--- a/mix.exs
+++ b/mix.exs
@@ -276,7 +276,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:ots_erl, github: "emqx/ots_erl", tag: "0.2.4", override: true}
 
   def common_dep(:influxdb),
-    do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.18", override: true}
+    do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.19", override: true}
 
   def common_dep(:wolff), do: {:wolff, "4.2.1"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}

--- a/rel/i18n/emqx_bridge_influxdb.hocon
+++ b/rel/i18n/emqx_bridge_influxdb.hocon
@@ -32,10 +32,18 @@ TLDR:<br/>
 ```
 <measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]
 ```
-Please note that a placeholder for an integer value must be annotated with a suffix `i`. For example `${payload.int_value}i`."""
+Please note that a placeholder for an integer value must be annotated with a suffix `i`. For example `${payload.int_value}i`.
+
+If a line consists of exactly one placeholder, the rendered value is written verbatim as a line protocol. This makes it possible to write a select result that is already a formatted line protocol, e.g. `write_syntax = "${payload.line}"`."""
 
 write_syntax.label:
 """Write Syntax"""
+
+bucket.desc:
+"""Bucket name to write data points to. It overrides the bucket (v2) or database (v1/v3) configured in the connector for this action. Placeholders are supported, so the bucket can be selected dynamically from the rule SQL result, e.g. `${payload.bucket_name}`. If the rendered value is empty or the referenced field is missing, the bucket configured in the connector is used."""
+
+bucket.label:
+"""Bucket"""
 
 action_parameters.label:
 """Action Parameters"""


### PR DESCRIPTION
Resolves #17468 (milestone 6.1.5).

## What

Two features for the InfluxDB action:

1. **Dynamic bucket/database** — the action gains an optional, templatable `bucket` parameter that overrides the connector-level bucket/database per message. Rendered from the rule SQL result, e.g. `bucket = \"${payload.bucket_name}\"`. When the rendered value is empty or the field is missing it falls back to the connector value. Batched messages are grouped by the rendered bucket (one write request per group); async multi-group batches reply exactly once through an ets-coordinated callback.
2. **Raw line protocol** — a `write_syntax` line that consists of exactly one placeholder (e.g. `\"${line_protocol}\"`) is written verbatim, so a rule SQL `select` result that is already a formatted line protocol can be stored without re-encoding.

## Dependency

`mix.exs` pins the influxdb client to the `JimMoen/influxdb-client-erl` branch carrying the client-side support (see emqx/influxdb-client-erl#58). Once that PR is merged and tagged 1.1.19, this PR will switch back to `emqx/influxdb-client-erl` @ `1.1.19`.

## Verification

- eunit: 135 passed (parser, `render_bucket`, `data_to_points` raw line rendering, raw `write_syntax` parsing)
- CT: `scripts/ct/run.sh --ci --app apps/emqx_bridge_influxdb` — 122 ok / 0 failed (includes new `t_dynamic_bucket` and `t_raw_line_write_syntax` across api_v2 × tcp × sync/async × batch matrix)
- `make fmt` clean