### PR TITLE
feat(tls): serve a generated certificate when none is configured

### DIFF
--- a/apps/emqx/src/emqx_default_cert.erl
+++ b/apps/emqx/src/emqx_default_cert.erl
@@ -38,7 +38,7 @@ private key.
 -include("emqx_config.hrl").
 -include("logger.hrl").
 
--export([ensure_localhost_bundle/0]).
+-export([ensure_localhost_bundle/0, localhost_bundle/0]).
 
 %% Internal export: run under the lock by `emqx_utils_proc:singleton/4'.
 -export([generate_localhost_bundle/0]).
@@ -49,6 +49,20 @@ private key.
 %%--------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
+
+-doc """
+Returns the `localhost' bundle's files if this node already has a complete one,
+without generating it.
+
+Use this where a certificate is being read rather than served — inspecting the
+configuration a listener used to run with, for instance. Generating there would
+create a key as a side effect of looking at one.
+""".
+-spec localhost_bundle() ->
+    {ok, #{emqx_managed_certs:file_kind() => #{path := file:filename_all()}}}
+    | {error, term()}.
+localhost_bundle() ->
+    complete_bundle().
 
 -doc """
 Returns the `localhost' bundle's files, generating the bundle first if this

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -326,19 +326,10 @@ start_listener(Type, Name, #{enable := false}) ->
     ),
     ok.
 
-%% `ensure_default_certs/1' throws when a listener needs the node's own
-%% certificate and it cannot be had. Report that the way every other start
-%% failure is reported, rather than letting it escape as a crash. The try covers
-%% only that call: throws from starting the listener itself keep reaching their
-%% existing handlers unchanged.
+%% A listener that needs the node's own certificate and cannot be given one does
+%% not start: the failure is reported the way every other start failure is.
 start_listener_with_certs(Type, Name, ListenerId, Conf) ->
-    case
-        try
-            {ok, ensure_default_certs(Conf)}
-        catch
-            throw:Reason -> {error, Reason}
-        end
-    of
+    case ensure_default_certs(Conf) of
         {ok, ConfWithCerts} -> do_start_listener(Type, Name, ListenerId, ConfWithCerts);
         {error, _} = Error -> Error
     end.
@@ -382,18 +373,18 @@ update_listener(Type, Name, OldConf, NewConf) ->
     end.
 
 do_update_running_listener(Type, Name, OldConf, NewConf) ->
-    case
-        do_update_listener(
-            Type, Name, default_certs_if_present(OldConf), ensure_default_certs(NewConf)
-        )
-    of
-        ok ->
-            ok = maybe_unregister_ocsp_stapling_refresh(Type, Name, NewConf),
-            ok;
-        {skip, Error} when Type =:= quic ->
-            {error, {rollbacked, Error}};
-        {error, _Reason} ->
-            restart_listener(Type, Name, OldConf, NewConf)
+    maybe
+        {ok, NewConfWithCerts} ?= ensure_default_certs(NewConf),
+        OldConfWithCerts = default_certs_if_present(OldConf),
+        case do_update_listener(Type, Name, OldConfWithCerts, NewConfWithCerts) of
+            ok ->
+                ok = maybe_unregister_ocsp_stapling_refresh(Type, Name, NewConf),
+                ok;
+            {skip, Error} when Type =:= quic ->
+                {error, {rollbacked, Error}};
+            {error, _Reason} ->
+                restart_listener(Type, Name, OldConf, NewConf)
+        end
     end.
 
 restart_listener(Type, Name, OldConf, NewConf) ->
@@ -1144,9 +1135,12 @@ Applied to both sides of an update so the comparison that decides whether the
 transport has to be torn down stays symmetric.
 """.
 ensure_default_certs(#{ssl_options := SSLOpts} = Conf) ->
-    Conf#{ssl_options => emqx_tls_lib:ensure_default_certs(SSLOpts)};
+    case emqx_tls_lib:ensure_default_certs(SSLOpts) of
+        {ok, SSLOpts1} -> {ok, Conf#{ssl_options => SSLOpts1}};
+        {error, _} = Error -> Error
+    end;
 ensure_default_certs(Conf) ->
-    Conf.
+    {ok, Conf}.
 
 %% The config a listener is being updated away from is only compared against and
 %% rolled back to, never served.  Resolving it must not generate a certificate.

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -47,7 +47,6 @@
 
 -export([pre_config_update/3, post_config_update/5]).
 -export([post_zone_config_update/2, update_listener_for_zone_changes/3]).
--export([reconcile_cert_source/2]).
 
 -export([format_bind/1, format_bind_ip/1]).
 
@@ -282,7 +281,7 @@ start_listener(Type, Name, #{bind := Bind0, enable := true} = Conf0) ->
     Conf = Conf0#{bind := Bind},
     ListenerId = listener_id(Type, Name),
     ok = emqx_limiter:create_listener_limiters(ListenerId, Conf),
-    case do_start_listener(Type, Name, ListenerId, Conf) of
+    case start_listener_with_certs(Type, Name, ListenerId, Conf) of
         {ok, {skipped, Reason}} when
             Reason =:= quic_app_missing
         ->
@@ -327,6 +326,23 @@ start_listener(Type, Name, #{enable := false}) ->
     ),
     ok.
 
+%% `ensure_default_certs/1' throws when a listener needs the node's own
+%% certificate and it cannot be had. Report that the way every other start
+%% failure is reported, rather than letting it escape as a crash. The try covers
+%% only that call: throws from starting the listener itself keep reaching their
+%% existing handlers unchanged.
+start_listener_with_certs(Type, Name, ListenerId, Conf) ->
+    case
+        try
+            {ok, ensure_default_certs(Conf)}
+        catch
+            throw:Reason -> {error, Reason}
+        end
+    of
+        {ok, ConfWithCerts} -> do_start_listener(Type, Name, ListenerId, ConfWithCerts);
+        {error, _} = Error -> Error
+    end.
+
 %% @doc Restart all listeners
 -spec restart() -> ok.
 restart() ->
@@ -366,7 +382,11 @@ update_listener(Type, Name, OldConf, NewConf) ->
     end.
 
 do_update_running_listener(Type, Name, OldConf, NewConf) ->
-    case do_update_listener(Type, Name, OldConf, NewConf) of
+    case
+        do_update_listener(
+            Type, Name, default_certs_if_present(OldConf), ensure_default_certs(NewConf)
+        )
+    of
         ok ->
             ok = maybe_unregister_ocsp_stapling_refresh(Type, Name, NewConf),
             ok;
@@ -642,9 +662,8 @@ pre_config_update([?ROOT_KEY, _Type, _Name], {update, _Request}, undefined) ->
     {error, not_found};
 pre_config_update([?ROOT_KEY, Type, Name], {update, Request}, RawConf) ->
     RawConf1 = emqx_utils_maps:deep_merge(RawConf, Request),
-    RawConf2 = reconcile_cert_source(Request, RawConf1),
-    ok = assert_zone_exists(RawConf2),
-    {ok, convert_certs(Type, Name, RawConf2)};
+    ok = assert_zone_exists(RawConf1),
+    {ok, convert_certs(Type, Name, RawConf1)};
 pre_config_update([?ROOT_KEY, _Type, _Name], {action, _Action, Updated}, RawConf) ->
     {ok, emqx_utils_maps:deep_merge(RawConf, Updated)};
 pre_config_update([?ROOT_KEY, _Type, _Name], ?MARK_DEL, _RawConf) ->
@@ -1112,6 +1131,30 @@ enable_authn(Opts) ->
 ssl_opts(Opts) ->
     emqx_tls_lib:to_server_opts(tls, maps:get(ssl_options, Opts, #{})).
 
+-doc """
+Points a listener with no certificate of its own at the node's default bundle,
+generating it if this node has none.
+
+Done here, where a listener is actually started or updated, rather than in
+`ssl_opts/1': that is also called to compare two configurations, and
+`to_server_opts/2' is called by other applications to read a listener's
+certificate. Neither of those should mint one as a side effect.
+
+Applied to both sides of an update so the comparison that decides whether the
+transport has to be torn down stays symmetric.
+""".
+ensure_default_certs(#{ssl_options := SSLOpts} = Conf) ->
+    Conf#{ssl_options => emqx_tls_lib:ensure_default_certs(SSLOpts)};
+ensure_default_certs(Conf) ->
+    Conf.
+
+%% The config a listener is being updated away from is only compared against and
+%% rolled back to, never served.  Resolving it must not generate a certificate.
+default_certs_if_present(#{ssl_options := SSLOpts} = Conf) ->
+    Conf#{ssl_options => emqx_tls_lib:default_certs_if_present(SSLOpts)};
+default_certs_if_present(Conf) ->
+    Conf.
+
 tcp_opts(Opts) ->
     TcpOpts = maps:to_list(maps:get(tcp_options, Opts, #{})),
     lists:flatten(lists:map(fun tcp_opt/1, TcpOpts)).
@@ -1202,49 +1245,6 @@ convert_certs(ListenerConf) ->
         #{},
         ListenerConf
     ).
-
--doc """
-Enforce that a listener uses a single certificate source.
-
-`managed_certs' and file-based certificates (`certfile'/`keyfile') are mutually
-exclusive certificate sources.  Configuration updates are applied via `deep_merge',
-which can only add or override keys, never drop them.  Without this reconciliation an
-update that switches a listener from a managed certificate bundle back to file-based
-certificates would keep the stale `managed_certs' reference and fail to resolve a
-(possibly already deleted) bundle.
-
-When `Request' supplies file-based certificate material and does not itself reference
-`managed_certs', drop any residual `managed_certs' from `MergedConf' so the result
-uses only the requested certificate source.  A `managed_certs' explicitly set to JSON
-`null' (how the Dashboard clears it) or to an empty list is a request to stop using
-managed certificates, so the residual reference is dropped as well.  Both arguments
-are raw (binary-keyed) configs.
-""".
-reconcile_cert_source(Request, MergedConf) ->
-    case get_ssl_options(Request) of
-        RequestSSL when is_map(RequestSSL) ->
-            RequestSetsFileCerts =
-                maps:is_key(<<"certfile">>, RequestSSL) orelse
-                    maps:is_key(<<"keyfile">>, RequestSSL),
-            DropManaged =
-                case maps:get(<<"managed_certs">>, RequestSSL, undefined) of
-                    undefined -> RequestSetsFileCerts;
-                    null -> true;
-                    [] -> true;
-                    _ -> false
-                end,
-            case DropManaged of
-                true -> drop_managed_certs(MergedConf);
-                false -> MergedConf
-            end;
-        _ ->
-            MergedConf
-    end.
-
-drop_managed_certs(#{<<"ssl_options">> := SSL} = Conf) when is_map(SSL) ->
-    Conf#{<<"ssl_options">> => maps:remove(<<"managed_certs">>, SSL)};
-drop_managed_certs(Conf) ->
-    Conf.
 
 convert_certs(Type, Name, Conf) ->
     CertsDir = certs_dir(Type, Name),

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2583,8 +2583,8 @@ filter(Opts) ->
 
 %% @private This function defines the SSL opts which are commonly used by
 %% SSL listener and client.
--spec common_ssl_opts_schema(map(), server | client) -> hocon_schema:field_schema().
-common_ssl_opts_schema(Defaults, Type) ->
+-spec common_ssl_opts_schema(map()) -> hocon_schema:field_schema().
+common_ssl_opts_schema(Defaults) ->
     D = fun(Field) -> maps:get(Field, Defaults, undefined) end,
     Df = fun(Field, Default) -> maps:get(Field, Defaults, Default) end,
     Collection = maps:get(versions, Defaults, tls_all_available),
@@ -2593,7 +2593,6 @@ common_ssl_opts_schema(Defaults, Type) ->
             sc(
                 binary(),
                 #{
-                    default => cert_file("cacert.pem", Type),
                     required => false,
                     desc => ?DESC(common_ssl_opts_schema_cacertfile)
                 }
@@ -2610,7 +2609,6 @@ common_ssl_opts_schema(Defaults, Type) ->
             sc(
                 binary(),
                 #{
-                    default => cert_file("cert.pem", Type),
                     required => false,
                     desc => ?DESC(common_ssl_opts_schema_certfile)
                 }
@@ -2619,7 +2617,6 @@ common_ssl_opts_schema(Defaults, Type) ->
             sc(
                 binary(),
                 #{
-                    default => cert_file("key.pem", Type),
                     required => false,
                     desc => ?DESC(common_ssl_opts_schema_keyfile)
                 }
@@ -2734,7 +2731,7 @@ server_ssl_opts_schema(Defaults0, IsRanchListener) ->
     Defaults = maps:merge(#{reuse_sessions => false}, Defaults0),
     D = fun(Field) -> maps:get(Field, Defaults, undefined) end,
     Df = fun(Field, Default) -> maps:get(Field, Defaults, Default) end,
-    common_ssl_opts_schema(Defaults, server) ++
+    common_ssl_opts_schema(Defaults) ++
         [
             {"dhfile",
                 sc(
@@ -2925,7 +2922,7 @@ crl_outer_validator(_SSLOpts) ->
 %% @doc Make schema for SSL client.
 -spec client_ssl_opts_schema(map()) -> hocon_schema:field_schema().
 client_ssl_opts_schema(Defaults) ->
-    common_ssl_opts_schema(Defaults, client) ++
+    common_ssl_opts_schema(Defaults) ++
         [
             {"enable",
                 sc(
@@ -4068,22 +4065,15 @@ default_listener(ws) ->
         <<"websocket">> => #{<<"mqtt_path">> => <<"/mqtt">>}
     };
 default_listener(SSLListener) ->
-    %% The env variable is resolved in emqx_tls_lib by calling naive_env_interpolate
-    SslOptions = #{
-        <<"cacertfile">> => cert_file(<<"cacert.pem">>, server),
-        <<"certfile">> => cert_file(<<"cert.pem">>, server),
-        <<"keyfile">> => cert_file(<<"key.pem">>, server)
-    },
+    %% No certificate here on purpose: a listener with none configured serves
+    %% the node's own generated bundle, which is unique per installation. See
+    %% `emqx_default_cert'.
     case SSLListener of
         ssl ->
