### PR TITLE
fix(bpapi): use the PLT built for the OTP that is running

### DIFF
--- a/apps/emqx_bpapi/test/emqx_bpapi_static_checks.erl
+++ b/apps/emqx_bpapi/test/emqx_bpapi_static_checks.erl
@@ -421,17 +421,19 @@ dump() ->
     RootDir = project_root_dir(),
     BuildProfile = os:getenv("BPAPI_BUILD_PROFILE", "check"),
     TryRelDir = filename:join([RootDir, "_build", BuildProfile, "lib"]),
-    case {filelib:wildcard(RootDir ++ "/*_plt"), filelib:wildcard(TryRelDir)} of
-        {[PLT | _], [RelDir | _]} ->
+    PLT = plt_file(RootDir),
+    case {filelib:is_regular(PLT), filelib:wildcard(TryRelDir)} of
+        {true, [RelDir | _]} ->
             dump(#{
                 plt => PLT,
                 reldir => RelDir
             });
-        {[], _} ->
+        {false, _} ->
             logger:error(
-                "No usable PLT files found in \"~s\", abort ~n"
+                "No PLT for the running OTP at \"~s\", abort ~n"
+                "Found: ~p~n"
                 "Try running `rebar3 as check dialyzer` at least once first",
-                [RootDir]
+                [PLT, filelib:wildcard(RootDir ++ "/*_plt")]
             ),
             error(run_failed);
         {_, []} ->
@@ -441,6 +443,26 @@ dump() ->
                 [TryRelDir]
             ),
             error(run_failed)
+    end.
+
+%% The PLT `mix emqx.dialyzer' writes for the OTP running now. A checkout can
+%% hold several, one per OTP it has been built with, and a PLT that describes
+%% other code answers `none' for every lookup: the dump then either crashes in
+%% `enrich/2' or, worse, records the wrong signatures.
+-spec plt_file(file:filename()) -> file:filename().
+plt_file(RootDir) ->
+    filename:join(RootDir, "emqx_dialyzer_" ++ otp_version() ++ "_plt").
+
+%% Mirrors `EMQXUmbrella.MixProject.otp_release/0', which names the file.
+-spec otp_version() -> string().
+otp_version() ->
+    Major = erlang:system_info(otp_release),
+    File = filename:join([code:root_dir(), "releases", Major, "OTP_VERSION"]),
+    case file:read_file(File) of
+        {ok, Bin} ->
+            hd(string:split(string:trim(binary_to_list(Bin)), "**"));
+        {error, _} ->
+            Major
     end.
 
 %% Collect the local BPAPI modules to a dump file


### PR DESCRIPTION
Fixes:
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: pre-5.8

## Summary

`dump/0` selected the PLT with

```erlang
case {filelib:wildcard(RootDir ++ "/*_plt"), ...} of
    {[PLT | _], [RelDir | _]} -> dump(#{plt => PLT, ...})
```

`filelib:wildcard/1` returns names in order, so the choice was alphabetical. A
checkout accumulates one PLT per OTP it has been built with, and nothing tied the
one picked to the OTP actually running.

A PLT describing a different build answers `none` for every lookup, so
`enrich/2` fails with `case_clause` on `{none, none}`. That is the good outcome.
A PLT that matches only in part is worse: `dump_api/1` writes a dump with missing
or wrong signatures, and it looks entirely normal — which is the failure mode
this check exists to prevent.

A checkout accumulates them: switching between release branches changes
`.tool-versions`, and each OTP you build with leaves its own PLT behind. Nothing
removes the older ones.

This is not hypothetical — it happened three times while syncing the BPAPI work
across the release branches:

| checkout | PLTs present | picked |
|---|---|---|
| built for the 5.10 line | `27.3.4.2-6` months old, `27.3.4.2-8` built that day | the months-old one |
| a worktree for the r61-to-r62 sync | `28.4.1-3` months old, `28.4.1-4` built that day | the months-old one |
| built for the 5.8 line | `26.2.5.14-1`, `27.3.4.2-2` | the right one, by luck |

The third only worked because `26...` sorts before `27...`.

## The fix

Build the name the way `mix emqx.dialyzer` does — `plt_path/1` in
`emqx.dialyzer.ex` joins `emqx_dialyzer_#{UMP.otp_release()}_plt`, and
`otp_release/0` reads `<code:root_dir()>/releases/<otp_release>/OTP_VERSION`,
trimmed and cut at `**`. `otp_version/0` here mirrors that, including the
fallback to the major release when the file is absent, so both sides agree on the
name in every case.

Then read only that file. When it is missing, say which one was wanted and list
what is actually present, instead of reaching for one of them:

```
[error] No PLT for the running OTP at ".../emqx_dialyzer_27.3.4.2-8_plt", abort
Found: [".../emqx_dialyzer_27.3.4.2-1_plt"]
Try running `rebar3 as check dialyzer` at least once first
```

CI is unaffected: `make static_checks` runs dialyzer before the dump, which
creates the PLT under exactly this name.

## Verification

Three ways, because a check that only passes proves little:

- normal run — `make static_checks` passes;
- only a mismatched PLT present — the run fails and names both the wanted and the
  found file, where before it would have used the wrong one;
- a decoy sorting ahead of the correct PLT — the correct one is still chosen.
  This reproduces the r61-to-r62 case exactly.

`make fmt-diff` clean, elvis clean. No changelog: this is build tooling with no
user-visible behaviour change.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

