### PR TITLE
fix(mgmt): signal end of client message pagination

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1337,8 +1337,8 @@ client_msgs_schema(OpId, Desc, ContExample, RespSchema) ->
                     emqx_dashboard_swagger:schema_with_example(RespSchema, #{
                         <<"data">> => [message_example(OpId)],
                         <<"meta">> => #{
-                            <<"count">> => 100,
-                            <<"last">> => ContExample
+                            <<"start">> => ContExample,
+                            <<"position">> => <<"end_of_data">>
                         }
                     }),
                 400 =>
@@ -1617,8 +1617,9 @@ list_client_msgs(MsgType, ClientId, QString) ->
     case emqx_mgmt_api:parse_cont_pager_params(QString, pos_decoder(MsgType)) of
         false ->
             {400, #{code => <<"INVALID_PARAMETER">>, message => <<"position_limit_invalid">>}};
-        PagerParams = #{} ->
-            case emqx_mgmt:list_client_msgs(MsgType, ClientId, PagerParams) of
+        PagerParams = #{limit := Limit} ->
+            FetchPagerParams = PagerParams#{limit := Limit + 1},
+            case emqx_mgmt:list_client_msgs(MsgType, ClientId, FetchPagerParams) of
                 {error, not_found} ->
                     {404, ?CLIENTID_NOT_FOUND_OBJ};
                 {error, shutdown} ->
@@ -1630,10 +1631,18 @@ list_client_msgs(MsgType, ClientId, QString) ->
                     }};
                 {error, Reason} ->
                     ?INTERNAL_ERROR(Reason);