-            #{
-                <<"bind">> => 8883,
-                <<"ssl_options">> => SslOptions
-            };
+            #{<<"bind">> => 8883};
         wss ->
             #{
                 <<"bind">> => 8084,
-                <<"ssl_options">> => SslOptions,
                 <<"websocket">> => #{<<"mqtt_path">> => <<"/mqtt">>}
             }
     end.
@@ -4146,11 +4136,6 @@ ensure_default_listener(#{<<"default">> := _} = Map, _ListenerType) ->
 ensure_default_listener(Map, ListenerType) ->
     NewMap = Map#{<<"default">> => default_listener(ListenerType)},
     keep_default_tombstone(NewMap, #{}).
-
-cert_file(_File, client) ->
-    undefined;
-cert_file(File, server) ->
-    unicode:characters_to_binary(filename:join(["${EMQX_ETC_DIR}", "certs", File])).
 
 mqtt_converter(#{<<"keepalive_multiplier">> := Multi} = Mqtt, _Opts) ->
     case round(Multi * 100) =:= round(?DEFAULT_MULTIPLIER * 100) of

--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -33,7 +33,10 @@
 -export([
     to_server_opts/2,
     to_client_opts/1,
-    to_client_opts/2
+    to_client_opts/2,
+    ensure_default_certs/1,
+    is_cert_configured/1,
+    default_certs_if_present/1
 ]).
 
 %% ssl:tls_version/0 is not exported.
@@ -770,6 +773,142 @@ to_client_opts(Type, Opts = #{enable := true}) ->
     ensure_valid_options(TLSClientOpts);
 to_client_opts(_Type, #{}) ->
     [].
+
+-doc """
+Points a server at the node's default certificate bundle when it has no
+certificate of its own, generating that bundle if this node does not have one
+yet.
+
+Applied to *checked* configuration at listener start, immediately before
+`to_server_opts/2', and deliberately never to raw configuration. Raw
+configuration is what gets persisted and what later REST updates deep-merge
+against, so a bundle injected there would outlive the listener start and read
+back as a certificate the operator had configured, which they did not.
+
+Kept out of `to_server_opts/2' for the same reason it is kept out of raw
+configuration: that function is a plain conversion from configuration to `ssl'
+options, and this is a decision about what the configuration should have been.
+
+A server that cannot be given a default certificate is left as it was, to fail
+with whatever its own missing-certificate error is.
+""".
+-spec ensure_default_certs(map()) -> map().
+ensure_default_certs(Opts) ->
+    case is_cert_configured(Opts) of
+        true ->
+            Opts;
+        false ->
+            case emqx_default_cert:ensure_localhost_bundle() of
+                {ok, Files} ->
+                    use_default_certs(Opts, Files);
+                {error, Reason} ->
+                    %% Returning the configuration unchanged would leave a TLS
+                    %% server with no certificate at all. `ssl' accepts that at
+                    %% listen time and only fails each handshake afterwards, with
+                    %% an alert that names no cause, so the server would bind its
+                    %% port, look healthy and serve nobody. Fail here, where the
+                    %% cause is known.
+                    throw(#{
+                        error => <<"no_default_tls_certificate">>,
+                        bundle => ?NODE_DEFAULT_CERT_BUNDLE_NAME,
+                        reason => Reason
+                    })
+            end
+    end.
+
+-doc """
+Points this configuration at the node's default certificate only if the node
+already has one, generating nothing.
+
+Use this for a configuration that is being read rather than served, such as the
+one a running listener is being updated away from. Generating there would create
+a key as a side effect of inspecting one. A node with no bundle yet is not an
+error here: the configuration is simply left as it is.
+""".
+-spec default_certs_if_present(map()) -> map().
+default_certs_if_present(Opts) ->
+    case is_cert_configured(Opts) of
+        true ->
+            Opts;
+        false ->
+            case emqx_default_cert:localhost_bundle() of
+                {ok, Files} -> use_default_certs(Opts, Files);
+                {error, _NoBundle} -> Opts
+            end
+    end.
+
+%% Names the bundle's files directly rather than pointing `managed_certs' at it.
+%% Resolving a managed bundle replaces the whole certificate triple, which would
+%% drop a `cacertfile' the configuration sets to verify peers with.
+use_default_certs(Opts, Files) ->
+    #{
+        ?FILE_KIND_CHAIN := #{path := Chain},
+        ?FILE_KIND_KEY := #{path := Key}
+    } = Files,
+    use_default_cacertfile(Opts#{certfile => Chain, keyfile => Key}, Files).
+
+%% The bundle a node generates for itself holds no `ca' file, but an operator can
+%% install their own under the same name, and theirs may carry one. Use it, so a
+%% listener that verifies peers has the trust anchor its bundle came with.
+%%
+%% A `cacertfile' the configuration names wins: the bundle only fills a slot
+%% nothing else does. A file holding no certificate is ignored rather than
+%% passed on, because `ssl' refuses to start a listener with such a `cacertfile'.
+use_default_cacertfile(Opts, #{?FILE_KIND_CA := #{path := Path}}) ->
+    case is_configured(conf_get_opt(cacertfile, Opts)) of
+        true ->
+            Opts;
+        false ->
+            case holds_certificate(Path) of
+                true ->
+                    Opts#{cacertfile => Path};
+                false ->
+                    ?SLOG(warning, #{
+                        msg => "ignored_default_tls_ca_file_without_certificate",
+                        bundle => ?NODE_DEFAULT_CERT_BUNDLE_NAME,
+                        file => Path
+                    }),
+                    Opts
+            end
+    end;
+use_default_cacertfile(Opts, _Files) ->
+    Opts.
+
+holds_certificate(Path) ->
+    case file:read_file(Path) of
+        {ok, PEM} -> is_pem(PEM);
+        {error, _} -> false
+    end.
+
+-doc """
+Whether this configuration names a server certificate of its own, by file or by
+managed bundle. Empty values do not count: the schema can leave a key present
+and unset.
+
+`cacertfile' is deliberately not one of the keys. It names the authority used to
+verify peers, not this server's own identity, so a listener that sets only a
+`cacertfile' to require client certificates still has no certificate to present
+and still wants the default one.
+""".
+-spec is_cert_configured(map()) -> boolean().
+is_cert_configured(Opts) ->
+    lists:any(
+        fun(Key) -> is_configured(conf_get_opt(Key, Opts)) end,
+        [certfile, keyfile, managed_certs]
+    ).
+
+%% Not all of these are shapes the schema can produce. Most callers pass checked
+%% configuration, but `emqx_dashboard_listener_config' passes a request's own
+%% `ssl_options', which has only been through a converter: there, `null' is how
+%% a request clears a value, and an empty map is an emptied `managed_certs'
+%% object. If that caller ever goes, the clauses below can go with it.
+is_configured(undefined) -> false;
+is_configured(null) -> false;
+is_configured(<<>>) -> false;
+%% Also covers "": an empty string is an empty list.
+is_configured([]) -> false;
+is_configured(Map) when is_map(Map) -> map_size(Map) > 0;
+is_configured(_Other) -> true.
 
 resolve_managed_certs(undefined, Opts) ->
     Password = conf_get_password(password, Opts),

--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -789,30 +789,33 @@ Kept out of `to_server_opts/2' for the same reason it is kept out of raw
 configuration: that function is a plain conversion from configuration to `ssl'
 options, and this is a decision about what the configuration should have been.
 
-A server that cannot be given a default certificate is left as it was, to fail
-with whatever its own missing-certificate error is.
+Returns `{error, Reason}' when the node has no default certificate and cannot
+generate one. The caller declines to start that server: `ssl' would accept a
+listener with no certificate and only fail each handshake afterwards, with an
+alert that names no cause.
 """.
--spec ensure_default_certs(map()) -> map().
+-spec ensure_default_certs(map()) -> {ok, map()} | {error, map()}.
 ensure_default_certs(Opts) ->
     case is_cert_configured(Opts) of
         true ->
-            Opts;
+            {ok, Opts};
         false ->
             case emqx_default_cert:ensure_localhost_bundle() of
                 {ok, Files} ->
-                    use_default_certs(Opts, Files);
+                    {ok, use_default_certs(Opts, Files)};
                 {error, Reason} ->
                     %% Returning the configuration unchanged would leave a TLS
                     %% server with no certificate at all. `ssl' accepts that at
                     %% listen time and only fails each handshake afterwards, with
                     %% an alert that names no cause, so the server would bind its
-                    %% port, look healthy and serve nobody. Fail here, where the
-                    %% cause is known.
-                    throw(#{
+                    %% port, look healthy and serve nobody. Report the failure
+                    %% here, where the cause is known, and let the caller decline
+                    %% to start that server.
+                    {error, #{
                         error => <<"no_default_tls_certificate">>,
                         bundle => ?NODE_DEFAULT_CERT_BUNDLE_NAME,
                         reason => Reason
-                    })
+                    }}
             end
     end.
 

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -80,7 +80,8 @@ init_per_group(quic, Config) ->
                 "\n max_connections = 1024000"
                 "\n idle_timeout = 15s"
                 "\n ssl_options.verify = verify_peer"
-                "\n }"}
+                "\n }" ++
+                    emqx_common_test_helpers:listener_example_certs("listeners.quic.test")}
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -202,7 +202,7 @@ emqx_config() ->
                     }
         ssl_options { verify = verify_peer }
     }
-    """.
+    """ ++ emqx_common_test_helpers:listener_example_certs("listeners.ssl.default").
 
 end_per_group(GroupName, Config) when
     GroupName == gen_tcp_listener;

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -33,6 +33,8 @@
     client_ssl/0,
     client_ssl/1,
     client_mtls/0,
