### PR TITLE
feat(mqtt): limit CONNECT packet size and its user properties

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1448,11 +1448,18 @@ A counter name must come from a bounded set. Errors reported as an atom are
 already such a set, fixed by the parser, so the atom names its own counter.
 Errors reported as a map carry detail derived from the offending packet, so they
 share `Default'; the specific cause remains in the shutdown reason and in the
-trace. Oversized frames keep their own counter in every connection state, being
-a distinct operational signal rather than a malformed packet.
+trace.
+
+The causes listed below are the exception: each names a configured limit the
+client went over, not a property of the packet's content, so the set of names
+stays bounded and each is a distinct operational signal rather than a malformed
+packet. An operator reading the counters can tell "clients are hitting a limit
+you set" from "clients are sending garbage".
 """.
 frame_error_kind(Reason, _Default) when is_atom(Reason) -> Reason;
 frame_error_kind(#{cause := frame_too_large}, _Default) -> frame_too_large;
+frame_error_kind(#{cause := connect_packet_too_large}, _Default) -> connect_packet_too_large;
+frame_error_kind(#{cause := too_many_user_properties}, _Default) -> too_many_user_properties;
 frame_error_kind(_Reason, Default) -> Default.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -649,6 +649,7 @@ handle_msg(
             maps:get(conn_pid, QSS),
             {get_parser_state(Parser), Serialize, Channel}
         ),
+    ok = raise_packet_size_limit(State),
     ClientId = emqx_channel:info(clientid, Channel),
     emqx_cm:insert_channel_info(ClientId, info(State), stats(State)),
     {ok, ensure_stats_timer(State)};
@@ -902,6 +903,19 @@ enrich_reason(Reason, Hints) when is_map(Reason) ->
     maps:merge(Hints, Reason);
 enrich_reason(Reason, Hints) ->
     Hints#{reason => Reason}.
+
+%% The listener accepts with `packet_size' set to the CONNECT limit. Now that the
+%% client is connected, raise it to `max_packet_size' so ordinary packets are not
+%% held to the CONNECT limit. Only the whole-frame parser reads `packet_size'.
+raise_packet_size_limit(#state{
+    parser = {frame, _}, transport = Transport, socket = Socket, conf = Conf
+}) ->
+    #conf{zone = Zone} = Conf,
+    MaxSize = emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size]),
+    _ = Transport:setopts(Socket, [{packet_size, MaxSize}]),
+    ok;
+raise_packet_size_limit(_State) ->
+    ok.
 
 init_parser(Transport, Socket, FrameOpts) ->
     {ok, SocketOpts} = Transport:getopts(Socket, [packet]),
@@ -1549,6 +1563,10 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf} = State0) ->
         %% N.B.: when the listener's `parse_unit = frame`, `max_packet_size` from the new
         %% zone will **not** take effect after the override.
         max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size]),
