### PR TITLE
fix(api-key): keep the stored secret hash on bootstrap file reload

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -706,7 +706,7 @@ add_bootstrap_file(File, Dev, MP, Line) ->
                         #?APP{
                             name = generate_unique_name(?FROM_BOOTSTRAP_FILE_PREFIX, ApiKey),
                             api_key = ApiKey,
-                            api_secret_hash = emqx_dashboard_admin:hash_api_secret(ApiSecret),
+                            api_secret_hash = bootstrap_secret_hash(ApiKey, ApiSecret),
                             enable = true,
                             extra = Extra,
                             created_at = erlang:system_time(second),
@@ -742,6 +742,24 @@ add_bootstrap_file(File, Dev, MP, Line) ->
             ok;
         {error, Reason} ->
             throw(#{file => File, line => Line, reason => Reason})
+    end.
+
+%% Keep the hash already stored for this key when the bootstrap file still
+%% holds the same secret. A fresh hash on every boot rewrites the
+%% cluster-shared record in a format older nodes cannot verify during a
+%% rolling upgrade.
+bootstrap_secret_hash(ApiKey, ApiSecret) ->
+    case find_by_api_key(ApiKey) of
+        {ok, _Enable, _ExpiredAt, StoredHash, _Role, _Namespace, _Extra} ->
+            keep_or_rehash(ApiSecret, StoredHash);
+        {error, _} ->
+            emqx_dashboard_admin:hash_api_secret(ApiSecret)
+    end.
+
+keep_or_rehash(ApiSecret, StoredHash) ->
+    case emqx_dashboard_admin:verify_hash(ApiSecret, StoredHash) of
+        ok -> StoredHash;
+        error -> emqx_dashboard_admin:hash_api_secret(ApiSecret)
     end.
 
 read_line(Dev) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -95,6 +95,11 @@ groups() ->
             t_bootstrap_file_3_segment_publisher_seeds_publish_scope,
             t_bootstrap_file_ns_admin_seeds_ns_default_scopes,
             t_bootstrap_file_ns_admin_drops_out_of_allowlist_scopes,
+            t_bootstrap_file_override,
+            t_bootstrap_file_dup_override,
+            t_bootstrap_file_same_secret_keeps_hash,
+            t_bootstrap_file_rotated_secret_rehashes,
+            t_bootstrap_file_same_secret_updates_metadata,
             t_create_failed
         ]}
     ].
@@ -250,7 +255,7 @@ t_bootstrap_file_override(_) ->
         ]},
         emqx_mgmt_auth:trans(MatchFun, [<<"test-1">>])
     ),
-    ?assertEqual(ok, emqx_mgmt_auth:authorize(TestPath, <<"test-1">>, <<"duplicated-secret-1">>)),
+    ?assertMatch({ok, _}, auth_authorize(TestPath, <<"test-1">>, <<"duplicated-secret-1">>)),
 
     ?assertMatch(
         {ok, [
@@ -261,7 +266,7 @@ t_bootstrap_file_override(_) ->
         ]},
         emqx_mgmt_auth:trans(MatchFun, [<<"test-2">>])
     ),
-    ?assertEqual(ok, emqx_mgmt_auth:authorize(TestPath, <<"test-2">>, <<"duplicated-secret-2">>)),
+    ?assertMatch({ok, _}, auth_authorize(TestPath, <<"test-2">>, <<"duplicated-secret-2">>)),
     ok.
 
 t_bootstrap_file_dup_override(_) ->
