### PR TITLE
fix(connector api): stop rocketmq namespace shadowing the EMQX namespace

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -742,7 +742,15 @@ format_resource(
     Node
 ) ->
     ResourceData = lookup_channels(Namespace, Type, ConnectorName, ResourceData0),
-    RawConf = fill_defaults(Type, RawConf0),
+    RawConf1 = fill_defaults(Type, RawConf0),
+    %% The rocketmq connector schema defines its own top-level `namespace'
+    %% config field.  It has binary keys, while the EMQX namespace is merged in
+    %% below under an atom key.  Both encode to the JSON key "namespace", so the
+    %% response would carry that key twice and clients keep the last one.  Drop
+    %% the config field here so the single "namespace" key always holds the EMQX
+    %% namespace.  `restore_own_namespace/2' puts the stored value back when an
+    %% update omits it.
+    RawConf = maps:remove(<<"namespace">>, RawConf1),
     redact(
         maps:merge(
             RawConf#{
@@ -923,7 +931,9 @@ get_config(?global_ns, KeyPath, Default) ->
     emqx:get_config(KeyPath, Default).
 
 deobfuscate(Type, #{} = NewRawConf0, #{} = OldRawConf) ->
-    NewRawConf1 = emqx_utils:deobfuscate(NewRawConf0, OldRawConf),
+    NewRawConf1 = restore_own_namespace(
+        emqx_utils:deobfuscate(NewRawConf0, OldRawConf), OldRawConf
+    ),
     %% This is needed because MQTT connector has an array field which contains secrets
     %% within it, and `emqx_utils:deobfuscate` cannot handle general arrays, as there's no
     %% general way to map input configs (in which entries might have been added or removed
@@ -937,6 +947,21 @@ deobfuscate(Type, #{} = NewRawConf0, #{} = OldRawConf) ->
     end;
 deobfuscate(_Type, NewRawConf, _OldRawConf) ->
     NewRawConf.
+
+%% `format_resource/3' hides a connector's own `namespace' config field from API
+%% responses, so an update built from a `GET' body does not carry it.  Restore
+%% the stored value when the request omits it or sends it empty, so a read,
+%% modify and write back of an unrelated field keeps the namespace.
+restore_own_namespace(NewRawConf, OldRawConf) ->
+    case maps:get(<<"namespace">>, OldRawConf, <<>>) of
+        Stored when is_binary(Stored), Stored =/= <<>> ->
+            case maps:get(<<"namespace">>, NewRawConf, <<>>) of
+                <<>> -> NewRawConf#{<<"namespace">> => Stored};
+                _ -> NewRawConf
+            end;
+        _ ->
+            NewRawConf
+    end.
 
 deobfuscate_mqtt_connector(#{<<"static_clientids">> := _} = NewRawConf, OldRawConf) ->
     OldStaticClientidInfo = maps:get(<<"static_clientids">>, OldRawConf, []),

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -161,7 +161,8 @@ groups() ->
         t_actions_field,
         t_update_with_failed_validation,
         t_create_with_failed_root_validation,
-        t_create_or_update_with_unexpected_error_term
+        t_create_or_update_with_unexpected_error_term,
+        t_own_namespace_field_does_not_shadow_emqx_namespace
     ],
     ClusterOnlyTests = [
         t_inconsistent_state,
@@ -1890,4 +1891,63 @@ t_namespaced_load_on_restart(TCConfig) ->
     ConnResId = emqx_connector_resource:resource_id(NS1, ConnectorType, ConnectorName1),
     ?assertMatch({ok, _, _}, ?ON(N1, emqx_resource:get_instance(ConnResId))),
 
+    ok.
+
+-doc """
+The rocketmq connector schema defines its own top-level `namespace' config
+field, which used to collide with the EMQX namespace injected into API
+responses: both encoded to the JSON key "namespace" and clients kept the last
+one.  Checks that the response carries the key exactly once, holding the EMQX
+namespace, and that an update built from a `GET' body keeps the stored value.
+""".
+t_own_namespace_field_does_not_shadow_emqx_namespace(TCConfig) ->
+    Name = ?CONNECTOR_NAME,
+    OwnNamespace = <<"rmq-cn-fzh4bmq240a">>,
+    Config = #{
+        <<"type">> => <<"rocketmq">>,
+        <<"name">> => Name,
+        <<"enable">> => true,
+        <<"servers">> => <<"127.0.0.1:9876">>,
+        <<"namespace">> => OwnNamespace,
+        <<"access_key">> => <<"ak">>,
+        <<"secret_key">> => <<"sk">>
+    },
+    {ok, 201, _} = request(post, uri(["connectors"]), Config, TCConfig),
+    ConnectorId = emqx_connector_resource:connector_id(<<"rocketmq">>, Name),
+    {ok, 200, RawBody} = request(get, uri(["connectors", ConnectorId]), TCConfig),
+    %% The key must appear exactly once on the wire.  A duplicate is valid
+    %% Erlang but ambiguous JSON, and parsers keep the last occurrence.
+    ?assertEqual(
+        1,
+        length(binary:matches(RawBody, <<"\"namespace\":">>)),
+        #{raw_body => RawBody}
+    ),
+    %% and it must hold the EMQX namespace, which is `null' outside a
+    %% managed namespace.
+    ?assertMatch(#{<<"namespace">> := null}, emqx_utils_json:decode(RawBody)),
+    %% Read, change an unrelated field, write back: the connector's own
+    %% namespace must survive even though the body does not carry it.
+    Body0 = emqx_utils_json:decode(RawBody),
+    %% Drop the read-only metadata, as the dashboard does; note that
+    %% `namespace' is deliberately kept, carrying the `null' from the `GET'.
+    Body = maps:without(
+        [
+            <<"actions">>,
+            <<"sources">>,
+            <<"node">>,
+            <<"node_status">>,
+            <<"name">>,
+            <<"status">>,
+            <<"status_reason">>,
+            <<"type">>
+        ],
+        Body0
+    ),
+    {ok, 200, _} = request(
+        put, uri(["connectors", ConnectorId]), Body#{<<"pool_size">> => 16}, TCConfig
+    ),
+    ?assertMatch(
+        #{<<"namespace">> := OwnNamespace, <<"pool_size">> := 16},
+        emqx:get_raw_config([connectors, rocketmq, Name], #{})
+    ),
     ok.

--- a/changes/ee/fix-18767.en.md
+++ b/changes/ee/fix-18767.en.md
@@ -1,0 +1,11 @@
+Fixed the RocketMQ connector being reported as belonging to a namespace it does not belong to.
+
+The RocketMQ connector has its own `namespace` configuration field, holding the RocketMQ instance
+namespace. Connector API responses returned that value under the same JSON key used for the EMQX
+namespace, so the Dashboard treated the connector as owned by a namespace of that name. It showed
+"Only the administrator of namespace <name> can perform operations on the connector", and opening
+the connector failed with "Managed namespace not found".
+
+The `namespace` field in connector API responses now always holds the EMQX namespace. The RocketMQ
+instance namespace is no longer returned, and it is kept unchanged when a connector is updated
+without it.


### PR DESCRIPTION
Fixes:
Release version: 6.1.5, 6.2.4, 6.3.0, 7.0.0
Introduced in: 6.1.0

## Summary

A RocketMQ connector configured with a `namespace` (the Aliyun instance namespace, e.g.
`rmq-cn-fzh4bmq240a`) runs fine, but cannot be managed from the Dashboard. The Dashboard shows
"Only the administrator of namespace rmq-cn-fzh4bmq240a can perform operations on the connector",
and opening the connector returns `400 BAD_REQUEST: Managed namespace not found`.

### Cause

`emqx_connector_api:format_resource/3` merges the EMQX namespace into the raw config under the
atom key `namespace`, while the raw config uses binary keys. RocketMQ is the only connector type
with its own top-level `namespace` config field, so the response map holds both `namespace` and
`<<"namespace">>`. These are distinct Erlang terms, so nothing collapses them, but both encode to
the JSON key `"namespace"`. The response body carries the key twice:

```
"namespace":null, ... ,"namespace":"rmq-cn-fzh4bmq240a"
```

Every JSON parser keeps the last occurrence, so clients read the RocketMQ value. The Dashboard
concludes the connector belongs to a managed namespace and requests it with
`?ns=rmq-cn-fzh4bmq240a`, which does not exist.

Only the response is affected. The stored config is correct: the EMQX namespace is part of the
`emqx_config` mnesia key (`{Namespace, RootKey}`), never a field inside the value.

### Changes

`format_resource/3` removes the connector's own `namespace` field from the response, so the single
`"namespace"` key always holds the EMQX namespace.

Dropping the field alone would be unsafe. The Dashboard reads a connector, changes one field and
writes the whole body back, so an update would no longer carry the RocketMQ namespace and would
clear it. `restore_own_namespace/2`, called from the existing `deobfuscate/3` on the update path,
puts the stored value back when the request omits it or sends it empty. The value can still be
changed by sending a non-empty `namespace`.

I checked the alternative of keeping both and letting the EMQX namespace win the key. It is worse:
a read-modify-write then stores the EMQX namespace as the RocketMQ namespace, silently pointing the
connector at the wrong RocketMQ namespace.

### Scope

I expanded the schema registry on a running node and checked every registered type against all
metadata keys injected by the connector and action APIs (`namespace`, `node`, `status`,
`status_reason`, `node_status`, `actions`, `sources`, `error`, `rules`). Across 47 connector types
(including both `iotdb` union members), 44 action types and 4 source types, the RocketMQ connector's
`namespace` is the only collision. The `namespace` field in the S3Tables action sits under
`parameters`, so it is nested and unaffected.

`emqx_bridge_v2_api.erl:1624` injects metadata the same way and has the same latent problem, but no
action or source schema currently defines a colliding field, so it is left alone here.

### Follow-up

The injected `namespace` is not declared in the response schema, so it does not appear in the API
docs even though the Dashboard depends on it. The durable fix is to rename the injected key to
something that cannot collide (e.g. `managed_namespace`) at both injection sites and declare it in
the schema. That is a breaking response change needing a coordinated Dashboard update, so it is not
suitable for a patch release and is not attempted here.

### Tests

`t_own_namespace_field_does_not_shadow_emqx_namespace` asserts the response carries `"namespace"`
exactly once, that it holds the EMQX namespace, and that a read-modify-write of an unrelated field
keeps the stored RocketMQ namespace. Verified that it fails on the duplicate-key assertion without
the fix. The full `emqx_connector_api_SUITE` single group passes (31/31).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

Response shape change: the RocketMQ connector's `namespace` config field is no longer returned by
`GET /connectors`. It remains stored, keeps working, and is preserved across updates. Reverting this
would require the Dashboard change described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hgjpqnpr9PKXzAXkCVhZdQ
