### PR TITLE
test(tls): generate the test certificates instead of using the shipped ones

### DIFF
--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -81,7 +81,7 @@ init_per_group(quic, Config) ->
                 "\n idle_timeout = 15s"
                 "\n ssl_options.verify = verify_peer"
                 "\n }" ++
-                    emqx_common_test_helpers:listener_example_certs("listeners.quic.test")}
+                    emqx_common_test_helpers:listener_test_certs("listeners.quic.test")}
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -202,7 +202,7 @@ emqx_config() ->
                     }
         ssl_options { verify = verify_peer }
     }
-    """ ++ emqx_common_test_helpers:listener_example_certs("listeners.ssl.default").
+    """ ++ emqx_common_test_helpers:listener_test_certs("listeners.ssl.default").
 
 end_per_group(GroupName, Config) when
     GroupName == gen_tcp_listener;

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -33,8 +33,10 @@
     client_ssl/0,
     client_ssl/1,
     client_mtls/0,
-    listener_example_certs/0,
-    listener_example_certs/1,
+    ensure_test_certs/0,
+    test_cert/1,
+    listener_test_certs/0,
+    listener_test_certs/1,
     client_mtls/1,
     ensure_mnesia_stopped/0,
     ensure_quic_listener/2,
@@ -114,14 +116,17 @@
 
 -export([seed_defaults_for_all_roots_namespaced_cluster/2]).
 
--define(CERTS_PATH(CertName), filename:join(["etc", "certs", CertName])).
+%% Certificates the suites generate for themselves, kept beside the application in
+%% the build tree so that a listener on a peer node and a client here read the
+%% same files. See `ensure_test_certs/0'.
+-define(TEST_CERTS_DIR, "test-certs").
 -define(SECURITY_PROFILE_ENV_VAR, "EMQX_SECURITY_PROFILE").
 -define(DEFAULT_ADDRESS_CONF_KEY, [node, default_listener_address]).
 
 -define(MQTT_SSL_CLIENT_CERTS, [
-    {keyfile, ?CERTS_PATH("client-key.pem")},
-    {cacertfile, ?CERTS_PATH("cacert.pem")},
-    {certfile, ?CERTS_PATH("client-cert.pem")}
+    {keyfile, "client-key.pem"},
+    {cacertfile, "cacert.pem"},
+    {certfile, "client-cert.pem"}
 ]).
 
 -define(TLS_1_3_CIPHERS, [
@@ -431,38 +436,112 @@ client_mtls(TLSVsn) ->
     ssl_verify_fun_allow_any_host() ++ client_certs() ++ ciphers(TLSVsn).
 
 -doc """
-HOCON that points a listener at the shipped example certificates.
+Generates the certificates the test suites use, once, and returns their
+directory.
 
-The listener schema no longer defaults `certfile', `keyfile' and `cacertfile'; a
+A CA, a server certificate for `localhost' and a client certificate, equivalent
+in meaning to the example certificates EMQX used to ship: `CN=RootCA',
+`CN=localhost' with SANs `localhost' / `127.0.0.1' / `::1', and `CN=Client', all
+under `O=EMQ'. Suites assert on what a certificate contains, not on its bytes.
+
+Written beside the application in the build tree rather than into a per-case
+directory, because a cluster test starts its listener on a peer node while the
+client runs here: both read the path this returns. The first caller to finish
+wins and everyone reuses that set, so nodes never end up trusting different CAs.
+""".
+-spec ensure_test_certs() -> file:filename_all().
+ensure_test_certs() ->
+    Dir = test_certs_dir(),
+    case complete_test_certs(Dir) of
+        true -> Dir;
+        false -> generate_test_certs(Dir)
+    end.
+
+-doc "Absolute path of a file written by `ensure_test_certs/0'.".
+-spec test_cert(string()) -> file:filename_all().
+test_cert(Name) ->
+    filename:join(ensure_test_certs(), Name).
+
+test_certs_dir() ->
+    app_path(emqx, ?TEST_CERTS_DIR).
+
+test_cert_names() ->
+    ["cacert.pem", "cert.pem", "key.pem", "client-cert.pem", "client-key.pem"].
+
+complete_test_certs(Dir) ->
+    lists:all(
+        fun(Name) -> filelib:is_regular(filename:join(Dir, Name)) end,
+        test_cert_names()
+    ).
+
+%% Built in a temporary directory and moved into place, so a half-written set is
+%% never visible. Losing the race is fine: the winner's set is complete, and one
+%% complete set is all any of this needs.
+generate_test_certs(Dir) ->
+    Ca = #{cert_pem := CaPem} = emqx_utils_certs:generate_ca(#{cn => "RootCA", org => "EMQ"}),
+    #{cert_pem := ServerPem, key_pem := ServerKey} = emqx_utils_certs:generate_cert(Ca, #{
+        cn => "localhost",
+        org => "EMQ",
+        sans => [{dns, "localhost"}, {ip, {127, 0, 0, 1}}, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]
+    }),
+    #{cert_pem := ClientPem, key_pem := ClientKey} = emqx_utils_certs:generate_cert(Ca, #{
+        cn => "Client", org => "EMQ"
+    }),
+    TmpDir = Dir ++ "-" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_path(TmpDir),
+    Files = [
+        {"cacert.pem", CaPem},
+        {"cert.pem", ServerPem},
+        {"key.pem", ServerKey},
+        {"client-cert.pem", ClientPem},
+        {"client-key.pem", ClientKey}
+    ],
+    lists:foreach(
+        fun({Name, Pem}) -> ok = file:write_file(filename:join(TmpDir, Name), Pem) end,
+        Files
+    ),
+    case file:rename(TmpDir, Dir) of
+        ok ->
+            Dir;
+        {error, _} ->
+            %% Another node or process installed a set first. Use theirs.
+            _ = file:del_dir_r(TmpDir),
+            true = complete_test_certs(Dir),
+            Dir
+    end.
+
+-doc """
+HOCON that points a listener at the generated test certificates.
+
+The listener schema does not default `certfile', `keyfile' and `cacertfile'; a
 listener naming none of them serves the certificate the node generates for
-itself. Suites whose clients present or verify the example certificates have to
-name them, and this is the configuration that does it.
+itself. A suite whose clients present or verify the test CA has to name these.
 
 `ListenerPath' is the dotted path to the listener, such as
 `"listeners.ssl.default"'.
 """.
