### PR TITLE
fix(cli): correct misspelled 'enbale' field in listeners output

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -977,7 +977,7 @@ listeners([]) ->
                     {listen_on, {string, emqx_listeners:format_bind(Bind)}},
                     {acceptors, Acceptors},
                     {proxy_protocol, ProxyProtocol},
-                    {enbale, Enable},
+                    {enable, Enable},
                     {running, Running}
                 ] ++ CurrentConns ++ MaxConn ++ ShutdownCount,
             emqx_ctl:print("~ts~n", [Id]),

--- a/changes/ee/fix-18824.en.md
+++ b/changes/ee/fix-18824.en.md
@@ -1,0 +1,4 @@
+Fixed a misspelled field name in the `emqx ctl listeners` output.
+
+The command printed the listener's enabled flag as `enbale`. It now prints `enable`.
+Scripts that parse this output must be updated to match the corrected name.


### PR DESCRIPTION
Release versions:
6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0

Introduced in:
5.8.0

## Summary

`emqx ctl listeners` printed the listener's enabled flag with a misspelled label:

```
enbale             : true
```

The atom in the printed field list was `enbale` instead of `enable`. This is CLI output
users read and parse. The label is now `enable`.

The typo dates to `50595661c9` (2024-08-15), first released in 5.8.0. No test asserted the
misspelled label, so nothing else needed changing.

This is the v6 counterpart of #18823, which fixes the same line on `dev-58`. The v5 and v6
chains are separate, so both are needed.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
