### PR TITLE
fix(mq): do not auto create queues and streams by default

### DIFF
--- a/apps/emqx_mq/README.md
+++ b/apps/emqx_mq/README.md
@@ -104,7 +104,7 @@ The threshold and some other settings are configured via the `quota` section of 
 
 ## Queue auto creation
 
-Message Queues are automatically created when subscribing to a queue topic `$q/some/topic`. The auto creation is configured via the `auto_create` section of the global Message Queue configuration. By default, the queues are auto created as last-value queues.
+Message Queues can be automatically created when subscribing to a queue topic `$q/some/topic`. The auto creation is configured via the `auto_create` section of the global Message Queue configuration. Auto creation is disabled by default: subscribing to a queue topic does not create a queue.
 ```hocon
 ...
 auto_create {
@@ -115,7 +115,7 @@ auto_create {
 }
 ...
 ```
-One may change the auto creation settings to regular queues, or disable the auto creation. Obviously, one may not autocreate queues as regular and last-value at the same time.
+The example above enables auto creation of last-value queues. Set `regular` to a settings object instead to auto create regular queues. A queue cannot be auto created as regular and last-value at the same time.
 
 ## QoS handling
 

--- a/apps/emqx_mq/src/emqx_mq_schema.erl
+++ b/apps/emqx_mq/src/emqx_mq_schema.erl
@@ -65,7 +65,7 @@ fields(mq) ->
                 desc => ?DESC(auto_create),
                 default => #{
                     <<"regular">> => false,
