### PR TITLE
fix(dsraft): record OTX leadership before schema propagation

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
@@ -737,15 +737,17 @@ otx_get_latest_generation(DB, Shard) ->
     emqx_ds_storage_layer:generation_current({DB, Shard}).
 
 otx_become_leader(DB, Shard) ->
+    Timeout = ra_timeout(DB),
     maybe
         {ok, Leader} ?= local_raft_leader(DB, Shard),
         ok ?= check_min_rfsm_version(Leader, 1),
+        %% Establish presence:
+        {ok, TxSerial, _TxLastTimestamp} ?= announce_otx_leader_pid(Leader, 5_000, self()),
         %% Propagate my schema:
         SiteSchema = emqx_dsch:get_db_schema(DB),
         Command = emqx_ds_builtin_raft_machine:update_schema(SiteSchema, emqx_ds:timestamp_us()),
-        {ok, _TxLastTimestamp, Leader} ?= ra:process_command(Leader, Command, ra_timeout(DB)),
-        %% Establish presence:
-        {ok, TxSerial, TxLastTimestamp} ?= announce_otx_leader_pid(Leader, 5_000, self()),
+        {ok, {ok, TxLastTimestamp}, _Leader} ?= ra:process_command(Leader, Command, Timeout),
+        %% Announce to the cluster:
         register_global_otx_leader(DB, Shard),
         emqx_ds_builtin_raft_liveness:notify_shard_up(DB, Shard),
         {ok, TxSerial, TxLastTimestamp}

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_machine.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_machine.erl
@@ -388,7 +388,7 @@ apply(
         _ ->
             %% Leader mismatch:
             State = State0,
-            Result = ?err_unrec({not_the_leader, #{got => From, expect => Leader}}),
+            Result = ?err_rec({not_the_leader, #{got => From, expect => Leader}}),
             Effects = []
     end,
     {State, Result, Effects};

--- a/apps/emqx_durable_storage/mix.exs
+++ b/apps/emqx_durable_storage/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDurableStorage.MixProject do
   def project do
     [
       app: :emqx_durable_storage,
-      version: "6.2.0",
+      version: "6.2.1",
       build_path: "../../_build",
       compilers: [:yecc, :leex, :elixir, :asn1, :erlang, :app],
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -539,7 +539,7 @@ init({ShardId, Options}) ->
                 db = DB,
                 cf_refs = CFRefs
             },
-            {ok, S};
+            {ok, S, {continue, clean_orphans}};
         Schema ->
             Shard = open_shard(ShardId, DB, CFRefs, Schema),
             CurrentGenId = maps:get(current_generation, Schema),
@@ -557,6 +557,21 @@ init({ShardId, Options}) ->
             {ok, S, {continue, clean_orphans}}
     end.
 
+handle_continue(
+    clean_orphans,
+    S = #s_no_schema{shard_id = ShardId, db = DB, cf_refs = OrphanedCFRefs}
+) ->
+    %% Initial schema creation is not transactional.
+    %% Node may stop after the layout created some column families, but before
+    %% schema metadata was persisted. Since there is no schema, none of the
+    %% non-default column families can belong to a live generation.
+    lists:foreach(
+        fun({CFName, CFHandle}) ->
+            _ = drop_orphaned_column_family(ShardId, DB, CFName, CFHandle, S)
+        end,
+        OrphanedCFRefs
+    ),
+    {noreply, S#s_no_schema{cf_refs = []}};
 handle_continue(
     clean_orphans,
     S = #s{shard_id = ShardId, db = DB, cf_refs = CFRefs, schema = Schema}
@@ -586,22 +601,26 @@ handle_continue(
         [_ | _] ->
             lists:foreach(
                 fun({CFName, CFHandle}) ->
-                    Result = rocksdb:drop_column_family(DB, CFHandle),
-                    ?tp(
-                        warning,
-                        ds_storage_layer_dropped_orphaned_column_family,
-                        #{
-                            shard => ShardId,
-                            orphan => CFName,
-                            result => Result,
-                            s => format_state(S)
-                        }
-                    )
+                    _ = drop_orphaned_column_family(ShardId, DB, CFName, CFHandle, S)
                 end,
                 OrphanedCFRefs
             ),
             {noreply, S#s{cf_refs = CFRefs -- OrphanedCFRefs}}
     end.
+
+drop_orphaned_column_family(ShardId, DB, CFName, CFHandle, S) ->
+    Result = rocksdb:drop_column_family(DB, CFHandle),
+    ?tp(
+        warning,
+        ds_storage_layer_dropped_orphaned_column_family,
+        #{
+            shard => ShardId,
+            orphan => CFName,
+            result => Result,
+            s => format_state(S)
+        }
+    ),
+    Result.
 
 format_status(Status) ->
     maps:map(

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -44,7 +44,6 @@
 -export([
     init/1,
     format_status/1,
-    handle_continue/2,
     handle_call/3,
     handle_cast/2,
     handle_info/2,
@@ -539,7 +538,7 @@ init({ShardId, Options}) ->
                 db = DB,
                 cf_refs = CFRefs
             },
-            {ok, S, {continue, clean_orphans}};
+            {ok, S};
         Schema ->
             Shard = open_shard(ShardId, DB, CFRefs, Schema),
             CurrentGenId = maps:get(current_generation, Schema),
@@ -554,73 +553,8 @@ init({ShardId, Options}) ->
             },
             commit_metadata(S),
             ?tp(debug, ds_storage_init_state, #{shard => ShardId, s => S}),
-            {ok, S, {continue, clean_orphans}}
+            {ok, S}
     end.
-
-handle_continue(
-    clean_orphans,
-    S = #s_no_schema{shard_id = ShardId, db = DB, cf_refs = OrphanedCFRefs}
-) ->
-    %% Initial schema creation is not transactional.
-    %% Node may stop after the layout created some column families, but before
-    %% schema metadata was persisted. Since there is no schema, none of the
-    %% non-default column families can belong to a live generation.
-    lists:foreach(
-        fun({CFName, CFHandle}) ->
-            _ = drop_orphaned_column_family(ShardId, DB, CFName, CFHandle, S)
-        end,
-        OrphanedCFRefs
-    ),
-    {noreply, S#s_no_schema{cf_refs = []}};
-handle_continue(
-    clean_orphans,
-    S = #s{shard_id = ShardId, db = DB, cf_refs = CFRefs, schema = Schema}
-) ->
-    %% Add / drop generation are not transactional.
-    %% This means that the storage may contain "orphaned" column families, i.e.
-    %% column families that do not belong to a live generation. We need to clean
-    %% them, because an attempt to create existing column family is an error,
-    %% therefore `add_generation/2` is not idempotent. Cleaning seems to be safe:
-    %% either it's unfinished `handle_add_generation/2` meaning CFs are empty, or
-    %% it's unfinished `handle_drop_generation/2` meaning CFs was meant to be
-    %% dropped anyway.
-    CFNames = maps:fold(
-        fun
-            (?GEN_KEY(_), #{cf_names := GenCFNames}, Acc) ->
-                GenCFNames ++ Acc;
-            (_Prop, _, Acc) ->
-                Acc
-        end,
-        [],
-        Schema
-    ),
-    OrphanedCFRefs = lists:foldl(fun proplists:delete/2, CFRefs, CFNames),
-    case OrphanedCFRefs of
-        [] ->
-            {noreply, S};
-        [_ | _] ->
-            lists:foreach(
-                fun({CFName, CFHandle}) ->
-                    _ = drop_orphaned_column_family(ShardId, DB, CFName, CFHandle, S)
-                end,
-                OrphanedCFRefs
-            ),
-            {noreply, S#s{cf_refs = CFRefs -- OrphanedCFRefs}}
-    end.
-
-drop_orphaned_column_family(ShardId, DB, CFName, CFHandle, S) ->
-    Result = rocksdb:drop_column_family(DB, CFHandle),
-    ?tp(
-        warning,
-        ds_storage_layer_dropped_orphaned_column_family,
-        #{
-            shard => ShardId,
-            orphan => CFName,
-            result => Result,
-            s => format_state(S)
-        }
-    ),
-    Result.
 
 format_status(Status) ->
     maps:map(
@@ -644,10 +578,12 @@ handle_call(#call_ensure_schema{options = Opts, created_at = CreatedAt}, _From, 
     case S0 of
         #s{} ->
             %% Already exists:
+            report_orphaned_cfs(S0),
             {reply, ok, S0};
         #s_no_schema{shard_id = ShardId, db = DB, cf_refs = CFRefs} ->
             case handle_create_schema(ShardId, DB, CFRefs, Opts, CreatedAt) of
                 {ok, S} ->
+                    report_orphaned_cfs(S),
                     {reply, ok, S};
                 {error, _} = Err ->
                     {reply, Err, S0}
@@ -768,9 +704,10 @@ handle_add_generation(
     Shard1 = update_last_until(Shard0, Since),
     case Schema1 of
         _Updated = #{} ->
-            {GenId, Schema, NewCFRefs} =
-                new_generation(ShardId, DB, Schema1, MaybePrototype, Shard0, Since, Since, DBOpts),
-            CFRefs = NewCFRefs ++ CFRefs0,
+            {GenId, Schema, GenCFRefs} = new_generation(
+                ShardId, DB, CFRefs0, Schema1, MaybePrototype, Shard0, Since, Since, DBOpts
+            ),
+            CFRefs = cf_merge_refs(GenCFRefs, CFRefs0),
             Key = ?GEN_KEY(GenId),
             Generation = open_generation(ShardId, DB, CFRefs, GenId, maps:get(Key, Schema)),
             Shard = Shard1#{current_generation := GenId, Key => Generation},
@@ -913,15 +850,17 @@ create_new_shard_schema(
         ptrans => emqx_ds_payload_transform:default_schema(PType)
     },
     DBOpts = filter_layout_db_opts(Options),
-    {_NewGenId, Schema, NewCFRefs} =
-        new_generation(ShardId, DB, Schema0, Prototype, undefined, _Since = 0, CreatedAt, DBOpts),
-    {ok, Schema, NewCFRefs ++ CFRefs};
+    {_NewGenId, Schema, GenCFRefs} = new_generation(
+        ShardId, DB, CFRefs, Schema0, Prototype, undefined, _Since = 0, CreatedAt, DBOpts
+    ),
+    {ok, Schema, cf_merge_refs(GenCFRefs, CFRefs)};
 create_new_shard_schema(_ShardId, _DB, _CFRefs, Options, _CreatedAt) ->
     {error, {bad_options, Options}}.
 
 -spec new_generation(
     dbshard(),
     rocksdb:db_handle(),
+    cf_refs(),
     shard_schema(),
     prototype() | undefined,
     shard() | undefined,
@@ -930,7 +869,7 @@ create_new_shard_schema(_ShardId, _DB, _CFRefs, Options, _CreatedAt) ->
     emqx_ds:db_opts()
 ) ->
     {gen_id(), shard_schema(), cf_refs()}.
-new_generation(ShardId, DB, Schema0, MaybePrototype, Shard0, Since, CreatedAt, DBOpts) ->
+new_generation(ShardId, DB, CFRefs, Schema0, MaybePrototype, Shard0, Since, CreatedAt, DBOpts) ->
     #{current_generation := PrevGenId, prototype := OldPrototype} = Schema0,
     {Mod, ModConf} =
         case MaybePrototype of
@@ -952,7 +891,9 @@ new_generation(ShardId, DB, Schema0, MaybePrototype, Shard0, Since, CreatedAt, D
     end,
     %% Provide a small subset of DB options to the storage layout module.
     GenId = next_generation_id(PrevGenId),
-    {GenData, NewCFRefs} = Mod:create(ShardId, DB, GenId, ModConf, PrevRuntimeData, DBOpts),
+    {GenData, NewCFRefs} = Mod:create(
+        ShardId, DB, CFRefs, GenId, ModConf, PrevRuntimeData, DBOpts
+    ),
     GenSchema = #{
         module => Mod,
         data => GenData,
@@ -1160,6 +1101,35 @@ filter_layout_db_opts(Options) ->
 
 %%--------------------------------------------------------------------------------
 
+list_orphaned_cfs(#s{cf_refs = CFRefs, schema = Schema}) ->
+    %% Add / drop generation are not transactional.
+    %% This means that the storage may contain "orphaned" column families not
+    %% belonging to a live generation.
+    %% * Replay of generation creation can adopt matching column families.
+    %% * Leftovers from an interrupted deletion are reported for observability.
+    CFNames = maps:fold(
+        fun
+            (?GEN_KEY(_), #{cf_names := GenCFNames}, Acc) ->
+                GenCFNames ++ Acc;
+            (_Prop, _, Acc) ->
+                Acc
+        end,
+        [],
+        Schema
+    ),
+    lists:foldl(fun proplists:delete/2, CFRefs, CFNames).
+
+report_orphaned_cfs(S = #s{shard_id = ShardId}) ->
+    case list_orphaned_cfs(S) of
+        [] ->
+            ok;
+        OrphanedCFRefs ->
+            ?tp(warning, ds_storage_layer_orphaned_column_families, #{
+                shard => ShardId,
+                cf_names => cf_names(OrphanedCFRefs)
+            })
+    end.
+
 -spec cf_names(cf_refs()) -> [string()].
 cf_names(CFRefs) ->
     {CFNames, _CFHandles} = lists:unzip(CFRefs),
@@ -1172,6 +1142,10 @@ cf_ref(Name, CFRefs) ->
 -spec cf_handle(_Name :: string(), cf_refs()) -> rocksdb:cf_handle().
 cf_handle(Name, CFRefs) ->
     element(2, cf_ref(Name, CFRefs)).
+
+cf_merge_refs(NewCFRefs, CFRefs) ->
+    NewCFNames = cf_names(NewCFRefs),
+    NewCFRefs ++ [CFRef || {Name, _} = CFRef <- CFRefs, not lists:member(Name, NewCFNames)].
 
 %%--------------------------------------------------------------------------------
 %% Schema access

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -907,6 +907,11 @@ new_generation(ShardId, DB, CFRefs, Schema0, MaybePrototype, Shard0, Since, Crea
         current_generation => GenId,
         ?GEN_KEY(GenId) => GenSchema
     },
+    ?tp(debug, ds_storage_layer_new_generation, #{
+        shard => ShardId,
+        generation => GenId,
+        cf_names => cf_names(NewCFRefs)
+    }),
     {GenId, Schema, NewCFRefs}.
 
 -spec next_generation_id(gen_id()) -> gen_id().

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
@@ -69,6 +69,7 @@
 -callback create(
     emqx_ds_storage_layer:dbshard(),
     rocksdb:db_handle(),
+    emqx_ds_storage_layer:cf_refs(),
     emqx_ds:generation(),
     Options :: map(),
     emqx_ds_storage_layer:generation_data() | undefined,

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_skipstream_lts_v2.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_skipstream_lts_v2.erl
@@ -15,7 +15,7 @@
 
 %% behavior callbacks:
 -export([
-    create/6,
+    create/7,
     open/5,
     drop/5,
     prepare_tx/7,
@@ -109,7 +109,7 @@
 %% behavior callbacks
 %%================================================================================
 
-create(_ShardId, DBHandle, GenId, Schema0, SPrev, _DBOpts) ->
+create(_ShardId, DBHandle, CFRefs, GenId, Schema0, SPrev, _DBOpts) ->
     Defaults = #{
         wildcard_hash_bytes => 8,
         timestamp_bytes => 8,
@@ -119,8 +119,8 @@ create(_ShardId, DBHandle, GenId, Schema0, SPrev, _DBOpts) ->
     Schema = maps:merge(Defaults, Schema0),
     DataCFName = data_cf(GenId),
     TrieCFName = trie_cf(GenId),
-    {ok, DataCFHandle} = rocksdb:create_column_family(DBHandle, DataCFName, []),
-    {ok, TrieCFHandle} = rocksdb:create_column_family(DBHandle, TrieCFName, []),
+    DataCFHandle = ensure_column_family(DBHandle, CFRefs, DataCFName),
+    TrieCFHandle = ensure_column_family(DBHandle, CFRefs, TrieCFName),
     case SPrev of
         #s{trie = TriePrev} ->
             ok = emqx_ds_gen_skipstream_lts:copy_previous_trie(DBHandle, TrieCFHandle, TriePrev),
@@ -130,6 +130,18 @@ create(_ShardId, DBHandle, GenId, Schema0, SPrev, _DBOpts) ->
             ok
     end,
     {Schema, [{DataCFName, DataCFHandle}, {TrieCFName, TrieCFHandle}]}.
+
+ensure_column_family(DBHandle, CFRefs, CFName) ->
+    %% See if the column family has already been created.
+    %% If "add generation" operation was interrupted before finishing, one or
+    %% both column families may already be present in the DB.
+    case lists:keyfind(CFName, 1, CFRefs) of
+        false ->
+            {ok, CFHandle} = rocksdb:create_column_family(DBHandle, CFName, []),
+            CFHandle;
+        {CFName, CFHandle} ->
+            CFHandle
+    end.
 
 open(
     ShardId,

--- a/apps/emqx_durable_storage/test/emqx_ds_storage_SUITE.erl
+++ b/apps/emqx_durable_storage/test/emqx_ds_storage_SUITE.erl
@@ -6,9 +6,9 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include("../../emqx/include/emqx.hrl").
 -include("emqx_ds.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
 suite() -> [{timetrap, {minutes, 1}}].
@@ -59,6 +59,104 @@ t_snapshot_take_restore(Config) ->
         Batch1 ++ Batch2,
         %% Sort by timestamp (2nd element):
         lists:keysort(2, emqx_ds_test_helpers:storage_consume(Shard, ['#']))
+    ).
+
+%% @doc Verifies that initial schema creation can adopt CFs and succeed after a retry.
+t_initial_schema_creation_recovery(Config) ->
+    Shard = {?FUNCTION_NAME, <<"42">>},
+    Opts = opts(Config),
+    ?check_trace(
+        begin
+            %% 1. Make sure storage process crashes before committing initial metadata:
+            ?inject_crash(
+                #{?snk_kind := ds_storage_layer_new_generation, shard := Shard, generation := 1},
+                snabbkaffe_nemesis:recover_after(1)
+            ),
+            %% 2. Start the shard storage:
+            {ok, S0} = emqx_ds_storage_layer:start_link_no_schema(Shard, Opts),
+            %% 3. Create new shard schema, wait the process to terminate abnormally:
+            true = unlink(S0),
+            MRef = monitor(process, S0),
+            ?assertExit(_, emqx_ds_storage_layer:ensure_schema(Shard, Opts, 1)),
+            receive
+                {'DOWN', MRef, process, S0, Reason} ->
+                    ?assertEqual(notmyday, Reason)
+            after 1_000 ->
+                link(S0),
+                ct:fail({storage_still_alive, S0})
+            end,
+            %% 4. Restart and retry the new shard schema creation.
+            %%    New process adopts the column families left by the failed schema creation and
+            %%    finishes committing the schema.
+            {ok, S1} = emqx_ds_storage_layer:start_link_no_schema(Shard, Opts),
+            ?assertEqual(ok, emqx_ds_storage_layer:ensure_schema(Shard, Opts, 1)),
+            ?assertEqual([1], maps:keys(emqx_ds_storage_layer:list_slabs(Shard))),
+            ok = stop_shard(S1)
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [#{generation := 1, shard := Shard}],
+                ?of_kind(ds_storage_layer_new_generation, Trace)
+            ),
+            ?assertEqual(
+                [],
+                ?of_kind(ds_storage_layer_orphaned_column_families, Trace)
+            )
+        end
+    ).
+
+%% @doc Verifies that adding a generation can adopt CFs and succeed after a retry.
+t_add_generation_recovery(Config) ->
+    Shard = {?FUNCTION_NAME, <<"42">>},
+    Opts = opts(Config),
+    {ok, S0} = emqx_ds_storage_layer:start_link(Shard, Opts),
+    ?check_trace(
+        begin
+            %% 1. Make sure storage process crashes before committing generation metadata:
+            ?inject_crash(
+                #{?snk_kind := ds_storage_layer_new_generation, shard := Shard, generation := 2},
+                snabbkaffe_nemesis:recover_after(1)
+            ),
+            %% 2. Add new generation schema, wait the process to terminate abnormally:
+            true = unlink(S0),
+            MRef = monitor(process, S0),
+            ?assertExit(_, emqx_ds_storage_layer:add_generation(Shard, 10)),
+            receive
+                {'DOWN', MRef, process, S0, Reason} ->
+                    ?assertEqual(notmyday, Reason)
+            after 1_000 ->
+                link(S0),
+                ct:fail({storage_still_alive, S0})
+            end,
+            %% 4. Restart and retry adding the generation.
+            %% Startup reports the uncommitted generation's column families.
+            %% Retrying the command then adopts them and completes generation 2.
+            {ok, S1} = emqx_ds_storage_layer:start_link(Shard, Opts),
+            ?assertEqual(ok, emqx_ds_storage_layer:add_generation(Shard, 10)),
+            ?assertEqual(
+                [1, 2],
+                lists:sort(maps:keys(emqx_ds_storage_layer:list_slabs(Shard)))
+            ),
+            ok = stop_shard(S1)
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [#{generation := 2, shard := Shard}],
+                ?of_kind(ds_storage_layer_new_generation, Trace)
+            ),
+            ?assertMatch(
+                [
+                    #{
+                        shard := Shard,
+                        cf_names := [
+                            "emqx_ds_storage_skipstream_lts_v2_data2",
+                            "emqx_ds_storage_skipstream_lts_v2_trie2"
+                        ]
+                    }
+                ],
+                ?of_kind(ds_storage_layer_orphaned_column_families, Trace)
+            )
+        end
     ).
 
 transfer_snapshot(Reader, Writer) ->

--- a/changes/ee/fix-18822.en.md
+++ b/changes/ee/fix-18822.en.md
@@ -1,0 +1,1 @@
+Fixed rare issues that could prevent Durable Storage shards from recovering after node restarts or leadership changes. EMQX now treats additional transient DS Raft leadership errors as retryable, and incomplete RocksDB schema initialization no longer prevents shards from recovering.


### PR DESCRIPTION
Release version: 6.2.4, 6.3.1, 7.0.0
Introduced in: 6.1.1

## Summary

This PR refines DS Raft OTX leader startup.
1. When local leadership is obtained for a shard, Raft command `otx_new_leader(Pid)` is now applied first, before the local schema propagation. This helps to avoid situations when OTX leader startup advances shard timestamp before claiming leadership, causing transient `non_monotonic_timestamp` errors. This reordering appears to be safe: both operations must be appended to the log before OTX leader is announced to the cluster.
2. Raft machine now considers `not_the_leader` errors as recoverable.
3. Storage-layer RocksDB column families orphaned by incomplete schema initialization are now handled properly on re-initialization, making the whole operation idempotent. This is similar to the "incomplete creation of new generation" case.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible