### PR TITLE
fix(router_tool): validate scan_opts at the public boundary

### DIFF
--- a/apps/emqx/src/emqx_router_tool.erl
+++ b/apps/emqx/src/emqx_router_tool.erl
@@ -131,11 +131,15 @@ false positives caused by an unsubscribe (or a not-yet-synced subscribe)
 racing the scan.
 
 `scanned' is the number of distinct local topics inspected.
+
+`Opts' is validated before the walk starts. Raises
+`error({invalid_scan_opts, Reason})' when it is not a map, when it holds
+a key other than `chunk' and `sleep_ms', when `chunk' is not a positive
+integer, or when `sleep_ms' is not a non-negative integer.
 """.
 -spec scan_missing_routes(scan_opts()) -> scan_result().
 scan_missing_routes(Opts) ->
-    Chunk = maps:get(chunk, Opts, ?DEFAULT_CHUNK),
-    SleepMs = maps:get(sleep_ms, Opts, ?DEFAULT_SLEEP_MS),
+    #{chunk := Chunk, sleep_ms := SleepMs} = validate_scan_opts(Opts),
     Node = node(),
     Schema = safe_get_schema_vsn(),
     %% Pass 1: walk emqx_suboption; collect topics whose route is absent.
@@ -148,6 +152,31 @@ scan_missing_routes(Opts) ->
         scanned => Scanned,
         missing => Missing
     }.
+
+validate_scan_opts(Opts) when is_map(Opts) ->
+    ok = validate_known_keys(Opts),
+    #{
+        chunk => validate_chunk(maps:get(chunk, Opts, ?DEFAULT_CHUNK)),
+        sleep_ms => validate_sleep_ms(maps:get(sleep_ms, Opts, ?DEFAULT_SLEEP_MS))
+    };
+validate_scan_opts(Opts) ->
+    error({invalid_scan_opts, {not_a_map, Opts}}).
+
+validate_known_keys(Opts) ->
+    case lists:sort(maps:keys(maps:without([chunk, sleep_ms], Opts))) of
+        [] -> ok;
+        Unknown -> error({invalid_scan_opts, {unknown_keys, Unknown}})
+    end.
+
+validate_chunk(Chunk) when is_integer(Chunk), Chunk > 0 ->
+    Chunk;
+validate_chunk(Chunk) ->
+    error({invalid_scan_opts, {chunk, Chunk}}).
+
+validate_sleep_ms(SleepMs) when is_integer(SleepMs), SleepMs >= 0 ->
+    SleepMs;
+validate_sleep_ms(SleepMs) ->
+    error({invalid_scan_opts, {sleep_ms, SleepMs}}).
 
 walk_subopts(Node, Chunk, SleepMs) ->
     First = ets:first(?SUBOPTION),
@@ -209,6 +238,9 @@ local node via emqx_router:add_route/2 (the worker-serialized public API).
 
 Returns the scan totals plus a `repaired' list pairing each topic with
 the result of its add_route call.
+
+`Opts' is validated by scan_missing_routes/1 and raises the same
+`error({invalid_scan_opts, Reason})' on bad input.
 """.
 -spec reconcile_missing_routes(scan_opts()) -> reconcile_result().
 reconcile_missing_routes(Opts) ->

--- a/apps/emqx/test/emqx_router_tool_SUITE.erl
+++ b/apps/emqx/test/emqx_router_tool_SUITE.erl
@@ -143,3 +143,47 @@ t_scan_yields_after_chunk(_) ->
     Elapsed = erlang:monotonic_time(millisecond) - Start,
     %% 5 topics * 10ms, minus slack for timer granularity.
     ?assert(Elapsed >= 40, {elapsed, Elapsed}).
