### PR TITLE
docs(changes): drop Windows references from the #17854 changelog entry

### DIFF
--- a/changes/6.3.0.en.md
+++ b/changes/6.3.0.en.md
@@ -125,7 +125,7 @@
 
 - [#17603](https://github.com/emqx/emqx/pull/17603) Added support for extracting subject alternative names from directly connected TLS client certificates into MQTT client attributes with `cert_san.dns`, `cert_san.ip`, `cert_san.email`, and `cert_san.uri` in `mqtt.client_attrs_init`.
 
-- [#17854](https://github.com/emqx/emqx/pull/17854) Changed the default `tcp_backend` for MQTT TCP listeners to `socket` on Unix systems to improve message latency and resource usage. The `gen_tcp` backend remains available by setting `tcp_backend = gen_tcp`, and remains the default on Windows.
+- [#17854](https://github.com/emqx/emqx/pull/17854) Changed the default `tcp_backend` for MQTT TCP listeners to `socket` to improve message latency and resource usage. The `gen_tcp` backend remains available by setting `tcp_backend = gen_tcp`.
 
 - [#17870](https://github.com/emqx/emqx/pull/17870) Improved in-memory session delivery behavior for slow or congested subscribers.
 

--- a/changes/ee/feat-17854.en.md
+++ b/changes/ee/feat-17854.en.md
@@ -1,1 +1,1 @@
-Changed the default `tcp_backend` for MQTT TCP listeners to `socket` on Unix systems to improve message latency and resource usage. The `gen_tcp` backend remains available by setting `tcp_backend = gen_tcp`, and remains the default on Windows.
+Changed the default `tcp_backend` for MQTT TCP listeners to `socket` to improve message latency and resource usage. The `gen_tcp` backend remains available by setting `tcp_backend = gen_tcp`.


### PR DESCRIPTION
Fixes: N/A
Release version: 6.3.1, 7.0.0
Introduced in: N/A

## Summary

Mirrors emqx/emqx-docs#3896 back into this repo.

EMQX stopped releasing Windows packages in 5.4, so the #17854 changelog entry describing Windows behavior describes a platform we do not ship. Dropped `on Unix systems` and the trailing `and remains the default on Windows` clause.

Applied in both places the text lives:

- `changes/ee/feat-17854.en.md` — the per-PR entry
- `changes/6.3.0.en.md` — the aggregated release note

Wording now matches the docs repo verbatim. Changelog-only; no code or behavior change, and no changelog entry added for this PR itself.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|fix|perf|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)