+    listener_example_certs/0,
+    listener_example_certs/1,
     client_mtls/1,
     ensure_mnesia_stopped/0,
     ensure_quic_listener/2,
@@ -427,6 +429,36 @@ client_mtls() ->
 
 client_mtls(TLSVsn) ->
     ssl_verify_fun_allow_any_host() ++ client_certs() ++ ciphers(TLSVsn).
+
+-doc """
+HOCON that points a listener at the shipped example certificates.
+
+The listener schema no longer defaults `certfile', `keyfile' and `cacertfile'; a
+listener naming none of them serves the certificate the node generates for
+itself. Suites whose clients present or verify the example certificates have to
+name them, and this is the configuration that does it.
+
+`ListenerPath' is the dotted path to the listener, such as
+`"listeners.ssl.default"'.
+""".
+-spec listener_example_certs(string()) -> string().
+listener_example_certs(ListenerPath) ->
+    lists:flatten([
+        [ListenerPath, ".ssl_options.", binary_to_list(Key), " = \"", binary_to_list(File), "\"\n"]
+     || {Key, File} <- maps:to_list(listener_example_certs())
+    ]).
+
+-doc """
+The same example certificates as `listener_example_certs/1', as `ssl_options'
+entries, for a suite that builds its listener config as a map.
+""".
+-spec listener_example_certs() -> #{binary() => binary()}.
+listener_example_certs() ->
+    #{
+        <<"certfile">> => <<"${EMQX_ETC_DIR}/certs/cert.pem">>,
+        <<"keyfile">> => <<"${EMQX_ETC_DIR}/certs/key.pem">>,
+        <<"cacertfile">> => <<"${EMQX_ETC_DIR}/certs/cacert.pem">>
+    }.
 
 %% Paths prepended to cert filenames
 client_certs() ->

