### PR TITLE
fix(telemetry): return 400 when PUT /telemetry/status omits enable

### DIFF
--- a/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
@@ -108,6 +108,32 @@ t_send_request_api(_) ->
     erlang:exit(ClientId, kill),
     ok.
 
+%% `POST /gateways/coap/clients/:clientid/request` rejects a body that omits a
+%% declared field with 400, and does not leak an Erlang stack trace.
+t_send_request_missing_field(_) ->
+    Uri = emqx_mgmt_api_test_util:uri(["gateways", "coap", "clients", "client1", "request"]),
+    Full = #{
+        token => <<"atoken">>,
+        payload => <<"simple echo this">>,
+        timeout => <<"10s">>,
+        content_type => <<"text/plain">>,
+        method => <<"get">>
+    },
+    lists:foreach(
+        fun(Field) ->
+            RequestBody = maps:remove(Field, Full),
+            {ok, Status, Body} = emqx_mgmt_api_test_util:request(post, Uri, RequestBody),
+            ?assertEqual(400, Status, #{omitted_field => Field, body => Body}),
+            ?assertEqual(
+                nomatch,
+                binary:match(Body, <<"INTERNAL_ERROR">>),
+                #{omitted_field => Field, body => Body}
+            )
+        end,
+        maps:keys(Full)
+    ),
+    ok.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Internal Functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/apps/emqx_telemetry/src/emqx_telemetry.app.src
+++ b/apps/emqx_telemetry/src/emqx_telemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_telemetry, [
     {description, "Report telemetry data for EMQX Opensource edition"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, [emqx_telemetry_sup, emqx_telemetry]},
     {mod, {emqx_telemetry_app, []}},
     {applications, [

--- a/apps/emqx_telemetry/src/emqx_telemetry_api.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry_api.erl
@@ -99,7 +99,7 @@ fields(status) ->
                 boolean(),
                 #{
                     desc => ?DESC(enable),
-                    default => true,
+                    required => true,
                     example => false
                 }
             )}

--- a/apps/emqx_telemetry/test/emqx_telemetry_api_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_api_SUITE.erl
@@ -152,6 +152,21 @@ check_status(Default) ->
     ?assertEqual(Default, is_telemetry_process_enabled()),
     ok.
 
+%% `PUT /telemetry/status` rejects a body that omits `enable` with 400,
+%% and does not leak an Erlang stack trace.
+t_status_missing_enable(_) ->
+    {ok, Status, Body} = request(put, uri(["telemetry", "status"]), #{}),
+    ?assertEqual(400, Status),
+    #{<<"code">> := Code, <<"message">> := Message} = emqx_utils_json:decode(Body),
+    ?assertEqual(<<"BAD_REQUEST">>, Code),
+    ?assertMatch(
+        #{<<"reason">> := <<"required_field">>, <<"path">> := <<"root.enable">>},
+        emqx_utils_json:decode(Message)
+    ),
+    ?assertEqual(nomatch, binary:match(Body, <<"INTERNAL_ERROR">>)),
+    ?assertEqual(nomatch, binary:match(Body, <<"emqx_telemetry_api">>)),
+    ok.
+
 t_data(_) ->
     ?assert(is_telemetry_process_enabled()),
     {ok, 200, Result} =

--- a/changes/ee/fix-18820.en.md
+++ b/changes/ee/fix-18820.en.md
@@ -1,0 +1,3 @@
+Fixed `PUT /api/v5/telemetry/status` returning `500 INTERNAL_ERROR` with an Erlang stack trace when the request body omits the `enable` field.
+
+The endpoint now returns `400 BAD_REQUEST` with a validation message. The API documentation marks `enable` as required and no longer shows a default value for it, because the endpoint has never applied that default.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

Backport of #18816 (already merged to `dev-510`) to the head of the v5 chain, for issue #18815.

`PUT /api/v5/telemetry/status` with a body that omits `enable` returned `500 INTERNAL_ERROR` and echoed an Erlang stack trace to the client. The handler read the field with `maps:get/2`, so a missing key raised `{badkey, <<"enable">>}`.

The schema declared `default => true`, but the handler never saw that default. `emqx_telemetry_api:api_spec/0` passes `check_schema => true` without `translate_body`, which selects `emqx_dashboard_swagger:check_only/3`. That function runs `hocon_tconf:check_plain/3` for its validation errors and then discards its output, returning the raw request body. Hocon does fill the default, but the filled map is thrown away. The declared default also suppressed the required-field check, because hocon resolves a default before deciding whether a field is missing. So the schema promised a value the handler could never receive, and at the same time stopped validation from rejecting the empty body.

The fix declares `enable` as `required => true` and drops the unreachable default. Validation now rejects a body without `enable` before the handler runs, and the client gets:

```json
{"code":"BAD_REQUEST","message":"{\"reason\":\"required_field\",\"path\":\"root.enable\",\"kind\":\"validation_error\"}"}
```

Two alternatives were considered and rejected:

- `maps:get(<<"enable">>, Body, true)` — leaves the schema and the handler disagreeing, and makes `PUT {}` silently enable telemetry.
- switching the module to `translate_body => true` — hands the handler hocon's converted value and turns `{"enable":"true"}` from a 400 into a 200, loosening the endpoint beyond the reported bug.

The second commit is test-only. `emqx_coap_api:request/2` reads `content_type` and `timeout` with `maps:get/2` while their schema entries declare neither a default nor `required => true`, which looks like the same defect. It is not reachable: `emqx_coap_api` passes `requestBody` as a plain list of `{Name, Type}` pairs, so `emqx_dashboard_swagger:check_request_body/5` takes its `is_list(Spec)` branch and calls the check function with empty options, and `hocon_tconf:do_check/4` then merges `#{required => true}`. Every field of a list-form body is required regardless of its own schema. The new case pins that so the guarantee stops being an accident of the swagger layer.

Note for whoever runs the next sync round: the forward sync `dev-58` -> `dev-59` -> `dev-510` will meet the same change already on `dev-510`. The content is identical, so the merge should resolve cleanly.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

The schema change is backward compatible. The only newly rejected body is one without `enable`, which previously returned 500 and never succeeded.
