### PR TITLE
fix(audit): name the actor and target of an RBAC-denied request

### DIFF
--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -20,6 +20,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_dashboard/include/emqx_dashboard_rbac.hrl").
 
 all() ->
     [
@@ -365,6 +366,111 @@ t_license_key_redacted(_) ->
     ?assertEqual(nomatch, binary:match(AuditBody, <<"default">>), AuditBody),
     ?assertNotEqual(nomatch, binary:match(AuditBody, <<"******">>), AuditBody),
     ok.
+
+%% An authenticated dashboard user denied by RBAC is named in the audit record.
+%% The 403 record carries the username in `source' and the path parameters in
+%% `http_request.bindings'.
+t_rbac_denied_dashboard_user(_) ->
+    StartAt = erlang:system_time(microsecond),
+    Username = <<"audit_rbac_viewer">>,
+    Password = <<"public_www1">>,
+    {ok, _} = emqx_dashboard_admin:add_user(Username, Password, ?ROLE_VIEWER, <<"viewer">>),
+    {ok, ?ROLE_VIEWER, Token} = emqx_dashboard_admin:sign_token(Username, Password),
+    ClientId = <<"audit-rbac-denied-dashboard">>,
+    ?assertMatch({ok, 403, _}, delete_client(ClientId, bearer_header(Token))),
+    ?assertMatch(
+        #{
+            <<"from">> := <<"dashboard">>,
+            <<"source">> := Username,
+            <<"source_ip">> := <<"127.0.0.1">>,
+            <<"operation_id">> := <<"/clients/:clientid">>,
+            <<"operation_type">> := <<"clients">>,
+            <<"http_status_code">> := 403,
+            <<"operation_result">> := <<"failure">>,
+            <<"http_request">> := #{
+                <<"method">> := <<"delete">>,
+                <<"bindings">> := #{<<"clientid">> := ClientId}
+            }
+        },
+        latest_audit_record("http_status_code=403", StartAt)
+    ),
+    ok.
+
+%% An API key denied by RBAC is named in the audit record. The 403 record
+%% carries the API key in `source', `rest_api' in `from', and the path
+%% parameters in `http_request.bindings'.
+t_rbac_denied_api_key(_) ->
+    StartAt = erlang:system_time(microsecond),
+    Name = <<"audit_rbac_viewer_key">>,
+    Key = <<"audit_rbac_viewer_key">>,
+    Secret = <<"audit_rbac_viewer_secret">>,
+    ExpiredAt = erlang:system_time(second) + 3600,
+    {ok, _} = emqx_mgmt_auth:create(
+        Name, Key, Secret, true, ExpiredAt, <<"audit rbac test key">>, ?ROLE_API_VIEWER
+    ),
+    ClientId = <<"audit-rbac-denied-api-key">>,
+    AuthHeader = emqx_common_test_http:auth_header(
+        binary_to_list(Key), binary_to_list(Secret)
+    ),
+    ?assertMatch({ok, 403, _}, delete_client(ClientId, AuthHeader)),
+    ?assertMatch(
+        #{
+            <<"from">> := <<"rest_api">>,
+            <<"source">> := Key,
+            <<"operation_id">> := <<"/clients/:clientid">>,
+            <<"http_status_code">> := 403,
+            <<"operation_result">> := <<"failure">>,
+            <<"http_request">> := #{
+                <<"method">> := <<"delete">>,
+                <<"bindings">> := #{<<"clientid">> := ClientId}
+            }
+        },
+        latest_audit_record("http_status_code=403", StartAt)
+    ),
+    ok.
+
+%% An unauthenticated request is still recorded without an actor. A bad bearer
+%% token is rejected with 401 before any identity is established, so the record
+%% keeps an empty `source' and does not carry the path parameters.
+t_unauthenticated_request_has_no_actor(_) ->
+    StartAt = erlang:system_time(microsecond),
+    ClientId = <<"audit-bad-token">>,
+    ?assertMatch({ok, 401, _}, delete_client(ClientId, bearer_header(<<"not-a-token">>))),
+    Record = latest_audit_record("http_status_code=401", StartAt),
+    ?assertMatch(
+        #{
+            <<"from">> := <<"dashboard">>,
+            <<"source">> := <<"">>,
+            <<"http_status_code">> := 401,
+            <<"operation_result">> := <<"failure">>,
+            <<"http_request">> := #{<<"method">> := <<"delete">>}
+        },
+        Record
+    ),
+    #{<<"http_request">> := HttpRequest} = Record,
+    ?assertEqual(false, maps:is_key(<<"bindings">>, HttpRequest), HttpRequest),
+    ok.
+
+bearer_header(Token) ->
+    {"Authorization", "Bearer " ++ binary_to_list(Token)}.
+
+delete_client(ClientId, AuthHeader) ->
+    Path = emqx_mgmt_api_test_util:api_path(["clients", binary_to_list(ClientId)]),
+    emqx_mgmt_api_test_util:request_api(
+        delete, Path, "", AuthHeader, [], #{compatible_mode => true}
+    ).
+
+%% Fetch the newest audit record matching `Filter', created no earlier than
+%% `StartAt' (microseconds).
+latest_audit_record(Filter, StartAt) ->
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Query = lists:flatten(
+        io_lib:format("~s&gte_created_at=~B&limit=1", [Filter, StartAt])
+    ),
+    Res = wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, 5000),
+    #{<<"data">> := [Record]} = emqx_utils_json:decode(Res, [return_maps]),
+    Record.
 
 wait_for_matching_audit_entry(_AuditPath, _Query, _AuthHeader, RemainMs) when RemainMs =< 0 ->
     ct:fail(audit_entry_not_found_in_time);

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -270,6 +270,8 @@ audit_log_fun() ->
 
 %% dialyzer complains about the `unauthorized_role' clause...
 -dialyzer({no_match, [authorize/2, api_key_authorize/4]}).
+%% ...and about the helper that only those clauses call.
+-dialyzer({nowarn_function, [audit_rbac_denied/3]}).
 
 -endif.
 
@@ -286,7 +288,8 @@ authorize(Req, HandlerInfo) ->
                     {401, 'TOKEN_TIME_OUT', <<"Token expired, get new token by POST /login">>};
                 {error, not_found} ->
                     {401, 'BAD_TOKEN', <<"Get a token by POST /login">>};
-                {error, unauthorized_role} ->
+                {error, {unauthorized_role, Username}} ->
+                    ok = audit_rbac_denied(Req, jwt_token, Username),
                     {403, 'UNAUTHORIZED_ROLE',
                         <<"You don't have permission to access this resource">>}
             end;
@@ -296,6 +299,29 @@ authorize(Req, HandlerInfo) ->
                 <<"Support authorization: basic/bearer ">>
             )
     end.
+
+%% RBAC denies the request after the caller has been authenticated, so the
+%% actor is known. minirest never reaches its own meta-producing code on a
+%% failed authorization, so write the actor and the path parameters into the
+%% audit meta here. Only the routing bindings are added - no headers, no body.
+%%
+%% `update_log_meta/1' merges into the per-request meta that minirest
+%% initialises before it calls this authorizer. Tests call `authorize/2'
+%% directly, without that meta; `badmap' then means there is no request to
+%% audit, which must not change the authorization result.
+audit_rbac_denied(Req, AuthType, Source) ->
+    _ =
+        try
+            minirest_handler:update_log_meta(#{
+                auth_type => AuthType,
+                source => Source,
+                bindings => cowboy_req:bindings(Req)
+            })
+        catch
+            error:{badmap, undefined} ->
+                ok
+        end,
+    ok.
 
 return_unauthorized(Code, Message) ->
     {401,
@@ -330,6 +356,7 @@ api_key_authorize(Req, HandlerInfo, Key, Secret) ->
                     " path is not permitted">>
             );
         {error, unauthorized_role} ->
