### PR TITLE
fix(mqtt): reject any packet received before CONNECT

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -1556,18 +1556,8 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf} = State0) ->
             undefined ->
                 init_parser_and_serializer(FrameOpts0, State0);
             Parser1 ->
-                case emqx_frame:describe_state(Parser1) of
-                    #{state := Clean, proto_ver := ProtoVer, expect_connect := ExpectConnect} when
-                        Clean == frame; Clean == clean
-                    ->
-                        FrameOpts = FrameOpts0#{
-                            version => ProtoVer, expect_connect => ExpectConnect
-                        },
-                        init_parser_and_serializer(FrameOpts, State0);
-                    _ ->
-                        %% Keep state
-                        {State0#state.parser, State0#state.serialize}
-                end
+                {ok, Parser2, Serialize2} = emqx_frame:update_opts(Parser1, FrameOpts0),
+                {Parser2, Serialize2}
         end,
     GcThresholds =
         case emqx_config:get_zone_conf(Zone, [force_gc]) of

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -1547,7 +1547,9 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf} = State0) ->
         strict_mode => emqx_config:get_zone_conf(Zone, [mqtt, strict_mode]),
         %% N.B.: when the listener's `parse_unit = frame`, `max_packet_size` from the new
         %% zone will **not** take effect after the override.
-        max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size])
+        max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size]),
+        %% Any packet received before CONNECT is rejected by the parser.
+        expect_connect => true
     },
     {Parser, Serialize} =
         case State0#state.parser of
@@ -1555,8 +1557,12 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf} = State0) ->
                 init_parser_and_serializer(FrameOpts0, State0);
             Parser1 ->
                 case emqx_frame:describe_state(Parser1) of
-                    #{state := Clean, proto_ver := ProtoVer} when Clean == frame; Clean == clean ->
-                        FrameOpts = FrameOpts0#{version => ProtoVer},
+                    #{state := Clean, proto_ver := ProtoVer, expect_connect := ExpectConnect} when
+                        Clean == frame; Clean == clean
+                    ->
+                        FrameOpts = FrameOpts0#{
+                            version => ProtoVer, expect_connect => ExpectConnect
+                        },
                         init_parser_and_serializer(FrameOpts, State0);
                     _ ->
                         %% Keep state

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -29,7 +29,7 @@
     serialize/3
 ]).
 
