### PR TITLE
feat(api): add plugin_api scope for plugin-extended API calls

### DIFF
--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -584,7 +584,7 @@ t_ns_admin_gets_restricted_role_default_scopes(_Config) ->
         post, api_path(["users"]), auth_header(Token), Body
     ),
     EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(?NS_CONTROL_USER),
-    %% Must have the restricted subset (7 common).
+    %% Must have the restricted common subset.
     ?assert(lists:member(?SCOPE_CONNECTIONS, EffectiveScopes)),
     ?assert(lists:member(?SCOPE_MONITORING, EffectiveScopes)),
     ?assert(lists:member(?SCOPE_DATA_INTEGRATION, EffectiveScopes)),
@@ -595,6 +595,9 @@ t_ns_admin_gets_restricted_role_default_scopes(_Config) ->
     %% groups for namespaced callers.
     ?assert(lists:member(?SCOPE_CLUSTER_OPERATIONS, EffectiveScopes)),
     ?assert(lists:member(?SCOPE_LICENSE, EffectiveScopes)),
+    %% The plugin API gateway, which namespaced callers reached
+    %% through `system' before the `plugin_api' scope existed.
+    ?assert(lists:member(?SCOPE_PLUGIN_API, EffectiveScopes)),
     %% Must have the two allowed login-only scopes.
     ?assert(lists:member(?SCOPE_USER_MGMT, EffectiveScopes)),
     ?assert(lists:member(?SCOPE_API_KEY_MGMT, EffectiveScopes)),
@@ -605,8 +608,10 @@ t_ns_admin_gets_restricted_role_default_scopes(_Config) ->
     %% Must NOT have mfa, sso login-only scopes.
     ?assertNot(lists:member(?SCOPE_MFA_MGMT, EffectiveScopes)),
     ?assertNot(lists:member(?SCOPE_SSO_MGMT, EffectiveScopes)),
-    %% Exact count: 9 scopes (7 common + 2 login-only).
-    ?assertEqual(9, length(EffectiveScopes)).
+    %% The default is exactly the ns-admin allowlist: no more, no less.
+    ?assertEqual(
+        lists:sort(?NS_ADMIN_ALLOWED_SCOPES), lists:sort(EffectiveScopes)
+    ).
 
 %% PUT a namespaced administrator with only the description field
 %% updated (role + scopes unchanged).  The persisted scopes are the

--- a/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_user_scopes_SUITE.erl
@@ -169,8 +169,8 @@ t_post_users_response_includes_scopes(_Config) ->
     ?assertEqual(?ROLE_SUPERUSER, maps:get(<<"role">>, Resp)).
 
 %% Response from POST /users without an explicit `scopes' field
-%% materialises the role-default scope list (administrator -> 10 common
-%% + 4 login-only = 14 scopes). The legacy `<<"unset">>' sentinel is
+%% materialises the role-default scope list (administrator -> every common
+%% scope plus the 4 login-only scopes). The legacy `<<"unset">>' sentinel is
 %% reserved for records that survived an upgrade without scopes
 %% (pre-#17235); fresh POSTs never produce that state.
 t_post_users_response_role_default_scopes_when_not_set(_Config) ->
@@ -186,7 +186,7 @@ t_post_users_response_role_default_scopes_when_not_set(_Config) ->
         post, api_path(["users"]), auth_header(Token), Body
     ),
     Resp = emqx_utils_json:decode(RespBody),
-    %% Response carries the materialised admin defaults (10 common + 4 login-only).
+    %% Response carries the materialised admin defaults (all common + 4 login-only).
     CommonNames = [N || #{name := N} <- emqx_scope_catalog:common_scope_catalog()],
     LoginOnlyNames = [N || #{name := N} <- emqx_scope_catalog:admin_only_scope_catalog()],
     ExpectedScopes = lists:sort(CommonNames ++ LoginOnlyNames),
@@ -196,7 +196,7 @@ t_post_users_response_role_default_scopes_when_not_set(_Config) ->
     EffectiveScopes = emqx_dashboard_admin:effective_scopes_of(<<"no_scopes">>),
     ?assertEqual(ExpectedScopes, lists:sort(EffectiveScopes)).
 
-%% Viewer default = the 10 common scopes, no login-only ones.
+%% Viewer default = the common scopes, no login-only ones.
 t_post_users_response_viewer_default_scopes(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),
@@ -210,7 +210,7 @@ t_post_users_response_viewer_default_scopes(_Config) ->
         post, api_path(["users"]), auth_header(Token), Body
     ),
     Resp = emqx_utils_json:decode(RespBody),
-    %% Response carries the materialised viewer defaults (10 common, no login-only).
+    %% Response carries the materialised viewer defaults (common only, no login-only).
     CommonNames = [N || #{name := N} <- emqx_scope_catalog:common_scope_catalog()],
     ExpectedScopes = lists:sort(CommonNames),
     ?assertEqual(ExpectedScopes, lists:sort(maps:get(<<"scopes">>, Resp))),
@@ -570,7 +570,7 @@ t_ns_admin_can_hold_allowed_scopes(_Config) ->
 
 %% POST a namespaced administrator without an explicit `scopes'
 %% field — must materialise the restricted role defaults
-%% (7 common + 2 login-only), not the global-admin full set.
+%% (`?NS_ADMIN_ALLOWED_SCOPES'), not the global-admin full set.
 t_ns_admin_gets_restricted_role_default_scopes(_Config) ->
     add_admin(<<"admin">>),
     Token = jwt(<<"admin">>, test_password()),

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -73,11 +73,15 @@ parse_dashboard_role(Role) ->
 %%                                          point), so allow.
 %%   * scopes = [...]  (list)            -> the path's scopes must
 %%                                          overlap the listed scopes;
-%%                                          unmapped paths fail-open
-%%                                          (allow).
+%%                                          unmapped paths are denied
+%%                                          (fail closed).
 %%
-%% The unmapped-path fail-open is consistent with API key scope
-%% semantics (emqx_mgmt_auth:check_path_in_scopes/2). CT
+%% Public paths are allowed for every user. An unmapped path is allowed
+%% only for a user with no explicit scope list, so a catalog gap cannot
+%% grant a deliberately restricted user an endpoint nobody scoped.
+%%
+%% This differs from API keys: emqx_mgmt_auth:check_path_in_scopes/2
+%% allows unmapped paths even for a key with an explicit scope list. CT
 %% t_all_endpoints_covered_by_scopes guards against accidentally
 %% leaving a non-public path unmapped.
 %%

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -71,9 +71,10 @@ parse_dashboard_role(Role) ->
 %%   * scopes absent  (undefined)        -> fall back to RBAC default
 %%                                          (already passed at this
 %%                                          point), so allow.
-%%   * scopes = [...]  (list)            -> path must map to one of
-%%                                          the listed scopes; unmapped
-%%                                          paths fail-open (allow).
+%%   * scopes = [...]  (list)            -> the path's scopes must
+%%                                          overlap the listed scopes;
+%%                                          unmapped paths fail-open
+%%                                          (allow).
 %%
 %% The unmapped-path fail-open is consistent with API key scope
 %% semantics (emqx_mgmt_auth:check_path_in_scopes/2). CT
@@ -142,13 +143,15 @@ check_login_user_scopes_strict(Username, Path) ->
         %% governed by role-based RBAC alone, so they are not locked out.
         not_found ->
             emqx_dashboard_admin:scopes_of(Username) =:= undefined;
-        {scope, PathScope} ->
+        {scopes, PathScopes} ->
             %% Work on the effective scope list (role-default expanded) so
             %% administrators with no explicit scopes implicitly hold the
             %% full catalog and viewers implicitly hold the common scopes.
             %% Explicit [] is honoured as "no permissions".
+            %% A path may declare more than one acceptable scope; holding
+            %% any one of them grants access.
             Scopes = emqx_dashboard_admin:effective_scopes_of(Username),
-            lists:member(PathScope, Scopes)
+            emqx_mgmt_api_key_scopes:any_scope_granted(PathScopes, Scopes)
     end.
 
 %% Whitelist of self-service paths that may skip the login-user

--- a/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
@@ -193,21 +193,7 @@ split_segments(Path) ->
 %% after splitting so an encoded separator stays within its segment
 %% and never introduces an extra boundary.
 normalize_segments(Segments) ->
-    remove_dot_segments([urldecode(S) || S <- Segments], []).
-
-%% `cow_uri:urldecode/1' raises on a byte that is not valid in a URI
-%% path. Cowboy validates a request path before it dispatches, so such
-%% a byte can only reach here from a value that did not come from the
-%% router — a route template carrying `[...]', for one. Keep the
-%% segment verbatim in that case: it then matches only a template
-%% segment that is literally equal, and the authorisation path returns
-%% a decision instead of raising.
-urldecode(Segment) ->
-    try
-        cow_uri:urldecode(Segment)
-    catch
-        _:_ -> Segment
-    end.
+    remove_dot_segments([cow_uri:urldecode(S) || S <- Segments], []).
 
 remove_dot_segments([], Acc) ->
     lists:reverse(Acc);

--- a/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_key_scopes.erl
@@ -8,12 +8,19 @@
 API Key scope management.
 
 Each minirest_api module declares its scope via a `scopes/0` callback
-that returns either a scope name binary (all paths share the same
-scope) or a `#{Path => ScopeName}` map (for modules whose endpoints
-span multiple scopes).
+that returns either a scope declaration (all paths share it) or a
+`#{Path => ScopeDeclaration}` map (for modules whose endpoints span
+multiple scopes).
 
