### PR TITLE
fix(rocketmq): rename namespace config field to rocketmq_namespace

### DIFF
--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq.erl
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq.erl
@@ -154,7 +154,7 @@ fields(action_parameters) ->
         [
             servers,
             ssl,
-            namespace,
+            rocketmq_namespace,
             pool_size,
             auto_reconnect,
             access_key,

--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
@@ -46,10 +46,14 @@ roots() ->
 fields(config) ->
     [
         {servers, servers()},
-        {namespace,
+        {rocketmq_namespace,
             mk(
                 binary(),
-                #{required => false, desc => ?DESC(namespace)}
+                #{
+                    required => false,
+                    aliases => [namespace],
+                    desc => ?DESC(rocketmq_namespace)
+                }
             )},
         {topic,
             mk(
@@ -116,7 +120,7 @@ on_start(
     ),
     ClientId = client_id(InstanceId),
     ACLInfo = acl_info(AccessKey, SecretKey, SecurityToken),
-    Namespace = maps:get(namespace, Config, <<>>),
+    Namespace = maps:get(rocketmq_namespace, Config, <<>>),
     ClientCfg0 = #{acl_info => ACLInfo, namespace => Namespace},
     SSLOpts = emqx_tls_lib:to_client_opts(SSLOptsMap),
     ClientCfg = emqx_utils_maps:put_if(ClientCfg0, ssl_opts, SSLOpts, SSLOpts =/= []),

--- a/apps/emqx_bridge_rocketmq/test/emqx_bridge_rocketmq_SUITE.erl
+++ b/apps/emqx_bridge_rocketmq/test/emqx_bridge_rocketmq_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("emqx_resource/include/emqx_resource.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 %%------------------------------------------------------------------------------
 %% Defs
@@ -553,3 +554,40 @@ producer_request_count(ProducerPid) ->
     {_StateName, ProducerState} = sys:get_state(ProducerPid),
     Requests = element(14, ProducerState),
     map_size(Requests).
+
+-doc """
+`namespace' was renamed to `rocketmq_namespace'.  The old name collided with the
+EMQX namespace reported by the connector API: both encoded to the JSON key
+"namespace", the response carried it twice, and clients keep the last
+occurrence.  `namespace' is kept as an alias.
+
+Checks that a config using the old name is still accepted and is normalised to
+the new one, and that the response reports the two namespaces separately.
+""".
+t_rocketmq_namespace_alias(TCConfig) ->
+    ConnectorName = get_config(connector_name, TCConfig),
+    OwnNamespace = <<"rmq-cn-fzh4bmq240a">>,
+    %% Created with the legacy key.
+    {201, _} = create_connector_api(TCConfig, #{<<"namespace">> => OwnNamespace}),
+    %% Stored under the canonical name, with the alias dropped.
+    RawConf = emqx:get_raw_config([connectors, ?CONNECTOR_TYPE, ConnectorName], #{}),
+    ?assertMatch(#{<<"rocketmq_namespace">> := OwnNamespace}, RawConf),
+    ?assertNot(maps:is_key(<<"namespace">>, RawConf)),
+    %% The response keeps the two namespaces apart: `namespace' is the EMQX
+    %% namespace, `null' outside a managed namespace.
+    {200, Got} = emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:get_connector_api(?CONNECTOR_TYPE, ConnectorName)
+    ),
+    ?assertMatch(
+        #{<<"namespace">> := null, <<"rocketmq_namespace">> := OwnNamespace},
+        Got
+    ),
+    %% The value still reaches the connector runtime state.
+    ConnResId = emqx_connector_resource:resource_id(
+        ?global_ns, ?CONNECTOR_TYPE, ConnectorName
+    ),
+    ?assertMatch(
+        {ok, _, #{state := #{namespace := OwnNamespace}}},
+        emqx_resource:get_instance(ConnResId)
+    ),
+    ok.

--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -742,15 +742,7 @@ format_resource(
     Node
 ) ->
     ResourceData = lookup_channels(Namespace, Type, ConnectorName, ResourceData0),
-    RawConf1 = fill_defaults(Type, RawConf0),
-    %% The rocketmq connector schema defines its own top-level `namespace'
-    %% config field.  It has binary keys, while the EMQX namespace is merged in
-    %% below under an atom key.  Both encode to the JSON key "namespace", so the
-    %% response would carry that key twice and clients keep the last one.  Drop
-    %% the config field here so the single "namespace" key always holds the EMQX
-    %% namespace.  `restore_own_namespace/2' puts the stored value back when an
-    %% update omits it.
-    RawConf = maps:remove(<<"namespace">>, RawConf1),
+    RawConf = fill_defaults(Type, RawConf0),
     redact(
         maps:merge(
             RawConf#{
@@ -931,9 +923,7 @@ get_config(?global_ns, KeyPath, Default) ->
     emqx:get_config(KeyPath, Default).
 
 deobfuscate(Type, #{} = NewRawConf0, #{} = OldRawConf) ->
-    NewRawConf1 = restore_own_namespace(
-        emqx_utils:deobfuscate(NewRawConf0, OldRawConf), OldRawConf
-    ),
+    NewRawConf1 = emqx_utils:deobfuscate(NewRawConf0, OldRawConf),
     %% This is needed because MQTT connector has an array field which contains secrets
     %% within it, and `emqx_utils:deobfuscate` cannot handle general arrays, as there's no
     %% general way to map input configs (in which entries might have been added or removed
@@ -947,21 +937,6 @@ deobfuscate(Type, #{} = NewRawConf0, #{} = OldRawConf) ->
     end;
 deobfuscate(_Type, NewRawConf, _OldRawConf) ->
     NewRawConf.
-
-%% `format_resource/3' hides a connector's own `namespace' config field from API
-%% responses, so an update built from a `GET' body does not carry it.  Restore
-%% the stored value when the request omits it or sends it empty, so a read,
-%% modify and write back of an unrelated field keeps the namespace.
-restore_own_namespace(NewRawConf, OldRawConf) ->
-    case maps:get(<<"namespace">>, OldRawConf, <<>>) of
-        Stored when is_binary(Stored), Stored =/= <<>> ->
-            case maps:get(<<"namespace">>, NewRawConf, <<>>) of
-                <<>> -> NewRawConf#{<<"namespace">> => Stored};
-                _ -> NewRawConf
-            end;
-        _ ->
-            NewRawConf
-    end.
 
 deobfuscate_mqtt_connector(#{<<"static_clientids">> := _} = NewRawConf, OldRawConf) ->
     OldStaticClientidInfo = maps:get(<<"static_clientids">>, OldRawConf, []),

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -161,8 +161,7 @@ groups() ->
         t_actions_field,
         t_update_with_failed_validation,
         t_create_with_failed_root_validation,
-        t_create_or_update_with_unexpected_error_term,
-        t_own_namespace_field_does_not_shadow_emqx_namespace
+        t_create_or_update_with_unexpected_error_term
     ],
     ClusterOnlyTests = [
         t_inconsistent_state,
@@ -1891,63 +1890,4 @@ t_namespaced_load_on_restart(TCConfig) ->
     ConnResId = emqx_connector_resource:resource_id(NS1, ConnectorType, ConnectorName1),
     ?assertMatch({ok, _, _}, ?ON(N1, emqx_resource:get_instance(ConnResId))),
 
-    ok.
-
--doc """
-The rocketmq connector schema defines its own top-level `namespace' config
-field, which used to collide with the EMQX namespace injected into API
-responses: both encoded to the JSON key "namespace" and clients kept the last
-one.  Checks that the response carries the key exactly once, holding the EMQX
-namespace, and that an update built from a `GET' body keeps the stored value.
-""".
-t_own_namespace_field_does_not_shadow_emqx_namespace(TCConfig) ->
-    Name = ?CONNECTOR_NAME,
-    OwnNamespace = <<"rmq-cn-fzh4bmq240a">>,
-    Config = #{
-        <<"type">> => <<"rocketmq">>,
-        <<"name">> => Name,
-        <<"enable">> => true,
-        <<"servers">> => <<"127.0.0.1:9876">>,
-        <<"namespace">> => OwnNamespace,
-        <<"access_key">> => <<"ak">>,
-        <<"secret_key">> => <<"sk">>
-    },
-    {ok, 201, _} = request(post, uri(["connectors"]), Config, TCConfig),
-    ConnectorId = emqx_connector_resource:connector_id(<<"rocketmq">>, Name),
-    {ok, 200, RawBody} = request(get, uri(["connectors", ConnectorId]), TCConfig),
-    %% The key must appear exactly once on the wire.  A duplicate is valid
-    %% Erlang but ambiguous JSON, and parsers keep the last occurrence.
-    ?assertEqual(
-        1,
-        length(binary:matches(RawBody, <<"\"namespace\":">>)),
-        #{raw_body => RawBody}
-    ),
-    %% and it must hold the EMQX namespace, which is `null' outside a
-    %% managed namespace.
-    ?assertMatch(#{<<"namespace">> := null}, emqx_utils_json:decode(RawBody)),
-    %% Read, change an unrelated field, write back: the connector's own
-    %% namespace must survive even though the body does not carry it.
-    Body0 = emqx_utils_json:decode(RawBody),
-    %% Drop the read-only metadata, as the dashboard does; note that
-    %% `namespace' is deliberately kept, carrying the `null' from the `GET'.
-    Body = maps:without(
-        [
-            <<"actions">>,
-            <<"sources">>,
-            <<"node">>,
-            <<"node_status">>,
-            <<"name">>,
-            <<"status">>,
-            <<"status_reason">>,
-            <<"type">>
-        ],
-        Body0
-    ),
-    {ok, 200, _} = request(
-        put, uri(["connectors", ConnectorId]), Body#{<<"pool_size">> => 16}, TCConfig
-    ),
-    ?assertMatch(
-        #{<<"namespace">> := OwnNamespace, <<"pool_size">> := 16},
-        emqx:get_raw_config([connectors, rocketmq, Name], #{})
-    ),
     ok.

--- a/changes/ee/fix-18767.en.md
+++ b/changes/ee/fix-18767.en.md
@@ -6,6 +6,4 @@ namespace, so the Dashboard treated the connector as owned by a namespace of tha
 "Only the administrator of namespace <name> can perform operations on the connector", and opening
 the connector failed with "Managed namespace not found".
 
-The `namespace` field in connector API responses now always holds the EMQX namespace. The RocketMQ
-instance namespace is no longer returned, and it is kept unchanged when a connector is updated
-without it.
+The `namespace` field in connector API responses now always holds the EMQX namespace.

--- a/changes/ee/fix-18775.en.md
+++ b/changes/ee/fix-18775.en.md
@@ -1,0 +1,8 @@
+Renamed the RocketMQ connector's `namespace` configuration field to `rocketmq_namespace`.
+
+The old name is still accepted, so existing configurations, API calls and imported backups keep
+working without change. The field was renamed because its name collided with the EMQX namespace
+reported by the connector API, which made the Dashboard treat the connector as owned by a namespace
+named after the RocketMQ instance.
+
+The value is shown as `rocketmq_namespace` in API responses and in the Dashboard.

--- a/rel/i18n/emqx_bridge_rocketmq_connector.hocon
+++ b/rel/i18n/emqx_bridge_rocketmq_connector.hocon
@@ -51,8 +51,8 @@ topic.desc:
 topic.label:
 """RocketMQ Topic"""
 
-namespace.label: """Namespace / Instance ID"""
-namespace.desc:
+rocketmq_namespace.label: """Namespace / Instance ID"""
+rocketmq_namespace.desc:
 """The namespace field MUST be set if you are using the RocketMQ service in
 aliyun cloud and also the namespace is enabled,
 or if you have configured a namespace in your RocketMQ server.


### PR DESCRIPTION
Fixes:
Release version: 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: 6.1.0

Stacked on #18767 — that PR merges first, and this one reverts its API-layer workaround in favour
of fixing the collision at its source. Until #18767 merges, this PR shows both commits.

## Summary

The RocketMQ connector's own `namespace` config field collides with the EMQX namespace reported by
the connector API. Both encode to the JSON key `"namespace"`, so the response carries the key twice
and clients keep the last occurrence — the RocketMQ value. The Dashboard then treats the connector
as owned by a managed namespace and requests it with `?ns=<rocketmq namespace>`, which 400s with
"Managed namespace not found".

#18767 fixed the symptom by hiding the connector's own field from API responses. That left the
value invisible in the Dashboard form and impossible to clear, and needed `restore_own_namespace/2`
so that an update built from a `GET` body would not drop it.

This renames the config field to `rocketmq_namespace` and keeps `namespace` as an alias, per
@thalesmg's review suggestion. HOCON writes the value under the canonical name and drops the alias
(`hocon_tconf:map_fields_cont/4`), so the two namespaces stop sharing a name. The value stays
visible, editable and clearable, and the workaround from #18767 is reverted.

Also moves the regression test into the rocketmq suite, per the review comment on #18767.

## Compatibility

The alias covers existing configs, API clients and backups. Verified on a running node:

- **In-place upgrade** — created the connector on a build of #18767 so the old binary wrote
  `namespace = "..."`, then restarted on the renamed build against the same data dir. Config
  normalised to `rocketmq_namespace`, value preserved, connector `connected`, and the value reaches
  the connector runtime state.
- **Old config import** — `emqx ctl conf load --merge` with a legacy-key file, and importing a
  `data/export` archive taken from the old binary. Both normalise.
- **Legacy key over the API** — `POST` with `namespace` is still accepted and stored under the new
  name.
- **Both keys present** — the canonical name wins and the alias is dropped.
- **Action schema** — unchanged; no stray field in any of the five `rocketmq.*` action schemas.

Booting a renamed node does not rewrite `cluster.hocon` (byte-identical), so an upgrade alone does
not change persisted config. A config write does rewrite it, and an older node cannot then load it
(`unknown_fields`). Config changes during a rolling upgrade are not supported, so this is out of
scope.

## Follow-ups needed outside this repo

- **emqx-dashboard**: the connector form takes labels from a hardcoded per-type map keyed by field
  name (`BridgeSchema.rocketmq.*`). Without an entry for `rocketmq_namespace` the field renders as
  the raw key path. The entry is additive and works against both old and new EMQX, so it can land
  independently.
- **emqx-i18n**: rename `emqx_bridge_rocketmq_connector.namespace.{desc,label}` to
  `rocketmq_namespace.*`, or the Chinese description disappears — which affects Aliyun RocketMQ
  users specifically.

## Tests

- `emqx_bridge_rocketmq_SUITE:t_rocketmq_namespace_alias` — new; asserts a config using the old name
  is accepted and normalised, that the response reports the two namespaces separately, and that the
  value reaches the runtime state.
- Full `apps/emqx_bridge_rocketmq` CT against real brokers: 17/17.
- `emqx_connector_api_SUITE`: 30/30.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

Schema change: the config field is renamed, with the old name kept as an alias, so existing configs
and API calls keep working. `changes/ee/fix-18767.en.md` is edited to drop a sentence describing the
behaviour this PR replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hgjpqnpr9PKXzAXkCVhZdQ
