### PR TITLE
ci: speed up macos package builds

### DIFF
--- a/.github/actions/package-macos/action.yaml
+++ b/.github/actions/package-macos/action.yaml
@@ -19,6 +19,9 @@ inputs:
     required: false
   apple_developer_id_bundle_password:
     required: false
+  notarize:
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -34,6 +37,7 @@ runs:
         PROFILE: ${{ inputs.profile }}
         OTP_VERSION: ${{ inputs.otp }}
         APPLE_SIGN_BINARIES: 1
+        APPLE_NOTARIZE_PACKAGE: ${{ inputs.notarize }}
         APPLE_ID: developers@emqx.io
         APPLE_TEAM_ID: 26N6HYJLZA
         APPLE_ID_PASSWORD: ${{ inputs.apple_id_password }}
@@ -45,7 +49,21 @@ runs:
         erl -s init stop
         elixir -e "System.version() |> IO.puts()"
         # needed by greptimedb-ingester-erlnif
-        brew install protobuf
+        if ! command -v protoc >/dev/null 2>&1; then
+          brew install protobuf
+        fi
+        if ! command -v gsha256sum >/dev/null 2>&1; then
+          brew install coreutils
+        fi
+        for coreutils_bin in \
+          /opt/homebrew/opt/coreutils/libexec/gnubin \
+          /usr/local/opt/coreutils/libexec/gnubin
+        do
+          if [ -d "$coreutils_bin" ]; then
+            export PATH="$coreutils_bin:$PATH"
+          fi
+        done
+        sha256sum --version | head -1 || true
         make ensure-rebar3
         mkdir -p $HOME/bin
         cp rebar3 $HOME/bin/rebar3
@@ -69,6 +87,7 @@ runs:
         ./emqx/bin/emqx ping
         ./emqx/bin/emqx help
         ./emqx/bin/emqx ctl status
+        ./emqx/bin/emqx eval 'emqx_conf:check_dynamic_desc()'
         ./emqx/bin/emqx stop
     - name: show logs
       shell: bash

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -58,6 +58,7 @@ jobs:
       profile: ${{ steps.parse-git-ref.outputs.profile }}
       release: ${{ steps.parse-git-ref.outputs.release }}
       latest: ${{ steps.parse-git-ref.outputs.latest }}
+      official_release: ${{ steps.parse-git-ref.outputs.official_release }}
       ct-matrix: ${{ steps.matrix.outputs.ct-matrix }}
       ct-host: ${{ steps.matrix.outputs.ct-host }}
       ct-docker: ${{ steps.matrix.outputs.ct-docker }}
@@ -78,9 +79,11 @@ jobs:
           PROFILE=$(echo "$JSON" | jq -cr '.profile')
           RELEASE=$(echo "$JSON" | jq -cr '.release')
           LATEST=$(echo "$JSON"  | jq -cr '.latest')
+          OFFICIAL_RELEASE=$(echo "$JSON"  | jq -cr '.official_release')
           echo "profile=$PROFILE" | tee -a $GITHUB_OUTPUT
           echo "release=$RELEASE" | tee -a $GITHUB_OUTPUT
           echo "latest=$LATEST"   | tee -a $GITHUB_OUTPUT
+          echo "official_release=$OFFICIAL_RELEASE" | tee -a $GITHUB_OUTPUT
       - name: Build matrix
         id: matrix
         run: |
@@ -102,6 +105,7 @@ jobs:
     with:
       profile: ${{ needs.prepare.outputs.profile }}
       publish: true
+      notarize: ${{ needs.prepare.outputs.official_release == 'true' }}
       otp_vsn: ${{ needs.init.outputs.OTP_VSN }}
       elixir_vsn: ${{ needs.init.outputs.ELIXIR_VSN }}
       builder_vsn: ${{ needs.init.outputs.BUILDER_VSN }}

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -13,6 +13,10 @@ on:
       publish:
         required: true
         type: boolean
+      notarize:
+        required: false
+        type: boolean
+        default: false
       otp_vsn:
         required: true
         type: string
@@ -53,6 +57,10 @@ on:
         required: true
         default: 'emqx-enterprise'
       publish:
+        required: false
+        type: boolean
+        default: false
+      notarize:
         required: false
         type: boolean
         default: false
@@ -145,21 +153,29 @@ jobs:
         otp: ${{ matrix.otp }}
         elixir: ${{ matrix.elixir }}
         os: ${{ matrix.os }}
+        notarize: false
         apple_id_password: ${{ secrets.APPLE_ID_PASSWORD }}
         apple_developer_identity: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
         apple_developer_id_bundle: ${{ (matrix.os == 'macos-14') && secrets.APPLE_DEVELOPER_ID_BUNDLE || secrets.APPLE_DEVELOPER_ID_BUNDLE_NEW }}
         apple_developer_id_bundle_password: ${{ (matrix.os == 'macos-14') && secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD || secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD_NEW }}
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      if: success()
+      if: success() && inputs.publish
+      with:
+        name: build-${{ matrix.profile }}-${{ matrix.os }}-${{ matrix.otp }}
+        path: _packages/${{ matrix.profile }}/
+        retention-days: 7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      if: success() && !inputs.publish
       with:
         name: ${{ matrix.profile }}-${{ matrix.os }}-${{ matrix.otp }}
         path: _packages/${{ matrix.profile }}/
         retention-days: 7
 