-                    <<"lastvalue">> => #{}
+                    <<"lastvalue">> => false
                 }
             })},
         {quota,
@@ -102,7 +102,7 @@ fields(auto_create) ->
         {lastvalue,
             mk(hoconsc:union([false, ref(auto_create_lastvalue)]), #{
                 required => true,
-                default => #{},
+                default => false,
                 converter => serialize_converter(
                     fun
                         (false) ->

--- a/apps/emqx_mq/test/emqx_mq_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_SUITE.erl
@@ -1286,6 +1286,24 @@ t_auto_create_disabled(_Config) ->
     %% Clean up
     ok = emqtt:disconnect(CSub).
 
+%% Verify that the default configuration does not automatically create queues
+t_auto_create_disabled_by_default(_Config) ->
+    %% Take the `auto_create' settings straight from the schema defaults
+    #{<<"mq">> := #{<<"auto_create">> := AutoCreate}} =
+        emqx_config:fill_defaults(#{<<"mq">> => #{}}),
+    ?assertEqual(#{<<"regular">> => false, <<"lastvalue">> => false}, AutoCreate),
+    {ok, _} = emqx:update_config([mq, auto_create], AutoCreate),
+
+    %% Connect a client and subscribe to a non-existent queue
+    CSub = emqx_mq_test_utils:emqtt_connect([]),
+    emqx_mq_test_utils:emqtt_sub_mq(CSub, <<"auto_create_default">>, <<"non-existent/#">>),
+
+    %% Verify that the queue was not automatically created
+    ?assertEqual(not_found, emqx_mq_registry:find(<<"auto_create_default">>)),
+
+    %% Clean up
+    ok = emqtt:disconnect(CSub).
+
 %% Subscribe to the same name under different topic filters
 t_conflicting_queues(_Config) ->
     %% Enable automatic creation of regular queues

--- a/apps/emqx_streams/src/emqx_streams_schema.erl
+++ b/apps/emqx_streams/src/emqx_streams_schema.erl
@@ -65,7 +65,7 @@ fields(?SCHEMA_ROOT) ->
                 desc => ?DESC(auto_create),
                 default => #{
                     <<"regular">> => false,
-                    <<"lastvalue">> => #{}
+                    <<"lastvalue">> => false
                 }
             })},
         {quota,
@@ -102,7 +102,7 @@ fields(auto_create) ->
         {lastvalue,
             mk(hoconsc:union([false, ref(auto_create_lastvalue)]), #{
                 required => true,
-                default => #{},
+                default => false,
                 converter => serialize_converter(
                     fun
                         (false) ->

--- a/apps/emqx_streams/test/emqx_streams_SUITE.erl
+++ b/apps/emqx_streams/test/emqx_streams_SUITE.erl
@@ -740,6 +740,26 @@ t_autocreate_stream(_Config) ->
     %% Clean up
     ok = emqtt:disconnect(CSub).
 
+%% Verify that the default configuration does not automatically create streams
+t_autocreate_stream_disabled_by_default(_Config) ->
+    %% Take the `auto_create' settings straight from the schema defaults
+    #{<<"streams">> := #{<<"auto_create">> := AutoCreate}} =
+        emqx_config:fill_defaults(#{<<"streams">> => #{}}),
+    ?assertEqual(#{<<"regular">> => false, <<"lastvalue">> => false}, AutoCreate),
+    {ok, _} = emqx:update_config([streams, auto_create], AutoCreate),
+
+    %% Connect a client and subscribe to a non-existent stream
+    CSub = emqx_streams_test_utils:emqtt_connect([]),
+    ok = emqx_streams_test_utils:emqtt_sub(CSub, [
+        <<"$stream/auto_create_default/a/#">>
+    ]),
+
+    %% Verify that no stream was automatically created
+    ?assertEqual([], emqx_utils_stream:consume(emqx_streams_registry:list())),
+
+    %% Clean up
+    ok = emqtt:disconnect(CSub).
+
 %% Verify that the data retention period is applied correctly
 t_data_retention_period(_Config) ->
     %% Create a lastvalue and a regular streams with 1s data retention period

--- a/changes/ee/breaking-18788.en.md
+++ b/changes/ee/breaking-18788.en.md
@@ -1,0 +1,15 @@
+Changed the default of `mq.auto_create` and `streams.auto_create` to disable automatic creation.
+
+Previously, subscribing to a `$queue/...` topic created a last-value message queue, and subscribing
+to a `$stream/...` topic created a last-value message stream, when the queue or stream did not exist.
+Both now default to `false`, so a subscription no longer creates anything implicitly.
+
+To keep the previous behaviour, enable automatic creation explicitly:
+
+```
+mq.auto_create.lastvalue = {}
+streams.auto_create.lastvalue = {}
+```
+
+Set `regular` instead of `lastvalue` to automatically create regular queues or streams. Only one of
+the two can be enabled at a time. Message queues and streams that already exist are not affected.

--- a/rel/i18n/emqx_mq_schema.hocon
+++ b/rel/i18n/emqx_mq_schema.hocon
@@ -152,19 +152,23 @@ emqx_mq_schema {
     auto_create {
         desc: """~
             Settings for automatically creating the Message Queue if it does not exist
-            when subscribing to the queue topic."""
+            when subscribing to the queue topic.
+            Automatic creation is disabled by default. Set either <code>regular</code> or
+            <code>lastvalue</code> to enable it. They cannot be enabled at the same time."""
         label: "Auto Create Settings"
     }
 
     auto_create_regular {
         desc: """~
-            Regular Message Queue settings for automatic creation"""
+            Regular Message Queue settings for automatic creation.
+            Set to <code>false</code> to not automatically create regular Message Queues."""
         label: "Auto Create Regular Settings"
     }
 
     auto_create_lastvalue {
         desc: """~
-            Last-Value Message Queue settings for automatic creation"""
+            Last-Value Message Queue settings for automatic creation.
+            Set to <code>false</code> to not automatically create Last-Value Message Queues."""
         label: "Auto Create Last-Value Settings"
     }
 

--- a/rel/i18n/emqx_streams_schema.hocon
+++ b/rel/i18n/emqx_streams_schema.hocon
@@ -46,19 +46,23 @@ max_shard_message_bytes {
 auto_create {
     desc: """~
         Settings for automatically creating the Message Stream if it does not exist
-        when subscribing to the queue topic."""
+        when subscribing to the queue topic.
+        Automatic creation is disabled by default. Set either <code>regular</code> or
+        <code>lastvalue</code> to enable it. They cannot be enabled at the same time."""
     label: "Auto Create Settings"
 }
 
 auto_create_regular {
     desc: """~
-        Regular Message Stream settings for automatic creation"""
+        Regular Message Stream settings for automatic creation.
+        Set to <code>false</code> to not automatically create regular Message Streams."""
     label: "Auto Create Regular Settings"
 }
 
 auto_create_lastvalue {
     desc: """~
-        Last-Value Message Stream settings for automatic creation"""
+        Last-Value Message Stream settings for automatic creation.
+        Set to <code>false</code> to not automatically create Last-Value Message Streams."""
     label: "Auto Create Last-Value Settings"
 }
 


### PR DESCRIPTION
Fixes:
Release version: 6.3.2, 7.0.0
Introduced in: N/A

## Summary

Message queues and message streams were auto-created by default. `mq.auto_create.lastvalue` and
`streams.auto_create.lastvalue` both defaulted to an empty settings object, which
`emqx_mq_config:auto_create/3` and `emqx_streams_config:auto_create/3` match as "enabled". A plain
`$queue/<name>/<topic>` or `$stream/<name>/<topic>` subscription therefore created a last-value queue
or stream on a stock installation.

Both defaults are now `false`, so nothing is created implicitly. `auto_create/3` falls through to its
final clause and returns `false`. `validate_auto_create/1` still returns `ok`, because it only rejects
enabling `regular` and `lastvalue` at the same time.

Relevant changes:

- `apps/emqx_mq/src/emqx_mq_schema.erl` and `apps/emqx_streams/src/emqx_streams_schema.erl` — the
  `lastvalue` field default and the parent `auto_create` default map.
- `rel/i18n/emqx_mq_schema.hocon` and `rel/i18n/emqx_streams_schema.hocon` — say that automatic
  creation is off by default.
- `apps/emqx_mq/README.md` — the auto creation section stated the old default.
- New test cases `t_auto_create_disabled_by_default` and `t_autocreate_stream_disabled_by_default`
  read the `auto_create` settings from the schema defaults, assert both are `false`, apply them, and
  check that a subscription creates nothing.

This is a change of default behaviour. Users who relied on implicit creation must set
`mq.auto_create.lastvalue = {}` or `streams.auto_create.lastvalue = {}`. Existing queues and streams
are unaffected, and an explicit `auto_create` setting in `cluster.hocon` or `emqx.conf` keeps working.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hgjpqnpr9PKXzAXkCVhZdQ