--- a/apps/emqx/test/emqx_default_cert_SUITE.erl
+++ b/apps/emqx/test/emqx_default_cert_SUITE.erl
@@ -25,6 +25,18 @@ all() ->
 emqx_app_spec() ->
     {emqx, #{override_env => [{boot_modules, [broker]}]}}.
 
+init_per_testcase(t_listener_without_cert_serves_default = TCName, TCConfig) ->
+    Port = emqx_common_test_helpers:select_free_port(ssl),
+    Config =
+        "listeners.tcp.default.enable = false\n"
+        "listeners.ws.default.enable = false\n"
+        "listeners.wss.default.enable = false\n"
+        "listeners.ssl.default.bind = \"127.0.0.1:" ++ integer_to_list(Port) ++ "\"\n",
+    Apps = emqx_cth_suite:start(
+        [{emqx, #{config => Config}}],
+        #{work_dir => emqx_cth_suite:work_dir(TCName, TCConfig)}
+    ),
+    [{apps, Apps}, {port, Port} | TCConfig];
 init_per_testcase(t_bundles_are_per_node = TCName, TCConfig) ->
     Nodes = emqx_cth_cluster:start(
         [
@@ -195,6 +207,53 @@ t_bundle_has_chain_and_no_ca_file(_TCConfig) ->
         #'BasicConstraints'{cA = true},
         extension(?'id-ce-basicConstraints', CaCert)
     ).
+
+-doc """
+A `ca' file an operator installed in the bundle is served as the `cacertfile',
+so a listener that verifies peers gets the trust anchor its bundle came with.
+The generated bundle holds no such file.
+""".
+t_installed_ca_file_is_used(_TCConfig) ->
+    _ = ensure(),
+    CaPath = install_bundle_ca_file(ca_pem()),
+    ?assertMatch(
+        #{cacertfile := CaPath},
+        emqx_tls_lib:ensure_default_certs(#{})
+    ).
+
+-doc """
+A `cacertfile' the configuration names wins over one in the bundle: the bundle
+only fills a slot nothing else does.
+""".
+t_configured_cacertfile_wins_over_bundle(_TCConfig) ->
+    _ = ensure(),
+    _ = install_bundle_ca_file(ca_pem()),
+    ?assertMatch(
+        #{cacertfile := <<"/configured/ca.pem">>},
+        emqx_tls_lib:ensure_default_certs(#{cacertfile => <<"/configured/ca.pem">>})
+    ).
+
+-doc """
+A `ca' file holding no certificate is ignored. `ssl' refuses to start a listener
+whose `cacertfile' decodes to nothing, so passing it on would take the listener
+down instead of leaving it without a trust anchor.
+""".
+t_installed_ca_file_without_certificate_is_ignored(_TCConfig) ->
+    _ = ensure(),
+    _ = install_bundle_ca_file(<<>>),
+    ?assertNot(maps:is_key(cacertfile, emqx_tls_lib:ensure_default_certs(#{}))).
+
+%% Stands in for a bundle an operator installed themselves, which may carry a CA
+%% the generated one does not.
+install_bundle_ca_file(Contents) ->
+    Dir = emqx_managed_certs:dir(?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME),
+    Path = filename:join(Dir, "ca.pem"),
+    ok = file:write_file(Path, Contents),
+    unicode:characters_to_binary(Path).
+
+ca_pem() ->
+    #{cert_pem := Pem} = emqx_utils_certs:generate_ca(#{cn => "test-ca"}),
+    Pem.
 
 -doc "The bundle holds no CA private key: the signing key is discarded at generation time.".
 t_no_ca_key_in_bundle(_TCConfig) ->
@@ -371,6 +430,23 @@ t_caller_gives_up_on_a_wedged_generator(_TCConfig) ->
     end,
     ?assertMatch({error, _}, emqx_default_cert:ensure_localhost_bundle()),
     exit(Wedged, kill).
+
+-doc """
+An MQTT TLS listener with no certificate configured serves the node's default
+bundle. The whole chain end to end: the schema leaves the listener without a
+certificate, the fallback notices and points it at the default bundle, and the
+bundle is generated on the way.
+""".
+t_listener_without_cert_serves_default(TCConfig) ->
+    Port = ?config(port, TCConfig),
+    {ok, Sock} = ssl:connect("127.0.0.1", Port, [{verify, verify_none}], 5_000),
+    {ok, Der} = ssl:peercert(Sock),
+    ok = ssl:close(Sock),
+    ?assertEqual(<<"localhost">>, common_name(public_key:pkix_decode_cert(Der, otp))),
+    %% It is this node's own bundle that was served, not something else.
+    #{?FILE_KIND_CHAIN := ChainPem} = contents(bundle_files()),
+    {LeafDer, _CaDer} = chain_entries(ChainPem),
+    ?assertEqual(LeafDer, Der).
 
 -doc """
 Each node generates and keeps its own bundle: the default certificate is a

--- a/apps/emqx/test/emqx_default_cert_SUITE.erl
+++ b/apps/emqx/test/emqx_default_cert_SUITE.erl
@@ -37,6 +37,20 @@ init_per_testcase(t_listener_without_cert_serves_default = TCName, TCConfig) ->
         #{work_dir => emqx_cth_suite:work_dir(TCName, TCConfig)}
     ),
     [{apps, Apps}, {port, Port} | TCConfig];
+init_per_testcase(t_enabling_a_listener_generates_the_bundle = TCName, TCConfig) ->
+    Port = emqx_common_test_helpers:select_free_port(ssl),
+    %% Every TLS listener starts disabled, so nothing needs the bundle at boot.
+    Config =
+        "listeners.tcp.default.enable = false\n"
+        "listeners.ws.default.enable = false\n"
+        "listeners.wss.default.enable = false\n"
+        "listeners.ssl.default.enable = false\n"
+        "listeners.ssl.default.bind = \"127.0.0.1:" ++ integer_to_list(Port) ++ "\"\n",
+    Apps = emqx_cth_suite:start(
+        [{emqx, #{config => Config}}],
+        #{work_dir => emqx_cth_suite:work_dir(TCName, TCConfig)}
+    ),
+    [{apps, Apps}, {port, Port} | TCConfig];
 init_per_testcase(t_bundles_are_per_node = TCName, TCConfig) ->
     Nodes = emqx_cth_cluster:start(
         [
@@ -445,6 +459,29 @@ t_listener_without_cert_serves_default(TCConfig) ->
     ok = ssl:close(Sock),
     ?assertEqual(<<"localhost">>, common_name(public_key:pkix_decode_cert(Der, otp))),
     %% It is this node's own bundle that was served, not something else.
+    #{?FILE_KIND_CHAIN := ChainPem} = contents(bundle_files()),
+    {LeafDer, _CaDer} = chain_entries(ChainPem),
+    ?assertEqual(LeafDer, Der).
+
+-doc """
+A listener that starts disabled generates nothing, and generates the bundle when
+it is enabled at runtime -- how the Dashboard and the REST API turn one on. The
+certificate is created when a server first needs it, not only at boot.
+""".
+t_enabling_a_listener_generates_the_bundle(TCConfig) ->
+    Port = ?config(port, TCConfig),
+    %% Nothing has needed a certificate yet.
+    ?assertEqual(#{}, bundle_files()),
+
+    {ok, _} = emqx:update_config(
+        [listeners, ssl, default], {update, #{<<"enable">> => true}}
+    ),
+    ?assertMatch(#{?FILE_KIND_KEY := _, ?FILE_KIND_CHAIN := _}, bundle_files()),
+
+    %% And the listener that was just enabled serves it.
+    {ok, Sock} = ssl:connect("127.0.0.1", Port, [{verify, verify_none}], 5_000),
+    {ok, Der} = ssl:peercert(Sock),
+    ok = ssl:close(Sock),
     #{?FILE_KIND_CHAIN := ChainPem} = contents(bundle_files()),
     {LeafDer, _CaDer} = chain_entries(ChainPem),
     ?assertEqual(LeafDer, Der).

--- a/apps/emqx/test/emqx_default_cert_SUITE.erl
+++ b/apps/emqx/test/emqx_default_cert_SUITE.erl
@@ -217,7 +217,7 @@ t_installed_ca_file_is_used(_TCConfig) ->
     _ = ensure(),
     CaPath = install_bundle_ca_file(ca_pem()),
     ?assertMatch(
-        #{cacertfile := CaPath},
+        {ok, #{cacertfile := CaPath}},
         emqx_tls_lib:ensure_default_certs(#{})
     ).
 
@@ -229,7 +229,7 @@ t_configured_cacertfile_wins_over_bundle(_TCConfig) ->
     _ = ensure(),
     _ = install_bundle_ca_file(ca_pem()),
     ?assertMatch(
-        #{cacertfile := <<"/configured/ca.pem">>},
+        {ok, #{cacertfile := <<"/configured/ca.pem">>}},
         emqx_tls_lib:ensure_default_certs(#{cacertfile => <<"/configured/ca.pem">>})
     ).
 
@@ -241,7 +241,8 @@ down instead of leaving it without a trust anchor.
 t_installed_ca_file_without_certificate_is_ignored(_TCConfig) ->
     _ = ensure(),
     _ = install_bundle_ca_file(<<>>),
-    ?assertNot(maps:is_key(cacertfile, emqx_tls_lib:ensure_default_certs(#{}))).
+    {ok, Opts} = emqx_tls_lib:ensure_default_certs(#{}),
+    ?assertNot(maps:is_key(cacertfile, Opts)).
 
 %% Stands in for a bundle an operator installed themselves, which may carry a CA
 %% the generated one does not.

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -1583,59 +1583,6 @@ t_format_bind(_) ->
         lists:flatten(emqx_listeners:format_bind(":1883"))
     ).
 
--doc """
-Tests `emqx_listeners:reconcile_cert_source/2`: a residual `managed_certs` in the
-merged config is dropped when the update request switches to file-based certificates
-or explicitly clears `managed_certs` (JSON `null` or an empty list), and is kept when
-the request references a managed bundle or touches neither certificate source.
-""".
-t_reconcile_cert_source(_Config) ->
-    Managed = [#{<<"bundle_name">> => <<"bundle">>}],
-    Merged = #{
-        <<"ssl_options">> => #{
-            <<"certfile">> => <<"cert.pem">>,
-            <<"keyfile">> => <<"key.pem">>,
-            <<"managed_certs">> => Managed
-        }
-    },
-    Dropped = emqx_utils_maps:deep_remove([<<"ssl_options">>, <<"managed_certs">>], Merged),
-    ReqSSL = fun(SSL) -> #{<<"ssl_options">> => SSL} end,
-    %% Request sets file certs without mentioning managed certs: drop.
-    ?assertEqual(
-        Dropped,
-        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"certfile">> => <<"cert.pem">>}), Merged)
-    ),
-    %% Request explicitly clears managed certs (JSON `null' or empty list): drop,
-    %% with or without accompanying file certs.
-    ?assertEqual(
-        Dropped,
-        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"managed_certs">> => null}), Merged)
-    ),
-    ?assertEqual(
-        Dropped,
-        emqx_listeners:reconcile_cert_source(
-            ReqSSL(#{<<"certfile">> => <<"cert.pem">>, <<"managed_certs">> => null}), Merged
-        )
-    ),
-    ?assertEqual(
-        Dropped,
-        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"managed_certs">> => []}), Merged)
-    ),
-    %% Request references a managed bundle: keep.
-    ?assertEqual(
-        Merged,
-        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"managed_certs">> => Managed}), Merged)
-    ),
-    %% Request touches neither certificate source: keep.
-    ?assertEqual(
-        Merged,
-        emqx_listeners:reconcile_cert_source(ReqSSL(#{<<"verify">> => <<"verify_none">>}), Merged)
-    ),
-    ?assertEqual(
-        Merged,
-        emqx_listeners:reconcile_cert_source(#{<<"bind">> => <<"0.0.0.0:8883">>}, Merged)
-    ).
-
 generate_tls_certs(Config) ->
     PrivDir = ?config(priv_dir, Config),
     emqx_common_test_helpers:gen_ca(PrivDir, "ca"),

--- a/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
@@ -119,7 +119,13 @@ init_per_testcase(TestCase, Config) when
             Apps = emqx_cth_suite:start(
                 [
                     emqx_conf,
-                    emqx,
+                    %% The listener needs a certificate of its own: the OCSP
+                    %% stapling rules under test are only reached once one is
+                    %% configured.
+                    {emqx,
+                        emqx_common_test_helpers:listener_example_certs(
+                            "listeners.ssl.default"
+                        )},
                     emqx_management,
                     {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
                 ],
@@ -908,13 +914,12 @@ do_t_validations(_Config) ->
                     }
             }
         ),
-    ListenerData3 = emqx_utils_maps:deep_remove(
-        [<<"ssl_options">>, <<"certfile">>], ListenerData3a
-    ),
-    {error, {_, _, ResRaw3}} = update_listener_via_api(ListenerId, ListenerData3),
+    %% The request keeps its `certfile': nothing defaults one any more, and a
+    %% request naming no server certificate is rejected by the stapling rule
+    %% above before it reaches the issuer file.
+    {error, {_, _, ResRaw3}} = update_listener_via_api(ListenerId, ListenerData3a),
     #{<<"code">> := <<"BAD_REQUEST">>, <<"message">> := MsgRaw3} =
         emqx_utils_json:decode(ResRaw3),
-    %% we can't remove certfile now, because it has default value.
     ?assertMatch({match, _}, re:run(MsgRaw3, <<"enoent">>)),
     ?assertMatch({match, _}, re:run(MsgRaw3, <<"ocsp\\.issuer_pem">>)),
     ok.

--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -130,7 +130,10 @@ init_per_group(quic, Config0) ->
             <<"quic">> => #{
                 <<"test">> => #{
                     <<"enable">> => true,
-                    <<"ssl_options">> => #{<<"verify">> => <<"verify_peer">>}
+                    <<"ssl_options">> => maps:merge(
+                        #{<<"verify">> => <<"verify_peer">>},
+                        emqx_common_test_helpers:listener_example_certs()
+                    )
                 }
             }
         }

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -177,6 +177,33 @@ default_mqtt_tcp_backend() ->
         {win32, _} -> gen_tcp
     end.
 
+managed_certs_null_clears_test_() ->
+    Sc = #{
+        roots => [mqtt_ssl_listener],
+        fields => #{mqtt_ssl_listener => emqx_schema:fields("mqtt_ssl_listener")}
+    },
+    Opts = #{atom_key => true, required => false},
+    Check = fun(ManagedCerts) ->
+        Conf = #{
+            <<"mqtt_ssl_listener">> => #{
+                <<"bind">> => <<"0.0.0.0:9883">>,
+                <<"ssl_options">> => #{<<"managed_certs">> => ManagedCerts}
+            }
+        },
+        #{mqtt_ssl_listener := #{ssl_options := SSL}} = hocon_tconf:check_plain(Sc, Conf, Opts),
+        maps:get(managed_certs, SSL, absent)
+    end,
+    [
+        %% How an update request asks a listener to stop using managed
+        %% certificates: the key cannot be dropped by a deep merge, so the
+        %% request names `null' and the schema check removes it.
+        {"null clears the field", ?_assertEqual(absent, Check(null))},
+        {"a bundle is kept",
+            ?_assertMatch(
+                [#{bundle_name := <<"b">>}], Check([#{<<"bundle_name">> => <<"b">>}])
+            )}
+    ].
+
 fail_if_no_peer_cert_test_() ->
     Sc = #{
         roots => [mqtt_ssl_listener],
@@ -483,6 +510,10 @@ server_ssl_opts_managed_certs_ocsp_validation_test() ->
     },
     InvalidListener = #{
         <<"ssl_options">> => #{
+            %% Explicit, because OCSP stapling requires a server certificate and
+            %% nothing is defaulted any more. Without it this configuration is
+            %% rejected for that instead, before reaching the rule under test.
+            <<"certfile">> => <<"/path/to/cert.pem">>,
             <<"managed_certs">> => [#{<<"bundle_name">> => <<"b">>}],
             <<"ocsp">> => #{
                 <<"enable_ocsp_stapling">> => true,

--- a/apps/emqx/test/emqx_tls_auth_ext_SUITE.erl
+++ b/apps/emqx/test/emqx_tls_auth_ext_SUITE.erl
@@ -36,7 +36,13 @@ end_per_suite(_Config) ->
 init_per_group(Profile, Config) when Profile =:= legacy; Profile =:= hardened ->
     ok = emqx_common_test_helpers:set_security_profile(Profile),
     Apps = emqx_cth_suite:start(
-        [{emqx, ?BASE_CONF}],
+        [
+            {emqx,
+                ?BASE_CONF ++
+                    emqx_common_test_helpers:listener_example_certs(
+                        "listeners.ssl.auth_ext"
+                    )}
+        ],
         #{work_dir => emqx_cth_suite:work_dir(Profile, Config)}
     ),
     emqx_listeners:restart(),

--- a/apps/emqx/test/emqx_tls_lib_tests.erl
+++ b/apps/emqx/test/emqx_tls_lib_tests.erl
@@ -26,13 +26,13 @@ ensure_default_certs_without_a_bundle_test() ->
     meck:new(emqx_default_cert, [passthrough, no_link, no_history]),
     meck:expect(emqx_default_cert, ensure_localhost_bundle, fun() -> {error, no_bundle} end),
     try
-        ?assertThrow(
-            #{error := <<"no_default_tls_certificate">>, reason := no_bundle},
+        ?assertMatch(
+            {error, #{error := <<"no_default_tls_certificate">>, reason := no_bundle}},
             emqx_tls_lib:ensure_default_certs(#{})
         ),
         %% A configuration that names its own certificate never asks for one.
         ?assertEqual(
-            #{certfile => <<"/x/cert.pem">>},
+            {ok, #{certfile => <<"/x/cert.pem">>}},
             emqx_tls_lib:ensure_default_certs(#{certfile => <<"/x/cert.pem">>})
         )
     after

--- a/apps/emqx/test/emqx_tls_lib_tests.erl
+++ b/apps/emqx/test/emqx_tls_lib_tests.erl
@@ -18,6 +18,68 @@
 -define(bundle, <<"some_bundle">>).
 -define(bundle2, <<"some_bundle2">>).
 
+%% A TLS server that cannot get the node's certificate must not start. `ssl'
+%% would accept a listener with no certificate and fail every handshake
+%% afterwards with an alert that names no cause, so the failure has to be raised
+%% where the reason is still known.
+ensure_default_certs_without_a_bundle_test() ->
+    meck:new(emqx_default_cert, [passthrough, no_link, no_history]),
+    meck:expect(emqx_default_cert, ensure_localhost_bundle, fun() -> {error, no_bundle} end),
+    try
+        ?assertThrow(
+            #{error := <<"no_default_tls_certificate">>, reason := no_bundle},
+            emqx_tls_lib:ensure_default_certs(#{})
+        ),
+        %% A configuration that names its own certificate never asks for one.
+        ?assertEqual(
+            #{certfile => <<"/x/cert.pem">>},
+            emqx_tls_lib:ensure_default_certs(#{certfile => <<"/x/cert.pem">>})
+        )
+    after
+        meck:unload(emqx_default_cert)
+    end.
+
+%% Inspecting a configuration is not serving it: a node with no bundle is
+%% expected here, and the configuration is left as it is.
+default_certs_if_present_without_a_bundle_test() ->
+    meck:new(emqx_default_cert, [passthrough, no_link, no_history]),
+    meck:expect(emqx_default_cert, localhost_bundle, fun() -> {error, no_bundle} end),
+    try
+        ?assertEqual(#{}, emqx_tls_lib:default_certs_if_present(#{}))
+    after
+        meck:unload(emqx_default_cert)
+    end.
+
+is_cert_configured_test_() ->
+    Configured = fun(V) -> emqx_tls_lib:is_cert_configured(V) end,
+    [
+        {"nothing at all", ?_assertNot(Configured(#{}))},
+        {"a file path counts", ?_assert(Configured(#{certfile => <<"/x/cert.pem">>}))},
+        {"binary keys count, since raw config reaches here too",
+            ?_assert(Configured(#{<<"keyfile">> => <<"/x/key.pem">>}))},
+        {"a single managed bundle counts, not just an array",
+            ?_assert(Configured(#{managed_certs => #{bundle_name => <<"b">>}}))},
+        {"an array of bundles counts",
+            ?_assert(Configured(#{managed_certs => [#{bundle_name => <<"b">>}]}))},
+        %% Values the schema will not produce, but a request can.
+        {"unset keys do not count",
+            ?_assertNot(Configured(#{certfile => undefined, keyfile => undefined}))},
+        {"empty values do not count", ?_assertNot(Configured(#{certfile => <<>>, keyfile => ""}))},
+        {"an empty bundle array does not count", ?_assertNot(Configured(#{managed_certs => []}))},
+        {"an emptied bundle object does not count",
+            ?_assertNot(Configured(#{managed_certs => #{}}))},
+        {"null, how a request clears a value, does not count",
+            ?_assertNot(Configured(#{<<"managed_certs">> => null}))},
+        %% `cacertfile' verifies peers; it is not a certificate of this server's
+        %% own, so it must not suppress the default one.
+        {"a cacertfile alone does not count",
+            ?_assertNot(Configured(#{cacertfile => <<"/x/ca.pem">>}))},
+        {"an mTLS listener with only a cacertfile still wants the default cert",
+            ?_assertNot(
+                Configured(#{cacertfile => <<"/x/ca.pem">>, verify => verify_peer})
+            )}
+    ].
+
 ensure_tls13_ciphers_added_test() ->
     Ciphers = emqx_tls_lib:integral_ciphers(['tlsv1.3'], [?TLS_12_CIPHER]),
     ?assert(lists:member(?TLS_12_CIPHER, Ciphers)),

--- a/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
@@ -1200,10 +1200,13 @@ t_precondition_check_cert_cn(init, TCConfig) ->
     {ok, _} = emqx:update_config(
         [listeners, ssl, default],
         {update, #{
-            <<"ssl_options">> => #{
-                <<"verify">> => verify_peer,
-                <<"fail_if_no_peer_cert">> => true
-            }
+            <<"ssl_options">> => maps:merge(
+                #{
+                    <<"verify">> => verify_peer,
+                    <<"fail_if_no_peer_cert">> => true
+                },
+                emqx_common_test_helpers:listener_example_certs()
+            )
         }}
     ),
     TCConfig;

--- a/apps/emqx_conf/etc/base.hocon
+++ b/apps/emqx_conf/etc/base.hocon
@@ -32,11 +32,5 @@ dashboard {
     listeners {
         http.bind = 18083
         # https.bind = 18084
-        https {
-            ssl_options {
-                certfile = "${EMQX_ETC_DIR}/certs/cert.pem"
-                keyfile = "${EMQX_ETC_DIR}/certs/key.pem"
-            }
-        }
     }
 }

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -462,9 +462,6 @@ listeners_test(Profile) ->
         <<"wss">> := #{<<"default">> := DefaultWss, <<"new">> := NewWss},
         <<"ssl">> := #{<<"default">> := Ssl}
     } = Listeners,
-    DefaultCacertFile = <<"${EMQX_ETC_DIR}/certs/cacert.pem">>,
-    DefaultCertFile = <<"${EMQX_ETC_DIR}/certs/cert.pem">>,
-    DefaultKeyFile = <<"${EMQX_ETC_DIR}/certs/key.pem">>,
     TcpBind = expected_default_listener_bind(Profile, 1883),
     WsBind = expected_default_listener_bind(Profile, 8083),
     SslBind = expected_configured_listener_bind(Profile, 9999),
@@ -485,44 +482,41 @@ listeners_test(Profile) ->
         },
         Ws
     ),
-    ?assertMatch(
-        #{
-            <<"bind">> := SslBind,
-            <<"ssl_options">> := #{
-                <<"cacertfile">> := DefaultCacertFile,
-                <<"certfile">> := DefaultCertFile,
-                <<"keyfile">> := DefaultKeyFile
-            }
-        },
-        Ssl
-    ),
+    %% No certificate defaults: a listener that configures none serves the
+    %% node's own generated bundle instead of a shipped example certificate.
+    ?assertMatch(#{<<"bind">> := SslBind}, Ssl),
+    assert_no_cert_defaults(Ssl),
+    %% What the configuration sets is kept; what it does not set stays unset.
     ?assertMatch(
         #{
             <<"bind">> := DefaultWssBind,
             <<"websocket">> := #{<<"mqtt_path">> := "/mqtt"},
-            <<"ssl_options">> :=
-                #{
-                    <<"cacertfile">> := <<"mytest/certs/cacert.pem">>,
-                    <<"certfile">> := DefaultCertFile,
-                    <<"keyfile">> := DefaultKeyFile
-                }
+            <<"ssl_options">> := #{<<"cacertfile">> := <<"mytest/certs/cacert.pem">>}
         },
         DefaultWss
     ),
+    assert_no_cert_defaults(DefaultWss, [<<"certfile">>, <<"keyfile">>]),
     ?assertMatch(
         #{
             <<"bind">> := NewWssBind,
-            <<"websocket">> := #{<<"mqtt_path">> := "/my-mqtt"},
-            <<"ssl_options">> :=
-                #{
-                    <<"cacertfile">> := DefaultCacertFile,
-                    <<"certfile">> := DefaultCertFile,
-                    <<"keyfile">> := DefaultKeyFile
-                }
+            <<"websocket">> := #{<<"mqtt_path">> := "/my-mqtt"}
         },
         NewWss
     ),
+    assert_no_cert_defaults(NewWss),
     ok.
+
+assert_no_cert_defaults(Listener) ->
+    assert_no_cert_defaults(Listener, [<<"cacertfile">>, <<"certfile">>, <<"keyfile">>]).
+
+assert_no_cert_defaults(Listener, Keys) ->
+    SslOpts = maps:get(<<"ssl_options">>, Listener, #{}),
+    lists:foreach(
+        fun(Key) ->
+            ?assertNot(maps:is_key(Key, SslOpts), #{key => Key, ssl_options => SslOpts})
+        end,
+        Keys
+    ).
 
 %% Schema defaults are static bare ports; the profile and the default
 %% address are applied at listener start, not in the schema.

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -26,6 +26,9 @@
 -export([authorize/2]).
 -export([get_namespace/1]).
 
+%% Exported for tests.
+-export([ensure_ssl_cert/1]).
+
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
 -include_lib("emqx_dashboard/include/emqx_dashboard_rbac.hrl").
@@ -424,7 +427,13 @@ jwt_token_bearer_authorize(Req, HandlerInfo, Token) ->
             {403, 'UNAUTHORIZED_ROLE', Msg}
     end.
 
-ensure_ssl_cert(Listeners = #{https := Https0 = #{ssl_options := SslOpts}}) ->
+%% `listeners/1' drops a listener bound to port 0, so it never starts and needs no
+%% certificate. Generating one here would create a key for a server that does not
+%% run, and again after every restart once an operator deleted it.
+ensure_ssl_cert(Listeners = #{https := #{bind := 0}}) ->
+    Listeners;
+ensure_ssl_cert(Listeners = #{https := Https0 = #{ssl_options := SslOpts0}}) ->
+    SslOpts = emqx_tls_lib:ensure_default_certs(SslOpts0),
     SslOpt1 = maps:from_list(emqx_tls_lib:to_server_opts(tls, SslOpts)),
     Https1 = maps:remove(ssl_options, Https0),
     Listeners#{https => maps:merge(Https1, SslOpt1)};

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -79,6 +79,7 @@ start_listeners(Listeners) ->
     %% Before starting the listeners, we do not generate the full dispatch upfront,
     %% because the listeners may fail to start and the generation may appear useless.
     InitDispatch = init_dispatch(),
+    {Listeners1, CertErrListeners} = ensure_ssl_cert_or_drop(Listeners),
     {OkListeners, ErrListeners} =
         lists:foldl(
             fun({Name, Protocol, Bind, RanchOptions, ProtoOpts}, {OkAcc, ErrAcc}) ->
@@ -101,8 +102,8 @@ start_listeners(Listeners) ->
                         {OkAcc, [Name | ErrAcc]}
                 end
             end,
-            {[], []},
-            listeners(ensure_ssl_cert(Listeners))
+            {[], CertErrListeners},
+            listeners(Listeners1)
         ),
     ok = emqx_dashboard_dispatch:regenerate_dispatch(OkListeners),
     case ErrListeners of
@@ -427,18 +428,35 @@ jwt_token_bearer_authorize(Req, HandlerInfo, Token) ->
             {403, 'UNAUTHORIZED_ROLE', Msg}
     end.
 
+%% Leaves out the HTTPS listener when it cannot be given a certificate, rather
+%% than letting the failure stop the others: plain HTTP still starts, and the
+%% dashboard reports HTTPS as the listener that failed.
+ensure_ssl_cert_or_drop(Listeners) ->
+    case ensure_ssl_cert(Listeners) of
+        {ok, Listeners1} ->
+            {Listeners1, []};
+        {error, Reason} ->
+            ?SLOG(error, #{
+                msg => "dashboard_https_listener_not_started",
+                reason => Reason
+            }),
+            {maps:remove(https, Listeners), [listener_name(https)]}
+    end.
+
 %% `listeners/1' drops a listener bound to port 0, so it never starts and needs no
 %% certificate. Generating one here would create a key for a server that does not
 %% run, and again after every restart once an operator deleted it.
 ensure_ssl_cert(Listeners = #{https := #{bind := 0}}) ->
-    Listeners;
+    {ok, Listeners};
 ensure_ssl_cert(Listeners = #{https := Https0 = #{ssl_options := SslOpts0}}) ->
-    SslOpts = emqx_tls_lib:ensure_default_certs(SslOpts0),
-    SslOpt1 = maps:from_list(emqx_tls_lib:to_server_opts(tls, SslOpts)),
-    Https1 = maps:remove(ssl_options, Https0),
-    Listeners#{https => maps:merge(Https1, SslOpt1)};
+    maybe
+        {ok, SslOpts} ?= emqx_tls_lib:ensure_default_certs(SslOpts0),
+        SslOpt1 = maps:from_list(emqx_tls_lib:to_server_opts(tls, SslOpts)),
+        Https1 = maps:remove(ssl_options, Https0),
+        {ok, Listeners#{https => maps:merge(Https1, SslOpt1)}}
+    end;
 ensure_ssl_cert(Listeners) ->
-    Listeners.
+    {ok, Listeners}.
 
 static_dispatch(SwaggerSupport) ->
     StaticFiles = ["/editor.worker.js", "/json.worker.js", "/version"],

--- a/apps/emqx_dashboard/src/emqx_dashboard_listener_config.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_listener_config.erl
@@ -162,10 +162,19 @@ ensure_ssl_cert(#{<<"listeners">> := #{<<"https">> := #{<<"bind">> := Bind} = Ht
     Https1 = emqx_dashboard_schema:https_converter(Https0, #{}),
     Conf1 = emqx_utils_maps:deep_put([<<"listeners">>, <<"https">>], Conf0, Https1),
     Ssl = maps:get(<<"ssl_options">>, Https1, undefined),
-    Opts = #{required_keys => [[<<"keyfile">>], [<<"certfile">>]]},
+    Opts = required_cert_keys(Ssl),
     case emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir(?DIR, Ssl, Opts) of
         {ok, undefined} ->
-            {error, <<"ssl_cert_not_found">>};
+            case emqx_tls_lib:is_cert_configured(Ssl) of
+                false ->
+                    %% No certificate is named: the listener serves the one this
+                    %% node generated for itself.
+                    {ok, Conf1};
+                true ->
+                    %% Something was configured but could not be resolved,
+                    %% which is still the operator's mistake to hear about.
+                    {error, <<"ssl_cert_not_found">>}
+            end;
         {ok, NewSsl} ->
             Keys = [<<"listeners">>, <<"https">>, <<"ssl_options">>],
             {ok, emqx_utils_maps:deep_put(Keys, Conf1, NewSsl)};
@@ -175,6 +184,15 @@ ensure_ssl_cert(#{<<"listeners">> := #{<<"https">> := #{<<"bind">> := Bind} = Ht
     end;
 ensure_ssl_cert(Conf) ->
     {ok, Conf}.
+
+%% A listener that names no certificate of its own is served by the one this node
+%% generated for itself, so the key/certificate pair is only required once the
+%% configuration names something. Naming one without the other stays an error.
+required_cert_keys(Ssl) ->
+    case emqx_tls_lib:is_cert_configured(Ssl) of
+        true -> #{required_keys => [[<<"keyfile">>], [<<"certfile">>]]};
+        false -> #{}
+    end.
 
 %% NOTE: some requests for dashboard update may be issued from pre/post_config_update hooks.
 %% We should wait for the config update to be completed before performing the requested updates.

--- a/apps/emqx_dashboard/test/emqx_dashboard_https_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_https_SUITE.erl
@@ -10,6 +10,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
+-include_lib("emqx/include/emqx_managed_certs.hrl").
 
 -define(NAME, 'https:dashboard').
 -define(HOST_HTTPS, "https://127.0.0.1:18084").
@@ -144,7 +146,10 @@ t_default_ssl_cert('end', Config) ->
     Apps = ?config(apps, Config),
     emqx_cth_suite:stop(Apps).
 t_default_ssl_cert(_Config) ->
-    validate_https(512, default_ssl_cert(), verify_none).
+    %% No certificate is configured, so the listener serves the one this node
+    %% generated for itself. There is no `cacertfile': that slot is the trust
+    %% anchor for verifying peers, which the generated bundle does not fill.
+    validate_https(512, node_default_cert(), verify_none).
 
 t_compatibility_ssl_cert(init, Config) ->
     MaxConnection = 1000,
@@ -226,8 +231,8 @@ t_verify_cacertfile('end', Config) ->
     ok.
 t_verify_cacertfile(Config) ->
     MaxConnection = ?config(max_connection, Config),
-    DefaultSSLCert = default_ssl_cert(),
-    SSLCert = DefaultSSLCert#{cacertfile => <<"">>},
+    NodeDefaultCert = node_default_cert(),
+    SSLCert = NodeDefaultCert#{cacertfile => <<"">>},
 
     %% validate with default #{verify => verify_none}
     ct:pal("testing with verify_none"),
@@ -267,7 +272,7 @@ t_verify_cacertfile(Config) ->
     %% hence the expected observation on the client side is an error
     ErrorReason =
         try
-            validate_https(MaxConnection, DefaultSSLCert, verify_peer)
+            validate_https(MaxConnection, NodeDefaultCert, verify_peer)
         catch
             error:{https_client_error, Reason} ->
                 Reason
@@ -425,6 +430,21 @@ default_ssl_cert() ->
         certfile => <<"${EMQX_ETC_DIR}/certs/cert.pem">>,
         keyfile => <<"${EMQX_ETC_DIR}/certs/key.pem">>
     }.
+
+%% The certificate this node generated for itself, as the listener resolves it:
+%% the bundle's chain and key, and no CA.
+node_default_cert() ->
+    {ok, Files} = emqx_managed_certs:list_managed_files(
+        ?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME
+    ),
+    #{
+        certfile => bundle_path(?FILE_KIND_CHAIN, Files),
+        keyfile => bundle_path(?FILE_KIND_KEY, Files)
+    }.
+
+bundle_path(Kind, Files) ->
+    #{Kind := #{path := Path}} = Files,
+    unicode:characters_to_list(Path).
 
 emqx_cth_suite_start(Case, DashboardConf, Config) ->
     emqx_cth_suite:start(

--- a/apps/emqx_dashboard/test/emqx_dashboard_tests.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_tests.erl
@@ -11,8 +11,22 @@
 %% behind this call.
 ensure_ssl_cert_skips_disabled_https_test() ->
     Listeners = #{https => #{bind => 0, ssl_options => #{}}},
-    ?assertEqual(Listeners, emqx_dashboard:ensure_ssl_cert(Listeners)).
+    ?assertEqual({ok, Listeners}, emqx_dashboard:ensure_ssl_cert(Listeners)).
 
 ensure_ssl_cert_leaves_other_listeners_alone_test() ->
     Listeners = #{http => #{bind => 18083}},
-    ?assertEqual(Listeners, emqx_dashboard:ensure_ssl_cert(Listeners)).
+    ?assertEqual({ok, Listeners}, emqx_dashboard:ensure_ssl_cert(Listeners)).
+
+%% An HTTPS listener that cannot be given a certificate must not stop the others
+%% from starting, so the failure is reported rather than raised.
+ensure_ssl_cert_reports_a_missing_certificate_test() ->
+    meck:new(emqx_default_cert, [passthrough, no_link, no_history]),
+    meck:expect(emqx_default_cert, ensure_localhost_bundle, fun() -> {error, no_bundle} end),
+    try
+        ?assertMatch(
+            {error, #{error := <<"no_default_tls_certificate">>}},
+            emqx_dashboard:ensure_ssl_cert(#{https => #{bind => 18084, ssl_options => #{}}})
+        )
+    after
+        meck:unload(emqx_default_cert)
+    end.

--- a/apps/emqx_dashboard/test/emqx_dashboard_tests.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_tests.erl
@@ -1,0 +1,18 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_dashboard_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% `emqx_dashboard:listeners/1' drops a listener bound to port 0, so it never
+%% starts. Leaving its config untouched is what keeps the node from generating a
+%% certificate for a server that does not run: everything that generates one sits
+%% behind this call.
+ensure_ssl_cert_skips_disabled_https_test() ->
+    Listeners = #{https => #{bind => 0, ssl_options => #{}}},
+    ?assertEqual(Listeners, emqx_dashboard:ensure_ssl_cert(Listeners)).
+
+ensure_ssl_cert_leaves_other_listeners_alone_test() ->
+    Listeners = #{http => #{bind => 18083}},
+    ?assertEqual(Listeners, emqx_dashboard:ensure_ssl_cert(Listeners)).

--- a/apps/emqx_gateway/src/emqx_gateway_utils_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils_conf.erl
@@ -495,9 +495,21 @@ ensure_dtls_protocol(_, SSLOpts) ->
     SSLOpts.
 
 ssl_server_opts(ssl_options, SSLOpts) ->
-    emqx_tls_lib:to_server_opts(tls, emqx_tls_lib:ensure_default_certs(SSLOpts));
+    emqx_tls_lib:to_server_opts(tls, with_default_certs(SSLOpts));
 ssl_server_opts(dtls_options, SSLOpts) ->
-    emqx_tls_lib:to_server_opts(dtls, emqx_tls_lib:ensure_default_certs(SSLOpts)).
+    emqx_tls_lib:to_server_opts(dtls, with_default_certs(SSLOpts)).
+
+%% A listener that cannot be given the node's own certificate does not start.
+%% Reported as a bad `listeners' config, which is how this module reports every
+%% other unusable listener option, so the gateway fails to load with a message
+%% naming the cause instead of binding a port it cannot serve on.
+with_default_certs(SSLOpts) ->
+    case emqx_tls_lib:ensure_default_certs(SSLOpts) of
+        {ok, SSLOpts1} ->
+            SSLOpts1;
+        {error, Reason} ->
+            error({badconf, #{key => listeners, value => SSLOpts, reason => Reason}})
+    end.
 
 default_tcp_options() ->
     [

--- a/apps/emqx_gateway/src/emqx_gateway_utils_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils_conf.erl
@@ -495,9 +495,9 @@ ensure_dtls_protocol(_, SSLOpts) ->
     SSLOpts.
 
 ssl_server_opts(ssl_options, SSLOpts) ->
-    emqx_tls_lib:to_server_opts(tls, SSLOpts);
+    emqx_tls_lib:to_server_opts(tls, emqx_tls_lib:ensure_default_certs(SSLOpts));
 ssl_server_opts(dtls_options, SSLOpts) ->
-    emqx_tls_lib:to_server_opts(dtls, SSLOpts).
+    emqx_tls_lib:to_server_opts(dtls, emqx_tls_lib:ensure_default_certs(SSLOpts)).
 
 default_tcp_options() ->
     [

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -24,6 +24,9 @@
 ]).
 -export([scopes/0]).
 
+%% Exported for tests.
+-export([reconcile_cert_source/2]).
+
 -import(emqx_dashboard_swagger, [error_codes/2, error_codes/1]).
 
 -import(emqx_mgmt_listeners_conf, [
@@ -439,10 +442,7 @@ crud_listeners_by_id(put, #{bindings := #{id := Id}, body := Body0}) ->
                     %% overwrite stored secrets.
                     Conf1 = emqx_utils:deobfuscate(Conf, PrevConf),
                     MergeConf0 = emqx_utils_maps:deep_merge(PrevConf, Conf1),
-                    %% The merge above cannot drop keys, so a switch away from a managed
-                    %% certificate bundle would retain the stale `managed_certs'.  Let the
-                    %% raw request decide the certificate source.
-                    MergeConf = emqx_listeners:reconcile_cert_source(Conf1, MergeConf0),
+                    MergeConf = reconcile_cert_source(Conf1, MergeConf0),
                     case update(Type, Name, MergeConf) of
                         {ok, #{raw_config := _RawConf}} ->
                             crud_listeners_by_id(get, #{bindings => #{id => Id}});
@@ -604,6 +604,59 @@ listener_status_by_id([NodeL | Rest], Acc) ->
         Listeners
     ),
     listener_status_by_id(Rest, Acc1).
+
+-doc """
+Keeps the certificate source an update request asks for.
+
+A `PUT' body is deep-merged over the stored configuration, and a deep merge
+cannot drop keys: a request that switches a listener to file certificates, or
+that clears `managed_certs' outright, would keep the stale bundle reference.
+Removing the key here would not last either, because
+`emqx_listeners:pre_config_update/3' merges this against the stored config once
+more and would bring it back.
+
+A request may spell the clear as `null' (what the Dashboard sends), as an empty
+string, or as an empty array. Whichever it uses, this writes `null', which is
+the only one that works as the marker: it survives both merges and the schema
+check drops it, leaving the checked configuration a listener runs with free of a
+bundle. An empty string written here would survive the schema check instead --
+`hocon' passes it through unchecked and unconverted -- and reach the listener as
+a bundle reference. Normalising an empty string on the way in is what keeps a
+request that sends one out of that trap.
+
+Both arguments are raw (binary-keyed) configs.
+""".
+reconcile_cert_source(Request, MergedConf) ->
+    case clears_managed_certs(request_ssl_options(Request)) of
+        true -> clear_managed_certs(MergedConf);
+        false -> MergedConf
+    end.
+
+%% Whether the request names a certificate source that is not a managed bundle:
+%% file certificates, or an explicit clear. An empty array never reaches here
+%% through the API -- the schema validator rejects it -- but it means the same
+%% thing to a direct caller.
+clears_managed_certs(#{} = RequestSSL) ->
+    case maps:get(<<"managed_certs">>, RequestSSL, undefined) of
+        undefined ->
+            maps:is_key(<<"certfile">>, RequestSSL) orelse
+                maps:is_key(<<"keyfile">>, RequestSSL);
+        Cleared when Cleared =:= null; Cleared =:= <<>>; Cleared =:= [] ->
+            true;
+        %% A bundle, either as a single object or as an array of them.
+        _Bundles ->
+            false
+    end;
+clears_managed_certs(_NotAMap) ->
+    false.
+
+clear_managed_certs(#{<<"ssl_options">> := SSL} = Conf) when is_map(SSL) ->
+    Conf#{<<"ssl_options">> => SSL#{<<"managed_certs">> => null}};
+clear_managed_certs(Conf) ->
+    Conf.
+
+request_ssl_options(#{<<"ssl_options">> := SSL}) -> SSL;
+request_ssl_options(_Request) -> undefined.
 
 listener_type_filter(Type0, Listeners) ->
     lists:map(

--- a/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_certs_SUITE.erl
@@ -119,6 +119,13 @@ init_per_testcase(_TestCase, TCConfig) ->
         AuthHeader = ?ON(N1, emqx_mgmt_api_test_util:auth_header_()),
         put_auth_header(AuthHeader)
     end,
+    %% A node whose TLS listeners have no certificate configured generates its
+    %% own default bundle when they start, so the certs dir is not empty to
+    %% begin with. Clear it here as well as in `end_per_testcase/2', so every
+    %% case sees only what it creates itself.
+    Nodes = get_config(nodes, TCConfig),
+    ?ON_ALL(Nodes, ok = emqx_managed_certs:clean_certs_dir()),
+    ok = give_tls_listeners_own_certs(TCConfig),
     TCConfig.
 
 end_per_testcase(_TestCase, TCConfig) ->
@@ -349,6 +356,74 @@ ssl_listener_certfile() ->
     %% `ssl`; the checked config may still hold `${EMQX_ETC_DIR}`.
     Raw = emqx_config:get([listeners, ssl, default, ssl_options, certfile]),
     emqx_utils_conv:bin(emqx_schema:naive_env_interpolation(Raw)).
+
+%% This suite is about managed certificates and the PEM cache, not about the
+%% certificate a node generates for itself.  Give the TLS listeners certificates
+%% of their own so every case starts from the same listener config, and so a case
+%% that reads a listener's `certfile' has one to read.
+give_tls_listeners_own_certs(TCConfig) ->
+    %% Written to a path both cluster nodes can read, and configured as a path
+    %% rather than inline PEM: inline content is saved into each node's own
+    %% mutable certs dir, so the nodes would disagree on where the file is.
+    Dir = filename:join(get_config(priv_dir, TCConfig), "listener_certs"),
+    ok = filelib:ensure_path(Dir),
+    #{cert_key := Root} = gen_cert(#{key => ec, issuer => root}),
+    Certs = lists:map(
+        fun(Type) ->
+            #{cert_pem := Cert, key_pem := Key} = gen_cert(#{key => ec, issuer => Root}),
+            CertFile = filename:join(Dir, atom_to_list(Type) ++ "-cert.pem"),
+            KeyFile = filename:join(Dir, atom_to_list(Type) ++ "-key.pem"),
+            ok = file:write_file(CertFile, Cert),
+            ok = file:write_file(KeyFile, Key),
+            {Type, emqx_utils_conv:bin(CertFile), emqx_utils_conv:bin(KeyFile)}
+        end,
+        [ssl, wss]
+    ),
+    [N1 | _] = get_config(nodes, TCConfig),
+    %% Only the `ssl_options' subtree: a whole-listener update would also push this
+    %% node's `bind' onto the others.
+    ?ON(N1, begin
+        lists:foreach(
+            fun({Type, CertFile, KeyFile}) ->
+                {ok, _} = emqx_conf:update(
+                    [listeners, Type, default],
+                    {update, #{
+                        <<"ssl_options">> => #{
+                            <<"certfile">> => CertFile,
+                            <<"keyfile">> => KeyFile,
+                            <<"managed_certs">> => null
+                        }
+                    }},
+                    #{override_to => cluster}
+                )
+            end,
+            Certs
+        )
+    end),
+    ok.
+
+%% Restores a listener to the config a test started from.
+%%
+%% The update API deep-merges, so a certificate key a test added survives a plain
+%% round-trip of the original body: removing one takes an explicit `null'.  Clear
+%% every certificate key the pristine config did not itself carry.
+restore_listener(Type, Name, Listener) ->
+    SSLOpts0 = maps:get(<<"ssl_options">>, Listener, #{}),
+    SSLOpts = lists:foldl(
+        fun(Key, Acc) ->
+            case is_map_key(Key, Acc) of
+                true -> Acc;
+                false -> Acc#{Key => null}
+            end
+        end,
+        SSLOpts0,
+        [<<"certfile">>, <<"keyfile">>, <<"cacertfile">>, <<"managed_certs">>]
+    ),
+    {200, _} = update_listener_api(Type, Name, Listener#{<<"ssl_options">> => SSLOpts}),
+    ok.
+
+shift_date(Date, Offset) ->
+    calendar:gregorian_days_to_date(calendar:date_to_gregorian_days(Date) + Offset).
 
 gen_cert(Opts) ->
     #{
@@ -1075,10 +1150,16 @@ t_managed_certs_prometheus_expiry_date(_TCConfig) ->
         cert_key := CertKeyRoot1,
         cert_pem := CA1
     } = gen_cert(#{key => ec, issuer => root}),
+    %% An explicit validity, so this certificate's expiry differs from the one the
+    %% listeners start with whatever the generator's default window is.
     #{
         cert_pem := Cert1,
         key_pem := Key1
-    } = gen_cert(#{key => ec, issuer => CertKeyRoot1}),
+    } = gen_cert(#{
+        key => ec,
+        issuer => CertKeyRoot1,
+        validity => {shift_date(date(), -1), shift_date(date(), +30)}
+    }),
 
     Bundle1 = <<"my_bundle">>,
     Files1 = [
@@ -1094,7 +1175,7 @@ t_managed_certs_prometheus_expiry_date(_TCConfig) ->
         TLSListener0,
         [#{<<"bundle_name">> => Bundle1}]
     ),
-    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
     {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener1),
 
     %% Now, they are no longer the same: TLS listener is using the fresh managed cert bundle.
@@ -1121,9 +1202,9 @@ t_managed_certs_prometheus_expiry_date(_TCConfig) ->
     ok.
 
 -doc """
-Verifies that a listener using a managed certificate bundle can be switched back to
-file-based (default) certificates even after the bundle has been deleted out-of-band.
-The stale `managed_certs` reference must not survive the update and block it.
+Verifies that a listener using a managed certificate bundle can be switched to
+file-based certificates even after the bundle has been deleted out-of-band. The
+stale `managed_certs` reference must not survive the update and block it.
 """.
 t_switch_off_deleted_managed_bundle() ->
     [{matrix, true}].
@@ -1142,9 +1223,9 @@ t_switch_off_deleted_managed_bundle(_TCConfig) ->
     ],
     ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
 
-    %% Original config uses file-based (default) certs.
+    %% Original config names no certificate of its own.
     {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
-    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
 
     %% Switch the listener to the managed bundle.
     TLSListenerManaged = emqx_utils_maps:deep_put(
@@ -1158,9 +1239,14 @@ t_switch_off_deleted_managed_bundle(_TCConfig) ->
     %% refuses to delete a referenced bundle.
     ok = emqx_managed_certs:delete_bundle(?global_ns, Bundle),
 
-    %% Switching back to the original file-based config must succeed even though the
-    %% bundle is gone, and the resulting config must no longer reference managed certs.
-    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListener0)),
+    %% Naming file certificates switches the source away from the bundle. This must
+    %% succeed even though the bundle is gone, and the resulting config must no
+    %% longer reference managed certs.
+    TLSListenerFiles = emqx_utils_maps:deep_merge(
+        TLSListener0,
+        #{<<"ssl_options">> => #{<<"certfile">> => Cert, <<"keyfile">> => Key}}
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerFiles)),
     {200, TLSListenerFinal} = get_listener_api(<<"ssl">>, <<"default">>),
     ?assertNot(
         is_map_key(<<"managed_certs">>, maps:get(<<"ssl_options">>, TLSListenerFinal)),
@@ -1171,9 +1257,9 @@ t_switch_off_deleted_managed_bundle(_TCConfig) ->
 
 -doc """
 Verifies that a listener using a managed certificate bundle can be switched back to
-file-based (default) certificates while the bundle still exists.  The switch must
-actually take effect (the stale `managed_certs` reference must be dropped), not
-silently keep using the bundle.
+no certificate of its own while the bundle still exists, by clearing
+`managed_certs`.  The switch must actually take effect (the stale reference must be
+dropped), not silently keep using the bundle.
 """.
 t_switch_off_existing_managed_bundle() ->
     [{matrix, true}].
@@ -1193,7 +1279,7 @@ t_switch_off_existing_managed_bundle(_TCConfig) ->
     ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
 
     {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
-    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
 
     TLSListenerManaged = emqx_utils_maps:deep_put(
         [<<"ssl_options">>, <<"managed_certs">>],
@@ -1207,12 +1293,67 @@ t_switch_off_existing_managed_bundle(_TCConfig) ->
         TLSListenerManaged1
     ),
 
-    %% Switch back to file-based certs while the bundle still exists: the update must
-    %% take effect and drop the managed cert reference.
-    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListener0)),
+    %% Clear the bundle while it still exists: the update must take effect and drop
+    %% the managed cert reference.
+    TLSListenerCleared = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        null
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerCleared)),
     {200, TLSListenerFinal} = get_listener_api(<<"ssl">>, <<"default">>),
     ?assertNot(
         is_map_key(<<"managed_certs">>, maps:get(<<"ssl_options">>, TLSListenerFinal)),
+        TLSListenerFinal
+    ),
+
+    ok.
+
+-doc """
+Verifies that an update carrying no certificate material at all keeps the managed
+bundle the listener already uses.  Such a request is indistinguishable from a
+partial update of unrelated fields, so it must not be read as a request to stop
+using managed certificates: clearing takes an explicit `null`.
+""".
+t_update_without_certs_keeps_managed_bundle() ->
+    [{matrix, true}].
+t_update_without_certs_keeps_managed_bundle(matrix) ->
+    [[?local]];
+t_update_without_certs_keeps_managed_bundle(_TCConfig) ->
+    #{cert_key := CertKeyRoot} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := CA} = gen_cert(#{key => ec, issuer => root}),
+    #{cert_pem := Cert, key_pem := Key} = gen_cert(#{key => ec, issuer => CertKeyRoot}),
+
+    Bundle = <<"keep_managed_bundle">>,
+    Files = [
+        {?FILE_KIND_CA_BIN, <<"ca.pem">>, CA},
+        {?FILE_KIND_CHAIN_BIN, <<"chain.pem">>, Cert},
+        {?FILE_KIND_KEY_BIN, <<"key.pem">>, Key}
+    ],
+    ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
+
+    {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
+
+    TLSListenerManaged = emqx_utils_maps:deep_put(
+        [<<"ssl_options">>, <<"managed_certs">>],
+        TLSListener0,
+        [#{<<"bundle_name">> => Bundle}]
+    ),
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerManaged)),
+
+    %% A body that names no certificate at all must leave the bundle alone.
+    SSLOpts = maps:get(<<"ssl_options">>, TLSListener0),
+    TLSListenerNoCerts = TLSListener0#{
+        <<"ssl_options">> => maps:without(
+            [<<"certfile">>, <<"keyfile">>, <<"cacertfile">>, <<"managed_certs">>], SSLOpts
+        )
+    },
+    ?assertMatch({200, _}, update_listener_api(<<"ssl">>, <<"default">>, TLSListenerNoCerts)),
+    {200, TLSListenerFinal} = get_listener_api(<<"ssl">>, <<"default">>),
+    ?assertMatch(
+        [#{<<"bundle_name">> := Bundle}],
+        maps:get(<<"managed_certs">>, maps:get(<<"ssl_options">>, TLSListenerFinal), undefined),
         TLSListenerFinal
     ),
 
@@ -1228,7 +1369,7 @@ t_switch_to_missing_managed_bundle(matrix) ->
     [[?local]];
 t_switch_to_missing_managed_bundle(_TCConfig) ->
     {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
-    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
 
     TLSListenerMissing = emqx_utils_maps:deep_put(
         [<<"ssl_options">>, <<"managed_certs">>],
@@ -1267,7 +1408,7 @@ t_switch_off_deleted_managed_bundle_null(_TCConfig) ->
 
     %% Original config uses file-based (default) certs.
     {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
-    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
 
     %% Switch the listener to the managed bundle.
     TLSListenerManaged = emqx_utils_maps:deep_put(
@@ -1309,7 +1450,7 @@ t_managed_certs_empty_list_rejected(matrix) ->
     [[?local]];
 t_managed_certs_empty_list_rejected(_TCConfig) ->
     {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
-    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
 
     TLSListenerEmpty = emqx_utils_maps:deep_put(
         [<<"ssl_options">>, <<"managed_certs">>],
@@ -1350,7 +1491,7 @@ t_delete_referenced_bundle(_TCConfig) ->
     ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
 
     {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
-    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
     TLSListenerManaged = emqx_utils_maps:deep_put(
         [<<"ssl_options">>, <<"managed_certs">>],
         TLSListener0,
@@ -1407,7 +1548,7 @@ t_delete_referenced_bundle_ns(_TCConfig) ->
     ?assertMatch({204, _}, upload_files_multipart_ns(Ns, Bundle, Files)),
 
     {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
-    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
     TLSListenerManaged = emqx_utils_maps:deep_put(
         [<<"ssl_options">>, <<"managed_certs">>],
         TLSListener0,
@@ -1447,7 +1588,7 @@ t_prometheus_stats_dangling_managed_certs(_TCConfig) ->
     ?assertMatch({204, _}, upload_files_multipart_global(Bundle, Files)),
 
     {200, TLSListener0} = get_listener_api(<<"ssl">>, <<"default">>),
-    on_exit(fun() -> {200, _} = update_listener_api(<<"ssl">>, <<"default">>, TLSListener0) end),
+    on_exit(fun() -> restore_listener(<<"ssl">>, <<"default">>, TLSListener0) end),
     TLSListenerManaged = emqx_utils_maps:deep_put(
         [<<"ssl_options">>, <<"managed_certs">>],
         TLSListener0,

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_2_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_2_SUITE.erl
@@ -14,19 +14,11 @@ all() ->
 
 init_per_suite(Config) ->
     _ = application:load(emqx),
-    CertDir = filename:join([code:lib_dir(emqx), "etc", "certs"]),
-    Cert = fun(Name) -> filename:join(CertDir, Name) end,
     %% keep it the same as the dashboard defaults in apps/emqx_conf/etc/base.hocon
     Conf =
         [
             "dashboard.listeners.http { enable = true, bind = 18083 }",
-            "dashboard.listeners.https {\n",
-            "  bind = 0 # disabled by default\n",
-            "  ssl_options {\n",
-            "    certfile = \"" ++ Cert("cert.pem") ++ "\"\n",
-            "    keyfile = \"" ++ Cert("key.pem") ++ "\"\n",
-            "  }\n"
-            "}\n"
+            "dashboard.listeners.https { bind = 0 }\n"
         ],
     Apps = emqx_cth_suite:start(
         [
@@ -110,11 +102,25 @@ t_dashboard(_Config) ->
 
     ?assertMatch({ok, _}, update_config("dashboard", Dashboard)),
     {ok, Dashboard1} = get_config("dashboard"),
-    ?assertEqual(Dashboard, Dashboard1),
+    %% The update API deep-merges, and a deep merge cannot drop keys: the
+    %% certificate files set earlier in this case survive putting the original
+    %% config back.  Nothing defaults them, so the original carries none of them.
+    ?assertEqual(without_https_cert_files(Dashboard), without_https_cert_files(Dashboard1)),
     timer:sleep(1500),
     ok.
 
 %% Helpers
+
+without_https_cert_files(Conf) ->
+    lists:foldl(
+        fun(Key, Acc) ->
+            emqx_utils_maps:deep_remove(
+                [<<"listeners">>, <<"https">>, <<"ssl_options">>, Key], Acc
+            )
+        end,
+        Conf,
+        [<<"certfile">>, <<"keyfile">>, <<"cacertfile">>]
+    ).
 
 get_config(Name) ->
     Path = emqx_mgmt_api_test_util:api_path(["configs", Name]),

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_tests.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_tests.erl
@@ -1,0 +1,57 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_mgmt_api_listeners_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+reconcile_cert_source_test_() ->
+    Managed = [#{<<"bundle_name">> => <<"bundle">>}],
+    Merged = #{<<"ssl_options">> => #{<<"managed_certs">> => Managed}},
+    Cleared = #{<<"ssl_options">> => #{<<"managed_certs">> => null}},
+    Reconcile = fun(Request) -> emqx_mgmt_api_listeners:reconcile_cert_source(Request, Merged) end,
+    ReqSSL = fun(SSL) -> #{<<"ssl_options">> => SSL} end,
+    [
+        %% Switching to file certificates, or clearing outright, marks the merged
+        %% config so the stale bundle does not survive the merge in
+        %% `emqx_listeners:pre_config_update/3'.
+        {"a certfile switches the source",
+            ?_assertEqual(Cleared, Reconcile(ReqSSL(#{<<"certfile">> => <<"c.pem">>})))},
+        {"a keyfile switches the source",
+            ?_assertEqual(Cleared, Reconcile(ReqSSL(#{<<"keyfile">> => <<"k.pem">>})))},
+        {"null clears", ?_assertEqual(Cleared, Reconcile(ReqSSL(#{<<"managed_certs">> => null})))},
+        %% A request can carry an empty string: `hocon' passes it through the
+        %% schema check unaltered, so normalising it to `null' here is what keeps
+        %% it from reaching the listener as a bundle reference.
+        {"an empty string clears",
+            ?_assertEqual(Cleared, Reconcile(ReqSSL(#{<<"managed_certs">> => <<>>})))},
+        %% The schema validator rejects an empty array before the handler sees
+        %% it, so this only covers a direct caller.
+        {"an empty array clears",
+            ?_assertEqual(Cleared, Reconcile(ReqSSL(#{<<"managed_certs">> => []})))},
+        %% A request that names a bundle, or no certificate at all, is left alone:
+        %% the latter is indistinguishable from a partial update of other fields.
+        {"a bundle is kept",
+            ?_assertEqual(Merged, Reconcile(ReqSSL(#{<<"managed_certs">> => Managed})))},
+        %% The field is a union: a single bundle object is as valid as an array
+        %% of them, and means the same thing here.
+        {"a single bundle object is kept",
+            ?_assertEqual(
+                Merged, Reconcile(ReqSSL(#{<<"managed_certs">> => hd(Managed)}))
+            )},
+        %% A bundle named alongside file certificates still wins: naming a
+        %% bundle is not a switch away from one.
+        {"a bundle named with file certificates is kept",
+            ?_assertEqual(
+                Merged,
+                Reconcile(
+                    ReqSSL(#{
+                        <<"managed_certs">> => Managed, <<"certfile">> => <<"c.pem">>
+                    })
+                )
+            )},
+        {"an unrelated ssl option is kept",
+            ?_assertEqual(Merged, Reconcile(ReqSSL(#{<<"verify">> => <<"verify_none">>})))},
+        {"a request without ssl_options is kept",
+            ?_assertEqual(Merged, Reconcile(#{<<"bind">> => <<"0.0.0.0:8883">>}))}
+    ].

--- a/changes/ee/feat-18813.en.md
+++ b/changes/ee/feat-18813.en.md
@@ -1,0 +1,9 @@
+TLS listeners with no certificate configured now serve a certificate the node generates for itself, instead of an example certificate shipped with EMQX.
+
+Every installation used to ship the same example key pair, so that key was not private to anyone. A node now generates its own on first use, so no two installations share one.
+
+This affects a listener only if it has no `certfile` or `keyfile` of its own; explicitly configured certificates are untouched. Clients that trusted the shipped certificate, or the CA that signed it, no longer validate against such a listener and need the node's own certificate instead. It can be read from `data/certs2/global/localhost/chain.pem`, or replaced by storing your own certificate under that same bundle name.
+
+The Dashboard's HTTPS listener is included: enabling it by setting only a `bind` address used to serve the same example certificate, and now serves the node's own.
+
+`verify_peer` on a listener with no CA configured also no longer trusts the shipped CA, which anyone could obtain and issue client certificates against. Such a listener now has no trust anchor at all until one is configured.


### PR DESCRIPTION
Release version:
7.0.0

Introduced in:
N/A

## Summary

Finishes what #18597 and #18799 built: a TLS listener with no certificate configured now serves a
certificate the node generated for itself, instead of the example certificate every installation
shipped. This is the user-facing end of #4636.

The shipped `.pem` files stay for now. They go once the test suites stop depending on them.

## How it is wired

`emqx_tls_lib:ensure_default_certs/1` points a configuration with no certificate of its own at the
node's `localhost` bundle, generating it at that moment if the node has none. It is applied to
**checked** config at the point a server actually starts: MQTT `ssl`/`wss`/`quic`, the dashboard's
HTTPS listener, and gateway TLS/DTLS. Removing the schema defaults for `cacertfile`, `certfile` and
`keyfile` is what activates it — until now every listener had a certificate from the schema, so the
fallback never fired.

Three deliberate limits, each of which cost a bug to learn:

- **Never on raw config.** Raw config is what gets persisted and what later REST updates deep-merge
  against, so a bundle injected there would read back as a certificate the operator had configured.
- **Never on inspection.** `to_server_opts/2` stays a plain conversion. The config a running
  listener is being updated *away* from resolves through `default_certs_if_present/1`, which never
  generates: it is only compared against and rolled back to, so generating there created a key as a
  side effect of an update that did not need one.
- **`emqx_prometheus` is not wired.** Its `to_server_opts/2` call sits in `resolve_listener_certfile/3`,
  which feeds the cert-expiry metric by reading *other* listeners' certificates; applying the
  fallback there would generate a certificate as a side effect of a scrape. The cost is that a
  listener relying on the fallback reports no expiry metric.

The bundle a node generates holds a key and a chain. An operator can install their own under the
same name, and theirs may carry a `ca` file; that file is served as the `cacertfile`, so such a
listener can verify peers. A `cacertfile` the configuration names still wins, and one holding no
certificate is ignored — `ssl` refuses to start a listener whose `cacertfile` decodes to nothing.

## What removing the defaults exposed

Four bugs that the schema defaults had been masking. Each is a separate commit.

**Switching a listener off a managed bundle never worked end to end.** The update API drops the
residual `managed_certs`, then `pre_config_update/3` deep-merges against the stored config a second
time and a deep merge cannot drop keys, so the reference came back — and the request's `null` was
gone by then. A round-tripped body always carried `certfile`/`keyfile` from the defaults and so took
the file-certs branch instead, which is why the `null` clause added in #18043 had never fired. The
clear is now marked with `null`, which survives both merges and which the schema check drops.

That reconciliation is an artefact of how the *API* updates a listener, so it now lives in
`emqx_mgmt_api_listeners` rather than `emqx_listeners`, which loses ~75 lines and whose
`pre_config_update/3` just merges. A request may spell the clear as `null`, an empty string or an
empty array; all normalise to `null`. An empty string cannot be the marker: `hocon` passes it
through the schema check unchecked and unconverted, so it would reach the listener as a bundle
reference.

**A configured `cacertfile` was dropped.** Pointing `managed_certs` at the bundle replaced the whole
certificate triple, because resolving a managed bundle returns only that bundle's files. A listener
with `verify_peer` and a CA but no certificate of its own then failed to start with no trust anchor.
The fallback now names the bundle's key and chain directly and leaves the rest alone.

**The dashboard required `keyfile` and `certfile` unconditionally**, so updating the dashboard config
with no HTTPS certificate failed with `ssl_file_option_not_found`. They are required only once the
configuration names something; naming one without the other is still an error.

**A request that named no certificate could not be told from a partial update.** It is left alone,
so a client that PUTs a body without cert fields does not silently clear a bundle.

## Behaviour changes beyond the obvious

- `GET /listeners/:id` no longer returns `certfile`/`keyfile`/`cacertfile` for a listener that has
  none configured. Nothing is defaulted into the response any more.
- An HTTPS dashboard listener with no certificate is accepted rather than rejected. A certificate
  that is configured but cannot be resolved is still an error.
- `is_cert_configured/1` does not count `cacertfile`: it names the authority used to verify peers,
  not the server's own identity, so a listener setting only a `cacertfile` still gets the default
  certificate to present.
- OCSP stapling on a listener with no `certfile` is rejected with "Server certificate must be
  defined when using OCSP stapling". It was previously satisfied by the shipped default, which meant
  stapling against the certificate every installation shared.

## Test fallout

Suites that set `verify_peer` without naming a certificate, or whose clients present or verify the
shipped example certificates, now name them explicitly through
`emqx_common_test_helpers:listener_example_certs/0,1`. Most `init_per_suite` failures in a CI run
are cascade: one suite failing to start `ssl:default` leaves the node dirty and the next suites trip
`emqx_cth_suite`'s clean-state check.

Three cases assert the new behaviour instead of being restored to the old one: the dashboard serving
the node's own bundle, the OCSP validation ordering, and a config round-trip where a deep merge
cannot drop a `cacertfile` the case set earlier.

## Verification

Run locally, all green:

- `emqx_mgmt_api_certs_SUITE` 22/22, `emqx_default_cert_SUITE` 18/18, `emqx_listeners_SUITE` 33/33,
  `emqx_dashboard_https_SUITE` 11/11, `emqx_mgmt_api_listeners_SUITE` 27/27,
  `emqx_tls_auth_ext_SUITE` 4/4.
- 305 eunit tests across `emqx_tls_lib_tests`, `emqx_schema_tests`, `emqx_conf_schema_tests` and the
  new `emqx_mgmt_api_listeners_tests`.
- `emqx_default_cert_SUITE` includes an end-to-end case: a real MQTT TLS listener configured with no
  certificate accepts a TLS connection, serves `CN=localhost`, and the served DER is byte-identical
  to the leaf in this node's own bundle.
- `make static_checks`, `make fmt-diff` and `./scripts/elvis-check.sh` clean.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
