### PR TITLE
fix(mqtt): do not send topic alias to enhanced-auth clients

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -641,12 +641,17 @@ process_connect(?CONNECT_PACKET(ConnPkt) = Packet, Channel0) ->
     of
         {ok, NConnPkt, Channel1 = #channel{clientinfo = ClientInfo}} ->
             ?TRACE("MQTT", "mqtt_packet_received", #{packet => Packet}),
-            case authenticate(?CONNECT_PACKET(NConnPkt), Channel1) of
+            %% NOTE: Set alias_maximum before authentication, because enhanced
+            %% authentication completes in `handle_in(?AUTH_PACKET(...))', which
+            %% reaches `post_process_connect/2' without the connect packet.
+            Channel2 = Channel1#channel{
+                alias_maximum = init_alias_maximum(NConnPkt, ClientInfo)
+            },
+            case authenticate(?CONNECT_PACKET(NConnPkt), Channel2) of
                 {ok, Properties, Channel3} ->
                     Channel = Channel3#channel{
                         %% NOTE: Only store will_msg after successful authn.
-                        will_msg = emqx_packet:will_msg(NConnPkt),
-                        alias_maximum = init_alias_maximum(NConnPkt, ClientInfo)
+                        will_msg = emqx_packet:will_msg(NConnPkt)
                     },
                     post_process_connect(Properties, Channel);
                 {continue, Properties, Channel} ->

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -246,6 +246,44 @@ t_handle_in_extended_reauthentication(_) ->
         ok = emqx_hooks:del('client.authenticate', {?MODULE, authenticate_continue})
     end.
 
