### PR TITLE
perf(mt): build tenant limiter containers lazily

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
@@ -51,7 +51,7 @@
     config_from_rate_and_burst/2
 ]).
 
--export_type([zone/0, group/0, name/0, id/0, options/0, listener_id/0]).
+-export_type([zone/0, group/0, name/0, id/0, options/0, listener_id/0, client_options/0]).
 
 -type zone() :: atom().
 -type group() :: term().

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_client_container.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_client_container.erl
@@ -22,11 +22,15 @@
 %% Type declarations
 %%------------------------------------------------------------------------------
 
--type entry() :: emqx_limiter_client:t() | {lazy, [emqx_limiter:id()]}.
+%% A lazy spec names a limiter to connect on first use, optionally with
+%% client options (`not_found_mode => close` denies instead of failing
+%% open when the limiter's group is gone).
+-type lazy_spec() :: emqx_limiter:id() | {emqx_limiter:id(), emqx_limiter:client_options()}.
+-type entry() :: emqx_limiter_client:t() | {lazy, [lazy_spec()]}.
 -type t() :: #{emqx_limiter:name() => entry()}.
 -type reason() :: emqx_limiter_client:reason().
 
--export_type([t/0, entry/0, reason/0]).
+-export_type([t/0, entry/0, lazy_spec/0, reason/0]).
 
 %%--------------------------------------------------------------------
 %% API
@@ -49,12 +53,14 @@ try_consume_from_clients(Container, [], _Consumed) ->
     {true, Container};
 try_consume_from_clients(Container, [{Name, Amount} | Rest], Consumed) ->
     case Container of
-        #{Name := {lazy, LimiterIds}} ->
-            case materialize(LimiterIds) of
+        #{Name := {lazy, Specs}} ->
+            case materialize(Specs) of
                 unlimited ->
                     try_consume_from_clients(Container, Rest, Consumed);
                 {ok, Client} ->
-                    try_consume_from_client(Container, Client, Name, Amount, Rest, Consumed)
+                    try_consume_from_client(Container, Client, Name, Amount, Rest, Consumed);
+                {error, Reason} ->
+                    {false, put_back_to_clients(Container, Consumed), Reason}
             end;
         #{Name := Client} ->
             try_consume_from_client(Container, Client, Name, Amount, Rest, Consumed);
@@ -72,32 +78,66 @@ try_consume_from_client(Container, Client, Name, Amount, Rest, Consumed) ->
             {false, put_back_to_clients(Container#{Name => NewClient}, Consumed), Reason}
     end.
 
-materialize(LimiterIds) ->
-    case lists:all(fun is_unlimited/1, LimiterIds) of
-        true ->
+%% Decide what a lazy entry becomes on consume. While every limiter of the
+%% entry is unlimited it stays lazy. A limiter whose group or name is gone
+%% is treated as unlimited (fail open), consistent with how connected
+%% clients handle a vanished limiter, unless its spec asks for
+%% `not_found_mode => close`: then the consume is denied.
+materialize(Specs) ->
+    case classify(Specs, unlimited) of
+        unlimited ->
             unlimited;
-        false ->
-            {ok, connect_clients(LimiterIds)}
+        limited ->
+            {ok, connect_clients(Specs)};
+        {error, _} = Error ->
+            Error
     end.
 
-%% A limiter whose group or name is gone is treated as unlimited (fail open),
-%% consistent with how connected clients handle a vanished limiter.
-is_unlimited({Group, Name}) ->
-    case emqx_limiter_registry:find_group(Group) of
-        undefined ->
-            true;
-        {_Module, LimiterOptions} ->
-            case lists:keyfind(Name, 1, LimiterOptions) of
-                {_, #{capacity := infinity}} -> true;
-                {_, _} -> false;
-                false -> true
+classify([], Acc) ->
+    Acc;
+classify([Spec | Rest], Acc) ->
+    {LimiterId, ClientOpts} = spec(Spec),
+    case limiter_state(LimiterId) of
+        unlimited ->
+            classify(Rest, Acc);
+        limited ->
+            classify(Rest, limited);
+        missing ->
+            case maps:get(not_found_mode, ClientOpts, open) of
+                close -> {error, {limiter_not_found, LimiterId}};
+                open -> classify(Rest, Acc)
             end
     end.
 
-connect_clients([LimiterId]) ->
-    emqx_limiter:connect(LimiterId);
-connect_clients(LimiterIds) ->
-    emqx_limiter_composite:new([emqx_limiter:connect(Id) || Id <- LimiterIds]).
+limiter_state({Group, Name}) ->
+    case emqx_limiter_registry:find_group(Group) of
+        undefined ->
+            missing;
+        {_Module, LimiterOptions} ->
+            case lists:keyfind(Name, 1, LimiterOptions) of
+                {_, #{capacity := infinity}} -> unlimited;
+                {_, _} -> limited;
+                false -> missing
+            end
+    end.
+
+%% Vanished open-mode limiters are skipped: they count as unlimited.
+connect_clients(Specs) ->
+    Clients = [
+        emqx_limiter:connect(LimiterId, ClientOpts)
+     || Spec <- Specs,
+        {LimiterId, ClientOpts} <- [spec(Spec)],
+        limiter_state(LimiterId) =/= missing
+    ],
+    case Clients of
+        [Client] -> Client;
+        _ -> emqx_limiter_composite:new(Clients)
+    end.
+
+spec({LimiterId, ClientOpts}) when is_map(ClientOpts) ->
+    {LimiterId, ClientOpts};
+spec(LimiterId) ->
+    {LimiterId, #{}}.
 
 put_back_to_clients(Container, []) ->
     Container;

--- a/apps/emqx/test/emqx_limiter_client_container_SUITE.erl
+++ b/apps/emqx/test/emqx_limiter_client_container_SUITE.erl
@@ -178,3 +178,40 @@ t_lazy_entry_mixed_put_back(_) ->
         Container1,
         [{limiter1, 1}, {limiter2, 2}, {limiter3, 1}]
     ).
+
+-doc "A close-mode lazy spec whose group is gone denies instead of failing open.".
+t_lazy_entry_close_mode_missing_group(_) ->
+    Container0 = emqx_limiter_client_container:new([
+        {limiter1, {lazy, [{{nonexistent_group, limiter1}, #{not_found_mode => close}}]}}
+    ]),
+    {false, Container1, {limiter_not_found, {nonexistent_group, limiter1}}} =
+        emqx_limiter_client_container:try_consume(Container0, [{limiter1, 1}]),
+    ?assertEqual(Container0, Container1).
+
+-doc "A close-mode lazy spec connects a close-mode client and keeps denying after group deletion.".
+t_lazy_entry_close_mode_materializes(_) ->
+    ok = emqx_limiter:create_group(exclusive, group1, [
+        {limiter1, #{capacity => 2, interval => 60000, burst_capacity => 0}}
+    ]),
+    Container0 = emqx_limiter_client_container:new([
+        {limiter1, {lazy, [{{group1, limiter1}, #{not_found_mode => close}}]}}
+    ]),
+    {true, Container1} =
+        emqx_limiter_client_container:try_consume(Container0, [{limiter1, 2}]),
+    ?assertMatch(#{limiter1 := #{module := _, not_found_mode := close}}, Container1),
+    ok = emqx_limiter:delete_group(group1),
+    {false, _Container2, {limiter_not_found, {group1, limiter1}}} =
+        emqx_limiter_client_container:try_consume(Container1, [{limiter1, 1}]).
+
+-doc "A vanished open-mode limiter in a multi-id spec is skipped; the rest still enforce.".
+t_lazy_entry_skips_vanished_open_limiter(_) ->
+    ok = emqx_limiter:create_group(exclusive, group1, [
+        {limiter1, #{capacity => 2, interval => 60000, burst_capacity => 0}}
+    ]),
+    Container0 = emqx_limiter_client_container:new([
+        {limiter1, {lazy, [{nonexistent_group, limiter1}, {group1, limiter1}]}}
+    ]),
+    {true, Container1} =
+        emqx_limiter_client_container:try_consume(Container0, [{limiter1, 2}]),
+    {false, _Container2, {failed_to_consume_from_limiter, {group1, limiter1}}} =
+        emqx_limiter_client_container:try_consume(Container1, [{limiter1, 1}]).

--- a/apps/emqx_mt/src/emqx_mt_limiter.erl
+++ b/apps/emqx_mt/src/emqx_mt_limiter.erl
@@ -223,39 +223,30 @@ create_client_container(Zone, ListenerId, Ns, Names) ->
     ),
     emqx_limiter_client_container:new(Clients).
 
+%% Entries are lazy: the container connects the clients on the first
+%% consume after a finite limit exists (see emqx_limiter_client_container).
+%% Which groups apply is still decided here, at hook time.
 create_limiter(Zone, ListenerId, Ns, Name) ->
-    TenantLimiters = create_tenant_limiters(Zone, Ns, Name),
-    ClientLimiters = create_client_limiters(ListenerId, Ns, Name),
-    case TenantLimiters ++ ClientLimiters of
-        [Client] -> Client;
-        Clients -> emqx_limiter_composite:new(Clients)
-    end.
+    {lazy, tenant_limiter_specs(Zone, Ns, Name) ++ client_limiter_specs(ListenerId, Ns, Name)}.
 
-create_tenant_limiters(_Zone, _Ns, Name) when ?IS_CHANNEL_ONLY_LIMITER(Name) ->
+tenant_limiter_specs(_Zone, _Ns, Name) when ?IS_CHANNEL_ONLY_LIMITER(Name) ->
     [];
-create_tenant_limiters(Zone, Ns, Name) ->
-    ZoneLimiterId = {zone_group(Zone), Name},
-    ZoneLimiterClient = emqx_limiter:connect(ZoneLimiterId),
+tenant_limiter_specs(Zone, Ns, Name) ->
+    ZoneSpec = {zone_group(Zone), Name},
     case emqx_mt_config:get_tenant_limiter_config(Ns) of
         {ok, #{}} ->
-            TenantLimiterId = {tenant_group(Ns), Name},
-            TenantLimiterClient = emqx_limiter:connect(TenantLimiterId, #{not_found_mode => close}),
-            [ZoneLimiterClient, TenantLimiterClient];
+            [ZoneSpec, {{tenant_group(Ns), Name}, #{not_found_mode => close}}];
         _ ->
-            [ZoneLimiterClient]
+            [ZoneSpec]
     end.
 
-create_client_limiters(ListenerId, Ns, Name) ->
+client_limiter_specs(ListenerId, Ns, Name) ->
     case emqx_mt_config:get_client_limiter_config(Ns) of
         {ok, #{}} ->
-            ClientLimiterId = {client_group(Ns), Name},
-            ClientLimiterClient = emqx_limiter:connect(ClientLimiterId, #{not_found_mode => close}),
-            [ClientLimiterClient];
+            [{{client_group(Ns), Name}, #{not_found_mode => close}}];
         _ ->
             %% TODO: Isolate implementation details in `emqx_limiter` API.
-            LimiterId = {channel_group(ListenerId), Name},
-            LimiterClient = emqx_limiter:connect(LimiterId),
-            [LimiterClient]
+            [{channel_group(ListenerId), Name}]
     end.
 
 ensure_group_absent(Group) ->

--- a/changes/ee/perf-18875.en.md
+++ b/changes/ee/perf-18875.en.md
@@ -1,0 +1,6 @@
+Reduced memory usage of MQTT connections that belong to a multi-tenant namespace.
+
+Rate-limiter state for namespace clients is now allocated when a client first publishes,
+subscribes or receives a message, and only for limits that are actually configured, matching
+the behavior of ordinary connections. Configured tenant and client rate limits behave the
+same as before, including denial after a namespace's limiter configuration is removed.


### PR DESCRIPTION
Fixes:
Release version: 6.3.1, 7.0.0
Introduced in: 5.9.0

## Summary

#18806-#18808 made the limiter containers of ordinary MQTT clients lazy, but clients of a
multi-tenant namespace (`tns` attribute) still got fully connected containers from the
`'channel.limiter_adjustment'` / `'session.limiter_adjustment'` hooks, because
`emqx_mt_limiter` builds its containers with eager `emqx_limiter:connect/1,2` calls. A tenant
client therefore carried the full per-limiter client state at connect regardless of which
limits were configured.

This PR makes those containers lazy the same way, without changing when the hooks run or
what they decide:

* `emqx_limiter_client_container` lazy specs can now carry client options:
  `{lazy, [Id | {Id, #{not_found_mode => close}}]}`. On consume, a close-mode spec whose
  group is gone **denies** (`{limiter_not_found, Id}`) instead of counting as unlimited, so
  namespace deletion keeps its "clients stop being admitted" semantics
  (`emqx_mt_limiter:cleanup_configs/2`). Open-mode specs whose group is gone are skipped
  when the rest of the entry connects, instead of crashing the process on `connect`.
* `emqx_mt_limiter:create_limiter/4` emits `{lazy, Specs}` entries: the zone limiter,
  the tenant limiter (close mode) when the namespace has a tenant config, and the client
  limiter (close mode) or the listener's channel limiter otherwise. The config-presence
  decisions stay at hook time; only the `connect` is deferred, and the `mt_limiter_adjusted`
  trace still fires there.

Semantics: a tenant client materializes its clients on the first PUBLISH / SUBSCRIBE /
delivery after a finite limit exists, with exclusive buckets starting full at that moment —
the same behavior #18806-#18808 gave non-tenant clients.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
