### PR TITLE
Merge release-63 into dev-63 (reconcile 6.3.0-rc.4 divergence)

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -19,4 +19,4 @@
 %% NOTE: Also make sure to follow the instructions in end of
 %% `apps/emqx/src/bpapi/README.md'
 
--define(EMQX_RELEASE_EE, "6.3.0-rc.3").
+-define(EMQX_RELEASE_EE, "6.3.0-rc.4").

--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -740,7 +740,15 @@ format_resource(
     Node
 ) ->
     ResourceData = lookup_channels(Namespace, Type, ConnectorName, ResourceData0),
-    RawConf = fill_defaults(Type, RawConf0),
+    RawConf1 = fill_defaults(Type, RawConf0),
+    %% The rocketmq connector schema defines its own top-level `namespace'
+    %% config field.  It has binary keys, while the EMQX namespace is merged in
+    %% below under an atom key.  Both encode to the JSON key "namespace", so the
+    %% response would carry that key twice and clients keep the last one.  Drop
+    %% the config field here so the single "namespace" key always holds the EMQX
+    %% namespace.  `restore_own_namespace/2' puts the stored value back when an
+    %% update omits it.
+    RawConf = maps:remove(<<"namespace">>, RawConf1),
     redact(
         maps:merge(
             RawConf#{
@@ -923,7 +931,9 @@ get_config(?global_ns, KeyPath, Default) ->
     emqx:get_config(KeyPath, Default).
 
 deobfuscate(Type, #{} = NewRawConf0, #{} = OldRawConf) ->
-    NewRawConf1 = emqx_utils:deobfuscate(NewRawConf0, OldRawConf),
+    NewRawConf1 = restore_own_namespace(
+        emqx_utils:deobfuscate(NewRawConf0, OldRawConf), OldRawConf
+    ),
     %% This is needed because MQTT connector has an array field which contains secrets
     %% within it, and `emqx_utils:deobfuscate` cannot handle general arrays, as there's no
     %% general way to map input configs (in which entries might have been added or removed
@@ -937,6 +947,21 @@ deobfuscate(Type, #{} = NewRawConf0, #{} = OldRawConf) ->
     end;
 deobfuscate(_Type, NewRawConf, _OldRawConf) ->
     NewRawConf.
+
+%% `format_resource/3' hides a connector's own `namespace' config field from API
+%% responses, so an update built from a `GET' body does not carry it.  Restore
+%% the stored value when the request omits it or sends it empty, so a read,
+%% modify and write back of an unrelated field keeps the namespace.
+restore_own_namespace(NewRawConf, OldRawConf) ->
+    case maps:get(<<"namespace">>, OldRawConf, <<>>) of
+        Stored when is_binary(Stored), Stored =/= <<>> ->
+            case maps:get(<<"namespace">>, NewRawConf, <<>>) of
+                <<>> -> NewRawConf#{<<"namespace">> => Stored};
+                _ -> NewRawConf
+            end;
+        _ ->
+            NewRawConf
+    end.
 
 deobfuscate_mqtt_connector(#{<<"static_clientids">> := _} = NewRawConf, OldRawConf) ->
     OldStaticClientidInfo = maps:get(<<"static_clientids">>, OldRawConf, []),

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -161,7 +161,8 @@ groups() ->
         t_actions_field,
         t_update_with_failed_validation,
         t_create_with_failed_root_validation,
-        t_create_or_update_with_unexpected_error_term
+        t_create_or_update_with_unexpected_error_term,
+        t_own_namespace_field_does_not_shadow_emqx_namespace
     ],
     ClusterOnlyTests = [
         t_inconsistent_state,
@@ -1890,4 +1891,63 @@ t_namespaced_load_on_restart(TCConfig) ->
     ConnResId = emqx_connector_resource:resource_id(NS1, ConnectorType, ConnectorName1),
     ?assertMatch({ok, _, _}, ?ON(N1, emqx_resource:get_instance(ConnResId))),
 
+    ok.
+
+-doc """
+The rocketmq connector schema defines its own top-level `namespace' config
+field, which used to collide with the EMQX namespace injected into API
+responses: both encoded to the JSON key "namespace" and clients kept the last
+one.  Checks that the response carries the key exactly once, holding the EMQX
+namespace, and that an update built from a `GET' body keeps the stored value.
+""".
+t_own_namespace_field_does_not_shadow_emqx_namespace(TCConfig) ->
+    Name = ?CONNECTOR_NAME,
+    OwnNamespace = <<"rmq-cn-fzh4bmq240a">>,
+    Config = #{
+        <<"type">> => <<"rocketmq">>,
+        <<"name">> => Name,
+        <<"enable">> => true,
+        <<"servers">> => <<"127.0.0.1:9876">>,
+        <<"namespace">> => OwnNamespace,
+        <<"access_key">> => <<"ak">>,
+        <<"secret_key">> => <<"sk">>
+    },
+    {ok, 201, _} = request(post, uri(["connectors"]), Config, TCConfig),
+    ConnectorId = emqx_connector_resource:connector_id(<<"rocketmq">>, Name),
+    {ok, 200, RawBody} = request(get, uri(["connectors", ConnectorId]), TCConfig),
+    %% The key must appear exactly once on the wire.  A duplicate is valid
+    %% Erlang but ambiguous JSON, and parsers keep the last occurrence.
+    ?assertEqual(
+        1,
+        length(binary:matches(RawBody, <<"\"namespace\":">>)),
+        #{raw_body => RawBody}
+    ),
+    %% and it must hold the EMQX namespace, which is `null' outside a
+    %% managed namespace.
+    ?assertMatch(#{<<"namespace">> := null}, emqx_utils_json:decode(RawBody)),
+    %% Read, change an unrelated field, write back: the connector's own
+    %% namespace must survive even though the body does not carry it.
+    Body0 = emqx_utils_json:decode(RawBody),
+    %% Drop the read-only metadata, as the dashboard does; note that
+    %% `namespace' is deliberately kept, carrying the `null' from the `GET'.
+    Body = maps:without(
+        [
+            <<"actions">>,
+            <<"sources">>,
+            <<"node">>,
+            <<"node_status">>,
+            <<"name">>,
+            <<"status">>,
+            <<"status_reason">>,
+            <<"type">>
+        ],
+        Body0
+    ),
+    {ok, 200, _} = request(
+        put, uri(["connectors", ConnectorId]), Body#{<<"pool_size">> => 16}, TCConfig
+    ),
+    ?assertMatch(
+        #{<<"namespace">> := OwnNamespace, <<"pool_size">> := 16},
+        emqx:get_raw_config([connectors, rocketmq, Name], #{})
+    ),
     ok.

--- a/changes/6.3.0.en.md
+++ b/changes/6.3.0.en.md
@@ -408,6 +408,12 @@
 
 - [#18449](https://github.com/emqx/emqx/pull/18449) Fixed a rare race condition in which the PostgreSQL Action encountered a `sock_closed` error while writing data and incorrectly treated it as unrecoverable. EMQX treats the error as recoverable.
 
+- [#18767](https://github.com/emqx/emqx/pull/18767) Fixed the RocketMQ connector being reported as belonging to a namespace it does not belong to.
+
+  The RocketMQ connector has its own `namespace` configuration field, holding the RocketMQ instance namespace. Connector API responses returned that value under the same JSON key used for the EMQX namespace, so the Dashboard treated the connector as owned by a namespace of that name. It showed "Only the administrator of namespace <name> can perform operations on the connector", and opening the connector failed with "Managed namespace not found".
+
+  The `namespace` field in connector API responses now always holds the EMQX namespace. The RocketMQ instance namespace is no longer returned, and it is kept unchanged when a connector is updated without it.
+
 ### Rule Engine
 
 - [#18527](https://github.com/emqx/emqx/pull/18527) Fixed repeated `badarg` errors in the log when a message was published while the schema validation, message transformation, or rule engine topic index table was unavailable. Such a publish now proceeds as if no validation, transformation, or rule matched the topic, and the broker logs a throttled `topic_index_table_missing` message instead of one error per publish. The index tables now also survive a restart of their owner process, and the hooks are removed before the tables during application shutdown, which removes the known windows where a publish could find a table missing.

--- a/changes/ee/fix-18767.en.md
+++ b/changes/ee/fix-18767.en.md
@@ -1,0 +1,11 @@
+Fixed the RocketMQ connector being reported as belonging to a namespace it does not belong to.
+
+The RocketMQ connector has its own `namespace` configuration field, holding the RocketMQ instance
+namespace. Connector API responses returned that value under the same JSON key used for the EMQX
+namespace, so the Dashboard treated the connector as owned by a namespace of that name. It showed
+"Only the administrator of namespace <name> can perform operations on the connector", and opening
+the connector failed with "Managed namespace not found".
+
+The `namespace` field in connector API responses now always holds the EMQX namespace. The RocketMQ
+instance namespace is no longer returned, and it is kept unchanged when a connector is updated
+without it.

--- a/deploy/charts/emqx-enterprise/Chart.yaml
+++ b/deploy/charts/emqx-enterprise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 6.3.0-rc.3
+version: 6.3.0-rc.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 6.3.0-rc.3
+appVersion: 6.3.0-rc.4


### PR DESCRIPTION
Restores fast-forward compatibility between `dev-63` and `release-63`, and adds the corresponding release-note entry.

### Background

`release-63` is meant to be a fast-forward-only mirror of `dev-63`. It diverged when the `6.3.0-rc.4` hotfix was applied directly to `release-63`:

- `38742aae63` — cherry-pick of #18767 (`fix(connector api): stop rocketmq namespace shadowing the EMQX namespace`), picked ahead of the normal `dev-61` → `dev-62` → `dev-63` sync chain to make the RC.
- `9b06dc1ec0` — `chore: bump version to 6.3.0-rc.4`, created by `scripts/rel/cut.sh` when cutting the tag.

Both commits exist only on `release-63`, so the daily ff-sync bot cannot advance `release-63` from `dev-63`.

### What this does

- Merges `release-63` into `dev-63`, bringing both commits onto `dev-63` and making `release-63` an ancestor again, so the bot can fast-forward normally.
- Adds the #18767 entry to `changes/6.3.0.en.md` (Bug Fixes → Data Integration), which the cherry-pick did not update — it only carried the `changes/ee/fix-18767.en.md` fragment.

The merge is conflict-free. No reset or force-push of the protected `release-63` branch is involved.

### Note

#18767 is still open against `dev-61`. When it merges and travels the forward-sync chain, its content will reach `dev-63` again; the commit is already present here, so the later sync should resolve without reintroducing it.
