### PR TITLE
perf(sessmem): build the delivery limiter container on first use

### DIFF
--- a/apps/emqx/include/emqx_session_mem.hrl
+++ b/apps/emqx/include/emqx_session_mem.hrl
@@ -24,7 +24,9 @@
     %% Optionally, QoS0 messages pending transmission to the Client.
     mqueue :: emqx_mqueue:mqueue(),
     %% Delivery rate limiters.
-    quota :: emqx_limiter_client_container:t() | false,
+    %% `{lazy, ListenerId}` is a placeholder: the container is built on
+    %% first delivery, once a finite limit is configured.
+    quota :: emqx_limiter_client_container:t() | false | {lazy, emqx_limiter:listener_id()},
     %% Next packet id of the session
     next_pkt_id = 1 :: emqx_types:packet_id(),
     %% Retry interval for redelivering QoS1/2 messages (Unit: millisecond)

--- a/apps/emqx/src/emqx_hookpoints.erl
+++ b/apps/emqx/src/emqx_hookpoints.erl
@@ -286,8 +286,10 @@ when
 ) ->
     fold_callback_result(undefined | emqx_limiter_client:t()).
 
--callback 'session.limiter_adjustment'(emqx_types:clientinfo(), emqx_limiter_client:t()) ->
-    fold_callback_result(emqx_limiter_client:t()).
+-callback 'session.limiter_adjustment'(
+    emqx_types:clientinfo(), emqx_limiter_client:t() | {lazy, emqx_limiter:listener_id()}
+) ->
+    fold_callback_result(emqx_limiter_client:t() | {lazy, emqx_limiter:listener_id()}).
 
 %% NOTE
 %% Executed out of channel process context

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
@@ -24,7 +24,8 @@
     create_esockd_limiter_client/2,
     create_listener_limiter_client/2,
     create_channel_client_container/2,
-    create_session_client_container/1
+    create_session_client_container/1,
+    session_limits_configured/1
 ]).
 
 %% Generic limiter client API
@@ -50,7 +51,7 @@
     config_from_rate_and_burst/2
 ]).
 
--export_type([zone/0, group/0, name/0, id/0, options/0]).
+-export_type([zone/0, group/0, name/0, id/0, options/0, listener_id/0]).
 
 -type zone() :: atom().
 -type group() :: term().
@@ -147,6 +148,25 @@ create_channel_client_container(ZoneName, ListenerId) ->
 -spec create_session_client_container(listener_id()) -> emqx_limiter_client_container:t().
 create_session_client_container(ListenerId) ->
     create_session_client_container(ListenerId, ?SESSION_LIMITS).
