### PR TITLE
test: port d61 changes to ease branch syncing

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -1620,11 +1620,21 @@ start_cluster_ds(Config, ClusterSpec0, Opts) when is_list(ClusterSpec0) ->
     NodeSpecs = emqx_cth_cluster:mk_nodespecs(ClusterSpec, ClusterOpts),
     Nodes = emqx_cth_cluster:start(ClusterSpec, ClusterOpts),
     ExpectedOk = lists:duplicate(length(Nodes), {ok, ok}),
-    WaitReadinessTimeout = maps:get(wait_readiness_timeout, Opts, 15_000),
+    Timeout = maps:get(start_timeout, Opts, 30_000),
     ExpectedOk = erpc:multicall(
         Nodes, emqx_persistent_message, wait_readiness, [WaitReadinessTimeout], infinity
     ),
-    [{cluster_nodes, Nodes}, {node_specs, NodeSpecs}, {work_dir, WorkDir} | Config].
+    Config = [{cluster_nodes, Nodes}, {node_specs, NodeSpecs}, {work_dir, WorkDir} | Config0],
+    StopCluster =
+        fun() ->
+            emqx_common_test_helpers:stop_cluster_ds(Config)
+        end,
+    CleanWorkDir =
+        fun() ->
+            Clean = not maps:get(keep_work_dir, Opts, false),
+            Clean andalso emqx_cth_suite:clean_work_dir(WorkDir)
+        end,
+    [{cleanup, StopCluster}, {cleanup, CleanWorkDir}, {work_dir, WorkDir} | Config].
 
 stop_cluster_ds(Config) ->
     emqx_cth_cluster:stop(proplists:get_value(cluster_nodes, Config)),

--- a/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
@@ -1590,12 +1590,15 @@ check_stream_state_transitions(StreamId = {ClientId, Key}, [To | Rest], State) -
 start_cluster(TestCase, Config0, ClusterOpts) ->
     %% N.B.: some of the tests start a single-node cluster, so it's fine to test them with the
     %% `builtin_local' backend.
-    DurableSessionsOpts = #{
-        <<"checkpoint_interval">> => <<"500ms">>
+    EMQXConf = #{
+        <<"durable_sessions">> =>
+            #{
+                <<"checkpoint_interval">> => <<"500ms">>
+            }
     },
     Opts = emqx_utils_maps:deep_merge(ClusterOpts, #{
-        durable_sessions_opts => DurableSessionsOpts,
-        wait_readiness_timeout => 30_000,
+        start_timeout => 60_000,
+        emqx_conf => EMQXConf,
         work_dir => emqx_cth_suite:work_dir(TestCase, Config0)
     }),
     ClusterSpec = cluster(Opts),


### PR DESCRIPTION
Porting the state of `dev-61` to facilitate branch syncing / reducing conflicts.
