### PR TITLE
test(shared_sub): widen the hello2 wait in t_session_takeover

### DIFF
--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -1028,7 +1028,9 @@ t_session_takeover(Config) when is_list(Config) ->
     {ok, _} = emqtt:connect(ConnPid2),
     ?assertMatch([_], emqx:publish(Message3)),
     ?assertMatch([_], emqx:publish(Message4)),
-    {true, _} = last_message(<<"hello2">>, [ConnPid2]),
+    %% Messages published around the takeover are delivered by session
+    %% redelivery, which can take longer than the default 1s under CI load.
+    {true, _} = last_message(<<"hello2">>, [ConnPid2], 5_000),
     %% We may or may not recv dup hello2 due to QoS1 redelivery
     _ = last_message(<<"hello2">>, [ConnPid2]),
     {true, _} = last_message(<<"hello3">>, [ConnPid2], 5_000),


### PR DESCRIPTION
## Summary

`emqx_shared_sub_SUITE:t_session_takeover` failed on #18678 (unrelated PR — an a2a
registry/audit change):

```
{{badmatch,<<"not yet?">>}, [{emqx_shared_sub_SUITE,t_session_takeover,1, ... {line,1020}]}
```

https://github.com/emqx/emqx/actions/runs/33802842205/job/100810014870

`<<"not yet?">>` is the timeout return of `last_message/3`, whose 2-arity form defaults to
1000 ms. `hello2` is published after the first client is stopped, so it lands in that client's
session and only reaches the second client through post-takeover redelivery — the same path as
`hello3`/`hello4`, which already use a 5 s wait.

This is a straight backport of #18651 (merged, `dev-58`), which fixed the identical gap on the
v5 line. `dev-60` through `dev-70` all carry the same unfixed shape (checked
`apps/emqx/test/emqx_shared_sub_SUITE.erl` on each). After this change the case body is
byte-identical to `dev-58`'s.

## Validation

`make test-compile` passes. Could not run the suite locally this time — port 1883 is held by
another CT run active in this environment — so this rides on the PR's own CI, same as the
original dev-58 fix did when the local suite auto-skipped there.