### PR TITLE
fix(audit): redact SSO MFA credentials

### DIFF
--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -437,6 +437,106 @@ t_license_key_redacted(_) ->
     ?assertNotEqual(nomatch, binary:match(AuditBody, <<"******">>), AuditBody),
     ok.
 
+-doc """
+SSO MFA audit bodies retain only the non-secret identity fields. Unknown
+credential fields under the SSO MFA operation namespace must be redacted by
+position, so adding a new MFA credential cannot reintroduce an audit leak.
+""".
+t_sso_mfa_body_redacted_by_position(_) ->
+    Now = erlang:monotonic_time(),
+    Meta = #{
+        method => post,
+        code => 200,
+        operation_id => <<"/sso/mfa/future_challenge">>,
+        headers => #{},
+        bindings => #{},
+        body => #{
+            <<"username">> => <<"mfa-audit-user">>,
+            <<"backend">> => <<"ldap">>,
+            <<"future_credential">> => <<"file://credential">>,
+            <<"nested_credential">> => #{<<"value">> => <<"must-not-survive">>}
+        },
+        req_start => Now,
+        req_end => Now
+    },
+    Req = #{headers => #{}, peer => {{127, 0, 0, 1}, 18083}},
+    #{http_request := #{body := Body}} = emqx_dashboard_audit:log_meta(60, Meta, Req),
+    ?assertEqual(<<"mfa-audit-user">>, maps:get(<<"username">>, Body)),
+    ?assertEqual(<<"ldap">>, maps:get(<<"backend">>, Body)),
+    ?assertEqual(<<"******">>, maps:get(<<"future_credential">>, Body)),
+    ?assertEqual(<<"******">>, maps:get(<<"nested_credential">>, Body)),
+    ok.
+
+-doc """
+The three public SSO MFA endpoints must not persist their temporary tokens or
+TOTP codes in the audit record returned by GET /audit.
+""".
+t_sso_mfa_credentials_redacted(_) ->
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Cases = [
+        {
+            <<"/sso/mfa/setup_info">>,
+            ["sso", "mfa", "setup_info"],
+            #{
+                <<"setup_token">> => <<"setup-token-audit-probe">>,
+                <<"username">> => <<"mfa-audit-setup-user">>,
+                <<"backend">> => <<"ldap">>
+            },
+            [<<"setup-token-audit-probe">>]
+        },
+        {
+            <<"/sso/mfa/setup">>,
+            ["sso", "mfa", "setup"],
+            #{
+                <<"setup_token">> => <<"setup-token-audit-probe-2">>,
+                <<"totp_code">> => <<"123456">>,
+                <<"username">> => <<"mfa-audit-setup-user-2">>,
+                <<"backend">> => <<"ldap">>
+            },
+            [<<"setup-token-audit-probe-2">>, <<"123456">>]
+        },
+        {
+            <<"/sso/mfa/verify">>,
+            ["sso", "mfa", "verify"],
+            #{
+                <<"verify_token">> => <<"verify-token-audit-probe">>,
+                <<"totp_code">> => <<"654321">>,
+                <<"username">> => <<"mfa-audit-verify-user">>,
+                <<"backend">> => <<"ldap">>
+            },
+            [<<"verify-token-audit-probe">>, <<"654321">>]
+        }
+    ],
+    lists:foreach(
+        fun({OperationId, Parts, Body, Secrets}) ->
+            StartAt = erlang:system_time(microsecond),
+            {ok, 401, _} = emqx_mgmt_api_test_util:request_api_with_body(
+                post,
+                emqx_mgmt_api_test_util:api_path(Parts),
+                Body
+            ),
+            Query = lists:flatten(
+                io_lib:format(
+                    "operation_id=~ts&gte_created_at=~B&limit=1",
+                    [OperationId, StartAt]
+                )
+            ),
+            Res = wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, 2000),
+            #{<<"data">> := [#{<<"http_request">> := #{<<"body">> := AuditBody}}]} =
+                emqx_utils_json:decode(Res),
+            lists:foreach(
+                fun(Secret) ->
+                    ?assertEqual(nomatch, binary:match(AuditBody, Secret), AuditBody)
+                end,
+                Secrets
+            ),
+            ?assertNotEqual(nomatch, binary:match(AuditBody, <<"******">>), AuditBody)
+        end,
+        Cases
+    ),
+    ok.
+
 t_kickout_clients_without_log(_) ->
     process_flag(trap_exit, true),
     AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),

--- a/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_audit.erl
@@ -138,11 +138,8 @@ http_request(Meta) ->
         case maps:with([method, headers, bindings, body], Meta) of
             #{body := Body} = Request when is_binary(Body) ->
                 Request#{body => <<"******">>};
-            #{body := _} = Request ->
-                case is_sensitive_body_operation(Meta) of
-                    true -> Request#{body => <<"******">>};
-                    false -> Request
-                end;
+            #{body := Body} = Request ->
+                Request#{body => redact_request_body(Meta, Body)};
             Request ->
                 Request
         end,
