### PR TITLE
fix(cluster_rpc): do not log the result of a successful apply

### DIFF
--- a/apps/emqx/test/emqx_cth_log_capture.erl
+++ b/apps/emqx/test/emqx_cth_log_capture.erl
@@ -1,0 +1,69 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% Test helper to capture structured log reports emitted while running a function.
+%%
+%% Installs a temporary `logger' handler that forwards report-style log events at
+%% or above a given level to the calling process, runs the provided function, and
+%% returns the captured reports in emission order.
+
+-module(emqx_cth_log_capture).
+
+%% API
+-export([capture/1, capture/2]).
+
+%% logger handler callback
+-export([log/2]).
+
+-define(HANDLER_ID, ?MODULE).
+
+%% Same as capture(warning, Fun).
+-spec capture(fun(() -> term())) -> [map()].
+capture(Fun) ->
+    capture(warning, Fun).
+
+%% Run Fun while capturing log reports at or above Level, returning the captured
+%% reports (the Data maps passed to ?SLOG/?TRACE) in emission order.
+-spec capture(logger:level(), fun(() -> term())) -> [map()].
+capture(Level, Fun) ->
+    ok = logger:add_handler(?HANDLER_ID, ?MODULE, #{
+        level => Level,
+        config => #{test_pid => self()},
+        filter_default => log,
+        filters => []
+    }),
+    PrevLevel = emqx_logger:get_primary_log_level(),
+    ok = emqx_logger:set_primary_log_level(Level),
+    try
+        _ = Fun(),
+        collect([])
+    after
+        ok = emqx_logger:set_primary_log_level(PrevLevel),
+        ok = logger:remove_handler(?HANDLER_ID)
+    end.
+
+%% @private logger handler callback.
+log(#{msg := {report, Report}}, #{config := #{test_pid := Pid}}) when is_map(Report) ->
+    Pid ! {?MODULE, Report},
+    ok;
+log(_Event, _Config) ->
+    ok.
+
+collect(Acc) ->
+    receive
+        {?MODULE, Report} -> collect([Report | Acc])
+    after 200 -> lists:reverse(Acc)
+    end.

--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -686,20 +686,27 @@ is_success(ok) -> true;
 is_success({ok, _}) -> true;
 is_success(_) -> false.
 
+%% Report the shape of a successful result, never its value.
+%% The value can carry compiled runtime state, such as the HTTP authenticator
+%% header templates, which holds secrets emqx_utils:redact/1 does not cover.
+summarize_ok(ok) -> ok;
+summarize_ok({ok, _}) -> {ok, '_'}.
+
 log_and_alarm(IsSuccess, Res, #{kind := ?KIND_INITIATE} = Meta) ->
     %% no alarm or error log in case of failure at originating a new cluster-call
     %% because nothing is committed
     case IsSuccess of
         true ->
-            ?SLOG(debug, Meta#{msg => "cluster_rpc_apply_result", result => emqx_utils:redact(Res)});
+            ?SLOG(debug, Meta#{msg => "cluster_rpc_apply_result", result => summarize_ok(Res)});
         false ->
             ?SLOG(warning, Meta#{
                 msg => "cluster_rpc_apply_result", result => emqx_utils:redact(Res)
             })
     end;
 log_and_alarm(true, Res, Meta) ->
-    ?SLOG(debug, Meta#{msg => "cluster_rpc_apply_ok", result => emqx_utils:redact(Res)}),
-    do_alarm(deactivate, Res, Meta);
+    Summary = summarize_ok(Res),
+    ?SLOG(debug, Meta#{msg => "cluster_rpc_apply_ok", result => Summary}),
+    do_alarm(deactivate, Summary, Meta);
 log_and_alarm(false, Res, Meta) ->
     ?SLOG(error, Meta#{msg => "cluster_rpc_apply_failed", result => emqx_utils:redact(Res)}),
     do_alarm(activate, Res, Meta).

--- a/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
@@ -36,7 +36,8 @@ all() ->
         t_del_stale_mfa,
         t_skip_failed_commit,
         t_fast_forward_commit,
-        t_commit_concurrency
+        t_commit_concurrency,
+        t_apply_result_not_logged
     ].
 suite() -> [{timetrap, {minutes, 5}}].
 groups() -> [].
@@ -110,6 +111,37 @@ t_base_test(_Config) ->
                 ],
                 Status1
             )
+    end,
+    ok.
+
+%% Verify that a successful cluster-RPC apply logs only the shape of the result,
+%% never the value, and that a failed apply still logs the error term.
+t_apply_result_not_logged(_Config) ->
+    Marker = <<"UNIQUE_MARKER_423">>,
+    ok = start_log_capture(),
+    try
+        {M, F, A} = {?MODULE, echo_compiled, [Marker]},
+        ?assertMatch({ok, _, {ok, #{compiled := Marker}}}, multicall(M, F, A)),
+        Reports = collect_reports(),
+        ?assertMatch(
+            [#{result := {ok, '_'}}],
+            [R || #{msg := "cluster_rpc_apply_result"} = R <- Reports]
+        ),
+        %% one line per node applying the committed MFA
+        OkReports = [R || #{msg := "cluster_rpc_apply_ok"} = R <- Reports],
+        ?assertMatch([_, _ | _], OkReports),
+        lists:foreach(fun(R) -> ?assertMatch(#{result := {ok, '_'}}, R) end, OkReports),
+        Formatted = iolist_to_binary(io_lib:format("~p", [Reports])),
+        ?assertEqual(nomatch, binary:match(Formatted, Marker)),
+        %% a failure keeps reporting the error term
+        {M1, F1, A1} = {?MODULE, failed_on_node, [erlang:whereis(?NODE1)]},
+        ?assertMatch({ok, _, ok}, multicall(M1, F1, A1, 1, 1000)),
+        ?assertMatch(
+            #{result := "MFA return not ok"},
+            wait_for_report("cluster_rpc_apply_failed", 5_000)
+        )
+    after
+        stop_log_capture()
     end,
     ok.
 
@@ -425,6 +457,11 @@ echo(Pid, Msg, _) ->
     erlang:send(Pid, Msg),
     ok.
 
+%% Returns a value emqx_utils:redact/1 cannot mask, like the compiled runtime
+%% state a config update returns.
+echo_compiled(Value, _) ->
+    {ok, #{compiled => Value}}.
+
 format(Fmt, Args, _Opts) ->
     io:format(Fmt, Args).
 
@@ -473,4 +510,54 @@ flush_msg(Acc) ->
             flush_msg([Msg | Acc])
     after 10 ->
         Acc
+    end.
+
+%%--------------------------------------------------------------------
+%% log capture
+%%--------------------------------------------------------------------
+
+start_log_capture() ->
+    #{level := Level} = logger:get_primary_config(),
+    _ = erlang:put({?MODULE, primary_level}, Level),
+    ok = logger:set_primary_config(level, debug),
+    ok = logger:add_handler(?MODULE, ?MODULE, #{
+        level => debug,
+        config => #{pid => self()},
+        filter_default => stop,
+        filters => [{cluster_rpc, {fun ?MODULE:filter_cluster_rpc/2, []}}]
+    }).
+
+stop_log_capture() ->
+    _ = logger:remove_handler(?MODULE),
+    Level = erlang:erase({?MODULE, primary_level}),
+    ok = logger:set_primary_config(level, Level),
+    _ = collect_reports(),
+    ok.
+
+filter_cluster_rpc(#{meta := #{mfa := {emqx_cluster_rpc, _, _}}} = Event, _) -> Event;
+filter_cluster_rpc(_Event, _) -> stop.
+
+%% logger handler callback
+log(#{msg := {report, Report}}, #{config := #{pid := Pid}}) ->
+    _ = erlang:send(Pid, {?MODULE, log_report, Report}),
+    ok;
+log(_Event, _Config) ->
+    ok.
+
+collect_reports() ->
+    collect_reports([]).
+
+collect_reports(Acc) ->
+    receive
+        {?MODULE, log_report, Report} -> collect_reports([Report | Acc])
+    after 200 ->
+        lists:reverse(Acc)
+    end.
+
+wait_for_report(Msg, Timeout) ->
+    receive
+        {?MODULE, log_report, #{msg := Msg} = Report} -> Report;
+        {?MODULE, log_report, _} -> wait_for_report(Msg, Timeout)
+    after Timeout ->
+        error({timeout_waiting_for_log, Msg})
     end.

--- a/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
@@ -118,31 +118,31 @@ t_base_test(_Config) ->
 %% never the value, and that a failed apply still logs the error term.
 t_apply_result_not_logged(_Config) ->
     Marker = <<"UNIQUE_MARKER_423">>,
-    ok = start_log_capture(),
-    try
+    OkReports = emqx_cth_log_capture:capture(debug, fun() ->
         {M, F, A} = {?MODULE, echo_compiled, [Marker]},
-        ?assertMatch({ok, _, {ok, #{compiled := Marker}}}, multicall(M, F, A)),
-        Reports = collect_reports(),
-        ?assertMatch(
-            [#{result := {ok, '_'}}],
-            [R || #{msg := "cluster_rpc_apply_result"} = R <- Reports]
-        ),
-        %% one line per node applying the committed MFA
-        OkReports = [R || #{msg := "cluster_rpc_apply_ok"} = R <- Reports],
-        ?assertMatch([_, _ | _], OkReports),
-        lists:foreach(fun(R) -> ?assertMatch(#{result := {ok, '_'}}, R) end, OkReports),
-        Formatted = iolist_to_binary(io_lib:format("~p", [Reports])),
-        ?assertEqual(nomatch, binary:match(Formatted, Marker)),
-        %% a failure keeps reporting the error term
-        {M1, F1, A1} = {?MODULE, failed_on_node, [erlang:whereis(?NODE1)]},
-        ?assertMatch({ok, _, ok}, multicall(M1, F1, A1, 1, 1000)),
-        ?assertMatch(
-            #{result := "MFA return not ok"},
-            wait_for_report("cluster_rpc_apply_failed", 5_000)
-        )
-    after
-        stop_log_capture()
-    end,
+        ?assertMatch({ok, _, {ok, #{compiled := Marker}}}, multicall(M, F, A))
+    end),
+    ?assertMatch(
+        [#{result := {ok, '_'}}],
+        [R || #{msg := "cluster_rpc_apply_result"} = R <- OkReports]
+    ),
+    %% one line per node applying the committed MFA
+    AppliedReports = [R || #{msg := "cluster_rpc_apply_ok"} = R <- OkReports],
+    ?assertMatch([_, _ | _], AppliedReports),
+    lists:foreach(fun(R) -> ?assertMatch(#{result := {ok, '_'}}, R) end, AppliedReports),
+    ?assertEqual(
+        nomatch, binary:match(iolist_to_binary(io_lib:format("~p", [OkReports])), Marker)
+    ),
+    %% a failure keeps reporting the error term
+    FailReports = emqx_cth_log_capture:capture(debug, fun() ->
+        {M, F, A} = {?MODULE, failed_on_other_node, [self(), erlang:whereis(?NODE1)]},
+        ?assertMatch({ok, _, ok}, multicall(M, F, A, 1, 1000)),
+        ?assertEqual(ok, receive_msg(2, mfa_failed_on_other_node))
+    end),
+    ?assertMatch(
+        [#{result := "MFA return not ok"} | _],
+        [R || #{msg := "cluster_rpc_apply_failed"} = R <- FailReports]
+    ),
     ok.
 
 t_commit_fail_test(_Config) ->
@@ -462,6 +462,17 @@ echo(Pid, Msg, _) ->
 echo_compiled(Value, _) ->
     {ok, #{compiled => Value}}.
 
+%% Succeeds on the initiating node and fails on the others, telling the test
+%% process each time it fails.
+failed_on_other_node(TestPid, InitPid, _) ->
+    case self() =:= InitPid of
+        true ->
+            ok;
+        false ->
+            erlang:send(TestPid, mfa_failed_on_other_node),
+            "MFA return not ok"
+    end.
+
 format(Fmt, Args, _Opts) ->
     io:format(Fmt, Args).
 
@@ -510,54 +521,4 @@ flush_msg(Acc) ->
             flush_msg([Msg | Acc])
     after 10 ->
         Acc
-    end.
-
-%%--------------------------------------------------------------------
-%% log capture
-%%--------------------------------------------------------------------
-
-start_log_capture() ->
-    #{level := Level} = logger:get_primary_config(),
-    _ = erlang:put({?MODULE, primary_level}, Level),
-    ok = logger:set_primary_config(level, debug),
-    ok = logger:add_handler(?MODULE, ?MODULE, #{
-        level => debug,
-        config => #{pid => self()},
-        filter_default => stop,
-        filters => [{cluster_rpc, {fun ?MODULE:filter_cluster_rpc/2, []}}]
-    }).
-
-stop_log_capture() ->
-    _ = logger:remove_handler(?MODULE),
-    Level = erlang:erase({?MODULE, primary_level}),
-    ok = logger:set_primary_config(level, Level),
-    _ = collect_reports(),
-    ok.
-
-filter_cluster_rpc(#{meta := #{mfa := {emqx_cluster_rpc, _, _}}} = Event, _) -> Event;
-filter_cluster_rpc(_Event, _) -> stop.
-
-%% logger handler callback
-log(#{msg := {report, Report}}, #{config := #{pid := Pid}}) ->
-    _ = erlang:send(Pid, {?MODULE, log_report, Report}),
-    ok;
-log(_Event, _Config) ->
-    ok.
-
-collect_reports() ->
-    collect_reports([]).
-
-collect_reports(Acc) ->
-    receive
-        {?MODULE, log_report, Report} -> collect_reports([Report | Acc])
-    after 200 ->
-        lists:reverse(Acc)
-    end.
-
-wait_for_report(Msg, Timeout) ->
-    receive
-        {?MODULE, log_report, #{msg := Msg} = Report} -> Report;
-        {?MODULE, log_report, _} -> wait_for_report(Msg, Timeout)
-    after Timeout ->
-        error({timeout_waiting_for_log, Msg})
     end.

--- a/changes/ee/fix-18835.en.md
+++ b/changes/ee/fix-18835.en.md
@@ -1,0 +1,3 @@
+Stopped including the result of a successful configuration change in the cluster configuration sync debug logs.
+
+The result could carry compiled runtime state, such as the HTTP authenticator header templates, which held secrets that log redaction did not cover.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

Fixes https://github.com/emqx/emqx-dev-team-tasks/issues/423

`emqx_cluster_rpc` logged the full return value of every applied MFA at debug level, in
`cluster_rpc_apply_result` on the initiating node and in `cluster_rpc_apply_ok` on every node
that applied the committed MFA. For `emqx:update_config/3` that value carries the
`post_config_update` result, which includes compiled runtime state such as the HTTP
authenticator's `headers_template`. `emqx_utils:redact/1` matches config key names, so it does
not mask a secret embedded in a compiled template.

A successful apply now reports only the shape of the result: `ok` stays `ok` and `{ok, _}` is
logged as `{ok, '_'}`. The same summary goes into the alarm details on the deactivate path,
which are published to `$SYS/brokers/+/alarms/deactivate`. Failure logs are unchanged: they
still carry the redacted error term, which the operator needs.

This completes the redaction work started in https://github.com/emqx/emqx/pull/17857.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
