### PR TITLE
fix(telemetry): return 400 when PUT /telemetry/status omits enable

### DIFF
--- a/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
@@ -96,6 +96,34 @@ t_send_request_api(_) ->
     erlang:exit(ClientId, kill),
     ok.
 
+-doc """
+`POST /gateways/coap/clients/:clientid/request` rejects a body that omits a
+declared field with 400, and does not leak an Erlang stack trace.
+""".
+t_send_request_missing_field(_) ->
+    Uri = emqx_mgmt_api_test_util:uri(["gateways", "coap", "clients", "client1", "request"]),
+    Full = #{
+        token => <<"atoken">>,
+        payload => <<"simple echo this">>,
+        timeout => <<"10s">>,
+        content_type => <<"text/plain">>,
+        method => <<"get">>
+    },
+    lists:foreach(
+        fun(Field) ->
+            RequestBody = maps:remove(Field, Full),
+            {ok, Status, Body} = emqx_mgmt_api_test_util:request(post, Uri, RequestBody),
+            ?assertEqual(400, Status, #{omitted_field => Field, body => Body}),
+            ?assertEqual(
+                nomatch,
+                binary:match(Body, <<"INTERNAL_ERROR">>),
+                #{omitted_field => Field, body => Body}
+            )
+        end,
+        maps:keys(Full)
+    ),
+    ok.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Internal Functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/apps/emqx_telemetry/src/emqx_telemetry_api.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry_api.erl
@@ -92,7 +92,7 @@ fields(status) ->
                 boolean(),
                 #{
                     desc => ?DESC(enable),
-                    default => true,
+                    required => true,
                     example => false
                 }
             )}

--- a/apps/emqx_telemetry/test/emqx_telemetry_api_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_api_SUITE.erl
@@ -141,6 +141,23 @@ check_status(Default) ->
     ?assertEqual(Default, is_telemetry_process_enabled()),
     ok.
 
+-doc """
+`PUT /telemetry/status` rejects a body that omits `enable` with 400,
+and does not leak an Erlang stack trace.
+""".
+t_status_missing_enable(_) ->
+    {ok, Status, Body} = request(put, uri(["telemetry", "status"]), #{}),
+    ?assertEqual(400, Status),
+    #{<<"code">> := Code, <<"message">> := Message} = emqx_utils_json:decode(Body),
+    ?assertEqual(<<"BAD_REQUEST">>, Code),
+    ?assertMatch(
+        #{<<"reason">> := <<"required_field">>, <<"path">> := <<"root.enable">>},
+        emqx_utils_json:decode(Message)
+    ),
+    ?assertEqual(nomatch, binary:match(Body, <<"INTERNAL_ERROR">>)),
+    ?assertEqual(nomatch, binary:match(Body, <<"emqx_telemetry_api">>)),
+    ok.
+
 t_data(_) ->
     ?assert(is_telemetry_process_enabled()),
     {ok, 200, Result} =

--- a/changes/ee/fix-18816.en.md
+++ b/changes/ee/fix-18816.en.md
@@ -1,0 +1,3 @@
+Fixed `PUT /api/v5/telemetry/status` returning `500 INTERNAL_ERROR` with an Erlang stack trace when the request body omits the `enable` field.
+
+The endpoint now returns `400 BAD_REQUEST` with a validation message. The API documentation marks `enable` as required and no longer shows a default value for it, because the endpoint has never applied that default.


### PR DESCRIPTION
Release versions:
5.10.5

Introduced in:
pre-5.8

## Summary

Fixes #18815.

`PUT /api/v5/telemetry/status` with body `{}` returned `500 INTERNAL_ERROR` and echoed an Erlang stack trace to the client. It now returns:

```json
{"code":"BAD_REQUEST","message":"{\"reason\":\"required_field\",\"path\":\"root.enable\",\"kind\":\"validation_error\"}"}
```

### Why the declared default was never applied

The `enable` field declared `default => true`, yet the handler observably received `#{}`. `emqx_telemetry_api:api_spec/0` passes `check_schema => true` without `translate_body`, which selects `emqx_dashboard_swagger:check_only/3`. That function runs `hocon_tconf:check_plain/3` for its validation errors and then discards the result, returning the raw request body. Hocon does fill the default — verified directly against this schema — but the filled map is thrown away.

The declared default also suppressed the required-field check, because hocon resolves a default before deciding whether a field is missing. So the schema promised a value the handler could never receive, and at the same time stopped validation from rejecting the empty body.

This is general `emqx_dashboard_swagger` behaviour, not a telemetry bug: every module using `check_schema => true` without `translate_body` gets the raw body, so a `default` in a `ref`-form request body is inert there. This PR does not change the swagger layer — that would affect all API modules and needs its own decision.

### The fix

Declare `enable` as `required => true` and drop the unreachable default. Validation rejects the body before the handler runs.

This is a schema change and it is backward compatible: the only request shape it newly rejects is a body without `enable`, which previously returned 500 and never succeeded. The generated API docs now mark `enable` as required and no longer show a default for it.

Alternatives considered and rejected:

- `maps:get(<<"enable">>, Body, true)` in the handler. It leaves the schema and the handler disagreeing, and makes `PUT {}` silently enable telemetry.
- Switching the module to `translate_body => true`. It would hand the handler hocon's converted value and turn `{"enable":"true"}` from a 400 into a 200, loosening the endpoint beyond the reported bug.

### Audit of the same class

I checked every two-arity `maps:get(<<...>>, Body)` in `apps/*/src/*_api.erl`:

- `emqx_gateway_coap`: `content_type` and `timeout` are read with `maps:get/2` and declare neither a default nor `required => true`, which looks like the same defect. Checked end to end against unmodified source: omitting any field already returns 400. `emqx_coap_api` passes `requestBody` as a plain list, so `check_request_body/5` takes its `is_list(Spec)` branch and calls the check function with empty options; `hocon_tconf:do_check/4` then merges `#{required => true}`, making every field of a list-form body required. Added a regression test rather than a code change.
- `emqx_dashboard_api`: all call sites are list-form request bodies, so the same rule applies.
- `emqx_dashboard_sso_api` (4 call sites): all sit behind a successful `emqx_dashboard_sso:login/3`, which cannot succeed without a username. Left alone.

Two things worth noting separately, not changed here:

- The generated OpenAPI marks list-form request-body fields as optional while the server requires them. The docs and the server disagree for every such endpoint.
- The same telemetry defect exists on `dev-60` and `dev-70`. The v5 and v6 chains are separate, so that needs its own PR.

### Tests

- `emqx_telemetry_api_SUITE:t_status_missing_enable` — `PUT {}` returns 400, carries `BAD_REQUEST` and a `required_field` message, and contains no `INTERNAL_ERROR` and no module name from a stack trace.
- `emqx_coap_api_SUITE:t_send_request_missing_field` — omitting each declared body field returns 400 with no `INTERNAL_ERROR`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