+        max_connect_size => emqx_config:get_zone_conf(Zone, [mqtt, max_connect_packet_size]),
+        max_connect_user_properties => emqx_config:get_zone_conf(
+            Zone, [mqtt, max_connect_user_properties]
+        ),
         %% Any packet received before CONNECT is rejected by the parser.
         expect_connect => true
     },

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -1329,15 +1329,12 @@ handle_info(activate_socket, State = #state{sockstate = OldSst}) ->
             handle_info({sock_error, Reason}, State)
     end;
 handle_info({sock_error, Reason}, State) ->
-    %% Do not log warning for econnreset
-    maybe_log_first_packet_non_mqtt(Reason, State),
-    case ?IS_NORMAL_SOCKET_ERROR(Reason) orelse Reason =:= econnreset of
-        true ->
-            ok;
+    case connect_too_large_error(Reason, State) of
+        {true, FrameError} ->
+            handle_incoming(FrameError, close_socket(State));
         false ->
-            ?SLOG(warning, #{msg => "socket_error", reason => Reason})
-    end,
-    handle_info({sock_closed, Reason}, close_socket(State));
+            handle_sock_error(Reason, State)
+    end;
 %% handle QUIC control stream events
 handle_info({quic, Event, Handle, Prop}, State) when is_atom(Event) ->
     case emqx_quic_stream:Event(Handle, Prop, State) of
@@ -1348,6 +1345,54 @@ handle_info({quic, Event, Handle, Prop}, State) when is_atom(Event) ->
     end;
 handle_info(Info, State) ->
     with_channel(handle_info, [Info], State).
+
+handle_sock_error(Reason, State) ->
+    %% Do not log warning for econnreset
+    maybe_log_first_packet_non_mqtt(Reason, State),
+    case ?IS_NORMAL_SOCKET_ERROR(Reason) orelse Reason =:= econnreset of
+        true ->
+            ok;
+        false ->
+            ?SLOG(warning, #{msg => "socket_error", reason => Reason})
+    end,
+    handle_info({sock_closed, Reason}, close_socket(State)).
+
+-doc """
+Recognise a first frame the transport refused for being over `packet_size'.
+
+Before CONNECT, the whole-frame transports are set up with `packet_size' equal
+to `max_connect_packet_size', so they reject an oversized CONNECT before the
+parser sees a byte of it. `gen_tcp' reports `emsgsize'; `ssl' reports
+`{invalid_packet, Data}', carrying the client's bytes. Report both the way the
+stream parser reports the same packet, so the shutdown counter does not depend
+on the transport, and the client's bytes stay out of the exit reason.
+
+Only the error tag is kept: whether the refused frame really was a CONNECT is
+not knowable here, and neither is it in the stream parser's case.
+""".
+connect_too_large_error(Reason, #state{parser = {frame, _}, channel = Channel, conf = Conf}) ->
+    case transport_frame_too_large(Reason) andalso emqx_channel:info(conn_state, Channel) of
+        idle ->
+            #conf{zone = Zone} = Conf,
+            Limit = emqx_config:get_zone_conf(Zone, [mqtt, max_connect_packet_size]),
+            {true,
+                {frame_error, #{
+                    cause => connect_packet_too_large,
+                    limit => Limit,
+                    transport_error => transport_error_tag(Reason)
+                }}};
+        _ ->
+            false
+    end;
+connect_too_large_error(_Reason, _State) ->
+    false.
+
+transport_frame_too_large(emsgsize) -> true;
+transport_frame_too_large({invalid_packet, _Data}) -> true;
+transport_frame_too_large(_) -> false.
+
+transport_error_tag({invalid_packet, _Data}) -> invalid_packet;
+transport_error_tag(Reason) -> Reason.
 
 maybe_log_first_packet_non_mqtt(emsgsize, #state{channel = Channel}) ->
     case emqx_channel:info(conn_state, Channel) of

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -42,6 +42,8 @@
 -type options() :: #{
     strict_mode => boolean(),
     max_size => 1..?MAX_PACKET_SIZE,
+    max_connect_size => 1..?MAX_PACKET_SIZE,
+    max_connect_user_properties => non_neg_integer() | infinity,
     version => emqx_types:proto_ver(),
     expect_connect => boolean()
 }.
@@ -49,6 +51,11 @@
 -record(options, {
     strict_mode :: boolean(),
     max_size :: 1..?MAX_PACKET_SIZE,
+    %% Size limit for a CONNECT packet, on top of `max_size'.
+    max_connect_size :: 1..?MAX_PACKET_SIZE,
+    %% Limit on the number of 'User-Property' pairs in a CONNECT packet.
+    %% Applies to the CONNECT properties and the will properties separately.
+    max_connect_user_properties :: non_neg_integer() | infinity,
     version :: emqx_types:proto_ver(),
     %% When true, the next packet must be a CONNECT.
     expect_connect :: boolean()
@@ -73,6 +80,8 @@
 -define(DEFAULT_OPTIONS, #{
     strict_mode => true,
     max_size => ?MAX_PACKET_SIZE,
+    max_connect_size => ?MAX_PACKET_SIZE,
+    max_connect_user_properties => infinity,
     version => ?MQTT_PROTO_V4,
     expect_connect => false
 }).
@@ -149,7 +158,13 @@ version(#update{inner = Inner}) -> version(Inner).
 merge_opts(Options, NewOpts) ->
     Options#options{
         strict_mode = maps:get(strict_mode, NewOpts, Options#options.strict_mode),
-        max_size = maps:get(max_size, NewOpts, Options#options.max_size)
+        max_size = maps:get(max_size, NewOpts, Options#options.max_size),
+        max_connect_size = maps:get(
+            max_connect_size, NewOpts, Options#options.max_connect_size
+        ),
+        max_connect_user_properties = maps:get(
+            max_connect_user_properties, NewOpts, Options#options.max_connect_user_properties
+        )
     }.
 
 %%--------------------------------------------------------------------
@@ -166,6 +181,8 @@ initial_parse_state(Options) when is_map(Options) ->
     #options{
         strict_mode = maps:get(strict_mode, Effective),
         max_size = maps:get(max_size, Effective),
+        max_connect_size = maps:get(max_connect_size, Effective),
+        max_connect_user_properties = maps:get(max_connect_user_properties, Effective),
         version = maps:get(version, Effective),
         expect_connect = maps:get(expect_connect, Effective)
     }.
@@ -234,7 +251,8 @@ parse_complete(
         <<0:8>> ->
             parse_bodyless_packet(Header);
         _ ->
-            {_RemLen, Rest2} = parse_variable_byte_integer(Rest1),
+            {RemLen, Rest2} = parse_variable_byte_integer(Rest1),
+            ok = validate_frame_len(RemLen, Header, Options),
             parse_packet_complete(Rest2, Header, Options)
     end.
 
@@ -344,13 +362,28 @@ parse_remaining_len(
     Header,
     Multiplier,
     Value,
-    Options = #options{max_size = MaxSize}
+    Options
 ) ->
     FrameLen = Value + Len * Multiplier,
-    case FrameLen > MaxSize of
-        true -> ?PARSE_ERR(#{cause => frame_too_large, limit => MaxSize, received => FrameLen});
-        false -> parse_body_frame(Rest, Header, FrameLen, <<>>, Options)
-    end.
+    ok = validate_frame_len(FrameLen, Header, Options),
+    parse_body_frame(Rest, Header, FrameLen, <<>>, Options).
+
+%% A CONNECT packet is held to `max_connect_size' as well as `max_size', so that
+%% an unauthenticated client cannot make the broker buffer a whole `max_size'
+%% body. Both limits are checked from the fixed header, before any body byte is
+%% read.
+validate_frame_len(
+    FrameLen,
+    #mqtt_packet_header{type = ?CONNECT},
+    #options{max_connect_size = MaxConnectSize}
+) when FrameLen > MaxConnectSize ->
+    ?PARSE_ERR(#{
+        cause => connect_packet_too_large, limit => MaxConnectSize, received => FrameLen
+    });
+validate_frame_len(FrameLen, _Header, #options{max_size = MaxSize}) when FrameLen > MaxSize ->
+    ?PARSE_ERR(#{cause => frame_too_large, limit => MaxSize, received => FrameLen});
+validate_frame_len(_FrameLen, _Header, _Options) ->
+    ok.
 
 -compile({inline, [parse_bodyless_packet/1]}).
 
@@ -422,7 +455,7 @@ parse_connect(Frame, Options = #options{strict_mode = StrictMode}) ->
     _ = validate_proto_name(ProtoName),
     {IsBridge, ProtoVer, Rest2} = parse_connect_proto_ver(Rest0),
     try
-        do_parse_connect(ProtoName, IsBridge, ProtoVer, Rest2, StrictMode)
+        do_parse_connect(ProtoName, IsBridge, ProtoVer, Rest2, Options)
     catch
         throw:{?FRAME_PARSE_ERROR, ReasonM} when is_map(ReasonM) ->
             ?PARSE_ERR(
@@ -469,7 +502,7 @@ do_parse_connect(
         KeepAlive:16/big,
         Rest/binary
     >>,
-    StrictMode
+    Options = #options{strict_mode = StrictMode, max_connect_user_properties = MaxUserProps}
 ) ->
     WillFlag = bool(WillFlagB),
     WillRetain = bool(WillRetainB),
@@ -487,7 +520,7 @@ do_parse_connect(
         UsernameFlag,
         PasswordFlag
     ),
-    {Properties, Rest3} = parse_properties(Rest, ProtoVer, StrictMode),
+    {Properties, Rest3} = parse_properties(Rest, ProtoVer, StrictMode, MaxUserProps),
     %% `strict_mode` here only rejects an invalid UTF-8 client ID. The length limit is
     %% applied later by emqx_packet:check_client_id/2 against `max_clientid_len`, for all
     %% MQTT versions alike (no separate MQTT 3.1 23-byte check). See emqx/emqx#18674.
@@ -506,7 +539,7 @@ do_parse_connect(
         properties = Properties,
         clientid = ClientId
     },
-    {ConnPacket1, Rest5} = parse_will_message(ConnPacket, Rest4, StrictMode),
+    {ConnPacket1, Rest5} = parse_will_message(ConnPacket, Rest4, Options),
     {Username, Rest6} = parse_optional(
         Rest5,
         fun(Bin) ->
@@ -530,7 +563,7 @@ do_parse_connect(
                 unexpected_trailing_bytes => byte_size(Rest7)
             })
     end;
-do_parse_connect(_ProtoName, _IsBridge, _ProtoVer, Bin, _StrictMode) ->
+do_parse_connect(_ProtoName, _IsBridge, _ProtoVer, Bin, _Options) ->
     %% sent less than 24 bytes
     ?PARSE_ERR(#{cause => malformed_connect, header_bytes => Bin}).
 
@@ -681,9 +714,9 @@ parse_will_message(
         proto_ver = Ver
     },
     Bin,
-    StrictMode
+    #options{strict_mode = StrictMode, max_connect_user_properties = MaxUserProps}
 ) ->
-    {Props, Rest} = parse_properties(Bin, Ver, StrictMode),
+    {Props, Rest} = parse_properties(Bin, Ver, StrictMode, MaxUserProps),
     {Topic, Rest1} = parse_utf8_string(Rest, StrictMode, _Cause = invalid_topic),
     {Payload, Rest2} = parse_will_payload(Rest1),
     {
@@ -694,7 +727,7 @@ parse_will_message(
         },
         Rest2
     };
-parse_will_message(Packet, Bin, _StrictMode) ->
+parse_will_message(Packet, Bin, _Options) ->
     {Packet, Bin}.
 
 -compile({inline, [parse_packet_id/1]}).
@@ -709,18 +742,25 @@ parse_connect_proto_ver(Bin) ->
     %% sent less than 1 bytes or empty
     ?PARSE_ERR(#{cause => malformed_connect, header_bytes => Bin}).
 
-parse_properties(Bin, Ver, _StrictMode) when Ver =/= ?MQTT_PROTO_V5 ->
+parse_properties(Bin, Ver, StrictMode) ->
+    parse_properties(Bin, Ver, StrictMode, infinity).
+
+%% `MaxUserProps' caps the number of 'User-Property' pairs in this properties
+%% block. Only the CONNECT and will properties pass a limit; every other packet
+%% type parses with `infinity'.
+parse_properties(Bin, Ver, _StrictMode, _MaxUserProps) when Ver =/= ?MQTT_PROTO_V5 ->
     {#{}, Bin};
 %% TODO: version mess?
-parse_properties(<<>>, ?MQTT_PROTO_V5, _StrictMode) ->
+parse_properties(<<>>, ?MQTT_PROTO_V5, _StrictMode, _MaxUserProps) ->
     {#{}, <<>>};
-parse_properties(<<0, Rest/binary>>, ?MQTT_PROTO_V5, _StrictMode) ->
+parse_properties(<<0, Rest/binary>>, ?MQTT_PROTO_V5, _StrictMode, _MaxUserProps) ->
     {#{}, Rest};
-parse_properties(Bin, ?MQTT_PROTO_V5, StrictMode) ->
+parse_properties(Bin, ?MQTT_PROTO_V5, StrictMode, MaxUserProps) ->
     {Len, Rest} = parse_variable_byte_integer(Bin),
     case Rest of
         <<PropsBin:Len/binary, Rest1/binary>> ->
-            {finalize_user_property(parse_property(PropsBin, #{}, StrictMode)), Rest1};
+            Props = parse_property(PropsBin, #{}, StrictMode, MaxUserProps, 0),
+            {finalize_user_property(Props), Rest1};
         _ ->
             ?PARSE_ERR(#{
                 cause => user_property_not_enough_bytes,
@@ -729,93 +769,241 @@ parse_properties(Bin, ?MQTT_PROTO_V5, StrictMode) ->
             })
     end.
 
-parse_property(<<>>, Props, _StrictMode) ->
+parse_property(<<>>, Props, _StrictMode, _MaxUserProps, _NUserProps) ->
     Props;
-parse_property(<<16#01, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Payload-Format-Indicator', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#02, Val:32/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Message-Expiry-Interval', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#03, Bin/binary>>, Props, StrictMode) ->
+parse_property(<<16#01, Val, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Payload-Format-Indicator', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#02, Val:32/big, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Message-Expiry-Interval', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#03, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_content_type),
-    parse_property(Rest, put_prop('Content-Type', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#08, Bin/binary>>, Props, StrictMode) ->
+    parse_property(
+        Rest, put_prop('Content-Type', Val, Props, StrictMode), StrictMode, MaxUserProps, NUserProps
+    );
+parse_property(<<16#08, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_response_topic),
-    parse_property(Rest, put_prop('Response-Topic', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#09, Len:16/big, Val:Len/binary, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Correlation-Data', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#0B, Bin/binary>>, Props, StrictMode) ->
+    parse_property(
+        Rest,
+        put_prop('Response-Topic', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(
+    <<16#09, Len:16/big, Val:Len/binary, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps
+) ->
+    parse_property(
+        Bin,
+        put_prop('Correlation-Data', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#0B, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     {Val, Rest} = parse_variable_byte_integer(Bin),
-    parse_property(Rest, put_prop('Subscription-Identifier', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#11, Val:32/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Session-Expiry-Interval', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#12, Bin/binary>>, Props, StrictMode) ->
+    parse_property(
+        Rest,
+        put_prop('Subscription-Identifier', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#11, Val:32/big, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Session-Expiry-Interval', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#12, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_assigned_client_id),
     parse_property(
-        Rest, put_prop('Assigned-Client-Identifier', Val, Props, StrictMode), StrictMode
+        Rest,
+        put_prop('Assigned-Client-Identifier', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
     );
-parse_property(<<16#13, Val:16, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Server-Keep-Alive', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#15, Bin/binary>>, Props, StrictMode) ->
+parse_property(<<16#13, Val:16, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Server-Keep-Alive', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#15, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_authn_method),
-    parse_property(Rest, put_prop('Authentication-Method', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#16, Len:16/big, Val:Len/binary, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Authentication-Data', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#17, Val, Bin/binary>>, Props, StrictMode) ->
     parse_property(
-        Bin, put_prop('Request-Problem-Information', Val, Props, StrictMode), StrictMode
+        Rest,
+        put_prop('Authentication-Method', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
     );
-parse_property(<<16#18, Val:32, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Will-Delay-Interval', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#19, Val, Bin/binary>>, Props, StrictMode) ->
+parse_property(
+    <<16#16, Len:16/big, Val:Len/binary, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps
+) ->
     parse_property(
-        Bin, put_prop('Request-Response-Information', Val, Props, StrictMode), StrictMode
+        Bin,
+        put_prop('Authentication-Data', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
     );
-parse_property(<<16#1A, Bin/binary>>, Props, StrictMode) ->
+parse_property(<<16#17, Val, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Request-Problem-Information', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#18, Val:32, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Will-Delay-Interval', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#19, Val, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Request-Response-Information', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#1A, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_response_info),
-    parse_property(Rest, put_prop('Response-Information', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#1C, Bin/binary>>, Props, StrictMode) ->
+    parse_property(
+        Rest,
+        put_prop('Response-Information', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#1C, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_server_reference),
-    parse_property(Rest, put_prop('Server-Reference', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#1F, Bin/binary>>, Props, StrictMode) ->
+    parse_property(
+        Rest,
+        put_prop('Server-Reference', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#1F, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     {Val, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_reason_string),
-    parse_property(Rest, put_prop('Reason-String', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#21, Val:16/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Receive-Maximum', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#22, Val:16/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Topic-Alias-Maximum', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#23, Val:16/big, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Topic-Alias', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#24, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Maximum-QoS', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#25, Val, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Retain-Available', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#26, Bin/binary>>, Props, StrictMode) ->
+    parse_property(
+        Rest,
+        put_prop('Reason-String', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#21, Val:16/big, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Receive-Maximum', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#22, Val:16/big, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Topic-Alias-Maximum', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#23, Val:16/big, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin, put_prop('Topic-Alias', Val, Props, StrictMode), StrictMode, MaxUserProps, NUserProps
+    );
+parse_property(<<16#24, Val, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin, put_prop('Maximum-QoS', Val, Props, StrictMode), StrictMode, MaxUserProps, NUserProps
+    );
+parse_property(<<16#25, Val, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Retain-Available', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<16#26, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    ok = validate_user_property_count(NUserProps, MaxUserProps),
     {Pair, Rest} = parse_utf8_pair(Bin, StrictMode),
+    N = NUserProps + 1,
     %% Accumulate in reverse order to keep this O(1) per entry; the list is
-    %% reversed back to wire order in parse_properties/3 once parsing finishes.
+    %% reversed back to wire order in parse_properties/4 once parsing finishes.
     case Props of
         #{'User-Property' := UserProps} ->
-            parse_property(Rest, Props#{'User-Property' := [Pair | UserProps]}, StrictMode);
+            NProps = Props#{'User-Property' := [Pair | UserProps]},
+            parse_property(Rest, NProps, StrictMode, MaxUserProps, N);
         #{} ->
-            parse_property(Rest, Props#{'User-Property' => [Pair]}, StrictMode)
+            parse_property(Rest, Props#{'User-Property' => [Pair]}, StrictMode, MaxUserProps, N)
     end;
-parse_property(<<16#27, Val:32, Bin/binary>>, Props, StrictMode) ->
-    parse_property(Bin, put_prop('Maximum-Packet-Size', Val, Props, StrictMode), StrictMode);
-parse_property(<<16#28, Val, Bin/binary>>, Props, StrictMode) ->
+parse_property(<<16#27, Val:32, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     parse_property(
-        Bin, put_prop('Wildcard-Subscription-Available', Val, Props, StrictMode), StrictMode
+        Bin,
+        put_prop('Maximum-Packet-Size', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
     );
-parse_property(<<16#29, Val, Bin/binary>>, Props, StrictMode) ->
+parse_property(<<16#28, Val, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     parse_property(
-        Bin, put_prop('Subscription-Identifier-Available', Val, Props, StrictMode), StrictMode
+        Bin,
+        put_prop('Wildcard-Subscription-Available', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
     );
-parse_property(<<16#2A, Val, Bin/binary>>, Props, StrictMode) ->
+parse_property(<<16#29, Val, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
     parse_property(
-        Bin, put_prop('Shared-Subscription-Available', Val, Props, StrictMode), StrictMode
+        Bin,
+        put_prop('Subscription-Identifier-Available', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
     );
-parse_property(<<Property:8, _Rest/binary>>, _Props, _StrictMode) ->
+parse_property(<<16#2A, Val, Bin/binary>>, Props, StrictMode, MaxUserProps, NUserProps) ->
+    parse_property(
+        Bin,
+        put_prop('Shared-Subscription-Available', Val, Props, StrictMode),
+        StrictMode,
+        MaxUserProps,
+        NUserProps
+    );
+parse_property(<<Property:8, _Rest/binary>>, _Props, _StrictMode, _MaxUserProps, _NUserProps) ->
     ?PARSE_ERR(#{cause => invalid_property_code, property_code => Property}).
 %% TODO: invalid property in specific packet.
+
+%% Reject the pair before it is parsed, so that an oversized properties block
+%% cannot be turned into a list of terms first and rejected afterwards.
+validate_user_property_count(_N, infinity) ->
+    ok;
+validate_user_property_count(N, Max) when N < Max ->
+    ok;
+validate_user_property_count(_N, Max) ->
+    ?PARSE_ERR(#{cause => too_many_user_properties, limit => Max}).
 
 -doc """
 Insert a non-repeatable property into the properties map.
@@ -830,7 +1018,7 @@ put_prop(Key, Val, Props, _StrictMode) ->
     Props#{Key => Val}.
 
 -doc """
-Restore wire order for the 'User-Property' list, which parse_property/3
+Restore wire order for the 'User-Property' list, which parse_property/5
 accumulates in reverse to keep per-entry cost constant.
 """.
 finalize_user_property(#{'User-Property' := UserProps} = Props) ->

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -733,15 +733,22 @@ do_post_zone_config_update(true, OldZones, NewZones) ->
             )
     end.
 
+%% Zone settings that `choose_packet_opts/1' bakes into the listener socket
+%% options, and so require the listener to be updated when they change.
+-define(PACKET_OPT_KEYS, [max_packet_size, max_connect_packet_size]).
+
 find_zones_with_relevant_changes([], _OldZones, _NewZones, Acc) ->
     Acc;
 find_zones_with_relevant_changes([Zone | Zones], OldZones, NewZones, Acc) ->
-    OldConfig = emqx_utils_maps:deep_get([Zone, mqtt, max_packet_size], OldZones, none),
-    NewConfig = emqx_utils_maps:deep_get([Zone, mqtt, max_packet_size], NewZones, none),
-    case OldConfig =:= NewConfig of
-        true ->
-            find_zones_with_relevant_changes(Zones, OldZones, NewZones, Acc);
+    Read = fun(Config, Key) -> emqx_utils_maps:deep_get([Zone, mqtt, Key], Config, none) end,
+    Changed = lists:any(
+        fun(Key) -> Read(OldZones, Key) =/= Read(NewZones, Key) end,
+        ?PACKET_OPT_KEYS
+    ),
+    case Changed of
         false ->
+            find_zones_with_relevant_changes(Zones, OldZones, NewZones, Acc);
+        true ->
             find_zones_with_relevant_changes(Zones, OldZones, NewZones, [Zone | Acc])
     end.
 
@@ -955,7 +962,14 @@ choose_packet_opts(Opts) ->
     HasPacketParser = is_packet_parser_available(mqtt),
     case ParseUnit of
         frame when HasPacketParser ->
-            PacketSize = emqx_config:get_zone_conf(zone(Opts), [mqtt, max_packet_size]),
+            %% Accept with the CONNECT limit, so the kernel does not buffer a
+            %% whole `max_packet_size' frame for a client that has not connected
+            %% yet. `emqx_connection' raises it once the client is connected.
+            Zone = zone(Opts),
+            PacketSize = min(
+                emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size]),
+                emqx_config:get_zone_conf(Zone, [mqtt, max_connect_packet_size])
+            ),
             [{packet, mqtt}, {packet_size, PacketSize}, {mode, binary}];
         frame ->
             %% NOTE: Silently ignoring the setting if BEAM does not provide `mqtt` parser.

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -4217,6 +4217,24 @@ mqtt_general() ->
                     desc => ?DESC(mqtt_max_packet_size)
                 }
             )},