+            ok = audit_rbac_denied(Req, api_key, Key),
             {403, 'UNAUTHORIZED_ROLE', ?API_KEY_NOT_ALLOW_MSG};
         {error, _} ->
             return_unauthorized(

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -388,7 +388,7 @@ sign_token(Username, Password) ->
 -spec verify_token(_, Token :: binary()) ->
     Result ::
         {ok, binary()}
-        | {error, token_timeout | not_found | unauthorized_role}.
+        | {error, token_timeout | not_found | {unauthorized_role, Username :: binary()}}.
 verify_token(Req, Token) ->
     emqx_dashboard_token:verify(Req, Token).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_token.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_token.erl
@@ -61,7 +61,7 @@ sign(User, Password) ->
 -spec verify(_, Token :: binary()) ->
     Result ::
         {ok, binary()}
-        | {error, token_timeout | not_found | unauthorized_role}.
+        | {error, token_timeout | not_found | {unauthorized_role, Username :: binary()}}.
 verify(Req, Token) ->
     do_verify(Req, Token).
 
@@ -124,7 +124,7 @@ do_sign(#?ADMIN{username = Username} = User, Password) ->
 -spec do_verify(_, Token :: binary()) ->
     Result ::
         {ok, binary()}
-        | {error, token_timeout | not_found | unauthorized_role}.
+        | {error, token_timeout | not_found | {unauthorized_role, Username :: binary()}}.
 do_verify(Req, Token) ->
     case lookup(Token) of
         {ok, JWT = #?ADMIN_JWT{exptime = ExpTime, extra = _Extra, username = _Username}} ->
@@ -252,7 +252,9 @@ check_rbac(Req, JWT) ->
         true ->
             save_new_jwt(JWT);
         _ ->
-            {error, unauthorized_role}
+            %% The token is valid, so the caller is authenticated. Return the
+            %% username so the audit record can name who was denied.
+            {error, {unauthorized_role, Username}}
     end.
 
 -else.

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -186,8 +186,8 @@ t_change_pwd(_) ->
     %% viewer can change own password
     ?assertEqual({ok, Viewer1}, change_pwd(Viewer1Token, Viewer1)),
     %% viewer can't change other's password
-    ?assertEqual({error, unauthorized_role}, change_pwd(Viewer1Token, Viewer2)),
-    ?assertEqual({error, unauthorized_role}, change_pwd(Viewer1Token, SuperUser)),
+    ?assertEqual({error, {unauthorized_role, Viewer1}}, change_pwd(Viewer1Token, Viewer2)),
+    ?assertEqual({error, {unauthorized_role, Viewer1}}, change_pwd(Viewer1Token, SuperUser)),
     %% superuser can change other's password
     ?assertEqual({ok, SuperUser}, change_pwd(SuperToken, Viewer1)),
     ?assertEqual({ok, SuperUser}, change_pwd(SuperToken, Viewer2)),

--- a/changes/ee/fix-18877.en.md
+++ b/changes/ee/fix-18877.en.md
@@ -1,0 +1,3 @@
+Audit records for requests denied by role-based access control now include the authenticated dashboard user or API key and the request's path parameters.
+
+Before this change, a request that passed authentication but was denied by role-based access control was recorded with an empty `source` and without `http_request.bindings`, so `GET /api/v5/audit` could not show who made the request or what it targeted. Records for unauthenticated requests are unchanged.


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.6

Introduced in:
pre-5.8

## Summary

Fixes #18821. The v6 counterpart is #18879; the token and RBAC code differs between the two lines, so that one is a hand port, not a cherry-pick.

An authenticated request that is denied by role-based access control (HTTP 403 `UNAUTHORIZED_ROLE`) was audited without an actor and without a target: `source` was empty and `http_request` held only `method`. A `PUT /gateways/jt808` denied for a `viewer` could not be attributed to anyone.

minirest produces the auth meta and parses the request parameters only after a successful authorization, so nothing on the deny path ever wrote `source` or `bindings`. The identity is known at that point — the token has been verified, or the API key secret has been checked — and was discarded.

Crucial changes:

* `emqx_dashboard:authorize/2` and `api_key_authorize/4` write the actor and the routing bindings into the audit meta through `minirest_handler:update_log_meta/1`, the same hook the dashboard API modules already use. Only the routing bindings are added — no headers and no body.
* `emqx_dashboard_token:verify/2` returns `{error, {unauthorized_role, Username}}`. Widening the return keeps the audit side effect in `authorize/2` next to the other meta production, instead of putting minirest process-dictionary calls into the token module. The API key path needs no such change: the key is already bound at the deny site.
* The audit write is wrapped so that a missing per-request meta cannot change the authorization result. `authorize/2` is also called directly from tests, where minirest never initialised that meta.

401 records are unchanged. Those requests are not authenticated, so there is no actor to name.

REST API impact: `GET /api/v5/audit` records for 403 responses now carry a non-empty `source` and a populated `http_request.bindings`. Additive and backward compatible.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoGvpRh1mJGj9UonfY3m86
