### PR TITLE
fix(audit): name the actor and target of an RBAC-denied request

### DIFF
--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -601,6 +601,118 @@ wait_for_dirty_write_log_done(Prev, RemainMs) ->
             wait_for_dirty_write_log_done(New, RemainMs - SleepMs)
     end.
 
+-doc """
+An authenticated dashboard user denied by role-based access control is named in
+the audit record. The 403 record carries the username in `source` and the path
+parameters in `http_request.bindings`.
+""".
+t_rbac_denied_dashboard_user(_) ->
+    StartAt = erlang:system_time(microsecond),
+    Username = <<"audit_rbac_viewer">>,
+    Password = <<"public_www1">>,
+    {ok, _} = emqx_dashboard_admin:add_user(Username, Password, ?ROLE_VIEWER, <<"viewer">>),
+    {ok, #{role := ?ROLE_VIEWER, token := Token}} =
+        emqx_dashboard_admin:sign_token(Username, Password),
+    ClientId = <<"audit-rbac-denied-dashboard">>,
+    ?assertMatch({ok, 403, _}, delete_client(ClientId, bearer_header(Token))),
+    ?assertMatch(
+        #{
+            <<"from">> := <<"dashboard">>,
+            <<"source">> := Username,
+            <<"source_ip">> := <<"127.0.0.1">>,
+            <<"operation_id">> := <<"/clients/:clientid">>,
+            <<"operation_type">> := <<"clients">>,
+            <<"http_status_code">> := 403,
+            <<"operation_result">> := <<"failure">>,
+            <<"http_request">> := #{
+                <<"method">> := <<"delete">>,
+                <<"bindings">> := #{<<"clientid">> := ClientId}
+            }
+        },
+        latest_audit_record("http_status_code=403", StartAt)
+    ),
+    ok.
+
+-doc """
+An API key denied by role-based access control is named in the audit record.
+The 403 record carries the API key in `source`, `rest_api` in `from`, and the
+path parameters in `http_request.bindings`.
+""".
+t_rbac_denied_api_key(_) ->
+    StartAt = erlang:system_time(microsecond),
+    Name = <<"audit_rbac_viewer_key">>,
+    Key = <<"audit_rbac_viewer_key">>,
+    Secret = <<"audit_rbac_viewer_secret">>,
+    ExpiredAt = erlang:system_time(second) + 3600,
+    {ok, _} = emqx_mgmt_auth:create_with_key(
+        Name, Key, Secret, true, ExpiredAt, <<"audit rbac test key">>, ?ROLE_API_VIEWER
+    ),
+    ClientId = <<"audit-rbac-denied-api-key">>,
+    AuthHeader = emqx_common_test_http:auth_header(
+        binary_to_list(Key), binary_to_list(Secret)
+    ),
+    ?assertMatch({ok, 403, _}, delete_client(ClientId, AuthHeader)),
+    ?assertMatch(
+        #{
+            <<"from">> := <<"rest_api">>,
+            <<"source">> := Key,
+            <<"operation_id">> := <<"/clients/:clientid">>,
+            <<"http_status_code">> := 403,
+            <<"operation_result">> := <<"failure">>,
+            <<"http_request">> := #{
+                <<"method">> := <<"delete">>,
+                <<"bindings">> := #{<<"clientid">> := ClientId}
+            }
+        },
+        latest_audit_record("http_status_code=403", StartAt)
+    ),
+    ok.
+
+-doc """
+An unauthenticated request is still recorded without an actor. A bad bearer
+token is rejected with 401 before any identity is established, so the record
+keeps an empty `source` and does not carry the path parameters.
+""".
+t_unauthenticated_request_has_no_actor(_) ->
+    StartAt = erlang:system_time(microsecond),
+    ClientId = <<"audit-bad-token">>,
+    ?assertMatch({ok, 401, _}, delete_client(ClientId, bearer_header(<<"not-a-token">>))),
+    Record = latest_audit_record("http_status_code=401", StartAt),
+    ?assertMatch(
+        #{
+            <<"from">> := <<"dashboard">>,
+            <<"source">> := <<"">>,
+            <<"http_status_code">> := 401,
+            <<"operation_result">> := <<"failure">>,
+            <<"http_request">> := #{<<"method">> := <<"delete">>}
+        },
+        Record
+    ),
+    #{<<"http_request">> := HttpRequest} = Record,
+    ?assertEqual(false, maps:is_key(<<"bindings">>, HttpRequest), HttpRequest),
+    ok.
+
+bearer_header(Token) ->
+    {"Authorization", "Bearer " ++ binary_to_list(Token)}.
+
+delete_client(ClientId, AuthHeader) ->
+    Path = emqx_mgmt_api_test_util:api_path(["clients", binary_to_list(ClientId)]),
+    emqx_mgmt_api_test_util:request_api(
+        delete, Path, "", AuthHeader, [], #{compatible_mode => true}
+    ).
+
+%% Fetch the newest audit record matching `Filter', created no earlier than
+%% `StartAt' (microseconds).
+latest_audit_record(Filter, StartAt) ->
+    AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Query = lists:flatten(
+        io_lib:format("~s&gte_created_at=~B&limit=1", [Filter, StartAt])
+    ),
+    Res = wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, 5000),
+    #{<<"data">> := [Record]} = emqx_utils_json:decode(Res),
+    Record.
+
 wait_for_matching_audit_entry(_AuditPath, _Query, _AuthHeader, RemainMs) when RemainMs =< 0 ->
     ct:fail(audit_entry_not_found_in_time);
 wait_for_matching_audit_entry(AuditPath, Query, AuthHeader, RemainMs) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -385,6 +385,7 @@ api_key_authorize(Req, HandlerInfo, Key, Secret) ->
                     " path is not permitted">>
             );
         {error, {unauthorized_role, Msg}} when is_binary(Msg) ->
