### PR TITLE
fix(redact): preserve masked HTTP headers across case changes

### DIFF
--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
@@ -155,6 +155,47 @@ t_create_authenticator_redacts_secrets(_) ->
     ),
     ok.
 
+t_http_authenticator_preserves_redacted_header_across_case_change(_) ->
+    Secret = <<"abcd1234">>,
+    Redacted = emqx_utils_redact:redacted_value(),
+    AuthenticatorID = "password_based:http",
+    Config0 = (emqx_authn_test_lib:http_example())#{
+        method => <<"get">>,
+        headers => #{<<"Authorization">> => Secret}
+    },
+    {ok, 200, _} = request(
+        post,
+        uri([?CONF_NS]),
+        Config0
+    ),
+
+    {ok, 200, GetBody0} = request(
+        get,
+        uri([?CONF_NS, AuthenticatorID])
+    ),
+    #{<<"headers">> := Headers0} = emqx_utils_json:decode(GetBody0),
+    ?assertEqual(Redacted, maps:get(<<"authorization">>, Headers0)),
+
+    Config1 = Config0#{
+        headers => #{<<"Authorization">> => Redacted}
+    },
+    {ok, 204, _} = request(
+        put,
+        uri([?CONF_NS, AuthenticatorID]),
+        Config1
+    ),
+
+    {ok, 200, GetBody1} = request(
+        get,
+        uri([?CONF_NS, AuthenticatorID])
+    ),
+    #{<<"headers">> := Headers1} = emqx_utils_json:decode(GetBody1),
+    ?assertEqual(Redacted, maps:get(<<"authorization">>, Headers1)),
+
+    [#{<<"headers">> := RawHeaders}] = emqx:get_raw_config([authentication]),
+    ?assertEqual(Secret, maps:get(<<"Authorization">>, RawHeaders)),
+    ok.
+
 t_authenticator_position(_) ->
     test_authenticator_position([]).
 

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -224,6 +224,37 @@ check_is_sensitive_header(Key) ->
     Key2 = string:trim(emqx_utils_conv:str(Key1)),
     is_sensitive_header(string:lowercase(Key2)).
 
+normalize_header_name(Key) ->
+    Key1 =
+        try iolist_to_binary(Key) of
+            Bin -> Bin
+        catch
+            _:_ -> Key
+        end,
+    list_to_binary(string:lowercase(emqx_utils_conv:str(Key1))).
+
+find_header(Key, Headers) ->
+    case maps:find(Key, Headers) of
+        {ok, _} = Found ->
+            Found;
+        error ->
+            NormalizedKey = normalize_header_name(Key),
+            MatchingValues = [
+                Value
+             || {OldKey, Value} <- maps:to_list(Headers),
+                normalize_header_name(OldKey) =:= NormalizedKey
+            ],
+            find_unambiguous_header(MatchingValues)
+    end.
+
+find_unambiguous_header([]) ->
+    error;
+find_unambiguous_header([Value | Values]) ->
+    case lists:all(fun(V) -> V =:= Value end, Values) of
+        true -> {ok, Value};
+        false -> error
+    end.
+
 is_sensitive_header("authorization") ->
     true;
 is_sensitive_header("api-key") ->
@@ -301,13 +332,24 @@ do_redact_v(F) ->
             ?REDACT_VAL
     end.
 
+deobfuscate_headers(NewHeaders, OldHeaders) ->
+    deobfuscate(
+        NewHeaders,
+        OldHeaders,
+        fun check_is_sensitive_header/1,
+        fun find_header/2
+    ).
+
 deobfuscate(NewConf, OldConf) ->
     deobfuscate(NewConf, OldConf, fun(_) -> false end).
 
 deobfuscate(NewConf, OldConf, IsSensitiveFun) ->
+    deobfuscate(NewConf, OldConf, IsSensitiveFun, fun maps:find/2).
+
+deobfuscate(NewConf, OldConf, IsSensitiveFun, FindOldValue) ->
     maps:fold(
         fun(K, V, Acc) ->
-            case maps:find(K, OldConf) of
+            case FindOldValue(K, OldConf) of
                 error ->
                     case is_redacted(K, V, IsSensitiveFun) of
                         %% don't put redacted value into new config
@@ -315,7 +357,7 @@ deobfuscate(NewConf, OldConf, IsSensitiveFun) ->
                         false -> Acc#{K => V}
                     end;
                 {ok, OldV} when is_map(V), is_map(OldV), ?IS_KEY_HEADERS(K) ->
-                    Acc#{K => deobfuscate(V, OldV, fun check_is_sensitive_header/1)};
+                    Acc#{K => deobfuscate_headers(V, OldV)};
                 {ok, OldV} when is_map(V), is_map(OldV), ?IS_KEY_CLIENT_JWKS(K) ->
                     Acc#{K => deobfuscate(V, OldV, fun is_client_jwks_file_key/1)};
                 {ok, OldV} when is_map(V), is_map(OldV) ->
@@ -482,6 +524,67 @@ deobfuscate_test() ->
     HeaderConf1 = #{<<"headers">> => #{<<"Authorization">> => <<"Bearer token">>}},
     HeaderConf1Obs = #{<<"headers">> => #{<<"Authorization">> => ?REDACT_VAL}},
     ?assertEqual(HeaderConf1, deobfuscate(HeaderConf1Obs, HeaderConf1)),
+
+    HeaderConf2 = #{<<"headers">> => #{<<"authorization">> => <<"Bearer token">>}},
+    HeaderConf2Obs = #{<<"headers">> => #{<<"Authorization">> => ?REDACT_VAL}},
+    ?assertEqual(
+        #{<<"headers">> => #{<<"Authorization">> => <<"Bearer token">>}},
+        deobfuscate(HeaderConf2Obs, HeaderConf2)
+    ),
+
+    DuplicateHeaders = #{
+        <<"headers">> => #{
+            <<"Authorization">> => <<"upper-secret">>,
+            <<"authorization">> => <<"lower-secret">>
+        }
+    },
+    DuplicateHeadersObs = #{
+        <<"headers">> => #{
+            <<"Authorization">> => ?REDACT_VAL,
+            <<"authorization">> => ?REDACT_VAL
+        }
+    },
+    ?assertEqual(DuplicateHeaders, deobfuscate(DuplicateHeadersObs, DuplicateHeaders)),
+
+    AmbiguousHeadersObs = #{
+        <<"headers">> => #{<<"AUTHORIZATION">> => ?REDACT_VAL}
+    },
+    ?assertEqual(
+        #{<<"headers">> => #{}},
+        deobfuscate(AmbiguousHeadersObs, DuplicateHeaders)
+    ),
+
+    EqualDuplicateHeaders = #{
+        <<"headers">> => #{
+            <<"Authorization">> => <<"same-secret">>,
+            <<"authorization">> => <<"same-secret">>
+        }
+    },
+    EqualDuplicateHeadersObs = #{
+        <<"headers">> => #{<<"AUTHORIZATION">> => ?REDACT_VAL}
+    },
+    ?assertEqual(
+        #{<<"headers">> => #{<<"AUTHORIZATION">> => <<"same-secret">>}},
+        deobfuscate(EqualDuplicateHeadersObs, EqualDuplicateHeaders)
+    ),
+
+    HeaderConf3 = #{<<"headers">> => #{<<"authorization">> => <<"Bearer token">>}},
+    HeaderConf3Obs = #{<<"headers">> => #{<<" Authorization ">> => ?REDACT_VAL}},
+    ?assertEqual(
+        #{<<"headers">> => #{}},
+        deobfuscate(HeaderConf3Obs, HeaderConf3)
+    ),
+
+    NestedHeaderConf = #{
+        <<"headers">> => #{<<"X-Meta">> => #{<<"Token">> => <<"old-token">>}}
+    },
+    NestedHeaderConfObs = #{
+        <<"headers">> => #{<<"x-meta">> => #{<<"token">> => ?REDACT_VAL}}
+    },
+    ?assertEqual(
+        #{<<"headers">> => #{<<"x-meta">> => #{}}},
+        deobfuscate(NestedHeaderConfObs, NestedHeaderConf)
+    ),
 
     ok.
 

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -212,26 +212,17 @@ do_redact_headers(Value) ->
     Value.
 
 check_is_sensitive_header(Key) ->