--spec listener_example_certs(string()) -> string().
-listener_example_certs(ListenerPath) ->
+-spec listener_test_certs(string()) -> string().
+listener_test_certs(ListenerPath) ->
     lists:flatten([
         [ListenerPath, ".ssl_options.", binary_to_list(Key), " = \"", binary_to_list(File), "\"\n"]
-     || {Key, File} <- maps:to_list(listener_example_certs())
+     || {Key, File} <- maps:to_list(listener_test_certs())
     ]).
 
 -doc """
-The same example certificates as `listener_example_certs/1', as `ssl_options'
-entries, for a suite that builds its listener config as a map.
+The same certificates as `listener_test_certs/1', as `ssl_options' entries, for
+a suite that builds its listener config as a map.
 """.
--spec listener_example_certs() -> #{binary() => binary()}.
-listener_example_certs() ->
+-spec listener_test_certs() -> #{binary() => binary()}.
+listener_test_certs() ->
     #{
-        <<"certfile">> => <<"${EMQX_ETC_DIR}/certs/cert.pem">>,
-        <<"keyfile">> => <<"${EMQX_ETC_DIR}/certs/key.pem">>,
-        <<"cacertfile">> => <<"${EMQX_ETC_DIR}/certs/cacert.pem">>
+        <<"certfile">> => iolist_to_binary(test_cert("cert.pem")),
+        <<"keyfile">> => iolist_to_binary(test_cert("key.pem")),
+        <<"cacertfile">> => iolist_to_binary(test_cert("cacert.pem"))
     }.
 
 %% Paths prepended to cert filenames
 client_certs() ->
-    [{Key, app_path(emqx, FilePath)} || {Key, FilePath} <- ?MQTT_SSL_CLIENT_CERTS].
+    [{Key, test_cert(FilePath)} || {Key, FilePath} <- ?MQTT_SSL_CLIENT_CERTS].
 
 client_ssl() ->
     client_ssl(default).

--- a/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
@@ -123,7 +123,7 @@ init_per_testcase(TestCase, Config) when
                     %% stapling rules under test are only reached once one is
                     %% configured.
                     {emqx,
-                        emqx_common_test_helpers:listener_example_certs(
+                        emqx_common_test_helpers:listener_test_certs(
                             "listeners.ssl.default"
                         )},
                     emqx_management,

--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -132,7 +132,7 @@ init_per_group(quic, Config0) ->
                     <<"enable">> => true,
                     <<"ssl_options">> => maps:merge(
                         #{<<"verify">> => <<"verify_peer">>},
-                        emqx_common_test_helpers:listener_example_certs()
+                        emqx_common_test_helpers:listener_test_certs()
                     )
                 }
             }

--- a/apps/emqx/test/emqx_tls_auth_ext_SUITE.erl
+++ b/apps/emqx/test/emqx_tls_auth_ext_SUITE.erl
@@ -39,7 +39,7 @@ init_per_group(Profile, Config) when Profile =:= legacy; Profile =:= hardened ->
         [
             {emqx,
                 ?BASE_CONF ++
-                    emqx_common_test_helpers:listener_example_certs(
+                    emqx_common_test_helpers:listener_test_certs(
                         "listeners.ssl.auth_ext"
                     )}
         ],

--- a/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
@@ -1206,7 +1206,7 @@ t_precondition_check_cert_cn(init, TCConfig) ->
                     <<"verify">> => verify_peer,
                     <<"fail_if_no_peer_cert">> => true
                 },