+
+%% Check whether any session (delivery) limiter has a finite limit.
+-spec session_limits_configured(listener_id()) -> boolean().
+session_limits_configured(ListenerId) ->
+    case emqx_limiter_registry:find_group(channel_group(ListenerId)) of
+        undefined ->
+            false;
+        {_Module, LimiterOptions} ->
+            lists:any(
+                fun(Name) ->
+                    case lists:keyfind(Name, 1, LimiterOptions) of
+                        {_, #{capacity := infinity}} -> false;
+                        {_, _} -> true;
+                        false -> false
+                    end
+                end,
+                ?SESSION_LIMITS
+            )
+    end.
 
 -spec create_esockd_limiter_client(zone(), listener_id()) -> emqx_esockd_limiter:create_options().
 create_esockd_limiter_client(ZoneName, ListenerId) ->

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -219,8 +219,17 @@ create(
 create_limiter(_ClientInfo, #{enable_quota := false}) ->
     false;
 create_limiter(#{listener := ListenerId} = ClientInfo, _Conf) ->
-    Limiter = emqx_limiter:create_session_client_container(ListenerId),
-    emqx_hooks:run_fold('session.limiter_adjustment', [ClientInfo], Limiter).
+    %% A hook callback may install a limiter container here (e.g.
+    %% multi-tenant limiters). Otherwise the compact placeholder stays
+    %% and the container is built on first delivery; see
+    %% try_consume_delivery_rate_limit/2.
+    %%
+    %% The hook must run here, not at materialization: materialization
+    %% is gated by emqx_limiter:session_limits_configured/1, which only
+    %% sees listener-level limits. A hook-installed container (e.g. a
+    %% tenant with delivery limits under a listener with none) must not
+    %% depend on that gate.
+    emqx_hooks:run_fold('session.limiter_adjustment', [ClientInfo], {lazy, ListenerId}).
 
 get_mqueue_conf(Zone) ->
     #{
@@ -1177,6 +1186,14 @@ publish_will_message_now(#session{} = Session, #message{} = WillMsg) ->
 
 try_consume_delivery_rate_limit(_Msg, Limiter = false) ->
     {true, Limiter};
+try_consume_delivery_rate_limit(Msg, {lazy, ListenerId} = Limiter) ->
+    case emqx_limiter:session_limits_configured(ListenerId) of
+        false ->
+            {true, Limiter};
+        true ->
+            Container = emqx_limiter:create_session_client_container(ListenerId),
+            try_consume_delivery_rate_limit(Msg, Container)
+    end;
 try_consume_delivery_rate_limit(Msg, Limiter0) ->
     Ret = emqx_limiter_client_container:try_consume(Limiter0, [
         {delivery_bytes, emqx_message:estimate_size(Msg)},

--- a/apps/emqx/test/emqx_session_mem_SUITE.erl
+++ b/apps/emqx/test/emqx_session_mem_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx/include/emqx_session_mem.hrl").
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -702,6 +703,50 @@ test_retry_dequeue(QoS, _TCConfig) ->
     Session5 = emqx_session_mem:set_field(quota, limiter_client(ListenerId), Session4),
     {ok, [], _Session6} =
         emqx_session_mem:handle_timeout(clientinfo(), ?RETRY_DEQUEUE_TIMER, Session5).
+
+-doc """
+The session keeps the compact limiter placeholder while no delivery limit is configured.
+""".
+t_delivery_quota_lazy_stays_placeholder(_TCConfig) ->
+    ListenerId = 'tcp:lazy_no_limit',
+    create_limiters(ListenerId, #{}),
+    ?on_exit(delete_limiters(ListenerId)),
+    Session0 = session(#{listener => ListenerId}, #{}),
+    ?assertMatch(#session{quota = {lazy, ListenerId}}, Session0),
+    Delivers = enrich([delivery(?QOS_1, <<"t1">>), delivery(?QOS_1, <<"t2">>)], Session0),
+    {ok, [_Pub1, _Pub2], Session1} =
+        emqx_session_mem:deliver(clientinfo(), Delivers, [], Session0),
+    ?assertMatch(#session{quota = {lazy, ListenerId}}, Session1).
+
+-doc """
+A delivery limit configured after session creation applies without reconnect:
+the placeholder materializes into a container on the next delivery.
+""".
+t_delivery_quota_lazy_hot_update(_TCConfig) ->
+    ListenerId = 'tcp:lazy_hot_update',
+    create_limiters(ListenerId, #{}),
+    ?on_exit(delete_limiters(ListenerId)),
+    Session0 = session(#{listener => ListenerId}, #{}),
+    ?assertMatch(#session{quota = {lazy, ListenerId}}, Session0),
+    %% Configure a tight rate at runtime.
+    {ok, MessagesRate} = emqx_limiter_schema:to_rate("2/1s"),
+    ok = emqx_limiter:update_listener_limiters(ListenerId, #{
+        delivery_messages_rate => MessagesRate
+    }),
+    Delivers = enrich(
+        [
+            delivery(?QOS_1, <<"t1">>),
+            delivery(?QOS_1, <<"t2">>),
+            delivery(?QOS_1, <<"t3">>),
+            delivery(?QOS_1, <<"t4">>)
+        ],
+        Session0
+    ),
+    %% Only two messages come out; the rest wait for the retry timer.
+    {Effect, [_Pub1, _Pub2], Session1} =
+        emqx_session_mem:deliver(clientinfo(), Delivers, [], Session0),
+    ?assertMatch({set_timer, ?RETRY_DEQUEUE_TIMER, _}, Effect),
+    ?assertMatch(#session{quota = #{}}, Session1).
 
 -doc """
 Verifies that delivery limits do not compromise message ordering.

--- a/changes/ee/perf-18807.en.md
+++ b/changes/ee/perf-18807.en.md
@@ -1,0 +1,6 @@
+Reduced memory usage of MQTT sessions.
+
+Each session allocated delivery rate-limiter state at creation, even when no delivery rate
+limit is configured. The state is now allocated on first delivery after a delivery rate limit
+is configured, saving about 0.5 KB per session. Configured delivery rate limits behave the
+same as before.


### PR DESCRIPTION
Fixes:
Release version: 6.3.1, 7.0.0
Introduced in: 6.1.2

## Summary

Every in-memory MQTT session carries a delivery limiter client container (64 words of live
heap) even when no delivery rate limit is configured. The container is only consumed on
message delivery.

This PR stores a compact `{lazy, ListenerId}` placeholder in `#session.quota` instead:

* `emqx_session_mem:create_limiter/2` runs the `'session.limiter_adjustment'` hook over the
  placeholder. A hook callback (multi-tenant limiters) may still install a real container at
  session creation; the MQTT-SN `enable_quota => false` path is unchanged.
* `try_consume_delivery_rate_limit/2` checks the limiter registry when it sees the
  placeholder: with no finite delivery limit it grants and keeps the placeholder; once a
  finite limit is configured (also at runtime, without reconnect) it builds the container via
  `emqx_limiter:create_session_client_container/1` and consumes from it. The registry read
  matches what a materialized client already performs on every consume.
* New helper `emqx_limiter:session_limits_configured/1` reports whether any session
  (delivery) limiter of a listener has a finite limit.

Related: #18806 applies the same treatment to the channel-level limiter container.

## Measured effect

10,000 idle MQTT v5 connections (`emqtt-bench conn -c 10000 -R 1000 -k 300`, connect only,
default config, socket TCP backend), single node, 6 minutes idle, after a forced full GC of
every channel process. Before = `dev-63` @ 96e1af4f78 (includes #18806), after = this branch
rebased on it; identical procedure and timing on the same host.

| Metric (per connection, mean over 10k) | before | after | delta |
|---|---:|---:|---:|
| `#session.quota` live size (`erts_debug:flat_size`) | 64 words | 3 words (placeholder) | -61 w |
| Connection `#state{}` live size | 358 words | 297 words | -17% |
| Process memory, hibernated channels | 4,216 B | 3,888 B | -8% |
| Process memory, resident channels | 8,128 B | 6,171 B | -24% |

The resident saving is larger than the raw 61 words because 297 live words fit one BEAM
heap-size step lower (377 instead of 610). The whole-population mean depends on the
hibernated fraction at sample time (95% vs 79% in these runs), so the split means are the
comparable figures.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)