+        {"max_connect_packet_size",
+            sc(
+                bytesize(),
+                #{
+                    default => <<"64KB">>,
+                    validator => fun ?MODULE:validate_max_packet_size/1,
+                    converter => fun ?MODULE:convert_max_packet_size/2,
+                    desc => ?DESC(mqtt_max_connect_packet_size)
+                }
+            )},
+        {"max_connect_user_properties",
+            sc(
+                hoconsc:union([infinity, non_neg_integer()]),
+                #{
+                    default => 10,
+                    desc => ?DESC(mqtt_max_connect_user_properties)
+                }
+            )},
         {"max_clientid_len",
             sc(
                 %% MQTT-v3.1.1-[MQTT-3.1.3-5], MQTT-v5.0-[MQTT-3.1.3-5]

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1541,6 +1541,10 @@ init_zone_specific_state(Zone, Opts, #state{conf = Conf0} = State0) ->
         %% N.B.: when the listener's `parse_unit = frame`, `max_packet_size` from the new
         %% zone will **not** take effect after the override.
         max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size]),
+        max_connect_size => emqx_config:get_zone_conf(Zone, [mqtt, max_connect_packet_size]),
+        max_connect_user_properties => emqx_config:get_zone_conf(
+            Zone, [mqtt, max_connect_user_properties]
+        ),
         %% Any packet received before CONNECT is rejected by the parser.
         expect_connect => true
     },

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -986,6 +986,10 @@ init_zone_specific_state(Zone, _Opts, #state{} = State0) ->
         %% N.B.: when the listener's `parse_unit = frame`, `max_packet_size` from the new
         %% zone will **not** take effect after the override.
         max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size]),