-This module collects those declarations, builds a path → scope cache,
-and exposes the user-visible scope catalog.
+A scope declaration is either a single scope name binary or a
+non-empty list of scope names. A list means the path is reachable by
+a holder of *any one* of the listed scopes. Use it only where an
+endpoint genuinely has two legitimate audiences — for example the
+plugin API gateway, which a dedicated restricted scope reaches and
+which `system` must keep reaching for backward compatibility.
+
+This module collects those declarations, builds a path → scopes
+cache, and exposes the user-visible scope catalog.
 
 Scopes are decoupled from OpenAPI tags: scope names are stable
 identifiers defined in `emqx_mgmt_api_key_scopes.hrl`.  The internal
@@ -25,7 +32,8 @@ affecting user-facing API key configurations.
 -include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
 
 -export([
-    path_to_scope/1,
+    path_to_scopes/1,
+    any_scope_granted/2,
     classify_path/1,
     init_cache/0,
     clear_cache/0,
@@ -42,13 +50,15 @@ affecting user-facing API key configurations.
 -endif.
 
 -define(CACHE_KEY, {?MODULE, scope_cache}).
+-define(CATCH_ALL_SEGMENT, <<"[...]">>).
 %%--------------------------------------------------------------------
 %% Path → scope lookup
 %%--------------------------------------------------------------------
 
 -doc """
-Given a request path, return the scope name for this path, or
-`undefined` if unmapped.
+Given a request path, return the scopes that grant access to it, or
+`undefined` if unmapped. Holding any one of the returned scopes is
+enough — see `any_scope_granted/2`.
 
 The cache stores OpenAPI route templates such as
 `<<"/users/:username/mfa">>`. Callers that already have a template
@@ -56,47 +66,62 @@ The cache stores OpenAPI route templates such as
 an O(1) map lookup. Callers that have a concrete cowboy request path
 such as `<<"/users/john/mfa">>` (e.g. dashboard login user RBAC,
 which receives `cowboy_req:path/1`) fall through to a segment-wise
-match against every template — `:`-prefixed segments wildcard.
+match against every template — `:`-prefixed segments match one
+segment, a trailing `[...]` matches the rest of the path.
 
-Both forms must produce the same scope; otherwise scope checks would
+Both forms must produce the same scopes; otherwise scope checks would
 silently fail-open for any endpoint with a path parameter.
 """.
--spec path_to_scope(binary()) -> binary() | undefined.
-path_to_scope(Path) ->
+-spec path_to_scopes(binary()) -> [binary(), ...] | undefined.
+path_to_scopes(Path) ->
     %% Two-way view kept for the API-key authorisation path
     %% (`emqx_mgmt_auth:check_path_in_scopes/2'), which treats both
     %% "public" and "unmapped" as unscoped. Callers that must tell the
     %% two apart use `classify_path/1'.
     case classify_path(Path) of
-        {scope, Scope} -> Scope;
+        {scopes, Scopes} -> Scopes;
         public -> undefined;
         not_found -> undefined
     end.
 
 -doc """
+Return `true` when the holder's scope list covers a path, i.e. it
+contains at least one of the scopes the path declares.
+
+A path may declare several acceptable scopes, so membership of any
+one of them grants access. Both the API-key check
+(`emqx_mgmt_auth:check_path_in_scopes/2`) and the login-user check
+(`emqx_dashboard_rbac:check_login_user_scopes/2`) must use this
+predicate, so the two never diverge on a multi-scope path.
+""".
+-spec any_scope_granted([binary()], [binary()]) -> boolean().
+any_scope_granted(PathScopes, HeldScopes) ->
+    lists:any(fun(S) -> lists:member(S, HeldScopes) end, PathScopes).
+
+-doc """
 Three-way classification of a request path:
 
-* `{scope, Name}' — the path maps to the known scope `Name'.
-* `public'        — the path exactly matches a `?SCOPE_PUBLIC' sentinel.
-* `not_found'     — the path maps to no scope at all.
+* `{scopes, Names}' — any one of `Names' grants access to the path.
+* `public'          — the path exactly matches a `?SCOPE_PUBLIC' sentinel.
+* `not_found'       — the path maps to no scope at all.
 
-Unlike `path_to_scope/1', which collapses `public' and `not_found'
+Unlike `path_to_scopes/1', which collapses `public' and `not_found'
 into `undefined', this keeps them distinct so a caller can allow
 public paths while denying genuinely-unmapped ones (fail closed).
 """.
--spec classify_path(binary()) -> {scope, binary()} | public | not_found.
+-spec classify_path(binary()) -> {scopes, [binary(), ...]} | public | not_found.
 classify_path(Path) ->
     case get_cache() of
         undefined ->
             init_cache(),
             classify_with_cache(Path);
-        #{path_to_scope := PathMap} ->
+        #{path_to_scopes := PathMap} ->
             classify(Path, PathMap)
     end.
 
 classify_with_cache(Path) ->
     case get_cache() of
-        #{path_to_scope := PathMap} ->
+        #{path_to_scopes := PathMap} ->
             classify(Path, PathMap);
         _ ->
             not_found
@@ -107,21 +132,22 @@ classify(Path, PathMap) ->
         undefined ->
             case match_template(Path, PathMap) of
                 undefined -> not_found;
-                Scope -> {scope, Scope}
+                Scopes -> {scopes, Scopes}
             end;
-        ?SCOPE_PUBLIC ->
+        [?SCOPE_PUBLIC] ->
             %% Exact-match hit on a path explicitly declared public.
             public;
-        Scope ->
-            {scope, Scope}
+        Scopes ->
+            {scopes, Scopes}
     end.
 
-%% Iterate templates and return the scope for the first one whose
+%% Iterate templates and return the scopes of the first one whose
 %% segments match the request path. Concrete path segments must equal
 %% template segments verbatim except where the template segment starts
-%% with `:' (path parameter), which matches any single segment.
+%% with `:' (path parameter), which matches any single segment, or is
+%% the trailing `[...]' catch-all, which matches the rest of the path.
 %%
-%% Entries whose value is ?SCOPE_PUBLIC are skipped: they are kept in
+%% Entries whose value is `[?SCOPE_PUBLIC]' are skipped: they are kept in
 %% the cache as sentinels (so exact-match lookup can distinguish
 %% "intentionally public" from "genuinely unmapped"), but they must
 %% not claim a sibling concrete path via wildcard segment match.
@@ -141,11 +167,11 @@ match_template_iter(PathSegs, Iter) ->
     case maps:next(Iter) of
         none ->
             undefined;
-        {_Tmpl, ?SCOPE_PUBLIC, Iter1} ->
+        {_Tmpl, [?SCOPE_PUBLIC], Iter1} ->
             match_template_iter(PathSegs, Iter1);
-        {Tmpl, Scope, Iter1} ->
+        {Tmpl, Scopes, Iter1} ->
             case segments_match(PathSegs, split_segments(Tmpl)) of
-                true -> Scope;
+                true -> Scopes;
                 false -> match_template_iter(PathSegs, Iter1)
             end
     end.
@@ -167,7 +193,21 @@ split_segments(Path) ->
 %% after splitting so an encoded separator stays within its segment
 %% and never introduces an extra boundary.
 normalize_segments(Segments) ->
-    remove_dot_segments([cow_uri:urldecode(S) || S <- Segments], []).
+    remove_dot_segments([urldecode(S) || S <- Segments], []).
+
+%% `cow_uri:urldecode/1' raises on a byte that is not valid in a URI
+%% path. Cowboy validates a request path before it dispatches, so such
+%% a byte can only reach here from a value that did not come from the
+%% router — a route template carrying `[...]', for one. Keep the
+%% segment verbatim in that case: it then matches only a template
+%% segment that is literally equal, and the authorisation path returns
+%% a decision instead of raising.
+urldecode(Segment) ->
+    try
+        cow_uri:urldecode(Segment)
+    catch
+        _:_ -> Segment
+    end.
 
 remove_dot_segments([], Acc) ->
     lists:reverse(Acc);
@@ -180,6 +220,12 @@ remove_dot_segments([<<"..">> | Segments], [_ | Acc]) ->
 remove_dot_segments([Segment | Segments], Acc) ->
     remove_dot_segments(Segments, [Segment | Acc]).
 
+%% A trailing `[...]' is cowboy's catch-all: it matches the whole
+%% remainder of the path, including an empty remainder. It may only
+%% appear as the last template segment, so this clause consumes
+%% everything that is left.
+segments_match(_PathSegs, [?CATCH_ALL_SEGMENT]) ->
+    true;
 segments_match([], []) ->
     true;
 segments_match([_ | _], []) ->
@@ -268,8 +314,8 @@ Should be called once after the dashboard HTTP server has started.
 """.
 -spec init_cache() -> ok.
 init_cache() ->
-    PathToScope = collect_scopes_from_modules(),
-    persistent_term:put(?CACHE_KEY, #{path_to_scope => PathToScope}),
+    PathToScopes = collect_scopes_from_modules(),
+    persistent_term:put(?CACHE_KEY, #{path_to_scopes => PathToScopes}),
     ok.
 
 -doc "Clear the scope cache.".
@@ -285,9 +331,9 @@ clear_cache() ->
 get_cache() ->
     persistent_term:get(?CACHE_KEY, undefined).
 
-%% @doc Collect path → scope mappings from all API modules that export scopes/0.
-%% Returns a flat map: #{<<"/clients">> => <<"connections">>, ...}.
--spec collect_scopes_from_modules() -> #{binary() => binary()}.
+%% @doc Collect path → scopes mappings from all API modules that export scopes/0.
+%% Returns a flat map: #{<<"/clients">> => [<<"connections">>], ...}.
+-spec collect_scopes_from_modules() -> #{binary() => [binary(), ...]}.
 collect_scopes_from_modules() ->
     Modules = find_api_modules(),
     lists:foldl(fun collect_module_scopes/2, #{}, Modules).
@@ -333,8 +379,10 @@ is_test_module(Module) ->
 
 %% Collect scopes from a single API module.
 %% The module must export scopes/0 returning either:
-%%   - a binary (all paths share this scope)
-%%   - a #{Path => Scope} map (per-path scope assignment)
+%%   - a scope declaration (all paths share it)
+%%   - a #{Path => ScopeDeclaration} map (per-path assignment)
+%% A scope declaration is a scope name binary, or a non-empty list of
+%% scope names meaning "any one of these grants access".
 collect_module_scopes(Module, Acc) ->
     try
         case erlang:function_exported(Module, scopes, 0) of
@@ -360,21 +408,11 @@ collect_module_scopes(Module, Acc) ->
             Acc
     end.
 
-collect_paths_with_scope(_Module, Paths, ScopeName, Acc) when is_binary(ScopeName) ->
-    %% Simple form: all paths share the same scope
-    lists:foldl(
-        fun(Path, InnerAcc) ->
-            PathBin = path_to_binary(Path),
-            InnerAcc#{PathBin => ScopeName}
-        end,
-        Acc,
-        Paths
-    );
 collect_paths_with_scope(Module, Paths, ScopeMap, Acc) when is_map(ScopeMap) ->
     %% Map form: per-path scope assignment. The sentinel ?SCOPE_PUBLIC
     %% marks paths that are intentionally unscoped (pre-login entry
     %% points and static catalog endpoints). Such paths ARE inserted
-    %% into the cache, carrying ?SCOPE_PUBLIC as the value, so that:
+    %% into the cache, carrying `[?SCOPE_PUBLIC]' as the value, so that:
     %%
     %%   * exact-match lookup can distinguish "explicitly public" from
     %%     "genuinely unmapped" and return `undefined' for the former
@@ -396,15 +434,58 @@ collect_paths_with_scope(Module, Paths, ScopeMap, Acc) when is_map(ScopeMap) ->
                         path => PathBin
                     }),
                     InnerAcc;
-                ?SCOPE_PUBLIC ->
-                    InnerAcc#{PathBin => ?SCOPE_PUBLIC};
-                ScopeName ->
-                    InnerAcc#{PathBin => ScopeName}
+                Declared ->
+                    insert_path_scopes(Module, PathBin, Declared, InnerAcc)
             end
         end,
         Acc,
         Paths
+    );
+collect_paths_with_scope(Module, Paths, Declared, Acc) ->
+    %% Simple form: all paths share the same scope declaration.
+    lists:foldl(
+        fun(Path, InnerAcc) ->
+            insert_path_scopes(Module, path_to_binary(Path), Declared, InnerAcc)
+        end,
+        Acc,
+        Paths
     ).
+
+insert_path_scopes(Module, PathBin, Declared, Acc) ->
+    case normalize_declaration(Declared) of
+        invalid ->
+            %% Leave the path unmapped rather than guessing. Same
+            %% outcome as a module whose scopes/0 crashes: the path
+            %% falls through to the unmapped fail-open, and the warning
+            %% is the signal that the declaration needs fixing.
+            ?SLOG(warning, #{
+                msg => "invalid_scope_declaration",
+                module => Module,
+                path => PathBin,
+                declared => Declared
+            }),
+            Acc;
+        Scopes ->
+            Acc#{PathBin => Scopes}
+    end.
+
+%% Normalize a declared scope value to a non-empty list of scope
+%% names. `?SCOPE_PUBLIC' is exclusive: a public path is unscoped, so
+%% listing it alongside a real scope is a contradiction, not a union.
+normalize_declaration(Scope) when is_binary(Scope) ->
+    [Scope];
+normalize_declaration([?SCOPE_PUBLIC]) ->
+    [?SCOPE_PUBLIC];
+normalize_declaration([_ | _] = Scopes) ->
+    IsValid =
+        lists:all(fun is_binary/1, Scopes) andalso
+            not lists:member(?SCOPE_PUBLIC, Scopes),
+    case IsValid of
+        true -> Scopes;
+        false -> invalid
+    end;
+normalize_declaration(_Other) ->
+    invalid.
 
 path_to_binary(Path) when is_binary(Path) ->
     ensure_leading_slash(Path);

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -388,7 +388,7 @@ check_scopes_for_path(Extra, Path) ->
     end.
 
 check_path_in_scopes(Path, Scopes) ->
-    case emqx_mgmt_api_key_scopes:path_to_scope(Path) of
+    case emqx_mgmt_api_key_scopes:path_to_scopes(Path) of
         undefined ->
             %% Path not mapped to any scope — allow access regardless of
             %% whether `Scopes' is empty. This keeps unmapped public
@@ -397,8 +397,10 @@ check_path_in_scopes(Path, Scopes) ->
             %% bootstrap loader, so an operator can still observe the
             %% node and reconfigure the key via the UI.
             ok;
-        PathScope ->
-            case lists:member(PathScope, Scopes) of
+        PathScopes ->
+            %% A path may declare more than one acceptable scope;
+            %% holding any one of them grants access.
+            case emqx_mgmt_api_key_scopes:any_scope_granted(PathScopes, Scopes) of
                 true -> ok;
                 false -> {error, unauthorized_role}
             end
@@ -406,9 +408,11 @@ check_path_in_scopes(Path, Scopes) ->
 
 %% @doc Check if a path belongs to a denied scope.
 is_denied_path(Path) ->
-    case emqx_mgmt_api_key_scopes:path_to_scope(Path) of
-        undefined -> false;
-        Scope -> emqx_mgmt_api_key_scopes:is_denied_scope(Scope)
+    case emqx_mgmt_api_key_scopes:path_to_scopes(Path) of
+        undefined ->
+            false;
+        PathScopes ->
+            lists:any(fun emqx_mgmt_api_key_scopes:is_denied_scope/1, PathScopes)
     end.
 
 get_scopes(#{scopes := Scopes}) when is_list(Scopes) ->

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -437,7 +437,7 @@ maybe_set_scopes(Extra, Scopes) when is_list(Scopes) ->
 %% list (POST without `scopes', 2-/3-segment bootstrap line). Accepts a
 %% bare role or a serialized namespaced role (`ns:<ns>::<role>').
 %%
-%%   * global administrator / viewer -> `?GENERIC_SCOPES' (10 management
+%%   * global administrator / viewer -> `?GENERIC_SCOPES' (the management
 %%     scopes, no login-only scopes — those are reserved for dashboard
 %%     users).
 %%   * namespaced administrator -> `?NS_ADMIN_COMMON_SCOPES': the subset a

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -635,21 +635,21 @@ t_bootstrap_file_lenient_order_independence(_) ->
 t_bootstrap_file_scope_runtime_check(_) ->
     File = "./bootstrap_api_keys.txt",
     %% Sanity-check that the path-to-scope cache is populated for the
-    %% endpoints we exercise below — otherwise `path_to_scope/1' returns
+    %% endpoints we exercise below — otherwise `path_to_scopes/1' returns
     %% `undefined' and `check_path_in_scopes/2' would silently allow
     %% access regardless of the scope list, turning this test green for
     %% the wrong reason.
     ?assertEqual(
-        ?SCOPE_CONNECTIONS,
-        emqx_mgmt_api_key_scopes:path_to_scope(<<"/banned">>)
+        [?SCOPE_CONNECTIONS],
+        emqx_mgmt_api_key_scopes:path_to_scopes(<<"/banned">>)
     ),
     ?assertEqual(
-        ?SCOPE_PUBLISH,
-        emqx_mgmt_api_key_scopes:path_to_scope(<<"/publish">>)
+        [?SCOPE_PUBLISH],
+        emqx_mgmt_api_key_scopes:path_to_scopes(<<"/publish">>)
     ),
     ?assertEqual(
-        ?SCOPE_SYSTEM,
-        emqx_mgmt_api_key_scopes:path_to_scope(<<"/status">>)
+        [?SCOPE_SYSTEM],
+        emqx_mgmt_api_key_scopes:path_to_scopes(<<"/status">>)
     ),
 
     %% A single key scoped to `connections`. Endpoints that map to OTHER scopes
@@ -722,7 +722,7 @@ t_bootstrap_file_scope_runtime_check(_) ->
         auth_authorize(StatusPath, <<"scope-empty">>, <<"secret-3">>)
     ),
     %% Unmapped path: there should not be any in the management app at the
-    %% time this suite starts, but if `path_to_scope/1' returns `undefined'
+    %% time this suite starts, but if `path_to_scopes/1' returns `undefined'
     %% for a path the key with `scopes=[]' is allowed to reach it. We test
     %% that contract directly:
     ?assertEqual(

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -733,7 +733,7 @@ t_api_update_scopes(_Config) ->
     Name = <<"SCOPES-API-UPDATE">>,
     {ok, Created} = create_app(Name),
     %% POST without `scopes' now materialises the role-default scope list
-    %% (administrator -> the 10 common management scopes). The legacy
+    %% (administrator -> the common management scopes). The legacy
     %% `<<"unset">>' sentinel is reserved for records that pre-date the
     %% scopes feature and was thus upgraded without a scopes field.
     DefaultAdminScopes = lists:sort(?GENERIC_SCOPES),

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -29,11 +29,14 @@ groups() ->
         {unit_tests, [], [
             t_init_cache,
             t_scope_catalog,
-            t_path_to_scope,
+            t_path_to_scopes,
             t_path_to_scope_denied,
-            t_path_to_scope_no_cache,
-            t_path_to_scope_canonicalizes_request_path,
+            t_path_to_scopes_no_cache,
+            t_path_to_scopes_canonicalizes_request_path,
             t_classify_path,
+            t_multi_scope_path,
+            t_catch_all_template_matches_remainder,
+            t_lookup_tolerates_undecodable_segment,
             t_validate_scopes,
             t_validate_scopes_bad_input,
             t_is_denied_scope,
@@ -97,7 +100,7 @@ t_init_cache(_Config) ->
     ?assertEqual(ok, emqx_mgmt_api_key_scopes:init_cache()),
     Cache = persistent_term:get({emqx_mgmt_api_key_scopes, scope_cache}, undefined),
     ?assertNotEqual(undefined, Cache),
-    ?assertMatch(#{path_to_scope := _}, Cache),
+    ?assertMatch(#{path_to_scopes := _}, Cache),
     ?assertEqual(ok, emqx_mgmt_api_key_scopes:clear_cache()),
     ?assertEqual(
         undefined, persistent_term:get({emqx_mgmt_api_key_scopes, scope_cache}, undefined)
@@ -133,19 +136,19 @@ t_scope_catalog(_Config) ->
     %% $denied must NOT be in the catalog
     ?assertNot(lists:member(?SCOPE_DENIED, Names)).
 
-t_path_to_scope(_Config) ->
+t_path_to_scopes(_Config) ->
     emqx_mgmt_api_key_scopes:init_cache(),
-    %% "/clients" should resolve to <<"connections">>
-    ?assertEqual(?SCOPE_CONNECTIONS, emqx_mgmt_api_key_scopes:path_to_scope(<<"/clients">>)),
+    %% "/clients" should resolve to [<<"connections">>]
+    ?assertEqual([?SCOPE_CONNECTIONS], emqx_mgmt_api_key_scopes:path_to_scopes(<<"/clients">>)),
     %% "/clients/:clientid" should also be connections
     ?assertEqual(
-        ?SCOPE_CONNECTIONS,
-        emqx_mgmt_api_key_scopes:path_to_scope(<<"/clients/:clientid">>)
+        [?SCOPE_CONNECTIONS],
+        emqx_mgmt_api_key_scopes:path_to_scopes(<<"/clients/:clientid">>)
     ),
-    %% "/publish" should resolve to <<"publish">>
-    ?assertEqual(?SCOPE_PUBLISH, emqx_mgmt_api_key_scopes:path_to_scope(<<"/publish">>)),
+    %% "/publish" should resolve to [<<"publish">>]
+    ?assertEqual([?SCOPE_PUBLISH], emqx_mgmt_api_key_scopes:path_to_scopes(<<"/publish">>)),
     %% Unknown path → undefined
-    ?assertEqual(undefined, emqx_mgmt_api_key_scopes:path_to_scope(<<"/nonexistent">>)),
+    ?assertEqual(undefined, emqx_mgmt_api_key_scopes:path_to_scopes(<<"/nonexistent">>)),
     emqx_mgmt_api_key_scopes:clear_cache().
 
 t_path_to_scope_denied(_Config) ->
@@ -156,26 +159,26 @@ t_path_to_scope_denied(_Config) ->
     %% sso_management). API keys still cannot reach these endpoints
     %% — minirest's bearer-only `security` declaration
     %% rejects API key authentication before scope check.
-    ?assertEqual(?SCOPE_USER_MGMT, emqx_mgmt_api_key_scopes:path_to_scope(<<"/users">>)),
-    ?assertEqual(?SCOPE_API_KEY_MGMT, emqx_mgmt_api_key_scopes:path_to_scope(<<"/api_key">>)),
+    ?assertEqual([?SCOPE_USER_MGMT], emqx_mgmt_api_key_scopes:path_to_scopes(<<"/users">>)),
+    ?assertEqual([?SCOPE_API_KEY_MGMT], emqx_mgmt_api_key_scopes:path_to_scopes(<<"/api_key">>)),
     emqx_mgmt_api_key_scopes:clear_cache().
 
-t_path_to_scope_no_cache(_Config) ->
+t_path_to_scopes_no_cache(_Config) ->
     emqx_mgmt_api_key_scopes:clear_cache(),
     %% Should lazy-init and return correct scope
-    ?assertEqual(?SCOPE_CONNECTIONS, emqx_mgmt_api_key_scopes:path_to_scope(<<"/clients">>)).
+    ?assertEqual([?SCOPE_CONNECTIONS], emqx_mgmt_api_key_scopes:path_to_scopes(<<"/clients">>)).
 
 -doc """
 `classify_path/1' distinguishes the three cases the login-user scope
 check needs to tell apart: a known scope, an explicitly public path,
-and a genuinely-unmapped path. `path_to_scope/1' keeps collapsing the
+and a genuinely-unmapped path. `path_to_scopes/1' keeps collapsing the
 last two to `undefined' for the API-key path.
 """.
 t_classify_path(_Config) ->
     emqx_mgmt_api_key_scopes:init_cache(),
-    %% Mapped path -> {scope, Name}.
+    %% Mapped path -> {scopes, Names}.
     ?assertEqual(
-        {scope, ?SCOPE_CONNECTIONS},
+        {scopes, [?SCOPE_CONNECTIONS]},
         emqx_mgmt_api_key_scopes:classify_path(<<"/clients">>)
     ),
     %% Genuinely unmapped -> not_found (login-user path denies these).
@@ -187,12 +190,130 @@ t_classify_path(_Config) ->
     Modules = emqx_mgmt_api_key_scopes:find_api_modules(),
     [PublicPath | _] = collect_public_paths(Modules),
     ?assertEqual(public, emqx_mgmt_api_key_scopes:classify_path(PublicPath)),
-    %% path_to_scope/1 still collapses public and unmapped to undefined.
-    ?assertEqual(undefined, emqx_mgmt_api_key_scopes:path_to_scope(PublicPath)),
+    %% path_to_scopes/1 still collapses public and unmapped to undefined.
+    ?assertEqual(undefined, emqx_mgmt_api_key_scopes:path_to_scopes(PublicPath)),
     ?assertEqual(
-        undefined, emqx_mgmt_api_key_scopes:path_to_scope(<<"/some/unmapped/path">>)
+        undefined, emqx_mgmt_api_key_scopes:path_to_scopes(<<"/some/unmapped/path">>)
     ),
     emqx_mgmt_api_key_scopes:clear_cache().
+
+-doc """
+A path may declare several acceptable scopes. `classify_path/1'
+returns all of them and `any_scope_granted/2' grants access to a
+holder of any single one, so an endpoint with two legitimate
+audiences does not have to pick one of them.
+""".
+t_multi_scope_path(_Config) ->
+    Path = <<"/__test_multi_scope__">>,
+    with_scope_cache(
+        #{Path => [?SCOPE_MONITORING, ?SCOPE_SYSTEM]},
+        fun() ->
+            ?assertEqual(
+                {scopes, [?SCOPE_MONITORING, ?SCOPE_SYSTEM]},
+                emqx_mgmt_api_key_scopes:classify_path(Path)
+            ),
+            ?assertEqual(
+                [?SCOPE_MONITORING, ?SCOPE_SYSTEM],
+                emqx_mgmt_api_key_scopes:path_to_scopes(Path)
+            )
+        end
+    ),
+    PathScopes = [?SCOPE_MONITORING, ?SCOPE_SYSTEM],
+    ?assert(emqx_mgmt_api_key_scopes:any_scope_granted(PathScopes, [?SCOPE_SYSTEM])),
+    ?assert(emqx_mgmt_api_key_scopes:any_scope_granted(PathScopes, [?SCOPE_MONITORING])),
+    ?assert(
+        emqx_mgmt_api_key_scopes:any_scope_granted(
+            PathScopes, [?SCOPE_PUBLISH, ?SCOPE_MONITORING]
+        )
+    ),
+    ?assertNot(emqx_mgmt_api_key_scopes:any_scope_granted(PathScopes, [?SCOPE_PUBLISH])),
+    ?assertNot(emqx_mgmt_api_key_scopes:any_scope_granted(PathScopes, [])).
+
+-doc """
+A trailing `[...]' in a route template is cowboy's catch-all: it
+matches the remainder of the request path, including an empty
+remainder. Without this, a concrete request against a catch-all route
+resolves to no scope while the route template itself resolves to one
+— the two forms must agree, otherwise the login-user check (which
+sees concrete paths) and the API-key check (which sees templates)
+disagree on the same endpoint.
+""".
+t_catch_all_template_matches_remainder(_Config) ->
+    Template = <<"/__test_catch_all__/:name/[...]">>,
+    with_scope_cache(
+        #{Template => [?SCOPE_MONITORING]},
+        fun() ->
+            Expected = {scopes, [?SCOPE_MONITORING]},
+            %% The template form itself (API-key authorisation path).
+            ?assertEqual(Expected, emqx_mgmt_api_key_scopes:classify_path(Template)),
+            %% Concrete request paths (login-user RBAC path): empty,
+            %% single and multi-segment remainders all match.
+            ?assertEqual(
+                Expected,
+                emqx_mgmt_api_key_scopes:classify_path(<<"/__test_catch_all__/x">>)
+            ),
+            ?assertEqual(
+                Expected,
+                emqx_mgmt_api_key_scopes:classify_path(<<"/__test_catch_all__/x/y">>)
+            ),
+            ?assertEqual(
+                Expected,
+                emqx_mgmt_api_key_scopes:classify_path(<<"/__test_catch_all__/x/y/z">>)
+            ),
+            %% The catch-all does not reach past its own prefix.
+            ?assertEqual(
+                not_found,
+                emqx_mgmt_api_key_scopes:classify_path(<<"/__test_catch_all__">>)
+            ),
+            ?assertEqual(
+                not_found,
+                emqx_mgmt_api_key_scopes:classify_path(<<"/__other__/x/y">>)
+            )
+        end
+    ).
+
+-doc """
+A lookup must return a decision, never raise. Percent-decoding
+rejects bytes that are invalid in a URI path, and route templates
+carrying `[...]' contain such bytes — so a template that misses the
+exact-match lookup reaches the segment matcher. Raising there would
+turn an authorisation check into a 500.
+""".
+t_lookup_tolerates_undecodable_segment(_Config) ->
+    with_scope_cache(
+        #{<<"/clients">> => [?SCOPE_CONNECTIONS]},
+        fun() ->
+            ?assertEqual(
+                undefined,
+                emqx_mgmt_api_key_scopes:path_to_scopes(<<"/plugin_api/:plugin/[...]">>)
+            ),
+            ?assertEqual(
+                undefined,
+                emqx_mgmt_api_key_scopes:path_to_scopes(<<"/a b/%zz">>)
+            ),
+            %% Ordinary paths still resolve.
+            ?assertEqual(
+                [?SCOPE_CONNECTIONS],
+                emqx_mgmt_api_key_scopes:path_to_scopes(<<"/clients">>)
+            )
+        end
+    ).
+
+%% Run `Fun' against a synthetic path -> scopes cache, so the
+%% lookup semantics can be exercised without depending on which API
+%% modules happen to be loaded. Restores the previous cache after.
+with_scope_cache(PathMap, Fun) ->
+    Key = {emqx_mgmt_api_key_scopes, scope_cache},
+    Prev = persistent_term:get(Key, undefined),
+    persistent_term:put(Key, #{path_to_scopes => PathMap}),
+    try
+        Fun()
+    after
+        case Prev of
+            undefined -> emqx_mgmt_api_key_scopes:clear_cache();
+            _ -> persistent_term:put(Key, Prev)
+        end
+    end.
 
 -doc """
 A concrete request path must map to the same scope regardless of
@@ -200,21 +321,21 @@ percent-encoding or `.'/`..' segments, so the lookup agrees with the
 path the router dispatched on. Otherwise an obfuscated path resolves
 to `undefined' (unmapped) and slips the scope gate.
 """.
-t_path_to_scope_canonicalizes_request_path(_Config) ->
+t_path_to_scopes_canonicalizes_request_path(_Config) ->
     emqx_mgmt_api_key_scopes:init_cache(),
-    Canonical = emqx_mgmt_api_key_scopes:path_to_scope(<<"/users">>),
-    ?assertEqual(?SCOPE_USER_MGMT, Canonical),
+    Canonical = emqx_mgmt_api_key_scopes:path_to_scopes(<<"/users">>),
+    ?assertEqual([?SCOPE_USER_MGMT], Canonical),
     %% percent-encoded characters in a static segment
-    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scope(<<"/user%73">>)),
-    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scope(<<"/%75sers">>)),
+    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scopes(<<"/user%73">>)),
+    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scopes(<<"/%75sers">>)),
     %% dot-segments that the router collapses before dispatch