-  test-mac:
+  finalize-mac:
     needs:
       - mac
       - prepare-matrix
+    if: inputs.publish
     strategy:
       fail-fast: false
       matrix:
@@ -176,19 +192,31 @@ jobs:
         ref: ${{ github.event.inputs.ref }}
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: ${{ matrix.profile }}-${{ matrix.os }}-${{ matrix.otp }}
-    - name: Test macOS package
+        name: build-${{ matrix.profile }}-${{ matrix.os }}-${{ matrix.otp }}
+    - name: Finalize macOS package
+      shell: bash
+      env:
+        APPLE_SIGN_BINARIES: 1
+        APPLE_NOTARIZE_PACKAGE: ${{ inputs.notarize }}
+        APPLE_ID: developers@emqx.io
+        APPLE_TEAM_ID: 26N6HYJLZA
+        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
       run: |
+        set -euo pipefail
         pkg_name=$(find . -mindepth 1 -maxdepth 1 -iname \*.zip)
-        mkdir emqx
-        unzip -d emqx $pkg_name > /dev/null
-        ./emqx/bin/emqx start || cat emqx/log/erlang.log.1
-        ./scripts/test/emqx-smoke-test.sh 127.0.0.1 18083
-        ./emqx/bin/emqx ping
-        ./emqx/bin/emqx help
-        ./emqx/bin/emqx ctl status
-        ./emqx/bin/emqx eval 'emqx_conf:check_dynamic_desc()'
-        ./emqx/bin/emqx stop || cat emqx/log/erlang.log.1
+        if [ "${APPLE_NOTARIZE_PACKAGE}" = "true" ]; then
+          ./scripts/rel/macos-notarize-package.sh "$pkg_name"
+        else
+          echo "Skipping macOS package notarization for this ref"
+        fi
+        openssl dgst -sha256 "$pkg_name" | cut -d ' ' -f 2 > "$pkg_name.sha256"
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ matrix.profile }}-${{ matrix.os }}-${{ matrix.otp }}
+        path: |
+          *.zip
+          *.zip.sha256
+        retention-days: 7
 
   linux:
     needs: prepare-matrix
@@ -338,8 +366,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - plugins-linux-debian13-amd64
-      - mac
-      - test-mac
+      - finalize-mac
       - linux
       - snap
     if: inputs.publish

--- a/scripts/parse-git-ref.sh
+++ b/scripts/parse-git-ref.sh
@@ -32,6 +32,7 @@ is_latest_stable() {
 }
 
 PROFILE=emqx-enterprise
+OFFICIAL_RELEASE=false
 
 if [[ $1 =~ ^refs/tags/[6-9]\.[0-9]+\.[0-9]+-M[0-9]+\.[0-9]+$ ]]; then
     RELEASE=true
@@ -44,9 +45,11 @@ elif [[ $1 =~ ^refs/tags/[6-9]\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
     LATEST=false
 elif [[ $1 =~ ^refs/tags/[6-9]\.[0-9]+\.[0-9]+$ ]]; then
     RELEASE=true
+    OFFICIAL_RELEASE=true
     LATEST=$(is_latest_stable "$1")
 elif [[ $1 =~ ^refs/tags/[6-9]\.[0-9]+\.[0-9]+-patch\.[0-9]+$ ]]; then
     RELEASE=true
+    OFFICIAL_RELEASE=true
     LATEST=false
 elif [[ $1 =~ ^refs/tags/.+ ]]; then
     echo "Unrecognized tag: $1" 1>&2
@@ -66,5 +69,5 @@ else
 fi
 
 cat <<EOF
-{"profile": "$PROFILE", "release": $RELEASE, "latest": $LATEST}
+{"profile": "$PROFILE", "release": $RELEASE, "latest": $LATEST, "official_release": $OFFICIAL_RELEASE}
 EOF

--- a/scripts/rel/macos-notarize-package.sh
+++ b/scripts/rel/macos-notarize-package.sh
@@ -13,6 +13,13 @@ if [ "${APPLE_SIGN_BINARIES:-0}" == 0 ]; then
     exit 0
 fi
 
+case "${APPLE_NOTARIZE_PACKAGE:-1}" in
+    0|false|False|FALSE|no|No|NO)
+        echo "Apple package notarization is disabled, exiting"
+        exit 0
+        ;;
+esac
+
 if [[ "${APPLE_ID:-0}" == 0 || "${APPLE_ID_PASSWORD:-0}" == 0 || "${APPLE_TEAM_ID:-0}" == 0 ]]; then
     echo "Apple ID is not configured, skipping notarization."
     exit 0
@@ -25,7 +32,7 @@ fi
 
 ZIP_PACKAGE_PATH="${1}"
 
-echo 'Submitting the package for notarization to Apple (normally takes 1-2 minutes)'
+echo 'Submitting the package for notarization to Apple'
 notarytool_output="$(xcrun notarytool submit \
                                            --apple-id "${APPLE_ID}" \
                                            --password "${APPLE_ID_PASSWORD}" \
@@ -43,4 +50,3 @@ echo "$notarytool_output" | grep -q 'status: Accepted' || {
         --team-id "${APPLE_TEAM_ID}" "$submission_id"
     exit 1;
 }