-    %% Header keys may be stored as iolists (e.g. `[<<"x-api-key">>]`, a shape
-    %% produced by template parsers). `emqx_utils_conv:str/1` JSON-encodes
-    %% non-printable lists, so normalise to a binary first to keep the name intact.
-    Key1 =
-        try iolist_to_binary(Key) of
-            Bin -> Bin
-        catch
-            _:_ -> Key
-        end,
-    Key2 = string:trim(emqx_utils_conv:str(Key1)),
-    is_sensitive_header(string:lowercase(Key2)).
+    is_sensitive_header(normalize_header_name(Key)).
 
 normalize_header_name(Key) ->
+    %% Keep this in sync with emqx_auth_http_utils:transform_header_name/1.
     Key1 =
         try iolist_to_binary(Key) of
             Bin -> Bin
         catch
             _:_ -> Key
         end,
-    list_to_binary(string:lowercase(emqx_utils_conv:str(Key1))).
+    string:lowercase(emqx_utils_conv:str(Key1)).
 
 find_header(Key, Headers) ->
     case maps:find(Key, Headers) of
@@ -250,6 +241,8 @@ find_header(Key, Headers) ->
 find_unambiguous_header([]) ->
     error;
 find_unambiguous_header([Value | Values]) ->
+    %% Raw connector and bridge configurations may preserve multiple casing
+    %% variants. Do not choose one when their stored values disagree.
     case lists:all(fun(V) -> V =:= Value end, Values) of
         true -> {ok, Value};
         false -> error
