### PR TITLE
fix(mt): deny connections to tombstoned namespaces

### DIFF
--- a/apps/emqx_mt/src/emqx_mt_hookcb.erl
+++ b/apps/emqx_mt/src/emqx_mt_hookcb.erl
@@ -68,11 +68,17 @@ register_in_namespace(_ClientInfo) ->
 on_authenticate(
     #{clientid := ClientId, client_attrs := #{?CLIENT_ATTR_NAME_TNS := Tns}}, DefaultResult
 ) ->
-    case emqx_config:get_namespace_config_errors(Tns) of
-        undefined ->
-            do_on_authenticate(ClientId, Tns, DefaultResult);
-        #{} ->
-            {stop, {error, server_unavailable}}
+    case emqx_mt_state:is_tombstoned(Tns) of
+        true ->
+            ?TRACE("deny_due_to_namespace_being_deleted", #{}),
+            {stop, {error, server_unavailable}};
+        false ->
+            case emqx_config:get_namespace_config_errors(Tns) of
+                undefined ->
+                    do_on_authenticate(ClientId, Tns, DefaultResult);
+                #{} ->
+                    {stop, {error, server_unavailable}}
+            end
     end;
 on_authenticate(_, DefaultResult) ->
     AllowOnlyManagedNSs = emqx_mt_config:get_allow_only_managed_namespaces(),

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -720,6 +720,24 @@ t_allow_only_managed_namespaces(_Config) ->
     ?assertMatch({error, {not_authorized, _}}, emqtt:connect(Pid)),
     ok.
 
+t_deny_tombstoned_namespace(_Config) ->
+    Ns = <<"ns-being-deleted">>,
+    {204, _} = create_managed_ns(Ns),
+    Janitor = whereis(emqx_mt_config_janitor),
+    ok = sys:suspend(Janitor),
+    on_exit(fun() -> catch sys:resume(Janitor) end),
+
+    {204, _} = delete_ns(Ns),
+    ?assert(emqx_mt_state:is_tombstoned(Ns)),
+    ?assertError(
+        {error, {server_unavailable, _}},
+        connect(?NEW_CLIENTID(1), Ns)
+    ),
+    ?assertMatch({200, []}, list_nss(#{})),
+
+    ok = sys:resume(Janitor),
+    ok.
+
 %% Verifies bulk import config endpoint
 t_bulk_import_configs(_Config) ->
     %% Seed config with some preexisting configs and namespaces

--- a/changes/ee/fix-18774.en.md
+++ b/changes/ee/fix-18774.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where clients could connect to a deleted multi-tenancy namespace while its resources were still being cleaned up.


### PR DESCRIPTION
Fixes: https://github.com/emqx/emqx-dev-team-tasks/issues/65
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: 6.0.0

## Summary

Reject MQTT connections to tombstoned namespaces while namespace cleanup is in progress with `server_unavailable` error.

The fix is not ideal because races may still occur. A tombstone may be written after the check but before the namespace is automatically recreated. Addressing these races would require significant changes to the model. At a minimum, connection admission and session registration would need to be synchronous and transactional, which is unacceptable for the connection path.

A more robust fix would use a standard indirection pattern. We should not use `tns()` directly as an external key. Instead, a single index table should map each `tns()` to a surrogate ID, and all other tables should use that ID. Deletion would then remove the index entry. If the same namespace name were recreated, it would receive a new ID and represent a distinct namespace. However, this would require substantial refactoring and schema changes.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