-                emqx_common_test_helpers:listener_example_certs()
+                emqx_common_test_helpers:listener_test_certs()
             )
         }}
     ),
@@ -1353,7 +1353,7 @@ t_zone_override(TCConfig) ->
                     }
                 };
             [quic] ->
-                CertsPath = emqx_common_test_helpers:deps_path(emqx, "etc/certs"),
+                CertsPath = emqx_common_test_helpers:ensure_test_certs(),
                 QuicLConfig = #{
                     <<"bind">> => <<"127.0.0.1:14567">>,
                     <<"ssl_options">> => #{
@@ -1413,8 +1413,7 @@ t_zone_override(TCConfig) ->
 %%------------------------------------------------------------------------------
 
 cert_path(FileName) ->
-    Dir = code:lib_dir(emqx),
-    filename:join([Dir, <<"etc/certs">>, FileName]).
+    emqx_common_test_helpers:test_cert(FileName).
 
 %%------------------------------------------------------------------------------
 %% Templated host (one-off request) tests
@@ -1710,8 +1709,7 @@ inline_ssl_certs() ->
     }.
 
 pem(Name) ->
-    Path = filename:join([code:lib_dir(emqx), etc, certs, Name]),
-    {ok, Pem} = file:read_file(Path),
+    {ok, Pem} = file:read_file(emqx_common_test_helpers:test_cert(Name)),
     Pem.
 
 assert_ssl_certs_are_saved(SSL, SavedSSL) ->


### PR DESCRIPTION
Release version:
7.0.0

Introduced in:
N/A

## Summary

First half of moving the test suites off the certificates EMQX ships in
`apps/emqx/etc/certs/`. Test code only; nothing under any `src/` changes.

`emqx_common_test_helpers:ensure_test_certs/0` generates a CA, a server certificate and a client
certificate the first time a suite asks for them, and the shared helpers (`client_mtls/0,1`,
`client_certs/0`, `listener_test_certs/0,1`, `test_cert/1`) hand out those instead of the shipped
files.

The generated identities mean the same as the shipped ones — `CN=RootCA`, `CN=localhost` with SANs
`localhost` / `127.0.0.1` / `::1`, and `CN=Client`, all under `O=EMQ` — because the suites assert on
what a certificate contains, not on its bytes.

`listener_example_certs/0,1`, added in #18813, becomes `listener_test_certs/0,1`: it was named after
the shipped example certificates and no longer points at them.

This PR covers every consumer of the shared helpers. Suites that read `etc/certs` by path still do,
and are migrated in the follow-up; the shipped files stay until both are done.

## Where the certificates live, and why

Beside the application in the build tree (`_build/<profile>/lib/emqx/test-certs/`), not in a per-case
directory. A cluster test starts its listener on a peer node while the client runs on the test node,
so both sides have to resolve the same absolute path — which is exactly why the shipped certificates
worked across nodes.

The set is built in a temporary directory and moved into place, so a half-written set is never
visible and whichever node gets there first wins. One complete set is all any of this needs, so
losing that race is not a failure.

## Verification

The point of this change is that the suites no longer read the shipped files, and **green CI does not
prove that** while those files are still present to fall back on. So the suites were run with the
directory moved aside:

```sh
mv apps/emqx/etc/certs apps/emqx/etc/certs.bak
```

| Suite | Result |
| --- | --- |
| `emqx_ocsp_cache_SUITE` | 20/20 |
| `emqx_broker_SUITE` | 54/54 |
| `emqx_client_SUITE` (ssl group) | 7/7 |
| `emqx_tls_auth_ext_SUITE` | 4/4 |
| `emqx_persistent_session_SUITE` (quic group, clustered) | 24/24, 1 skipped |
| `emqx_authn_http_SUITE` | 41/41 |

That run also confirmed the generated files are what gets used: with the directory gone,
`_build/.../lib/emqx/test-certs/` is created and `openssl x509` reports `CN=RootCA`, `CN=localhost`
with the three SANs, and `CN=Client`.

It caught three places in `emqx_authn_http_SUITE` that read `etc/certs` by path rather than through a
helper (`pem/1`, `cert_path/1`, and a QUIC listener config). Those pass in ordinary CI and fail only
with the directory moved aside, which is the reason for running it this way. They are migrated here.

With the directory restored, the same suites pass unchanged, as does `emqx_default_cert_SUITE` (19/19)
from #18813.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