@@ -333,6 +326,8 @@ do_redact_v(F) ->
     end.
 
 deobfuscate_headers(NewHeaders, OldHeaders) ->
+    %% Case-insensitive lookup applies only to direct entries of this map.
+    %% Nested maps re-enter deobfuscate/3 and retain exact-key matching.
     deobfuscate(
         NewHeaders,
         OldHeaders,
@@ -532,6 +527,17 @@ deobfuscate_test() ->
         deobfuscate(HeaderConf2Obs, HeaderConf2)
     ),
 
+    AtomHeaderConf = #{
+        <<"headers">> => #{authorization => <<"Bearer token">>}
+    },
+    AtomHeaderConfObs = #{
+        <<"headers">> => #{<<"Authorization">> => ?REDACT_VAL}
+    },
+    ?assertEqual(
+        #{<<"headers">> => #{<<"Authorization">> => <<"Bearer token">>}},
+        deobfuscate(AtomHeaderConfObs, AtomHeaderConf)
+    ),
+
     DuplicateHeaders = #{
         <<"headers">> => #{
             <<"Authorization">> => <<"upper-secret">>,
@@ -571,7 +577,7 @@ deobfuscate_test() ->
     HeaderConf3 = #{<<"headers">> => #{<<"authorization">> => <<"Bearer token">>}},
     HeaderConf3Obs = #{<<"headers">> => #{<<" Authorization ">> => ?REDACT_VAL}},
     ?assertEqual(
-        #{<<"headers">> => #{}},
+        HeaderConf3Obs,
         deobfuscate(HeaderConf3Obs, HeaderConf3)
     ),
 
@@ -587,6 +593,12 @@ deobfuscate_test() ->
     ),
 
     ok.
+
+noncanonical_header_name_is_not_redacted_test() ->
+    HeaderConf = #{
+        <<"headers">> => #{<<" Authorization ">> => <<"secret">>}
+    },
+    ?assertEqual(HeaderConf, redact(HeaderConf)).
 
 redact_header_test_() ->
     Types = [string, binary, atom],

--- a/changes/ee/fix-18859.en.md
+++ b/changes/ee/fix-18859.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where changing only the letter casing of a sensitive HTTP header name while updating a configuration could remove its stored value.


### PR DESCRIPTION
Fixes: #18761
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: pre-5.8

## Summary

HTTP header names are case-insensitive, but sensitive-value deobfuscation matched header map keys case-sensitively before authentication schema normalization. A casing-only edit could therefore drop a masked header instead of restoring its stored value.

This change preserves exact-key round trips and falls back to case-insensitive lookup only when the stored value is unambiguous. Ambiguous casing variants remain fail-closed, and case-insensitive matching is limited to direct HTTP header entries so ordinary nested configuration maps keep exact-key semantics.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)