### PR TITLE
perf(limiter): keep container entries lazy until a finite limit is set

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
@@ -410,27 +410,18 @@ create_listener_limiter(ZoneName, ListenerId, Name) ->
         ZoneLimiterClient, ListenerLimiterClient
     ]).
 
-create_channel_limiter(_ZoneName, ListenerId, Name) when ?IS_CHANNEL_ONLY_LIMITER(Name) ->
-    ChannelLimiterId = {channel_group(ListenerId), Name},
-    connect(ChannelLimiterId);
-create_channel_limiter(ZoneName, ListenerId, Name) ->
-    ZoneLimiterId = {zone_group(ZoneName), Name},
-    ZoneLimiterClient = connect(ZoneLimiterId),
-    ChannelLimiterId = {channel_group(ListenerId), Name},
-    ChannelLimiterClient = connect(ChannelLimiterId),
-    emqx_limiter_composite:new([
-        ZoneLimiterClient, ChannelLimiterClient
-    ]).
+%% Containers hold lazy entries: compact limiter id lists that connect into
+%% real clients on the first consume after a finite limit is configured.
 
-create_session_limiter(ListenerId, Name) ->
-    ChannelLimiterId = {channel_group(ListenerId), Name},
-    connect(ChannelLimiterId).
+channel_limiter_ids(_ZoneName, ListenerId, Name) when ?IS_CHANNEL_ONLY_LIMITER(Name) ->
+    [{channel_group(ListenerId), Name}];
+channel_limiter_ids(ZoneName, ListenerId, Name) ->
+    [{zone_group(ZoneName), Name}, {channel_group(ListenerId), Name}].
 
 create_channel_client_container(ZoneName, ListenerId, Names) ->
     Clients = lists:map(
         fun(Name) ->
-            LimiterClient = create_channel_limiter(ZoneName, ListenerId, Name),
-            {Name, LimiterClient}
+            {Name, {lazy, channel_limiter_ids(ZoneName, ListenerId, Name)}}
         end,
         Names
     ),
@@ -439,8 +430,7 @@ create_channel_client_container(ZoneName, ListenerId, Names) ->
 create_session_client_container(ListenerId, Names) ->
     Clients = lists:map(
         fun(Name) ->
-            LimiterClient = create_session_limiter(ListenerId, Name),
-            {Name, LimiterClient}
+            {Name, {lazy, [{channel_group(ListenerId), Name}]}}
         end,
         Names
     ),

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_client_container.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_client_container.erl
@@ -6,6 +6,11 @@
 %% A convenience module for managing a collection of limiters identified by names.
 %% It allows to consume from several limiters with a single call.
 %%