-

--- a/scripts/shelltest/parse-git-ref.test
+++ b/scripts/shelltest/parse-git-ref.test
@@ -55,37 +55,62 @@ Unrecognized tag: refs/tags/e5.3.0-rc.1
 
 ./parse-git-ref.sh refs/tags/6.0.0-M1.202507
 >>>
-{"profile": "emqx-enterprise", "release": true, "latest": false}
+{"profile": "emqx-enterprise", "release": true, "latest": false, "official_release": false}
 >>>= 0
 
 ./parse-git-ref.sh refs/tags/6.0.0-M1.202507-alpha.1
 >>>
-{"profile": "emqx-enterprise", "release": true, "latest": false}
+{"profile": "emqx-enterprise", "release": true, "latest": false, "official_release": false}
 >>>= 0
 
 ./parse-git-ref.sh refs/tags/6.0.0-M1.202507-beta.1
 >>>
-{"profile": "emqx-enterprise", "release": true, "latest": false}
+{"profile": "emqx-enterprise", "release": true, "latest": false, "official_release": false}
 >>>= 0
 
 ./parse-git-ref.sh refs/tags/6.0.0-M1.202507-rc.1
 >>>
-{"profile": "emqx-enterprise", "release": true, "latest": false}
+{"profile": "emqx-enterprise", "release": true, "latest": false, "official_release": false}
 >>>= 0
 
 ./parse-git-ref.sh refs/tags/6.1.0-M2.202508
 >>>
-{"profile": "emqx-enterprise", "release": true, "latest": false}
+{"profile": "emqx-enterprise", "release": true, "latest": false, "official_release": false}
 >>>= 0
 
 ./parse-git-ref.sh refs/tags/6.1.0-M2.202508-alpha.2
 >>>
-{"profile": "emqx-enterprise", "release": true, "latest": false}
+{"profile": "emqx-enterprise", "release": true, "latest": false, "official_release": false}
+>>>= 0
+
+./parse-git-ref.sh refs/tags/6.3.0-patch.1
+>>>
+{"profile": "emqx-enterprise", "release": true, "latest": false, "official_release": true}
+>>>= 0
+
+./parse-git-ref.sh refs/tags/6.3.0 | jq -cr '.official_release'
+>>>
+true
+>>>= 0
+
+./parse-git-ref.sh refs/tags/6.3.0-alpha.1 | jq -cr '.official_release'
+>>>
+false
+>>>= 0
+
+./parse-git-ref.sh refs/tags/6.3.0-beta.1 | jq -cr '.official_release'
+>>>
+false
+>>>= 0
+
+./parse-git-ref.sh refs/tags/6.3.0-rc.1 | jq -cr '.official_release'
+>>>
+false
 >>>= 0
 
 ./parse-git-ref.sh refs/heads/master
 >>>
-{"profile": "emqx-enterprise", "release": false, "latest": false}
+{"profile": "emqx-enterprise", "release": false, "latest": false, "official_release": false}
 >>>= 0
 
 ./parse-git-ref.sh refs/heads/release-51
@@ -105,7 +130,7 @@ Unrecognized git ref: refs/heads/release-53
 
 ./parse-git-ref.sh refs/heads/ci/foobar
 >>>
-{"profile": "emqx-enterprise", "release": false, "latest": false}
+{"profile": "emqx-enterprise", "release": false, "latest": false, "official_release": false}
 >>>= 0
 
 ./parse-git-ref.sh refs/heads/release-44


### PR DESCRIPTION
## Summary

- split macOS package building from publish-time finalization so build jobs do not wait on Apple notarization
- notarize only official release tags such as `6.3.0` and `6.3.0-patch.1`; skip alpha, beta, rc, and milestone tags
- keep macOS smoke coverage in the package action and add GNU coreutils PATH setup for `jq` checksum validation

## Testing

- `make fmt-diff`
- `scripts/shelltest/run_tests.sh`
- `bash -n scripts/parse-git-ref.sh scripts/rel/macos-notarize-package.sh scripts/rel/macos-sign-binaries.sh`
- PyYAML parse for changed workflow/action YAML
- Dockerized `actionlint -shellcheck=` for `_push-entrypoint.yaml` and `build_packages.yaml`
- `git diff --check`