+-doc """
+A client that connects with enhanced authentication and does not advertise a
+`Topic Alias Maximum` must not be sent any topic alias [MQTT-3.1.2-27].
+""".
+t_handle_in_extended_auth_no_topic_alias(_) ->
+    try
+        {ok, Agent} = emqx_utils_agent:start_link({stop, {continue, #{}}}),
+        emqx_hooks:add(
+            'client.authenticate',
+            {?MODULE, authenticate_continue, [self(), Agent]},
+            ?HP_HIGHEST
+        ),
+        %% CONNECT starts the enhanced authentication exchange.  It carries no
+        %% `Topic-Alias-Maximum`, so the default of 0 applies.
+        Properties = #{
+            'Authentication-Method' => <<"auth_method">>,
+            'Authentication-Data' => <<"auth_data">>
+        },
+        ConnPkt = (connpkt())#mqtt_packet_connect{
+            proto_ver = ?MQTT_PROTO_V5,
+            properties = Properties
+        },
+        {ok, [_, {outgoing, ?AUTH_PACKET(?RC_CONTINUE_AUTHENTICATION)}], Channel1} =
+            emqx_channel:handle_in(?CONNECT_PACKET(ConnPkt), channel(#{conn_state => idle})),
+        %% The client completes the exchange with an AUTH packet.
+        ok = emqx_utils_agent:set(Agent, {stop, ok}),
+        {continue, [_, _, {connack, ?CONNACK_PACKET(?RC_SUCCESS, 0, _)}], Channel} =
+            emqx_channel:handle_in(
+                ?AUTH_PACKET(?RC_CONTINUE_AUTHENTICATION, Properties), Channel1
+            ),
+        ?assertMatch(#{outbound := 0}, emqx_channel:info(alias_maximum, Channel)),
+        Packet = #mqtt_packet{variable = #mqtt_packet_publish{topic_name = <<"t">>}},
+        {PackedPacket, _} = emqx_channel:packing_alias(Packet, Channel),
+        ?assertEqual(Packet, PackedPacket)
+    after
+        ok = emqx_hooks:del('client.authenticate', {?MODULE, authenticate_continue})
+    end.
+
 t_handle_in_unexpected_packet(_) ->
     Channel = emqx_channel:set_field(conn_state, idle, channel()),
     Packet = ?DISCONNECT_PACKET(?RC_PROTOCOL_ERROR),

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -1553,6 +1553,42 @@ t_subscribe_topic_alias(Config) ->
 
     ok = emqtt:disconnect(Client1).
 
+-doc """
+A client whose `Topic Alias Maximum` is absent or 0 is never sent a topic alias
+[MQTT-3.1.2-27].
+""".
+t_subscribe_no_topic_alias(Config) ->
+    %% Client omits `Topic Alias Maximum`, so it defaults to 0.
+    ok = check_no_topic_alias_sent(#{}, Config),
+    %% Client sends `Topic Alias Maximum` = 0 explicitly.
+    ok = check_no_topic_alias_sent(#{'Topic-Alias-Maximum' => 0}, Config).
+
+check_no_topic_alias_sent(ConnProps, Config) ->
+    ConnFun = ?config(conn_fun, Config),
+    Topic = nth(1, ?TOPICS),
+    {ok, Client} = emqtt:start_link([
+        {proto_ver, v5},
+        {properties, ConnProps}
+        | Config
+    ]),
+    {ok, _} = emqtt:ConnFun(Client),
+    {ok, _, [0]} = emqtt:subscribe(Client, Topic, qos0),
+    %% Publish twice: an alias is only assigned on the first delivery to a topic,
+    %% and reused (with an empty topic name) on the following ones.
+    lists:foreach(
+        fun(N) ->
+            Payload = integer_to_binary(N),
+            ok = emqtt:publish(Client, Topic, #{}, Payload, [{qos, ?QOS_0}]),
+            [Msg] = receive_messages(1),
+            ?assertEqual(Payload, maps:get(payload, Msg)),
+            %% [MQTT-3.1.2-27]
+            ?assertEqual(#{}, maps:get(properties, Msg, #{})),
+            ?assertEqual(Topic, maps:get(topic, Msg))
+        end,
+        [1, 2]
+    ),
+    ok = emqtt:disconnect(Client).
+
 t_subscribe_no_local(Config) ->
     ConnFun = ?config(conn_fun, Config),
     Topic = nth(1, ?TOPICS),

--- a/changes/ee/fix-18811.en.md
+++ b/changes/ee/fix-18811.en.md
@@ -1,0 +1,5 @@
+Stopped sending topic aliases to MQTT v5 clients that connect with enhanced authentication and do not accept topic aliases.
+
+A client that omits the `Topic Alias Maximum` property, or sets it to 0, does not accept topic aliases.
+Such a client was still sent PUBLISH packets carrying a `Topic-Alias` property when it authenticated
+with enhanced authentication, for example SCRAM.

--- a/changes/ee/fix-18811.en.md
+++ b/changes/ee/fix-18811.en.md
@@ -1,5 +1,5 @@
-Stopped sending topic aliases to MQTT v5 clients that connect with enhanced authentication and do not accept topic aliases.
+Fixed a regression in 6.3.0 that sent topic aliases to MQTT v5 clients which do not accept them.
 
-A client that omits the `Topic Alias Maximum` property, or sets it to 0, does not accept topic aliases.
-Such a client was still sent PUBLISH packets carrying a `Topic-Alias` property when it authenticated
-with enhanced authentication, for example SCRAM.
+A client that omits the `Topic Alias Maximum` property, or sets it to 0, was still sent PUBLISH
+packets carrying a `Topic-Alias` property when it authenticated with enhanced authentication,
+for example SCRAM.


### PR DESCRIPTION
Fixes: #18797
Release version: 6.3.1, 7.0.0
Introduced in: 6.3.0

## Summary

A client that omits the `Topic Alias Maximum` property in CONNECT, or sets it to 0, does not
accept topic aliases:

> If Topic Alias Maximum is absent or zero, the Server MUST NOT send any Topic Aliases to the
> Client [MQTT-3.1.2-27].

EMQX 6.3.0 still sent a `Topic-Alias` property to such a client when the client authenticated
with enhanced authentication, for example SCRAM. The reporter of #18797 confirmed SCRAM is in
use. Plain authentication is not affected.

### Cause

`emqx_channel:process_connect/2` set `#channel.alias_maximum` only on the branch where
`authenticate/2` succeeds from the CONNECT packet alone. Enhanced authentication returns
`{continue, ...}` on that call and completes later in `handle_in(?AUTH_PACKET(...))`, which
reaches `post_process_connect/2` on its own and never had the connect packet to derive the
value from. Such a channel kept `alias_maximum = undefined`, and `packing_alias/2` reads
`undefined` as "no limit":

```erlang
case (Limits =:= undefined) orelse (AliasId =< maps:get(outbound, Limits, 0)) of
```

so it assigned an alias and sent it.

`alias_maximum` was set before authentication until 6.2, which is why 6.2.2 behaves correctly.
It was moved into the success branch by c5db54554b, a delivery-limiter refactor.

### Change

`apps/emqx/src/emqx_channel.erl` — set `alias_maximum` before `authenticate/2` again, so both
paths into `post_process_connect/2` get it. `will_msg` stays where it is; it must only be
stored after successful authentication (#8886).

### Tests

- `emqx_channel_SUITE:t_handle_in_extended_auth_no_topic_alias` — drives a full enhanced-auth
  exchange and asserts the channel ends with `alias_maximum` `#{outbound := 0}` and that
  `packing_alias/2` leaves the packet untouched. Fails on the parent commit.
- `emqx_mqtt_protocol_v5_SUITE:t_subscribe_no_topic_alias` — end-to-end, for both an absent
  `Topic Alias Maximum` and an explicit 0, checking the second delivery to the same topic as
  well as the first. Runs in every transport group of that suite.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHCNBuYeHB7xatu1hb1KCP
