### PR TITLE
build(deps): bump native dependencies

### DIFF
--- a/apps/emqx_bridge_datalayers/mix.exs
+++ b/apps/emqx_bridge_datalayers/mix.exs
@@ -32,7 +32,7 @@ defmodule EMQXBridgeDatalayers.MixProject do
   def deps() do
     UMP.deps([
       :influxdb,
-      {:datalayers, github: "datalayers-io/datalayers-adapter-erl", tag: "0.1.4", override: true},
+      {:datalayers, github: "datalayers-io/datalayers-adapter-erl", tag: "0.1.5", override: true},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}

--- a/mix.exs
+++ b/mix.exs
@@ -316,7 +316,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.2"}
 
   def common_dep(:greptimedb_rs),
-    do: {:greptimedb_rs, github: "emqx/greptimedb-ingester-erlnif", tag: "0.1.12"}
+    do: {:greptimedb_rs, github: "emqx/greptimedb-ingester-erlnif", tag: "0.1.13"}
 
   def common_dep(:sbom), do: {:sbom, "~> 0.8", runtime: false}
 
@@ -1153,7 +1153,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict with emqx and emqtt
       do: [
         {:quicer,
-         github: "emqx/quic", tag: "0.4.9", override: true, system_env: quicer_build_env()}
+         github: "emqx/quic", tag: "0.4.11", override: true, system_env: quicer_build_env()}
       ],
       else: []
   end


### PR DESCRIPTION
## Summary

- Bump `datalayers` to `0.1.5`.
- Bump `greptimedb_rs` to `0.1.13`.
- Bump `quicer` to `0.4.11`.
- These releases include published macOS 14/15/26 OTP 28 assets.

## Validation

- `make fmt-diff`
- `git diff --check`