+        max_connect_size => emqx_config:get_zone_conf(Zone, [mqtt, max_connect_packet_size]),
+        max_connect_user_properties => emqx_config:get_zone_conf(
+            Zone, [mqtt, max_connect_user_properties]
+        ),
         %% Any packet received before CONNECT is rejected by the parser.
         expect_connect => true
     },

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -113,6 +113,8 @@ groups() ->
             t_connect_packet_too_large,
             t_connect_too_many_user_properties,
             t_frame_error_shutdown_count_idle,
+            t_shutdown_count_connect_packet_too_large,
+            t_shutdown_count_too_many_user_properties,
             t_frame_error_shutdown_count_connected,
             t_frame_error_shutdown_count_is_bounded,
             t_sock_closed_incomplete_qos2_transmission
@@ -1669,6 +1671,33 @@ t_first_packet_not_connect(Config) ->
     end.
 
 -doc """
+An oversized CONNECT shuts the connection down under its own counter, so an
+operator can tell a client hitting `mqtt.max_connect_packet_size` from a client
+sending garbage.
+""".
+t_shutdown_count_connect_packet_too_large(Config) ->
+    Limit = emqx_config:get_zone_conf(default, [mqtt, max_connect_packet_size]),
+    Socket = socket_connect(Config, [{active, true}, binary]),
+    %% No parser trace to assert on here: with `parse_unit = frame' the
+    %% transport refuses the frame before the parser sees it.
+    {ExitReason, _Reports} = assert_shutdown_counted(
+        Config, Socket, oversized_connect(Limit), connect_packet_too_large
+    ),
+    ?assertMatch({shutdown, #{cause := connect_packet_too_large, limit := Limit}}, ExitReason).
+
+-doc """
+A CONNECT with too many user properties shuts the connection down under its own
+counter.
+""".
+t_shutdown_count_too_many_user_properties(Config) ->
+    Limit = emqx_config:get_zone_conf(default, [mqtt, max_connect_user_properties]),
+    Socket = socket_connect(Config, [{active, true}, binary]),
+    ExitReason = assert_frame_error_shutdown(
+        Config, Socket, connect_with_user_properties(Limit + 1), too_many_user_properties
+    ),
+    ?assertMatch({shutdown, #{cause := too_many_user_properties, limit := Limit}}, ExitReason).
+
+-doc """
 A non-MQTT first packet shuts the connection down under the fixed
 `invalid_connect_packet` counter, rather than being reported as an unidentified
 shutdown at error level. The cause stays in the shutdown reason.
@@ -1765,6 +1794,19 @@ send_malformed_when_connected(Config, Malformed) ->
 %% Send `Malformed' and assert the connection exits with a reason the connection
 %% supervisor attributes to `Cause'. Returns the exit reason.
 assert_frame_error_shutdown(Config, Socket, Malformed, Cause) ->
+    {ExitReason, Reports} = assert_shutdown_counted(Config, Socket, Malformed, Cause),
+    %% The shutdown counter only names a kind, so the specific cause and the
+    %% offending bytes must stay reachable through `emqx_trace'.
+    ?assertMatch(
+        [#{reason := #{cause := _}, input_bytes := Malformed, at_state := _} | _],
+        [R1 || #{msg := "frame_parse_error"} = R1 <- Reports]
+    ),
+    ExitReason.
+
+%% Send `Malformed', wait for the connection to terminate, and assert the
+%% shutdown was attributed to `Cause' and counted. Returns the exit reason and
+%% the captured log reports.
+assert_shutdown_counted(Config, Socket, Malformed, Cause) ->
     CountBefore = shutdown_count(Config, Cause),
     Self = self(),
     Reports = emqx_cth_log_capture:capture(debug, fun() ->
@@ -1777,12 +1819,6 @@ assert_frame_error_shutdown(Config, Socket, Malformed, Cause) ->
             {exit_reason, R0} -> R0
         after 0 -> ct:fail(no_terminate_event)
         end,
-    %% The shutdown counter only names a kind, so the specific cause and the
-    %% offending bytes must stay reachable through `emqx_trace'.
-    ?assertMatch(
-        [#{reason := #{cause := _}, input_bytes := Malformed, at_state := _} | _],
-        [R1 || #{msg := "frame_parse_error"} = R1 <- Reports]
-    ),
     %% esockd attributes a shutdown to a cause when the reason is either a plain
     %% atom or a map tagged with `shutdown_count'; anything else is reported as
     %% an unidentified shutdown at error level and left uncounted.
@@ -1794,7 +1830,7 @@ assert_frame_error_shutdown(Config, Socket, Malformed, Cause) ->
     %% Counter only moves on the info-level branch, so this also proves no
     %% error-level supervisor report was emitted.
     ?WAIT(?assertEqual(CountBefore + 1, shutdown_count(Config, Cause)), 5),
-    ExitReason.
+    {ExitReason, Reports}.
 
 shutdown_count(Config, Cause) ->
     proplists:get_value(Cause, shutdown_counts(Config), 0).

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -110,6 +110,8 @@ groups() ->
             t_congestion_qos0_no_send_timeout,
             t_congestion_decongested,
             t_first_packet_not_connect,
+            t_connect_packet_too_large,
+            t_connect_too_many_user_properties,
             t_frame_error_shutdown_count_idle,
             t_frame_error_shutdown_count_connected,
             t_frame_error_shutdown_count_is_bounded,
@@ -117,6 +119,7 @@ groups() ->
         ]},
         {socket, [], [
             t_connection_stats,
+            t_publish_larger_than_connect_limit,
             t_connect_silent_idle_timeout,
             t_connect_idle_timeout,
             t_sock_keepalive,
@@ -1069,6 +1072,23 @@ h_sock_closed_on_kick_shutdown(_ClientInfo, _Reason, _ConnInfo, Socket) ->
     ok = socket_close(Socket),
     ok = timer:sleep(5).
 
+-doc """
+`mqtt.max_connect_packet_size` bounds the CONNECT packet only. A PUBLISH larger
+than that limit, but within `mqtt.max_packet_size`, still round-trips.
+""".
+t_publish_larger_than_connect_limit(Config) ->
+    ConnectLimit = emqx_config:get_zone_conf(default, [mqtt, max_connect_packet_size]),
+    MaxPacketSize = emqx_config:get_zone_conf(default, [mqtt, max_packet_size]),
+    Payload = binary:copy(<<"x">>, ConnectLimit * 2),
+    ?assert(byte_size(Payload) < MaxPacketSize),
+    Topic = atom_to_binary(?FUNCTION_NAME),
+    {ok, Client} = emqtt:start_link([{clientid, Topic} | socket_emqtt_opts(Config)]),
+    {ok, _} = emqtt:connect(Client),
+    {ok, _, [?QOS_1]} = emqtt:subscribe(Client, Topic, ?QOS_1),
+    {ok, _} = emqtt:publish(Client, Topic, Payload, ?QOS_1),
+    ?assertReceive({publish, #{topic := Topic, payload := Payload}}, 5000),
+    ok = emqtt:disconnect(Client).
+
 t_connection_stats(_) ->
     ClientId = atom_to_binary(?FUNCTION_NAME),
     {ok, Client} = emqtt:start_link([{port, 1883}, {clientid, ClientId}]),
@@ -1584,6 +1604,57 @@ loop_slow_consumer(active, Socket, Recvlen, Interval) ->
         {error, closed} ->
             closed
     end.
+
+-doc """
+A CONNECT larger than `mqtt.max_connect_packet_size` is refused and the
+connection is closed, without a CONNACK.
+""".
+t_connect_packet_too_large(Config) ->
+    Limit = emqx_config:get_zone_conf(default, [mqtt, max_connect_packet_size]),
+    Socket = socket_connect(Config, [{active, true}, binary]),
+    ok = socket_send(Socket, oversized_connect(Limit)),
+    ?assertEqual(ok, wait_socket_closed(Socket)).
+
+-doc """
+A CONNECT carrying more user properties than
+`mqtt.max_connect_user_properties` is refused and the connection is closed.
+""".
+t_connect_too_many_user_properties(Config) ->
+    Limit = emqx_config:get_zone_conf(default, [mqtt, max_connect_user_properties]),
+    Socket = socket_connect(Config, [{active, true}, binary]),
+    ok = socket_send(Socket, connect_with_user_properties(Limit + 1)),
+    ?assertEqual(ok, wait_socket_closed(Socket)).
+
+wait_socket_closed(Socket) ->
+    receive
+        {tcp_closed, RawSocket} when RawSocket =:= element(2, Socket) -> ok;
+        {ssl_closed, RawSocket} when RawSocket =:= element(2, Socket) -> ok
+    after 5000 ->
+        ct:fail("Expected socket to be closed")
+    end.
+
+%% A well-formed MQTT v5 CONNECT whose size exceeds `Limit`, padded with user
+%% properties. Sent in full so that the whole-frame transport also sees it.
+oversized_connect(Limit) ->
+    connect_with_user_properties((Limit div 8) + 1).
+
+connect_with_user_properties(N) ->
+    Props = iolist_to_binary([
+        begin
+            V = integer_to_binary(I),
+            <<16#26, 0:16, (byte_size(V)):16, V/binary>>
+        end
+     || I <- lists:seq(1, N)
+    ]),
+    PropsSection = <<(encode_vbi(byte_size(Props)))/binary, Props/binary>>,
+    VarHeader = <<4:16, "MQTT", 5:8, 2:8, 60:16, PropsSection/binary>>,
+    Body = <<VarHeader/binary, 0:16>>,
+    <<16#10, (encode_vbi(byte_size(Body)))/binary, Body/binary>>.
+
+encode_vbi(N) when N < 16#80 ->
+    <<N>>;
+encode_vbi(N) ->
+    <<1:1, (N rem 16#80):7, (encode_vbi(N div 16#80))/binary>>.
 
 t_first_packet_not_connect(Config) ->
     Socket = socket_connect(Config, [{active, true}, binary]),

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -575,6 +575,8 @@ zone_global_defaults() ->
                 keepalive_check_interval => 30000,
                 max_awaiting_rel => 32,
                 max_clientid_len => 65535,
+                max_connect_packet_size => 65536,
+                max_connect_user_properties => 10,
                 max_inflight => 32,
                 max_mqueue_len => 1000,
                 max_packet_size => 1048576,

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -54,6 +54,9 @@ groups() ->
             t_serialize_parse_v4_connect,
             t_serialize_parse_v5_connect,
             t_parse_many_user_properties_is_linear,
+            t_parse_connect_packet_too_large,
+            t_parse_connect_too_many_user_properties,
+            t_parse_connect_user_properties_unlimited_by_default,
             t_parse_duplicate_connect_property_strict,
             t_parse_duplicate_connect_property_lenient,
             t_parse_repeated_user_property_strict,
@@ -564,6 +567,113 @@ t_parse_many_user_properties_is_linear(_) ->
     %% not a microbenchmark. The old quadratic path took seconds here.
     ?assert(Elapsed < 2000, #{elapsed_ms => Elapsed}),
     ok.
+
+-doc """
+A CONNECT larger than `max_connect_size' is rejected from the fixed header,
+before any body byte is buffered. The limit applies only to CONNECT.
+""".
+t_parse_connect_packet_too_large(_) ->
+    Limit = 512,
+    PState = emqx_frame:initial_parse_state(#{max_connect_size => Limit}),
+    Frame = make_v5_connect_frame(user_properties(200)),
+    ?assert(byte_size(Frame) > Limit),
+    %% Feed only the fixed header and the remaining-length bytes: an error here
+    %% means the body was never buffered.
+    <<Header:3/binary, _/binary>> = Frame,
+    ?ASSERT_FRAME_THROW(
+        #{cause := connect_packet_too_large, limit := Limit},
+        emqx_frame:parse(Header, PState)
+    ),
+    ?ASSERT_FRAME_THROW(
+        #{cause := connect_packet_too_large, limit := Limit},
+        emqx_frame:parse(Frame, PState)
+    ),
+    %% The whole-frame parser applies the same limit.
+    ?ASSERT_FRAME_THROW(
+        #{cause := connect_packet_too_large, limit := Limit},
+        emqx_frame:parse_complete(Frame, PState)
+    ),
+    %% A CONNECT within the limit still parses.
+    Small = make_v5_connect_frame(user_properties(1)),
+    ?assertMatch({_Packet, <<>>, _}, emqx_frame:parse(Small, PState)),
+    %% The limit does not apply to other packet types.
+    Publish = ?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, payload(2048)),
+    PublishBin = serialize_to_binary(Publish),
+    ?assertMatch({Publish, <<>>, _}, emqx_frame:parse(PublishBin, PState)).
+
+-doc """
+A CONNECT carrying more 'User-Property' pairs than `max_connect_user_properties'
+is rejected. The limit applies to the CONNECT properties and to the will
+properties separately.
+""".
+t_parse_connect_too_many_user_properties(_) ->
+    PState = emqx_frame:initial_parse_state(#{max_connect_user_properties => 2}),
+    ?assertMatch(
+        {_Packet, <<>>, _},
+        emqx_frame:parse(make_v5_connect_frame(user_properties(2)), PState)
+    ),
+    ?ASSERT_FRAME_THROW(
+        #{cause := too_many_user_properties, limit := 2},
+        emqx_frame:parse(make_v5_connect_frame(user_properties(3)), PState)
+    ),
+    %% Will properties are held to the same limit.
+    ?assertMatch(
+        {_Packet, <<>>, _},
+        emqx_frame:parse(make_v5_connect_with_will_frame(<<>>, user_properties(2)), PState)
+    ),
+    ?ASSERT_FRAME_THROW(
+        #{cause := too_many_user_properties, limit := 2},
+        emqx_frame:parse(make_v5_connect_with_will_frame(<<>>, user_properties(3)), PState)
+    ),
+    %% Each block is counted on its own, not summed.
+    ?assertMatch(
+        {_Packet, <<>>, _},
+        emqx_frame:parse(
+            make_v5_connect_with_will_frame(user_properties(2), user_properties(2)), PState
+        )
+    ).
+
+-doc """
+The default parse state does not limit the number of 'User-Property' pairs, so
+`emqx_frame:parse/1' and the round-trip tests are unaffected.
+""".
+t_parse_connect_user_properties_unlimited_by_default(_) ->
+    ?assertMatch(
+        {_Packet, <<>>, _},
+        emqx_frame:parse(make_v5_connect_frame(user_properties(1000)))
+    ).
+
+%% N user properties on the wire, each with an empty key and an indexed value.
+user_properties(N) ->
+    iolist_to_binary([
+        begin
+            V = integer_to_binary(I),
+            <<16#26, 0:16, (byte_size(V)):16, V/binary>>
+        end
+     || I <- lists:seq(1, N)
+    ]).
+
+%% Build a raw MQTT v5 CONNECT frame with the will flag set, carrying the given
+%% raw CONNECT properties and will properties.
+make_v5_connect_with_will_frame(ConnPropsBin, WillPropsBin) ->
+    ConnPropsSection = <<(encode_vbi(byte_size(ConnPropsBin)))/binary, ConnPropsBin/binary>>,
+    WillPropsSection = <<(encode_vbi(byte_size(WillPropsBin)))/binary, WillPropsBin/binary>>,
+    %% username=0, password=0, will_retain=0, will_qos=0, will_flag=1, clean_start=1
+    Flags = <<2#00000110>>,
+    VarHeader = <<4:16, "MQTT", ?MQTT_PROTO_V5:8, Flags/binary, 60:16, ConnPropsSection/binary>>,
+    Body = <<
+        VarHeader/binary,
+        %% empty client id
+        0:16,
+        WillPropsSection/binary,
+        %% will topic
+        4:16,
+        "will",
+        %% will payload
+        2:16,
+        "hi"
+    >>,
+    <<16#10, (encode_vbi(byte_size(Body)))/binary, Body/binary>>.
 
 %% Encode an unsigned integer as an MQTT variable byte integer.
 encode_vbi(N) when N < 16#80 ->

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -47,7 +47,8 @@ groups() ->
             t_parse_after_connect,
             t_parse_no_connect_expected,
             t_update_opts,
-            t_update_opts_mid_frame
+            t_update_opts_mid_frame,
+            t_update_opts_connect_limits
         ]},
         {connect, [parallel], [
             t_serialize_parse_v3_connect,
@@ -429,6 +430,34 @@ t_update_opts(_) ->
     Publish = ?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, <<"payload">>),
     PublishBin = serialize_to_binary(Publish, ?MQTT_PROTO_V5),
     ?assertMatch({Publish, <<>>, _}, emqx_frame:parse(PublishBin, PState3)).
+
+%% The CONNECT limits are zone settings too, so a config change must carry them
+%% onto an existing parse state rather than leave the old ones in place.
+t_update_opts_connect_limits(_) ->
+    PState0 = emqx_frame:initial_parse_state(#{
+        expect_connect => true,
+        max_connect_size => 1024,
+        max_connect_user_properties => 10
+    }),
+    {ok, PState1, _Serialize} = emqx_frame:update_opts(PState0, #{
+        max_connect_size => 32,
+        max_connect_user_properties => 1
+    }),
+    Connect = ?CONNECT_PACKET(#mqtt_packet_connect{proto_ver = ?MQTT_PROTO_V5}),
+    ConnectBin = serialize_to_binary(Connect, ?MQTT_PROTO_V5),
+    ?assert(byte_size(ConnectBin) < 32),
+    %% The tightened size limit is in force ...
+    ?ASSERT_FRAME_THROW(
+        #{cause := connect_packet_too_large, limit := 32},
+        emqx_frame:parse(make_v5_connect_frame(user_properties(20)), PState1)
+    ),
+    %% ... and so is the tightened pair limit.
+    ?ASSERT_FRAME_THROW(
+        #{cause := too_many_user_properties, limit := 1},
+        emqx_frame:parse(make_v5_connect_frame(user_properties(2)), PState1)
+    ),
+    %% A CONNECT within both limits still parses.
+    ?assertMatch({_Packet, <<>>, _}, emqx_frame:parse(ConnectBin, PState1)).
 
 %% A frame in flight is parsed under the options it started with. The new
 %% options are held and take effect from the next frame, not dropped.

--- a/changes/ee/breaking-18829.en.md
+++ b/changes/ee/breaking-18829.en.md
@@ -3,7 +3,7 @@ MQTT listeners now bound what a client can send before it is connected. Two new 
 - `mqtt.max_connect_packet_size` limits the size of a CONNECT packet. Default: `64KB`.
 - `mqtt.max_connect_user_properties` limits how many `User-Property` pairs a CONNECT may carry, counted separately for the CONNECT properties and the will properties. Default: `10`.
 
-A CONNECT above either limit is refused and the connection is closed. Both limits apply to CONNECT only; other packet types are unchanged.
+A CONNECT above either limit is refused and the connection is closed, under its own shutdown counter (`connect_packet_too_large` or `too_many_user_properties`), so these are easy to tell apart from malformed input in `emqx ctl listeners`. Both limits apply to CONNECT only; other packet types are unchanged.
 
 Previously a CONNECT could be as large as `mqtt.max_packet_size` (1MB by default) and carry any number of user properties, so a client that had not connected yet could tie up that much memory on the broker.
 

--- a/changes/ee/breaking-18829.en.md
+++ b/changes/ee/breaking-18829.en.md
@@ -1,0 +1,10 @@
+MQTT listeners now bound what a client can send before it is connected. Two new settings limit the CONNECT packet:
+
+- `mqtt.max_connect_packet_size` limits the size of a CONNECT packet. Default: `64KB`.
+- `mqtt.max_connect_user_properties` limits how many `User-Property` pairs a CONNECT may carry, counted separately for the CONNECT properties and the will properties. Default: `10`.
+
+A CONNECT above either limit is refused and the connection is closed. Both limits apply to CONNECT only; other packet types are unchanged.
+
+Previously a CONNECT could be as large as `mqtt.max_packet_size` (1MB by default) and carry any number of user properties, so a client that had not connected yet could tie up that much memory on the broker.
+
+Clients that send unusually large credentials or last-will payloads, or more than 10 user properties in CONNECT, need the matching setting raised.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1593,6 +1593,26 @@ Note: changing this config at runtime may only take effect for newly established
 mqtt_max_packet_size.label:
 """Max Packet Size"""
 
+mqtt_max_connect_packet_size.desc:
+"""Maximum size of a CONNECT packet. Default: 64 KB.
+A CONNECT packet larger than this is rejected and the connection is closed, before the packet body is read into memory.
+This limit applies in addition to `max_packet_size`, and the smaller of the two applies to CONNECT.
+Raise it if clients send unusually large credentials or last-will payloads.
+Note: changing this config at runtime may only take effect for newly established connections after the change."""
+
+mqtt_max_connect_packet_size.label:
+"""Max CONNECT Packet Size"""
+
+mqtt_max_connect_user_properties.desc:
+"""Maximum number of 'User-Property' pairs accepted in a CONNECT packet. Default: 10.
+The limit applies separately to the CONNECT properties and to the will properties.
+A CONNECT carrying more pairs than this is rejected and the connection is closed.
+Set to `infinity` to accept any number.
+Note: changing this config at runtime may only take effect for newly established connections after the change."""
+
+mqtt_max_connect_user_properties.label:
+"""Max CONNECT User Properties"""
+
 common_ssl_opts_schema_reuse_sessions.desc:
 """Enable TLS 1.2 session resumption for TLS client.
 It has no effect when TLS version is configured (or negotiated) to 1.3."""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1597,8 +1597,7 @@ mqtt_max_connect_packet_size.desc:
 """Maximum size of a CONNECT packet. Default: 64 KB.
 A CONNECT packet larger than this is rejected and the connection is closed, before the packet body is read into memory.
 This limit applies in addition to `max_packet_size`, and the smaller of the two applies to CONNECT.
-Raise it if clients send unusually large credentials or last-will payloads.
-Note: changing this config at runtime may only take effect for newly established connections after the change."""
+Raise it if clients send unusually large credentials or last-will payloads."""
 
 mqtt_max_connect_packet_size.label:
 """Max CONNECT Packet Size"""
@@ -1607,8 +1606,7 @@ mqtt_max_connect_user_properties.desc:
 """Maximum number of 'User-Property' pairs accepted in a CONNECT packet. Default: 10.
 The limit applies separately to the CONNECT properties and to the will properties.
 A CONNECT carrying more pairs than this is rejected and the connection is closed.
-Set to `infinity` to accept any number.
-Note: changing this config at runtime may only take effect for newly established connections after the change."""
+Set to `infinity` to accept any number."""
 
 mqtt_max_connect_user_properties.label:
 """Max CONNECT User Properties"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1595,7 +1595,7 @@ mqtt_max_packet_size.label:
 
 mqtt_max_connect_packet_size.desc:
 """Maximum size of a CONNECT packet. Default: 64 KB.
-A CONNECT packet larger than this is rejected and the connection is closed, before the packet body is read into memory.
+EMQX closes the connection when a CONNECT packet is larger than this. It does so before the packet body is read into memory.
 This limit applies in addition to `max_packet_size`, and the smaller of the two applies to CONNECT.
 Raise it if clients send unusually large credentials or last-will payloads."""
 
@@ -1605,7 +1605,7 @@ mqtt_max_connect_packet_size.label:
 mqtt_max_connect_user_properties.desc:
 """Maximum number of 'User-Property' pairs accepted in a CONNECT packet. Default: 10.
 The limit applies separately to the CONNECT properties and to the will properties.
-A CONNECT carrying more pairs than this is rejected and the connection is closed.
+EMQX closes the connection when a CONNECT carries more pairs than this.
 Set to `infinity` to accept any number."""
 
 mqtt_max_connect_user_properties.label:


### PR DESCRIPTION
Fixes:
Release version: 7.0.0
Introduced in: pre-5.8

## Summary

Two zone settings bound what an unauthenticated client can make the broker hold.

- `mqtt.max_connect_packet_size`, default `64KB`, caps a CONNECT packet on top of
  `mqtt.max_packet_size` (1MB by default, 256MB at most). `emqx_frame` checks it from the fixed
  header, before any body byte is read, in both the stream parser and the whole-frame parser.
  The cause is reported as `connect_packet_too_large`; a CONNECT above `max_packet_size` still
  reports `frame_too_large`, so the existing shutdown counters are unchanged.
- `mqtt.max_connect_user_properties`, default `10`, caps the number of `User-Property` pairs in a
  CONNECT. The CONNECT properties and the will properties are counted separately. The check runs
  before each pair is parsed, so an oversized properties block is never turned into a list of terms
  and rejected afterwards.

The second limit is not redundant with the first. The parsed term is much larger than the wire
bytes: measured with the real parser, 1MB of empty user properties parses into ~20MB of process
heap (19x), and those properties are then kept in `conninfo` for the whole session and copied into
the `emqx_cm` channel-info table. A byte budget alone does not bound that; a pair count does.

Both limits apply to CONNECT only. `parse_properties/4` takes the limit and only the CONNECT and
will-properties call sites pass one; the other nine call sites delegate with `infinity`, so PUBLISH
and SUBSCRIBE parsing is unchanged.

### Whole-frame listeners

With the default `parse_unit = frame` the socket is opened with `{packet, mqtt}` and the kernel
buffers a whole frame before EMQX sees it, so a parser-side limit alone would reject an oversized
CONNECT without saving the memory. `emqx_listeners:choose_packet_opts/1` now accepts with
`packet_size` set to the CONNECT limit, and `emqx_connection` raises it to `max_packet_size` once
the client is connected. `find_zones_with_relevant_changes/4` watches both settings, so changing
either one updates the listener.

`emqx_socket_connection` never uses the whole-frame parser, and the OTP `socket` backend does not
honour the inet `packet_size` option, so it is unaffected. `t_publish_larger_than_connect_limit`
covers that: it publishes a payload twice the CONNECT limit and asserts it round-trips, on the
gen_tcp, ssl and socket-backend listeners alike.

### Shutdown counters

Each cause gets its own shutdown counter through `frame_error_kind/2`, so an operator reading
`emqx ctl listeners` can tell clients hitting a configured limit from clients sending garbage. Both
causes name a limit rather than a property of the packet's content, so the bounded set of counter
names that function documents is preserved.

On a listener with `parse_unit = frame` the transport refuses an oversized CONNECT before the
parser sees it, and each transport reports it differently: `gen_tcp` gives `emsgsize`, `ssl` gives
`{invalid_packet, Data}`. `emqx_connection` now recognises both at `conn_state = idle` and routes
them through the same `{frame_error, ...}` path the stream parser uses, so the counter does not
depend on the transport.

That also fixes an existing problem on `ssl` listeners: the reason carried the client's raw frame
bytes, which esockd cannot attribute to a counter, so the shutdown was logged as an unidentified
shutdown at error level with packet data in the log. Only the error tag is kept now.

The inference is worth naming: at idle the transport reports only "the first frame exceeded
`packet_size`", and since `packet_size` is deliberately set to the CONNECT limit before CONNECT, it
is reported as `connect_packet_too_large`. Whether the refused frame really was a CONNECT is not
knowable there -- nor is it in the stream parser's case.

### Notes for review

- Rejection is silent. At `conn_state = idle` the channel closes without a CONNACK because no
  protocol version is known yet — we reject before any body byte. This matches today's
  `max_packet_size` behaviour, but a client over either limit sees a bare TCP close.
- The default is a behaviour change: a CONNECT above 64KB, or with more than 10 user properties,
  was previously accepted. The changelog is filed as breaking for that reason.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
