### PR TITLE
fix(telemetry): return 400 when PUT /telemetry/status omits enable

### DIFF
--- a/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
@@ -96,6 +96,34 @@ t_send_request_api(_) ->
     erlang:exit(ClientId, kill),
     ok.
 
+-doc """
+`POST /gateways/coap/clients/:clientid/request` rejects a body that omits a
+declared field with 400, and does not leak an Erlang stack trace.
+""".
+t_send_request_missing_field(_) ->
+    Uri = emqx_mgmt_api_test_util:uri(["gateways", "coap", "clients", "client1", "request"]),
+    Full = #{
+        token => <<"atoken">>,
+        payload => <<"simple echo this">>,
+        timeout => <<"10s">>,
+        content_type => <<"text/plain">>,
+        method => <<"get">>
+    },
+    lists:foreach(
+        fun(Field) ->
+            RequestBody = maps:remove(Field, Full),
+            {ok, Status, Body} = emqx_mgmt_api_test_util:request(post, Uri, RequestBody),
+            ?assertEqual(400, Status, #{omitted_field => Field, body => Body}),
+            ?assertEqual(
+                nomatch,
+                binary:match(Body, <<"INTERNAL_ERROR">>),
+                #{omitted_field => Field, body => Body}
+            )
+        end,
+        maps:keys(Full)
+    ),
+    ok.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Internal Functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/apps/emqx_telemetry/src/emqx_telemetry_api.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry_api.erl
@@ -91,7 +91,7 @@ fields(status) ->
                 boolean(),
                 #{
                     desc => ?DESC(enable),
-                    default => true,
+                    required => true,
                     example => false
                 }
             )}

--- a/apps/emqx_telemetry/test/emqx_telemetry_api_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_api_SUITE.erl
@@ -141,6 +141,23 @@ check_status(Default) ->
     ?assertEqual(Default, is_telemetry_process_enabled()),
     ok.
 
+-doc """
+`PUT /telemetry/status` rejects a body that omits `enable` with 400,
+and does not leak an Erlang stack trace.
+""".
+t_status_missing_enable(_) ->
+    {ok, Status, Body} = request(put, uri(["telemetry", "status"]), #{}),
+    ?assertEqual(400, Status),
+    #{<<"code">> := Code, <<"message">> := Message} = emqx_utils_json:decode(Body),
+    ?assertEqual(<<"BAD_REQUEST">>, Code),
+    ?assertMatch(
+        #{<<"reason">> := <<"required_field">>, <<"path">> := <<"root.enable">>},
+        emqx_utils_json:decode(Message)
+    ),
+    ?assertEqual(nomatch, binary:match(Body, <<"INTERNAL_ERROR">>)),
+    ?assertEqual(nomatch, binary:match(Body, <<"emqx_telemetry_api">>)),
+    ok.
+
 t_data(_) ->
     ?assert(is_telemetry_process_enabled()),
     {ok, 200, Result} =

--- a/changes/ee/fix-18817.en.md
+++ b/changes/ee/fix-18817.en.md
@@ -1,0 +1,3 @@
+Fixed `PUT /api/v5/telemetry/status` returning `500 INTERNAL_ERROR` with an Erlang stack trace when the request body omits the `enable` field.
+
+The endpoint now returns `400 BAD_REQUEST` with a validation message. The API documentation marks `enable` as required and no longer shows a default value for it, because the endpoint has never applied that default.


### PR DESCRIPTION
Fixes: #18815
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: pre-5.8

## Summary

v6 counterpart of #18816. The v5 and v6 chains are separate, so this PR is what carries the fix from 6.0 to `master`. Same fix shape as #18816.

`PUT /api/v5/telemetry/status` with a body that omits `enable` returned `500 INTERNAL_ERROR` and serialised an Erlang stack trace into the response. `emqx_telemetry_api:status/2` read the field with `maps:get/2`, so a missing key raised `{badkey, <<"enable">>}` and minirest converted the uncaught exception into a 500.

The field's schema declared `default => true`, but that default never reached the handler. `emqx_telemetry_api` calls `emqx_dashboard_swagger:spec/2` with `check_schema => true` and no `translate_body`, which selects `filter_check_request/2`. That filter validates the body with `check_only/3`, which runs `hocon_tconf:check_plain/3` for its side effect and then returns the original map. Any schema default on a request body is dropped on this path. That is general dashboard-swagger behaviour, not a telemetry bug, and it affects every API module that uses `check_schema => true` without `translate_body`. This PR does not change it — that needs its own decision.

The fix declares `enable` as `required => true` and drops the unused default. Validation now rejects the body before the handler runs. For a `PUT` that toggles a setting, an empty body is a caller mistake, not a request to enable telemetry, so requiring the field is the better contract than making the handler fall back to `true`.

Response for `PUT /api/v5/telemetry/status` with `{}`:

```json
{"code":"BAD_REQUEST","message":"{\"reason\":\"required_field\",\"path\":\"root.enable\",\"kind\":\"validation_error\"}"}
```

`{"enable":null}`, `{"enable":1}` and `{"wrong":true}` also return 400.

### CoAP gateway

`emqx_coap_api:request/2` reads `content_type` and `timeout` with `maps:get/2` while their schema entries declare neither `default` nor `required => true`, which looks like the same defect. It is not reachable. A list-form `requestBody` is validated field by field with `Opts = #{}`, and hocon treats a root field as required unless told otherwise, so `POST /gateways/coap/clients/{clientid}/request` already answers 400 when any of the five fields is missing. Verified against the real module through `emqx_dashboard_swagger:filter_check_request_and_translate_body/2`. No source change; a test pins the behaviour.

Worth noting separately: the generated OpenAPI marks a field required only when the schema says `required => true`, so the CoAP request body is documented as all-optional while the server requires all five fields. That is a documentation mismatch, not a crash, and is left for a follow-up.

### Checked, not changed

`emqx_dashboard_sso_api` has four `maps:get(<<"username">>, Body)` call sites. All sit in branches reached only after `emqx_dashboard_sso:login/3` succeeds, and login cannot succeed without a username, so the key is present by construction.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