--export([describe_state/1]).
+-export([describe_state/1, update_opts/2]).
 
 -export_type([
     options/0,
@@ -56,8 +56,10 @@
 
 -record(remlen, {hdr, len, mult, opts :: #options{}}).
 -record(body, {hdr, need, acc :: iodata(), opts :: #options{}}).
+%% Options to apply once the frame being parsed is complete.
+-record(update, {inner :: #remlen{} | #body{}, opts :: options()}).
 
--type parse_state() :: #remlen{} | #body{} | parse_state_initial().
+-type parse_state() :: #remlen{} | #body{} | #update{} | parse_state_initial().
 -type parse_state_initial() :: #options{}.
 
 -type parse_result() ::
@@ -85,29 +87,69 @@
 describe_state({frame, Options = #options{}}) ->
     #{
         state => frame,
-        proto_ver => Options#options.version,
-        expect_connect => Options#options.expect_connect
+        proto_ver => Options#options.version
     };
 describe_state(Options = #options{}) ->
     #{
         state => clean,
-        proto_ver => Options#options.version,
-        expect_connect => Options#options.expect_connect
+        proto_ver => Options#options.version
     };
 describe_state(#remlen{opts = Options}) ->
     #{
         state => parsing_varint_length,
-        proto_ver => Options#options.version,
-        expect_connect => Options#options.expect_connect
+        proto_ver => Options#options.version
     };
 describe_state(#body{hdr = Hdr, need = Need, acc = Acc, opts = Options}) ->
     #{
         state => parsing_body,
         proto_ver => Options#options.version,
-        expect_connect => Options#options.expect_connect,
         parsed_header => Hdr,
         expected_bytes_remain => Need,
         received_bytes => iolist_size(Acc)
+    };
+describe_state(#update{inner = Inner}) ->
+    (describe_state(Inner))#{pending_opts_update => true}.
+
+-doc """
+Apply new configuration options to a parse state and its serializer.
+
+Only the options an operator can change at runtime are taken from `NewOpts';
+everything the parser owns is kept, in particular the negotiated protocol
+version and whether a CONNECT is still expected. Callers holding a parse state
+across a config change use this instead of building a fresh state, which would
+drop that.
+
+A frame being parsed keeps the options it started under. If one is in flight,
+the new options are held and applied as soon as it completes, so they take
+effect from the next frame rather than being dropped.
+""".
+-spec update_opts(parse_state(), options()) -> {ok, parse_state(), serialize_opts()}.
+update_opts(ParseState, NewOpts) ->
+    %% The serializer has no frame in flight, so it always takes them now.
+    SerializeOpts = initial_serialize_opts(NewOpts#{version => version(ParseState)}),
+    {ok, do_update_opts(ParseState, NewOpts), SerializeOpts}.
+
+%% `{frame, _}' is the whole-frame parser, which only ever sees complete frames.
+do_update_opts({frame, Options}, NewOpts) ->
+    {frame, merge_opts(Options, NewOpts)};
+do_update_opts(Options = #options{}, NewOpts) ->
+    merge_opts(Options, NewOpts);
+do_update_opts(#update{inner = Inner}, NewOpts) ->
+    %% A second change before the frame completes: the last one wins.
+    #update{inner = Inner, opts = NewOpts};
+do_update_opts(Inner, NewOpts) ->
+    #update{inner = Inner, opts = NewOpts}.
+
+version({frame, #options{version = Version}}) -> Version;
+version(#options{version = Version}) -> Version;
+version(#remlen{opts = #options{version = Version}}) -> Version;
+version(#body{opts = #options{version = Version}}) -> Version;
+version(#update{inner = Inner}) -> version(Inner).
+
+merge_opts(Options, NewOpts) ->
+    Options#options{
+        strict_mode = maps:get(strict_mode, NewOpts, Options#options.strict_mode),
+        max_size = maps:get(max_size, NewOpts, Options#options.max_size)
     }.
 
 %%--------------------------------------------------------------------
@@ -161,6 +203,14 @@ parse(
     #body{hdr = Header, need = Need, acc = Body, opts = Options}
 ) ->
     parse_body_frame(Bin, Header, Need, Body, Options);
+parse(Bin, #update{inner = Inner, opts = NewOpts}) ->
+    case parse(Bin, Inner) of
+        {Packet, Rest, Options} ->
+            %% The frame is complete, so the held options take effect now.
+            {Packet, Rest, merge_opts(Options, NewOpts)};
+        {More, NInner} ->
+            {More, #update{inner = NInner, opts = NewOpts}}
+    end;
 parse(<<>>, State) ->
     {some_more, State}.
 

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -42,13 +42,16 @@
 -type options() :: #{
     strict_mode => boolean(),
     max_size => 1..?MAX_PACKET_SIZE,
-    version => emqx_types:proto_ver()
+    version => emqx_types:proto_ver(),
+    expect_connect => boolean()
 }.
 
 -record(options, {
     strict_mode :: boolean(),
     max_size :: 1..?MAX_PACKET_SIZE,
-    version :: emqx_types:proto_ver()
+    version :: emqx_types:proto_ver(),
+    %% When true, the next packet must be a CONNECT.
+    expect_connect :: boolean()
 }).
 
 -record(remlen, {hdr, len, mult, opts :: #options{}}).
@@ -68,7 +71,8 @@
 -define(DEFAULT_OPTIONS, #{
     strict_mode => true,
     max_size => ?MAX_PACKET_SIZE,
-    version => ?MQTT_PROTO_V4
+    version => ?MQTT_PROTO_V4,
+    expect_connect => false
 }).
 
 -define(PARSE_ERR(Reason), ?THROW_FRAME_ERROR(Reason)).
@@ -81,22 +85,26 @@
 describe_state({frame, Options = #options{}}) ->
     #{
         state => frame,
-        proto_ver => Options#options.version
+        proto_ver => Options#options.version,
+        expect_connect => Options#options.expect_connect
     };
 describe_state(Options = #options{}) ->
     #{
         state => clean,
-        proto_ver => Options#options.version
+        proto_ver => Options#options.version,
+        expect_connect => Options#options.expect_connect
     };
 describe_state(#remlen{opts = Options}) ->
     #{
         state => parsing_varint_length,
-        proto_ver => Options#options.version
+        proto_ver => Options#options.version,
+        expect_connect => Options#options.expect_connect
     };
 describe_state(#body{hdr = Hdr, need = Need, acc = Acc, opts = Options}) ->
     #{
         state => parsing_body,
         proto_ver => Options#options.version,
+        expect_connect => Options#options.expect_connect,
         parsed_header => Hdr,
         expected_bytes_remain => Need,
         received_bytes => iolist_size(Acc)
@@ -116,7 +124,8 @@ initial_parse_state(Options) when is_map(Options) ->
     #options{
         strict_mode = maps:get(strict_mode, Effective),
         max_size = maps:get(max_size, Effective),
-        version = maps:get(version, Effective)
+        version = maps:get(version, Effective),
+        expect_connect = maps:get(expect_connect, Effective)
     }.
 
 %%--------------------------------------------------------------------
@@ -132,6 +141,7 @@ parse(
     <<Type:4, Dup:1, QoS:2, Retain:1, Rest/binary>>,
     Options = #options{strict_mode = StrictMode}
 ) ->
+    ok = validate_connect_first(Type, Options),
     %% Validate header if strict mode.
     StrictMode andalso validate_header(Type, Dup, QoS, Retain),
     Header = #mqtt_packet_header{
@@ -161,6 +171,7 @@ parse_complete(
     <<Type:4, Dup:1, QoS:2, Retain:1, Rest1/binary>>,
     Options = #options{strict_mode = StrictMode}
 ) ->
+    ok = validate_connect_first(Type, Options),
     %% Validate header if strict mode.
     StrictMode andalso validate_header(Type, Dup, QoS, Retain),
     Header = #mqtt_packet_header{
@@ -176,6 +187,18 @@ parse_complete(
             {_RemLen, Rest2} = parse_variable_byte_integer(Rest1),
             parse_packet_complete(Rest2, Header, Options)
     end.
+
+%% Reject any packet received before CONNECT, while only the fixed header is
+%% read, so that no body byte is buffered for an unauthenticated connection.
+validate_connect_first(?CONNECT, _Options) ->
+    ok;
+validate_connect_first(_Type, #options{expect_connect = false}) ->
+    ok;
+validate_connect_first(Type, _Options) ->
+    ?PARSE_ERR(#{
+        cause => unexpected_packet_before_connect,
+        header_type => emqx_packet:type_name(Type)
+    }).
 
 -spec guess_first_packet_protocol(binary()) -> map().
 guess_first_packet_protocol(<<Type:4, _Flags:4, _/binary>> = Data) ->
@@ -328,7 +351,7 @@ packet(Header, Variable, Payload) ->
 parse_packet_complete(Frame, Header = #mqtt_packet_header{type = ?CONNECT}, Options) ->
     Variable = parse_connect(Frame, Options),
     Packet = packet(Header, Variable),
-    NOptions = update_parse_state(Variable#mqtt_packet_connect.proto_ver, Options),
+    NOptions = connect_parsed(Variable#mqtt_packet_connect.proto_ver, Options),
     [Packet, NOptions];
 parse_packet_complete(Frame, Header, Options) ->
     parse_packet(Frame, Header, Options).
@@ -337,7 +360,7 @@ parse_packet_complete(Frame, Header, Options) ->
 parse_packet(Frame, Header = #mqtt_packet_header{type = ?CONNECT}, Options, Rest) ->
     Variable = parse_connect(Frame, Options),
     Packet = packet(Header, Variable),
-    {Packet, Rest, update_parse_state(Variable#mqtt_packet_connect.proto_ver, Options)};
+    {Packet, Rest, connect_parsed(Variable#mqtt_packet_connect.proto_ver, Options)};
 parse_packet(Frame, Header, Options, Rest) ->
     Packet = parse_packet(Frame, Header, Options),
     {Packet, Rest, Options}.
@@ -374,6 +397,12 @@ parse_connect(Frame, Options = #options{strict_mode = StrictMode}) ->
     parse_state_initial().
 update_parse_state(ProtoVer, Options) ->
     Options#options{version = ProtoVer}.
+
+%% CONNECT is parsed: record the protocol version and stop requiring CONNECT.
+-spec connect_parsed(emqx_types:proto_ver(), parse_state_initial()) ->
+    parse_state_initial().
+connect_parsed(ProtoVer, Options) ->
+    Options#options{version = ProtoVer, expect_connect = false}.
 
 do_parse_connect(
     ProtoName,

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1548,18 +1548,8 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf0} = State0) ->
             undefined ->
                 init_parser_and_serializer(FrameOpts0);
             Parser1 ->
-                case emqx_frame:describe_state(Parser1) of
-                    #{state := Clean, proto_ver := ProtoVer, expect_connect := ExpectConnect} when
-                        Clean == frame; Clean == clean
-                    ->
-                        FrameOpts = FrameOpts0#{
-                            version => ProtoVer, expect_connect => ExpectConnect
-                        },
-                        init_parser_and_serializer(FrameOpts);
-                    _ ->
-                        %% Keep state
-                        {State0#state.parser, State0#state.serialize}
-                end
+                {ok, Parser2, Serialize2} = emqx_frame:update_opts(Parser1, FrameOpts0),
+                {Parser2, Serialize2}
         end,
     GcThresholds =
         case emqx_config:get_zone_conf(Zone, [force_gc]) of

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1539,7 +1539,9 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf0} = State0) ->
         strict_mode => emqx_config:get_zone_conf(Zone, [mqtt, strict_mode]),
         %% N.B.: when the listener's `parse_unit = frame`, `max_packet_size` from the new
         %% zone will **not** take effect after the override.
-        max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size])
+        max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size]),
+        %% Any packet received before CONNECT is rejected by the parser.
+        expect_connect => true
     },
     {Parser, Serialize} =
         case State0#state.parser of
@@ -1547,8 +1549,12 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf0} = State0) ->
                 init_parser_and_serializer(FrameOpts0);
             Parser1 ->
                 case emqx_frame:describe_state(Parser1) of
-                    #{state := Clean, proto_ver := ProtoVer} when Clean == frame; Clean == clean ->
-                        FrameOpts = FrameOpts0#{version => ProtoVer},
+                    #{state := Clean, proto_ver := ProtoVer, expect_connect := ExpectConnect} when
+                        Clean == frame; Clean == clean
+                    ->
+                        FrameOpts = FrameOpts0#{
+                            version => ProtoVer, expect_connect => ExpectConnect
+                        },
                         init_parser_and_serializer(FrameOpts);
                     _ ->
                         %% Keep state

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -960,18 +960,8 @@ init_zone_specific_state(Zone, _Opts, #state{} = State0) ->
             undefined ->
                 init_parser_and_serializer(FrameOpts0);
             Parser1 ->
-                case emqx_frame:describe_state(Parser1) of
-                    #{state := Clean, proto_ver := ProtoVer, expect_connect := ExpectConnect} when
-                        Clean == frame; Clean == clean
-                    ->
-                        FrameOpts = FrameOpts0#{
-                            version => ProtoVer, expect_connect => ExpectConnect
-                        },
-                        init_parser_and_serializer(FrameOpts);
-                    _ ->
-                        %% Keep state
-                        {State0#state.parse_state, State0#state.serialize}
-                end
+                {ok, Parser2, Serialize2} = emqx_frame:update_opts(Parser1, FrameOpts0),
+                {Parser2, Serialize2}
         end,
     GcState = get_force_gc(Zone),
     StatsTimer = get_stats_enable(Zone),

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -951,7 +951,9 @@ init_zone_specific_state(Zone, _Opts, #state{} = State0) ->
         strict_mode => emqx_config:get_zone_conf(Zone, [mqtt, strict_mode]),
         %% N.B.: when the listener's `parse_unit = frame`, `max_packet_size` from the new
         %% zone will **not** take effect after the override.
-        max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size])
+        max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size]),
+        %% Any packet received before CONNECT is rejected by the parser.
+        expect_connect => true
     },
     {Parser, Serialize} =
         case State0#state.parse_state of
@@ -959,8 +961,12 @@ init_zone_specific_state(Zone, _Opts, #state{} = State0) ->
                 init_parser_and_serializer(FrameOpts0);
             Parser1 ->
                 case emqx_frame:describe_state(Parser1) of
-                    #{state := Clean, proto_ver := ProtoVer} when Clean == frame; Clean == clean ->
-                        FrameOpts = FrameOpts0#{version => ProtoVer},
+                    #{state := Clean, proto_ver := ProtoVer, expect_connect := ExpectConnect} when
+                        Clean == frame; Clean == clean
+                    ->
+                        FrameOpts = FrameOpts0#{
+                            version => ProtoVer, expect_connect => ExpectConnect
+                        },
                         init_parser_and_serializer(FrameOpts);
                     _ ->
                         %% Keep state

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -153,7 +153,7 @@ t_handle_msg(_) ->
     %% buffering the bytes silently.
     ?assertMatch(
         {ok, {incoming, {frame_error, bad_frame_header}}, _St},
-        handle_msg({tcp, From, <<"for_testing">>}, st())
+        handle_msg({tcp, From, <<"for_testing">>}, st_after_connect())
     ),
     ?assertMatch({ok, _St}, handle_msg(for_testing, st())).
 
@@ -251,15 +251,16 @@ t_parse_incoming(_) ->
     %% would have buffered as partial bytes.
     ?assertMatch(
         {0, [{frame_error, bad_frame_header}], _NState},
-        emqx_connection:parse_incoming(<<"for_testing">>, st())
+        emqx_connection:parse_incoming(<<"for_testing">>, st_after_connect())
     ),
-    %% SUBSCRIBE with remaining_len=0 in idle state:
-    %% parser throws zero_remaining_len, enriched with protocol hints
+    %% SUBSCRIBE as the first packet: rejected before CONNECT,
+    %% enriched with protocol hints
     ?assertMatch(
         {0,
             [
                 {frame_error, #{
-                    cause := zero_remaining_len,
+                    cause := unexpected_packet_before_connect,
+                    header_type := 'SUBSCRIBE',
                     packet_type := 'SUBSCRIBE',
                     resemble_protocol := _
                 }}
@@ -296,7 +297,7 @@ t_parse_incoming(_) ->
         {0, [{frame_error, bad_subqos}], _NState},
         emqx_connection:parse_incoming(
             <<16#82, 16#06, 16#00, 16#01, 16#00, 16#01, $t, 16#03>>,
-            st()
+            st_after_connect()
         )
     ),
     ok = meck:new(emqx_frame, [passthrough, no_history, no_link]),
@@ -383,6 +384,26 @@ t_packet_data_logging(_) ->
             tcp, default, [allow_log_packet_data_from], OldIPMasks
         )
     end.
+
+-doc """
+A non-CONNECT first packet is rejected from its fixed header, before the
+announced body is buffered.
+""".
+t_parse_incoming_before_connect(_) ->
+    %% PUBLISH fixed header announcing a 268435455 byte body.
+    %% Only the header is fed: an error here means the body was never buffered.
+    Publish = <<(?PUBLISH bsl 4), 16#FF, 16#FF, 16#FF, 16#7F>>,
+    ?assertMatch(
+        {0,
+            [
+                {frame_error, #{
+                    cause := unexpected_packet_before_connect,
+                    header_type := 'PUBLISH'
+                }}
+            ],
+            _NState},
+        emqx_connection:parse_incoming(Publish, st(#{}, #{conn_state => idle}))
+    ).
 
 t_next_incoming_msgs(_) ->
     ?assertEqual(
@@ -698,6 +719,14 @@ make_frame(Packet) ->
 payload(Len) -> iolist_to_binary(lists:duplicate(Len, 1)).
 
 st() -> st(#{}, #{}).
+
+%% Connection state whose parser has already accepted a CONNECT, so that the
+%% packets after it are parsed as usual.
+st_after_connect() ->
+    Connect = iolist_to_binary(emqx_frame:serialize(?CONNECT_PACKET(#mqtt_packet_connect{}))),
+    {1, [_], St} = emqx_connection:parse_incoming(Connect, st()),
+    St.
+
 st(InitFields) when is_map(InitFields) ->
     st(InitFields, #{}).
 st(InitFields, ChannelFields) when is_map(InitFields) ->

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -405,6 +405,42 @@ t_parse_incoming_before_connect(_) ->
         emqx_connection:parse_incoming(Publish, st(#{}, #{conn_state => idle}))
     ).
 
+%% A zone change re-reads the zone settings but must keep the parser's own
+%% state: a connection that has sent CONNECT must not go back to expecting one.
+t_zone_change_keeps_parser_state(_) ->
+    {ok, St} = handle_msg({event, {zone_changed, default}}, st_after_connect()),
+    Publish = <<(?PUBLISH bsl 4), 3, 0, 1, $t>>,
+    ?assertMatch(
+        {1, [?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, <<>>)], _NState},
+        emqx_connection:parse_incoming(Publish, St)
+    ).
+
+%% A chunk may hold a CONNECT and the start of the next packet, so the parser
+%% can be mid-frame when the channel reports the zone change that CONNECT
+%% caused. The in-flight frame completes, and the new zone settings take effect
+%% from the frame after it.
+t_zone_change_mid_frame(_) ->
+    Old = emqx_config:get_zone_conf(default, [mqtt, max_packet_size]),
+    try
+        Connect = iolist_to_binary(emqx_frame:serialize(?CONNECT_PACKET(#mqtt_packet_connect{}))),
+        %% CONNECT, then the header of a PUBLISH whose body has not arrived.
+        {1, [?CONNECT_PACKET(_)], St0} =
+            emqx_connection:parse_incoming(<<Connect/binary, (?PUBLISH bsl 4), 3>>, st()),
+        %% The new zone allows far smaller packets than the one in flight.
+        ok = emqx_config:put_zone_conf(default, [mqtt, max_packet_size], 2),
+        {ok, St1} = handle_msg({event, {zone_changed, default}}, St0),
+        %% The in-flight frame still completes ...
+        {1, [?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, <<>>)], St2} =
+            emqx_connection:parse_incoming(<<0, 1, $t>>, St1),
+        %% ... and the new limit is in force from the next frame on.
+        ?assertMatch(
+            {0, [{frame_error, #{cause := frame_too_large, limit := 2}}], _NState},
+            emqx_connection:parse_incoming(<<(?PUBLISH bsl 4), 3, 0, 1, $t>>, St2)
+        )
+    after
+        emqx_config:put_zone_conf(default, [mqtt, max_packet_size], Old)
+    end.
+
 t_next_incoming_msgs(_) ->
     ?assertEqual(
         {incoming, packet},

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -41,7 +41,11 @@ groups() ->
             t_parse_malformed_utf8_string,
             t_default_parse_state_is_strict,
             t_parse_bad_v5_publish_packet,
-            t_guess_first_packet_protocol
+            t_guess_first_packet_protocol,
+            t_parse_non_connect_before_connect,
+            t_parse_complete_non_connect_before_connect,
+            t_parse_after_connect,
+            t_parse_no_connect_expected
         ]},
         {connect, [parallel], [
             t_serialize_parse_v3_connect,
@@ -129,6 +133,81 @@ init_per_group(_Group, Config) ->
 
 end_per_group(_Group, _Config) ->
     ok.
+
+-doc """
+A non-CONNECT first packet is rejected from the fixed header alone, before any
+body byte is buffered, when the parser is told to expect CONNECT first.
+""".
+t_parse_non_connect_before_connect(_) ->
+    ParseState = emqx_frame:initial_parse_state(#{expect_connect => true}),
+    lists:foreach(
+        fun({FirstByte, TypeName}) ->
+            %% Only the fixed header byte is fed, nothing can be buffered yet.
+            ?ASSERT_FRAME_THROW(
+                #{
+                    cause := unexpected_packet_before_connect,
+                    header_type := TypeName
+                },
+                emqx_frame:parse(<<FirstByte>>, ParseState)
+            ),
+            %% A 256 MB remaining length is rejected without buffering a body.
+            ?ASSERT_FRAME_THROW(
+                #{cause := unexpected_packet_before_connect},
+                emqx_frame:parse(<<FirstByte, 16#FF, 16#FF, 16#FF, 16#7F>>, ParseState)
+            )
+        end,
+        first_bytes()
+    ).
+
+-doc """
+The whole-frame parser applies the same check as the stream parser.
+""".
+t_parse_complete_non_connect_before_connect(_) ->
+    ParseState = emqx_frame:initial_parse_state(#{expect_connect => true}),
+    lists:foreach(
+        fun({FirstByte, TypeName}) ->
+            ?ASSERT_FRAME_THROW(
+                #{
+                    cause := unexpected_packet_before_connect,
+                    header_type := TypeName
+                },
+                emqx_frame:parse_complete(<<FirstByte, 0>>, ParseState)
+            )
+        end,
+        first_bytes()
+    ).
+
+-doc """
+Once CONNECT is parsed, the packets after it are parsed as usual.
+""".
+t_parse_after_connect(_) ->
+    ParseState = emqx_frame:initial_parse_state(#{expect_connect => true}),
+    Connect = ?CONNECT_PACKET(#mqtt_packet_connect{}),
+    Publish = ?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, <<"payload">>),
+    %% Stream parser.
+    {Connect, <<>>, ParseState1} = emqx_frame:parse(serialize_to_binary(Connect), ParseState),
+    ?assertMatch(
+        {Publish, <<>>, _},
+        emqx_frame:parse(serialize_to_binary(Publish), ParseState1)
+    ),
+    %% Whole-frame parser.
+    [Connect, ParseState2] = emqx_frame:parse_complete(serialize_to_binary(Connect), ParseState),
+    ?assertMatch(
+        Publish,
+        emqx_frame:parse_complete(serialize_to_binary(Publish), ParseState2)
+    ).
+
+-doc """
+The default parse state does not require CONNECT to come first.
+""".
+t_parse_no_connect_expected(_) ->
+    Publish = ?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, <<"payload">>),
+    PublishBin = serialize_to_binary(Publish),
+    ?assertMatch({Publish, <<>>, _}, emqx_frame:parse(PublishBin)),
+    ?assertMatch(
+        {Publish, <<>>, _},
+        emqx_frame:parse(PublishBin, emqx_frame:initial_parse_state(#{}))
+    ).
 
 t_parse_cont(_) ->
     Packet = ?CONNECT_PACKET(#mqtt_packet_connect{}),
@@ -1227,3 +1306,14 @@ parse_to_packet(Bin, Opts) ->
     Packet.
 
 payload(Len) -> iolist_to_binary(lists:duplicate(Len, 1)).
+
+%% Fixed header first bytes of the packet types a client may send.
+first_bytes() ->
+    [
+        {?PUBLISH bsl 4, 'PUBLISH'},
+        {(?SUBSCRIBE bsl 4) bor 2, 'SUBSCRIBE'},
+        {(?UNSUBSCRIBE bsl 4) bor 2, 'UNSUBSCRIBE'},
+        {?PINGREQ bsl 4, 'PINGREQ'},
+        {?DISCONNECT bsl 4, 'DISCONNECT'},
+        {?AUTH bsl 4, 'AUTH'}
+    ].

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -45,7 +45,9 @@ groups() ->
             t_parse_non_connect_before_connect,
             t_parse_complete_non_connect_before_connect,
             t_parse_after_connect,
-            t_parse_no_connect_expected
+            t_parse_no_connect_expected,
+            t_update_opts,
+            t_update_opts_mid_frame
         ]},
         {connect, [parallel], [
             t_serialize_parse_v3_connect,
@@ -396,6 +398,52 @@ t_guess_first_packet_protocol(_) ->
             <<"TRACE / HTTP/1.1\r\n">>,
             <<"PATCH / HTTP/1.1\r\n">>
         ]
+    ).
+
+%% update_opts/2 applies new settings but keeps everything the parser owns:
+%% the negotiated version and the CONNECT fence.
+t_update_opts(_) ->
+    PState0 = emqx_frame:initial_parse_state(#{expect_connect => true, max_size => 1024}),
+    {ok, PState1, Serialize1} = emqx_frame:update_opts(PState0, #{max_size => 8}),
+    %% The new size limit applies to both the parser and the serializer ...
+    ?assertMatch(#{max_size := 8}, Serialize1),
+    Connect = ?CONNECT_PACKET(#mqtt_packet_connect{proto_ver = ?MQTT_PROTO_V5}),
+    ConnectBin = serialize_to_binary(Connect, ?MQTT_PROTO_V5),
+    ?ASSERT_FRAME_THROW(
+        #{cause := frame_too_large, limit := 8},
+        emqx_frame:parse(ConnectBin, PState1)
+    ),
+    %% ... while the CONNECT fence is kept.
+    ?ASSERT_FRAME_THROW(
+        #{cause := unexpected_packet_before_connect},
+        emqx_frame:parse(<<(?PUBLISH bsl 4)>>, PState1)
+    ),
+    %% After a CONNECT, the version and the cleared fence are kept too.
+    {Connect, <<>>, PState2} = emqx_frame:parse(ConnectBin, PState0),
+    {ok, PState3, Serialize3} = emqx_frame:update_opts(PState2, #{max_size => 2048}),
+    ?assertMatch(#{version := ?MQTT_PROTO_V5, max_size := 2048}, Serialize3),
+    ?assertMatch(#{proto_ver := ?MQTT_PROTO_V5}, emqx_frame:describe_state(PState3)),
+    Publish = ?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, <<"payload">>),
+    PublishBin = serialize_to_binary(Publish, ?MQTT_PROTO_V5),
+    ?assertMatch({Publish, <<>>, _}, emqx_frame:parse(PublishBin, PState3)).
+
+%% A frame in flight is parsed under the options it started with. The new
+%% options are held and take effect from the next frame, not dropped.
+t_update_opts_mid_frame(_) ->
+    PState0 = emqx_frame:initial_parse_state(#{max_size => 1024}),
+    Publish = ?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, payload(64)),
+    PublishBin = serialize_to_binary(Publish),
+    <<Head:2/binary, Tail/binary>> = PublishBin,
+    {_More, Cont} = emqx_frame:parse(Head, PState0),
+    %% A limit too small for the frame already in flight.
+    {ok, Cont1, _Serialize} = emqx_frame:update_opts(Cont, #{max_size => 16}),
+    ?assertMatch(#{pending_opts_update := true}, emqx_frame:describe_state(Cont1)),
+    %% The in-flight frame still completes under the old limit ...
+    {Publish, <<>>, PState1} = emqx_frame:parse(Tail, Cont1),
+    %% ... and the held limit is in force from the next frame on.
+    ?ASSERT_FRAME_THROW(
+        #{cause := frame_too_large, limit := 16},
+        emqx_frame:parse(PublishBin, PState1)
     ).
 
 %% TODO: parse v3 with 0 length clientid

--- a/apps/emqx/test/emqx_socket_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_socket_connection_SUITE.erl
@@ -143,12 +143,13 @@ t_parse_incoming_first_packet_hints(_) ->
             {0, 0, [], _NState},
             emqx_socket_connection:parse_incoming(<<>>, mk_connstate(channel(idle)))
         ),
-        %% SUBSCRIBE with remaining_len=0 in idle state: enriched with hints.
+        %% SUBSCRIBE as the first packet: rejected before CONNECT, enriched with hints.
         ?assertMatch(
             {0, 0,
                 [
                     {frame_error, #{
-                        cause := zero_remaining_len,
+                        cause := unexpected_packet_before_connect,
+                        header_type := 'SUBSCRIBE',
                         packet_type := 'SUBSCRIBE',
                         resemble_protocol := _
                     }}
@@ -166,7 +167,7 @@ t_parse_incoming_first_packet_hints(_) ->
             {0, 0, [{frame_error, bad_subqos}], _NState},
             emqx_socket_connection:parse_incoming(
                 <<?SUBSCRIBE:4, 2:4, 16#06, 16#00, 16#01, 16#00, 16#01, $t, 16#03>>,
-                mk_connstate(channel(connected))
+                connstate_after_connect(channel(connected))
             )
         ),
         ok = meck:expect(emqx_frame, parse, fun(_, _) ->
@@ -193,6 +194,14 @@ mk_connstate() ->
 
 mk_connstate(Channel) ->
     emqx_socket_connection:set_field(channel, Channel, mk_connstate()).
+
+%% Connection state whose parser has already accepted a CONNECT, so that the
+%% packets after it are parsed as usual.
+connstate_after_connect(Channel) ->
+    Connect = iolist_to_binary(emqx_frame:serialize(?CONNECT_PACKET(#mqtt_packet_connect{}))),
+    {0, 1, [_], State} =
+        emqx_socket_connection:parse_incoming(Connect, mk_connstate(Channel)),
+    State.
 
 channel(ConnState) ->
     ConnInfo = #{

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -292,7 +292,7 @@ t_ws_non_check_origin(_) ->
 t_websocket_handle_binary(_) ->
     {ok, _} = ?ws_conn:websocket_handle({binary, <<>>}, st()),
     {ok, _} = ?ws_conn:websocket_handle({binary, [<<>>]}, st()),
-    {[{binary, Frame}], _} = ?ws_conn:websocket_handle({binary, <<192, 0>>}, st()),
+    {[{binary, Frame}], _} = ?ws_conn:websocket_handle({binary, <<192, 0>>}, st_after_connect()),
     ?assertEqual(
         iolist_to_binary(Frame),
         iolist_to_binary(emqx_frame:serialize(?PACKET(?PINGRESP)))
@@ -305,7 +305,7 @@ t_websocket_handle_packet_order(_) ->
     ],
     <<Frag1:2/bytes, Frag2/bytes>> =
         iolist_to_binary([emqx_frame:serialize(P, ?MQTT_PROTO_V5) || P <- Publishes]),
-    {ok, St1} = ?ws_conn:websocket_handle({binary, Frag1}, st()),
+    {ok, St1} = ?ws_conn:websocket_handle({binary, Frag1}, st_after_connect()),
     {[{binary, Frame1}, {binary, Frame2}], _} = ?ws_conn:websocket_handle({binary, Frag2}, St1),
     ?assertEqual(
         iolist_to_binary(Frame1),
@@ -439,7 +439,7 @@ t_handle_timeout_emit_stats(_) ->
     ?assertEqual(undefined, ?ws_conn:info(stats_timer, St)).
 
 t_parse_incoming(_) ->
-    {Packets, St} = ?ws_conn:parse_incoming(<<48, 3>>, [], st()),
+    {Packets, St} = ?ws_conn:parse_incoming(<<48, 3>>, [], st_after_connect()),
     {Packets1, _} = ?ws_conn:parse_incoming(<<0, 1, 116>>, Packets, St),
     Packet = ?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, <<>>),
     ?assertEqual([Packet], Packets1).
@@ -449,22 +449,38 @@ t_parse_incoming_order(_) ->
     Packet2 = ?PUBLISH_PACKET(?QOS_0, <<"t2">>, undefined, <<>>),
     Bin1 = emqx_frame:serialize(Packet1),
     Bin2 = emqx_frame:serialize(Packet2),
-    {Packets1, _} = ?ws_conn:parse_incoming(erlang:iolist_to_binary([Bin1, Bin2]), [], st()),
+    {Packets1, _} = ?ws_conn:parse_incoming(
+        erlang:iolist_to_binary([Bin1, Bin2]), [], st_after_connect()
+    ),
     ?assertEqual([Packet1, Packet2], Packets1).
 
 t_parse_incoming_frame_error(_) ->
     %% Strict-mode default rejects the reserved/invalid header outright,
     %% before per-packet parsing has a chance to surface `malformed_packet`.
-    {Packets, _St} = ?ws_conn:parse_incoming(<<3, 2, 1, 0>>, [], st()),
+    {Packets, _St} = ?ws_conn:parse_incoming(<<3, 2, 1, 0>>, [], st_after_connect()),
     ?assertMatch(
         [{frame_error, bad_frame_header}],
+        Packets
+    ).
+
+-doc """
+A non-CONNECT first packet is rejected from its fixed header, before the
+announced body is buffered.
+""".
+t_parse_incoming_before_connect(_) ->
+    %% PUBLISH fixed header announcing a 268435455 byte body.
+    Publish = <<(?PUBLISH bsl 4), 16#FF, 16#FF, 16#FF, 16#7F>>,
+    St0 = st(#{channel => channel(#{conn_state => idle})}),
+    {Packets, _St} = ?ws_conn:parse_incoming(Publish, [], St0),
+    ?assertMatch(
+        [{frame_error, #{cause := unexpected_packet_before_connect, header_type := 'PUBLISH'}}],
         Packets
     ).
 
 t_parse_incoming_fragment_then_bad_subqos_idle(_) ->
     %% Feed an invalid SUBSCRIBE in two chunks while channel is idle.
     %% This exercises frame parsing after parser state has already advanced.
-    St0 = st(#{channel => channel(#{conn_state => idle})}),
+    St0 = st_after_connect(#{channel => channel(#{conn_state => idle})}),
     Frag1 = <<16#82, 16#06, 16#00>>,
     Frag2 = <<16#01, 16#00, 16#01, $t, 16#03>>,
     {Packets1, St1} = ?ws_conn:parse_incoming(Frag1, [], St0),
@@ -511,6 +527,15 @@ conninfo() ->
     }.
 
 st() -> st(#{}).
+
+%% Connection state whose parser has already accepted a CONNECT, so that the
+%% packets after it are parsed as usual.
+st_after_connect() -> st_after_connect(#{}).
+st_after_connect(InitFields) ->
+    Connect = iolist_to_binary(emqx_frame:serialize(?CONNECT_PACKET(#mqtt_packet_connect{}))),
+    {[_], St} = ?ws_conn:parse_incoming(Connect, [], st(InitFields)),
+    St.
+
 st(InitFields) when is_map(InitFields) ->
     {ok, St, _} = ?ws_conn:websocket_init([
         conninfo(),

--- a/changes/ee/fix-18828.en.md
+++ b/changes/ee/fix-18828.en.md
@@ -1,0 +1,3 @@
+MQTT listeners now close a connection as soon as its first packet is not a CONNECT, before reading the packet body.
+
+Previously the body was read into memory first, up to `mqtt.max_packet_size`, so a client that had not connected could tie up that much memory per connection.


### PR DESCRIPTION
Fixes:
Release version: 6.3.1, 7.0.0
Introduced in: pre-5.8

## Summary

A client that has not sent CONNECT could send any packet type. The frame parser
buffered the announced body, up to `mqtt.max_packet_size` (1 MB by default,
256 MB at most), before `emqx_channel` rejected the packet on the fully parsed
frame. An unauthenticated client could tie up that much memory per connection.

`emqx_frame` now carries an `expect_connect` flag in its parse options. While
the flag is set, a fixed header whose type is not CONNECT throws
`unexpected_packet_before_connect`, so the remaining length is never read and no
body byte is buffered. The check runs in both `parse/2` (stream parser) and
`parse_complete/2` (whole-frame parser). The parser clears the flag when a
CONNECT parses, so a second CONNECT on an established connection is unaffected.

`emqx_connection`, `emqx_socket_connection` and `emqx_ws_connection` set the flag
when they build the parser, and carry its value across the parser re-init that
`init_zone_specific_state/3` performs on a zone change. Without that, the
re-init would re-arm the fence on a connection that had already sent CONNECT.

`emqx_channel` needs no change: a frame error in `idle` state already shuts the
connection down under the `invalid_connect_packet` counter and sends no CONNACK.

The check lives in the parser rather than in the three connection modules. The
parser already owns the record of what it has seen on this connection, and one
copy covers both parse modes and every transport. Gateways use their own frame
modules and are out of scope.

The flag defaults to `false`, so `emqx_frame:parse/1` and the standalone
round-trip tests keep working.

Existing unit tests that fed a non-CONNECT packet into a fresh parser now send a
CONNECT first, through new `st_after_connect/0` helpers.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
