### PR TITLE
perf(channel): build the limiter container on first use

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -240,6 +240,8 @@ info(alias_maximum, #channel{alias_maximum = Limits}) ->
     Limits;
 info(timers, #channel{timers = Timers}) ->
     Timers;
+info(quota, #channel{quota = Quota}) ->
+    Quota;
 info(session_state, #channel{session = Session}) ->
     Session;
 info(impl, #channel{session = Session}) ->
@@ -667,7 +669,7 @@ post_process_connect(
     }
 ) ->
     Channel = Channel0#channel{
-        quota = create_limiter(ClientInfo)
+        quota = adjust_limiter(ClientInfo)
     },
     case emqx_cm:open_session(CleanStart, ClientInfo, ConnInfo, MaybeWillMsg) of
         {ok, #{session := Session, present := false}} ->
@@ -689,9 +691,17 @@ post_process_connect(
             handle_out(connack, ?RC_UNSPECIFIED_ERROR, Channel)
     end.
 
-create_limiter(#{zone := Zone, listener := ListenerId} = ClientInfo) ->
-    Limiter = emqx_limiter:create_channel_client_container(Zone, ListenerId),
-    emqx_hooks:run_fold('channel.limiter_adjustment', [ClientInfo], Limiter).
+%% A hook callback may install a limiter container at connect time
+%% (e.g. multi-tenant limiters). Otherwise the field stays `undefined`
+%% and the container is built on first use; see ensure_quota/1.
+adjust_limiter(ClientInfo) ->
+    emqx_hooks:run_fold('channel.limiter_adjustment', [ClientInfo], undefined).
+
+ensure_quota(#channel{quota = undefined, clientinfo = ClientInfo} = Channel) ->
+    #{zone := Zone, listener := ListenerId} = ClientInfo,
+    Channel#channel{quota = emqx_limiter:create_channel_client_container(Zone, ListenerId)};
+ensure_quota(Channel) ->
+    Channel.
 
 handle_zone_change(
     _Output,
@@ -706,7 +716,7 @@ handle_zone_change(_Output, Channel) ->
 recreate_limiter(#channel{quota = undefined} = Channel) ->
     Channel;
 recreate_limiter(#channel{clientinfo = ClientInfo} = Channel) ->
-    Channel#channel{quota = create_limiter(ClientInfo)}.
+    Channel#channel{quota = adjust_limiter(ClientInfo)}.
 
 handle_session_zone_change(#channel{session = undefined} = Channel) ->
     Channel;
@@ -2946,8 +2956,9 @@ packing_alias(Packet, Channel) ->
 %% Check quota state
 
 check_quota_exceeded(
-    ?PUBLISH_PACKET(_QoS, Topic, _PacketId, Payload), #channel{quota = Quota} = Chann
+    ?PUBLISH_PACKET(_QoS, Topic, _PacketId, Payload), Chann0
 ) ->
+    #channel{quota = Quota} = Chann = ensure_quota(Chann0),
     Result = emqx_limiter_client_container:try_consume(
         Quota, [{bytes, erlang:byte_size(Payload)}, {messages, 1}]
     ),
@@ -2967,8 +2978,9 @@ check_quota_exceeded(
     end.
 
 check_subscribe_quota_exceeded(
-    #subscribe_operation{topic_filters = TopicFilters}, #channel{quota = Limiter0} = Chann
+    #subscribe_operation{topic_filters = TopicFilters}, Chann0
 ) ->
+    #channel{quota = Limiter0} = Chann = ensure_quota(Chann0),
     Result = emqx_limiter_client_container:try_consume(
         Limiter0, [{subscribes, 1}]
     ),

--- a/apps/emqx/src/emqx_hookpoints.erl
+++ b/apps/emqx/src/emqx_hookpoints.erl
@@ -281,8 +281,10 @@ when
 }) ->
     callback_result().
 
--callback 'channel.limiter_adjustment'(emqx_types:clientinfo(), emqx_limiter_client:t()) ->
-    fold_callback_result(emqx_limiter_client:t()).
+-callback 'channel.limiter_adjustment'(
+    emqx_types:clientinfo(), undefined | emqx_limiter_client:t()
+) ->
+    fold_callback_result(undefined | emqx_limiter_client:t()).
 
 -callback 'session.limiter_adjustment'(emqx_types:clientinfo(), emqx_limiter_client:t()) ->
     fold_callback_result(emqx_limiter_client:t()).

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -821,6 +821,63 @@ t_quota_bytes(_) ->
         emqx_channel:handle_in(Pub, Chann3),
     ok.
 
+-doc "A channel without a limiter container keeps none while only non-consuming packets arrive.".
+t_quota_lazy_stays_absent(_) ->
+    Chann = channel(#{conn_state => connected, quota => undefined}),
+    {ok, {outgoing, ?PACKET(?PINGRESP)}, Chann1} =
+        emqx_channel:handle_in(?PACKET(?PINGREQ), Chann),
+    ?assertEqual(undefined, emqx_channel:info(quota, Chann1)).
+
+-doc "Publish builds the limiter container on first use and the limit applies.".
+t_quota_lazy_build_on_publish(_) ->
+    timer:sleep(1200),
+    ok = meck:expect(emqx_broker, publish, fun(_) -> [{node(), <<"topic">>, {ok, 4}}] end),
+    Chann = channel(
+        clientinfo(#{listener => 'tcp:low_message_rate'}),
+        #{conn_state => connected, quota => undefined},
+        #{listener => {tcp, low_message_rate}}
+    ),
+    ?assertEqual(undefined, emqx_channel:info(quota, Chann)),
+    Pub = ?PUBLISH_PACKET(?QOS_1, <<"topic">>, 1, <<"payload">>),
+    {ok, {outgoing, ?PUBACK_PACKET(1, ?RC_SUCCESS)}, Chann1} =
+        emqx_channel:handle_in(Pub, Chann),
+    ?assertNotEqual(undefined, emqx_channel:info(quota, Chann1)),
+    {ok, {outgoing, ?PUBACK_PACKET(1, ?RC_QUOTA_EXCEEDED)}, _} =
+        emqx_channel:handle_in(Pub, Chann1),
+    ok.
+
+-doc "A rate limit configured after connect applies to a channel that built its container lazily.".
+t_quota_lazy_hot_update(_) ->
+    ListenerId = 'tcp:lazy_hot_update',
+    DefaultConf = emqx_config:get_listener_conf(tcp, default, []),
+    emqx_config:put_listener_conf(tcp, lazy_hot_update, [], DefaultConf),
+    ok = emqx_limiter:create_listener_limiters(ListenerId, #{}),
+    try
+        ok = meck:expect(emqx_broker, publish, fun(_) -> [{node(), <<"topic">>, {ok, 4}}] end),
+        Chann = channel(
+            clientinfo(#{listener => ListenerId}),
+            #{conn_state => connected, quota => undefined},
+            #{listener => {tcp, lazy_hot_update}}
+        ),
+        Pub = ?PUBLISH_PACKET(?QOS_1, <<"topic">>, 1, <<"payload">>),
+        %% No limit configured: both publishes pass.
+        {ok, {outgoing, ?PUBACK_PACKET(1, ?RC_SUCCESS)}, Chann1} =
+            emqx_channel:handle_in(Pub, Chann),
+        {ok, {outgoing, ?PUBACK_PACKET(1, ?RC_SUCCESS)}, Chann2} =
+            emqx_channel:handle_in(Pub, Chann1),
+        %% Configure a tight rate at runtime; the limit must apply without reconnect.
+        {ok, MessagesRate} = emqx_limiter_schema:to_rate("1/s"),
+        ok = emqx_limiter:update_listener_limiters(ListenerId, #{messages_rate => MessagesRate}),
+        timer:sleep(1200),
+        {ok, {outgoing, ?PUBACK_PACKET(1, ?RC_SUCCESS)}, Chann3} =
+            emqx_channel:handle_in(Pub, Chann2),
+        {ok, {outgoing, ?PUBACK_PACKET(1, ?RC_QUOTA_EXCEEDED)}, _} =
+            emqx_channel:handle_in(Pub, Chann3),
+        ok
+    after
+        emqx_limiter:delete_listener_limiters(ListenerId)
+    end.
+
 t_mount_will_msg(_) ->
     Self = self(),
     ClientInfo = clientinfo(#{mountpoint => <<"prefix/">>}),

--- a/changes/ee/perf-18806.en.md
+++ b/changes/ee/perf-18806.en.md
@@ -1,0 +1,6 @@
+Reduced memory usage of MQTT connections.
+
+Each connection allocated rate-limiter state at connect time, even when no rate limit is
+configured. The state is now allocated when the client first publishes or subscribes, so
+connections that only stay connected use about 2 KB less memory each. Configured rate limits
+behave the same as before.


### PR DESCRIPTION
Fixes:
Release version: 6.3.1, 7.0.0
Introduced in: 5.9.0

## Summary

An idle connection carries a fully built limiter client container in the channel state
(~2.2 KB of live heap per connection) even when no rate limit is configured. The container is
only consumed on PUBLISH and SUBSCRIBE, so connect-only clients pay for state they never
read. At 20k idle connections this is one BEAM heap-size step per connection process.

This PR builds the container on first use:

* At connect, `emqx_channel` runs only the `'channel.limiter_adjustment'` hook. A hook
  callback (multi-tenant limiters) may still install a container at that point; for everyone
  else the `quota` field stays `undefined`.
* `check_quota_exceeded/2` and `check_subscribe_quota_exceeded/2` materialize the container
  on first use via `ensure_quota/1`.
* A rate limit configured at runtime still applies: materialization happens on the consume
  path, and limiter clients re-read options from the limiter registry on every consume.
* Zone change resets the field back to the connect-time state, so the container is rebuilt
  with the new zone on next use.

Late materialization starts the exclusive buckets full at that moment, which equals the state
a connect-time bucket would have refilled to while idle, so no client gains tokens it could
not have had.

## Measured effect

10,000 idle MQTT v5 connections (`emqtt-bench conn -c 10000 -R 1000 -k 300`, connect only,
default config, socket TCP backend), single node, 6 minutes idle, after a forced full GC of
every channel process. Before = `dev-63` @ f8746e1359, after = this branch; identical
procedure and timing on the same host.

| Metric (per connection, mean over 10k) | before | after | delta |
|---|---:|---:|---:|
| `#channel.quota` live size (`erts_debug:flat_size`) | 270 words | 0 (atom) | -270 w |
| Connection `#state{}` live size | 628 words | 358 words | -43% |
| Process memory, hibernated channels (99+% of them) | 5,840 B | 4,280 B | -27% |
| Process memory, all channels | 5,934 B | 4,293 B | -28% |
| `erlang:memory(processes)` at 10k connections | 130 MB | 114 MB | -16 MB |

The -16 MB per 10k connections scales to ~1.6 GB per million idle connections.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)