-                {Msgs, Meta = #{}} when is_list(Msgs) ->
+                {Msgs0, Meta0 = #{}} when is_list(Msgs0) ->
+                    {Msgs, Meta} = take_client_msgs_page(MsgType, Msgs0, Limit, Meta0),
                     format_msgs_resp(MsgType, Msgs, Meta, QString)
             end
     end.
+
+take_client_msgs_page(MsgType, Msgs0, Limit, Meta0) when length(Msgs0) > Limit ->
+    {Msgs, _Lookahead} = lists:split(Limit, Msgs0),
+    LastMsg = lists:last(Msgs),
+    {Msgs, Meta0#{position := msg_position(MsgType, LastMsg)}};
+take_client_msgs_page(_MsgType, Msgs, _Limit, Meta) ->
+    {Msgs, Meta#{position := end_of_data}}.
 
 pos_decoder(mqueue_msgs) -> fun decode_mqueue_pos/1;
 pos_decoder(inflight_msgs) -> fun decode_msg_pos/1.
@@ -1643,6 +1652,8 @@ encode_msgs_meta(_MsgType, #{start := StartPos, position := Pos}) ->
 
 encode_pos(none) ->
     none;
+encode_pos(end_of_data) ->
+    end_of_data;
 encode_pos({MsgPos, PrioPos}) ->
     MsgPosBin = integer_to_binary(MsgPos),
     PrioPosBin =

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1384,18 +1384,18 @@ publish_msgs(Topic, Count) ->
     ).
 
 test_messages(Path, Topic, Count, AuthHeader, PayloadEncoding, IsMqueue) ->
-    Qs0 = io_lib:format("payload=~s", [PayloadEncoding]),
+    Qs0 = io_lib:format("payload=~s&limit=~p", [PayloadEncoding, Count]),
 
-    {Msgs, StartPos, Pos} = ?retry(500, 10, begin
+    {Msgs, StartPos, FinalMsgPos} = ?retry(500, 10, begin
         {ok, MsgsResp} = emqx_mgmt_api_test_util:request_api(get, Path, Qs0, AuthHeader),
         #{<<"meta">> := Meta, <<"data">> := Msgs} = emqx_utils_json:decode(MsgsResp),
-        #{<<"start">> := StartPos, <<"position">> := Pos} = Meta,
+        #{<<"start">> := StartPos, <<"position">> := Position} = Meta,
 
         ?assertEqual(StartPos, msg_pos(hd(Msgs), IsMqueue)),
-        ?assertEqual(Pos, msg_pos(lists:last(Msgs), IsMqueue)),
+        ?assertEqual(<<"end_of_data">>, Position),
         ?assertEqual(length(Msgs), Count),
 
-        {Msgs, StartPos, Pos}
+        {Msgs, StartPos, msg_pos(lists:last(Msgs), IsMqueue)}
     end),
 
     lists:foreach(
@@ -1423,7 +1423,12 @@ test_messages(Path, Topic, Count, AuthHeader, PayloadEncoding, IsMqueue) ->
     %% so we cover both cases:
     %% - when total payload size exceeds the limit,
     %% - when the first message payload already exceeds the limit but is still returned in the response.
-    QsPayloadLimit = io_lib:format("payload=~s&max_payload_bytes=1", [PayloadEncoding]),
+    %% Use a small page limit so that intermediate requests exercise both source-page
+    %% lookahead and max_payload_bytes truncation.
+    PayloadPageLimit = 2,
+    QsPayloadLimit = io_lib:format("payload=~s&max_payload_bytes=1&limit=~p", [
+        PayloadEncoding, PayloadPageLimit
+    ]),
     {ok, LimitedMsgsResp} = emqx_mgmt_api_test_util:request_api(
         get, Path, QsPayloadLimit, AuthHeader
     ),
@@ -1437,11 +1442,13 @@ test_messages(Path, Topic, Count, AuthHeader, PayloadEncoding, IsMqueue) ->
     %% returned message, not at the last message walked before the cut, so that paging
     %% skips no message.
     ?assertEqual(TruncatedPos, msg_pos(hd(FirstMsgOnly), IsMqueue)),
+    ?assertNotEqual(<<"end_of_data">>, TruncatedPos),
     %% Page through the remaining messages one message per page.
     lists:foldl(
         fun(Seq, PosIn) ->
             PageQs = io_lib:format(
-                "payload=~s&max_payload_bytes=1&position=~s", [PayloadEncoding, PosIn]
+                "payload=~s&max_payload_bytes=1&limit=~p&position=~s",
+                [PayloadEncoding, PayloadPageLimit, PosIn]
             ),
             {ok, PageResp} = emqx_mgmt_api_test_util:request_api(get, Path, PageQs, AuthHeader),
             #{<<"meta">> := #{<<"position">> := PosOut}, <<"data">> := PageMsgs} =
@@ -1451,7 +1458,12 @@ test_messages(Path, Topic, Count, AuthHeader, PayloadEncoding, IsMqueue) ->
                 integer_to_binary(Seq),
                 decode_payload(maps:get(<<"payload">>, hd(PageMsgs)), PayloadEncoding)
             ),
-            ?assertEqual(PosOut, msg_pos(hd(PageMsgs), IsMqueue)),
+            ExpectedPos =
+                case Seq =:= Count of
+                    true -> <<"end_of_data">>;
+                    false -> msg_pos(hd(PageMsgs), IsMqueue)
+                end,
+            ?assertEqual(ExpectedPos, PosOut),
             PosOut
         end,
         TruncatedPos,
@@ -1468,6 +1480,7 @@ test_messages(Path, Topic, Count, AuthHeader, PayloadEncoding, IsMqueue) ->
                 <<"data">> := MsgsPage
             } = emqx_utils_json:decode(MsgsRespPage),
 
+            ?assertNotEqual(<<"end_of_data">>, NextPos),
             ?assertEqual(NextPos, msg_pos(lists:last(MsgsPage), IsMqueue)),
             %% Start position is the same in every response and points to the first msg
             ?assertEqual(StartPos, ThisStart),
@@ -1491,11 +1504,12 @@ test_messages(Path, Topic, Count, AuthHeader, PayloadEncoding, IsMqueue) ->
     LastPartialPage = Count div 19 + 1,
     LastQs = io_lib:format("payload=~s&position=~s&limit=~p", [PayloadEncoding, LastPos, Limit]),
     {ok, MsgsRespLastP} = emqx_mgmt_api_test_util:request_api(get, Path, LastQs, AuthHeader),
-    #{<<"meta">> := #{<<"position">> := LastPartialPos}, <<"data">> := MsgsLastPage} = emqx_utils_json:decode(
+    #{<<"meta">> := #{<<"position">> := <<"end_of_data">>}, <<"data">> := MsgsLastPage} = emqx_utils_json:decode(
         MsgsRespLastP
     ),
-    %% The same as the position of all messages returned in one request
-    ?assertEqual(Pos, LastPartialPos),
+    ExpectedLastPageSize = Count rem Limit,
+    ?assertEqual(ExpectedLastPageSize, length(MsgsLastPage)),
+    ?assert(length(MsgsLastPage) =< Limit),
 
     ?assertEqual(
         integer_to_binary(LastPartialPage * Limit - Limit + 1),
@@ -1505,15 +1519,16 @@ test_messages(Path, Topic, Count, AuthHeader, PayloadEncoding, IsMqueue) ->
         integer_to_binary(Count),
         decode_payload(maps:get(<<"payload">>, lists:last(MsgsLastPage)), PayloadEncoding)
     ),
+    ?assertEqual(FinalMsgPos, msg_pos(lists:last(MsgsLastPage), IsMqueue)),
 
     ExceedQs = io_lib:format("payload=~s&position=~s&limit=~p", [
-        PayloadEncoding, LastPartialPos, Limit
+        PayloadEncoding, FinalMsgPos, Limit
     ]),
     {ok, MsgsEmptyResp} = emqx_mgmt_api_test_util:request_api(get, Path, ExceedQs, AuthHeader),
     ?assertMatch(
         #{
             <<"data">> := [],
-            <<"meta">> := #{<<"position">> := LastPartialPos, <<"start">> := StartPos}
+            <<"meta">> := #{<<"position">> := <<"end_of_data">>, <<"start">> := StartPos}
         },
         emqx_utils_json:decode(MsgsEmptyResp)
     ),

--- a/changes/ee/fix-18860.en.md
+++ b/changes/ee/fix-18860.en.md
@@ -1,0 +1,3 @@
+Fixed client message pagination returning a continuation position on the final page.
+
+`GET /clients/{clientid}/mqueue_messages` and `GET /clients/{clientid}/inflight_messages` now return `meta.position` as `end_of_data` when no more messages are available. API clients can stop without requesting an additional empty page.

--- a/rel/i18n/emqx_dashboard_swagger.hocon
+++ b/rel/i18n/emqx_dashboard_swagger.hocon
@@ -21,8 +21,9 @@ hasnext.desc: "Flag indicating whether there are more results available on next 
 hasnext.label: "Has Next"
 
 position.desc: """~
-    An opaque token that can then be in subsequent requests to get the next chunk of results: `?position={prev_response.meta.position}`.
-    It is used instead of `page` parameter to traverse highly volatile data. Can be omitted or set to `none` to get the first chunk of data.~"""
+    An opaque token returned in `meta.position` that can be used in a subsequent request to get the next chunk of results: `?position={prev_response.meta.position}`.
+    It is used instead of the `page` parameter to traverse highly volatile data. It can be omitted or set to `none` to get the first chunk of data.
+    If `meta.position` is `end_of_data`, there are no more results. Do not send `end_of_data` in a subsequent request.~"""
 position.label: "Position"
 
 start.desc: "The position of the current first element of the data collection."


### PR DESCRIPTION
Fixes: #18758
Release version: 6.0.4
Introduced in: N/A

## Summary

The client mqueue/inflight message APIs previously returned a concrete continuation position on the final page. API consumers such as Dashboard could not distinguish a full final page from a page with more data and issued one unnecessary empty request.

The API now fetches one lookahead message internally, returns at most the requested limit, and returns `meta.position = end_of_data` when no more messages are available. Payload-size truncation continues to rewind the position to the last message actually returned, so no messages are skipped.

The response example and shared position documentation now describe the current `start`/`position` contract and the terminal sentinel.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (the existing `position` schema already permits `end_of_data`)