### PR TITLE
fix(saml): preserve empty SP private key in API response

### DIFF
--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_api.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_api.erl
@@ -447,8 +447,6 @@ redact_config(#{backend := saml} = Config) ->
     emqx_dashboard_sso_saml:redact_config(Config);
 redact_config(#{<<"backend">> := saml} = Config) ->
     emqx_dashboard_sso_saml:redact_config(Config);
-redact_config(#{<<"backend">> := <<"saml">>} = Config) ->
-    emqx_dashboard_sso_saml:redact_config(Config);
 redact_config(Config) ->
     emqx_utils:redact(Config).
 

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_api.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_api.erl
@@ -437,11 +437,20 @@ handle_backend_update_result({error, Reason}, _) ->
 
 to_redacted_json(Data) ->
     emqx_utils_maps:jsonable_map(
-        emqx_utils:redact(Data),
+        redact_config(Data),
         fun(K, V) ->
             {K, emqx_utils_maps:binary_string(V)}
         end
     ).
+
+redact_config(#{backend := saml} = Config) ->
+    emqx_dashboard_sso_saml:redact_config(Config);
+redact_config(#{<<"backend">> := saml} = Config) ->
+    emqx_dashboard_sso_saml:redact_config(Config);
+redact_config(#{<<"backend">> := <<"saml">>} = Config) ->
+    emqx_dashboard_sso_saml:redact_config(Config);
+redact_config(Config) ->
+    emqx_utils:redact(Config).
 
 redact_sso_request(#{body := Body} = Request) when is_binary(Body) ->
     redact_sso_request(Request#{body => <<"******">>});

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
@@ -27,7 +27,7 @@
     convert_certs/2
 ]).
 
--export([login/2, callback/2]).
+-export([login/2, callback/2, redact_config/1]).
 
 %% Export internal functions for testing
 -ifdef(TEST).
@@ -213,6 +213,15 @@ convert_certs(
     end;
 convert_certs(_Dir, Conf) ->
     Conf.
+
+%% An empty private key is a valid SAML configuration when SP request signing
+%% is disabled. Keep the generic redactor unchanged for other sensitive fields.
+redact_config(#{sp_private_key := <<>>} = Config) ->
+    (emqx_utils:redact(Config))#{sp_private_key := <<>>};
+redact_config(#{<<"sp_private_key">> := <<>>} = Config) ->
+    (emqx_utils:redact(Config))#{<<"sp_private_key">> := <<>>};
+redact_config(Config) ->
+    emqx_utils:redact(Config).
 
 %%------------------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
@@ -211,12 +211,12 @@ t_redact_config(_Config) ->
     ),
     ?assertEqual(
         #{
-            <<"backend">> => <<"saml">>,
+            <<"backend">> => saml,
             <<"sp_private_key">> => <<>>,
             <<"password">> => <<"******">>
         },
         emqx_dashboard_sso_saml:redact_config(#{
-            <<"backend">> => <<"saml">>,
+            <<"backend">> => saml,
             <<"sp_private_key">> => <<>>,
             <<"password">> => <<>>
         })

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
@@ -45,11 +45,13 @@ groups() ->
         {unit, [sequence], [
             t_validate_signature_config,
             t_maybe_load_cert_or_key,
+            t_redact_config,
             t_callback_rejects_xxe_response,
             t_callback_rejects_deflate_xxe_response
         ]},
         {api, [sequence], [
             t_sso_running_disabled,
+            t_saml_get_preserves_empty_private_key,
             t_saml_metadata_not_initialized
         ]},
         {keycloak_integration, [sequence], [
@@ -194,6 +196,45 @@ t_maybe_load_cert_or_key(_Config) ->
 
     ok.
 
+t_redact_config(_Config) ->
+    ?assertEqual(
+        #{
+            backend => saml,
+            sp_private_key => <<>>,
+            password => <<"******">>
+        },
+        emqx_dashboard_sso_saml:redact_config(#{
+            backend => saml,
+            sp_private_key => <<>>,
+            password => <<>>
+        })
+    ),
+    ?assertEqual(
+        #{
+            <<"backend">> => <<"saml">>,
+            <<"sp_private_key">> => <<>>,
+            <<"password">> => <<"******">>
+        },
+        emqx_dashboard_sso_saml:redact_config(#{
+            <<"backend">> => <<"saml">>,
+            <<"sp_private_key">> => <<>>,
+            <<"password">> => <<>>
+        })
+    ),
+    ?assertEqual(
+        #{sp_private_key => <<"******">>},
+        emqx_dashboard_sso_saml:redact_config(#{
+            sp_private_key => <<"private-key">>
+        })
+    ),
+    ?assertEqual(
+        #{<<"sp_private_key">> => <<"******">>},
+        emqx_dashboard_sso_saml:redact_config(#{
+            <<"sp_private_key">> => <<"private-key">>
+        })
+    ),
+    ok.
+
 t_callback_rejects_xxe_response(Config) ->
     assert_callback_rejects_xxe_response(Config, undefined).
 
@@ -223,6 +264,29 @@ t_sso_running_disabled(_Config) ->
     %% SSO running endpoint should show empty when not configured
     {ok, 200, Result} = request(get, uri(["sso", "running"]), []),
     ?assertEqual([], emqx_utils_json:decode(Result, [return_maps])),
+    ok.
+
+t_saml_get_preserves_empty_private_key(_Config) ->
+    Path = uri(["sso", "saml"]),
+    Config = #{
+        <<"backend">> => <<"saml">>,
+        <<"enable">> => false,
+        <<"dashboard_addr">> => <<"https://127.0.0.1:18083">>,
+        <<"idp_metadata_url">> => <<"https://idp.example.com">>,
+        <<"sp_sign_request">> => false,
+        <<"sp_public_key">> => <<>>,
+        <<"sp_private_key">> => <<>>,
+        <<"idp_signs_envelopes">> => true,
+        <<"idp_signs_assertions">> => true
+    },
+    {ok, 200, PutResult} = request(put, Path, Config),
+    PutResponse = emqx_utils_json:decode(PutResult, [return_maps]),
+    ?assertEqual(<<>>, maps:get(<<"sp_private_key">>, PutResponse)),
+    {ok, 200, GetResult} = request(get, Path, []),
+    GetResponse = emqx_utils_json:decode(GetResult, [return_maps]),
+    ?assertEqual(false, maps:get(<<"sp_sign_request">>, GetResponse)),
+    ?assertEqual(<<>>, maps:get(<<"sp_private_key">>, GetResponse)),
+    ?assertEqual(<<>>, maps:get(<<"sp_public_key">>, GetResponse)),
     ok.
 
 t_saml_metadata_not_initialized(_Config) ->

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_saml_SUITE.erl
@@ -35,9 +35,11 @@
 all() ->
     [
         {group, unit},
-        {group, api},
         {group, keycloak_integration},
-        {group, signature_combinations}
+        {group, signature_combinations},
+        %% The API tests create and delete a SAML backend. The testcase cleanup
+        %% stops esaml, so keep them after tests that restart and reuse esaml.
+        {group, api}
     ].
 
 groups() ->

--- a/changes/ee/fix-18872.en.md
+++ b/changes/ee/fix-18872.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where `GET /api/v5/sso/saml` returned `******` for an empty `sp_private_key` after SAML request signing was disabled. The SAML API now returns an empty value when no SP private key is configured, while non-empty private keys remain redacted.


### PR DESCRIPTION
Fixes: #18753
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: N/A

## Summary

When SAML request signing was disabled, the effective configuration contained an empty `sp_private_key`, but `GET /api/v5/sso/saml` returned the redaction placeholder `******`.

The fix keeps the empty value readable only for SAML API configuration responses. Non-empty SAML private keys remain redacted, and all other SSO backends and common redaction behavior are unchanged.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)