### PR TITLE
fix(gateway): handle CoAP state machine timeouts

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -204,6 +204,8 @@ handle_timeout(_, {keepalive, NewVal}, #channel{keepalive = KeepAlive} = Channel
         {error, timeout} ->
             {shutdown, timeout, ensure_disconnected(keepalive_timeout, Channel)}
     end;
+handle_timeout(_, {state_machine, Msg}, Channel) ->
+    call_session(timeout, Msg, Channel);
 handle_timeout(_, {transport, Msg}, Channel) ->
     call_session(timeout, Msg, Channel);
 handle_timeout(_, sock_closed_takeover_cleanup, Channel) ->

--- a/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_tm.erl
@@ -94,13 +94,27 @@ handle_request(#coap_message{id = MsgId} = Msg, TM) ->
     end.
 
 %% client response
-handle_response(#coap_message{type = Type, id = MsgId, token = Token} = Msg, TM) ->
+handle_response(
+    #coap_message{type = Type, method = Method, id = MsgId, token = Token} = Msg,
+    TM
+) ->
     Id = {out, MsgId},
     TokenId = ?TOKEN_ID(Token),
-    case find_machine_by_keys([Id, TokenId], TM) of
+    MachineIdKeys =
+        case {Type, Method} of
+            {ack, undefined} ->
+                [Id];
+            {reset, _} ->
+                [Id];
+            _ ->
+                [Id, TokenId]
+        end,
+    case find_machine_by_keys(MachineIdKeys, TM) of
         undefined ->
-            case Type of
-                reset ->
+            case {Type, Method} of
+                {reset, _} ->
+                    empty();
+                {ack, undefined} ->
                     empty();
                 _ ->
                     reset(Msg)

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -22,6 +22,18 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+-record(channel, {
+    ctx,
+    conninfo,
+    clientinfo,
+    session,
+    keepalive,
+    timers,
+    connection_required,
+    conn_state,
+    token
+}).
+
 -define(CONF_DEFAULT, <<
     "\n"
     "gateway.coap\n"
@@ -43,6 +55,7 @@
 -define(PS_PREFIX, "coap://127.0.0.1/ps").
 -define(MQTT_PREFIX, "coap://127.0.0.1/mqtt").
 -define(REQUEST_TIMEOUT, 5000).
+-define(ACK_TIMEOUT_WAIT, 70000).
 -define(OBSERVE_NOTIFICATION_QUEUE_MAX_LEN, 100).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
@@ -704,6 +717,62 @@ t_observe_con_notify_queue_drains_after_reset(_) ->
         with_connection(Fun)
     end).
 
+t_observe_con_notify_timeout_retransmits_and_drains_pending(_) ->
+    ct:timetrap({seconds, 150}),
+    with_notify_type(con, fun() ->
+        Topic = <<"coap/observe_notify_timeout">>,
+        ObserveToken = <<"observe-timeout">>,
+        Channel0 = new_test_channel(),
+        Channel1 = direct_observe_channel(Topic, ObserveToken, Channel0),
+
+        {ok, [{outgoing, [NotifyA]}], Channel2} =
+            emqx_coap_channel:handle_deliver(
+                [direct_deliver(Topic, ?QOS_0, <<"first-unacknowledged">>)],
+                Channel1
+            ),
+        ?assertEqual(con, NotifyA#coap_message.type),
+        ?assertEqual(ObserveToken, NotifyA#coap_message.token),
+        ?assertEqual(<<"first-unacknowledged">>, NotifyA#coap_message.payload),
+
+        {ok, [{outgoing, []}], Channel3} =
+            emqx_coap_channel:handle_deliver(
+                [direct_deliver(Topic, ?QOS_0, <<"second-pending">>)],
+                Channel2
+            ),
+
+        {ok, [{outgoing, [Retry1]}], Channel4} = ack_timeout(Channel3),
+        {ok, [{outgoing, [Retry2]}], Channel5} = ack_timeout(Channel4),
+        {ok, [{outgoing, [Retry3]}], Channel6} = ack_timeout(Channel5),
+        {ok, [{outgoing, [Retry4]}], Channel7} = ack_timeout(Channel6),
+        assert_retransmission(NotifyA, Retry1),
+        assert_retransmission(NotifyA, Retry2),
+        assert_retransmission(NotifyA, Retry3),
+        assert_retransmission(NotifyA, Retry4),
+
+        {ok, [{outgoing, [NotifyB]}], Channel8} = ack_timeout(Channel7),
+        ?assertEqual(con, NotifyB#coap_message.type),
+        ?assertEqual(ObserveToken, NotifyB#coap_message.token),
+        ?assertEqual(<<"second-pending">>, NotifyB#coap_message.payload),
+        ?assertNotEqual(NotifyA#coap_message.id, NotifyB#coap_message.id),
+        ?assertEqual(1, proplists:get_value(inflight_cnt, emqx_coap_channel:stats(Channel8))),
+
+        OldAck = #coap_message{
+            type = ack,
+            id = NotifyA#coap_message.id,
+            token = ObserveToken
+        },
+        {ok, Channel9} = emqx_coap_channel:handle_in(OldAck, Channel8),
+        ?assertEqual(1, proplists:get_value(inflight_cnt, emqx_coap_channel:stats(Channel9))),
+
+        CurrentAck = #coap_message{
+            type = ack,
+            id = NotifyB#coap_message.id,
+            token = ObserveToken
+        },
+        {ok, Channel10} = emqx_coap_channel:handle_in(CurrentAck, Channel9),
+        ?assertEqual(0, proplists:get_value(inflight_cnt, emqx_coap_channel:stats(Channel10)))
+    end).
+
 t_observe_cancel_drops_pending_notifications(_) ->
     with_notify_type(con, fun() ->
         Fun = fun(Channel, Token) ->
@@ -1167,6 +1236,51 @@ assert_notify(Channel, Type, Payload) ->
 assert_notify(Channel, Type) ->
     {ok, content, Notify = #coap_message{type = Type}} = with_message_response(Channel),
     Notify.
+
+new_test_channel() ->
+    ConnInfo = #{
+        peername => {{127, 0, 0, 1}, 9999},
+        sockname => {{127, 0, 0, 1}, 5683}
+    },
+    emqx_coap_channel:init(
+        ConnInfo,
+        #{
+            ctx => #{gwname => coap, cm => self()},
+            connection_required => false
+        }
+    ).
+
+direct_observe_channel(Topic, ObserveToken, #channel{session = Session0} = Channel) ->
+    SubData = #{topic => Topic, token => ObserveToken, subopts => #{qos => 0}},
+    ObserveReq = #coap_message{
+        type = con,
+        method = get,
+        id = 730,
+        token = ObserveToken,
+        options = #{observe => 0}
+    },
+    #{session := Session1} =
+        emqx_coap_session:process_subscribe(SubData, ObserveReq, #{}, Session0),
+    Channel#channel{session = Session1}.
+
+direct_deliver(Topic, QoS, Payload) ->
+    {deliver, Topic, emqx_message:make(undefined, QoS, Topic, Payload)}.
+
+ack_timeout(Channel) ->
+    receive
+        {timeout, TRef, {state_machine, {_SeqId, state_timeout, ack_timeout}} = Msg} ->
+            emqx_coap_channel:handle_timeout(TRef, Msg, Channel);
+        Other ->
+            ct:fail({unexpected_ack_timeout_message, Other})
+    after ?ACK_TIMEOUT_WAIT ->
+        ct:fail(ack_timeout_not_received)
+    end.
+
+assert_retransmission(Expected, Actual) ->
+    ?assertEqual(Expected#coap_message.id, Actual#coap_message.id),
+    ?assertEqual(Expected#coap_message.token, Actual#coap_message.token),
+    ?assertEqual(Expected#coap_message.type, Actual#coap_message.type),
+    ?assertEqual(Expected#coap_message.payload, Actual#coap_message.payload).
 
 notify_payload(Notify) ->
     #coap_content{payload = Payload} = er_coap_message:get_content(Notify),

--- a/apps/emqx_gateway_coap/test/emqx_coap_channel_tests.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_channel_tests.erl
@@ -37,3 +37,37 @@ sock_closed_cleanup_uses_keepalive_interval_test() ->
         meck:unload(emqx_keepalive),
         meck:unload(emqx_utils)
     end.
+
+state_machine_stop_timeout_is_forwarded_test() ->
+    Session = session_marker,
+    Channel =
+        {channel, #{}, #{}, #{}, Session, undefined, #{}, false, connected, undefined},
+    TimerMsg = {1, stop_timeout, stop},
+    ok = meck:new(emqx_coap_session, [passthrough]),
+    try
+        ok = meck:expect(
+            emqx_coap_session,
+            timeout,
+            fun(Received, ReceivedSession) ->
+                ?assertEqual(TimerMsg, Received),
+                ?assertEqual(Session, ReceivedSession),
+                #{session => ReceivedSession}
+            end
+        ),
+        TRef = emqx_utils:start_timer(0, {state_machine, TimerMsg}),
+        receive
+            {timeout, TRef, Payload} ->
+                {ok, _} = emqx_coap_channel:handle_timeout(TRef, Payload, Channel)
+        after 1000 ->
+            ?assert(false)
+        end,
+        ?assert(
+            meck:called(
+                emqx_coap_session,
+                timeout,
+                [TimerMsg, Session]
+            )
+        )
+    after
+        meck:unload(emqx_coap_session)
+    end.

--- a/apps/emqx_gateway_coap/test/emqx_coap_tm_tests.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_tm_tests.erl
@@ -1,0 +1,53 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_coap_tm_tests).
+
+-include("../include/emqx_coap.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+late_empty_ack_does_not_match_new_same_token_transaction_test() ->
+    Token = <<"observe-token">>,
+    Notification = #coap_message{
+        type = con,
+        method = {ok, content},
+        token = Token,
+        options = #{observe => 1}
+    },
+    TM0 = emqx_coap_tm:new(),
+    #{out := [First], tm := TM1} = emqx_coap_tm:handle_out(Notification, TM0),
+    SeqId = maps:get({token, Token}, TM1),
+
+    #{tm := TM2, observe_notification_done := 1} =
+        emqx_coap_tm:timeout({SeqId, stop_timeout, stop}, TM1),
+
+    #{out := [Second], tm := TM3} = emqx_coap_tm:handle_out(Notification, TM2),
+    LateAck = #coap_message{
+        type = ack,
+        id = First#coap_message.id,
+        token = Token
+    },
+    ?assertEqual(#{}, emqx_coap_tm:handle_response(LateAck, TM3)),
+
+    CurrentAck = #coap_message{
+        type = ack,
+        id = Second#coap_message.id,
+        token = Token
+    },
+    ?assertMatch(
+        #{observe_notification_done := 1},
+        emqx_coap_tm:handle_response(CurrentAck, TM3)
+    ).

--- a/changes/ee/fix-18825.en.md
+++ b/changes/ee/fix-18825.en.md
@@ -1,0 +1,1 @@
+- [#18825](https://github.com/emqx/emqx/pull/18825) Fixed CoAP Observe notifications not being retransmitted after a missing ACK, which could leave subsequent notifications blocked in the pending queue.


### PR DESCRIPTION
Release versions: 5.10.5

Introduced in: pre-5.8
Fix: #18819

## Summary

CoAP transaction timers are delivered with the `state_machine` tag, but release-510 only routed the legacy `transport` tag. This dropped ACK retry and stop timeouts, leaving confirmable Observe notifications and pending queue entries stuck.

This change routes state-machine timeouts through the CoAP session, prevents late ACK/RST packets from matching a newer same-token transaction, and adds real-timer/channel-level regression coverage for retransmission and queue draining.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)