+
+-doc "Invalid scan options are rejected at the boundary instead of silently disabling throttling.".
+t_scan_rejects_invalid_opts(_) ->
+    Invalid = [
+        %% chunk must be a positive integer; 0 and -1 used to make the
+        %% maybe_yield/3 guard raise badarith, which silently skipped
+        %% every sleep and ran the scan unthrottled.
+        #{chunk => 0},
+        #{chunk => -1},
+        #{chunk => bad},
+        %% sleep_ms must be a non-negative integer; -1 used to be
+        %% accepted and bad used to crash inside timer:sleep/1.
+        #{sleep_ms => -1},
+        #{sleep_ms => bad},
+        %% A typo in a key name used to be ignored without any report.
+        #{chunks => 10},
+        %% A non-map used to raise badmap from maps:get/3.
+        not_a_map
+    ],
+    lists:foreach(
+        fun(Opts) ->
+            ?assertError(
+                {invalid_scan_opts, _},
+                emqx_router_tool:scan_missing_routes(Opts),
+                #{opts => Opts}
+            ),
+            ?assertError(
+                {invalid_scan_opts, _},
+                emqx_router_tool:reconcile_missing_routes(Opts),
+                #{opts => Opts}
+            )
+        end,
+        Invalid
+    ),
+    %% Positive control: the defaults and the smallest valid values are
+    %% still accepted and return a scan_result().
+    ?assertMatch(
+        #{node := _, schema := _, scanned := _, missing := _},
+        emqx_router_tool:scan_missing_routes(#{})
+    ),
+    ?assertMatch(
+        #{node := _, schema := _, scanned := _, missing := _},
+        emqx_router_tool:scan_missing_routes(#{chunk => 1, sleep_ms => 0})
+    ).

--- a/changes/ee/fix-18862.en.md
+++ b/changes/ee/fix-18862.en.md
@@ -1,0 +1,3 @@
+Validate the options passed to `emqx_router_tool:scan_missing_routes/1` and `emqx_router_tool:reconcile_missing_routes/1`.
+
+Invalid `chunk` or `sleep_ms` values were accepted silently and disabled the scan throttling, so the scan ran at full speed while the operator believed it was throttled. The tool now raises an error naming the offending option instead. Unknown option keys, such as a misspelled `chunks`, are rejected as well.


### PR DESCRIPTION
Fixes: #18858
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: 6.1.3

## Summary

This is the v6 counterpart of #18861 (`dev-510`). Same commit content; it reaches `master` through the `dev-60` → `dev-61` → `dev-62` → `dev-63` → `dev-70` sync chain.

`emqx_router_tool:scan_missing_routes/1` read `chunk` and `sleep_ms` straight out of the options map without checking them. The declared `scan_opts()` type says `chunk => pos_integer()` and `sleep_ms => non_neg_integer()`, but nothing enforced it, so invalid values did not fail. They changed behaviour in a way the operator could not see.

The values are consumed only in the `maybe_yield/3` guard:

```erlang
maybe_yield(Scanned, Chunk, SleepMs) when
    Scanned rem Chunk =:= 0, SleepMs > 0
->
```

That guard explains the inconsistent behaviour the reporter saw:

* `chunk => 0`, `-1` or an atom made `Scanned rem Chunk` raise `badarith` inside the guard. A guard exception only makes the clause fail to match, so the walk fell through to the catch-all clause and scanned the whole table without sleeping. Throttling was off and nothing reported it.
* `sleep_ms => -1` was accepted the same way, through the catch-all.
* `sleep_ms => bad` passed the guard, because an atom is greater than a number in Erlang term order, and crashed in `timer:sleep/1` from deep inside the walk. This is the one case that looked rejected, by accident.
* A non-map `Opts` raised `badmap` from `maps:get/3`, also by accident.

None of that is validation. This PR moves the decision to the boundary.

`scan_missing_routes/1` now validates `Opts` before the walk starts and raises `error({invalid_scan_opts, Reason})`, with `Reason` naming the offending key and value: `{chunk, 0}`, `{sleep_ms, -1}`, `{unknown_keys, [chunks]}`, `{not_a_map, Opts}`. The tool runs from `emqx eval`, so a stack trace naming the bad option is the right feedback.

Invalid values are rejected, not clamped and not replaced by the default. An operator must not believe throttling is on when it is not.

Unknown keys are rejected too. The option set is two keys, and a typo such as `#{chunks => 10}` is the same silent misconfiguration this PR is about.

`reconcile_missing_routes/1` calls `scan_missing_routes/1`, so both public entry points are covered. `maybe_yield/3` keeps its guard: with validated input the `rem` can no longer raise, and `SleepMs > 0` still means something for `sleep_ms => 0`.

Relevant files: `apps/emqx/src/emqx_router_tool.erl`, `apps/emqx/test/emqx_router_tool_SUITE.erl`.

The new `t_scan_rejects_invalid_opts` covers the reporter's matrix plus the accidental cases, and asserts as a positive control that `#{}` and `#{chunk => 1, sleep_ms => 0}` still return a `scan_result()`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