+            ok = audit_rbac_denied(Req, api_key, Key),
             {403, 'UNAUTHORIZED_ROLE', Msg};
         {error, _} ->
             return_unauthorized(
@@ -415,9 +416,33 @@ jwt_token_bearer_authorize(Req, HandlerInfo, Token) ->
             {401, 'TOKEN_TIME_OUT', token_timeout_message(HandlerInfo)};
         {error, not_found} ->
             {401, 'BAD_TOKEN', bad_token_message(HandlerInfo)};
-        {error, {unauthorized_role, Msg}} when is_binary(Msg) ->
+        {error, {unauthorized_role, Msg, AdminKey}} when is_binary(Msg) ->
+            ok = audit_rbac_denied(Req, jwt_token, AdminKey),
             {403, 'UNAUTHORIZED_ROLE', Msg}
     end.
+
+%% RBAC denies the request after the caller has been authenticated, so the
+%% actor is known. minirest never reaches its own meta-producing code on a
+%% failed authorization, so write the actor and the path parameters into the
+%% audit meta here. Only the routing bindings are added - no headers, no body.
+%%
+%% `update_log_meta/1' merges into the per-request meta that minirest
+%% initialises before it calls this authorizer. Tests call `authorize/2'
+%% directly, without that meta; `badmap' then means there is no request to
+%% audit, which must not change the authorization result.
+audit_rbac_denied(Req, AuthType, Source) ->
+    _ =
+        try
+            minirest_handler:update_log_meta(#{
+                auth_type => AuthType,
+                source => Source,
+                bindings => cowboy_req:bindings(Req)
+            })
+        catch
+            error:{badmap, undefined} ->
+                ok
+        end,
+    ok.
 
 ensure_ssl_cert(Listeners = #{https := Https0 = #{ssl_options := SslOpts}}) ->
     SslOpt1 = maps:from_list(emqx_tls_lib:to_server_opts(tls, SslOpts)),

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -1052,7 +1052,7 @@ sign_token(Username, Password, MfaToken) ->
 
 -spec verify_token(emqx_dashboard:request(), emqx_dashboard:handler_info(), Token :: binary()) ->
     {ok, emqx_dashboard_rbac:actor_context()}
-    | {error, token_timeout | not_found | {unauthorized_role, binary()}}.
+    | {error, token_timeout | not_found | {unauthorized_role, binary(), dashboard_username()}}.
 verify_token(Req, HandlerInfo, Token) ->
     emqx_dashboard_token:verify(Req, HandlerInfo, Token).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_token.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_token.erl
@@ -52,7 +52,7 @@
 
 -spec verify(emqx_dashboard:request(), emqx_dashboard:handler_info(), Token :: binary()) ->
     {ok, emqx_dashboard_rbac:actor_context()}
-    | {error, token_timeout | not_found | {unauthorized_role, binary()}}.
+    | {error, token_timeout | not_found | {unauthorized_role, binary(), dashboard_username()}}.
 verify(Req, HandlerInfo, Token) ->
     do_verify(Req, HandlerInfo, Token).
 
@@ -114,7 +114,7 @@ sign(#?ADMIN{username = Username} = User) ->
 
 -spec do_verify(emqx_dashboard:request(), emqx_dashboard:handler_info(), Token :: binary()) ->
     {ok, emqx_dashboard_rbac:actor_context()}
-    | {error, token_timeout | not_found | {unauthorized_role, binary()}}.
+    | {error, token_timeout | not_found | {unauthorized_role, binary(), dashboard_username()}}.
 do_verify(Req, HandlerInfo, Token) ->
     case lookup(Token) of
         {ok, JWT = #?ADMIN_JWT{exptime = ExpTime, extra = _Extra, username = _Username}} ->
@@ -297,11 +297,17 @@ check_rbac(Req, HandlerInfo, JWT) ->
                     ok = save_new_jwt(JWT),
                     {ok, ActorContextFinal};
                 false ->
-                    {error,
-                        {unauthorized_role, <<"Login user scope does not permit this endpoint">>}}
+                    {error, {
+                        unauthorized_role,
+                        <<"Login user scope does not permit this endpoint">>,
+                        AdminKey
+                    }}
             end;
         {error, Reason} when is_binary(Reason) ->
-            {error, {unauthorized_role, Reason}}
+            %% The token is valid, so the caller is authenticated. Return the
+            %% admin key so the audit record can name who was denied.
+            #?ADMIN_JWT{extra = Extra, username = Username} = JWT,
+            {error, {unauthorized_role, Reason, full_admin_key(Username, Extra)}}
     end.
 
 full_admin_key(Username, #{backend := ?BACKEND_LOCAL}) ->

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -249,8 +249,8 @@ t_change_pwd(_) ->
     %% viewer can change own password
     ?assertMatch({ok, #{actor := Viewer1}}, change_pwd(Viewer1Token, Viewer1)),
     %% viewer can't change other's password
-    ?assertMatch({error, {unauthorized_role, _}}, change_pwd(Viewer1Token, Viewer2)),
-    ?assertMatch({error, {unauthorized_role, _}}, change_pwd(Viewer1Token, SuperUser)),
+    ?assertMatch({error, {unauthorized_role, _, _}}, change_pwd(Viewer1Token, Viewer2)),
+    ?assertMatch({error, {unauthorized_role, _, _}}, change_pwd(Viewer1Token, SuperUser)),
     %% superuser can change other's password
     ?assertMatch({ok, #{actor := SuperUser}}, change_pwd(SuperToken, Viewer1)),
     ?assertMatch({ok, #{actor := SuperUser}}, change_pwd(SuperToken, Viewer2)),
@@ -368,8 +368,8 @@ test_mfa(VerifyFn) ->
     %% viewer can change own MFA
     ?assertMatch({ok, #{actor := Viewer1}}, VerifyFn(Viewer1Token, Viewer1)),
     %% viewer can't change other's MFA
-    ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, Viewer2)),
-    ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(Viewer1Token, SuperUser)),
+    ?assertMatch({error, {unauthorized_role, _, _}}, VerifyFn(Viewer1Token, Viewer2)),
+    ?assertMatch({error, {unauthorized_role, _, _}}, VerifyFn(Viewer1Token, SuperUser)),
     %% superuser can change other's MFA
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, Viewer1)),
     ?assertMatch({ok, #{actor := SuperUser}}, VerifyFn(SuperToken, Viewer2)),
@@ -379,7 +379,7 @@ test_mfa(VerifyFn) ->
         {ok, #{actor := NamespacedSuperUser}},
         VerifyFn(NamespacedSuperToken, NamespacedSuperUser)
     ),
-    ?assertMatch({error, {unauthorized_role, _}}, VerifyFn(NamespacedSuperToken, Viewer1)),
+    ?assertMatch({error, {unauthorized_role, _, _}}, VerifyFn(NamespacedSuperToken, Viewer1)),
     ok.
 
 %%--------------------------------------------------------------------

--- a/changes/ee/fix-18879.en.md
+++ b/changes/ee/fix-18879.en.md
@@ -1,0 +1,3 @@
+Audit records for requests denied by role-based access control now include the authenticated dashboard user or API key and the request's path parameters.
+
+Before this change, a request that passed authentication but was denied by role-based access control was recorded with an empty `source` and without `http_request.bindings`, so `GET /api/v5/audit` could not show who made the request or what it targeted. Records for unauthenticated requests are unchanged.


### PR DESCRIPTION
Fixes: #18821
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.2, 7.0.0
Introduced in: pre-5.8

## Summary

This is the v6 counterpart of #18877 (based on `dev-58`). The token and RBAC code differs between the two lines, so the fix was ported by hand rather than cherry-picked.

An authenticated request that is denied by role-based access control (HTTP 403 `UNAUTHORIZED_ROLE`) was audited without an actor and without a target: `source` was empty and `http_request` held only `method`. A `PUT /gateways/jt808` denied for a `viewer` could not be attributed to anyone.

minirest produces the auth meta and parses the request parameters only after a successful authorization, so nothing on the deny path ever wrote `source` or `bindings`. The identity is known at that point — the token has been verified, or the API key secret has been checked — and was discarded.

Crucial changes:

* `emqx_dashboard:jwt_token_bearer_authorize/3` and `api_key_authorize/4` write the actor and the routing bindings into the audit meta through `minirest_handler:update_log_meta/1`, the same hook the dashboard API modules already use. Only the routing bindings are added — no headers and no body.
* `emqx_dashboard_token:verify/3` returns `{error, {unauthorized_role, Message, AdminKey}}`. The admin key is what the success path already records as `source`, so a denied record names the caller the same way an allowed one does. The API key path needs no such change: the key is already bound at the deny site.
* The audit write is wrapped so that a missing per-request meta cannot change the authorization result. `emqx_dashboard:authorize/2` is also called directly from tests, where minirest never initialised that meta.

401 records are unchanged. Those requests are not authenticated, so there is no actor to name.

REST API impact: `GET /api/v5/audit` records for 403 responses now carry a non-empty `source` and a populated `http_request.bindings`. Additive and backward compatible.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