@@ -167,10 +164,36 @@ maybe_put(Key, Value, Map) -> Map#{Key => Value}.
 non_empty_map(Map) when is_map(Map), map_size(Map) > 0 -> Map;
 non_empty_map(_) -> undefined.
 
-%% Endpoints whose request body carries a secret under a key name that
-%% the generic key-name based redaction does not cover.
-is_sensitive_body_operation(#{operation_id := <<"/license">>}) -> true;
-is_sensitive_body_operation(_) -> false.
+%% Some endpoints carry credentials under names that the generic redactor
+%% cannot safely infer. Redact by the credential-bearing operation boundary
+%% before the generic key-name redaction runs.
+redact_request_body(#{operation_id := <<"/license">>}, _Body) ->
+    <<"******">>;
+redact_request_body(#{operation_id := <<"/sso/mfa/", _/binary>>}, Body) ->
+    redact_sso_mfa_body(Body);
+redact_request_body(_Meta, Body) ->
+    Body.
+
+redact_sso_mfa_body(Body) when is_map(Body) ->
+    maps:map(
+        fun(Key, Value) ->
+            case is_sso_mfa_audit_safe_key(Key) of
+                true -> Value;
+                false -> <<"******">>
+            end
+        end,
+        Body
+    );
+redact_sso_mfa_body(_Body) ->
+    <<"******">>.
+
+is_sso_mfa_audit_safe_key(username) -> true;
+is_sso_mfa_audit_safe_key("username") -> true;
+is_sso_mfa_audit_safe_key(<<"username">>) -> true;
+is_sso_mfa_audit_safe_key(backend) -> true;
+is_sso_mfa_audit_safe_key("backend") -> true;
+is_sso_mfa_audit_safe_key(<<"backend">>) -> true;
+is_sso_mfa_audit_safe_key(_) -> false.
 
 operation_result(302, _) -> success;
 operation_result(Code, _) when Code >= 300 -> failure;

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -111,11 +111,20 @@ is_sensitive_key(<<"sentinel_password">>) -> true;
 is_sensitive_key(service_account_json) -> true;
 is_sensitive_key("service_account_json") -> true;
 is_sensitive_key(<<"service_account_json">>) -> true;
+is_sensitive_key(setup_token) -> true;
+is_sensitive_key("setup_token") -> true;
+is_sensitive_key(<<"setup_token">>) -> true;
 is_sensitive_key(sp_private_key) -> true;
 is_sensitive_key(<<"sp_private_key">>) -> true;
 is_sensitive_key(token) -> true;
 is_sensitive_key("token") -> true;
 is_sensitive_key(<<"token">>) -> true;
+is_sensitive_key(totp_code) -> true;
+is_sensitive_key("totp_code") -> true;
+is_sensitive_key(<<"totp_code">>) -> true;
+is_sensitive_key(verify_token) -> true;
+is_sensitive_key("verify_token") -> true;
+is_sensitive_key(<<"verify_token">>) -> true;
 is_sensitive_key(_) -> false.
 
 redact(Term) ->

--- a/apps/emqx_utils/test/emqx_utils_redact_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_redact_tests.erl
@@ -217,6 +217,24 @@ redact_dashboard_secret_fields_test() ->
         })
     ).
 
+redact_sso_mfa_secret_fields_test() ->
+    ?assertEqual(
+        #{
+            setup_token => <<"******">>,
+            <<"verify_token">> => <<"******">>,
+            "totp_code" => "******",
+            username => <<"alice">>,
+            backend => <<"ldap">>
+        },
+        redact(#{
+            setup_token => <<"setup-token">>,
+            <<"verify_token">> => <<"verify-token">>,
+            "totp_code" => "123456",
+            username => <<"alice">>,
+            backend => <<"ldap">>
+        })
+    ).
+
 deobfuscate_file_path_secrets_test_() ->
     Original1 = #{foo => #{bar => #{headers => #{"authorization" => "file://a"}}}},
     Original2 = #{foo => #{bar => #{headers => #{"authorization" => "a"}}}},

--- a/changes/ee/fix-18853.en.md
+++ b/changes/ee/fix-18853.en.md
@@ -1,0 +1,3 @@
+Fixed an issue where SSO MFA setup and verification credentials could be stored unredacted in audit logs when audit logging was enabled.
+
+SSO MFA request bodies now keep only `username` and `backend` in audit records; temporary tokens, TOTP codes, and unknown credential fields are redacted before being written to audit files or the audit database.


### PR DESCRIPTION
Fixes: emqx/emqx-dev-team-tasks#384
Release version: 6.0.4
Introduced in: 6.0.3

## Summary

When audit logging was enabled, the SSO MFA setup and verification endpoints could retain temporary tokens and TOTP codes in structured audit request bodies. The shared redactor only recognized a fixed set of field names, so `setup_token`, `verify_token`, and `totp_code` were persisted unredacted.

The audit boundary now masks these credential names and treats `/sso/mfa/*` request bodies as credential-bearing data by default. It retains only `username` and `backend`; unknown and nested fields are redacted before the audit event reaches the file and database sinks. The original request body passed to the MFA handlers is unchanged.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
