### PR TITLE
perf(limiter): drop copied static data from shared client state

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_shared/emqx_limiter_bucket_registry.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_shared/emqx_limiter_bucket_registry.erl
@@ -1,12 +1,20 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2019-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
-%% @doc Registry for shared limiter buckets.
-
+%% @doc Registry of shared limiter instances (buckets).
+%%
+%% `emqx_limiter_registry' holds limiter prototypes (options); this module
+%% holds the live buckets of the shared limiter kind, keyed by group.
+%%
+%% Buckets are stored in `persistent_term', one key per group, so that a
+%% consumer reads its bucket as a literal reference: no ETS copy, no
+%% garbage. Writes go through this process. A group's buckets are stored
+%% once at creation (a new key: no global GC) and erased with the group.
+%% Option updates reset the atomics in place and never rewrite the key.
 -module(emqx_limiter_bucket_registry).
+
 -include_lib("emqx/include/logger.hrl").
--include_lib("stdlib/include/ms_transform.hrl").
 
 -behaviour(gen_server).
 
@@ -15,10 +23,6 @@
     find_bucket/1,
     insert_buckets/2,
     delete_buckets/1
-]).
-
--export([
-    create_table/0
 ]).
 
 -export([
@@ -34,39 +38,33 @@
 -type bucket_ref() :: emqx_limiter_shared:bucket_ref().
 -type limiter_id() :: emqx_limiter:id().
 
--define(TABLE, ?MODULE).
-
--record(bucket_ref, {
-    key :: {group(), name() | '_'},
-    bucket_ref :: bucket_ref() | '_'
-}).
+-define(PT_KEY(GROUP), {?MODULE, GROUP}).
 
 %%--------------------------------------------------------------------
-%%  Messages
+%% gen_server messages
 %%--------------------------------------------------------------------
 
 -record(insert_buckets, {
-    group :: emqx_limiter:group(),
-    buckets :: [{emqx_limiter:name(), bucket_ref()}]
+    group :: group(),
+    buckets :: [{name(), bucket_ref()}]
 }).
 
 -record(delete_buckets, {
-    group :: emqx_limiter:group()
+    group :: group()
 }).
 
 %%--------------------------------------------------------------------
-%%  API
+%% API
 %%--------------------------------------------------------------------
 
 -spec find_bucket(limiter_id()) -> bucket_ref() | undefined.
-find_bucket(LimiterId) ->
-    try
-        ets:lookup_element(?TABLE, LimiterId, #bucket_ref.bucket_ref)
-    catch
-        error:badarg -> undefined
+find_bucket({Group, Name}) ->
+    case persistent_term:get(?PT_KEY(Group), undefined) of
+        #{Name := BucketRef} -> BucketRef;
+        _ -> undefined
     end.
 
--spec insert_buckets(group(), [{limiter_id(), bucket_ref()}]) -> ok.
+-spec insert_buckets(group(), [{name(), bucket_ref()}]) -> ok.
 insert_buckets(Group, Buckets) ->
     gen_server:call(?MODULE, #insert_buckets{group = Group, buckets = Buckets}, infinity).
 
@@ -78,47 +76,35 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %%--------------------------------------------------------------------
-%% Internal API
-%%--------------------------------------------------------------------
-
-create_table() ->
-    ok = emqx_utils_ets:new(?TABLE, [named_table, ordered_set, public, {keypos, #bucket_ref.key}]).
-
-%%--------------------------------------------------------------------
-%%  gen_server callbacks
+%% gen_server callbacks
 %%--------------------------------------------------------------------
 
 init([]) ->
-    {ok, #{}}.
+    process_flag(trap_exit, true),
+    {ok, #{groups => sets:new([{version, 2}])}}.
 
-handle_call(
-    #insert_buckets{group = Group, buckets = Buckets},
-    _From,
-    State
-) ->
-    Records = lists:map(
-        fun({Name, BucketRef}) ->
-            #bucket_ref{key = {Group, Name}, bucket_ref = BucketRef}
+handle_call(#insert_buckets{group = Group, buckets = Buckets}, _From, #{groups := Groups} = State) ->
+    _ = persistent_term:put(?PT_KEY(Group), maps:from_list(Buckets)),
+    {reply, ok, State#{groups := sets:add_element(Group, Groups)}};
+handle_call(#delete_buckets{group = Group}, _From, #{groups := Groups} = State) ->
+    _ = persistent_term:erase(?PT_KEY(Group)),
+    {reply, ok, State#{groups := sets:del_element(Group, Groups)}};
+handle_call(Req, _From, State) ->
+    ?SLOG(error, #{msg => "unexpected_call", call => Req}),
+    {reply, ignore, State}.
+
+handle_cast(Req, State) ->
+    ?SLOG(error, #{msg => "unexpected_cast", cast => Req}),
+    {noreply, State}.
+
+handle_info(Req, State) ->
+    ?SLOG(error, #{msg => "unexpected_info", info => Req}),
+    {noreply, State}.
+
+terminate(_Reason, #{groups := Groups} = _State) ->
+    lists:foreach(
+        fun(Group) ->
+            _ = persistent_term:erase(?PT_KEY(Group))
         end,
-        Buckets
-    ),
-    _ = ets:insert(?TABLE, Records),
-    {reply, ok, State};
-handle_call(#delete_buckets{group = Group}, _From, State) ->
-    MatchSpec = #bucket_ref{key = {Group, '_'}, _ = '_'},
-    _ = ets:match_delete(?TABLE, MatchSpec),
-    {reply, ok, State};
-handle_call(Request, _From, State) ->
-    ?SLOG(warning, #{msg => unknown_request, request => Request}),
-    {reply, {error, not_implemented}, State}.
-
-handle_cast(Request, State) ->
-    ?SLOG(warning, #{msg => unknown_cast, request => Request}),
-    {noreply, State}.
-
-handle_info(Request, State) ->
-    ?SLOG(warning, #{msg => unknown_info, request => Request}),
-    {noreply, State}.
-
-terminate(_Reason, _State) ->
-    ok.
+        sets:to_list(Groups)
+    ).

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_shared/emqx_limiter_shared.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_shared/emqx_limiter_shared.erl
@@ -59,12 +59,11 @@
     last_burst_time := atomic_value()
 }.
 
--type client_state() :: #{
-    limiter_id := emqx_limiter:id(),
-    bucket_ref := bucket_ref(),
-    mode := mode(),
-    options := emqx_limiter:options()
-}.
+%% The client state is just the limiter identity. The options come from
+%% the limiter registry and the bucket from the bucket registry on every
+%% use; both are persistent_term reads. This keeps the per-process copy
+%% small: channels hold a client per limiter.
+-type client_state() :: emqx_limiter:id().
 
 -type reason() :: emqx_limiter_client:reason().
 
@@ -98,7 +97,7 @@
 ]) -> ok | {error, term()}.
 create_group(Group, LimiterConfigs) when length(LimiterConfigs) > 0 ->
     Size = length(LimiterConfigs),
-    %% Factor 3 is because we have 4 atomics per limiter:
+    %% Factor 4 is because we have 4 atomics per limiter:
     %% mini_tokens
     %% last_time
     %% burst_tokens
@@ -117,7 +116,7 @@ delete_group(Group) ->
 update_group(Group, LimiterConfigs) ->
     NowUs = now_us_monotonic(),
     Buckets = [
-        emqx_limiter_bucket_registry:find_bucket({Group, Name})
+        find_bucket({Group, Name})
      || {Name, _} <- LimiterConfigs
     ],
     ok = reset_buckets(LimiterConfigs, Buckets, NowUs),
@@ -125,70 +124,78 @@ update_group(Group, LimiterConfigs) ->
 
 -spec connect(emqx_limiter:id()) -> emqx_limiter_client:t().
 connect(LimiterId) ->
-    case emqx_limiter_bucket_registry:find_bucket(LimiterId) of
+    case find_bucket(LimiterId) of
         undefined ->
             error({bucket_not_found, LimiterId});
-        BucketRef ->
-            Options = emqx_limiter_registry:get_limiter_options(LimiterId),
-            emqx_limiter_client:new(
-                ?MODULE,
-                _State = #{
-                    limiter_id => LimiterId,
-                    bucket_ref => BucketRef,
-                    mode => calc_mode(Options),
-                    options => Options
-                }
-            )
+        _BucketRef ->
+            emqx_limiter_client:new(?MODULE, _State = LimiterId)
     end.
+
+find_bucket(LimiterId) ->
+    emqx_limiter_bucket_registry:find_bucket(LimiterId).
 
 %%--------------------------------------------------------------------
 %% emqx_limiter_client callbacks
 %%--------------------------------------------------------------------
 
 -spec try_consume(client_state(), non_neg_integer()) ->
-    true | {true, client_state()} | {false, client_state(), reason()}.
-try_consume(#{limiter_id := LimiterId} = State, Amount) ->
+    true | {false, client_state(), reason()}.
+try_consume(LimiterId, Amount) ->
     Options = emqx_limiter_registry:get_limiter_options(LimiterId),
     case Options of
         #{capacity := infinity} ->
             true;
         _ ->
-            Result =
-                case try_consume(State, Options, Amount) of
-                    {true = Success, State1} ->
-                        {true, State1};
-                    {false = Success, State1} ->
-                        {false, State1, {failed_to_consume_from_limiter, LimiterId}}
+            Success =
+                case find_bucket(LimiterId) of
+                    undefined ->
+                        %% The group is gone (e.g. deleted concurrently); fail open.
+                        true;
+                    BucketRef ->
+                        do_try_consume(BucketRef, calc_mode(Options), Options, Amount)
                 end,
             ?tp(limiter_shared_try_consume, #{
                 limiter_id => LimiterId,
                 amount => Amount,
                 success => Success
             }),
-            Result
+            case Success of
+                true ->
+                    true;
+                false ->
+                    {false, LimiterId, {failed_to_consume_from_limiter, LimiterId}}
+            end
     end.
 
 -spec put_back(client_state(), non_neg_integer()) -> client_state().
-put_back(#{bucket_ref := BucketRef, mode := Mode} = State, Amount) ->
-    case Mode of
-        #token_mode{us_per_token = UsPerToken} ->
-            #{last_time := LastTime} = BucketRef,
-            ok = atomic_sub(LastTime, UsPerToken * Amount);
-        #mini_token_mode{} ->
-            #{mini_tokens := MiniTokens} = BucketRef,
-            AmountMini = Amount * 1000,
-            ok = atomic_add(MiniTokens, AmountMini)
-    end,
-    State.
+put_back(LimiterId, Amount) ->
+    Options = emqx_limiter_registry:get_limiter_options(LimiterId),
+    case find_bucket(LimiterId) of
+        undefined ->
+            LimiterId;
+        BucketRef ->
+            case calc_mode(Options) of
+                #token_mode{us_per_token = UsPerToken} ->
+                    #{last_time := LastTime} = BucketRef,
+                    ok = atomic_sub(LastTime, UsPerToken * Amount);
+                #mini_token_mode{} ->
+                    #{mini_tokens := MiniTokens} = BucketRef,
+                    AmountMini = Amount * 1000,
+                    ok = atomic_add(MiniTokens, AmountMini)
+            end,
+            LimiterId
+    end.
 
 -spec inspect(client_state()) -> map().
-inspect(#{bucket_ref := BucketRef, mode := Mode, options := Options} = _State) ->
+inspect(LimiterId) ->
+    Options = emqx_limiter_registry:get_limiter_options(LimiterId),
+    BucketRef = find_bucket(LimiterId),
     #{last_time := LastTime, mini_tokens := MiniTokens} = BucketRef,
     LastTimeUs = atomic_get(LastTime),
     #{capacity := Capacity, interval := IntervalMs} = Options,
     TimeLeftUs = now_us_monotonic() - LastTimeUs,
     #{
-        mode => Mode,
+        mode => calc_mode(Options),
         time_left_us => TimeLeftUs,
         mini_tokens => atomic_get(MiniTokens),
         tokens_left => ((TimeLeftUs * Capacity) div IntervalMs) div 1000
@@ -229,36 +236,35 @@ init_bucket(BucketRef, Options, NowUs) ->
     ok = apply_burst(BucketRef, Options, NowUs),
     ok.
 
-try_consume(State0, Options, Amount) ->
-    {Mode, State1} = mode(State0, Options),
-    {try_consume(State1, Mode, Options, Amount, now_us_monotonic()), State1}.
+do_try_consume(BucketRef, Mode, Options, Amount) ->
+    do_try_consume(BucketRef, Mode, Options, Amount, now_us_monotonic()).
 
-try_consume(State, Mode, #{burst_capacity := 0} = Options, Amount, NowUs) ->
-    case try_consume_regular(State, Mode, Options, Amount, NowUs) of
+do_try_consume(BucketRef, Mode, #{burst_capacity := 0} = Options, Amount, NowUs) ->
+    case try_consume_regular(BucketRef, Mode, Options, Amount, NowUs) of
         ok ->
             true;
         failed ->
             false
     end;
-try_consume(State, Mode, Options, Amount, NowUs) ->
-    case try_consume_accumulated_burst(State, Amount) of
+do_try_consume(BucketRef, Mode, Options, Amount, NowUs) ->
+    case try_consume_accumulated_burst(BucketRef, Amount) of
         ok ->
             true;
         {failed, LastBurstTimeUs} ->
-            case try_consume_regular(State, Mode, Options, Amount, NowUs) of
+            case try_consume_regular(BucketRef, Mode, Options, Amount, NowUs) of
                 ok ->
                     true;
                 failed ->
-                    case try_burst(State, Options, LastBurstTimeUs, NowUs) of
+                    case try_burst(BucketRef, Options, LastBurstTimeUs, NowUs) of
                         ok ->
-                            try_consume(State, Mode, Options, Amount, now_us_monotonic());
+                            do_try_consume(BucketRef, Mode, Options, Amount);
                         failed ->
                             false
                     end
             end
     end.
 
-try_consume_accumulated_burst(#{bucket_ref := BucketRef}, Amount) ->
+try_consume_accumulated_burst(BucketRef, Amount) ->
     #{
         burst_tokens := BurstTokens,
         last_burst_time := LastBurstTime
@@ -281,7 +287,7 @@ try_consume_accumulated_burst(#{bucket_ref := BucketRef}, Amount) ->
 Try to consume regular tokens when there are no accumulated burst tokens.
 """.
 try_consume_regular(
-    #{bucket_ref := BucketRef} = State,
+    BucketRef,
     #token_mode{us_per_token = UsPerToken, max_time_us = MaxTimeUs} = Mode,
     Options,
     Amount,
@@ -293,12 +299,12 @@ try_consume_regular(
         ok ->
             ok;
         retry ->
-            try_consume_regular(State, Mode, Options, Amount, now_us_monotonic());
+            try_consume_regular(BucketRef, Mode, Options, Amount, now_us_monotonic());
         failed ->
             failed
     end;
 try_consume_regular(
-    #{bucket_ref := BucketRef} = State,
+    BucketRef,
     #mini_token_mode{mini_tokens_per_ms = MiniTokensPerMs, max_time_us = MaxTimeUs} = Mode,
     Options,
     Amount,
@@ -322,14 +328,14 @@ try_consume_regular(
                 ok ->
                     ok = atomic_add(MiniTokens, LeftOver);
                 retry ->
-                    try_consume_regular(State, Mode, Options, Amount, now_us_monotonic());
+                    try_consume_regular(BucketRef, Mode, Options, Amount, now_us_monotonic());
                 failed ->
                     failed
             end
     end.
 
 try_burst(
-    #{bucket_ref := BucketRef} = _State,
+    BucketRef,
     #{burst_interval := BurstIntervalMs} = Options,
     LastBurstTimeUs,
     NowUs
@@ -408,13 +414,7 @@ init_last_time(
 now_us_monotonic() ->
     erlang:monotonic_time(microsecond).
 
-%% Do not re-calculate the mode if Options did not change
-mode(#{options := Options, mode := Mode} = State, Options) ->
-    {Mode, State};
-mode(State, NewOptions) ->
-    Mode = calc_mode(NewOptions),
-    {Mode, State#{mode := Mode}}.
-
+-spec calc_mode(emqx_limiter:options()) -> mode().
 calc_mode(#{capacity := infinity}) ->
     #token_mode{us_per_token = 1, max_time_us = 1};
 calc_mode(#{capacity := Capacity, interval := IntervalMs}) ->

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_sup.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_sup.erl
@@ -30,7 +30,6 @@ init([]) ->
         period => 3600
     },
 
-    ok = emqx_limiter_bucket_registry:create_table(),
     Childs = [
         child_spec(emqx_limiter_registry, worker),
         child_spec(emqx_limiter_bucket_registry, worker)

--- a/apps/emqx/test/emqx_limiter_composite_SUITE.erl
+++ b/apps/emqx/test/emqx_limiter_composite_SUITE.erl
@@ -18,7 +18,18 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx], #{work_dir => emqx_cth_suite:work_dir(Config)}),
+    %% No listener is needed; not binding ports lets the suite run
+    %% beside a running broker.
+    ListenerConf = """
+    listeners.tcp.default.enable = false
+    listeners.ssl.default.enable = false
+    listeners.ws.default.enable = false
+    listeners.wss.default.enable = false
+    """,
+    Apps = emqx_cth_suite:start(
+        [{emqx, ListenerConf}],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->

--- a/apps/emqx/test/emqx_limiter_shared_SUITE.erl
+++ b/apps/emqx/test/emqx_limiter_shared_SUITE.erl
@@ -20,7 +20,18 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx], #{work_dir => emqx_cth_suite:work_dir(Config)}),
+    %% No listener is needed; not binding ports lets the suite run
+    %% beside a running broker.
+    ListenerConf = """
+    listeners.tcp.default.enable = false
+    listeners.ssl.default.enable = false
+    listeners.ws.default.enable = false
+    listeners.wss.default.enable = false
+    """,
+    Apps = emqx_cth_suite:start(
+        [{emqx, ListenerConf}],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->

--- a/changes/ee/perf-18809.en.md
+++ b/changes/ee/perf-18809.en.md
@@ -1,0 +1,5 @@
+Reduced memory usage of MQTT connections when rate limits are configured.
+
+Rate-limiter bookkeeping shared by all connections is no longer copied into each connection,
+saving about 0.5 KB per connection with rate limits enabled. Rate-limit behavior is
+unchanged.


### PR DESCRIPTION
Fixes:
Release version: 6.3.1, 7.0.0
Introduced in: 5.9.0

## Summary

A shared limiter client copies per-limiter constants into every holding process:
`bucket_ref` (40 words), `options` (6) and `mode` (4) beside the 6-word `limiter_id` — 76
words per client, and channels hold one shared client per zone limiter. All of it except the
identity is derivable at consume time:

* `options` is already re-read from `emqx_limiter_registry` (persistent_term) on every
  `try_consume`; the copy was only used by `put_back` and `inspect`.
* `bucket_ref` lived in the bucket registry, an ETS table.
* `mode` is arithmetic over the options.

This PR keeps only the limiter id as the client state (76 -> 6 words per shared client) and
derives the rest per call:

* `emqx_limiter_bucket_registry` keeps its role as the registry of shared limiter
  *instances* (`insert_buckets/2`, `delete_buckets/1`, `find_bucket/1`), but is backed by
  persistent_term instead of ETS — one key per group holding `Name => bucket_ref`. A consumer
  reads its bucket as a literal reference: no ETS copy, no garbage. The group registry stays a
  registry of prototypes; it is not touched.
* Per consume, `emqx_limiter_shared` reads options from the group registry and the bucket
  from the bucket registry (two persistent_term reads) and derives the mode arithmetically.
  The unlimited (default) configuration short-circuits on the options before touching the
  bucket, so it gains no cost. A vanished bucket fails open, as before.
* persistent_term writes: creating a shared group inserts two new keys (options, buckets) —
  new keys never trigger the literal-area GC, so creation stays as cheap as base. Option
  updates still reset the atomics in place without rewriting either key. Deleting a shared
  group erases two keys instead of one (one extra global GC sweep per deleted shared group);
  deletion is the rarest of the three operations.

**Measured cost** (micro-benchmark, 1M `try_consume` ops, 4 schedulers, finite limit
configured, three rounds each): one consume takes 1.57-1.60 us (regular capacity) and
1.55-1.57 us (exhausted tight limit), versus 1.55-1.63 us and 1.55-1.57 us on the base
commit — parity; the two literal reads cost the same as the old cached-state path. (An
earlier revision that resolved the bucket with `ets:lookup_element` per consume measured
+0.25-0.38 us.) With default (unlimited) settings there is no change.

Also makes `emqx_limiter_shared_SUITE` and `emqx_limiter_composite_SUITE` boot without
binding listener ports, so they can run beside a running broker.

Related: #18806, #18807, #18808 (lazy limiter containers; independent of this change).

## Measured effect

Single node, default config plus finite zone limits high enough never to throttle
(`mqtt.limiter.messages_rate = "1000000/s"`, `bytes_rate = "1GB/s"`), so the zone shared
clients materialize. Before = `dev-63` @ dbe4425ea0 (this PR's merge base, includes
#18806-#18808), after = this branch; identical procedure and timing on the same host.

**Memory** — 10,000 MQTT v5 publishers, each publishing one 32 B QoS 0 message per minute
(`emqtt-bench pub -c 10000 -R 1000 -I 60000 -s 32`), sampled 6 minutes in after a forced
full GC of every channel process (numbers from the previous revision; the client state and
the container are byte-for-byte the same in this revision):

| Metric (per connection, mean over 10k) | before | after | delta |
|---|---:|---:|---:|
| `#channel.quota` live size (`erts_debug:flat_size`) | 261 words | 141 words | -46% |
| Connection `#state{}` live size | 558 words | 438 words | -22% |
| Process memory, hibernated channels | 5,881 B | 5,143 B | -13% |
| Process memory, resident channels | 14,008 B | 13,057 B | -7% |
| `erlang:memory(processes)` at 10k connections | 200 MB | 188 MB | -12 MB |

The 120-word drop is the two zone shared clients (`messages`, `bytes`) at ~62 words each.

**Throughput** — same node and zone limits, with the 10k slow publishers still connected,
plus 200 publishers at 100 msg/s each (`emqtt-bench pub -c 200 -I 10 -s 64`, QoS 0, no
subscribers). Two independent passes per side, two 60 s windows per pass; per-message cost
is beam CPU time over `messages.received`: before 143-166 us/msg at 20.8k msg/s, after
154-174 us/msg at 20.8-21.0k msg/s (previous revision). The per-pass spread on this shared
host is ~10%, larger than any difference between the sides; the publish path shows no
measurable change, consistent with the micro-benchmark.

**persistent_term writes** — 1,000 namespaces' worth of groups (one shared tenant group + one
exclusive client group each) created, updated and deleted the way emqx_mt does, with 10k idle
connections present; wall time, emulator CPU during the phase, and CPU in the following 5 s
(the asynchronous literal-area GC):

| phase (2,000 groups, 10k conns) | base `dev-63` (ETS buckets) | this PR (buckets in persistent_term) |
|---|---:|---:|
| create: wall | 78 ms | 88 ms |
| create: CPU during + after | 0.06 s + 0.5 s | 0.08 s + 0.6 s |
| update: wall | 1.8 s | 1.8 s |
| update: CPU during + after | 5.1 s + 12.7 s | 5.1 s + 12.9 s |
| delete: wall | 1.8 s | 2.7 s |
| delete: CPU during + after | 4.8 s + 13.5 s | 7.5 s + 13.6 s |
| persistent_term keys after create | 2,459 | 3,466 |

Creation and update match base: new keys are plain inserts, and updates rewrite only the
options key as before. Deletion erases the buckets key as well as the options key, hence the
extra caller-side time for 1,000 shared groups; the asynchronous sweep work is unchanged
because the two erases of a group are collected together. Namespaces without a limiter
config create no groups and no keys.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