-    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scope(<<"/x/../users">>)),
-    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scope(<<"/./users">>)),
+    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scopes(<<"/x/../users">>)),
+    ?assertEqual(Canonical, emqx_mgmt_api_key_scopes:path_to_scopes(<<"/./users">>)),
     %% same invariant for a path-parameter endpoint
-    ClientsScope = emqx_mgmt_api_key_scopes:path_to_scope(<<"/clients/:clientid">>),
+    ClientsScopes = emqx_mgmt_api_key_scopes:path_to_scopes(<<"/clients/:clientid">>),
     ?assertEqual(
-        ClientsScope,
-        emqx_mgmt_api_key_scopes:path_to_scope(<<"/client%73/abc">>)
+        ClientsScopes,
+        emqx_mgmt_api_key_scopes:path_to_scopes(<<"/client%73/abc">>)
     ),
     emqx_mgmt_api_key_scopes:clear_cache().
 
@@ -278,11 +399,13 @@ t_all_modules_have_scopes(_Config) ->
             [?SCOPE_PUBLIC] ++
             ?LOGIN_ONLY_SCOPES,
     maps:foreach(
-        fun(Path, Scope) ->
-            ?assert(
-                lists:member(Scope, AllValidScopes),
+        fun(Path, Scopes) ->
+            Unknown = [S || S <- Scopes, not lists:member(S, AllValidScopes)],
+            ?assertEqual(
+                [],
+                Unknown,
                 lists:flatten(
-                    io_lib:format("Path ~s mapped to unknown scope ~s", [Path, Scope])
+                    io_lib:format("Path ~s mapped to unknown scope(s) ~p", [Path, Unknown])
                 )
             )
         end,
@@ -373,7 +496,7 @@ safe_paths(M) ->
 
 -doc """
 ?SCOPE_PUBLIC paths must keep the unmapped/fail-open semantics that
-production already relies on for `/login' and friends: `path_to_scope/1'
+production already relies on for `/login' and friends: `path_to_scopes/1'
 must return `undefined' for these paths so the runtime authorisation
 layer treats them as unscoped.
 
@@ -381,7 +504,7 @@ The cache itself MAY carry ?SCOPE_PUBLIC sentinel values internally
 (this is how exact-match lookup distinguishes "intentionally public"
 from "genuinely unmapped" and stops sibling wildcard templates from
 claiming a public endpoint -- see `t_wildcard_does_not_claim_public_path').
-The user-visible invariant being asserted here is the `path_to_scope/1'
+The user-visible invariant being asserted here is the `path_to_scopes/1'
 return value, not the cache representation.
 """.
 t_public_paths_not_in_cache(_Config) ->
@@ -396,7 +519,7 @@ t_public_paths_not_in_cache(_Config) ->
         fun(Path) ->
             ?assertEqual(
                 undefined,
-                emqx_mgmt_api_key_scopes:path_to_scope(Path),
+                emqx_mgmt_api_key_scopes:path_to_scopes(Path),
                 lists:flatten(io_lib:format("public path ~s leaked into cache", [Path]))
             )
         end,
@@ -411,7 +534,7 @@ claimed by a sibling wildcard template at scope-lookup time.
 Concrete example: `/sso/running' is declared ?SCOPE_PUBLIC, while
 the sibling template `/sso/:backend' is mapped to `sso_management'.
 Without the sentinel-in-cache fix, segment-wise match would let the
-wildcard absorb the public path and `path_to_scope(<<"/sso/running">>)'
+wildcard absorb the public path and `path_to_scopes(<<"/sso/running">>)'
 would return `sso_management', collapsing defense-in-depth (the
 runtime auth layer separately bypasses the scope check via
 `security => []' on these endpoints, but the catalog itself was
@@ -419,7 +542,7 @@ incorrect).
 
 This test asserts the catalog stays honest:
   * every declared ?SCOPE_PUBLIC path resolves to `undefined' via
-    `path_to_scope/1';
+    `path_to_scopes/1';
   * sibling wildcard templates still resolve correctly for genuine
     parameterised requests (e.g. `/sso/oidc' -> `sso_management').
 """.
@@ -435,7 +558,7 @@ t_wildcard_does_not_claim_public_path(_Config) ->
         fun(Path) ->
             ?assertEqual(
                 undefined,
-                emqx_mgmt_api_key_scopes:path_to_scope(Path),
+                emqx_mgmt_api_key_scopes:path_to_scopes(Path),
                 lists:flatten(
                     io_lib:format(
                         "public path ~s wrongly claimed by a sibling wildcard template",
@@ -453,8 +576,8 @@ t_wildcard_does_not_claim_public_path(_Config) ->
     case lists:member(<<"/sso/running">>, PublicPaths) of
         true ->
             ?assertEqual(
-                <<"sso_management">>,
-                emqx_mgmt_api_key_scopes:path_to_scope(<<"/sso/oidc">>)
+                [<<"sso_management">>],
+                emqx_mgmt_api_key_scopes:path_to_scopes(<<"/sso/oidc">>)
             );
         false ->
             ok
@@ -535,8 +658,8 @@ t_authorize_denied_path(_Config) ->
     %% rejects API key access to such paths.
     DeniedPath = <<"/__test_denied__">>,
     meck:new(emqx_mgmt_api_key_scopes, [passthrough]),
-    meck:expect(emqx_mgmt_api_key_scopes, path_to_scope, fun
-        (P) when P =:= DeniedPath -> ?SCOPE_DENIED;
+    meck:expect(emqx_mgmt_api_key_scopes, path_to_scopes, fun
+        (P) when P =:= DeniedPath -> [?SCOPE_DENIED];
         (P) -> meck:passthrough([P])
     end),
     try

--- a/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_key_scopes_SUITE.erl
@@ -36,7 +36,6 @@ groups() ->
             t_classify_path,
             t_multi_scope_path,
             t_catch_all_template_matches_remainder,
-            t_lookup_tolerates_undecodable_segment,
             t_validate_scopes,
             t_validate_scopes_bad_input,
             t_is_denied_scope,
@@ -268,33 +267,6 @@ t_catch_all_template_matches_remainder(_Config) ->
             ?assertEqual(
                 not_found,
                 emqx_mgmt_api_key_scopes:classify_path(<<"/__other__/x/y">>)
-            )
-        end
-    ).
-
--doc """
-A lookup must return a decision, never raise. Percent-decoding
-rejects bytes that are invalid in a URI path, and route templates
-carrying `[...]' contain such bytes — so a template that misses the
-exact-match lookup reaches the segment matcher. Raising there would
-turn an authorisation check into a 500.
-""".
-t_lookup_tolerates_undecodable_segment(_Config) ->
-    with_scope_cache(
-        #{<<"/clients">> => [?SCOPE_CONNECTIONS]},
-        fun() ->
-            ?assertEqual(
-                undefined,
-                emqx_mgmt_api_key_scopes:path_to_scopes(<<"/plugin_api/:plugin/[...]">>)
-            ),
-            ?assertEqual(
-                undefined,
-                emqx_mgmt_api_key_scopes:path_to_scopes(<<"/a b/%zz">>)
-            ),
-            %% Ordinary paths still resolve.
-            ?assertEqual(
-                [?SCOPE_CONNECTIONS],
-                emqx_mgmt_api_key_scopes:path_to_scopes(<<"/clients">>)
             )
         end
     ).

--- a/apps/emqx_plugins/src/emqx_plugins_api_endpoint.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_api_endpoint.erl
@@ -21,7 +21,12 @@
 api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => false}).
 
-scopes() -> ?SCOPE_SYSTEM.
+%% Two scopes reach this gateway. `?SCOPE_PLUGIN_API` is the restricted
+%% scope for callers that only need to talk to a plugin. `?SCOPE_SYSTEM`
+%% is kept because it was the only way in before `?SCOPE_PLUGIN_API`
+%% existed: dropping it would break every API key and dashboard user
+%% created earlier.
+scopes() -> [?SCOPE_PLUGIN_API, ?SCOPE_SYSTEM].
 
 paths() ->
     ["/plugin_api/:plugin/[...]"].

--- a/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_api_endpoint_SUITE.erl
@@ -9,8 +9,14 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_utils/include/emqx_api_key_scopes.hrl").
 
 -define(SERVER, "http://127.0.0.1:18083/api/v5").
+%% `emqx_plugins` does not depend on `emqx_dashboard` at compile time,
+%% so the role constant is spelled out rather than included.
+-define(ADMIN_ROLE, <<"administrator">>).
+-define(GATEWAY_TEMPLATE, <<"/plugin_api/:plugin/[...]">>).
+-define(GATEWAY_PATH, <<"/plugin_api/fake/ping">>).
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -20,7 +26,10 @@ init_per_suite(Config) ->
         [
             emqx_conf,
             emqx_management,
-            emqx_mgmt_api_test_util:emqx_dashboard()
+            emqx_mgmt_api_test_util:emqx_dashboard(),
+            %% Needed by the login-user scope tests, which call
+            %% `emqx_dashboard_rbac:check_login_user_scopes/2' directly.
+            emqx_dashboard_rbac
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
@@ -135,6 +144,142 @@ t_plugin_api_path_remainder_is_percent_decoded(_Config) ->
     ),
     {200, Body} = request(get, ?SERVER ++ "/plugin_api/fake/user%2Fname"),
     ?assertEqual(#{<<"ok">> => true}, Body).
+
+%%--------------------------------------------------------------------
+%% Scope tests
+%%--------------------------------------------------------------------
+
+-doc """
+The gateway route declares both `plugin_api' and `system', and the
+route template and a concrete request path must resolve to the same
+pair. The API-key check looks the template up; the login-user check
+looks a concrete path up. If the two disagree the scope gate is
+enforced on only one of them.
+""".
+t_gateway_declares_both_scopes(_Config) ->
+    ?assertEqual([?SCOPE_PLUGIN_API, ?SCOPE_SYSTEM], emqx_plugins_api_endpoint:scopes()),
+    Expected = [?SCOPE_PLUGIN_API, ?SCOPE_SYSTEM],
+    ?assertEqual(Expected, emqx_mgmt_api_key_scopes:path_to_scopes(?GATEWAY_TEMPLATE)),
+    ?assertEqual(Expected, emqx_mgmt_api_key_scopes:path_to_scopes(?GATEWAY_PATH)),
+    %% The catch-all covers an empty and a multi-segment remainder too.
+    ?assertEqual(Expected, emqx_mgmt_api_key_scopes:path_to_scopes(<<"/plugin_api/fake">>)),
+    ?assertEqual(
+        Expected, emqx_mgmt_api_key_scopes:path_to_scopes(<<"/plugin_api/fake/a/b/c">>)
+    ).
+
+-doc """
+Backward-compatibility regression: an API key holding only `system'
+predates the `plugin_api' scope and must keep reaching the gateway.
+This case must fail if the `system' entry is ever dropped from
+`emqx_plugins_api_endpoint:scopes/0'.
+""".
+t_gateway_reachable_with_system_scope_key(_Config) ->
+    ok = mock_plugin_ok(),
+    with_api_key(<<"PLUGIN-API-SYSTEM">>, [?SCOPE_SYSTEM], fun(Auth) ->
+        ?assertMatch({200, #{<<"ok">> := true}}, request(get, gateway_url(), Auth))
+    end).
+
+-doc """
+An API key holding only `plugin_api' reaches the plugin gateway and
+nothing else: `/configs' (the `system' scope) is rejected.
+""".
+t_gateway_reachable_with_plugin_api_scope_key(_Config) ->
+    ok = mock_plugin_ok(),
+    with_api_key(<<"PLUGIN-API-ONLY">>, [?SCOPE_PLUGIN_API], fun(Auth) ->
+        ?assertMatch({200, #{<<"ok">> := true}}, request(get, gateway_url(), Auth)),
+        ?assertMatch({403, _}, request(get, ?SERVER ++ "/configs", Auth))
+    end).
+
+-doc "An API key holding neither scope is rejected on the plugin gateway.".
+t_gateway_denied_without_either_scope(_Config) ->
+    ok = mock_plugin_ok(),
+    with_api_key(<<"PLUGIN-API-NEITHER">>, [?SCOPE_MONITORING], fun(Auth) ->
+        ?assertMatch({403, _}, request(get, gateway_url(), Auth))
+    end).
+
+-doc """
+The login-user scope check runs on concrete request paths through
+`emqx_dashboard_rbac', separately from the API-key check. Both the new
+scope and the legacy `system' scope must grant the gateway there, and
+neither may grant it to a user holding some other scope.
+""".
+t_gateway_login_user_scopes(_Config) ->
+    Cases = [
+        {<<"plugin_api_user">>, [?SCOPE_PLUGIN_API], true},
+        {<<"system_user">>, [?SCOPE_SYSTEM], true},
+        {<<"monitoring_user">>, [?SCOPE_MONITORING], false}
+    ],
+    lists:foreach(
+        fun({Username, Scopes, Expected}) ->
+            with_login_user(Username, Scopes, fun() ->
+                ?assertEqual(
+                    Expected,
+                    emqx_dashboard_rbac:check_login_user_scopes(Username, ?GATEWAY_PATH),
+                    #{username => Username, scopes => Scopes}
+                )
+            end)
+        end,
+        Cases
+    ),
+    %% The plugin_api scope grants the gateway only. `/configs' stays
+    %% on `system'.
+    with_login_user(<<"plugin_api_user2">>, [?SCOPE_PLUGIN_API], fun() ->
+        ?assertNot(
+            emqx_dashboard_rbac:check_login_user_scopes(
+                <<"plugin_api_user2">>, <<"/configs">>
+            )
+        )
+    end).
+
+%%--------------------------------------------------------------------
+%% Scope test helpers
+%%--------------------------------------------------------------------
+
+gateway_url() ->
+    ?SERVER ++ "/plugin_api/fake/ping".
+
+mock_plugin_ok() ->
+    meck:expect(
+        emqx_plugins,
+        handle_api_call,
+        fun(<<"fake">>, _Request, _Timeout) -> {200, #{ok => true}} end
+    ).
+
+%% Create an API key holding exactly `Scopes', run `Fun' with its
+%% basic-auth header, then delete the key.
+with_api_key(Name, Scopes, Fun) ->
+    {ok, #{token := Token}} = emqx_dashboard_admin:sign_token(<<"admin">>, <<"public">>),
+    AdminAuth = {"Authorization", "Bearer " ++ binary_to_list(Token)},
+    Path = emqx_mgmt_api_test_util:api_path(["api_key"]),
+    Body = #{
+        name => Name,
+        expired_at => <<"2099-01-01T00:00:00.000Z">>,
+        desc => <<"plugin api scope test">>,
+        enable => true,
+        scopes => Scopes
+    },
+    {ok, Res} = emqx_mgmt_api_test_util:request_api(post, Path, "", AdminAuth, Body),
+    #{<<"api_key">> := Key, <<"api_secret">> := Secret} = emqx_utils_json:decode(Res),
+    Auth = emqx_common_test_http:auth_header(binary_to_list(Key), binary_to_list(Secret)),
+    try
+        Fun(Auth)
+    after
+        DeletePath = emqx_mgmt_api_test_util:api_path(["api_key", Name]),
+        {ok, _} = emqx_mgmt_api_test_util:request_api(delete, DeletePath, AdminAuth)
+    end.
+
+%% Create a dashboard login user holding exactly `Scopes', run `Fun',
+%% then remove the user.
+with_login_user(Username, Scopes, Fun) ->
+    {ok, _} = emqx_dashboard_admin:add_user(
+        Username, <<"public_Pass1!">>, ?ADMIN_ROLE, <<"plugin api scope test">>
+    ),
+    {ok, _} = emqx_dashboard_admin:set_user_scopes(Username, Scopes),
+    try
+        Fun()
+    after
+        _ = emqx_dashboard_admin:remove_user(Username)
+    end.
 
 request(Method, Url) ->
     request(Method, Url, emqx_mgmt_api_test_util:auth_header_()).

--- a/apps/emqx_utils/include/emqx_api_key_scopes.hrl
+++ b/apps/emqx_utils/include/emqx_api_key_scopes.hrl
@@ -29,6 +29,20 @@
 -define(SCOPE_AUDIT, <<"audit">>).
 -define(SCOPE_LICENSE, <<"license">>).
 
+%% Grants the plugin-extended API gateway (`/plugin_api/:plugin/...`)
+%% and nothing else. This is the surface a plugin publishes for its own
+%% callers, NOT plugin administration: installing, starting, stopping
+%% and configuring plugins stays on `?SCOPE_SYSTEM`.
+%%
+%% The gateway path also accepts `?SCOPE_SYSTEM`, so keys and users
+%% that predate this scope keep working. See
+%% `emqx_plugins_api_endpoint:scopes/0`.
+%%
+%% The scope says nothing about what a plugin does behind the gateway.
+%% A plugin is free to publish a dangerous endpoint, and holding this
+%% scope reaches it.
+-define(SCOPE_PLUGIN_API, <<"plugin_api">>).
+
 %% ── Internal scopes ────────────────────────────────────────────────
 
 %% Endpoints that API Keys must never access (dashboard login/SSO/
@@ -105,7 +119,8 @@
     ?SCOPE_CLUSTER_OPERATIONS,
     ?SCOPE_SYSTEM,
     ?SCOPE_AUDIT,
-    ?SCOPE_LICENSE
+    ?SCOPE_LICENSE,
+    ?SCOPE_PLUGIN_API
 ]).
 
 %% Namespaced-administrator scope defaults — a restricted subset of
@@ -130,7 +145,12 @@
     %% `GET /license/setting`, `GET /license/session_hwm_history`).
     %% RBAC blocks `POST /license` and `PUT /license/setting` for
     %% namespaced callers, so writes still return 403.
-    ?SCOPE_LICENSE
+    ?SCOPE_LICENSE,
+    %% The gateway forwards the caller's namespace to the plugin, and
+    %% namespaced callers reach it today through `?SCOPE_SYSTEM`.
+    %% Listing it keeps that reach and lets a namespaced caller be
+    %% narrowed down to the plugin API alone.
+    ?SCOPE_PLUGIN_API
 ]).
 -define(NS_ADMIN_LOGIN_SCOPES, [
     ?SCOPE_USER_MGMT,

--- a/apps/emqx_utils/include/emqx_api_key_scopes.hrl
+++ b/apps/emqx_utils/include/emqx_api_key_scopes.hrl
@@ -8,6 +8,11 @@
 %% returns one of these macros (or a map of path => macro for modules
 %% whose endpoints span multiple scopes).
 %%
+%% A path may also declare a non-empty LIST of these macros, meaning
+%% "a holder of any one of these scopes may call this path". Use a list
+%% only where an endpoint has two legitimate audiences that cannot be
+%% collapsed into one scope name.
+%%
 %% Using macros ensures compile-time safety: a typo in a scope name
 %% will cause a compilation error rather than a silent runtime bug.
 
@@ -35,9 +40,12 @@
 %% only return static catalog data (/user_scopes, /api_key_scopes).
 %% Modules using the map form of scopes/0 must declare such paths with
 %% this value rather than omitting them, so that genuinely forgotten
-%% paths still produce a startup warning. The collector treats this
-%% value as: do not insert into the runtime cache (preserves fail-open
-%% semantics) and do not emit path_missing_from_scopes_map.
+%% paths still produce a startup warning. The collector inserts the
+%% sentinel into the runtime cache so that an exact-match lookup can
+%% tell "explicitly public" from "genuinely unmapped", and skips those
+%% entries during wildcard template matching so a sibling template
+%% cannot claim a public path. Lookups still report a public path as
+%% unscoped, preserving fail-open semantics.
 -define(SCOPE_PUBLIC, <<"$public">>).
 
 %% ── Login-user-only scopes (since 5.10.4) ─────────────────────────────

--- a/apps/emqx_utils/src/emqx_scope_catalog.erl
+++ b/apps/emqx_utils/src/emqx_scope_catalog.erl
@@ -54,7 +54,8 @@ common_scope_catalog() ->
         #{name => ?SCOPE_CLUSTER_OPERATIONS, desc => ?DESC(scope_cluster_operations)},
         #{name => ?SCOPE_SYSTEM, desc => ?DESC(scope_system)},
         #{name => ?SCOPE_AUDIT, desc => ?DESC(scope_audit)},
-        #{name => ?SCOPE_LICENSE, desc => ?DESC(scope_license)}
+        #{name => ?SCOPE_LICENSE, desc => ?DESC(scope_license)},
+        #{name => ?SCOPE_PLUGIN_API, desc => ?DESC(scope_plugin_api)}
     ].
 
 %%--------------------------------------------------------------------

--- a/changes/ee/feat-18843.en.md
+++ b/changes/ee/feat-18843.en.md
@@ -1,0 +1,5 @@
+Added a new API scope, `plugin_api`, that grants access to the plugin-extended API endpoints (`/plugin_api/...`) and nothing else.
+
+Assign it to an API key or a Dashboard user to let them call the endpoints a plugin publishes, without granting them the `system` scope, which is administrator-equivalent. The `plugin_api` scope does not grant plugin installation, start, stop or configuration — those stay in the `system` scope.
+
+Existing API keys and Dashboard users that hold the `system` scope keep their access to the plugin-extended API endpoints.

--- a/rel/i18n/emqx_scope_catalog.hocon
+++ b/rel/i18n/emqx_scope_catalog.hocon
@@ -30,6 +30,9 @@ scope_audit.desc:
 scope_license.desc:
 """License management"""
 
+scope_plugin_api.desc:
+"""Call the API endpoints a plugin publishes, under /plugin_api. Does not grant plugin installation or configuration, which stay in the system scope"""
+
 scope_user_management.desc:
 """Manage dashboard users (create, update, delete, change other users' password)"""
 


### PR DESCRIPTION
Fixes:
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.2, 7.0.0
Introduced in:

## Summary

Adds `plugin_api`, an API scope that grants the plugin-extended API gateway and nothing else.

### The problem

All plugin-extended API calls go through one catch-all route in
`apps/emqx_plugins/src/emqx_plugins_api_endpoint.erl`:

```
"/plugin_api/:plugin/[...]"
```

It required the `system` scope. `system` is administrator-equivalent — it covers `/configs`
and `/data`, which can rewrite the whole node configuration. So anyone who needed to call a
plugin's API had to be handed the keys to the node.

**This is the plugin-extended API gateway only — the endpoints a plugin itself publishes.**
It is not `emqx_mgmt_api_plugins` (`/plugins`, `/plugins/:name`). Plugin administration —
install, start, stop, configure — stays on `system` and is untouched by this PR. The two are
easy to conflate.

### Backward compatibility

Existing API keys and Dashboard users that hold `system` must keep reaching the gateway. The
path therefore has to admit either scope, which the previous one-scope-per-path model could
not express. Two commits, so the mechanism change reads apart from the policy change.

**`refactor(api): let an API path declare several acceptable scopes`**

A `scopes/0` callback may now return a list of scope names, meaning a holder of any one of
them may call the path. A single binary keeps working, and the collector normalizes every
declaration to a list. Both scope checks — the API-key check in `emqx_mgmt_auth` and the
login-user check in `emqx_dashboard_rbac` — now test for a non-empty intersection through the
same `emqx_mgmt_api_key_scopes:any_scope_granted/2`, so a multi-scope path cannot be enforced
one way for keys and another for login users.

The alternative was to keep one scope per path and grant `plugin_api` implicitly to `system`
holders. The any-of declaration was chosen because an implication is invisible where a scope
list is read, and would have to be applied identically in API-key auth, login-user RBAC, the
role defaults and the bootstrap-file loader; missing one place breaks compatibility there
silently. The any-of form states the overlap where the path is declared, and one predicate
enforces it.

One lookup fix comes with it. The catch-all route needs it, and it is the only route of that
shape today:

* A trailing `[...]` template segment now matches the remainder of a concrete request path.
  Without it a concrete path resolved to no scope while its route template resolved to one,
  so the login-user check (which sees concrete paths) and the API-key check (which sees
  templates) disagreed about the same endpoint.

Handling of unmapped paths is unchanged. API keys are allowed through an unmapped path. Login users with an explicit scope list are denied it.

**`feat(api): add plugin_api scope for plugin-extended API calls`**

* `plugin_api` is a **restricted** scope, deliberately not in `?PRIVILEGE_SCOPES` — the whole
  point is a key that reaches a plugin without administering the node, and a privilege scope
  cannot be combined with restricted ones.
* It is in `?GENERIC_SCOPES` and `?NS_ADMIN_COMMON_SCOPES`, so accounts on the role defaults
  keep the access they have today. Namespaced callers reach the gateway through `system`
  today, and the gateway forwards the caller's namespace to the plugin.
* It is not in `?LOGIN_ONLY_SCOPES` or `?ADMIN_ONLY_SCOPES`, so API keys and Dashboard login
  users can both hold it.
* The gateway declares `[plugin_api, system]`. Keys and users created before this change hold
  `system` and keep working.

### Limitation

The scope says nothing about what a plugin does behind the gateway. A plugin can publish a
dangerous endpoint, and holding `plugin_api` reaches it. The scope bounds which EMQX surface
the caller reaches, not what the plugin exposes there.

### REST API impact

`plugin_api` is a new value in the `/api_key_scopes` and `/user_scopes` catalogs, and an
accepted value in the `POST /api_key`, `PUT /api_key/:name`, `POST /users` and
`PUT /users/:name` request bodies. Added enum value only; no endpoint, field or response shape
changed. Backward compatible.

### Tests

`emqx_plugins_api_endpoint_SUITE` (all through real HTTP against the gateway):

* `t_gateway_reachable_with_system_scope_key` — a key holding **only** `system` reaches the
  gateway. This is the compatibility regression guard: it fails if someone later removes the
  overlap.
* `t_gateway_reachable_with_plugin_api_scope_key` — a key holding only `plugin_api` reaches
  the gateway and is rejected (403) on `/configs`.
* `t_gateway_denied_without_either_scope` — a key holding neither is rejected.
* `t_gateway_login_user_scopes` — the login-user path, which runs through
  `emqx_dashboard_rbac:check_login_user_scopes/2` rather than
  `emqx_mgmt_auth:check_path_in_scopes/2`, for `plugin_api`, `system` and a third scope.
* `t_gateway_declares_both_scopes` — the route template and concrete request paths resolve to
  the same pair, including empty and multi-segment remainders.

`emqx_mgmt_api_key_scopes_SUITE`: `t_multi_scope_path` and `t_catch_all_template_matches_remainder` cover the mechanism directly against a synthetic
cache. `t_all_endpoints_covered_by_scopes` still guards against unmapped paths.

Suites run locally on the dev-60 base (OTP 27): `emqx_plugins_api_endpoint_SUITE` (13/13),
`emqx_mgmt_api_key_scopes_SUITE` (28/28), `emqx_dashboard_user_scopes_SUITE` (63/63),
`emqx_dashboard_rbac_SUITE` (31/31), `emqx_mgmt_api_api_keys_SUITE` (57/57).

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)