+%% An entry may be a connected client or a lazy `{lazy, LimiterIds}` spec.
+%% A lazy entry stays a compact id list while every one of its limiters is
+%% unlimited, and connects into a real client on the first consume after a
+%% finite limit is configured.
+%%
 -module(emqx_limiter_client_container).
 
 -export([
@@ -17,16 +22,17 @@
 %% Type declarations
 %%------------------------------------------------------------------------------
 
--type t() :: #{emqx_limiter:name() => emqx_limiter_client:t()}.
+-type entry() :: emqx_limiter_client:t() | {lazy, [emqx_limiter:id()]}.
+-type t() :: #{emqx_limiter:name() => entry()}.
 -type reason() :: emqx_limiter_client:reason().
 
--export_type([t/0, reason/0]).
+-export_type([t/0, entry/0, reason/0]).
 
 %%--------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
 
--spec new(list({emqx_limiter:name(), emqx_limiter_client:t()})) -> t().
+-spec new(list({emqx_limiter:name(), entry()})) -> t().
 new(Clients) ->
     maps:from_list(Clients).
 
@@ -43,18 +49,55 @@ try_consume_from_clients(Container, [], _Consumed) ->
     {true, Container};
 try_consume_from_clients(Container, [{Name, Amount} | Rest], Consumed) ->
     case Container of
-        #{Name := Client} ->
-            case emqx_limiter_client:try_consume(Client, Amount) of
-                {true, NewClient} ->
-                    try_consume_from_clients(Container#{Name => NewClient}, Rest, [
-                        {Name, Amount} | Consumed
-                    ]);
-                {false, NewClient, Reason} ->
-                    {false, put_back_to_clients(Container#{Name => NewClient}, Consumed), Reason}
+        #{Name := {lazy, LimiterIds}} ->
+            case materialize(LimiterIds) of
+                unlimited ->
+                    try_consume_from_clients(Container, Rest, Consumed);
+                {ok, Client} ->
+                    try_consume_from_client(Container, Client, Name, Amount, Rest, Consumed)
             end;
+        #{Name := Client} ->
+            try_consume_from_client(Container, Client, Name, Amount, Rest, Consumed);
         _ ->
             error({limiter_not_found_in_container, Name})
     end.
+
+try_consume_from_client(Container, Client, Name, Amount, Rest, Consumed) ->
+    case emqx_limiter_client:try_consume(Client, Amount) of
+        {true, NewClient} ->
+            try_consume_from_clients(Container#{Name => NewClient}, Rest, [
+                {Name, Amount} | Consumed
+            ]);
+        {false, NewClient, Reason} ->
+            {false, put_back_to_clients(Container#{Name => NewClient}, Consumed), Reason}
+    end.
+
+materialize(LimiterIds) ->
+    case lists:all(fun is_unlimited/1, LimiterIds) of
+        true ->
+            unlimited;
+        false ->
+            {ok, connect_clients(LimiterIds)}
+    end.
+
+%% A limiter whose group or name is gone is treated as unlimited (fail open),
+%% consistent with how connected clients handle a vanished limiter.
+is_unlimited({Group, Name}) ->
+    case emqx_limiter_registry:find_group(Group) of
+        undefined ->
+            true;
+        {_Module, LimiterOptions} ->
+            case lists:keyfind(Name, 1, LimiterOptions) of
+                {_, #{capacity := infinity}} -> true;
+                {_, _} -> false;
+                false -> true
+            end
+    end.
+
+connect_clients([LimiterId]) ->
+    emqx_limiter:connect(LimiterId);
+connect_clients(LimiterIds) ->
+    emqx_limiter_composite:new([emqx_limiter:connect(Id) || Id <- LimiterIds]).
 
 put_back_to_clients(Container, []) ->
     Container;

--- a/apps/emqx/test/emqx_limiter_client_container_SUITE.erl
+++ b/apps/emqx/test/emqx_limiter_client_container_SUITE.erl
@@ -18,7 +18,17 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx], #{work_dir => emqx_cth_suite:work_dir(Config)}),
+    %% No listener is needed; not binding ports lets the suite run
+    %% beside a running broker.
+    ListenerConf =
+        "listeners.tcp.default.enable = false\n"
+        "listeners.ssl.default.enable = false\n"
+        "listeners.ws.default.enable = false\n"
+        "listeners.wss.default.enable = false",
+    Apps = emqx_cth_suite:start(
+        [{emqx, ListenerConf}],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
@@ -69,4 +79,102 @@ t_try_consume_from_nonexistent_limiter(_) ->
     ?assertError(
         {limiter_not_found_in_container, limiter1},
         emqx_limiter_client_container:try_consume(Container, [{limiter1, 1}])
+    ).
+
+-doc "A lazy entry of an unlimited limiter grants consume and stays lazy.".
+t_lazy_entry_unlimited(_) ->
+    ok = emqx_limiter:create_group(exclusive, group1, [
+        {limiter1, #{capacity => infinity}}
+    ]),
+    Container0 = emqx_limiter_client_container:new([
+        {limiter1, {lazy, [{group1, limiter1}]}}
+    ]),
+    {true, Container1} =
+        emqx_limiter_client_container:try_consume(Container0, [{limiter1, 1000}]),
+    ?assertEqual(Container0, Container1).
+
+-doc "A lazy entry of a limited limiter connects on first consume and enforces the limit.".
+t_lazy_entry_materializes(_) ->
+    ok = emqx_limiter:create_group(exclusive, group1, [
+        {limiter1, #{capacity => 2, interval => 60000, burst_capacity => 0}}
+    ]),
+    Container0 = emqx_limiter_client_container:new([
+        {limiter1, {lazy, [{group1, limiter1}]}}
+    ]),
+    {true, Container1} =
+        emqx_limiter_client_container:try_consume(Container0, [{limiter1, 2}]),
+    ?assertMatch(#{limiter1 := #{module := _}}, Container1),
+    {false, _Container2, {failed_to_consume_from_limiter, {group1, limiter1}}} =
+        emqx_limiter_client_container:try_consume(Container1, [{limiter1, 1}]).
+
+-doc "A limit configured after container creation applies on the next consume.".
+t_lazy_entry_hot_update(_) ->
+    ok = emqx_limiter:create_group(exclusive, group1, [
+        {limiter1, #{capacity => infinity}}
+    ]),
+    Container0 = emqx_limiter_client_container:new([
+        {limiter1, {lazy, [{group1, limiter1}]}}
+    ]),
+    {true, Container1} =
+        emqx_limiter_client_container:try_consume(Container0, [{limiter1, 1000}]),
+    ?assertEqual(Container0, Container1),
+    ok = emqx_limiter:update_group(group1, [
+        {limiter1, #{capacity => 2, interval => 60000, burst_capacity => 0}}
+    ]),
+    {true, Container2} =
+        emqx_limiter_client_container:try_consume(Container1, [{limiter1, 2}]),
+    ?assertMatch(#{limiter1 := #{module := _}}, Container2),
+    {false, _Container3, {failed_to_consume_from_limiter, {group1, limiter1}}} =
+        emqx_limiter_client_container:try_consume(Container2, [{limiter1, 1}]).
+
+-doc "A lazy entry whose group is gone is treated as unlimited.".
+t_lazy_entry_missing_group(_) ->
+    Container0 = emqx_limiter_client_container:new([
+        {limiter1, {lazy, [{nonexistent_group, limiter1}]}}
+    ]),
+    {true, Container1} =
+        emqx_limiter_client_container:try_consume(Container0, [{limiter1, 1}]),
+    ?assertEqual(Container0, Container1).
+
+-doc "A lazy entry with several limiter ids connects them into a composite client.".
+t_lazy_entry_composite(_) ->
+    ok = emqx_limiter:create_group(exclusive, group1, [
+        {limiter1, #{capacity => 2, interval => 60000, burst_capacity => 0}}
+    ]),
+    ok = emqx_limiter:create_group(exclusive, group2, [
+        {limiter1, #{capacity => infinity}}
+    ]),
+    Container0 = emqx_limiter_client_container:new([
+        {limiter1, {lazy, [{group1, limiter1}, {group2, limiter1}]}}
+    ]),
+    {true, Container1} =
+        emqx_limiter_client_container:try_consume(Container0, [{limiter1, 2}]),
+    {false, _Container2, {failed_to_consume_from_limiter, {group1, limiter1}}} =
+        emqx_limiter_client_container:try_consume(Container1, [{limiter1, 1}]).
+
+-doc """
+When a later limiter denies, tokens consumed from real clients are put back;
+lazy-granted entries need no put-back.
+""".
+t_lazy_entry_mixed_put_back(_) ->
+    ok = emqx_limiter:create_group(exclusive, group1, [
+        {limiter1, #{capacity => infinity}},
+        {limiter2, #{capacity => 2, interval => 60000, burst_capacity => 0}},
+        {limiter3, #{capacity => 1, interval => 60000, burst_capacity => 0}}
+    ]),
+    Container0 = emqx_limiter_client_container:new([
+        {limiter1, {lazy, [{group1, limiter1}]}},
+        {limiter2, emqx_limiter:connect({group1, limiter2})},
+        {limiter3, emqx_limiter:connect({group1, limiter3})}
+    ]),
+    %% limiter3 denies; limiter2's tokens go back, limiter1 stays lazy.
+    {false, Container1, {failed_to_consume_from_limiter, {group1, limiter3}}} =
+        emqx_limiter_client_container:try_consume(
+            Container0,
+            [{limiter1, 1}, {limiter2, 2}, {limiter3, 2}]
+        ),
+    ?assertMatch(#{limiter1 := {lazy, _}}, Container1),
+    {true, _Container2} = emqx_limiter_client_container:try_consume(
+        Container1,
+        [{limiter1, 1}, {limiter2, 2}, {limiter3, 1}]
     ).

--- a/changes/ee/perf-18808.en.md
+++ b/changes/ee/perf-18808.en.md
@@ -1,0 +1,6 @@
+Reduced memory usage of MQTT connections that publish or subscribe.
+
+Rate-limiter state per connection is now allocated only for rate limits that are actually
+configured. With default settings (no rate limits) an active connection uses about 1.6 KB
+less memory. Configured rate limits behave the same as before, including limits added at
+runtime.


### PR DESCRIPTION
Fixes:
Release version: 6.3.1, 7.0.0
Introduced in: 5.9.0

## Summary

#18806 and #18807 stop idle connections from building limiter client containers. A
connection that publishes or subscribes still materializes the full container (~270 words of
live heap for the channel container) even when every limit is at its default (unlimited).

This PR makes the container entries themselves lazy:

* `emqx_limiter_client_container` entries may now be `{lazy, LimiterIds}` specs beside
  connected clients. On consume, a lazy entry checks the limiter registry: while every
  limiter of the entry is unlimited it grants and stays lazy (one persistent_term read, the
  same read a connected client performs on every consume); once a finite limit is configured
  — also at runtime, without reconnect — it connects into a real client (a composite for
  zone + listener pairs) and consumes from it.
* `emqx_limiter:create_channel_client_container/2` and
  `create_session_client_container/1` emit lazy entries instead of connecting eagerly.
* A vanished group or name is treated as unlimited, matching how connected clients fail
  open on a missing limiter.
* Multi-tenant containers (`emqx_mt_limiter`) still build connected clients; mixed
  containers work unchanged.

Also makes `emqx_limiter_client_container_SUITE` boot without binding listener ports, so it
can run beside a running broker.

With default settings an active connection's channel container drops from 270 words to 59;
combined with #18806/#18807, connect-only clients carry none at all.

## Measured effect

10,000 MQTT v5 clients that each SUBSCRIBE once and then idle (`emqtt-bench sub -c 10000
-R 1000 -k 300 -t 'bench/%i'`; SUBSCRIBE materializes the channel container), default
config, socket TCP backend, single node, 6 minutes idle, after a forced full GC of every
channel process. Before = `dev-63` @ a4f0a6304b (includes #18806 and #18807), after = this
branch on top of it; identical procedure and timing on the same host.

| Metric (per connection, mean over 10k) | before | after | delta |
|---|---:|---:|---:|
| `#channel.quota` live size (`erts_debug:flat_size`) | 270 words | 59 words | -78% |
| Connection `#state{}` live size | 591 words | 380 words | -36% |
| Process memory, hibernated channels (91-99% of them) | 6,023 B | 4,887 B | -19% |

The whole-population mean depends on the hibernated fraction at sample time (99.8% vs
90.9% in these runs), so the hibernated mean is the comparable figure. Idle connect-only
clients are unaffected by this PR (they carry no container since #18806).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