@@ -286,19 +291,10 @@ t_bootstrap_file_dup_override(_) ->
     MatchFun = fun(ApiKey) -> mnesia:match_object(#?APP{api_key = ApiKey, _ = '_'}) end,
 
     ?assertEqual({ok, ok}, emqx_mgmt_auth:trans(WriteFun, [SameAppWithDiffName])),
-    %% as erlang term order
-    ?assertMatch(
-        {ok, [
-            #?APP{
-                name = <<"name-1">>,
-                api_key = <<"test-1">>
-            },
-            #?APP{
-                name = <<"from_bootstrap_file_18926f94712af04e">>,
-                api_key = <<"test-1">>
-            }
-        ]},
-        emqx_mgmt_auth:trans(MatchFun, [TestApiKey])
+    %% `match_object' does not order its result, so compare the names as a set.
+    ?assertEqual(
+        [<<"from_bootstrap_file_18926f94712af04e">>, <<"name-1">>],
+        app_names(emqx_mgmt_auth:trans(MatchFun, [TestApiKey]))
     ),
 
     update_file(File),
@@ -306,20 +302,111 @@ t_bootstrap_file_dup_override(_) ->
     %% Similar to loading bootstrap file at node startup
     %% the duplicated apikey in mnesia will be cleaned up
     ?assertEqual(ok, emqx_mgmt_auth:init_bootstrap_file(File)),
-    ?assertMatch(
-        {ok, [
-            #?APP{
-                name = <<"from_bootstrap_file_18926f94712af04e">>,
-                api_key = <<"test-1">>
-            }
-        ]},
-        emqx_mgmt_auth:trans(MatchFun, [<<"test-1">>])
+    ?assertEqual(
+        [<<"from_bootstrap_file_18926f94712af04e">>],
+        app_names(emqx_mgmt_auth:trans(MatchFun, [<<"test-1">>]))
     ),
 
     %% the last apikey in bootstrap file will override the all in mnesia and the previous one(s) in bootstrap file
-    ?assertEqual(ok, emqx_mgmt_auth:authorize(TestPath, <<"test-1">>, <<"secret-1">>)),
+    ?assertMatch({ok, _}, auth_authorize(TestPath, <<"test-1">>, <<"secret-1">>)),
 
     ok.
+
+-doc """
+A bootstrap file re-read with an unchanged secret keeps the stored hash
+byte-identical, so a node joining a mixed-version cluster does not rewrite the
+shared record in a format the older nodes cannot verify.
+""".
+t_bootstrap_file_same_secret_keeps_hash(_) ->
+    TestPath = <<"/api/v5/status">>,
+    ApiKey = <<"keep-hash-1">>,
+    Secret = <<"secret-1">>,
+    File = "./bootstrap_api_keys.txt",
+    ok = file:write_file(File, <<ApiKey/binary, ":", Secret/binary>>),
+    update_file(File),
+    ?assertEqual(ok, emqx_mgmt_auth:init_bootstrap_file(File)),
+
+    %% Replace the hash with the pre-6.3 layout an older node writes.
+    LegacyHash = legacy_hash(<<"abcd">>, Secret),
+    ok = set_secret_hash(ApiKey, LegacyHash),
+    ?assertMatch({ok, _}, auth_authorize(TestPath, ApiKey, Secret)),
+
+    ?assertEqual(ok, emqx_mgmt_auth:init_bootstrap_file(File)),
+    ?assertEqual(LegacyHash, read_secret_hash(ApiKey)),
+    ?assertMatch({ok, _}, auth_authorize(TestPath, ApiKey, Secret)),
+    ok.
+
+-doc """
+A bootstrap file re-read with a rotated secret replaces the stored hash with the
+current format, the old secret stops working and the new one works.
+""".
+t_bootstrap_file_rotated_secret_rehashes(_) ->
+    TestPath = <<"/api/v5/status">>,
+    ApiKey = <<"rotate-hash-1">>,
+    Secret = <<"secret-1">>,
+    NewSecret = <<"secret-2">>,
+    File = "./bootstrap_api_keys.txt",
+    ok = file:write_file(File, <<ApiKey/binary, ":", Secret/binary>>),
+    update_file(File),
+    ?assertEqual(ok, emqx_mgmt_auth:init_bootstrap_file(File)),
+    ok = set_secret_hash(ApiKey, legacy_hash(<<"abcd">>, Secret)),
+
+    ok = file:write_file(File, <<ApiKey/binary, ":", NewSecret/binary>>),
+    ?assertEqual(ok, emqx_mgmt_auth:init_bootstrap_file(File)),
+
+    ?assertMatch(<<"$1$", _/binary>>, read_secret_hash(ApiKey)),
+    ?assertMatch({error, _}, auth_authorize(TestPath, ApiKey, Secret)),
+    ?assertMatch({ok, _}, auth_authorize(TestPath, ApiKey, NewSecret)),
+    ok.
+
+-doc """
+A role change in the bootstrap file takes effect on a re-read even though the
+secret is unchanged and the stored hash is kept.
+""".
+t_bootstrap_file_same_secret_updates_metadata(_) ->
+    ApiKey = <<"keep-hash-meta-1">>,
+    Secret = <<"secret-1">>,
+    File = "./bootstrap_api_keys.txt",
+    ok = file:write_file(File, <<ApiKey/binary, ":", Secret/binary, ":viewer">>),
+    update_file(File),
+    ?assertEqual(ok, emqx_mgmt_auth:init_bootstrap_file(File)),
+    ?assertEqual(<<"viewer">>, read_bootstrap_role(ApiKey)),
+    Hash = read_secret_hash(ApiKey),
+
+    ok = file:write_file(File, <<ApiKey/binary, ":", Secret/binary, ":administrator">>),
+    ?assertEqual(ok, emqx_mgmt_auth:init_bootstrap_file(File)),
+
+    ?assertEqual(Hash, read_secret_hash(ApiKey)),
+    ?assertEqual(<<"administrator">>, read_bootstrap_role(ApiKey)),
+    ok.
+
+app_names({ok, Apps}) ->
+    lists:sort([Name || #?APP{name = Name} <- Apps]).
+
+%% The pre-6.3 hash layout: 4 salt characters followed by sha256(Salt ++ Secret).
+legacy_hash(Salt, Secret) ->
+    <<Salt/binary, (crypto:hash(sha256, <<Salt/binary, Secret/binary>>))/binary>>.
+
+read_app_by_api_key(ApiKey) ->
+    MatchFun = fun(Key) -> mnesia:match_object(#?APP{api_key = Key, _ = '_'}) end,
+    {ok, [App]} = emqx_mgmt_auth:trans(MatchFun, [ApiKey]),
+    App.
+
+read_secret_hash(ApiKey) ->
+    (read_app_by_api_key(ApiKey))#?APP.api_secret_hash.
+
+set_secret_hash(ApiKey, Hash) ->
+    App = read_app_by_api_key(ApiKey),
+    WriteFun = fun(A) -> mnesia:write(A) end,
+    {ok, ok} = emqx_mgmt_auth:trans(WriteFun, [App#?APP{api_secret_hash = Hash}]),
+    ok.
+
+read_bootstrap_role(ApiKey) ->
+    {value, #{role := Role}} = lists:search(
+        fun(#{api_key := Key}) -> Key =:= ApiKey end,
+        emqx_mgmt_auth:list()
+    ),
+    Role.
 
 t_bootstrap_file_with_role(_) ->
     Search = fun(Name) ->

--- a/changes/ee/fix-18852.en.md
+++ b/changes/ee/fix-18852.en.md
@@ -1,0 +1,9 @@
+Fixed bootstrap API keys being rejected by the nodes still running the older version during a rolling upgrade to 6.3.
+
+When a 6.3 node started, it rewrote the cluster-shared API key record with a secret
+hash that older nodes cannot verify, so those nodes rejected the key. The bootstrap
+file loader now keeps the stored hash when the file still holds the same secret, and
+refreshes only the key metadata such as role and scopes.
+
+Changing the secret in the bootstrap file still replaces the hash. Rotate a bootstrap
+secret only after the whole cluster runs 6.3.


### PR DESCRIPTION
Fixes: #18851
Release version: 6.3.1, 7.0.0
Introduced in: 6.3.0

## Summary

The bootstrap API key file is loaded on every core boot
(`emqx_mgmt_app:start/2` → `emqx_mgmt_auth:try_init_bootstrap_file/0`). The loader
hashed the secret again for every line and wrote the record with
`mria:sync_transaction`, so the cluster-shared record was overwritten on each boot.

Since 6.3, `emqx_dashboard_admin:hash_api_secret/1` produces the `$1$` format.
6.2 only understands the legacy 36-byte layout, so once a 6.3 node booted into a
mixed cluster, every 6.2 node answered `401 BAD_API_KEY_OR_SECRET` for the
operator's bootstrap key. `verify_hash/2` deliberately avoids rehashing on login
for exactly this reason; the bootstrap loader defeated that.

`add_bootstrap_file/4` now resolves the hash through `bootstrap_secret_hash/2`:
when a record already exists for the key and the secret in the file verifies
against the stored hash, the stored hash is carried through unchanged. The record
is still written, so a role, namespace or scope edit in the file takes effect. A
changed secret is hashed as before. The lookup uses `find_by_api_key/1` (a read
transaction) rather than the write transaction, so the plain secret is never sent
to another node when the loader runs on a replicant.

Rotating the bootstrap secret during a rolling upgrade still replaces the hash and
still breaks the not-yet-upgraded nodes. Rotate only after the whole cluster runs
6.3. This is stated in the change log.

Note on the issue: #18851 reports the opposite direction — a new node rejecting a
key written by the old nodes. That direction does not reproduce; 6.3 verifies both
hash formats, and the record layout, the key lookup and the file parser are
unchanged between 6.2.0 and 6.3.0. The defect is that the 6.3 node breaks the key
on the older nodes, which is what this PR fixes.

Tests in `emqx_mgmt_api_api_keys_SUITE`: unchanged secret keeps the stored hash
byte-identical, a rotated secret replaces it, and a role change still applies while
the hash is kept. `t_bootstrap_file_override` and `t_bootstrap_file_dup_override`
covered the overwrite path but were left out of the group list and called a removed
`emqx_mgmt_auth:authorize/3`; both are repaired and run again.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
