### PR TITLE
fix(bridges): implement structural template interpolation for Doris

### DIFF
--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
@@ -201,7 +201,7 @@ prepare_sql_templates(#{
     sql := Template,
     batch_value_separator := _ConfiguredSeparator
 }) ->
-    case emqx_bridge_clickhouse_sql:compile(Template) of
+    case emqx_sql_plan:compile(emqx_bridge_clickhouse_sql, Template) of
         {ok, Plan} -> {ok, #{sql_plan => Plan}};
         {error, Reason} -> {error, Reason}
     end;
@@ -387,7 +387,7 @@ get_channel_state(ChannId, State) ->
     end.
 
 get_sql(channel_message, #{sql_plan := Plan}, Data, ChannelConf) ->
-    emqx_bridge_clickhouse_sql:render(Plan, Data, render_opts(ChannelConf));
+    emqx_sql_plan:render(Plan, Data, render_opts(ChannelConf));
 get_sql(_, _, SQL, _) ->
     {ok, SQL}.
 
@@ -413,7 +413,7 @@ on_batch_query(ResourceID, BatchReq, #{pool_name := PoolName} = State) ->
     #{sql_plan := Plan} = get_templates(ChannId, State),
     ChannelState = get_channel_state(ChannId, State),
     Opts = render_opts(maps:get(channel_conf, ChannelState, #{})),
-    case emqx_bridge_clickhouse_sql:render_batch(Plan, ObjectsToInsert, Opts) of
+    case emqx_sql_plan:render_batch(Plan, ObjectsToInsert, Opts) of
         {ok, SQL} ->
             ResultFromClickhouse = execute_sql_in_clickhouse_server(ChannId, PoolName, SQL),
             transform_and_log_clickhouse_result(ResultFromClickhouse, ResourceID, SQL);

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
@@ -5,10 +5,10 @@
 %% @doc Compile and render restricted ClickHouse INSERT templates.
 -module(emqx_bridge_clickhouse_sql).
 
--export([compile/1, render/3, render_batch/3, parse_placeholder/1]).
--export_type([plan/0]).
+-behaviour(emqx_sql_plan).
 
--elvis([{elvis_style, no_match_in_condition, disable}]).
+-export([compile/1, render/3, render_batch/3]).
+-export_type([plan/0]).
 
 -type placeholder() :: emqx_template:placeholder().
 
@@ -97,18 +97,6 @@ render_batch(
 ) ->
     render_batch_insert(Prefix, Plan, DataList, Opts, ?JSON_BATCH_SEPARATOR).
 
--spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
-parse_placeholder(Source) ->
-    case valid_placeholder_source(Source) of
-        true ->
-            case emqx_template:parse(Source) of
-                [{var, _, _} = Placeholder] -> {ok, Placeholder};
-                _ -> {error, invalid_placeholder}
-            end;
-        false ->
-            {error, invalid_placeholder}
-    end.
-
 %%------------------------------------------------------------------------------
 %% Private funs
 %%------------------------------------------------------------------------------
@@ -120,7 +108,7 @@ render_insert(Prefix, Template, Data, Opts) ->
     end.
 
 render_batch_insert(Prefix, Plan, DataList, Opts, Separator) ->
-    case render_batch_units(DataList, Plan, Opts, _Index = 1, _Acc = [], Separator) of
+    case render_batch_units(DataList, Plan, Opts, 1, [], Separator) of
         {ok, Rendered} -> {ok, [Prefix, Rendered]};
         {error, _} = Error -> Error
     end.
@@ -626,27 +614,13 @@ hex_digit(Char) when Char >= $A, Char =< $F -> Char - $A + 10;
 hex_digit(Char) when Char >= $a, Char =< $f -> Char - $a + 10;
 hex_digit(Char) -> error({invalid_hex_digit, Char}).
 
-%% Restrict emqx_template's envelope to nonempty dotted paths.
-%% Retain `${}` and `${.}`.
-%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
-valid_placeholder_source(<<"${}">>) ->
-    true;
-valid_placeholder_source(<<"${.}">>) ->
-    true;
-valid_placeholder_source(Source) ->
-    re:run(
-        Source,
-        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
-        [{capture, none}]
-    ) =:= match.
-
 take_placeholder(Bin) ->
     case binary:match(Bin, <<"}">>) of
         {End, 1} ->
             Size = End + 1,
             Source = binary:part(Bin, 0, Size),
             Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
-            case parse_placeholder(Source) of
+            case emqx_sql_plan:parse_placeholder(Source) of
                 {ok, Placeholder} -> {Placeholder, Rest};
                 {error, _} -> error({invalid_placeholder, Source})
             end;
@@ -889,7 +863,7 @@ parse_insert_sql_template_test() ->
     ).
 
 test_placeholder(Name) ->
-    {ok, Placeholder} = parse_placeholder(<<"${", Name/binary, "}">>),
+    {ok, Placeholder} = emqx_sql_plan:parse_placeholder(<<"${", Name/binary, "}">>),
     Placeholder.
 
 test_tpl_placeholder(Name) ->

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql.erl
@@ -936,6 +936,32 @@ values_compile_and_render_test() ->
         rendered_binary(render(Plan, #{key => 1, data => <<"hello">>, timestamp => 2}, null_opts()))
     ).
 
+escaped_dollar_test() ->
+    Cases = [
+        {<<"${$}">>, <<"$">>},
+        {<<"${$}{amount}">>, <<"${amount}">>},
+        {<<"${$}${$}{amount}${$}">>, <<"$${amount}$">>},
+        {<<"${$}{$}">>, <<"${$}">>},
+        {<<"${$}{amount}${v}${$}{$}">>, <<"${amount}x${$}">>}
+    ],
+    Formats = [
+        {<<"VALUES ('">>, <<"')">>},
+        {<<"FORMAT Values ('">>, <<"')">>},
+        {<<"FORMAT JSONCompactEachRow [\"">>, <<"\"]">>}
+    ],
+    lists:foreach(
+        fun({{Prefix, Suffix}, {Body, Expected}}) ->
+            {ok, Plan} = compile(
+                <<"INSERT INTO t ", Prefix/binary, Body/binary, Suffix/binary>>
+            ),
+            ?assertEqual(
+                {ok, <<"INSERT INTO `t` ", Prefix/binary, Expected/binary, Suffix/binary>>},
+                rendered_binary(render(Plan, #{amount => 99, v => <<"x">>}, null_opts()))
+            )
+        end,
+        [{Format, Case} || Format <- Formats, Case <- Cases]
+    ).
+
 %% Checks rendering of CASE, logical operators, comparisons, and conditional functions.
 conditional_expression_test() ->
     SQL = <<

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.xrl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_sql_lexer.xrl
@@ -92,7 +92,7 @@ to_binary(Chars) ->
 
 placeholder(Chars, Line) ->
     Bin = to_binary(Chars),
-    case emqx_bridge_clickhouse_sql:parse_placeholder(Bin) of
+    case emqx_sql_plan:parse_placeholder(Bin) of
         {ok, Placeholder} -> {token, {placeholder, Line, Placeholder}};
         {error, _} -> {error, {invalid_placeholder, Line, Bin}}
     end.

--- a/apps/emqx_bridge_doris/README.md
+++ b/apps/emqx_bridge_doris/README.md
@@ -1,0 +1,41 @@
+# Doris Batch SQL Templates
+
+`emqx_doris_sql` compiles a restricted Doris `INSERT INTO ... VALUES (...)`
+template with one row. Batch rendering repeats that row. Single-message actions
+continue to use prepared statements through the shared MySQL protocol driver.
+
+Dynamic UTF-8 text uses single-quoted literals with Doris backslash escapes,
+including `\0` for NUL. Only invalid UTF-8 uses `UNHEX` to preserve the bytes.
+The shared connector clears `NO_BACKSLASH_ESCAPES` and `ANSI_QUOTES` when
+preparing statements and reconnecting.
+
+Ordinary and raw (`R'...'`, `r"..."`) strings support interpolation. Raw strings
+preserve their body bytes without decoding backslashes. The compiler normalizes
+raw literals to avoid Doris 2.1.9's inconsistent handling of the `R` prefix.
+Without a dynamic placeholder, `${$}` stays unchanged. With interpolation, it
+produces `$`, as in MySQL templates.
+
+## Limitations
+
+- Comments, dynamic identifiers, and multiple template rows are not supported.
+- `INSERT SELECT`, row aliases, and `ON DUPLICATE KEY UPDATE` are not supported.
+- `DEFAULT` is valid only as a direct row item.
+- Digit-starting identifiers require backticks.
+- MySQL hex literals and character-set introducers are not supported.
+
+## Maintenance
+
+The lexer and parser are hand-maintained against Doris 2.1.9, commit
+`3390475e02a359380b98cc99c965b65f77827054`:
+
+- [Upstream lexer](https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4)
+- [Upstream parser](https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4)
+- [LogicalPlanBuilder](https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java#L2391-L2405)
+- [LogicalPlanBuilderAssistant](https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilderAssistant.java)
+
+See `src/emqx_doris_sql_lexer.xrl` and `src/emqx_doris_sql_parser.yrl` for
+rule-specific references and deliberate deviations. Recheck compatibility when
+updating the supported Doris version.
+
+Run the Doris CT suites in the app's Docker CT environment. They cover the
+compiler, lexical boundaries, live value round trips, and batched actions.

--- a/apps/emqx_bridge_doris/src/emqx_bridge_doris.app.src
+++ b/apps/emqx_bridge_doris/src/emqx_bridge_doris.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_doris, [
     {description, "EMQX Enterprise Doris Bridge"},
-    {vsn, "1.0.0"},
+    {vsn, "1.0.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_doris/src/emqx_bridge_doris_impl.erl
+++ b/apps/emqx_bridge_doris/src/emqx_bridge_doris_impl.erl
@@ -32,7 +32,7 @@
 ]).
 
 %% API
--export([]).
+-export([prepare_conn/1]).
 
 %%------------------------------------------------------------------------------
 %% Type declarations
@@ -98,7 +98,13 @@ on_get_channels(ConnResId) ->
     {ok, connector_state()}.
 on_add_channel(ConnResId, ConnState, ChanResId, ActionConfig) ->
     emqx_bridge_mysql_connector:on_add_channel(
-        ConnResId, ConnState, ChanResId, ActionConfig#{sql_compiler => emqx_doris_sql}
+        ConnResId,
+        ConnState,
+        ChanResId,
+        ActionConfig#{
+            prepare_conn_fn => fun ?MODULE:prepare_conn/1,
+            sql_compiler => emqx_doris_sql
+        }
     ).
 
 -spec on_remove_channel(
@@ -146,6 +152,13 @@ on_batch_query(ConnResId, Queries, ConnState) ->
 %%------------------------------------------------------------------------------
 %% API
 %%------------------------------------------------------------------------------
+
+-spec prepare_conn(pid()) -> ok | {error, term()}.
+prepare_conn(Conn) ->
+    maybe
+        ok ?= mysql:query(Conn, <<"SET enable_nereids_planner = true">>),
+        ok ?= mysql:query(Conn, <<"SET enable_fallback_to_original_planner = false">>)
+    end.
 
 %%------------------------------------------------------------------------------
 %% Internal fns

--- a/apps/emqx_bridge_doris/src/emqx_bridge_doris_impl.erl
+++ b/apps/emqx_bridge_doris/src/emqx_bridge_doris_impl.erl
@@ -97,7 +97,9 @@ on_get_channels(ConnResId) ->
 ) ->
     {ok, connector_state()}.
 on_add_channel(ConnResId, ConnState, ChanResId, ActionConfig) ->
-    emqx_bridge_mysql_connector:on_add_channel(ConnResId, ConnState, ChanResId, ActionConfig).
+    emqx_bridge_mysql_connector:on_add_channel(
+        ConnResId, ConnState, ChanResId, ActionConfig#{sql_compiler => emqx_doris_sql}
+    ).
 
 -spec on_remove_channel(
     connector_resource_id(),

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql.erl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql.erl
@@ -5,10 +5,10 @@
 %% @doc Compile and render restricted Doris INSERT INTO VALUES templates.
 -module(emqx_doris_sql).
 
--export([compile/1, render/3, render_batch/3, parse_placeholder/1]).
--export_type([plan/0]).
+-behaviour(emqx_sql_plan).
 
--elvis([{elvis_style, no_match_in_condition, disable}]).
+-export([compile/1, render/3, render_batch/3]).
+-export_type([plan/0]).
 
 -type placeholder() :: emqx_template:placeholder().
 
@@ -70,21 +70,9 @@ render(#doris_plan{insert_prefix = Prefix, row_plan = Plan}, Data, Opts) ->
 
 -spec render_batch(plan(), [map()], map()) -> {ok, iolist()} | {error, term()}.
 render_batch(#doris_plan{insert_prefix = Prefix, row_plan = Plan}, DataList, Opts) ->
-    case render_batch_units(DataList, Plan, Opts, _Index = 1, _Acc = []) of
+    case render_batch_units(DataList, Plan, Opts, 1, []) of
         {ok, Rendered} -> {ok, [Prefix, Rendered]};
         {error, _} = Error -> Error
-    end.
-
--spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
-parse_placeholder(Source) ->
-    case valid_placeholder_source(Source) of
-        true ->
-            case emqx_template:parse(Source) of
-                [{var, _, _} = Placeholder] -> {ok, Placeholder};
-                _ -> {error, invalid_placeholder}
-            end;
-        false ->
-            {error, invalid_placeholder}
     end.
 
 %%------------------------------------------------------------------------------
@@ -369,27 +357,13 @@ merge_render_ops(Ops) ->
         )
     ).
 
-%% Restrict emqx_template's envelope to nonempty dotted paths.
-%% Retain `${}` and `${.}`.
-%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
-valid_placeholder_source(<<"${}">>) ->
-    true;
-valid_placeholder_source(<<"${.}">>) ->
-    true;
-valid_placeholder_source(Source) ->
-    re:run(
-        Source,
-        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
-        [{capture, none}]
-    ) =:= match.
-
 take_placeholder(Bin) ->
     case binary:match(Bin, <<"}">>) of
         {End, 1} ->
             Size = End + 1,
             Source = binary:part(Bin, 0, Size),
             Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
-            case parse_placeholder(Source) of
+            case emqx_sql_plan:parse_placeholder(Source) of
                 {ok, Placeholder} -> {Placeholder, Rest};
                 {error, _} -> error({invalid_placeholder, Source})
             end;

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql.erl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql.erl
@@ -1,0 +1,468 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc Compile and render restricted Doris INSERT INTO VALUES templates.
+-module(emqx_doris_sql).
+
+-export([compile/1, render/3, render_batch/3, parse_placeholder/1]).
+-export_type([plan/0]).
+
+-elvis([{elvis_style, no_match_in_condition, disable}]).
+
+-type placeholder() :: emqx_template:placeholder().
+
+%% Represent string templates, e.g. 'aaa ${bbb} ccc' as
+%% [
+%%   #string_raw{sql = <<"aaa ">>},
+%%   #string_placeholder{placeholder = {var, "bbb", ...}},
+%%   #string_raw{sql = <<"ccc ">>}
+%% ]
+-record(string_raw, {sql :: binary()}).
+-record(string_placeholder, {placeholder :: placeholder()}).
+-type string_part() :: #string_raw{} | #string_placeholder{}.
+-record(string_template, {parts :: [string_part()]}).
+
+%% Pre-rendered parts of a full SQL statement
+-record(raw, {sql :: binary()}).
+-record(value, {placeholder :: placeholder()}).
+
+-type render_op() :: #raw{} | #value{} | #string_template{}.
+-type render_plan() :: [render_op()].
+
+%% Doris has no row alias or ON DUPLICATE KEY UPDATE suffix.
+%% See README.md, Maintenance: Upstream parser.
+-record(doris_plan, {
+    insert_prefix :: binary(),
+    row_plan :: render_plan()
+}).
+
+-opaque plan() :: #doris_plan{}.
+
+-define(BATCH_SEPARATOR, <<", ">>).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec compile(binary()) -> {ok, plan()} | {error, term()}.
+compile(SQL) ->
+    try
+        case emqx_doris_sql_lexer:string(binary_to_list(SQL)) of
+            {ok, Tokens, _EndLine} ->
+                case emqx_doris_sql_parser:parse(Tokens) of
+                    {ok, AST} -> compile_ast(AST);
+                    {error, Reason} -> {error, {invalid_doris_insert_template, Reason}}
+                end;
+            {error, Reason, _EndLine} ->
+                {error, {invalid_doris_insert_template, Reason}}
+        end
+    catch
+        Class:CatchReason -> {error, {invalid_doris_insert_template, {Class, CatchReason}}}
+    end.
+
+-spec render(plan(), map(), map()) -> {ok, iolist()} | {error, term()}.
+render(#doris_plan{insert_prefix = Prefix, row_plan = Plan}, Data, Opts) ->
+    case render_unit(Plan, Data, Opts) of
+        {ok, Rendered} -> {ok, [Prefix, Rendered]};
+        {error, _} = Error -> Error
+    end.
+
+-spec render_batch(plan(), [map()], map()) -> {ok, iolist()} | {error, term()}.
+render_batch(#doris_plan{insert_prefix = Prefix, row_plan = Plan}, DataList, Opts) ->
+    case render_batch_units(DataList, Plan, Opts, _Index = 1, _Acc = []) of
+        {ok, Rendered} -> {ok, [Prefix, Rendered]};
+        {error, _} = Error -> Error
+    end.
+
+-spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
+parse_placeholder(Source) ->
+    case valid_placeholder_source(Source) of
+        true ->
+            case emqx_template:parse(Source) of
+                [{var, _, _} = Placeholder] -> {ok, Placeholder};
+                _ -> {error, invalid_placeholder}
+            end;
+        false ->
+            {error, invalid_placeholder}
+    end.
+
+%%------------------------------------------------------------------------------
+%% Private
+%%------------------------------------------------------------------------------
+
+render_batch_units([Data | Rest], Plan, Opts, Index, Acc) ->
+    case render_unit(Plan, Data, Opts) of
+        {ok, Rendered} ->
+            render_batch_units(Rest, Plan, Opts, Index + 1, [Rendered | Acc]);
+        {error, Reason} ->
+            {error, {doris_template_render_failed, #{batch_index => Index, reason => Reason}}}
+    end;
+render_batch_units([], _Plan, _Opts, _Index, Acc) ->
+    {ok, lists:join(?BATCH_SEPARATOR, lists:reverse(Acc))}.
+
+render_unit(Plan, Data, Opts) ->
+    render_plan(Plan, Data, Opts, #{}, []).
+
+render_plan([#raw{sql = SQL} | Rest], Data, Opts, Cache, Acc) ->
+    render_plan(Rest, Data, Opts, Cache, [SQL | Acc]);
+render_plan([#value{placeholder = Placeholder} | Rest], Data, Opts, Cache0, Acc) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            case encode_result(fun() -> encode_value(Value, Opts) end) of
+                {ok, Encoded} -> render_plan(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} -> {error, render_error(Placeholder, Reason)}
+            end;
+        {error, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end;
+render_plan([#string_template{parts = Parts} | Rest], Data, Opts, Cache0, Acc) ->
+    case render_string_parts(Parts, Data, Opts, Cache0, []) of
+        {ok, RenderedParts, Cache} ->
+            Rendered = render_concat(RenderedParts),
+            render_plan(Rest, Data, Opts, Cache, [Rendered | Acc]);
+        {error, Placeholder, Reason} ->
+            {error, render_error(Placeholder, Reason)}
+    end;
+render_plan([], _Data, _Opts, _Cache, Acc) ->
+    {ok, lists:reverse(Acc)}.
+
+render_string_parts([#string_raw{sql = SQL} | Rest], Data, Opts, Cache, Acc) ->
+    render_string_parts(Rest, Data, Opts, Cache, [SQL | Acc]);
+render_string_parts(
+    [#string_placeholder{placeholder = Placeholder} | Rest], Data, Opts, Cache0, Acc
+) ->
+    case resolve_placeholder(Placeholder, Data, Cache0) of
+        {ok, Value, Cache} ->
+            case encode_result(fun() -> encode_string(string_value(Value, Opts)) end) of
+                {ok, Encoded} ->
+                    render_string_parts(Rest, Data, Opts, Cache, [Encoded | Acc]);
+                {error, Reason} ->
+                    {error, Placeholder, Reason}
+            end;
+        {error, Reason} ->
+            {error, Placeholder, Reason}
+    end;
+render_string_parts([], _Data, _Opts, Cache, Acc) ->
+    {ok, lists:reverse(Acc), Cache}.
+
+render_concat([Only]) ->
+    Only;
+render_concat(Parts) ->
+    [<<"CONCAT(">>, lists:join(<<", ">>, Parts), <<")">>].
+
+resolve_placeholder({var, _Name, Accessor} = Placeholder, Data, Cache) ->
+    case Cache of
+        #{Placeholder := Value} ->
+            {ok, Value, Cache};
+        #{} ->
+            try emqx_jsonish:lookup(Accessor, Data) of
+                {ok, Value} -> {ok, Value, Cache#{Placeholder => Value}};
+                {error, _Reason} -> {ok, undefined, Cache#{Placeholder => undefined}}
+            catch
+                Class:Reason -> {error, {placeholder_lookup_failed, {Class, Reason}}}
+            end
+    end.
+
+render_error({var, Name, _Accessor}, Reason) ->
+    {invalid_sql_template_value, #{placeholder => Name, reason => Reason}}.
+
+encode_result(Encoder) ->
+    try
+        {ok, Encoder()}
+    catch
+        Class:Reason -> {error, {Class, Reason}}
+    end.
+
+compile_ast({insert, Target, Columns, Row}) ->
+    TargetSQL = serialize_target(Target),
+    ColumnsSQL = serialize_columns(Columns),
+    Prefix = <<"INSERT INTO ", TargetSQL/binary, ColumnsSQL/binary, " VALUES ">>,
+    RowPlan = merge_render_ops(compile_row(Row)),
+    {ok, #doris_plan{insert_prefix = Prefix, row_plan = RowPlan}}.
+
+serialize_target(Identifiers) ->
+    iolist_to_binary(lists:join($., [serialize_identifier(I) || I <- Identifiers])).
+
+serialize_columns(undefined) ->
+    <<>>;
+serialize_columns(Identifiers) ->
+    Content = lists:join(<<", ">>, [serialize_identifier(I) || I <- Identifiers]),
+    iolist_to_binary([" (", Content, ")"]).
+
+serialize_identifier({identifier, bare, Name}) ->
+    quote_identifier(Name);
+serialize_identifier({identifier, backtick, Source}) ->
+    ok = assert_no_placeholder(Source),
+    Source.
+
+serialize_reference_path(Identifiers) ->
+    iolist_to_binary(lists:join($., [serialize_reference_part(I) || I <- Identifiers])).
+
+%% The restricted lexer leaves unselected Doris keywords as bare identifiers.
+%% Keep quoting reference and function names as well as targets.
+%% See README.md, Maintenance: Upstream lexer, lines 93-558.
+serialize_reference_part({identifier, bare, Name}) ->
+    quote_identifier(Name);
+serialize_reference_part({identifier, backtick, Source}) ->
+    ok = assert_no_placeholder(Source),
+    Source.
+
+quote_identifier(Name) ->
+    Escaped = binary:replace(Name, <<"`">>, <<"``">>, [global]),
+    <<"`", Escaped/binary, "`">>.
+
+assert_no_placeholder(Source) ->
+    case binary:match(Source, <<"${">>) of
+        nomatch -> ok;
+        _ -> error(dynamic_identifier_not_allowed)
+    end.
+
+compile_row(Expressions) ->
+    [#raw{sql = <<"(">>} | join_ops(<<", ">>, [compile_expression(E) || E <- Expressions])] ++
+        [#raw{sql = <<")">>}].
+
+compile_expression({var, Placeholder}) ->
+    [#value{placeholder = Placeholder}];
+compile_expression({string, Source}) ->
+    case parse_sql_string(Source) of
+        {static, SQL} -> [#raw{sql = SQL}];
+        {dynamic, Parts} -> [#string_template{parts = Parts}]
+    end;
+compile_expression({number, Number}) ->
+    [#raw{sql = Number}];
+compile_expression(null) ->
+    [#raw{sql = <<"NULL">>}];
+compile_expression(true) ->
+    [#raw{sql = <<"TRUE">>}];
+compile_expression(false) ->
+    [#raw{sql = <<"FALSE">>}];
+compile_expression(default) ->
+    [#raw{sql = <<"DEFAULT">>}];
+compile_expression({identifier_ref, Name}) ->
+    [#raw{sql = serialize_reference_path(Name)}];
+compile_expression({call, Name, Args}) ->
+    FunctionName = serialize_reference_path(Name),
+    [
+        #raw{sql = <<FunctionName/binary, "(">>}
+        | join_ops(<<", ">>, [
+            compile_expression(E)
+         || E <- Args
+        ])
+    ] ++ [#raw{sql = <<")">>}];
+compile_expression({group, Expression}) ->
+    [#raw{sql = <<"(">>} | compile_expression(Expression)] ++ [#raw{sql = <<")">>}];
+compile_expression({unary, Operator, Expression}) ->
+    [#raw{sql = <<(atom_to_binary(Operator))/binary, "(">>} | compile_expression(Expression)] ++
+        [#raw{sql = <<")">>}];
+compile_expression({is_null, Expression, Negated}) ->
+    Suffix =
+        case Negated of
+            true -> <<" IS NOT NULL">>;
+            false -> <<" IS NULL">>
+        end,
+    compile_expression(Expression) ++ [#raw{sql = Suffix}];
+compile_expression({case_expression, Operand, Whens, Else}) ->
+    [#raw{sql = <<"CASE">>}] ++
+        compile_case_operand(Operand) ++
+        lists:append([compile_when_clause(Clause) || Clause <- Whens]) ++
+        compile_case_else(Else) ++
+        [#raw{sql = <<" END">>}];
+compile_expression({binary, Operator, Left, Right}) ->
+    compile_expression(Left) ++
+        [#raw{sql = <<" ", (atom_to_binary(Operator))/binary, " ">>}] ++
+        compile_expression(Right).
+
+compile_case_operand(undefined) ->
+    [];
+compile_case_operand(Expression) ->
+    [#raw{sql = <<" ">>} | compile_expression(Expression)].
+
+compile_when_clause({'when', Condition, Result}) ->
+    [#raw{sql = <<" WHEN ">>} | compile_expression(Condition)] ++
+        [#raw{sql = <<" THEN ">>} | compile_expression(Result)].
+
+compile_case_else(undefined) ->
+    [];
+compile_case_else(Expression) ->
+    [#raw{sql = <<" ELSE ">>} | compile_expression(Expression)].
+
+%% Raw STRING_LITERAL bodies have no escape sequences or doubled delimiters.
+%% See README.md, Maintenance: Upstream lexer, lines 599-604.
+%% Normalize raw bodies because visitStringLiteral strips only the first character
+%% and decodes backslashes even for R-prefixed tokens in Doris 2.1.9.
+%% See README.md, Maintenance: LogicalPlanBuilder, lines 2391-2405.
+parse_sql_string(<<R, _/binary>> = Source) when R =:= $R; R =:= $r ->
+    Body = binary:part(Source, 2, byte_size(Source) - 3),
+    parse_sql_string_body(Body, raw, [], []);
+parse_sql_string(Source) ->
+    Delimiter = binary:first(Source),
+    Body = binary:part(Source, 1, byte_size(Source) - 2),
+    parse_sql_string_body(Body, Delimiter, [], []).
+
+parse_sql_string_body(<<>>, Delimiter, Text, Parts) ->
+    case lists:reverse(flush_string_text(Text, Delimiter, Parts)) of
+        [] when Delimiter =:= raw ->
+            {static, iolist_to_binary(encode_string(<<>>))};
+        [] ->
+            {static, <<Delimiter, Delimiter>>};
+        [#string_raw{sql = SQL}] ->
+            {static, SQL};
+        FinalParts ->
+            ok = assert_safe_string_split(Text, Delimiter),
+            {dynamic, FinalParts}
+    end;
+parse_sql_string_body(<<"${$}", Rest/binary>>, Delimiter, Text, Parts) ->
+    parse_sql_string_body(Rest, Delimiter, [$$ | Text], Parts);
+parse_sql_string_body(<<"${", _/binary>> = Bin, Delimiter, Text, Parts) ->
+    ok = assert_safe_string_split(Text, Delimiter),
+    {Placeholder, Rest} = take_placeholder(Bin),
+    PartsNext = [
+        #string_placeholder{placeholder = Placeholder}
+        | flush_string_text(Text, Delimiter, Parts)
+    ],
+    parse_sql_string_body(Rest, Delimiter, [], PartsNext);
+parse_sql_string_body(<<Char, Rest/binary>>, Delimiter, Text, Parts) ->
+    parse_sql_string_body(Rest, Delimiter, [Char | Text], Parts).
+
+flush_string_text([], _Delimiter, Parts) ->
+    Parts;
+flush_string_text(Text, raw, Parts) ->
+    Body = iolist_to_binary(lists:reverse(Text)),
+    [#string_raw{sql = iolist_to_binary(encode_string(Body))} | Parts];
+flush_string_text(Text, Delimiter, Parts) ->
+    Body = iolist_to_binary(lists:reverse(Text)),
+    [#string_raw{sql = <<Delimiter, Body/binary, Delimiter>>} | Parts].
+
+assert_safe_string_split(_ReversedText, raw) ->
+    ok;
+assert_safe_string_split(ReversedText, _Delimiter) ->
+    case count_leading_backslashes(ReversedText, 0) rem 2 of
+        0 -> ok;
+        1 -> error(ambiguous_string_placeholder_boundary)
+    end.
+
+count_leading_backslashes([$\\ | Rest], Count) ->
+    count_leading_backslashes(Rest, Count + 1);
+count_leading_backslashes(_, Count) ->
+    Count.
+
+join_ops(_Separator, []) ->
+    [];
+join_ops(Separator, [Ops | Rest]) ->
+    lists:foldl(fun(Next, Acc) -> Acc ++ [#raw{sql = Separator} | Next] end, Ops, Rest).
+
+-spec merge_render_ops(render_plan()) -> render_plan().
+merge_render_ops(Ops) ->
+    lists:reverse(
+        lists:foldl(
+            fun
+                (#raw{sql = <<>>}, Acc) ->
+                    Acc;
+                (#raw{sql = SQL}, [#raw{sql = Previous} | Acc]) ->
+                    [#raw{sql = <<Previous/binary, SQL/binary>>} | Acc];
+                (Op, Acc) ->
+                    [Op | Acc]
+            end,
+            [],
+            Ops
+        )
+    ).
+
+%% Restrict emqx_template's envelope to nonempty dotted paths.
+%% Retain `${}` and `${.}`.
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
+valid_placeholder_source(<<"${}">>) ->
+    true;
+valid_placeholder_source(<<"${.}">>) ->
+    true;
+valid_placeholder_source(Source) ->
+    re:run(
+        Source,
+        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
+        [{capture, none}]
+    ) =:= match.
+
+take_placeholder(Bin) ->
+    case binary:match(Bin, <<"}">>) of
+        {End, 1} ->
+            Size = End + 1,
+            Source = binary:part(Bin, 0, Size),
+            Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
+            case parse_placeholder(Source) of
+                {ok, Placeholder} -> {Placeholder, Rest};
+                {error, _} -> error({invalid_placeholder, Source})
+            end;
+        nomatch ->
+            error(unterminated_placeholder)
+    end.
+
+encode_value(undefined, #{undefined_vars_as_null := false}) ->
+    encode_string(<<"undefined">>);
+encode_value(undefined, _Opts) ->
+    <<"NULL">>;
+encode_value(Value, _Opts) when is_integer(Value) ->
+    integer_to_binary(Value);
+encode_value(Value, _Opts) when is_float(Value) ->
+    emqx_template:to_string(Value);
+encode_value(Value, _Opts) ->
+    encode_string(to_text(Value)).
+
+string_value(undefined, Opts) ->
+    case maps:get(undefined_vars_as_null, Opts, true) of
+        true -> <<"null">>;
+        false -> <<"undefined">>
+    end;
+string_value(Value, _Opts) ->
+    to_text(Value).
+
+to_text(Value) when is_binary(Value) ->
+    Value;
+to_text(Value) ->
+    case unicode:characters_to_binary(emqx_template:to_string(Value)) of
+        Text when is_binary(Text) -> Text;
+        Error -> error({invalid_unicode, Error})
+    end.
+
+%% Doris accepts NUL as \0 and uses UNHEX instead of MySQL hex literals.
+%% See README.md, Maintenance: Upstream lexer, lines 599-604.
+encode_string(Text) ->
+    case unicode:characters_to_list(Text) of
+        Chars when is_list(Chars) ->
+            [<<"'">>, escape_string(Text), <<"'">>];
+        _ ->
+            encode_hex_string(Text)
+    end.
+
+encode_hex_string(Text) ->
+    Hex = binary:encode_hex(Text),
+    <<"UNHEX('", Hex/binary, "')">>.
+
+escape_string(Text) ->
+    escape_string(Text, []).
+
+%% Match LogicalPlanBuilderAssistant.escapeBackSlash in the pinned Doris source.
+%% See README.md, Maintenance: LogicalPlanBuilderAssistant.
+%% The shared connector clears NO_BACKSLASH_ESCAPES and ANSI_QUOTES per session.
+escape_string(<<>>, Acc) ->
+    lists:reverse(Acc);
+escape_string(<<0, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\0">> | Acc]);
+escape_string(<<$\b, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\b">> | Acc]);
+escape_string(<<$\t, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\t">> | Acc]);
+escape_string(<<$\n, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\n">> | Acc]);
+escape_string(<<$\r, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\r">> | Acc]);
+escape_string(<<16#1A, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\Z">> | Acc]);
+escape_string(<<$", Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\\"">> | Acc]);
+escape_string(<<$', Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\'">> | Acc]);
+escape_string(<<$\\, Rest/binary>>, Acc) ->
+    escape_string(Rest, [<<"\\\\">> | Acc]);
+escape_string(<<Char, Rest/binary>>, Acc) ->
+    escape_string(Rest, [Char | Acc]).

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql.erl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql.erl
@@ -227,6 +227,8 @@ compile_expression(false) ->
     [#raw{sql = <<"FALSE">>}];
 compile_expression(default) ->
     [#raw{sql = <<"DEFAULT">>}];
+compile_expression({builtin_expression, SQL}) ->
+    [#raw{sql = SQL}];
 compile_expression({identifier_ref, Name}) ->
     [#raw{sql = serialize_reference_path(Name)}];
 compile_expression({call, Name, Args}) ->

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql_lexer.xrl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql_lexer.xrl
@@ -90,7 +90,7 @@ Erlang code.
 to_binary(Chars) -> list_to_binary(Chars).
 
 placeholder(Chars, Line) ->
-    case emqx_doris_sql:parse_placeholder(to_binary(Chars)) of
+    case emqx_sql_plan:parse_placeholder(to_binary(Chars)) of
         {ok, Var} -> {token, {placeholder, Line, Var}};
         {error, Reason} -> {error, Reason}
     end.

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql_lexer.xrl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql_lexer.xrl
@@ -108,6 +108,13 @@ identifier(Chars, Line) ->
         <<"true">> -> {token, {true, Line}};
         <<"false">> -> {token, {false, Line}};
         <<"default">> -> {token, {default, Line}};
+        <<"current_date">> -> {token, {builtin_expression, Line, <<"CURRENT_DATE">>}};
+        <<"current_time">> -> {token, {builtin_expression, Line, <<"CURRENT_TIME">>}};
+        <<"current_timestamp">> -> {token, {builtin_expression, Line, <<"CURRENT_TIMESTAMP">>}};
+        <<"localtime">> -> {token, {builtin_expression, Line, <<"LOCALTIME">>}};
+        <<"localtimestamp">> -> {token, {builtin_expression, Line, <<"LOCALTIMESTAMP">>}};
+        <<"current_user">> -> {token, {builtin_expression, Line, <<"CURRENT_USER">>}};
+        <<"session_user">> -> {token, {builtin_expression, Line, <<"SESSION_USER">>}};
         <<"case">> -> {token, {case_kw, Line}};
         <<"when">> -> {token, {when_kw, Line}};
         <<"then">> -> {token, {then_kw, Line}};

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql_lexer.xrl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql_lexer.xrl
@@ -1,0 +1,121 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+%% Restricted lexer based on Doris 2.1.9. Not a full ANTLR translation.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4
+%% Input is bytes (0..255), with no Unicode validation. Leex uses longest match,
+%% then rule order. Numeric predicates are not translated; see README.md.
+
+Definitions.
+
+%% Quoted strings and identifiers. Strings use byte input and ASCII case-insensitive R.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L599-L604
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L647-L649
+STRING_LITERAL = ('(\\[\x{0}-\x{FF}]|''|[^'\\])*'|"(\\[\x{0}-\x{FF}]|""|[^"\\])*"|[Rr]'[^']*'|[Rr]"[^"]*")
+%% "
+BACKQUOTED_IDENTIFIER = (`([^`]|``)*`)
+%% Character and numeric definitions. LETTER uses bytes rather than Unicode code points.
+%% EXPONENT uses ASCII case-insensitive E.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L651-L668
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L625-L627
+LETTER = ([$A-Z_a-z]|[\x{80}-\x{FF}])
+DIGIT = [0-9]
+DECIMAL_DIGITS = ([0-9]+\.[0-9]*|\.[0-9]+)
+EXPONENT = ([Ee][+\-]?[0-9]+)
+INTEGER_VALUE = ([0-9]+)
+%% WS:
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L682-L684
+WS = ([\x{9}-\x{A}\x{D}\x{20}]+)
+%% Reject digit-starting bare identifiers because they are ambiguous with numeric literals.
+%% Local restriction of IDENTIFIER, which allows a leading digit upstream.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L643-L645
+IDENTIFIER = {LETTER}({LETTER}|{DIGIT})*
+%% EMQX ${...} placeholders have no upstream counterpart; Doris PLACEHOLDER is '?'.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L405
+PLACEHOLDER = \$\{[A-Za-z0-9_.]*\}
+%% Combine INTEGER_VALUE, EXPONENT_VALUE and DECIMAL_VALUE without Java predicates.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L625-L636
+NUMBER = ({INTEGER_VALUE}|{DECIMAL_DIGITS}){EXPONENT}?
+%% Fail closed instead of implementing ANTLR's decimal lookahead/backtracking.
+%% Valid exponents win equal-length matches.
+%% Local conservative approximation of isValidDecimal(), not an upstream token.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L29-L48
+BAD_DECIMAL = {DECIMAL_DIGITS}{EXPONENT}?[A-Za-z_][A-Za-z0-9_]*
+
+Rules.
+
+%% WS: skip rather than emit on the hidden channel.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L682-L684
+{WS} : skip_token.
+%% Reject SIMPLE_COMMENT and BRACKETED_COMMENT prefixes instead of consuming comments.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L670-L676
+-- : {error, comments_not_allowed}.
+\/\* : {error, comments_not_allowed}.
+%% Emit local tokens using the definitions and source references above.
+%% NUMBER merges INTEGER_VALUE, EXPONENT_VALUE and DECIMAL_VALUE.
+%% BAD_DECIMAL rejects unsupported boundaries; IDENTIFIER classifies keywords below.
+{PLACEHOLDER} : placeholder(TokenChars, TokenLine).
+{STRING_LITERAL} : {token, {string, TokenLine, to_binary(TokenChars)}}.
+{BACKQUOTED_IDENTIFIER} : {token, {bt_identifier, TokenLine, to_binary(TokenChars)}}.
+{NUMBER} : {token, {number, TokenLine, to_binary(TokenChars)}}.
+{BAD_DECIMAL} : {error, unsupported_decimal_boundary}.
+{IDENTIFIER} : identifier(TokenChars, TokenLine).
+%% Punctuation.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L61-L66
+; : {token, {';', TokenLine}}.
+\( : {token, {'(', TokenLine}}.
+\) : {token, {')', TokenLine}}.
+, : {token, {',', TokenLine}}.
+\. : {token, {'.', TokenLine}}.
+%% Comparison and arithmetic operators.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L571-L583
+(=|==) : {token, {'=', TokenLine}}.
+<=> : {token, {'<=>', TokenLine}}.
+(<>|!=) : {token, {'<>', TokenLine}}.
+< : {token, {'<', TokenLine}}.
+(<=|!>) : {token, {'<=', TokenLine}}.
+> : {token, {'>', TokenLine}}.
+(>=|!<) : {token, {'>=', TokenLine}}.
+\+ : {token, {'+', TokenLine}}.
+- : {token, {'-', TokenLine}}.
+\* : {token, {'*', TokenLine}}.
+/ : {token, {'/', TokenLine}}.
+\% : {token, {'%', TokenLine}}.
+%% Reject unsupported input rather than emit UNRECOGNIZED; Leex dot excludes LF.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L686-L691
+. : {error, {unsupported_token, to_binary(TokenChars)}}.
+
+Erlang code.
+
+to_binary(Chars) -> list_to_binary(Chars).
+
+placeholder(Chars, Line) ->
+    case emqx_doris_sql:parse_placeholder(to_binary(Chars)) of
+        {ok, Var} -> {token, {placeholder, Line, Var}};
+        {error, Reason} -> {error, Reason}
+    end.
+
+identifier(Chars, Line) ->
+    Bin = to_binary(Chars),
+    Lower = list_to_binary(string:lowercase(Chars)),
+    case Lower of
+        %% Selected Doris keywords; other names remain identifiers.
+        %% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L93-L558
+        <<"insert">> -> {token, {insert, Line}};
+        <<"into">> -> {token, {into, Line}};
+        <<"values">> -> {token, {values, Line}};
+        <<"null">> -> {token, {null, Line}};
+        <<"true">> -> {token, {true, Line}};
+        <<"false">> -> {token, {false, Line}};
+        <<"default">> -> {token, {default, Line}};
+        <<"case">> -> {token, {case_kw, Line}};
+        <<"when">> -> {token, {when_kw, Line}};
+        <<"then">> -> {token, {then_kw, Line}};
+        <<"else">> -> {token, {else_kw, Line}};
+        <<"end">> -> {token, {end_kw, Line}};
+        <<"is">> -> {token, {is_kw, Line}};
+        <<"and">> -> {token, {and_kw, Line}};
+        <<"or">> -> {token, {or_kw, Line}};
+        <<"not">> -> {token, {not_kw, Line}};
+        _ -> {token, {identifier, Line, Bin}}
+    end.

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql_lexer.xrl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql_lexer.xrl
@@ -36,11 +36,11 @@ PLACEHOLDER = \$\{[A-Za-z0-9_.]*\}
 %% Combine INTEGER_VALUE, EXPONENT_VALUE and DECIMAL_VALUE without Java predicates.
 %% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L625-L636
 NUMBER = ({INTEGER_VALUE}|{DECIMAL_DIGITS}){EXPONENT}?
-%% Fail closed instead of implementing ANTLR's decimal lookahead/backtracking.
-%% Valid exponents win equal-length matches.
-%% Local conservative approximation of isValidDecimal(), not an upstream token.
+%% Reject numeric prefixes followed by identifier characters. This enforces the
+%% local digit-starting identifier restriction and rejects unsupported suffixes.
+%% NUMBER precedes BAD_NUMBER so valid exponents win equal-length matches.
 %% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L29-L48
-BAD_DECIMAL = {DECIMAL_DIGITS}{EXPONENT}?[A-Za-z_][A-Za-z0-9_]*
+BAD_NUMBER = ({INTEGER_VALUE}|{DECIMAL_DIGITS}){EXPONENT}?{LETTER}({LETTER}|{DIGIT})*
 
 Rules.
 
@@ -53,12 +53,12 @@ Rules.
 \/\* : {error, comments_not_allowed}.
 %% Emit local tokens using the definitions and source references above.
 %% NUMBER merges INTEGER_VALUE, EXPONENT_VALUE and DECIMAL_VALUE.
-%% BAD_DECIMAL rejects unsupported boundaries; IDENTIFIER classifies keywords below.
+%% BAD_NUMBER rejects unsupported boundaries; IDENTIFIER classifies keywords below.
 {PLACEHOLDER} : placeholder(TokenChars, TokenLine).
 {STRING_LITERAL} : {token, {string, TokenLine, to_binary(TokenChars)}}.
 {BACKQUOTED_IDENTIFIER} : {token, {bt_identifier, TokenLine, to_binary(TokenChars)}}.
 {NUMBER} : {token, {number, TokenLine, to_binary(TokenChars)}}.
-{BAD_DECIMAL} : {error, unsupported_decimal_boundary}.
+{BAD_NUMBER} : {error, unsupported_number}.
 {IDENTIFIER} : identifier(TokenChars, TokenLine).
 %% Punctuation.
 %% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4#L61-L66

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql_parser.yrl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql_parser.yrl
@@ -13,6 +13,7 @@ Nonterminals
     expression unary_expression primary args opt_args case_expression opt_operand whens opt_else opt_semicolon.
 Terminals
     insert into values null true false default
+    builtin_expression
     case_kw when_kw then_kw else_kw end_kw is_kw and_kw or_kw not_kw
     identifier placeholder number string bt_identifier
     '(' ')' ',' '.' ';' '=' '<=>' '>=' '<=' '<>' '!=' '>' '<' '+' '-' '*' '/' '%'.
@@ -48,6 +49,9 @@ primary -> number : {number, value('$1')}.
 primary -> null : null.
 primary -> true : true.
 primary -> false : false.
+%% Bare temporal and user expressions from primaryExpression.
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4#L1479-L1485
+primary -> builtin_expression : {builtin_expression, value('$1')}.
 primary -> name_path : {identifier_ref, '$1'}.
 primary -> name_path '(' opt_args ')' : {call, '$1', '$3'}.
 primary -> '(' expression ')' : {group, '$2'}.

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql_parser.yrl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql_parser.yrl
@@ -16,12 +16,12 @@ Terminals
     builtin_expression
     case_kw when_kw then_kw else_kw end_kw is_kw and_kw or_kw not_kw
     identifier placeholder number string bt_identifier
-    '(' ')' ',' '.' ';' '=' '<=>' '>=' '<=' '<>' '!=' '>' '<' '+' '-' '*' '/' '%'.
+    '(' ')' ',' '.' ';' '=' '<=>' '>=' '<=' '<>' '>' '<' '+' '-' '*' '/' '%'.
 Rootsymbol template.
 Left 10 or_kw.
 Left 20 and_kw.
 Right 30 not_kw.
-Nonassoc 40 '=' '<=>' '>=' '<=' '<>' '!=' '>' '<' is_kw.
+Nonassoc 40 '=' '<=>' '>=' '<=' '<>' '>' '<' is_kw.
 Left 100 '+' '-'.
 Left 200 '*' '/' '%'.
 
@@ -65,7 +65,6 @@ expression -> expression '<=>' expression : {binary, '<=>', '$1', '$3'}.
 expression -> expression '>=' expression : {binary, '>=', '$1', '$3'}.
 expression -> expression '<=' expression : {binary, '<=', '$1', '$3'}.
 expression -> expression '<>' expression : {binary, '<>', '$1', '$3'}.
-expression -> expression '!=' expression : {binary, '!=', '$1', '$3'}.
 expression -> expression '>' expression : {binary, '>', '$1', '$3'}.
 expression -> expression '<' expression : {binary, '<', '$1', '$3'}.
 expression -> expression is_kw null : {is_null, '$1', false}.

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql_parser.yrl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql_parser.yrl
@@ -55,6 +55,7 @@ primary -> builtin_expression : {builtin_expression, value('$1')}.
 primary -> name_path : {identifier_ref, '$1'}.
 primary -> name_path '(' opt_args ')' : {call, '$1', '$3'}.
 primary -> '(' expression ')' : {group, '$2'}.
+primary -> case_expression : '$1'.
 unary_expression -> primary : '$1'.
 unary_expression -> '+' unary_expression : {unary, '+', '$2'}.
 unary_expression -> '-' unary_expression : {unary, '-', '$2'}.
@@ -76,7 +77,6 @@ expression -> expression '-' expression : {binary, '-', '$1', '$3'}.
 expression -> expression '*' expression : {binary, '*', '$1', '$3'}.
 expression -> expression '/' expression : {binary, '/', '$1', '$3'}.
 expression -> expression '%' expression : {binary, '%', '$1', '$3'}.
-primary -> case_expression : '$1'.
 case_expression -> case_kw opt_operand whens opt_else end_kw :
     {case_expression, '$2', '$3', '$4'}.
 opt_operand -> '$empty' : undefined.

--- a/apps/emqx_bridge_doris/src/emqx_doris_sql_parser.yrl
+++ b/apps/emqx_bridge_doris/src/emqx_doris_sql_parser.yrl
@@ -1,0 +1,90 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+%% Restricted Doris INSERT VALUES grammar, not a full dialect parser.
+%% Source: supportedDmlStatement, inlineTable, rowConstructor, expression,
+%% primaryExpression, multipartIdentifier in Doris 2.1.9:
+%% https://github.com/apache/doris/blob/3390475e02a359380b98cc99c965b65f77827054/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+%% DEFAULT is a direct row item only. Row aliases and duplicate-key suffixes
+%% are absent. One template row expands to multiple rows during rendering.
+
+Nonterminals
+    template name_path static_identifier opt_columns identifier_list row_items row_item
+    expression unary_expression primary args opt_args case_expression opt_operand whens opt_else opt_semicolon.
+Terminals
+    insert into values null true false default
+    case_kw when_kw then_kw else_kw end_kw is_kw and_kw or_kw not_kw
+    identifier placeholder number string bt_identifier
+    '(' ')' ',' '.' ';' '=' '<=>' '>=' '<=' '<>' '!=' '>' '<' '+' '-' '*' '/' '%'.
+Rootsymbol template.
+Left 10 or_kw.
+Left 20 and_kw.
+Right 30 not_kw.
+Nonassoc 40 '=' '<=>' '>=' '<=' '<>' '!=' '>' '<' is_kw.
+Left 100 '+' '-'.
+Left 200 '*' '/' '%'.
+
+template -> insert into name_path opt_columns values '(' row_items ')' opt_semicolon :
+    {insert, '$3', '$4', '$7'}.
+static_identifier -> identifier : {identifier, bare, value('$1')}.
+static_identifier -> bt_identifier : {identifier, backtick, value('$1')}.
+name_path -> static_identifier : ['$1'].
+name_path -> name_path '.' static_identifier : '$1' ++ ['$3'].
+opt_columns -> '$empty' : undefined.
+opt_columns -> '(' identifier_list ')' : '$2'.
+identifier_list -> static_identifier : ['$1'].
+identifier_list -> identifier_list ',' static_identifier : '$1' ++ ['$3'].
+row_items -> row_item : ['$1'].
+row_items -> row_items ',' row_item : '$1' ++ ['$3'].
+row_item -> default : default.
+row_item -> expression : '$1'.
+opt_args -> '$empty' : [].
+opt_args -> args : '$1'.
+args -> expression : ['$1'].
+args -> args ',' expression : '$1' ++ ['$3'].
+primary -> placeholder : {var, value('$1')}.
+primary -> string : {string, value('$1')}.
+primary -> number : {number, value('$1')}.
+primary -> null : null.
+primary -> true : true.
+primary -> false : false.
+primary -> name_path : {identifier_ref, '$1'}.
+primary -> name_path '(' opt_args ')' : {call, '$1', '$3'}.
+primary -> '(' expression ')' : {group, '$2'}.
+unary_expression -> primary : '$1'.
+unary_expression -> '+' unary_expression : {unary, '+', '$2'}.
+unary_expression -> '-' unary_expression : {unary, '-', '$2'}.
+expression -> unary_expression : '$1'.
+expression -> not_kw expression : {unary, 'NOT', '$2'}.
+expression -> expression '=' expression : {binary, '=', '$1', '$3'}.
+expression -> expression '<=>' expression : {binary, '<=>', '$1', '$3'}.
+expression -> expression '>=' expression : {binary, '>=', '$1', '$3'}.
+expression -> expression '<=' expression : {binary, '<=', '$1', '$3'}.
+expression -> expression '<>' expression : {binary, '<>', '$1', '$3'}.
+expression -> expression '!=' expression : {binary, '!=', '$1', '$3'}.
+expression -> expression '>' expression : {binary, '>', '$1', '$3'}.
+expression -> expression '<' expression : {binary, '<', '$1', '$3'}.
+expression -> expression is_kw null : {is_null, '$1', false}.
+expression -> expression is_kw not_kw null : {is_null, '$1', true}.
+expression -> expression and_kw expression : {binary, 'AND', '$1', '$3'}.
+expression -> expression or_kw expression : {binary, 'OR', '$1', '$3'}.
+expression -> expression '+' expression : {binary, '+', '$1', '$3'}.
+expression -> expression '-' expression : {binary, '-', '$1', '$3'}.
+expression -> expression '*' expression : {binary, '*', '$1', '$3'}.
+expression -> expression '/' expression : {binary, '/', '$1', '$3'}.
+expression -> expression '%' expression : {binary, '%', '$1', '$3'}.
+primary -> case_expression : '$1'.
+case_expression -> case_kw opt_operand whens opt_else end_kw :
+    {case_expression, '$2', '$3', '$4'}.
+opt_operand -> '$empty' : undefined.
+opt_operand -> expression : '$1'.
+whens -> when_kw expression then_kw expression : [{'when', '$2', '$4'}].
+whens -> whens when_kw expression then_kw expression : '$1' ++ [{'when', '$3', '$5'}].
+opt_else -> '$empty' : undefined.
+opt_else -> else_kw expression : '$2'.
+opt_semicolon -> '$empty' : false.
+opt_semicolon -> ';' : true.
+
+Erlang code.
+-ignore_xref({return_error, 2}).
+value({_Token, _Line, Value}) -> Value.

--- a/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
@@ -449,7 +449,8 @@ t_sql_compiler_roundtrip(Config) ->
     {ok, _, [[Modes]]} = mysql:query(C, <<"SELECT @@SESSION.sql_mode">>),
     ?assertEqual(nomatch, binary:match(Modes, <<"ANSI_QUOTES">>)),
     ?assertEqual(nomatch, binary:match(Modes, <<"NO_BACKSLASH_ESCAPES">>)),
-    {ok, Plan} = emqx_doris_sql:compile(
+    {ok, Plan} = emqx_sql_plan:compile(
+        emqx_doris_sql,
         <<"INSERT INTO mqtt.t_mqtt_msg(payload) VALUES (${payload})">>
     ),
     Values = [
@@ -467,7 +468,7 @@ t_sql_compiler_roundtrip(Config) ->
         <<16#ED, 16#A0, 16#80>>,
         <<16#F4, 16#90, 16#80, 16#80>>
     ],
-    {ok, SQL} = emqx_doris_sql:render_batch(
+    {ok, SQL} = emqx_sql_plan:render_batch(
         Plan, [#{payload => Value} || Value <- Values], #{}
     ),
     ?assertEqual(ok, mysql:query(C, iolist_to_binary(SQL))),
@@ -476,10 +477,11 @@ t_sql_compiler_roundtrip(Config) ->
         lists:sort([[binary:encode_hex(Value)] || Value <- Values]),
         lists:sort(Rows)
     ),
-    {ok, TextPlan} = emqx_doris_sql:compile(
+    {ok, TextPlan} = emqx_sql_plan:compile(
+        emqx_doris_sql,
         <<"INSERT INTO mqtt.t_mqtt_msg(payload) VALUES ('prefix ${payload} suffix')">>
     ),
-    {ok, TextSQL} = emqx_doris_sql:render_batch(
+    {ok, TextSQL} = emqx_sql_plan:render_batch(
         TextPlan, [#{payload => Value} || Value <- Values], #{}
     ),
     ?assertEqual(ok, mysql:query(C, iolist_to_binary(TextSQL))),
@@ -490,13 +492,14 @@ t_sql_compiler_roundtrip(Config) ->
         ),
         lists:sort(TextRows)
     ),
-    {ok, ExpressionPlan} = emqx_doris_sql:compile(
+    {ok, ExpressionPlan} = emqx_sql_plan:compile(
+        emqx_doris_sql,
         ~B"""
         INSERT INTO mqtt.t_mqtt_msg(payload)
         VALUES (CONCAT('a''b', R'c\', ${value}))
         """
     ),
-    {ok, ExpressionSQL} = emqx_doris_sql:render(ExpressionPlan, #{value => <<"d">>}, #{}),
+    {ok, ExpressionSQL} = emqx_sql_plan:render(ExpressionPlan, #{value => <<"d">>}, #{}),
     ?assertEqual(ok, mysql:query(C, iolist_to_binary(ExpressionSQL))),
     %% Ordinary literals keep server semantics; raw bodies keep their bytes.
     {ok, _, [[Expected]]} = eval_query(<<"SELECT HEX(CONCAT('a''b', 'c\\\\', 'd'))">>, Config),
@@ -523,10 +526,11 @@ t_escaped_dollar_roundtrip(Config) ->
     ],
     ExpectedRows = [
         begin
-            {ok, Plan} = emqx_doris_sql:compile(
+            {ok, Plan} = emqx_sql_plan:compile(
+                emqx_doris_sql,
                 <<"INSERT INTO mqtt.t_mqtt_msg(payload) VALUES (", Quote, Body/binary, Quote, ")">>
             ),
-            {ok, SQL} = emqx_doris_sql:render(Plan, #{v => <<"x">>, amount => 99}, #{}),
+            {ok, SQL} = emqx_sql_plan:render(Plan, #{v => <<"x">>, amount => 99}, #{}),
             ?assertEqual(ok, mysql:query(C, iolist_to_binary(SQL))),
             [Expected]
         end
@@ -573,11 +577,12 @@ t_raw_string_roundtrip(Config) ->
     ],
     Expected = lists:append([
         begin
-            {ok, Plan} = emqx_doris_sql:compile(
+            {ok, Plan} = emqx_sql_plan:compile(
+                emqx_doris_sql,
                 <<"INSERT INTO mqtt.t_mqtt_msg(payload) VALUES (", R, Quote, Body/binary, Quote,
                     ")">>
             ),
-            {ok, SQL} = emqx_doris_sql:render_batch(Plan, [#{v => V} || V <- Values], #{}),
+            {ok, SQL} = emqx_sql_plan:render_batch(Plan, [#{v => V} || V <- Values], #{}),
             ?assertEqual(ok, mysql:query(C, iolist_to_binary(SQL)), {R, Quote, Body}),
             [[binary:encode_hex(ToExpected(V))] || V <- Values]
         end

--- a/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
@@ -437,6 +437,57 @@ t_batch_render_failure(Config) ->
         eval_query(<<"SELECT payload FROM mqtt.t_mqtt_msg ORDER BY payload">>, Config)
     ).
 
+t_connection_initialization(Config) ->
+    ok = meck:new(mysql, [passthrough, no_link]),
+    emqx_common_test_helpers:on_exit(fun() -> meck:unload(mysql) end),
+    ok = meck:expect(mysql, start_link, fun(Opts) ->
+        Queries = [
+            <<"SET SESSION sql_mode = 'ANSI_QUOTES,NO_BACKSLASH_ESCAPES'">>
+            | proplists:get_value(queries, Opts, [])
+        ],
+        meck:passthrough([[{queries, Queries} | proplists:delete(queries, Opts)]])
+    end),
+    ConnectorConfig = emqx_utils_maps:deep_merge(?config(connector_config, Config), #{
+        <<"pool_size">> => 1,
+        <<"resource_opts">> => #{<<"health_check_interval">> => <<"1h">>}
+    }),
+    {ok, {{_, 201, _}, _, _}} = emqx_bridge_v2_testlib:create_bridge_api([
+        {connector_config, ConnectorConfig} | Config
+    ]),
+    Name = ?config(connector_name, Config),
+    [{_, Worker}] = ecpool:workers(<<"connector:doris:", Name/binary>>),
+    {ok, Conn} = ecpool_worker:client(Worker),
+    assert_session_initialized(Conn),
+    ok = mysql:stop(Conn),
+    ?retry(
+        200,
+        100,
+        begin
+            {ok, NewConn} = ecpool_worker:client(Worker),
+            ?assertNotEqual(Conn, NewConn),
+            assert_session_initialized(NewConn)
+        end
+    ).
+
+assert_session_initialized(Conn) ->
+    ?assert(meck:called(mysql, query, [Conn, <<"SET enable_nereids_planner = true">>])),
+    ?assert(
+        meck:called(mysql, query, [Conn, <<"SET enable_fallback_to_original_planner = false">>])
+    ),
+    ?assertMatch(
+        {ok, _, [[1, 0]]},
+        mysql:query(
+            Conn,
+            <<
+                "SELECT @@SESSION.enable_nereids_planner, "
+                "@@SESSION.enable_fallback_to_original_planner"
+            >>
+        )
+    ),
+    {ok, _, [[Modes]]} = mysql:query(Conn, <<"SELECT @@SESSION.sql_mode">>),
+    ?assertEqual(nomatch, binary:match(Modes, <<"ANSI_QUOTES">>)),
+    ?assertEqual(nomatch, binary:match(Modes, <<"NO_BACKSLASH_ESCAPES">>)).
+
 t_sql_compiler_roundtrip(Config) ->
     {ok, C} = mysql:start_link([
         {host, emqx_utils_conv:str(host(Config))},
@@ -445,7 +496,7 @@ t_sql_compiler_roundtrip(Config) ->
         {basic_capabilities, #{?CLIENT_TRANSACTIONS => false}}
     ]),
     ok = mysql:query(C, <<"SET SESSION sql_mode = 'ANSI_QUOTES,NO_BACKSLASH_ESCAPES'">>),
-    ok = emqx_mysql:prepare_sql_to_conn(C, []),
+    ok = emqx_mysql:prepare_sql_to_conn(C, [], fun emqx_bridge_doris_impl:prepare_conn/1),
     {ok, _, [[Modes]]} = mysql:query(C, <<"SELECT @@SESSION.sql_mode">>),
     ?assertEqual(nomatch, binary:match(Modes, <<"ANSI_QUOTES">>)),
     ?assertEqual(nomatch, binary:match(Modes, <<"NO_BACKSLASH_ESCAPES">>)),
@@ -514,7 +565,7 @@ t_escaped_dollar_roundtrip(Config) ->
         {user, ?USERNAME},
         {basic_capabilities, #{?CLIENT_TRANSACTIONS => false}}
     ]),
-    ok = emqx_mysql:prepare_sql_to_conn(C, []),
+    ok = emqx_mysql:prepare_sql_to_conn(C, [], fun emqx_bridge_doris_impl:prepare_conn/1),
     Cases = [
         {<<"${$}">>, <<"$">>},
         {<<"cost: ${$}{amount}">>, <<"cost: ${amount}">>},
@@ -548,9 +599,7 @@ t_raw_string_roundtrip(Config) ->
         {basic_capabilities, #{?CLIENT_TRANSACTIONS => false}}
     ]),
     ok = mysql:query(C, <<"SET SESSION sql_mode = 'ANSI_QUOTES,NO_BACKSLASH_ESCAPES'">>),
-    ok = emqx_mysql:prepare_sql_to_conn(C, []),
-    ok = mysql:query(C, <<"SET enable_nereids_planner = true">>),
-    ok = mysql:query(C, <<"SET enable_fallback_to_original_planner = false">>),
+    ok = emqx_mysql:prepare_sql_to_conn(C, [], fun emqx_bridge_doris_impl:prepare_conn/1),
     %% Record native raw behavior separately from the compiler's byte-preserving semantics.
     Native = mysql:query(C, <<"SELECT HEX(R'a\\n'), HEX(r\"a\\n\"), HEX(R'a\\'), HEX(R'')">>),
     ct:print("Native Doris raw literals: ~p", [Native]),

--- a/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
@@ -602,7 +602,7 @@ t_raw_string_roundtrip(Config) ->
     ok = emqx_mysql:prepare_sql_to_conn(C, [], fun emqx_bridge_doris_impl:prepare_conn/1),
     %% Record native raw behavior separately from the compiler's byte-preserving semantics.
     Native = mysql:query(C, <<"SELECT HEX(R'a\\n'), HEX(r\"a\\n\"), HEX(R'a\\'), HEX(R'')">>),
-    ct:print("Native Doris raw literals: ~p", [Native]),
+    ct:pal("Native Doris raw literals: ~p", [Native]),
     ?assertMatch(
         {ok, _, [[<<"27610A">>, <<"22610A">>, <<"27615C">>, <<"27">>]]}, Native
     ),

--- a/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
@@ -271,6 +271,12 @@ t_rule_action(Config) when is_list(Config) ->
 t_batch_rule_action(Config) ->
     ActionConfig0 = ?config(action_config, Config),
     ActionConfig = emqx_utils_maps:deep_merge(ActionConfig0, #{
+        <<"parameters">> => #{
+            <<"sql">> => <<
+                "insert into t_mqtt_msg(msgid, topic, qos, payload, arrived)"
+                " values (${id}, ${topic}, ${qos}, ${payload}, CURRENT_TIMESTAMP)"
+            >>
+        },
         <<"resource_opts">> => #{<<"batch_size">> => 2, <<"batch_time">> => 10}
     }),
     BatchConfig = [{action_config, ActionConfig} | proplists:delete(action_config, Config)],

--- a/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_bridge_doris_SUITE.erl
@@ -267,3 +267,325 @@ t_rule_action(Config) when is_list(Config) ->
         post_publish_fn => PostPublishFn
     },
     emqx_bridge_v2_testlib:t_rule_action(Config, Opts).
+
+t_batch_rule_action(Config) ->
+    ActionConfig0 = ?config(action_config, Config),
+    ActionConfig = emqx_utils_maps:deep_merge(ActionConfig0, #{
+        <<"resource_opts">> => #{<<"batch_size">> => 2, <<"batch_time">> => 10}
+    }),
+    BatchConfig = [{action_config, ActionConfig} | proplists:delete(action_config, Config)],
+    Payload = <<"a'b\\c", 0, 255>>,
+    Expected = binary:encode_hex(Payload),
+    emqx_bridge_v2_testlib:t_rule_action(BatchConfig, #{
+        payload_fn => fun() -> Payload end,
+        post_publish_fn => fun(_Context) ->
+            ?retry(
+                100,
+                50,
+                ?assertMatch(
+                    {ok, _, [[Expected]]},
+                    eval_query(<<"SELECT HEX(payload) FROM mqtt.t_mqtt_msg">>, Config)
+                )
+            )
+        end
+    }).
+
+t_batch_values() ->
+    [{matrix, true}].
+t_batch_values(matrix) ->
+    [[null_missing], [text_missing]];
+t_batch_values(Config) when is_list(Config) ->
+    AsNull = lists:member(null_missing, group_path(Config, [])),
+    SQL = ~B"""
+    INSERT INTO t_mqtt_msg(msgid, topic, qos, payload) VALUES (
+        ${missing}, '${id}/${payload.n}/${missing}',
+        CASE
+            WHEN ${payload.n} IS NULL THEN 0
+            WHEN NOT ${payload.n} <=> 2 THEN (${payload.n} + 1) * 3
+            ELSE 1 + 2 * 3
+        END,
+        CONCAT(R'path\${payload.v}', '${$}{v}')
+    )
+    """,
+    ?assertMatch(
+        {ok, {{_, 201, _}, _, _}},
+        emqx_bridge_v2_testlib:create_bridge_api(Config, #{
+            <<"parameters">> => #{<<"sql">> => SQL, <<"undefined_vars_as_null">> => AsNull},
+            <<"resource_opts">> => #{
+                <<"batch_size">> => 3,
+                <<"batch_time">> => 1000,
+                <<"worker_pool_size">> => 1,
+                <<"query_mode">> => <<"async">>
+            }
+        })
+    ),
+    Name = ?config(action_name, Config),
+    _ = emqx_bridge_v2_testlib:kickoff_action_health_check(?ACTION_TYPE, Name),
+    Unicode = unicode:characters_to_binary([16#E9, 16#1F642]),
+    Messages = [
+        #{id => <<"a">>, payload => #{n => 2, v => <<"a'b\\c">>}},
+        #{id => <<"b">>, payload => emqx_utils_json:encode(#{n => 4, v => Unicode})},
+        #{id => <<"c">>, payload => #{n => 0, v => <<0, 255>>}}
+    ],
+    {Missing, Text} =
+        case AsNull of
+            true -> {null, <<"null">>};
+            false -> {<<"undefined">>, <<"undefined">>}
+        end,
+    ?check_trace(
+        begin
+            {_, {ok, _}} = ?wait_async_action(
+                lists:foreach(
+                    fun(Msg) ->
+                        ?assertEqual(ok, emqx_bridge_v2:send_message(?ACTION_TYPE, Name, Msg, #{}))
+                    end,
+                    Messages
+                ),
+                #{?snk_kind := mysql_connector_on_batch_query_return, result := ok},
+                10_000
+            ),
+            Expected = [
+                [Missing, <<"a/2/", Text/binary>>, 7, binary:encode_hex(<<"path\\a'b\\c${v}">>)],
+                [
+                    Missing,
+                    <<"b/4/", Text/binary>>,
+                    15,
+                    binary:encode_hex(<<"path\\", Unicode/binary, "${v}">>)
+                ],
+                [
+                    Missing,
+                    <<"c/0/", Text/binary>>,
+                    3,
+                    binary:encode_hex(<<"path\\", 0, 255, "${v}">>)
+                ]
+            ],
+            ?assertMatch(
+                {ok, _, Expected},
+                eval_query(
+                    <<"SELECT msgid, topic, qos, HEX(payload) FROM mqtt.t_mqtt_msg ORDER BY topic">>,
+                    Config
+                )
+            )
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [#{sql_func := query, data := no_params}],
+                ?of_kind(mysql_connector_send_query, Trace)
+            )
+        end
+    ).
+
+t_batch_render_failure(Config) ->
+    ?assertMatch(
+        {ok, {{_, 201, _}, _, _}},
+        emqx_bridge_v2_testlib:create_bridge_api(Config, #{
+            <<"parameters">> => #{
+                <<"sql">> => <<"INSERT INTO t_mqtt_msg(payload) VALUES ('value ${payload.v}')">>
+            },
+            <<"resource_opts">> => #{
+                <<"batch_size">> => 2,
+                <<"batch_time">> => 1000,
+                <<"worker_pool_size">> => 1,
+                <<"query_mode">> => <<"async">>
+            }
+        })
+    ),
+    Name = ?config(action_name, Config),
+    _ = emqx_bridge_v2_testlib:kickoff_action_health_check(?ACTION_TYPE, Name),
+    Send = fun(Value) ->
+        ?assertEqual(
+            ok,
+            emqx_bridge_v2:send_message(?ACTION_TYPE, Name, #{payload => #{v => Value}}, #{})
+        )
+    end,
+    ?check_trace(
+        begin
+            {_, {ok, _}} = ?wait_async_action(
+                begin
+                    Send(1),
+                    Send({unsupported})
+                end,
+                #{
+                    ?snk_kind := mysql_connector_on_batch_query_return,
+                    result :=
+                        {error,
+                            {unrecoverable_error,
+                                {doris_template_render_failed, #{
+                                    batch_index := 2,
+                                    reason :=
+                                        {invalid_sql_template_value, #{placeholder := "payload.v"}}
+                                }}}}
+                },
+                10_000
+            ),
+            ?assertMatch(
+                {ok, _, [[0]]}, eval_query(<<"SELECT COUNT(*) FROM mqtt.t_mqtt_msg">>, Config)
+            )
+        end,
+        fun(Trace) -> ?assertEqual([], ?of_kind(mysql_connector_send_query, Trace)) end
+    ),
+    {_, {ok, _}} = ?wait_async_action(
+        begin
+            Send(2),
+            Send(3)
+        end,
+        #{?snk_kind := mysql_connector_on_batch_query_return, result := ok},
+        10_000
+    ),
+    ?assertMatch(
+        {ok, _, [[<<"value 2">>], [<<"value 3">>]]},
+        eval_query(<<"SELECT payload FROM mqtt.t_mqtt_msg ORDER BY payload">>, Config)
+    ).
+
+t_sql_compiler_roundtrip(Config) ->
+    {ok, C} = mysql:start_link([
+        {host, emqx_utils_conv:str(host(Config))},
+        {port, port(Config)},
+        {user, ?USERNAME},
+        {basic_capabilities, #{?CLIENT_TRANSACTIONS => false}}
+    ]),
+    ok = mysql:query(C, <<"SET SESSION sql_mode = 'ANSI_QUOTES,NO_BACKSLASH_ESCAPES'">>),
+    ok = emqx_mysql:prepare_sql_to_conn(C, []),
+    {ok, _, [[Modes]]} = mysql:query(C, <<"SELECT @@SESSION.sql_mode">>),
+    ?assertEqual(nomatch, binary:match(Modes, <<"ANSI_QUOTES">>)),
+    ?assertEqual(nomatch, binary:match(Modes, <<"NO_BACKSLASH_ESCAPES">>)),
+    {ok, Plan} = emqx_doris_sql:compile(
+        <<"INSERT INTO mqtt.t_mqtt_msg(payload) VALUES (${payload})">>
+    ),
+    Values = [
+        <<"hello">>,
+        <<"a'b\\c">>,
+        <<"a", 0, "b">>,
+        <<255>>,
+        <<>>,
+        <<"a''b\"c\\">>,
+        <<"%_\\%\\_\\n\\0\\q">>,
+        list_to_binary(lists:seq(0, 127)),
+        unicode:characters_to_binary([16#E9, 16#4E2D, 16#1F642]),
+        <<16#C3>>,
+        <<16#C0, 16#80>>,
+        <<16#ED, 16#A0, 16#80>>,
+        <<16#F4, 16#90, 16#80, 16#80>>
+    ],
+    {ok, SQL} = emqx_doris_sql:render_batch(
+        Plan, [#{payload => Value} || Value <- Values], #{}
+    ),
+    ?assertEqual(ok, mysql:query(C, iolist_to_binary(SQL))),
+    {ok, _, Rows} = eval_query(<<"SELECT HEX(payload) FROM mqtt.t_mqtt_msg">>, Config),
+    ?assertEqual(
+        lists:sort([[binary:encode_hex(Value)] || Value <- Values]),
+        lists:sort(Rows)
+    ),
+    {ok, TextPlan} = emqx_doris_sql:compile(
+        <<"INSERT INTO mqtt.t_mqtt_msg(payload) VALUES ('prefix ${payload} suffix')">>
+    ),
+    {ok, TextSQL} = emqx_doris_sql:render_batch(
+        TextPlan, [#{payload => Value} || Value <- Values], #{}
+    ),
+    ?assertEqual(ok, mysql:query(C, iolist_to_binary(TextSQL))),
+    {ok, _, TextRows} = eval_query(<<"SELECT HEX(payload) FROM mqtt.t_mqtt_msg">>, Config),
+    ?assertEqual(
+        lists:sort(
+            Rows ++ [[binary:encode_hex(<<"prefix ", V/binary, " suffix">>)] || V <- Values]
+        ),
+        lists:sort(TextRows)
+    ),
+    {ok, ExpressionPlan} = emqx_doris_sql:compile(
+        ~B"""
+        INSERT INTO mqtt.t_mqtt_msg(payload)
+        VALUES (CONCAT('a''b', R'c\', ${value}))
+        """
+    ),
+    {ok, ExpressionSQL} = emqx_doris_sql:render(ExpressionPlan, #{value => <<"d">>}, #{}),
+    ?assertEqual(ok, mysql:query(C, iolist_to_binary(ExpressionSQL))),
+    %% Ordinary literals keep server semantics; raw bodies keep their bytes.
+    {ok, _, [[Expected]]} = eval_query(<<"SELECT HEX(CONCAT('a''b', 'c\\\\', 'd'))">>, Config),
+    {ok, _, AllRows} = eval_query(<<"SELECT HEX(payload) FROM mqtt.t_mqtt_msg">>, Config),
+    ?assertEqual(lists:sort([[Expected] | TextRows]), lists:sort(AllRows)),
+    ok = mysql:stop(C).
+
+t_escaped_dollar_roundtrip(Config) ->
+    {ok, C} = mysql:start_link([
+        {host, emqx_utils_conv:str(host(Config))},
+        {port, port(Config)},
+        {user, ?USERNAME},
+        {basic_capabilities, #{?CLIENT_TRANSACTIONS => false}}
+    ]),
+    ok = emqx_mysql:prepare_sql_to_conn(C, []),
+    Cases = [
+        {<<"${$}">>, <<"$">>},
+        {<<"cost: ${$}{amount}">>, <<"cost: ${amount}">>},
+        {<<"${$}${$}{amount}${$}">>, <<"$${amount}$">>},
+        {<<"${$}{$}">>, <<"${$}">>},
+        {<<"\\${$}{amount}">>, <<"${amount}">>},
+        {<<"\\\\${$}{amount}">>, <<"\\${amount}">>},
+        {<<"${$}{amount}${v}${$}{$}">>, <<"${amount}x${$}">>}
+    ],
+    ExpectedRows = [
+        begin
+            {ok, Plan} = emqx_doris_sql:compile(
+                <<"INSERT INTO mqtt.t_mqtt_msg(payload) VALUES (", Quote, Body/binary, Quote, ")">>
+            ),
+            {ok, SQL} = emqx_doris_sql:render(Plan, #{v => <<"x">>, amount => 99}, #{}),
+            ?assertEqual(ok, mysql:query(C, iolist_to_binary(SQL))),
+            [Expected]
+        end
+     || Quote <- "'\"", {Body, Expected} <- Cases
+    ],
+    {ok, _, Rows} = mysql:query(C, <<"SELECT payload FROM mqtt.t_mqtt_msg">>),
+    ?assertEqual(lists:sort(ExpectedRows), lists:sort(Rows)),
+    ok = mysql:stop(C).
+
+t_raw_string_roundtrip(Config) ->
+    {ok, C} = mysql:start_link([
+        {host, emqx_utils_conv:str(host(Config))},
+        {port, port(Config)},
+        {user, ?USERNAME},
+        {basic_capabilities, #{?CLIENT_TRANSACTIONS => false}}
+    ]),
+    ok = mysql:query(C, <<"SET SESSION sql_mode = 'ANSI_QUOTES,NO_BACKSLASH_ESCAPES'">>),
+    ok = emqx_mysql:prepare_sql_to_conn(C, []),
+    ok = mysql:query(C, <<"SET enable_nereids_planner = true">>),
+    ok = mysql:query(C, <<"SET enable_fallback_to_original_planner = false">>),
+    %% Record native raw behavior separately from the compiler's byte-preserving semantics.
+    Native = mysql:query(C, <<"SELECT HEX(R'a\\n'), HEX(r\"a\\n\"), HEX(R'a\\'), HEX(R'')">>),
+    ct:print("Native Doris raw literals: ~p", [Native]),
+    ?assertMatch(
+        {ok, _, [[<<"27610A">>, <<"22610A">>, <<"27615C">>, <<"27">>]]}, Native
+    ),
+    Values = [<<>>, <<"a'b\"c\\">>, <<0, 255>>, <<"\\n">>],
+    Cases = [
+        {<<>>, fun(_) -> <<>> end},
+        {<<"static\\n${$}">>, fun(_) -> <<"static\\n$">> end},
+        {<<"cost: ${$}{v}">>, fun(_) -> <<"cost: ${v}">> end},
+        {<<"${$}${$}{v}${$}">>, fun(_) -> <<"$${v}$">> end},
+        {<<"${$}{$}">>, fun(_) -> <<"${$}">> end},
+        {<<"\\${$}{v}\\">>, fun(_) -> <<"\\${v}\\">> end},
+        {<<0, 255, "${$}">>, fun(_) -> <<0, 255, "$">> end},
+        {<<"${v}">>, fun(V) -> V end},
+        {<<"${v}${v}">>, fun(V) -> <<V/binary, V/binary>> end},
+        {<<"${$}${v}${$}">>, fun(V) -> <<"$", V/binary, "$">> end},
+        {<<"\\${v}\\">>, fun(V) -> <<"\\", V/binary, "\\">> end},
+        {<<"\\\\${v}\\n">>, fun(V) -> <<"\\\\", V/binary, "\\n">> end},
+        {<<0, 255, "${v}">>, fun(V) -> <<0, 255, V/binary>> end},
+        {<<"'${v}'">>, fun(V) -> <<"'", V/binary, "'">> end},
+        {<<"\"${v}\"">>, fun(V) -> <<"\"", V/binary, "\"">> end}
+    ],
+    Expected = lists:append([
+        begin
+            {ok, Plan} = emqx_doris_sql:compile(
+                <<"INSERT INTO mqtt.t_mqtt_msg(payload) VALUES (", R, Quote, Body/binary, Quote,
+                    ")">>
+            ),
+            {ok, SQL} = emqx_doris_sql:render_batch(Plan, [#{v => V} || V <- Values], #{}),
+            ?assertEqual(ok, mysql:query(C, iolist_to_binary(SQL)), {R, Quote, Body}),
+            [[binary:encode_hex(ToExpected(V))] || V <- Values]
+        end
+     || R <- "Rr",
+        Quote <- "'\"",
+        {Body, ToExpected} <- Cases,
+        binary:match(Body, <<Quote>>) =:= nomatch
+    ]),
+    {ok, _, Rows} = mysql:query(C, <<"SELECT HEX(payload) FROM mqtt.t_mqtt_msg">>),
+    ?assertEqual(lists:sort(Expected), lists:sort(Rows)),
+    ok = mysql:stop(C).

--- a/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
@@ -461,61 +461,6 @@ t_compiler_dispatch(_Config) ->
     ),
     ?assert(maps:is_key({test, batch}, MySQLTemplates)).
 
-t_mysql_parity(_Config) ->
-    Templates = [
-        <<"INSERT INTO t VALUES (${v}, '${v}', \"${v}\")">>,
-        <<"INSERT INTO t VALUES ('', 'a${$}b', \"${$}{v}\", 'a\\n', 'a''b')">>,
-        <<"INSERT INTO t VALUES ('${v}${v}', '${$}${v}${$}', \"a${v}b\")">>,
-        <<"INSERT INTO t VALUES ('a\\\\${v}', 'a\\'${v}', \"a\\\"${v}\")">>,
-        ~b"""
-        INSERT INTO db.t(c) VALUES (
-            `f`(${v}, 1),
-            CASE WHEN ${v} IS NULL THEN -(2) ELSE 3 END
-        )
-        """
-    ],
-    Rows = [#{v => <<"a'b\"c\\">>}, #{v => 7}, #{v => 1.5}, #{v => [16#1F642]}, #{}],
-    lists:foreach(
-        fun(SQL) ->
-            {ok, MySQL} = emqx_mysql_sql:compile(SQL),
-            {ok, Doris} = emqx_doris_sql:compile(SQL),
-            lists:foreach(
-                fun(Opts) ->
-                    lists:foreach(
-                        fun(Data) ->
-                            ?assertEqual(
-                                rendered(emqx_mysql_sql:render(MySQL, Data, Opts)),
-                                rendered(emqx_doris_sql:render(Doris, Data, Opts)),
-                                {SQL, Data, Opts}
-                            )
-                        end,
-                        Rows
-                    ),
-                    ?assertEqual(
-                        rendered(emqx_mysql_sql:render_batch(MySQL, Rows, Opts)),
-                        rendered(emqx_doris_sql:render_batch(Doris, Rows, Opts))
-                    ),
-                    ?assertEqual(
-                        rendered(emqx_mysql_sql:render_batch(MySQL, [], Opts)),
-                        rendered(emqx_doris_sql:render_batch(Doris, [], Opts))
-                    )
-                end,
-                [#{}, #{undefined_vars_as_null => true}, #{undefined_vars_as_null => false}]
-            )
-        end,
-        Templates
-    ),
-    lists:foreach(
-        fun(Body) ->
-            SQL = <<"INSERT INTO t VALUES (", Body/binary, ")">>,
-            {error, {invalid_mysql_insert_template, Reason}} = emqx_mysql_sql:compile(SQL),
-            ?assertEqual(
-                {error, {invalid_doris_insert_template, Reason}}, emqx_doris_sql:compile(SQL)
-            )
-        end,
-        [<<"'a\\${v}'">>, <<"'${bad-name}'">>, <<"'${v'">>]
-    ).
-
 t_escaped_dollar(_Config) ->
     Cases = [
         {<<>>, <<>>},

--- a/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
@@ -451,7 +451,7 @@ t_compiler_dispatch(_Config) ->
     #{query_templates := #{{test, batch} := Plan}} = emqx_mysql:parse_prepare_sql(test, Config),
     ?assertEqual(
         <<"INSERT INTO `t` VALUES (UNHEX('FF'))">>,
-        rendered(emqx_doris_sql:render(Plan, #{v => <<255>>}, #{}))
+        rendered(emqx_sql_plan:render(Plan, #{v => <<255>>}, #{}))
     ),
     Rejected = Config#{sql => <<"INSERT INTO t VALUES (f(DEFAULT))">>},
     #{query_templates := Templates} = emqx_mysql:parse_prepare_sql(test, Rejected),
@@ -733,7 +733,9 @@ t_placeholder_paths(_Config) ->
     ),
     lists:foreach(
         fun(Source) ->
-            ?assertEqual({error, invalid_placeholder}, emqx_doris_sql:parse_placeholder(Source)),
+            ?assertEqual(
+                {error, invalid_placeholder}, emqx_sql_plan:parse_placeholder(Source)
+            ),
             lists:foreach(
                 fun({Open, Close}) ->
                     ?assertMatch(

--- a/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
@@ -1,0 +1,813 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_doris_sql_SUITE).
+-compile(export_all).
+-compile(nowarn_export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+t_compile_and_render(_Config) ->
+    SQL = ~b"""
+    INSERT INTO mqtt(payload, arrived)
+    VALUES (${payload}, FROM_UNIXTIME(${timestamp}/1000))
+    """,
+    {ok, Plan} = emqx_doris_sql:compile(SQL),
+    ?assertEqual(
+        <<"INSERT INTO `mqtt` (`payload`, `arrived`) VALUES ('hello', `FROM_UNIXTIME`(2000 / 1000))">>,
+        rendered(emqx_doris_sql:render(Plan, #{payload => <<"hello">>, timestamp => 2000}, #{}))
+    ),
+    ?assertEqual(
+        <<
+            "INSERT INTO `mqtt` (`payload`, `arrived`) VALUES "
+            "(1, `FROM_UNIXTIME`(2 / 1000)), (3, `FROM_UNIXTIME`(4 / 1000))"
+        >>,
+        rendered(
+            emqx_doris_sql:render_batch(
+                Plan, [#{payload => 1, timestamp => 2}, #{payload => 3, timestamp => 4}], #{}
+            )
+        )
+    ).
+
+t_static_plan_compaction(_Config) ->
+    Prefix = <<"INSERT INTO `db`.`t` (`c`) VALUES ">>,
+    {ok, Static} = emqx_doris_sql:compile(
+        ~b"""
+        INSERT INTO db.t(c) VALUES (
+            f(1 + 2, 'a${$}b'),
+            CASE WHEN TRUE THEN -(3) ELSE 0 END,
+            R'raw'
+        )
+        """
+    ),
+    ?assertEqual(
+        {ok, [Prefix, [<<"(`f`(1 + 2, 'a$b'), CASE WHEN TRUE THEN -((3)) ELSE 0 END, 'raw')">>]]},
+        emqx_doris_sql:render(Static, #{}, #{})
+    ),
+    {ok, Mixed} = emqx_doris_sql:compile(
+        <<"INSERT INTO db.t(c) VALUES (f(1, ${v} + 2), 'a${v}b${v}c', '${v}${v}', '', t.c)">>
+    ),
+    Text = [<<"'">>, "7", <<"'">>],
+    ?assertEqual(
+        {ok, [
+            Prefix,
+            [
+                <<"(`f`(1, ">>,
+                <<"7">>,
+                <<" + 2), ">>,
+                [
+                    <<"CONCAT(">>,
+                    [
+                        <<"'a'">>,
+                        <<", ">>,
+                        Text,
+                        <<", ">>,
+                        <<"'b'">>,
+                        <<", ">>,
+                        Text,
+                        <<", ">>,
+                        <<"'c'">>
+                    ],
+                    <<")">>
+                ],
+                <<", ">>,
+                [<<"CONCAT(">>, [Text, <<", ">>, Text], <<")">>],
+                <<", '', `t`.`c`)">>
+            ]
+        ]},
+        emqx_doris_sql:render(Mixed, #{v => 7}, #{})
+    ).
+
+t_raw_static_compaction(_Config) ->
+    Prefix = <<"INSERT INTO `t` VALUES ">>,
+    Cases = [
+        {<<>>, <<"''">>},
+        {<<"plain\\n\\q\\">>, <<"'plain\\\\n\\\\q\\\\'">>},
+        {<<"${$}{amount}">>, <<"'${amount}'">>},
+        {<<0, 255>>, <<"UNHEX('00FF')">>}
+    ],
+    lists:foreach(
+        fun({R, Quote, Body, Literal}) ->
+            {ok, Plan} = emqx_doris_sql:compile(
+                <<Prefix/binary, "(", R, Quote, Body/binary, Quote, ")">>
+            ),
+            Row = <<"(", Literal/binary, ")">>,
+            Data = #{amount => {must_not_resolve}},
+            ?assertEqual({ok, [Prefix, [Row]]}, emqx_doris_sql:render(Plan, Data, #{})),
+            ?assertEqual(
+                <<Prefix/binary, Row/binary, ", ", Row/binary>>,
+                rendered(emqx_doris_sql:render_batch(Plan, [#{}, Data], #{}))
+            )
+        end,
+        [{R, Q, B, L} || R <- "Rr", Q <- "'\"", {B, L} <- Cases]
+    ).
+
+t_row_lookup_cache(_Config) ->
+    {ok, Plan} = emqx_doris_sql:compile(
+        <<"INSERT INTO t VALUES (${payload.v}, '${payload.v}', ${payload.v}, R'${payload.v}')">>
+    ),
+    ok = meck:new(emqx_jsonish, [passthrough]),
+    try
+        Rows = [#{payload => <<"{\"v\":1}">>}, #{}, #{payload => #{v => 2}}],
+        ?assertEqual(
+            <<"INSERT INTO `t` VALUES (1, '1', 1, '1'), (NULL, 'null', NULL, 'null'), (2, '2', 2, '2')">>,
+            rendered(emqx_doris_sql:render_batch(Plan, Rows, #{}))
+        ),
+        ?assertEqual(3, meck:num_calls(emqx_jsonish, lookup, 2)),
+        ?assertEqual(
+            <<"INSERT INTO `t` VALUES (3, '3', 3, '3')">>,
+            rendered(emqx_doris_sql:render(Plan, #{payload => #{v => 3}}, #{}))
+        ),
+        ?assertEqual(4, meck:num_calls(emqx_jsonish, lookup, 2)),
+        ok = meck:expect(emqx_jsonish, lookup, fun(_, _) -> error(lookup_failed) end),
+        Error =
+            {invalid_sql_template_value, #{
+                placeholder => "payload.v",
+                reason => {placeholder_lookup_failed, {error, lookup_failed}}
+            }},
+        ?assertEqual({error, Error}, emqx_doris_sql:render(Plan, #{}, #{})),
+        ?assertEqual(
+            {error, {doris_template_render_failed, #{batch_index => 1, reason => Error}}},
+            emqx_doris_sql:render_batch(Plan, [#{}], #{})
+        )
+    after
+        meck:unload(emqx_jsonish)
+    end.
+
+t_lexical_rules(_Config) ->
+    Accepted = [
+        <<"INSERT\r\nINTO\tt VALUES (1)">>,
+        <<"INSERT INTO $table VALUES (1)">>,
+        unicode:characters_to_binary(["INSERT INTO ", 16#1F642, " VALUES (1)"]),
+        <<"INSERT INTO `a``b` VALUES ('a''b', \"a\"\"b\", 'a\\q', 'a\\\nb')">>,
+        <<"INSERT INTO t VALUES (R'a\\', r\"b\\\")">>,
+        <<"INSERT INTO t VALUES (R'${v}')">>,
+        <<"INSERT INTO t VALUES (1, 1., .2, 1e2, 1.2E-3, DEFAULT)">>,
+        <<"INSERT INTO t VALUES (1 == 1, 1 !> 2, 1 !< 0)">>
+    ],
+    lists:foreach(fun(SQL) -> ?assertMatch({ok, _}, emqx_doris_sql:compile(SQL)) end, Accepted),
+    Rejected = [
+        <<"INSERT", 11, "INTO t VALUES (1)">>,
+        <<"INSERT", 12, "INTO t VALUES (1)">>,
+        <<"INSERT INTO t VALUES (X'61')">>,
+        <<"INSERT INTO t VALUES (_utf8mb4 'a')">>,
+        <<"INSERT INTO t VALUES (2.3W)">>,
+        <<"INSERT INTO t VALUES (2.3_)">>,
+        <<"INSERT INTO t VALUES ('unclosed)">>,
+        <<"INSERT INTO t VALUES (R'a''b')">>,
+        <<"INSERT INTO t VALUES ('prefix\\${v}')">>
+    ],
+    lists:foreach(fun(SQL) -> ?assertMatch({error, _}, emqx_doris_sql:compile(SQL)) end, Rejected).
+
+t_identifier_starts(_Config) ->
+    Accepted = [<<"a123">>, <<"Z123">>, <<"_123">>, <<"$123">>, <<128, "123">>, <<255, "123">>],
+    Rejected = [
+        <<"123abc">>,
+        <<"123d">>,
+        <<"123bd">>,
+        <<"0x12">>,
+        <<"1L">>,
+        <<"123_">>,
+        <<"123$">>,
+        <<"123", 255>>
+    ],
+    lists:foreach(
+        fun({Name, Expected}) ->
+            Templates = [
+                <<"INSERT INTO ", Name/binary, " VALUES (1)">>,
+                <<"INSERT INTO db.", Name/binary, " VALUES (1)">>,
+                <<"INSERT INTO ", Name/binary, ".t VALUES (1)">>,
+                <<"INSERT INTO t (", Name/binary, ") VALUES (1)">>,
+                <<"INSERT INTO t VALUES (", Name/binary, ")">>,
+                <<"INSERT INTO t VALUES (t.", Name/binary, ")">>,
+                <<"INSERT INTO t VALUES (", Name/binary, ".c)">>,
+                <<"INSERT INTO t VALUES (", Name/binary, "(1))">>,
+                <<"INSERT INTO t VALUES (db.", Name/binary, "(1))">>,
+                <<"INSERT INTO t VALUES (", Name/binary, ".f(1))">>,
+                <<"INSERT INTO t VALUES (f(", Name/binary, "))">>
+            ],
+            lists:foreach(
+                fun(SQL) ->
+                    ?assertEqual(Expected, element(1, emqx_doris_sql:compile(SQL)), SQL)
+                end,
+                Templates
+            )
+        end,
+        [{Name, ok} || Name <- Accepted] ++
+            [{Name, error} || Name <- Rejected] ++
+            [{<<"`", Name/binary, "`">>, ok} || Name <- Rejected]
+    ),
+    lists:foreach(
+        fun({Source, Suffix}) ->
+            ?assertEqual(
+                {ok, [{number, 1, <<"123">>}, {identifier, 1, Suffix}], 1},
+                emqx_doris_sql_lexer:string(Source)
+            )
+        end,
+        [{"123d", <<"d">>}, {"123bd", <<"bd">>}]
+    ).
+
+t_generated_byte_rules(_Config) ->
+    lists:foreach(
+        fun(Byte) ->
+            Text = <<Byte>>,
+            ?assertEqual(
+                {ok, [{identifier, 1, Text}], 1},
+                emqx_doris_sql_lexer:string([Byte])
+            ),
+            lists:foreach(
+                fun(Chars) ->
+                    Source = list_to_binary(Chars),
+                    ?assertEqual(
+                        {ok, [{string, 1, Source}], 1},
+                        emqx_doris_sql_lexer:string(Chars)
+                    ),
+                    SQL = <<"INSERT INTO t VALUES (", Source/binary, ")">>,
+                    {ok, Plan} = emqx_doris_sql:compile(SQL),
+                    Expected =
+                        case Chars of
+                            [$r | _] -> <<"UNHEX('", (binary:encode_hex(Text))/binary, "')">>;
+                            _ -> Source
+                        end,
+                    ?assertEqual(
+                        <<"INSERT INTO `t` VALUES (", Expected/binary, ")">>,
+                        rendered(emqx_doris_sql:render(Plan, #{}, #{}))
+                    )
+                end,
+                [[$', Byte, $'], [$', $\\, Byte, $'], [$r, $', Byte, $']]
+            )
+        end,
+        lists:seq(16#80, 16#FF)
+    ),
+    lists:foreach(
+        fun(Bytes) ->
+            SQL = <<"INSERT INTO ", Bytes/binary, " VALUES ('", Bytes/binary, "')">>,
+            {ok, Plan} = emqx_doris_sql:compile(SQL),
+            ?assertEqual(
+                <<"INSERT INTO `", Bytes/binary, "` VALUES ('", Bytes/binary, "')">>,
+                rendered(emqx_doris_sql:render(Plan, #{}, #{}))
+            )
+        end,
+        [<<255>>, <<16#ED, 16#A0, 16#80>>, <<16#F4, 16#90, 16#80, 16#80>>]
+    ),
+    ?assertMatch({ok, _}, emqx_doris_sql:compile(<<"INSERT INTO t VALUES ('hello')">>)),
+    lists:foreach(
+        fun(Byte) ->
+            ?assertEqual(
+                {ok, [{string, 1, <<$', $\\, Byte, $'>>}], 1},
+                emqx_doris_sql_lexer:string([$', $\\, Byte, $'])
+            )
+        end,
+        [0, $[, $], $^, $-, ${, $}, $%, $\\, $', $"]
+    ).
+
+t_generated_all_bytes(_Config) ->
+    lists:foreach(
+        fun({Text, Token}) ->
+            ?assertEqual({ok, [{Token, 1}], 1}, emqx_doris_sql_lexer:string(Text))
+        end,
+        [
+            {";", ';'},
+            {"(", '('},
+            {")", ')'},
+            {",", ','},
+            {".", '.'},
+            {"=", '='},
+            {"==", '='},
+            {"<=>", '<=>'},
+            {"<>", '<>'},
+            {"!=", '<>'},
+            {"<", '<'},
+            {"<=", '<='},
+            {"!>", '<='},
+            {">", '>'},
+            {">=", '>='},
+            {"!<", '>='},
+            {"+", '+'},
+            {"-", '-'},
+            {"*", '*'},
+            {"/", '/'},
+            {"%", '%'}
+        ]
+    ),
+    lists:foreach(
+        fun(Byte) ->
+            lists:foreach(
+                fun(Quote) ->
+                    lists:foreach(
+                        fun({Prefix, Body, Expected}) ->
+                            Chars = Prefix ++ [Quote] ++ Body ++ [Quote],
+                            Source = list_to_binary(Chars),
+                            Matches =
+                                case emqx_doris_sql_lexer:string(Chars) of
+                                    {ok, [{string, _, Source}], _} -> true;
+                                    _ -> false
+                                end,
+                            ?assertEqual(Expected, Matches, {Byte, Quote, Prefix, Body})
+                        end,
+                        [
+                            {[], [Byte], Byte =/= Quote andalso Byte =/= $\\},
+                            {[], [$\\, Byte], true},
+                            {[], [Quote, Quote, $\\, Byte], true},
+                            {"R", [Byte], Byte =/= Quote},
+                            {"r", [Byte], Byte =/= Quote}
+                        ]
+                    )
+                end,
+                [$', $"]
+            ),
+            Backticks = [$`, Byte, $`],
+            BacktickSource = list_to_binary(Backticks),
+            BacktickMatches =
+                case emqx_doris_sql_lexer:string(Backticks) of
+                    {ok, [{bt_identifier, _, BacktickSource}], _} -> true;
+                    _ -> false
+                end,
+            ?assertEqual(Byte =/= $`, BacktickMatches),
+            Identifier = [$a, Byte, $z],
+            IdentifierSource = list_to_binary(Identifier),
+            IdentifierMatches =
+                case emqx_doris_sql_lexer:string(Identifier) of
+                    {ok, [{identifier, _, IdentifierSource}], _} -> true;
+                    _ -> false
+                end,
+            ?assertEqual(
+                (Byte >= $A andalso Byte =< $Z) orelse
+                    (Byte >= $a andalso Byte =< $z) orelse
+                    (Byte >= $0 andalso Byte =< $9) orelse
+                    Byte =:= $$ orelse Byte =:= $_ orelse Byte >= 16#80,
+                IdentifierMatches
+            )
+        end,
+        lists:seq(0, 255)
+    ).
+
+t_grammar_subset(_Config) ->
+    ?assertMatch(
+        {ok, _},
+        emqx_doris_sql:compile(
+            ~b"""
+            INSERT INTO t VALUES (
+                DEFAULT,
+                -2 * 3,
+                CASE
+                    WHEN ${v} IS NOT NULL AND NOT FALSE THEN IF(TRUE, 1, 2)
+                    ELSE 0
+                END
+            );
+            """
+        )
+    ),
+    Rejected = [
+        <<"INSERT INTO t VALUES ((DEFAULT))">>,
+        <<"INSERT INTO t VALUES (f(DEFAULT))">>,
+        <<"INSERT INTO t VALUES (DEFAULT + 1)">>,
+        <<"INSERT INTO t VALUES (1) AS new">>,
+        <<"INSERT INTO t VALUES (1) ON DUPLICATE KEY UPDATE c = 1">>,
+        <<"INSERT INTO t VALUES (1), (2)">>,
+        <<"INSERT INTO t SELECT 1">>,
+        <<"INSERT INTO ${table} VALUES (1)">>,
+        <<"INSERT INTO `t${suffix}` VALUES (1)">>,
+        <<"INSERT INTO t VALUES (1) -- note">>,
+        <<"INSERT INTO t VALUES (1) /* note */">>
+    ],
+    lists:foreach(fun(SQL) -> ?assertMatch({error, _}, emqx_doris_sql:compile(SQL)) end, Rejected).
+
+t_strings_and_binary(_Config) ->
+    {ok, Plan} = emqx_doris_sql:compile(
+        <<"INSERT INTO t VALUES (${v}, 'prefix ${v} suffix', \"${v}\")">>
+    ),
+    Value = <<"a'b\\c", 0, 255>>,
+    Result = rendered(emqx_doris_sql:render(Plan, #{v => Value}, #{})),
+    ?assertEqual(
+        <<
+            "INSERT INTO `t` VALUES (UNHEX('6127625C6300FF'), "
+            "CONCAT('prefix ', UNHEX('6127625C6300FF'), ' suffix'), UNHEX('6127625C6300FF'))"
+        >>,
+        Result
+    ),
+    ?assertMatch({ok, _}, emqx_doris_sql:compile(Result)),
+    {ok, Escaped} = emqx_doris_sql:compile(
+        <<"INSERT INTO t VALUES ('a''${v}', \"b\\\"${v}\", '${$}{v}')">>
+    ),
+    ?assertEqual(
+        <<"INSERT INTO `t` VALUES (CONCAT('a''', 'x'), CONCAT(\"b\\\"\", 'x'), '${v}')">>,
+        rendered(emqx_doris_sql:render(Escaped, #{v => <<"x">>}, #{}))
+    ).
+
+t_text_escaping(_Config) ->
+    {ok, Plan} = emqx_doris_sql:compile(
+        <<"INSERT INTO t VALUES (${v}, 'prefix ${v} suffix', \"${v}\")">>
+    ),
+    Unicode = unicode:characters_to_binary([16#E9, 16#4E2D, 16#1F642]),
+    Cases = [
+        {<<>>, <<"''">>},
+        {<<"hello">>, <<"'hello'">>},
+        {<<"a''b\"c\\">>, <<"'a\\'\\'b\\\"c\\\\'">>},
+        {<<0, 8, 9, 10, 13, 26>>, <<"'\\0\\b\\t\\n\\r\\Z'">>},
+        {<<1, 11, 12, 31, 127>>, <<"'", 1, 11, 12, 31, 127, "'">>},
+        {<<"%_\\%\\_\\n\\0\\q">>, <<"'%_\\\\%\\\\_\\\\n\\\\0\\\\q'">>},
+        {Unicode, <<"'", Unicode/binary, "'">>},
+        {<<255>>, <<"UNHEX('FF')">>},
+        {<<16#C3>>, <<"UNHEX('C3')">>},
+        {<<16#C0, 16#80>>, <<"UNHEX('C080')">>},
+        {<<16#ED, 16#A0, 16#80>>, <<"UNHEX('EDA080')">>},
+        {<<16#F4, 16#90, 16#80, 16#80>>, <<"UNHEX('F4908080')">>}
+    ],
+    lists:foreach(
+        fun({Value, Literal}) ->
+            Expected = <<
+                "INSERT INTO `t` VALUES (",
+                Literal/binary,
+                ", CONCAT('prefix ', ",
+                Literal/binary,
+                ", ' suffix'), ",
+                Literal/binary,
+                ")"
+            >>,
+            ?assertEqual(Expected, rendered(emqx_doris_sql:render(Plan, #{v => Value}, #{})))
+        end,
+        Cases
+    ).
+
+t_missing_and_errors(_Config) ->
+    {ok, Plan} = emqx_doris_sql:compile(<<"INSERT INTO t VALUES (${v}, '${v}')">>),
+    ?assertEqual(
+        <<"INSERT INTO `t` VALUES (NULL, 'null')">>,
+        rendered(emqx_doris_sql:render(Plan, #{}, #{undefined_vars_as_null => true}))
+    ),
+    ?assertEqual(
+        <<"INSERT INTO `t` VALUES ('undefined', 'undefined')">>,
+        rendered(emqx_doris_sql:render(Plan, #{}, #{undefined_vars_as_null => false}))
+    ),
+    ?assertMatch(
+        {error, {doris_template_render_failed, #{batch_index := 2}}},
+        emqx_doris_sql:render_batch(Plan, [#{v => 1}, #{v => {unsupported}}], #{})
+    ).
+
+t_compiler_dispatch(_Config) ->
+    Config = #{sql => <<"INSERT INTO t VALUES (${v})">>, sql_compiler => emqx_doris_sql},
+    #{query_templates := #{{test, batch} := Plan}} = emqx_mysql:parse_prepare_sql(test, Config),
+    ?assertEqual(
+        <<"INSERT INTO `t` VALUES (UNHEX('FF'))">>,
+        rendered(emqx_doris_sql:render(Plan, #{v => <<255>>}, #{}))
+    ),
+    Rejected = Config#{sql => <<"INSERT INTO t VALUES (f(DEFAULT))">>},
+    #{query_templates := Templates} = emqx_mysql:parse_prepare_sql(test, Rejected),
+    ?assertNot(maps:is_key({test, batch}, Templates)),
+    #{query_templates := MySQLTemplates} = emqx_mysql:parse_prepare_sql(
+        test, maps:remove(sql_compiler, Rejected)
+    ),
+    ?assert(maps:is_key({test, batch}, MySQLTemplates)).
+
+t_mysql_parity(_Config) ->
+    Templates = [
+        <<"INSERT INTO t VALUES (${v}, '${v}', \"${v}\")">>,
+        <<"INSERT INTO t VALUES ('', 'a${$}b', \"${$}{v}\", 'a\\n', 'a''b')">>,
+        <<"INSERT INTO t VALUES ('${v}${v}', '${$}${v}${$}', \"a${v}b\")">>,
+        <<"INSERT INTO t VALUES ('a\\\\${v}', 'a\\'${v}', \"a\\\"${v}\")">>,
+        ~b"""
+        INSERT INTO db.t(c) VALUES (
+            `f`(${v}, 1),
+            CASE WHEN ${v} IS NULL THEN -(2) ELSE 3 END
+        )
+        """
+    ],
+    Rows = [#{v => <<"a'b\"c\\">>}, #{v => 7}, #{v => 1.5}, #{v => [16#1F642]}, #{}],
+    lists:foreach(
+        fun(SQL) ->
+            {ok, MySQL} = emqx_mysql_sql:compile(SQL),
+            {ok, Doris} = emqx_doris_sql:compile(SQL),
+            lists:foreach(
+                fun(Opts) ->
+                    lists:foreach(
+                        fun(Data) ->
+                            ?assertEqual(
+                                rendered(emqx_mysql_sql:render(MySQL, Data, Opts)),
+                                rendered(emqx_doris_sql:render(Doris, Data, Opts)),
+                                {SQL, Data, Opts}
+                            )
+                        end,
+                        Rows
+                    ),
+                    ?assertEqual(
+                        rendered(emqx_mysql_sql:render_batch(MySQL, Rows, Opts)),
+                        rendered(emqx_doris_sql:render_batch(Doris, Rows, Opts))
+                    ),
+                    ?assertEqual(
+                        rendered(emqx_mysql_sql:render_batch(MySQL, [], Opts)),
+                        rendered(emqx_doris_sql:render_batch(Doris, [], Opts))
+                    )
+                end,
+                [#{}, #{undefined_vars_as_null => true}, #{undefined_vars_as_null => false}]
+            )
+        end,
+        Templates
+    ),
+    lists:foreach(
+        fun(Body) ->
+            SQL = <<"INSERT INTO t VALUES (", Body/binary, ")">>,
+            {error, {invalid_mysql_insert_template, Reason}} = emqx_mysql_sql:compile(SQL),
+            ?assertEqual(
+                {error, {invalid_doris_insert_template, Reason}}, emqx_doris_sql:compile(SQL)
+            )
+        end,
+        [<<"'a\\${v}'">>, <<"'${bad-name}'">>, <<"'${v'">>]
+    ).
+
+t_escaped_dollar(_Config) ->
+    Cases = [
+        {<<>>, <<>>},
+        {<<"plain\\n\\q">>, <<"plain\\n\\q">>},
+        {<<"${$}">>, <<"$">>},
+        {<<"cost: ${$}{amount}">>, <<"cost: ${amount}">>},
+        {<<"${$}${$}{amount}${$}">>, <<"$${amount}$">>},
+        {<<"${$}{$}">>, <<"${$}">>},
+        {<<"\\${$}{amount}">>, <<"\\${amount}">>},
+        {<<"\\\\${$}{amount}">>, <<"\\\\${amount}">>},
+        {<<"${$}\\\\">>, <<"$\\\\">>}
+    ],
+    lists:foreach(
+        fun({Quote, Body, Expected}) ->
+            Prefix = <<"INSERT INTO `t` VALUES ">>,
+            {ok, Plan} = emqx_doris_sql:compile(
+                <<Prefix/binary, "(", Quote, Body/binary, Quote, ")">>
+            ),
+            Row = <<"(", Quote, Expected/binary, Quote, ")">>,
+            lists:foreach(
+                fun(Data) ->
+                    ?assertEqual({ok, [Prefix, [Row]]}, emqx_doris_sql:render(Plan, Data, #{}))
+                end,
+                [#{}, #{amount => {must_not_resolve}}]
+            ),
+            ?assertEqual(
+                <<Prefix/binary, Row/binary, ", ", Row/binary>>,
+                rendered(emqx_doris_sql:render_batch(Plan, [#{}, #{amount => 99}], #{}))
+            )
+        end,
+        [{Q, B, E} || Q <- "'\"", {B, E} <- Cases ++ [{<<Q, Q>>, <<Q, Q>>}]]
+    ),
+    lists:foreach(
+        fun(Quote) ->
+            {ok, Plan} = emqx_doris_sql:compile(
+                <<"INSERT INTO t VALUES (", Quote, "${$}{amount}${v}${$}{$}", Quote, ")">>
+            ),
+            ?assertEqual(
+                <<"INSERT INTO `t` VALUES (CONCAT(", Quote, "${amount}", Quote, ", 'x', ", Quote,
+                    "${$}", Quote, "))">>,
+                rendered(
+                    emqx_doris_sql:render(Plan, #{v => <<"x">>, amount => {must_not_resolve}}, #{})
+                )
+            )
+        end,
+        "'\""
+    ).
+
+t_raw_strings(_Config) ->
+    Cases = [
+        {<<>>, <<"''">>},
+        {<<"a${$}b\\n">>, <<"'a$b\\\\n'">>},
+        {<<"${$}">>, <<"'$'">>},
+        {<<"cost: ${$}{amount}">>, <<"'cost: ${amount}'">>},
+        {<<"${$}${$}{amount}${$}">>, <<"'$${amount}$'">>},
+        {<<"${$}{$}">>, <<"'${$}'">>},
+        {<<"\\${$}{amount}\\">>, <<"'\\\\${amount}\\\\'">>},
+        {<<0, 255, "${$}">>, <<"UNHEX('00FF24')">>},
+        {<<"${$}{amount}${v}${$}{$}">>, <<"CONCAT('${amount}', 'x', '${$}')">>},
+        {<<"${v}">>, <<"'x'">>},
+        {<<"${v}${v}">>, <<"CONCAT('x', 'x')">>},
+        {<<"${$}${v}${$}">>, <<"CONCAT('$', 'x', '$')">>},
+        {<<"\\${v}\\">>, <<"CONCAT('\\\\', 'x', '\\\\')">>},
+        {<<"\\\\${v}">>, <<"CONCAT('\\\\\\\\', 'x')">>},
+        {<<"\\n${v}\\q">>, <<"CONCAT('\\\\n', 'x', '\\\\q')">>},
+        {<<0, 255, "${v}">>, <<"CONCAT(UNHEX('00FF'), 'x')">>}
+    ],
+    lists:foreach(
+        fun({R, Quote}) ->
+            OtherQuote =
+                case Quote of
+                    $' -> $";
+                    $" -> $'
+                end,
+            lists:foreach(
+                fun({Body, Expected}) ->
+                    SQL = <<"INSERT INTO t VALUES (", R, Quote, Body/binary, Quote, ")">>,
+                    {ok, Plan} = emqx_doris_sql:compile(SQL),
+                    ?assertEqual(
+                        <<"INSERT INTO `t` VALUES (", Expected/binary, ")">>,
+                        rendered(
+                            emqx_doris_sql:render(
+                                Plan, #{v => <<"x">>, amount => {must_not_resolve}}, #{}
+                            )
+                        ),
+                        SQL
+                    )
+                end,
+                Cases ++
+                    [
+                        {
+                            <<OtherQuote, "${v}", OtherQuote>>,
+                            <<"CONCAT('\\", OtherQuote, "', 'x', '\\", OtherQuote, "')">>
+                        }
+                    ]
+            ),
+            {ok, Plan} = emqx_doris_sql:compile(
+                <<"INSERT INTO t VALUES (${v}, ", R, Quote, "${v}", Quote, ")">>
+            ),
+            ?assertEqual(
+                <<"INSERT INTO `t` VALUES (NULL, 'null')">>,
+                rendered(emqx_doris_sql:render(Plan, #{}, #{undefined_vars_as_null => true}))
+            ),
+            ?assertEqual(
+                <<"INSERT INTO `t` VALUES ('undefined', 'undefined')">>,
+                rendered(emqx_doris_sql:render(Plan, #{}, #{undefined_vars_as_null => false}))
+            ),
+            ?assertEqual(
+                <<"INSERT INTO `t` VALUES (UNHEX('FF'), UNHEX('FF'))">>,
+                rendered(emqx_doris_sql:render(Plan, #{v => <<255>>}, #{}))
+            ),
+            ?assertMatch(
+                {error, {invalid_sql_template_value, #{placeholder := "v"}}},
+                emqx_doris_sql:render(Plan, #{v => {unsupported}}, #{})
+            ),
+            {ok, TextPlan} = emqx_doris_sql:compile(
+                <<"INSERT INTO t VALUES (", R, Quote, "${v}", Quote, ")">>
+            ),
+            ?assertMatch(
+                {error, {invalid_sql_template_value, #{placeholder := "v"}}},
+                emqx_doris_sql:render(TextPlan, #{v => {unsupported}}, #{})
+            ),
+            ?assertMatch(
+                {error, {doris_template_render_failed, #{batch_index := 2}}},
+                emqx_doris_sql:render_batch(TextPlan, [#{v => 1}, #{v => {unsupported}}], #{})
+            )
+        end,
+        [{R, Q} || R <- "Rr", Q <- "'\""]
+    ).
+
+t_expression_rendering(_Config) ->
+    Cases = [
+        {<<"TRUE, FALSE, NULL, DEFAULT, 1., .2, 1.2E-3">>,
+            <<"TRUE, FALSE, NULL, DEFAULT, 1., .2, 1.2E-3">>},
+        {<<"${v} + 2 * 3, (${v} + 2) * 3, 8 - 3 - 1, 8 / (4 / 2), -${v} % +2">>,
+            <<"4 + 2 * 3, (4 + 2) * 3, 8 - 3 - 1, 8 / (4 / 2), -(4) % +(2)">>},
+        {<<"CASE ${v} WHEN 1 THEN 'one' WHEN 4 THEN 'four' END">>,
+            <<"CASE 4 WHEN 1 THEN 'one' WHEN 4 THEN 'four' END">>},
+        {
+            ~b"""
+            CASE
+                WHEN ${v} IS NOT NULL AND NOT ${v} <=> 0 OR FALSE THEN IF(TRUE, ${v}, 0)
+                ELSE NULL
+            END
+            """,
+            <<"CASE WHEN 4 IS NOT NULL AND NOT(4 <=> 0) OR FALSE THEN `IF`(TRUE, 4, 0) ELSE NULL END">>
+        },
+        {<<"${v} == 4, ${v} != 3, ${v} !> 5, ${v} !< 3, ${v} < 5, ${v} > 3">>,
+            <<"4 = 4, 4 <> 3, 4 <= 5, 4 >= 3, 4 < 5, 4 > 3">>},
+        {<<"Db.Fn(), `a``b`.`c``d`, KeY, UpDaTe">>,
+            <<"`Db`.`Fn`(), `a``b`.`c``d`, `KeY`, `UpDaTe`">>}
+    ],
+    lists:foreach(
+        fun({Source, Expected}) ->
+            {ok, Plan} = emqx_doris_sql:compile(
+                <<"insert into `a``b`(KeY) values (", Source/binary, ");">>
+            ),
+            ?assertEqual(
+                <<"INSERT INTO `a``b` (`KeY`) VALUES (", Expected/binary, ")">>,
+                rendered(emqx_doris_sql:render(Plan, #{v => 4}, #{})),
+                Source
+            )
+        end,
+        Cases
+    ).
+
+t_value_conversions(_Config) ->
+    {ok, Plan} = emqx_doris_sql:compile(
+        <<"INSERT INTO t VALUES (${v}, '${v}', R'${v}')">>
+    ),
+    Unicode = unicode:characters_to_binary([16#E9, 16#1F642]),
+    Cases = [
+        {42, <<"42">>, <<"'42'">>},
+        {-12345678901234567890, <<"-12345678901234567890">>, <<"'-12345678901234567890'">>},
+        {1.25, <<"1.25">>, <<"'1.25'">>},
+        {true, <<"'true'">>, <<"'true'">>},
+        {false, <<"'false'">>, <<"'false'">>},
+        {null, <<"'null'">>, <<"'null'">>},
+        {ready, <<"'ready'">>, <<"'ready'">>},
+        {[], <<"''">>, <<"''">>},
+        {[16#E9, 16#1F642], <<"'", Unicode/binary, "'">>, <<"'", Unicode/binary, "'">>},
+        {#{}, <<"'{}'">>, <<"'{}'">>},
+        {#{n => 2}, <<"'{\\\"n\\\":2}'">>, <<"'{\\\"n\\\":2}'">>},
+        {[true, 2, null], <<"'[true,2,null]'">>, <<"'[true,2,null]'">>}
+    ],
+    lists:foreach(
+        fun({Value, Scalar, Text}) ->
+            ?assertEqual(
+                <<"INSERT INTO `t` VALUES (", Scalar/binary, ", ", Text/binary, ", ", Text/binary,
+                    ")">>,
+                rendered(emqx_doris_sql:render(Plan, #{v => Value}, #{})),
+                Value
+            )
+        end,
+        Cases
+    ).
+
+t_placeholder_paths(_Config) ->
+    {ok, Plan} = emqx_doris_sql:compile(
+        <<"INSERT INTO t VALUES (${payload.n}, '${.payload.n}', R'${payload.n}', ${missing.n})">>
+    ),
+    lists:foreach(
+        fun(Data) ->
+            ?assertEqual(
+                <<"INSERT INTO `t` VALUES (2, '2', '2', NULL)">>,
+                rendered(emqx_doris_sql:render(Plan, Data, #{}))
+            )
+        end,
+        [#{payload => #{n => 2}}, #{<<"payload">> => <<"{\"n\":2}">>}]
+    ),
+    {ok, Root} = emqx_doris_sql:compile(<<"INSERT INTO t VALUES (${}, '${.}', R'${}')">>),
+    ?assertEqual(
+        <<"INSERT INTO `t` VALUES ('{}', '{}', '{}')">>,
+        rendered(emqx_doris_sql:render(Root, #{}, #{}))
+    ),
+    lists:foreach(
+        fun(Source) ->
+            ?assertEqual({error, invalid_placeholder}, emqx_doris_sql:parse_placeholder(Source)),
+            lists:foreach(
+                fun({Open, Close}) ->
+                    ?assertMatch(
+                        {error, {invalid_doris_insert_template, _}},
+                        emqx_doris_sql:compile(
+                            <<"INSERT INTO t VALUES (", Open/binary, Source/binary, Close/binary,
+                                ")">>
+                        )
+                    )
+                end,
+                [{<<>>, <<>>}, {<<"'">>, <<"'">>}, {<<"\"">>, <<"\"">>}, {<<"R'">>, <<"'">>}]
+            )
+        end,
+        [<<"${bad-name}">>, <<"${v..n}">>, <<"${v.}">>, <<"${ v}">>, <<"${v">>]
+    ).
+
+t_rejected_statement_forms(_Config) ->
+    Rejected = [
+        <<>>,
+        <<"SELECT 1">>,
+        <<"UPDATE t SET c = 1">>,
+        <<"INSERT INTO t VALUES ()">>,
+        <<"INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)">>,
+        <<"INSERT INTO t VALUES (1) # note">>,
+        <<"INSERT /* note */ INTO t VALUES (1)">>,
+        <<"INSERT INTO \"t\" VALUES (1)">>,
+        <<"INSERT INTO t (${column}) VALUES (1)">>,
+        <<"INSERT INTO t (`${column}`) VALUES (1)">>,
+        <<"INSERT INTO t VALUES (`${function}`(1))">>,
+        <<"INSERT INTO t VALUES (t.`${column}`)">>,
+        <<"INSERT INTO t VALUES (CASE WHEN TRUE THEN DEFAULT END)">>,
+        <<"INSERT INTO t VALUES (1 IN (1, 2))">>,
+        <<"INSERT INTO t VALUES ((SELECT 1))">>,
+        <<"INSERT INTO t VALUES (1) alias">>
+    ],
+    lists:foreach(
+        fun(SQL) ->
+            ?assertMatch(
+                {error, {invalid_doris_insert_template, _}}, emqx_doris_sql:compile(SQL), SQL
+            )
+        end,
+        Rejected
+    ).
+
+t_render_error_details(_Config) ->
+    lists:foreach(
+        fun(Expression) ->
+            {ok, Plan} = emqx_doris_sql:compile(
+                <<"INSERT INTO t VALUES (", Expression/binary, ")">>
+            ),
+            Bad = #{payload => #{v => {unsupported}}},
+            {error, Reason} = emqx_doris_sql:render(Plan, Bad, #{}),
+            ?assertMatch(
+                {invalid_sql_template_value, #{
+                    placeholder := "payload.v", reason := {error, function_clause}
+                }},
+                Reason
+            ),
+            lists:foreach(
+                fun(Index) ->
+                    Rows = lists:duplicate(Index - 1, #{payload => #{v => 1}}) ++ [Bad, #{}],
+                    ?assertEqual(
+                        {error,
+                            {doris_template_render_failed, #{
+                                batch_index => Index, reason => Reason
+                            }}},
+                        emqx_doris_sql:render_batch(Plan, Rows, #{})
+                    )
+                end,
+                [1, 2, 3]
+            ),
+            ?assertMatch({ok, _}, emqx_doris_sql:render(Plan, #{payload => #{v => 2}}, #{}))
+        end,
+        [<<"${payload.v}">>, <<"'prefix ${payload.v}'">>, <<"R'prefix ${payload.v}'">>]
+    ).
+
+rendered({ok, SQL}) -> iolist_to_binary(SQL).

--- a/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
@@ -199,13 +199,13 @@ t_identifier_starts(_Config) ->
             [{<<"`", Name/binary, "`">>, ok} || Name <- Rejected]
     ),
     lists:foreach(
-        fun({Source, Suffix}) ->
+        fun(Source) ->
             ?assertEqual(
-                {ok, [{number, 1, <<"123">>}, {identifier, 1, Suffix}], 1},
-                emqx_doris_sql_lexer:string(Source)
+                {error, {1, emqx_doris_sql_lexer, {user, unsupported_number}}, 1},
+                emqx_doris_sql_lexer:string(binary_to_list(Source))
             )
         end,
-        [{"123d", <<"d">>}, {"123bd", <<"bd">>}]
+        Rejected
     ).
 
 t_generated_byte_rules(_Config) ->

--- a/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
+++ b/apps/emqx_bridge_doris/test/emqx_doris_sql_SUITE.erl
@@ -595,6 +595,16 @@ t_expression_rendering(_Config) ->
     Cases = [
         {<<"TRUE, FALSE, NULL, DEFAULT, 1., .2, 1.2E-3">>,
             <<"TRUE, FALSE, NULL, DEFAULT, 1., .2, 1.2E-3">>},
+        {
+            <<
+                "current_date, Current_Time, CURRENT_TIMESTAMP, localtime, "
+                "LocalTimestamp, CURRENT_USER, session_user"
+            >>,
+            <<
+                "CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, LOCALTIME, "
+                "LOCALTIMESTAMP, CURRENT_USER, SESSION_USER"
+            >>
+        },
         {<<"${v} + 2 * 3, (${v} + 2) * 3, 8 - 3 - 1, 8 / (4 / 2), -${v} % +2">>,
             <<"4 + 2 * 3, (4 + 2) * 3, 8 - 3 - 1, 8 / (4 / 2), -(4) % +(2)">>},
         {<<"CASE ${v} WHEN 1 THEN 'one' WHEN 4 THEN 'four' END">>,

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -304,7 +304,7 @@ create_channel_state(
         <<>> ->
             {error, missing_sql_template};
         SQL ->
-            case emqx_bridge_sqlserver_sql:compile(SQL) of
+            case emqx_sql_plan:compile(emqx_bridge_sqlserver_sql, SQL) of
                 {ok, Plan} -> {ok, #{sql_plan => Plan, channel_conf => ChannelConf}};
                 {error, _} = Error -> Error
             end
@@ -653,7 +653,7 @@ get_query_tuple([_InsertQuery | _] = Reqs) ->
 apply_template(
     {?ACTION_SEND_MESSAGE, Msg}, Plan, ChannelConf
 ) ->
-    emqx_bridge_sqlserver_sql:render(Plan, Msg, render_opts(ChannelConf));
+    emqx_sql_plan:render(Plan, Msg, render_opts(ChannelConf));
 %% batch inserts
 apply_template(
     [{?ACTION_SEND_MESSAGE, _Msg} | _] = BatchReqs,
@@ -661,7 +661,7 @@ apply_template(
     ChannelConf
 ) ->
     DataList = [Msg || {?ACTION_SEND_MESSAGE, Msg} <- BatchReqs],
-    emqx_bridge_sqlserver_sql:render_batch(Plan, DataList, render_opts(ChannelConf));
+    emqx_sql_plan:render_batch(Plan, DataList, render_opts(ChannelConf));
 apply_template(Query, _Plan, _) ->
     %% TODO: more detail information
     ?SLOG(error, #{msg => "apply_sql_template_failed", query => Query}),

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
@@ -264,13 +264,11 @@ compile_row({row, Expressions}) ->
 compile_expression({var, Placeholder}) ->
     [#value{placeholder = Placeholder}];
 compile_expression({string, Style, Source}) ->
-    Parts = parse_string(Source, Style),
-    case lists:any(fun is_variable_part/1, Parts) of
-        true ->
-            [compile_string_op(Style, Parts)];
-        false ->
-            [#tpl_text{text = Text}] = Parts,
-            [#raw{sql = iolist_to_binary(encode_string(Text, Style))}]
+    case parse_string(Source, Style) of
+        [#tpl_text{text = Text}] ->
+            [#raw{sql = iolist_to_binary(encode_string(Text, Style))}];
+        Parts ->
+            [compile_string_op(Style, Parts)]
     end;
 compile_expression({number, Number}) ->
     [#raw{sql = Number}];
@@ -403,9 +401,6 @@ finish_parts(Text, Parts) ->
 
 strip_quotes(Source) ->
     binary:part(Source, 1, byte_size(Source) - 2).
-
-is_variable_part(#tpl_placeholder{}) -> true;
-is_variable_part(_) -> false.
 
 join_ops(_Separator, []) ->
     [];
@@ -583,6 +578,20 @@ scalar_template_value_types_test() ->
                 null_opts()
             )
         )
+    ).
+
+template_parts_classification_test() ->
+    lists:foreach(
+        fun(Prefix) ->
+            {ok, Plan} = compile(
+                <<"INSERT INTO t VALUES (", Prefix/binary, "'', ", Prefix/binary, "'${a}${b}')">>
+            ),
+            ?assertEqual(
+                {ok, <<"INSERT INTO [t] VALUES (", Prefix/binary, "'', ", Prefix/binary, "'xy')">>},
+                rendered_binary(render(Plan, #{a => <<"x">>, b => <<"y">>}, null_opts()))
+            )
+        end,
+        [<<>>, <<"N">>]
     ).
 
 escaped_dollar_test() ->

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
@@ -585,6 +585,27 @@ scalar_template_value_types_test() ->
         )
     ).
 
+escaped_dollar_test() ->
+    Cases = [
+        {<<"${$}">>, <<"$">>},
+        {<<"${$}{amount}">>, <<"${amount}">>},
+        {<<"${$}${$}{amount}${$}">>, <<"$${amount}$">>},
+        {<<"${$}{$}">>, <<"${$}">>},
+        {<<"${$}{amount}${v}${$}{$}">>, <<"${amount}x${$}">>}
+    ],
+    lists:foreach(
+        fun({Prefix, Body, Expected}) ->
+            {ok, Plan} = compile(
+                <<"INSERT INTO t VALUES (", Prefix/binary, "'", Body/binary, "')">>
+            ),
+            ?assertEqual(
+                {ok, <<"INSERT INTO [t] VALUES (", Prefix/binary, "'", Expected/binary, "')">>},
+                rendered_binary(render(Plan, #{amount => 99, v => <<"x">>}, null_opts()))
+            )
+        end,
+        [{Prefix, Body, Expected} || Prefix <- [<<>>, <<"N">>], {Body, Expected} <- Cases]
+    ).
+
 %% Checks missing string values with both undefined-value policies.
 undefined_string_template_values_test() ->
     {ok, Plan} = compile(<<"INSERT INTO t VALUES ('${missing}')">>),

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql.erl
@@ -5,10 +5,10 @@
 %% @doc Compile and render restricted SQL Server INSERT INTO VALUES templates.
 -module(emqx_bridge_sqlserver_sql).
 
--export([compile/1, render/3, render_batch/3, parse_placeholder/1]).
--export_type([plan/0]).
+-behaviour(emqx_sql_plan).
 
--elvis([{elvis_style, no_match_in_condition, disable}]).
+-export([compile/1, render/3, render_batch/3]).
+-export_type([plan/0]).
 
 -type placeholder() :: emqx_template:placeholder().
 
@@ -82,24 +82,12 @@ render_batch(#sqlserver_plan{insert_prefix = Prefix, plan = Plan}, DataList, Opt
     %% https://learn.microsoft.com/en-us/sql/t-sql/queries/table-value-constructor-transact-sql#limitations
     length(DataList) =< 1000
 ->
-    case render_batch_units(DataList, Plan, Opts, _Index = 1, _Acc = []) of
+    case render_batch_units(DataList, Plan, Opts, 1, []) of
         {ok, Rendered} -> {ok, [Prefix, Rendered]};
         {error, _} = Error -> Error
     end;
 render_batch(_Plan, _DataList, _Opts) ->
     {error, sqlserver_values_row_limit_exceeded}.
-
--spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
-parse_placeholder(Source) ->
-    case valid_placeholder_source(Source) of
-        true ->
-            case emqx_template:parse(Source) of
-                [{var, _, _} = Placeholder] -> {ok, Placeholder};
-                _ -> {error, invalid_placeholder}
-            end;
-        false ->
-            {error, invalid_placeholder}
-    end.
 
 %%------------------------------------------------------------------------------
 %% Private funs
@@ -362,27 +350,13 @@ parse_string_body(<<"${", _/binary>> = Bin, Text, Parts) ->
 parse_string_body(<<Char, Rest/binary>>, Text, Parts) ->
     parse_string_body(Rest, [Char | Text], Parts).
 
-%% Restrict emqx_template's envelope to nonempty dotted paths.
-%% Retain `${}` and `${.}`.
-%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
-valid_placeholder_source(<<"${}">>) ->
-    true;
-valid_placeholder_source(<<"${.}">>) ->
-    true;
-valid_placeholder_source(Source) ->
-    re:run(
-        Source,
-        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
-        [{capture, none}]
-    ) =:= match.
-
 take_placeholder(Bin) ->
     case binary:match(Bin, <<"}">>) of
         {End, 1} ->
             Size = End + 1,
             Source = binary:part(Bin, 0, Size),
             Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
-            case parse_placeholder(Source) of
+            case emqx_sql_plan:parse_placeholder(Source) of
                 {ok, Placeholder} -> {Placeholder, Rest};
                 {error, _} -> error({invalid_placeholder, Source})
             end;
@@ -490,7 +464,7 @@ assert_no_nul(Text) ->
 
 %% Checks that compilation merges adjacent static SQL around a value placeholder.
 compile_merges_raw_segments_test() ->
-    {ok, Placeholder} = parse_placeholder(<<"${value}">>),
+    {ok, Placeholder} = emqx_sql_plan:parse_placeholder(<<"${value}">>),
     {ok, #sqlserver_plan{plan = [#raw{sql = <<"(1, 2)">>}]}} =
         compile(<<"INSERT INTO t VALUES (1, 2)">>),
     {ok, #sqlserver_plan{plan = Plan}} =

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_lexer.xrl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_sql_lexer.xrl
@@ -83,7 +83,7 @@ to_binary(Chars) ->
 
 placeholder(Chars, Line) ->
     Bin = to_binary(Chars),
-    case emqx_bridge_sqlserver_sql:parse_placeholder(Bin) of
+    case emqx_sql_plan:parse_placeholder(Bin) of
         {ok, Placeholder} -> {token, {placeholder, Line, Placeholder}};
         {error, _} -> {error, {invalid_placeholder, Line, Bin}}
     end.

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
@@ -225,7 +225,7 @@ on_query(InstanceId, {ChannelId, Data}, #{channels := Channels} = State) ->
     case maps:find(ChannelId, Channels) of
         {ok, #{sql_plan := Plan, opts := Opts} = ChannelState} ->
             RenderOpts = render_opts(maps:get(channel_conf, ChannelState, #{})),
-            case emqx_bridge_tdengine_sql:render(Plan, Data, RenderOpts) of
+            case emqx_sql_plan:render(Plan, Data, RenderOpts) of
                 {ok, Query} ->
                     emqx_trace:rendered_action_template(ChannelId, #{query => Query}),
                     do_query_job(InstanceId, {?MODULE, execute, [Query, Opts]}, State);
@@ -376,7 +376,7 @@ execute(Conn, Query, Opts) ->
 
 do_batch_insert(Conn, Plan, BatchReqs, Opts, TraceRenderedCTX, ChannelConf) ->
     DataList = [Data || {_, Data} <- BatchReqs],
-    case emqx_bridge_tdengine_sql:render_batch(Plan, DataList, render_opts(ChannelConf)) of
+    case emqx_sql_plan:render_batch(Plan, DataList, render_opts(ChannelConf)) of
         {ok, SQL} ->
             try
                 emqx_trace:rendered_action_template_with_ctx(
@@ -399,7 +399,7 @@ connect(Opts) ->
     tdengine:start_link(NOpts).
 
 parse_prepare_sql(SQL) ->
-    case emqx_bridge_tdengine_sql:compile(SQL) of
+    case emqx_sql_plan:compile(emqx_bridge_tdengine_sql, SQL) of
         {ok, Plan} -> {ok, #{sql_plan => Plan}};
         {error, Reason} -> {error, Reason}
     end.

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
@@ -268,9 +268,10 @@ compile_target({target, Database, Component}) ->
     DatabaseOps ++ compile_target_component(Component).
 
 compile_target_component({identifier_parts, Parts} = Identifier) ->
-    case lists:any(fun is_variable_part/1, Parts) of
-        true -> [#identifier{parts = Parts}];
-        false -> [#raw{sql = serialize_identifier(Identifier)}]
+    case Parts of
+        [] -> [#raw{sql = serialize_identifier(Identifier)}];
+        [#tpl_text{}] -> [#raw{sql = serialize_identifier(Identifier)}];
+        _ -> [#identifier{parts = Parts}]
     end;
 compile_target_component({identifier_placeholder, Placeholder}) ->
     [#identifier{parts = [#tpl_placeholder{placeholder = Placeholder}]}];
@@ -300,13 +301,11 @@ compile_row({row, Values}) ->
 compile_value({var, Placeholder}) ->
     [#value{placeholder = Placeholder}];
 compile_value({string, Style, Source}) ->
-    Parts = parse_string(Source, Style),
-    case lists:any(fun is_variable_part/1, Parts) of
-        true ->
-            [#string{parts = Parts}];
-        false ->
-            [#tpl_text{text = Text}] = Parts,
-            [#raw{sql = encode_string(Text)}]
+    case parse_string(Source, Style) of
+        [#tpl_text{text = Text}] ->
+            [#raw{sql = encode_string(Text)}];
+        Parts ->
+            [#string{parts = Parts}]
     end;
 compile_value({number, Number}) ->
     [#raw{sql = Number}];
@@ -441,9 +440,6 @@ finish_parts(Text, Parts) ->
 
 strip_quotes(Source) ->
     binary:part(Source, 1, byte_size(Source) - 2).
-
-is_variable_part(#tpl_placeholder{}) -> true;
-is_variable_part(_) -> false.
 
 join_ops(_Separator, []) ->
     [];
@@ -620,6 +616,36 @@ multi_table_compile_and_render_test() ->
             "`test_client-1` USING s_tab TAGS ('client-1') VALUES (2, 'hello')"
         >>,
         iolist_to_binary(Rendered)
+    ).
+
+template_parts_classification_test() ->
+    lists:foreach(
+        fun(Quote) ->
+            {ok, Plan} = compile(
+                <<"INSERT INTO `a``b` VALUES (", Quote, Quote, ", ", Quote, "${a}${b}", Quote, ")">>
+            ),
+            ?assertEqual(
+                {ok, <<"INSERT INTO `a``b` VALUES ('', 'xy')">>},
+                rendered_binary(render(Plan, #{a => <<"x">>, b => <<"y">>}, null_opts()))
+            )
+        end,
+        "'\""
+    ),
+    lists:foreach(
+        fun(Target) ->
+            {ok, Plan} = compile(<<"INSERT INTO ", Target/binary, " VALUES (1)">>),
+            ?assertEqual(
+                {ok, <<"INSERT INTO `xy` VALUES (1)">>},
+                rendered_binary(
+                    render(Plan, #{a => <<"x">>, b => <<"y">>, table => <<"xy">>}, null_opts())
+                )
+            )
+        end,
+        [<<"${a}${b}">>, <<"`${a}${b}`">>, <<"`${table}`">>]
+    ),
+    ?assertEqual(
+        {error, {invalid_tdengine_insert_template, {error, dynamic_identifier_not_allowed}}},
+        compile(<<"INSERT INTO `` VALUES (1)">>)
     ).
 
 escaped_dollar_test() ->

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
@@ -318,6 +318,8 @@ compile_value({time_arithmetic, Base, Ops}) ->
 
 serialize_identifier({identifier, bare, Name}) ->
     Name;
+serialize_identifier({identifier_parts, []}) ->
+    error({invalid_tdengine_identifier, empty});
 serialize_identifier({identifier_parts, Parts}) ->
     case Parts of
         [#tpl_text{text = Text}] -> quote_identifier(Text);
@@ -620,7 +622,7 @@ template_parts_classification_test() ->
         [<<"${a}${b}">>, <<"`${a}${b}`">>, <<"`${table}`">>]
     ),
     ?assertEqual(
-        {error, {invalid_tdengine_insert_template, {error, dynamic_identifier_not_allowed}}},
+        {error, {invalid_tdengine_insert_template, {error, {invalid_tdengine_identifier, empty}}}},
         compile(<<"INSERT INTO `` VALUES (1)">>)
     ).
 

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
@@ -5,7 +5,9 @@
 %% @doc Compile and render restricted TDengine multi-table INSERT templates.
 -module(emqx_bridge_tdengine_sql).
 
--export([compile/1, render/3, render_batch/3, parse_placeholder/1, parse_identifier_parts/2]).
+-behaviour(emqx_sql_plan).
+
+-export([compile/1, render/3, render_batch/3, parse_identifier_parts/2]).
 -export_type([plan/0]).
 
 -type placeholder() :: emqx_template:placeholder().
@@ -93,18 +95,6 @@ parse_identifier_parts(Source, Style) ->
         {ok, parse_identifier_parts(Source, Style, [], [])}
     catch
         error:Reason -> {error, Reason}
-    end.
-
--spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
-parse_placeholder(Source) ->
-    case valid_placeholder_source(Source) of
-        true ->
-            case emqx_template:parse(Source) of
-                [{var, _, _} = Placeholder] -> {ok, Placeholder};
-                _ -> {error, invalid_placeholder}
-            end;
-        false ->
-            {error, invalid_placeholder}
     end.
 
 %%------------------------------------------------------------------------------
@@ -401,27 +391,13 @@ decode_escape($%) -> <<"\\%">>;
 decode_escape($_) -> <<"\\_">>;
 decode_escape(Char) -> Char.
 
-%% Restrict emqx_template's envelope to nonempty dotted paths.
-%% Retain `${}` and `${.}`.
-%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
-valid_placeholder_source(<<"${}">>) ->
-    true;
-valid_placeholder_source(<<"${.}">>) ->
-    true;
-valid_placeholder_source(Source) ->
-    re:run(
-        Source,
-        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
-        [{capture, none}]
-    ) =:= match.
-
 take_placeholder(Bin) ->
     case binary:match(Bin, <<"}">>) of
         {End, 1} ->
             Size = End + 1,
             Source = binary:part(Bin, 0, Size),
             Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
-            case parse_placeholder(Source) of
+            case emqx_sql_plan:parse_placeholder(Source) of
                 {ok, Placeholder} -> {Placeholder, Rest};
                 {error, _} -> error({invalid_placeholder, Source})
             end;
@@ -576,7 +552,7 @@ assert_no_nul(Text) ->
 
 %% Checks that compilation merges adjacent static SQL around a value placeholder.
 compile_merges_raw_segments_test() ->
-    {ok, Placeholder} = parse_placeholder(<<"${value}">>),
+    {ok, Placeholder} = emqx_sql_plan:parse_placeholder(<<"${value}">>),
     {ok, #tdengine_plan{plan = [#raw{sql = <<"t VALUES (1, 2)">>}]}} =
         compile(<<"INSERT INTO t VALUES (1, 2)">>),
     {ok, #tdengine_plan{plan = Plan}} =

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql.erl
@@ -622,6 +622,27 @@ multi_table_compile_and_render_test() ->
         iolist_to_binary(Rendered)
     ).
 
+escaped_dollar_test() ->
+    Cases = [
+        {<<"${$}">>, <<"$">>},
+        {<<"${$}{amount}">>, <<"${amount}">>},
+        {<<"${$}${$}{amount}${$}">>, <<"$${amount}$">>},
+        {<<"${$}{$}">>, <<"${$}">>},
+        {<<"${$}{amount}${v}${$}{$}">>, <<"${amount}x${$}">>}
+    ],
+    lists:foreach(
+        fun({Quote, Body, Expected}) ->
+            {ok, Plan} = compile(
+                <<"INSERT INTO t VALUES (", Quote, Body/binary, Quote, ")">>
+            ),
+            ?assertEqual(
+                {ok, <<"INSERT INTO t VALUES ('", Expected/binary, "')">>},
+                rendered_binary(render(Plan, #{amount => 99, v => <<"x">>}, null_opts()))
+            )
+        end,
+        [{Quote, Body, Expected} || Quote <- "'\"", {Body, Expected} <- Cases]
+    ).
+
 %% Checks leading-dot placeholders in dynamic identifiers and values.
 leading_dot_placeholder_test() ->
     {ok, Plan} = compile(<<"INSERT INTO test_${.clientid} VALUES (${.payload})">>),

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.xrl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_sql_lexer.xrl
@@ -86,7 +86,7 @@ to_binary(Chars) ->
 
 placeholder(Chars, Line) ->
     Bin = to_binary(Chars),
-    case emqx_bridge_tdengine_sql:parse_placeholder(Bin) of
+    case emqx_sql_plan:parse_placeholder(Bin) of
         {ok, Placeholder} -> {token, {placeholder, Line, Placeholder}};
         {error, _} -> {error, {invalid_placeholder, Line, Bin}}
     end.

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -3,6 +3,13 @@
 %%--------------------------------------------------------------------
 -module(emqx_mysql).
 
+%% The shared connector dispatches to the configured SQL compiler.
+-elvis([
+    {elvis_style, invalid_dynamic_call, #{
+        ignore => [{emqx_mysql, parse_batch_sql, 4}, {emqx_mysql, on_batch_insert, 5}]
+    }}
+]).
+
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("emqx_connector/include/emqx_connector.hrl").
 -include_lib("typerefl/include/types.hrl").

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -25,7 +25,9 @@
 ]).
 
 %% ecpool connect & reconnect
--export([connect/1, prepare_sql_to_conn/2, get_reconnect_callback_signature/1]).
+-export([
+    connect/1, prepare_sql_to_conn/2, prepare_sql_to_conn/3, get_reconnect_callback_signature/1
+]).
 
 -export([
     init_prepare/1,
@@ -339,22 +341,28 @@ maybe_prepare_sql(SQLOrKey, State = #{query_templates := Templates}) ->
         false -> {error, {unrecoverable_error, prepared_statement_invalid}}
     end.
 
-prepare_sql(#{query_templates := Templates, pool_name := PoolName}) ->
-    prepare_sql(maps:to_list(Templates), PoolName).
+prepare_sql(#{query_templates := Templates, pool_name := PoolName} = State) ->
+    PrepareConnFn = maps:get(prepare_conn_fn, State, undefined),
+    prepare_sql(maps:to_list(Templates), PoolName, PrepareConnFn).
 
 prepare_sql(Templates, PoolName) ->
-    case do_prepare_sql(Templates, PoolName) of
+    prepare_sql(Templates, PoolName, undefined).
+
+prepare_sql(Templates, PoolName, PrepareConnFn) ->
+    case do_prepare_sql(Templates, PoolName, PrepareConnFn) of
         ok ->
             %% prepare for reconnect
-            ecpool:add_reconnect_callback(PoolName, {?MODULE, prepare_sql_to_conn, [Templates]}),
+            ecpool:add_reconnect_callback(
+                PoolName, {?MODULE, prepare_sql_to_conn, [Templates, PrepareConnFn]}
+            ),
             ok;
         {error, R} ->
             {error, R}
     end.
 
-do_prepare_sql(Templates, PoolName) ->
+do_prepare_sql(Templates, PoolName, PrepareConnFn) ->
     Conns = get_connections_from_pool(PoolName),
-    prepare_sql_to_conn_list(Conns, Templates).
+    prepare_sql_to_conn_list(Conns, Templates, PrepareConnFn).
 
 get_connections_from_pool(PoolName) ->
     lists:map(
@@ -368,12 +376,12 @@ get_connections_from_pool(PoolName) ->
 pool_workers(PoolName) ->
     lists:map(fun({_Name, Worker}) -> Worker end, ecpool:workers(PoolName)).
 
-prepare_sql_to_conn_list([], _Templates) ->
+prepare_sql_to_conn_list([], _Templates, _PrepareConnFn) ->
     ok;
-prepare_sql_to_conn_list([Conn | ConnList], Templates) ->
-    case prepare_sql_to_conn(Conn, Templates) of
+prepare_sql_to_conn_list([Conn | ConnList], Templates, PrepareConnFn) ->
+    case prepare_sql_to_conn(Conn, Templates, PrepareConnFn) of
         ok ->
-            prepare_sql_to_conn_list(ConnList, Templates);
+            prepare_sql_to_conn_list(ConnList, Templates, PrepareConnFn);
         {error, R} ->
             %% rollback
             _ = [unprepare_sql_to_conn(Conn, Template) || Template <- Templates],
@@ -381,9 +389,9 @@ prepare_sql_to_conn_list([Conn | ConnList], Templates) ->
     end.
 
 %% this callback accepts the arg list provided to
-%% ecpool:add_reconnect_callback(PoolName, {?MODULE, prepare_sql_to_conn, [Templates]})
+%% ecpool:add_reconnect_callback(PoolName, {?MODULE, prepare_sql_to_conn, [Templates | _]})
 %% so ecpool_worker can de-duplicate the callbacks based on the signature.
-get_reconnect_callback_signature([Templates]) ->
+get_reconnect_callback_signature([Templates | _]) ->
     [{{ChannelID, _}, _}] = lists:filter(
         fun
             ({{_, prepstmt}, _}) ->
@@ -394,6 +402,14 @@ get_reconnect_callback_signature([Templates]) ->
         Templates
     ),
     ChannelID.
+
+prepare_sql_to_conn(Conn, Templates, undefined) ->
+    prepare_sql_to_conn(Conn, Templates);
+prepare_sql_to_conn(Conn, Templates, PrepareConnFn) ->
+    case PrepareConnFn(Conn) of
+        ok -> prepare_sql_to_conn(Conn, Templates);
+        {error, _} = Error -> Error
+    end.
 
 prepare_sql_to_conn(Conn, Templates) ->
     case clear_unsafe_sql_modes(Conn) of

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -3,13 +3,6 @@
 %%--------------------------------------------------------------------
 -module(emqx_mysql).
 
-%% The shared connector dispatches to the configured SQL compiler.
--elvis([
-    {elvis_style, invalid_dynamic_call, #{
-        ignore => [{emqx_mysql, parse_batch_sql, 4}, {emqx_mysql, on_batch_insert, 5}]
-    }}
-]).
-
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("emqx_connector/include/emqx_connector.hrl").
 -include_lib("typerefl/include/types.hrl").
@@ -71,7 +64,7 @@
 
 -define(READ_SQL_MODE_QUERY, <<"SELECT @@SESSION.sql_mode">>).
 
--type template() :: {unicode:chardata(), emqx_template:str()} | emqx_mysql_sql:plan().
+-type template() :: {unicode:chardata(), emqx_template:str()} | emqx_sql_plan:plan().
 -type state() ::
     #{
         pool_name := binary(),
@@ -522,7 +515,7 @@ parse_prepare_sql(Key, Query, Acc, Compiler) ->
 parse_batch_sql(Key, Query, Acc, Compiler) ->
     case emqx_utils_sql:get_statement_type(Query) of
         insert ->
-            case Compiler:compile(Query) of
+            case emqx_sql_plan:compile(Compiler, Query) of
                 {ok, Plan} ->
                     Acc#{{Key, batch} => Plan};
                 {error, Reason} ->
@@ -569,8 +562,7 @@ on_batch_insert(InstId, BatchReqs, Plan, State, ChannelConfig) ->
     RenderOpts = #{
         undefined_vars_as_null => maps:get(undefined_vars_as_null, ChannelConfig, false)
     },
-    Compiler = maps:get(sql_compiler, ChannelConfig, emqx_mysql_sql),
-    case Compiler:render_batch(Plan, DataList, RenderOpts) of
+    case emqx_sql_plan:render_batch(Plan, DataList, RenderOpts) of
         {ok, Query} ->
             on_sql_query(InstId, query, Query, no_params, default_timeout, State);
         {error, Reason} ->

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -501,18 +501,21 @@ parse_prepare_sql(Key, Config) ->
             _ ->
                 #{}
         end,
-    Templates = maps:fold(fun parse_prepare_sql/3, #{}, Queries),
+    Compiler = maps:get(sql_compiler, Config, emqx_mysql_sql),
+    Templates = maps:fold(
+        fun(K, Q, Acc) -> parse_prepare_sql(K, Q, Acc, Compiler) end, #{}, Queries
+    ),
     #{query_templates => Templates}.
 
-parse_prepare_sql(Key, Query, Acc) ->
+parse_prepare_sql(Key, Query, Acc, Compiler) ->
     Template = emqx_template_sql:parse_prepstmt(Query, #{parameters => '?'}),
     AccNext = Acc#{{Key, prepstmt} => Template},
-    parse_batch_sql(Key, Query, AccNext).
+    parse_batch_sql(Key, Query, AccNext, Compiler).
 
-parse_batch_sql(Key, Query, Acc) ->
+parse_batch_sql(Key, Query, Acc, Compiler) ->
     case emqx_utils_sql:get_statement_type(Query) of
         insert ->
-            case emqx_mysql_sql:compile(Query) of
+            case Compiler:compile(Query) of
                 {ok, Plan} ->
                     Acc#{{Key, batch} => Plan};
                 {error, Reason} ->
@@ -559,7 +562,8 @@ on_batch_insert(InstId, BatchReqs, Plan, State, ChannelConfig) ->
     RenderOpts = #{
         undefined_vars_as_null => maps:get(undefined_vars_as_null, ChannelConfig, false)
     },
-    case emqx_mysql_sql:render_batch(Plan, DataList, RenderOpts) of
+    Compiler = maps:get(sql_compiler, ChannelConfig, emqx_mysql_sql),
+    case Compiler:render_batch(Plan, DataList, RenderOpts) of
         {ok, Query} ->
             on_sql_query(InstId, query, Query, no_params, default_timeout, State);
         {error, Reason} ->

--- a/apps/emqx_mysql/src/emqx_mysql_sql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql.erl
@@ -5,10 +5,10 @@
 %% @doc Compile and render restricted MySQL INSERT INTO VALUES templates.
 -module(emqx_mysql_sql).
 
--export([compile/1, render/3, render_batch/3, parse_placeholder/1]).
--export_type([plan/0]).
+-behaviour(emqx_sql_plan).
 
--elvis([{elvis_style, no_match_in_condition, disable}]).
+-export([compile/1, render/3, render_batch/3]).
+-export_type([plan/0]).
 
 -type placeholder() :: emqx_template:placeholder().
 
@@ -72,21 +72,9 @@ render(#mysql_plan{insert_prefix = Prefix, row_plan = Plan, suffix = Suffix}, Da
 render_batch(
     #mysql_plan{insert_prefix = Prefix, row_plan = Plan, suffix = Suffix}, DataList, Opts
 ) ->
-    case render_batch_units(DataList, Plan, Opts, _Index = 1, _Acc = []) of
+    case render_batch_units(DataList, Plan, Opts, 1, []) of
         {ok, Rendered} -> {ok, [Prefix, Rendered, Suffix]};
         {error, _} = Error -> Error
-    end.
-
--spec parse_placeholder(binary()) -> {ok, placeholder()} | {error, invalid_placeholder}.
-parse_placeholder(Source) ->
-    case valid_placeholder_source(Source) of
-        true ->
-            case emqx_template:parse(Source) of
-                [{var, _, _} = Placeholder] -> {ok, Placeholder};
-                _ -> {error, invalid_placeholder}
-            end;
-        false ->
-            {error, invalid_placeholder}
     end.
 
 %%------------------------------------------------------------------------------
@@ -392,27 +380,13 @@ merge_render_ops(Ops) ->
         )
     ).
 
-%% Restrict emqx_template's envelope to nonempty dotted paths.
-%% Retain `${}` and `${.}`.
-%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
-valid_placeholder_source(<<"${}">>) ->
-    true;
-valid_placeholder_source(<<"${.}">>) ->
-    true;
-valid_placeholder_source(Source) ->
-    re:run(
-        Source,
-        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
-        [{capture, none}]
-    ) =:= match.
-
 take_placeholder(Bin) ->
     case binary:match(Bin, <<"}">>) of
         {End, 1} ->
             Size = End + 1,
             Source = binary:part(Bin, 0, Size),
             Rest = binary:part(Bin, Size, byte_size(Bin) - Size),
-            case parse_placeholder(Source) of
+            case emqx_sql_plan:parse_placeholder(Source) of
                 {ok, Placeholder} -> {Placeholder, Rest};
                 {error, _} -> error({invalid_placeholder, Source})
             end;

--- a/apps/emqx_mysql/src/emqx_mysql_sql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql.erl
@@ -328,42 +328,30 @@ compile_case_else(Expression) ->
 parse_sql_string(Source) ->
     Delimiter = binary:first(Source),
     Body = binary:part(Source, 1, byte_size(Source) - 2),
-    parse_sql_string_body(Body, Delimiter, Source, [], [], false, false).
+    parse_sql_string_body(Body, Delimiter, [], []).
 
-%% Arguments are
-%% * the remaining body
-%% * quote delimiter
-%% * original token
-%% * reversed text acc
-%% * reversed compiled parts
-%% * IsDynamic flag
-%% * Rewritten flag for escaped dollars
-%% Return the original token only when neither flag is set.
-%% The first placeholder switches IsDynamic to true and starts accumulating compiled parts.
-parse_sql_string_body(<<>>, _Delimiter, Source, _Text, _Parts, false, false) ->
-    {static, Source};
-parse_sql_string_body(<<>>, Delimiter, _Source, Text, [], false, true) ->
-    [#string_raw{sql = SQL}] = flush_string_text(Text, Delimiter, []),
-    {static, SQL};
-parse_sql_string_body(<<>>, Delimiter, _Source, Text, Parts, true, _Rewritten) ->
-    ok = assert_safe_string_split(Text),
-    {dynamic, lists:reverse(flush_string_text(Text, Delimiter, Parts))};
-parse_sql_string_body(
-    <<"${$}", Rest/binary>>, Delimiter, Source, Text, Parts, IsDynamic, _Rewritten
-) ->
-    parse_sql_string_body(Rest, Delimiter, Source, [$$ | Text], Parts, IsDynamic, true);
-parse_sql_string_body(
-    <<"${", _/binary>> = Bin, Delimiter, Source, Text, Parts, _IsDynamic, Rewritten
-) ->
+parse_sql_string_body(<<>>, Delimiter, Text, Parts) ->
+    case lists:reverse(flush_string_text(Text, Delimiter, Parts)) of
+        [] ->
+            {static, <<Delimiter, Delimiter>>};
+        [#string_raw{sql = SQL}] ->
+            {static, SQL};
+        FinalParts ->
+            ok = assert_safe_string_split(Text),
+            {dynamic, FinalParts}
+    end;
+parse_sql_string_body(<<"${$}", Rest/binary>>, Delimiter, Text, Parts) ->
+    parse_sql_string_body(Rest, Delimiter, [$$ | Text], Parts);
+parse_sql_string_body(<<"${", _/binary>> = Bin, Delimiter, Text, Parts) ->
     ok = assert_safe_string_split(Text),
     {Placeholder, Rest} = take_placeholder(Bin),
     PartsNext = [
         #string_placeholder{placeholder = Placeholder}
         | flush_string_text(Text, Delimiter, Parts)
     ],
-    parse_sql_string_body(Rest, Delimiter, Source, [], PartsNext, true, Rewritten);
-parse_sql_string_body(<<Char, Rest/binary>>, Delimiter, Source, Text, Parts, IsDynamic, Rewritten) ->
-    parse_sql_string_body(Rest, Delimiter, Source, [Char | Text], Parts, IsDynamic, Rewritten).
+    parse_sql_string_body(Rest, Delimiter, [], PartsNext);
+parse_sql_string_body(<<Char, Rest/binary>>, Delimiter, Text, Parts) ->
+    parse_sql_string_body(Rest, Delimiter, [Char | Text], Parts).
 
 flush_string_text([], _Delimiter, Parts) ->
     Parts;

--- a/apps/emqx_mysql/src/emqx_mysql_sql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql.erl
@@ -328,7 +328,7 @@ compile_case_else(Expression) ->
 parse_sql_string(Source) ->
     Delimiter = binary:first(Source),
     Body = binary:part(Source, 1, byte_size(Source) - 2),
-    parse_sql_string_body(Body, Delimiter, Source, [], [], false).
+    parse_sql_string_body(Body, Delimiter, Source, [], [], false, false).
 
 %% Arguments are
 %% * the remaining body
@@ -337,17 +337,23 @@ parse_sql_string(Source) ->
 %% * reversed text acc
 %% * reversed compiled parts
 %% * IsDynamic flag
-%% IsDynamic starts as false. When no placeholder is found, return the original token.
+%% * Rewritten flag for escaped dollars
+%% Return the original token only when neither flag is set.
 %% The first placeholder switches IsDynamic to true and starts accumulating compiled parts.
-parse_sql_string_body(_Body = <<>>, _Delimiter, Source, _Text, _Parts, _IsDynamic = false) ->
+parse_sql_string_body(<<>>, _Delimiter, Source, _Text, _Parts, false, false) ->
     {static, Source};
-parse_sql_string_body(<<>>, Delimiter, _Source, Text, Parts, _IsDynamic = true) ->
+parse_sql_string_body(<<>>, Delimiter, _Source, Text, [], false, true) ->
+    [#string_raw{sql = SQL}] = flush_string_text(Text, Delimiter, []),
+    {static, SQL};
+parse_sql_string_body(<<>>, Delimiter, _Source, Text, Parts, true, _Rewritten) ->
     ok = assert_safe_string_split(Text),
     {dynamic, lists:reverse(flush_string_text(Text, Delimiter, Parts))};
-parse_sql_string_body(<<"${$}", Rest/binary>>, Delimiter, Source, Text, Parts, IsDynamic) ->
-    parse_sql_string_body(Rest, Delimiter, Source, [$$ | Text], Parts, IsDynamic);
 parse_sql_string_body(
-    <<"${", _/binary>> = Bin, Delimiter, Source, Text, Parts, _IsDynamic
+    <<"${$}", Rest/binary>>, Delimiter, Source, Text, Parts, IsDynamic, _Rewritten
+) ->
+    parse_sql_string_body(Rest, Delimiter, Source, [$$ | Text], Parts, IsDynamic, true);
+parse_sql_string_body(
+    <<"${", _/binary>> = Bin, Delimiter, Source, Text, Parts, _IsDynamic, Rewritten
 ) ->
     ok = assert_safe_string_split(Text),
     {Placeholder, Rest} = take_placeholder(Bin),
@@ -355,9 +361,9 @@ parse_sql_string_body(
         #string_placeholder{placeholder = Placeholder}
         | flush_string_text(Text, Delimiter, Parts)
     ],
-    parse_sql_string_body(Rest, Delimiter, Source, [], PartsNext, true);
-parse_sql_string_body(<<Char, Rest/binary>>, Delimiter, Source, Text, Parts, IsDynamic) ->
-    parse_sql_string_body(Rest, Delimiter, Source, [Char | Text], Parts, IsDynamic).
+    parse_sql_string_body(Rest, Delimiter, Source, [], PartsNext, true, Rewritten);
+parse_sql_string_body(<<Char, Rest/binary>>, Delimiter, Source, Text, Parts, IsDynamic, Rewritten) ->
+    parse_sql_string_body(Rest, Delimiter, Source, [Char | Text], Parts, IsDynamic, Rewritten).
 
 flush_string_text([], _Delimiter, Parts) ->
     Parts;
@@ -632,6 +638,63 @@ double_quoted_string_test() ->
     ?assertEqual(
         {ok, <<"INSERT INTO `a``b` (`c``d`) VALUES ('changed')">>},
         rendered_binary(render(BacktickPlan, #{value => <<"changed">>}, null_opts()))
+    ).
+
+escaped_dollar_static_test() ->
+    Cases = [
+        {<<>>, <<>>},
+        {<<"plain\\n\\q">>, <<"plain\\n\\q">>},
+        {<<"${$}">>, <<"$">>},
+        {<<"cost: ${$}{amount}">>, <<"cost: ${amount}">>},
+        {<<"${$}${$}{amount}${$}">>, <<"$${amount}$">>},
+        {<<"${$}{$}">>, <<"${$}">>},
+        {<<"\\${$}{amount}">>, <<"\\${amount}">>},
+        {<<"\\\\${$}{amount}">>, <<"\\\\${amount}">>},
+        {<<"${$}\\\\">>, <<"$\\\\">>}
+    ],
+    lists:foreach(
+        fun({Quote, Body, Expected}) ->
+            Prefix = <<"INSERT INTO `t` VALUES ">>,
+            {ok, Plan} = compile(<<Prefix/binary, "(", Quote, Body/binary, Quote, ")">>),
+            Row = <<"(", Quote, Expected/binary, Quote, ")">>,
+            ?assertMatch(#mysql_plan{row_plan = [#raw{sql = Row}]}, Plan),
+            lists:foreach(
+                fun(Data) ->
+                    ?assertEqual(
+                        {ok, <<Prefix/binary, Row/binary>>},
+                        rendered_binary(render(Plan, Data, #{}))
+                    )
+                end,
+                [#{}, #{amount => {must_not_resolve}}]
+            ),
+            ?assertEqual(
+                {ok, <<Prefix/binary, Row/binary, ", ", Row/binary>>},
+                rendered_binary(render_batch(Plan, [#{}, #{amount => 99}], #{}))
+            )
+        end,
+        [{Q, B, E} || Q <- "'\"", {B, E} <- Cases ++ [{<<Q, Q>>, <<Q, Q>>}]]
+    ),
+    {ok, UpdatePlan} = compile(
+        <<"INSERT INTO t VALUES (1) ON DUPLICATE KEY UPDATE c = 'cost: ${$}{amount}'">>
+    ),
+    ?assertEqual(
+        {ok, <<"INSERT INTO `t` VALUES (1) ON DUPLICATE KEY UPDATE c = 'cost: ${amount}'">>},
+        rendered_binary(render(UpdatePlan, #{amount => 99}, #{}))
+    ).
+
+escaped_dollar_dynamic_test() ->
+    lists:foreach(
+        fun(Quote) ->
+            SQL = <<"INSERT INTO t VALUES (", Quote, "${$}{amount}${v}${$}{$}", Quote, ")">>,
+            {ok, Plan} = compile(SQL),
+            ?assertEqual(
+                {ok,
+                    <<"INSERT INTO `t` VALUES (CONCAT(", Quote, "${amount}", Quote, ", 'x', ",
+                        Quote, "${$}", Quote, "))">>},
+                rendered_binary(render(Plan, #{v => <<"x">>, amount => {must_not_resolve}}, #{}))
+            )
+        end,
+        "'\""
     ).
 
 %% Checks escaped-quote boundaries and rejection of placeholders preceded by an invalid escape.

--- a/apps/emqx_mysql/src/emqx_mysql_sql_lexer.xrl
+++ b/apps/emqx_mysql/src/emqx_mysql_sql_lexer.xrl
@@ -102,7 +102,7 @@ to_binary(Chars) ->
 
 placeholder(Chars, Line) ->
     Bin = to_binary(Chars),
-    case emqx_mysql_sql:parse_placeholder(Bin) of
+    case emqx_sql_plan:parse_placeholder(Bin) of
         {ok, Placeholder} -> {token, {placeholder, Line, Placeholder}};
         {error, _} -> {error, {invalid_placeholder, Line, Bin}}
     end.

--- a/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
+++ b/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
@@ -142,6 +142,36 @@ t_segmented_batch_template(_Config) ->
     ok = mysql:query(Conn, [<<"DROP TABLE ">>, Table]),
     ok = mysql:stop(Conn).
 
+t_escaped_dollar_roundtrip(_Config) ->
+    Conn = connect_mysql(),
+    ok = emqx_mysql:prepare_sql_to_conn(Conn, []),
+    ok = mysql:query(Conn, <<"CREATE TEMPORARY TABLE mqtt.emqx_mysql_dollar (txt TEXT)">>),
+    Cases = [
+        {<<"${$}">>, <<"$">>},
+        {<<"cost: ${$}{amount}">>, <<"cost: ${amount}">>},
+        {<<"${$}${$}{amount}${$}">>, <<"$${amount}$">>},
+        {<<"${$}{$}">>, <<"${$}">>},
+        {<<"\\${$}{amount}">>, <<"${amount}">>},
+        {<<"\\\\${$}{amount}">>, <<"\\${amount}">>},
+        {<<"${$}{amount}${v}${$}{$}">>, <<"${amount}x${$}">>}
+    ],
+    lists:foreach(
+        fun({Quote, Body, Expected}) ->
+            {ok, Plan} = emqx_mysql_sql:compile(
+                <<"INSERT INTO mqtt.emqx_mysql_dollar VALUES (", Quote, Body/binary, Quote, ")">>
+            ),
+            {ok, SQL} = emqx_mysql_sql:render(Plan, #{v => <<"x">>, amount => 99}, #{}),
+            ok = mysql:query(Conn, SQL),
+            ?assertEqual(
+                {ok, [<<"txt">>], [[Expected]]},
+                mysql:query(Conn, <<"SELECT txt FROM mqtt.emqx_mysql_dollar">>)
+            ),
+            ok = mysql:query(Conn, <<"DELETE FROM mqtt.emqx_mysql_dollar">>)
+        end,
+        [{Q, B, E} || Q <- "'\"", {B, E} <- Cases]
+    ),
+    ok = mysql:stop(Conn).
+
 perform_lifecycle_check(ResourceId, InitialConfig) ->
     {ok, #{config := CheckedConfig}} =
         emqx_resource:check_config(?MYSQL_RESOURCE_MOD, InitialConfig),

--- a/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
+++ b/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
@@ -67,7 +67,7 @@ t_sql_renderer(_Config) ->
         "(txt, encoded_text, json_value, binary_value) ",
         "VALUES (${txt}, ${encoded_text}, ${json}, ${binary})"
     >>,
-    {ok, Plan} = emqx_mysql_sql:compile(SQL),
+    {ok, Plan} = emqx_sql_plan:compile(emqx_mysql_sql, SQL),
     Attack = <<"'); DROP TABLE mqtt.emqx_mysql_sql_modes; -- ">>,
     EncodedText = <<"你好", 0, "😀"/utf8>>,
     Data = #{
@@ -76,7 +76,7 @@ t_sql_renderer(_Config) ->
         json => #{<<"key">> => <<"a\\b">>},
         binary => <<16#FF>>
     },
-    {ok, Query} = emqx_mysql_sql:render(Plan, Data, #{undefined_vars_as_null => true}),
+    {ok, Query} = emqx_sql_plan:render(Plan, Data, #{undefined_vars_as_null => true}),
     ok = mysql:query(Conn, Query),
     {ok, Columns, [[Attack, EncodedTextHex, <<"a\\b">>, <<"FF">>]]} = mysql:query(
         Conn,
@@ -95,8 +95,8 @@ t_sql_renderer(_Config) ->
         "VALUES (CASE WHEN ${txt} = 'null' THEN NULL ELSE ${txt} END, "
         "${encoded_text}, ${json}, ${binary})"
     >>,
-    {ok, CasePlan} = emqx_mysql_sql:compile(CaseSQL),
-    {ok, CaseQuery} = emqx_mysql_sql:render(
+    {ok, CasePlan} = emqx_sql_plan:compile(emqx_mysql_sql, CaseSQL),
+    {ok, CaseQuery} = emqx_sql_plan:render(
         CasePlan,
         #{txt => <<"null">>, encoded_text => <<"case">>, json => #{}, binary => <<>>},
         #{undefined_vars_as_null => true}
@@ -126,7 +126,7 @@ t_segmented_batch_template(_Config) ->
     #{query_templates := #{{send_message, batch} := Plan}} =
         emqx_mysql:parse_prepare_sql(#{sql => SQL}),
     BatchValue = <<"batch\\value">>,
-    {ok, BatchSQL} = emqx_mysql_sql:render_batch(
+    {ok, BatchSQL} = emqx_sql_plan:render_batch(
         Plan,
         [#{value => BatchValue}],
         #{undefined_vars_as_null => true}
@@ -157,10 +157,11 @@ t_escaped_dollar_roundtrip(_Config) ->
     ],
     lists:foreach(
         fun({Quote, Body, Expected}) ->
-            {ok, Plan} = emqx_mysql_sql:compile(
+            {ok, Plan} = emqx_sql_plan:compile(
+                emqx_mysql_sql,
                 <<"INSERT INTO mqtt.emqx_mysql_dollar VALUES (", Quote, Body/binary, Quote, ")">>
             ),
-            {ok, SQL} = emqx_mysql_sql:render(Plan, #{v => <<"x">>, amount => 99}, #{}),
+            {ok, SQL} = emqx_sql_plan:render(Plan, #{v => <<"x">>, amount => 99}, #{}),
             ok = mysql:query(Conn, SQL),
             ?assertEqual(
                 {ok, [<<"txt">>], [[Expected]]},

--- a/apps/emqx_utils/src/emqx_sql_plan.erl
+++ b/apps/emqx_utils/src/emqx_sql_plan.erl
@@ -1,0 +1,86 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_sql_plan).
+
+-export([compile/2, render/3, render_batch/3, parse_placeholder/1]).
+-export_type([plan/0]).
+
+-elvis([
+    {elvis_style, invalid_dynamic_call, #{
+        ignore => [
+            {emqx_sql_plan, compile, 2},
+            {emqx_sql_plan, render, 3},
+            {emqx_sql_plan, render_batch, 3}
+        ]
+    }}
+]).
+
+-record(plan, {plan :: term(), cb_mod :: module()}).
+-opaque plan() :: #plan{}.
+
+-callback compile(unicode:chardata()) -> {ok, term()} | {error, term()}.
+-callback render(term(), map(), map()) -> {ok, iolist()} | {error, term()}.
+-callback render_batch(term(), [map()], map()) -> {ok, iolist()} | {error, term()}.
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec compile(module(), unicode:chardata()) -> {ok, plan()} | {error, term()}.
+compile(Module, Template) ->
+    case Module:compile(Template) of
+        {ok, Plan} -> {ok, #plan{plan = Plan, cb_mod = Module}};
+        {error, _} = Error -> Error
+    end.
+
+-spec render(plan(), map(), map()) -> {ok, iolist()} | {error, term()}.
+render(#plan{plan = Plan, cb_mod = Module}, Data, Opts) ->
+    Module:render(Plan, Data, Opts).
+
+-spec render_batch(plan(), [map()], map()) -> {ok, iolist()} | {error, term()}.
+render_batch(#plan{plan = Plan, cb_mod = Module}, Data, Opts) ->
+    Module:render_batch(Plan, Data, Opts).
+
+-spec parse_placeholder(binary()) ->
+    {ok, emqx_template:placeholder()} | {error, invalid_placeholder}.
+parse_placeholder(Source) ->
+    case valid_placeholder_source(Source) of
+        true ->
+            case emqx_template:parse(Source) of
+                [{var, _, _} = Placeholder] -> {ok, Placeholder};
+                _ -> {error, invalid_placeholder}
+            end;
+        false ->
+            {error, invalid_placeholder}
+    end.
+
+%%------------------------------------------------------------------------------
+%% Private
+%%------------------------------------------------------------------------------
+
+%% Restrict emqx_template's envelope to nonempty dotted paths.
+%% Retain `${}` and `${.}`.
+%% See emqx_template:parse/1 in apps/emqx_utils/src/emqx_template.erl.
+valid_placeholder_source(<<"${}">>) ->
+    true;
+valid_placeholder_source(<<"${.}">>) ->
+    true;
+valid_placeholder_source(Source) ->
+    re:run(
+        Source,
+        <<"^\\$\\{\\.?[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*\\}$">>,
+        [{capture, none}]
+    ) =:= match.

--- a/changes/ee/fix-18846.en.md
+++ b/changes/ee/fix-18846.en.md
@@ -1,1 +1,1 @@
-Fixed SQL template rendering in data integrations. Doris batch inserts now use Doris-compatible syntax and escaping for text and binary values. MySQL templates now handle escaped dollar signs correctly. SQL Server and TDengine templates now handle empty strings and adjacent placeholders correctly.
+Fixed SQL template rendering in data integrations. Doris batch inserts now use Doris-compatible syntax and escaping for text and binary values. MySQL templates now handle escaped dollar signs correctly.

--- a/changes/ee/fix-18846.en.md
+++ b/changes/ee/fix-18846.en.md
@@ -1,0 +1,1 @@
+Fixed SQL template rendering in data integrations. Doris batch inserts now use Doris-compatible syntax and escaping for text and binary values. MySQL templates now handle escaped dollar signs correctly. SQL Server and TDengine templates now handle empty strings and adjacent placeholders correctly.


### PR DESCRIPTION
Release versions: 5.10.5, 6.0, 6.1, 6.2, 6.3, 7.0

Introduced in: 5.10

## Summary

Use a Doris-specific restricted SQL compiler for batch inserts. Validate Doris syntax and render interpolated values with Doris-compatible escaping, including raw strings and binary data. Single-message Doris actions continue to use prepared statements.

Small fixes/refactorings:
- Fix literal-dollar interpolation in MySQL SQL templates.
- Use a shared SQL-plan interface and placeholder validation across backends.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)