### PR TITLE
fix(listener): validate listener names before atom conversion

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -38,7 +38,9 @@
 
 -export([
     listener_id/2,
+    validate_listener_name/1,
     parse_listener_id/1,
+    parse_listener_id_without_atom/1,
     esockd_access_rules/1
 ]).
 
@@ -83,6 +85,7 @@
 -define(COWBOY_LISTENER(T), (T == ws orelse T == wss)).
 
 -define(ROOT_KEY, listeners).
+-define(MAX_LISTENER_NAME_BYTES, 64).
 -define(CONF_KEY_PATH, [?ROOT_KEY, '?', '?']).
 -define(TYPES_STRING, ["tcp", "ssl", "ws", "wss", "quic"]).
 -define(MARK_DEL, ?TOMBSTONE_CONFIG_CHANGE_REQ).
@@ -576,7 +579,12 @@ resume_cowboy_listener(Id, Retries) ->
 pre_config_update([?ROOT_KEY, Type, Name], {create, NewConf}, V) when
     V =:= undefined orelse V =:= ?TOMBSTONE_VALUE
 ->
-    {ok, convert_certs(Type, Name, NewConf)};
+    case validate_listener_name(Name) of
+        ok ->
+            {ok, convert_certs(Type, Name, NewConf)};
+        {error, _} = Error ->
+            Error
+    end;
 pre_config_update([?ROOT_KEY, _Type, _Name], {create, _NewConf}, _RawConf) ->
     {error, already_exist};
 pre_config_update([?ROOT_KEY, _Type, _Name], {update, _Request}, undefined) ->
@@ -591,8 +599,13 @@ pre_config_update([?ROOT_KEY, _Type, _Name], ?MARK_DEL, _RawConf) ->
     {ok, ?TOMBSTONE_VALUE};
 pre_config_update([?ROOT_KEY], RawConf, RawConf) ->
     {ok, RawConf};
-pre_config_update([?ROOT_KEY], NewConf, _RawConf) ->
-    {ok, convert_certs(NewConf)}.
+pre_config_update([?ROOT_KEY], NewConf, OldConf) ->
+    case validate_new_listener_ids(NewConf, OldConf) of
+        ok ->
+            {ok, convert_certs(NewConf)};
+        {error, _} = Error ->
+            Error
+    end.
 
 post_config_update([?ROOT_KEY, Type, Name], {create, _Request}, NewConf, OldConf, _AppEnvs) when
     OldConf =:= undefined orelse OldConf =:= ?TOMBSTONE_TYPE
@@ -863,16 +876,60 @@ format_bind(Bin) when is_binary(Bin) ->
 listener_id(Type, ListenerName) ->
     list_to_atom(lists:append([str(Type), ":", str(ListenerName)])).
 
