### PR TITLE
build(quicer): bump to 0.4.9 with QUICER_TLS_VER=auto, bump to 5.10.5-rc.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ print-ee-dashboard-version:
 	@echo $(EMQX_EE_DASHBOARD_VERSION)
 
 export EMQX_REL_FORM ?= tgz
-export QUICER_TLS_VER ?= sys
+# 'auto' resolves to 'sys' (link system libcrypto) when the build host has
+# OpenSSL >= 3.0, and to quicer's bundled quictls otherwise.
+export QUICER_TLS_VER ?= auto
 
 -include default-profile.mk
 PROFILE ?= emqx-enterprise

--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -19,4 +19,4 @@
 %% NOTE: Also make sure to follow the instructions in end of
 %% `apps/emqx/src/bpapi/README.md'
 
--define(EMQX_RELEASE_EE, "5.10.5-rc.1").
+-define(EMQX_RELEASE_EE, "5.10.5-rc.2").

--- a/deploy/charts/emqx-enterprise/Chart.yaml
+++ b/deploy/charts/emqx-enterprise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.10.5-rc.1
+version: 5.10.5-rc.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 5.10.5-rc.1
+appVersion: 5.10.5-rc.2

--- a/mix.exs
+++ b/mix.exs
@@ -1127,7 +1127,7 @@ defmodule EMQXUmbrella.MixProject do
     if enable_quicer?(),
       # in conflict with emqx and emqtt
       do: [
-        {:quicer, github: "emqx/quic", tag: "0.4.8", override: true}
+        {:quicer, github: "emqx/quic", tag: "0.4.9", override: true}
       ],
       else: []
   end

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -36,7 +36,7 @@ assert_otp() ->
     end.
 
 quicer() ->
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.8"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.4.9"}}}.
 
 jq() ->
     {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.17"}}}.


### PR DESCRIPTION
Release versions:
5.10.5

Introduced in:
N/A

## Summary

The `e5.10.5-rc.1` package build failed on `ubuntu20.04`, `debian11`, `el8` and `amzn2` (amd64 and arm64), so nothing for that tag was published to S3/CDN:

```
QUICER: Failed to download pre-built binary, building from source
CMake Error at msquic/submodules/CMakeLists.txt:361 (message):
  OpenSSL 3.0 not found, found 1.1.1f
```

Cause: #18262 bumped quicer to 0.4.8, whose msquic requires OpenSSL >= 3.0 when linking the system libcrypto, while `Makefile` still defaults to `QUICER_TLS_VER ?= sys`. No `sys` prebuilt is published for distros whose system OpenSSL is 1.1, so the build falls back to a source build against that OpenSSL and fails.

Fix, same as 90ba727806 on `dev-60`:

- bump quicer to 0.4.9 (`rebar.config.erl`, `mix.exs`)
- default `QUICER_TLS_VER` to `auto`, which resolves to `sys` on OpenSSL >= 3 builders and to the bundled quictls otherwise. Release packaging keeps its current linkage on the OpenSSL 3 distros; macOS keeps its explicit `quictls`.

Also bumps the version to `5.10.5-rc.2` so the fixed tag can be cut.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)