+-spec validate_listener_name(unicode:chardata() | atom()) ->
+    ok
+    | {error, {listener_name_invalid_chars | listener_name_too_long, binary()}}.
+validate_listener_name(Name) ->
+    NameBin = listener_id_part_to_binary(Name),
+    case byte_size(NameBin) =< ?MAX_LISTENER_NAME_BYTES of
+        false ->
+            Message = iolist_to_binary(
+                io_lib:format(
+                    "Listener name must not exceed ~B bytes", [?MAX_LISTENER_NAME_BYTES]
+                )
+            ),
+            {error, {listener_name_too_long, Message}};
+        true ->
+            case emqx_utils:is_restricted_str(NameBin) of
+                true ->
+                    ok;
+                false ->
+                    ErrMsg = <<
+                        "Listener name must start with a letter or digit "
+                        "and contain only letters, digits, '-' and '_'"
+                    >>,
+                    {error, {listener_name_invalid_chars, ErrMsg}}
+            end
+    end.
+
+listener_id_part_to_binary(Value) when is_binary(Value) ->
+    Value;
+listener_id_part_to_binary(Value) when is_atom(Value) ->
+    atom_to_binary(Value, utf8);
+listener_id_part_to_binary(Value) when is_list(Value) ->
+    unicode:characters_to_binary(Value).
+
 -spec parse_listener_id(listener_id()) -> {ok, #{type => atom(), name => atom()}} | {error, term()}.
 parse_listener_id(Id) ->
-    case string:split(str(Id), ":", leading) of
+    case parse_listener_id_without_atom(Id) of
+        {ok, #{type := Type, name := Name}} ->
+            {ok, #{type => binary_to_existing_atom(Type), name => binary_to_atom(Name)}};
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec parse_listener_id_without_atom(listener_id() | unicode:chardata()) ->
+    {ok, #{type => binary(), name => binary()}} | {error, {invalid_listener_id, binary()}}.
+parse_listener_id_without_atom(Id) ->
+    IdBin = listener_id_part_to_binary(Id),
+    case binary:split(IdBin, <<":">>) of
         [Type, Name] ->
-            case lists:member(Type, ?TYPES_STRING) of
-                true -> {ok, #{type => list_to_existing_atom(Type), name => list_to_atom(Name)}};
-                false -> {error, {invalid_listener_id, Id}}
+            case lists:member(binary_to_list(Type), ?TYPES_STRING) of
+                true -> {ok, #{type => Type, name => Name}};
+                false -> {error, {invalid_listener_id, <<"Unsupported listener type">>}}
             end;
         _ ->
-            {error, {invalid_listener_id, Id}}
+            {error, {invalid_listener_id, <<"Invalid listener ID format, expected type:name">>}}
     end.
 
 zone(Opts) ->
@@ -884,6 +941,20 @@ diff_confs(NewConfs, OldConfs) ->
         flatten_confs(OldConfs),
         fun({Type, Name, _}) -> {Type, Name} end
     ).
+
+validate_new_listener_ids(NewConf, OldConf) ->
+    #{added := Added} = diff_confs(NewConf, OldConf),
+    validate_listener_ids(Added).
+
+validate_listener_ids([]) ->
+    ok;
+validate_listener_ids([{_Type, Name, _Conf} | Rest]) ->
+    case validate_listener_name(Name) of
+        ok ->
+            validate_listener_ids(Rest);
+        {error, _} = Error ->
+            Error
+    end.
 
 flatten_confs(Confs) ->
     lists:flatmap(
@@ -978,7 +1049,9 @@ parse_bind(#{<<"bind">> := Bind}) ->
 
 %% The relative dir for ssl files.
 certs_dir(Type, Name) ->
-    iolist_to_binary(filename:join(["listeners", Type, Name])).
+    TypePath = binary_to_list(listener_id_part_to_binary(Type)),
+    NamePath = binary_to_list(listener_id_part_to_binary(Name)),
+    iolist_to_binary(filename:join(["listeners", TypePath, NamePath])).
 
 convert_certs(ListenerConf) ->
     maps:fold(

--- a/apps/emqx/test/emqx_listeners_update_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_update_SUITE.erl
@@ -54,6 +54,97 @@ t_default_conf(_Config) ->
     ),
     ok.
 
+t_listener_id_length(_Config) ->
+    InvalidNameReason =
+        {listener_name_invalid_chars,
+            <<"Listener name must start with a letter or digit and contain only letters, digits, '-' and '_'">>},
+    InvalidNameError = {error, InvalidNameReason},
+    TooLongReason =
+        {listener_name_too_long, <<"Listener name must not exceed 64 bytes">>},
+    TooLongError = {error, TooLongReason},
+    UnsupportedTypeError = {error, {invalid_listener_id, <<"Unsupported listener type">>}},
+    InvalidFormatError =
+        {error, {invalid_listener_id, <<"Invalid listener ID format, expected type:name">>}},
+    lists:foreach(
+        fun(NameBin) ->
+            lists:foreach(
+                fun(Value) ->
+                    ?assertEqual(InvalidNameError, emqx_listeners:validate_listener_name(Value))
+                end,
+                [NameBin, binary_to_atom(NameBin)]
+            )
+        end,
+        [<<"é"/utf8>>, <<"😀"/utf8>>, <<"你"/utf8>>]
+    ),
+    ?assertEqual(ok, emqx_listeners:validate_listener_name(binary:copy(<<"a">>, 64))),
+    UnicodeName = binary:copy(<<"你"/utf8>>, 20),
+    UnicodeNameAtom = binary_to_atom(UnicodeName, utf8),
+    ?assertEqual(InvalidNameError, emqx_listeners:validate_listener_name(UnicodeName)),
+    ?assertEqual(InvalidNameError, emqx_listeners:validate_listener_name(UnicodeNameAtom)),
+    UnicodeTooLongName = binary:copy(<<"你"/utf8>>, 22),
+    ?assertEqual(
+        TooLongError,
+        emqx_listeners:validate_listener_name(UnicodeTooLongName)
+    ),
+    ?assertEqual(
+        TooLongError,
+        emqx_listeners:validate_listener_name(binary_to_atom(UnicodeTooLongName, utf8))
+    ),
+    ?assertEqual(
+        TooLongError,
+        emqx_listeners:validate_listener_name(binary:copy(<<"a">>, 65))
+    ),
+    Raw = emqx:get_raw_config(?LISTENERS),
+    NonAsciiConf = emqx_utils_maps:deep_put(
+        [<<"tcp">>, <<"é"/utf8>>], Raw, #{<<"bind">> => <<"127.0.0.1:0">>}
+    ),
+    ?assertEqual(
+        {error, {pre_config_update, emqx_listeners, InvalidNameReason}},
+        emqx:update_config(?LISTENERS, NonAsciiConf)
+    ),
+    Name = binary:copy(<<"b">>, 65),
+    Tcp = maps:get(<<"tcp">>, Raw),
+    RawWithLongListener = Raw#{
+        <<"tcp">> => Tcp#{Name => #{<<"bind">> => <<"127.0.0.1:0">>}}
+    },
+    ?assertEqual(
+        {error, {pre_config_update, emqx_listeners, TooLongReason}},
+        emqx:update_config(?LISTENERS, RawWithLongListener)
+    ),
+    ?assertEqual(
+        {error, {pre_config_update, emqx_listeners, TooLongReason}},
+        emqx:update_config(
+            [listeners, tcp, Name],
+            {create, #{<<"bind">> => <<"127.0.0.1:0">>}}
+        )
+    ),
+    ?assertEqual(Raw, emqx:get_raw_config(?LISTENERS)),
+    ?assertEqual(InvalidNameError, emqx_listeners:validate_listener_name(<<"name/with/slash">>)),
+    ?assertEqual(InvalidNameError, emqx_listeners:validate_listener_name(<<"name#with#hash">>)),
+    ?assertEqual(
+        InvalidNameError, emqx_listeners:validate_listener_name(<<"name:with:delimiter">>)
+    ),
+    ?assertEqual(
+        InvalidNameError, emqx_listeners:validate_listener_name(<<"name\\with\\escape">>)
+    ),
+    ?assertEqual(ok, emqx_listeners:validate_listener_name(<<"name-with_under">>)),
+    ?assertEqual(
+        InvalidNameError, emqx_listeners:validate_listener_name(<<"_leading_underscore">>)
+    ),
+    ?assertEqual(
+        UnsupportedTypeError,
+        emqx_listeners:parse_listener_id_without_atom(<<"unknown:name">>)
+    ),
+    ?assertEqual(
+        InvalidFormatError,
+        emqx_listeners:parse_listener_id_without_atom(<<"missing-delimiter">>)
+    ),
+    ?assertEqual(
+        InvalidFormatError,
+        emqx_listeners:parse_listener_id(<<"missing-delimiter">>)
+    ),
+    ok.
+
 t_update_conf(_Conf) ->
     Raw = emqx:get_raw_config(?LISTENERS),
     Raw1 = emqx_utils_maps:deep_put(

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -86,20 +86,23 @@ listeners(post, #{bindings := #{name := Name0}, body := LConf}) ->
         _ = checks([<<"type">>, <<"name">>, <<"bind">>], LConf),
 
         Type = binary_to_existing_atom(maps:get(<<"type">>, LConf)),
-        LName = binary_to_atom(maps:get(<<"name">>, LConf)),
-
-        Path = [listeners, Type, LName],
-        case emqx_utils_maps:deep_get(Path, RunningConf, undefined) of
-            undefined ->
-                ListenerId = emqx_gateway_utils:listener_id(
-                    GwName, Type, LName
-                ),
-                {ok, RespConf} = emqx_gateway_http:add_listener(
-                    ListenerId, LConf
-                ),
-                {201, RespConf};
-            _ ->
-                return_http_error(400, ?DESC("listener_name_occupied"))
+        LNameBin = maps:get(<<"name">>, LConf),
+        case emqx_listeners:validate_listener_name(LNameBin) of
+            ok ->
+                LName = binary_to_atom(LNameBin),
+                ListenerId = emqx_gateway_utils:listener_id(GwName, Type, LName),
+                Path = [listeners, Type, LName],
+                case emqx_utils_maps:deep_get(Path, RunningConf, undefined) of
+                    undefined ->
+                        {ok, RespConf} = emqx_gateway_http:add_listener(
+                            ListenerId, LConf
+                        ),
+                        {201, RespConf};
+                    _ ->
+                        return_http_error(400, ?DESC("listener_name_occupied"))
+                end;
+            {error, Reason} ->
+                emqx_gateway_http:reason2resp(Reason)
         end
     end).
 

--- a/apps/emqx_gateway/src/emqx_gateway_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_conf.erl
@@ -101,7 +101,6 @@ unconvert_listeners(Ls) when is_list(Ls) ->
     lists:foldl(
         fun(Lis, Acc) ->
             {[Type, Name], Lis1} = maps_key_take([<<"type">>, <<"name">>], Lis),
-            _ = validate_listener_name(Name),
             NLis1 = maps:without([<<"id">>, <<"running">>], Lis1),
             emqx_utils_maps:deep_merge(Acc, #{Type => #{Name => NLis1}})
         end,
@@ -117,21 +116,6 @@ maps_key_take([K | Ks], M, Acc) ->
     case maps:take(K, M) of
         error -> error(bad_key);
         {V, M1} -> maps_key_take(Ks, M1, [V | Acc])
-    end.
-
-validate_listener_name(Name) ->
-    try
-        {match, _} = re:run(Name, "^[a-zA-Z][0-9a-zA-Z_-]*$"),
-        ok
-    catch
-        _:_ ->
-            error(
-                {badconf, #{
-                    key => name,
-                    value => Name,
-                    reason => bad_listener_name
-                }}
-            )
     end.
 
 -spec update_gateway(atom_or_bin(), map()) -> map_or_err().
@@ -393,8 +377,13 @@ import_config(_Namespace, RawConf) ->
 pre_config_update(?GATEWAY, {load_gateway, GwName, Conf}, RawConf) ->
     case maps:get(GwName, RawConf, undefined) of
         undefined ->
-            NConf = tune_gw_certs(fun convert_certs/2, GwName, Conf),
-            {ok, emqx_utils_maps:deep_put([GwName], RawConf, NConf)};
+            case validate_new_listener_ids(#{GwName => Conf}, RawConf) of
+                ok ->
+                    NConf = tune_gw_certs(fun convert_certs/2, GwName, Conf),
+                    {ok, emqx_utils_maps:deep_put([GwName], RawConf, NConf)};
+                {error, _} = Error ->
+                    Error
+            end;
         _ ->
             badres_gateway(already_exist, GwName)
     end;
@@ -413,13 +402,18 @@ pre_config_update(?GATEWAY, {unload_gateway, GwName}, RawConf) ->
 pre_config_update(?GATEWAY, {add_listener, GwName, {LType, LName}, Conf}, RawConf) ->
     case get_listener(GwName, LType, LName, RawConf) of
         undefined ->
-            NConf = convert_certs(certs_dir(GwName), Conf),
-            NListener = #{LType => #{LName => NConf}},
-            {ok,
-                emqx_utils_maps:deep_merge(
-                    RawConf,
-                    #{GwName => #{<<"listeners">> => NListener}}
-                )};
+            case emqx_listeners:validate_listener_name(LName) of
+                ok ->
+                    NConf = convert_certs(certs_dir(GwName), Conf),
+                    NListener = #{LType => #{LName => NConf}},
+                    {ok,
+                        emqx_utils_maps:deep_merge(
+                            RawConf,
+                            #{GwName => #{<<"listeners">> => NListener}}
+                        )};
+                {error, _} = Error ->
+                    Error
+            end;
         _ ->
             badres_listener(already_exist, GwName, LType, LName)
     end;
@@ -519,14 +513,19 @@ pre_config_update(?GATEWAY, {remove_authn, GwName, {LType, LName}}, RawConf) ->
     Path = [GwName, <<"listeners">>, LType, LName, ?AUTHN_BIN],
     {ok, emqx_utils_maps:deep_remove(Path, RawConf)};
 pre_config_update(?GATEWAY, NewRawConf0 = #{}, OldRawConf = #{}) ->
-    %% FIXME don't support gateway's listener's authn update.
-    %% load all authentications
-    NewRawConf1 = pre_load_authentications(NewRawConf0, OldRawConf),
-    %% load all listeners
-    NewRawConf2 = pre_load_listeners(NewRawConf1, OldRawConf),
-    %% load all gateway
-    NewRawConf3 = pre_load_gateways(NewRawConf2, OldRawConf),
-    {ok, NewRawConf3};
+    case validate_new_listener_ids(NewRawConf0, OldRawConf) of
+        ok ->
+            %% FIXME don't support gateway's listener's authn update.
+            %% load all authentications
+            NewRawConf1 = pre_load_authentications(NewRawConf0, OldRawConf),
+            %% load all listeners
+            NewRawConf2 = pre_load_listeners(NewRawConf1, OldRawConf),
+            %% load all gateway
+            NewRawConf3 = pre_load_gateways(NewRawConf2, OldRawConf),
+            {ok, NewRawConf3};
+        {error, _} = Error ->
+            Error
+    end;
 pre_config_update(Path, UnknownReq, _RawConf) ->
     ?SLOG(error, #{
         msg => "unknown_gateway_update_request",
@@ -534,6 +533,58 @@ pre_config_update(Path, UnknownReq, _RawConf) ->
         path => Path
     }),
     {error, badreq}.
+
+validate_new_listener_ids(NewRawConf, OldRawConf) ->
+    maps:fold(
+        fun
+            (_GwName, _GwConf, {error, _} = Error) ->
+                Error;
+            (GwName, GwConf, ok) ->
+                validate_gateway_listener_ids(GwName, GwConf, OldRawConf)
+        end,
+        ok,
+        NewRawConf
+    ).
+
+validate_gateway_listener_ids(GwName, GwConf, OldRawConf) ->
+    Listeners = maps:get(<<"listeners">>, GwConf, #{}),
+    case is_map(Listeners) of
+        false ->
+            ok;
+        true ->
+            maps:fold(
+                fun
+                    (_LType, _ListenerConfigs, {error, _} = Error) ->
+                        Error;
+                    (LType, ListenerConfigs, ok) when is_map(ListenerConfigs) ->
+                        validate_listener_configs(GwName, LType, ListenerConfigs, OldRawConf);
+                    (_LType, _ListenerConfigs, ok) ->
+                        ok
+                end,
+                ok,
+                Listeners
+            )
+    end.
+
+validate_listener_configs(GwName, LType, ListenerConfigs, OldRawConf) ->
+    maps:fold(
+        fun
+            (_LName, _ListenerConf, {error, _} = Error) ->
+                Error;
+            (LName, _ListenerConf, ok) ->
+                validate_new_listener(GwName, LType, LName, OldRawConf)
+        end,
+        ok,
+        ListenerConfigs
+    ).
+
+validate_new_listener(GwName, LType, LName, OldRawConf) ->
+    case get_listener(GwName, LType, LName, OldRawConf) of
+        undefined ->
+            emqx_listeners:validate_listener_name(LName);
+        _ ->
+            ok
+    end.
 
 pre_load_gateways(NewConf, OldConf) ->
     %% unload old gateways

--- a/apps/emqx_gateway/src/emqx_gateway_http.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_http.erl
@@ -484,6 +484,10 @@ reason2msg(
     );
 reason2msg({bad_ssl_config, Reason}) ->
     fmtstr("Bad TLS configuration: ~0p", [Reason]);
+reason2msg({listener_name_invalid_chars, Message}) ->
+    Message;
+reason2msg({listener_name_too_long, Message}) ->
+    Message;
 reason2msg(
     {#{roots := [{gateway, _}]}, [_ | _]} = Error
 ) ->

--- a/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
@@ -453,6 +453,81 @@ t_listeners_tcp(_) ->
     {404, _} = request(delete, "/gateways/stomp/listeners/stomp:tcp:def"),
     ok.
 
+t_listener_id_too_long(_) ->
+    {204, _} = request(put, "/gateways/stomp", #{}),
+    ?assertMatch(
+        {400, #{
+            code := <<"BAD_REQUEST">>,
+            message :=
+                <<"Listener name must start with a letter or digit and contain only letters, digits, '-' and '_'">>
+        }},
+        request(post, "/gateways/stomp/listeners", #{
+            name => <<"你好"/utf8>>, type => <<"tcp">>, bind => <<"127.0.0.1:61613">>
+        })
+    ),
+    ?assertMatch(
+        {400, #{
+            code := <<"BAD_REQUEST">>,
+            message :=
+                <<"Listener name must start with a letter or digit and contain only letters, digits, '-' and '_'">>
+        }},
+        request(post, "/gateways/stomp/listeners", #{
+            name => <<"name/with/slash">>, type => <<"tcp">>, bind => <<"127.0.0.1:61613">>
+        })
+    ),
+    ?assertMatch(
+        {400, #{
+            code := <<"BAD_REQUEST">>,
+            message :=
+                <<"Listener name must start with a letter or digit and contain only letters, digits, '-' and '_'">>
+        }},
+        request(post, "/gateways/stomp/listeners", #{
+            name => <<"_leading_underscore">>,
+            type => <<"tcp">>,
+            bind => <<"127.0.0.1:61613">>
+        })
+    ),
+    AllowedName = binary:copy(<<"a">>, 64),
+    AllowedConf = #{
+        name => AllowedName,
+        type => <<"tcp">>,
+        bind => <<"127.0.0.1:61613">>
+    },
+    {201, _} = request(post, "/gateways/stomp/listeners", AllowedConf),
+    AllowedId = atom_to_list(emqx_gateway_utils:listener_id(stomp, tcp, AllowedName)),
+    {204, _} = request(delete, "/gateways/stomp/listeners/" ++ AllowedId),
+
+    ListenerName = binary:copy(<<"a">>, 65),
+    ListenerConf = #{
+        name => ListenerName,
+        type => <<"tcp">>,
+        bind => <<"127.0.0.1:61613">>
+    },
+    {400, #{code := <<"BAD_REQUEST">>, message := Message}} = request(
+        post, "/gateways/stomp/listeners", ListenerConf
+    ),
+    ?assertEqual(<<"Listener name must not exceed 64 bytes">>, Message),
+    {200, []} = request(get, "/gateways/stomp/listeners"),
+    ok.
+
+t_gateway_listener_id_too_long(_) ->
+    ListenerName = binary:copy(<<"a">>, 65),
+    GatewayConf = #{
+        listeners => [
+            #{
+                name => ListenerName,
+                type => <<"tcp">>,
+                bind => <<"127.0.0.1:61613">>
+            }
+        ]
+    },
+    {400, #{code := <<"BAD_REQUEST">>, message := Message}} = request(
+        put, "/gateways/stomp", GatewayConf
+    ),
+    ?assertEqual(<<"Listener name must not exceed 64 bytes">>, Message),
+    ?assertEqual(undefined, emqx_gateway:lookup(stomp)),
+    ok.
+
 t_listeners_max_conns(_) ->
     {204, _} = request(put, "/gateways/stomp", #{}),
     {200, []} = request(get, "/gateways/stomp/listeners"),

--- a/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
@@ -313,6 +313,75 @@ t_load_unload_gateway(_) ->
     ?assertEqual(undefined, emqx_gateway:lookup('stomp')),
     ok.
 
+t_listener_id_length_validation(_) ->
+    Name = binary:copy(<<"a">>, 65),
+    Error =
+        {error, {listener_name_too_long, <<"Listener name must not exceed 64 bytes">>}},
+    EmptyGateway = #{<<"listeners">> => #{}},
+    ListenerConfig = #{
+        <<"listeners">> => #{<<"tcp">> => #{Name => #{}}}
+    },
+    ?assertEqual(
+        Error,
+        emqx_gateway_conf:pre_config_update(
+            [gateway],
+            {load_gateway, <<"stomp">>, ListenerConfig},
+            #{}
+        )
+    ),
+    ?assertEqual(
+        Error,
+        emqx_gateway_conf:pre_config_update(
+            [gateway],
+            {add_listener, <<"stomp">>, {<<"tcp">>, Name}, #{}},
+            #{<<"stomp">> => EmptyGateway}
+        )
+    ),
+    RawWithLongListener = #{<<"stomp">> => ListenerConfig},
+    ?assertEqual(
+        Error,
+        emqx_gateway_conf:pre_config_update(
+            [gateway],
+            RawWithLongListener,
+            #{<<"stomp">> => EmptyGateway}
+        )
+    ),
+    Raw0 = emqx:get_raw_config([gateway]),
+    ?assertEqual(
+        {error, {pre_config_update, emqx_gateway_conf, element(2, Error)}},
+        emqx:update_config([gateway], Raw0#{<<"stomp">> => ListenerConfig})
+    ),
+    ?assertMatch(
+        {ok, _},
+        emqx_gateway_conf:pre_config_update(
+            [gateway],
+            RawWithLongListener,
+            RawWithLongListener
+        )
+    ),
+    ?assert(is_atom(emqx_gateway_utils:listener_id(stomp, tcp, Name))),
+    InvalidName = <<"_invalid">>,
+    InvalidError =
+        {error,
+            {listener_name_invalid_chars,
+                <<"Listener name must start with a letter or digit and contain only letters, digits, '-' and '_'">>}},
+    InvalidListenerConfig = #{
+        <<"listeners">> => #{<<"tcp">> => #{InvalidName => #{}}}
+    },
+    ?assertEqual(
+        InvalidError,
+        emqx_gateway_conf:pre_config_update(
+            [gateway],
+            {add_listener, <<"stomp">>, {<<"tcp">>, InvalidName}, #{}},
+            #{<<"stomp">> => EmptyGateway}
+        )
+    ),
+    ?assertEqual(
+        {error, {pre_config_update, emqx_gateway_conf, element(2, InvalidError)}},
+        emqx:update_config([gateway], Raw0#{<<"stomp">> => InvalidListenerConfig})
+    ),
+    ok.
+
 t_authn_create_failure_log_redacts_secret(_) ->
     Secret = <<"secret-pass">>,
     StompConf = compose_authn(?CONF_STOMP_BAISC_1, jwt_authn_conf(Secret)),

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -201,9 +201,9 @@ schema("/listeners/:id/restart") ->
 fields(listener_id) ->
     [
         {id,
-            ?HOCON(atom(), #{
+            ?HOCON(binary(), #{
                 desc => ?DESC(listener_id),
-                example => 'tcp:demo',
+                example => <<"tcp:demo">>,
                 validator => fun validate_id/1,
                 required => true,
                 in => path
@@ -339,7 +339,7 @@ listeners_info(Opts) ->
                     {running,
                         ?HOCON(boolean(), #{desc => ?DESC("listener_status"), required => false})},
                     {id,
-                        ?HOCON(atom(), #{
+                        ?HOCON(binary(), #{
                             desc => ?DESC("listener_id"),
                             required => true,
                             validator => fun validate_id/1
@@ -371,7 +371,7 @@ listeners_ref(Type, #{bind := Bind}) ->
     Type ++ Suffix.
 
 validate_id(Id) ->
-    case emqx_listeners:parse_listener_id(Id) of
+    case emqx_listeners:parse_listener_id_without_atom(Id) of
         {error, Reason} -> {error, Reason};
         {ok, _} -> ok
     end.
@@ -399,13 +399,20 @@ list_listeners(get, #{query_string := Query}) ->
 list_listeners(post, #{body := Body}) ->
     create_listener(name, Body).
 
+crud_listeners_by_id(Method, #{bindings := #{id := Id0} = Bindings} = Request) when
+    Method =/= post, is_binary(Id0)
+->
+    case existing_listener_id(Id0) of
+        {ok, Id} -> crud_listeners_by_id(Method, Request#{bindings := Bindings#{id => Id}});
+        {error, not_found} -> {404, #{code => 'BAD_LISTENER_ID', message => ?LISTENER_NOT_FOUND}}
+    end;
 crud_listeners_by_id(get, #{bindings := #{id := Id}}) ->
     case find_listeners_by_id(Id) of
         [] -> {404, #{code => 'BAD_LISTENER_ID', message => ?LISTENER_NOT_FOUND}};
         [L] -> {200, L}
     end;
 crud_listeners_by_id(put, #{bindings := #{id := Id}, body := Body0}) ->
-    case parse_listener_conf(id, Body0) of
+    case parse_listener_conf(existing_id, Body0) of
         {Id, Type, Name, Conf} ->
             case get_raw(Type, Name) of
                 undefined ->
@@ -445,7 +452,38 @@ crud_listeners_by_id(delete, #{bindings := #{id := Id}}) ->
             {404, #{code => 'BAD_LISTENER_ID', message => ?LISTENER_NOT_FOUND}}
     end.
 
-parse_listener_conf(id, Conf0) ->
+%% Existing IDs may predate the creation restrictions.
+existing_listener_id(Id) when is_binary(Id) ->
+    case emqx_listeners:parse_listener_id_without_atom(Id) of
+        {ok, #{type := TypeBin, name := NameBin}} ->
+            try
+                Type = binary_to_existing_atom(TypeBin),
+                Name = binary_to_existing_atom(NameBin),
+                case get_raw(Type, Name) of
+                    undefined -> {error, not_found};
+                    _ -> {ok, emqx_listeners:listener_id(Type, Name)}
+                end
+            catch
+                error:badarg -> {error, not_found};
+                error:system_limit -> {error, not_found}
+            end;
+        {error, _} ->
+            {error, not_found}
+    end.
+
+parse_listener_conf(id, #{<<"id">> := Id} = Conf) ->
+    case emqx_listeners:parse_listener_id_without_atom(Id) of
+        {ok, #{name := Name}} ->
+            case emqx_listeners:validate_listener_name(Name) of
+                ok -> parse_listener_conf(new_id, Conf);
+                {error, _} = Error -> Error
+            end;
+        {error, _} = Error ->
+            Error
+    end;
+parse_listener_conf(id, _Conf) ->
+    {error, listener_config_invalid};
+parse_listener_conf(new_id, Conf0) ->
     Conf1 = maps:without([<<"running">>, <<"current_connections">>], Conf0),
     {TypeBin, Conf2} = maps:take(<<"type">>, Conf1),
     TypeAtom = binary_to_existing_atom(TypeBin),
@@ -453,8 +491,27 @@ parse_listener_conf(id, Conf0) ->
         {IdBin, Conf3} ->
             {ok, #{type := Type, name := Name}} = emqx_listeners:parse_listener_id(IdBin),
             case Type =:= TypeAtom of
-                true -> {binary_to_existing_atom(IdBin), TypeAtom, Name, Conf3};
+                true -> {binary_to_atom(IdBin), TypeAtom, Name, Conf3};
                 false -> {error, listener_type_inconsistent}
+            end;
+        _ ->
+            {error, listener_config_invalid}
+    end;
+parse_listener_conf(existing_id, Conf0) ->
+    Conf1 = maps:without([<<"running">>, <<"current_connections">>], Conf0),
+    {TypeBin, Conf2} = maps:take(<<"type">>, Conf1),
+    TypeAtom = binary_to_existing_atom(TypeBin),
+    case maps:take(<<"id">>, Conf2) of
+        {IdBin, Conf3} ->
+            case existing_listener_id(IdBin) of
+                {ok, Id} ->
+                    {ok, #{type := Type, name := Name}} = emqx_listeners:parse_listener_id(IdBin),
+                    case Type =:= TypeAtom of
+                        true -> {Id, TypeAtom, Name, Conf3};
+                        false -> {error, listener_type_inconsistent}
+                    end;
+                {error, _} = Error ->
+                    Error
             end;
         _ ->
             {error, listener_config_invalid}
@@ -466,7 +523,12 @@ parse_listener_conf(name, Conf0) ->
     case maps:take(<<"name">>, Conf2) of
         {Name, Conf3} ->
             IdBin = <<TypeBin/binary, $:, Name/binary>>,
-            {binary_to_atom(IdBin), TypeAtom, Name, Conf3};
+            case emqx_listeners:validate_listener_name(Name) of
+                ok ->
+                    {binary_to_atom(IdBin), TypeAtom, Name, Conf3};
+                {error, _} = Error ->
+                    Error
+            end;
         _ ->
             {error, listener_config_invalid}
     end.
@@ -487,6 +549,13 @@ restart_listeners_by_id(Method, Body = #{bindings := Bindings}) ->
         Body#{bindings := maps:put(action, restart, Bindings)}
     ).
 
+action_listeners_by_id(post, #{bindings := #{id := Id0} = Bindings} = Request) when
+    is_binary(Id0)
+->
+    case existing_listener_id(Id0) of
+        {ok, Id} -> action_listeners_by_id(post, Request#{bindings := Bindings#{id => Id}});
+        {error, not_found} -> {404, #{code => 'BAD_LISTENER_ID', message => ?LISTENER_NOT_FOUND}}
+    end;
 action_listeners_by_id(post, #{bindings := #{id := Id, action := Action}}) ->
     {ok, #{type := Type, name := Name}} = emqx_listeners:parse_listener_id(Id),
     case get_raw(Type, Name) of
@@ -509,6 +578,7 @@ enabled(start) -> #{<<"enable">> => true};
 enabled(stop) -> #{<<"enable">> => false};
 enabled(restart) -> #{<<"enable">> => true}.
 
+err_msg({_Reason, Message}) when is_binary(Message) -> Message;
 err_msg(Atom) when is_atom(Atom) -> atom_to_binary(Atom);
 err_msg(Reason) -> list_to_binary(err_msg_str(Reason)).
 

--- a/apps/emqx_management/src/emqx_mgmt_listeners_conf.erl
+++ b/apps/emqx_management/src/emqx_mgmt_listeners_conf.erl
@@ -30,7 +30,12 @@ action(Type, Name, Action, Conf) ->
     wrap(emqx_conf:update(?path(Type, Name), {action, Action, Conf}, ?OPTS)).
 
 create(Type, Name, Conf) ->
-    wrap(emqx_conf:update(?path(Type, Name), {create, Conf}, ?OPTS)).
+    case emqx_listeners:validate_listener_name(Name) of
+        ok ->
+            wrap(emqx_conf:update(?path(Type, Name), {create, Conf}, ?OPTS));
+        {error, _} = Error ->
+            Error
+    end.
 
 ensure_remove(Type, Name) ->
     wrap(emqx_conf:tombstone(?path(Type, Name), ?OPTS)).

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -148,6 +148,140 @@ t_list_listeners(Config) when is_list(Config) ->
     ?assertMatch({error, {"HTTP/1.1", 404, _}}, request(get, NewPath, [], [])),
     ok.
 
+t_listener_id_length(Config) when is_list(Config) ->
+    Path = emqx_mgmt_api_test_util:api_path(["listeners"]),
+    OriginPath = emqx_mgmt_api_test_util:api_path(["listeners", "tcp:default"]),
+    OriginListener = request(get, OriginPath, [], []),
+    OriginListener1 = maps:remove(<<"id">>, OriginListener),
+    Port = integer_to_binary(?PORT),
+    AllowedName = binary:copy(<<"a">>, 64),
+    AllowedId = <<"tcp:", AllowedName/binary>>,
+    AllowedPath = emqx_mgmt_api_test_util:api_path(["listeners", AllowedId]),
+    AllowedConf = OriginListener1#{
+        <<"name">> => AllowedName,
+        <<"bind">> => <<"0.0.0.0:", Port/binary>>
+    },
+    Created = request(post, Path, [], AllowedConf),
+    ?assertEqual(AllowedId, maps:get(<<"id">>, Created)),
+    AllowedGet = request(get, AllowedPath, [], []),
+    ?assertEqual(AllowedId, maps:get(<<"id">>, AllowedGet)),
+    ?assertEqual([], delete(AllowedPath)),
+
+    UnicodeName = binary:copy(<<"你"/utf8>>, 20),
+    UnicodeConf = OriginListener1#{
+        <<"name">> => UnicodeName,
+        <<"bind">> => <<"0.0.0.0:", Port/binary>>
+    },
+    UnicodeResult = request(post, Path, [], UnicodeConf, #{return_all => true}),
+    ?assertMatch({error, {{_, 400, _}, _, _}}, UnicodeResult),
+    {error, {_, _, UnicodeBody}} = UnicodeResult,
+    ?assertMatch(
+        #{
+            <<"code">> := <<"BAD_REQUEST">>,
+            <<"message">> :=
+                <<"Listener name must start with a letter or digit and contain only letters, digits, '-' and '_'">>
+        },
+        emqx_utils_json:decode(UnicodeBody)
+    ),
+
+    InvalidName = <<"_leading_underscore">>,
+    InvalidConf = OriginListener1#{
+        <<"name">> => InvalidName,
+        <<"bind">> => <<"0.0.0.0:", Port/binary>>
+    },
+    InvalidResult = request(post, Path, [], InvalidConf, #{return_all => true}),
+    ?assertMatch({error, {{_, 400, _}, _, _}}, InvalidResult),
+    {error, {{_, 400, _}, _, InvalidBody}} = InvalidResult,
+    ?assertMatch(
+        #{
+            <<"code">> := <<"BAD_REQUEST">>,
+            <<"message">> :=
+                <<"Listener name must start with a letter or digit and contain only letters, digits, '-' and '_'">>
+        },
+        emqx_utils_json:decode(InvalidBody)
+    ),
+
+    UniqueSuffix = integer_to_binary(erlang:unique_integer([positive])),
+    ColonName = <<"tcp:invalid_", UniqueSuffix/binary>>,
+    ColonId = <<"tcp:", ColonName/binary>>,
+    ?assertError(badarg, binary_to_existing_atom(ColonId)),
+    ColonConf = OriginListener1#{
+        <<"name">> => ColonName,
+        <<"bind">> => <<"0.0.0.0:", Port/binary>>
+    },
+    ColonResult = request(post, Path, [], ColonConf, #{return_all => true}),
+    ?assertMatch({error, {{_, 400, _}, _, _}}, ColonResult),
+    ?assertError(badarg, binary_to_existing_atom(ColonId)),
+    ?assertError(badarg, binary_to_existing_atom(ColonName)),
+    DeprecatedColonPath = emqx_mgmt_api_test_util:api_path(["listeners", ColonId]),
+    DeprecatedColonConf = ColonConf#{<<"id">> => ColonId},
+    DeprecatedColonResult = request(
+        post,
+        DeprecatedColonPath,
+        [],
+        DeprecatedColonConf,
+        #{return_all => true}
+    ),
+    ?assertMatch({error, {{_, 400, _}, _, _}}, DeprecatedColonResult),
+    ?assertError(badarg, binary_to_existing_atom(ColonId)),
+    ?assertError(badarg, binary_to_existing_atom(ColonName)),
+
+    TooLongName = binary:copy(<<"b">>, 65),
+    TooLongConf = OriginListener1#{
+        <<"name">> => TooLongName,
+        <<"bind">> => <<"0.0.0.0:", Port/binary>>
+    },
+    Result = request(post, Path, [], TooLongConf, #{return_all => true}),
+    ?assertMatch({error, {{_, 400, _}, _, _}}, Result),
+    {error, {{_, 400, _}, _, Body}} = Result,
+    #{<<"code">> := <<"BAD_REQUEST">>, <<"message">> := Message} =
+        emqx_utils_json:decode(Body),
+    ?assertEqual(<<"Listener name must not exceed 64 bytes">>, Message),
+    TooLongId = <<"tcp:", TooLongName/binary>>,
+    DeprecatedPath = emqx_mgmt_api_test_util:api_path(["listeners", TooLongId]),
+    DeprecatedConf = TooLongConf#{<<"id">> => TooLongId},
+    DeprecatedResult = request(post, DeprecatedPath, [], DeprecatedConf, #{return_all => true}),
+    ?assertMatch({error, {{_, 400, _}, _, _}}, DeprecatedResult),
+    ok.
+
+t_legacy_listener_id_update(Config) when is_list(Config) ->
+    assert_legacy_listener_id_update(binary:copy(<<"legacy">>, 11)).
+
+t_existing_id_atom_does_not_create_name_atom(Config) when is_list(Config) ->
+    UniqueSuffix = integer_to_binary(erlang:unique_integer([positive])),
+    Name = <<"missing_", UniqueSuffix/binary>>,
+    Id = <<"tcp:", Name/binary>>,
+    _ = binary_to_atom(Id),
+    ?assertError(badarg, binary_to_existing_atom(Name)),
+    Path = emqx_mgmt_api_test_util:api_path(["listeners", Id]),
+    Result = request(delete, Path, [], [], #{return_all => true}),
+    ?assertMatch({error, {{_, 404, _}, _, _}}, Result),
+    ?assertError(badarg, binary_to_existing_atom(Name)),
+    ok.
+
+assert_legacy_listener_id_update(Name) ->
+    NameAtom = binary_to_atom(Name),
+    Id = <<"tcp:", Name/binary>>,
+    Path = emqx_mgmt_api_test_util:api_path(["listeners", Id]),
+    %% Seed the configuration as if loaded from a pre-upgrade installation.
+    Raw = #{<<"enable">> => false, <<"bind">> => ?PORT},
+    emqx_config:put_raw([listeners, tcp, NameAtom], Raw),
+    emqx_config:put([listeners, tcp, NameAtom], #{
+        enable => false, bind => maps:get(<<"bind">>, Raw)
+    }),
+    try
+        Existing = request(get, Path, [], []),
+        Updated = request(put, Path, [], Existing#{<<"max_connections">> => 123}),
+        ?assertMatch(#{<<"max_connections">> := 123}, Updated)
+    after
+        ?assertEqual([], delete(Path))
+    end,
+    ?assertMatch(
+        {error, {_, 400, _}},
+        request(post, Path, [], Raw#{<<"id">> => Id, <<"type">> => <<"tcp">>})
+    ),
+    ok.
+
 t_tcp_crud_listeners_by_id(Config) when is_list(Config) ->
     ListenerId = <<"tcp:default">>,
     NewListenerId = <<"tcp:new">>,

--- a/changes/ee/fix-18789.en.md
+++ b/changes/ee/fix-18789.en.md
@@ -1,0 +1,1 @@
+MQTT and Gateway listener creation now rejects listener names longer than 64 bytes or not matching the restricted-name format with a clear `BAD_REQUEST` response. Existing listeners with longer names remain editable.


### PR DESCRIPTION
Fixes: #18747
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: pre-5.8

## Summary

Reject newly created MQTT and Gateway listener names longer than 64 bytes or outside the restricted-name format before atom conversion. REST listener IDs remain binary until they are safely parsed and matched to an existing listener, preventing invalid requests from creating atoms. Existing listeners with longer names remain editable and removable.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible to users has been added to changes/ee/fix-18789.en.md
- [x] Schema changes are backward compatible or intentionally breaking (new listener names are restricted to 64 bytes and the restricted-name format)
