### PR TITLE
test(pulsar): tolerate duplicate delivery in t_resilience

### DIFF
--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_connector_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_connector_SUITE.erl
@@ -497,6 +497,29 @@ receive_consumed(Timeout) ->
         ct:fail("no message consumed")
     end.
 
+receive_consumed_until_seqno(SeqNo, Timeout) ->
+    do_receive_consumed_until_seqno(SeqNo, Timeout, _Acc = #{}).
+
+do_receive_consumed_until_seqno(SeqNo, _Timeout, Acc) when map_size(Acc) == SeqNo ->
+    maps:values(Acc);
+do_receive_consumed_until_seqno(SeqNo, Timeout, Acc0) ->
+    receive
+        {pulsar_message, #{payloads := Payloads0}} ->
+            Payloads = lists:map(fun try_decode_json/1, Payloads0),
+            %% Pulsar apparently may resend some duplicate messages during/after
+            %% connectivity problems.
+            Acc = lists:foldl(
+                fun(#{<<"payload">> := N} = P, AccIn) ->
+                    AccIn#{N => P}
+                end,
+                Acc0,
+                Payloads
+            ),
+            do_receive_consumed_until_seqno(SeqNo, Timeout, Acc)
+    after Timeout ->
+        maps:values(Acc0)
+    end.
+
 flush_consumed() ->
     receive
         {pulsar_message, _} -> flush_consumed()
@@ -1239,13 +1262,30 @@ t_resilience(Config) ->
                     {done, SeqNo} -> SeqNo
                 after 1_000 -> ct:fail("producer didn't stop!")
                 end,
-            Consumed = lists:flatmap(
-                fun(_) -> receive_consumed(10_000) end, lists:seq(1, NumProduced)
-            ),
-            ?assertEqual(NumProduced, length(Consumed)),
-            ExpectedPayloads = lists:map(fun integer_to_binary/1, lists:seq(1, NumProduced)),
+            Consumed = receive_consumed_until_seqno(NumProduced, _Timeout = 10_000),
             ?assertEqual(
-                ExpectedPayloads, lists:map(fun(#{<<"payload">> := P}) -> P end, Consumed)
+                NumProduced,
+                length(Consumed),
+                #{
+                    num_produced => NumProduced,
+                    consumed => Consumed
+                }
+            ),
+            ExpectedPayloads = lists:map(fun integer_to_binary/1, lists:seq(1, NumProduced)),
+            ConsumedPayloads = lists:sort(
+                fun(ABin, BBin) -> binary_to_integer(ABin) =< binary_to_integer(BBin) end,
+                lists:map(
+                    fun(#{<<"payload">> := P}) -> P end,
+                    Consumed
+                )
+            ),
+            ?assertEqual(
+                ExpectedPayloads,
+                ConsumedPayloads,
+                #{
+                    missing => ExpectedPayloads -- ConsumedPayloads,
+                    unexpected => ConsumedPayloads -- ExpectedPayloads
+                }
             ),
             ok
         end,


### PR DESCRIPTION
## Summary

`emqx_bridge_pulsar_connector_SUITE:t_resilience` failed on #18877 (an unrelated audit fix):

```
?assertEqual(ExpectedPayloads, lists:map(fun(#{<<"payload">> := P}) -> P end, Consumed))
expected: [<<"1">>,<<"2">>,<<"3">>,<<"4">>,...]
value:    [<<"1">>,<<"2">>,<<"3">>,<<"3">>,<<"4">>,...]
```

https://github.com/emqx/emqx/actions/runs/34440830827/job/102763193870

The case drops the toxiproxy link to Pulsar mid-produce and heals it. After reconnect the
producer resends messages it never saw acknowledged — at-least-once delivery, so a duplicate is
correct behaviour. The case asserted exactly-once, in-order delivery.

The old consume loop also hid the real shape of the data:

```erlang
Consumed = lists:flatmap(fun(_) -> receive_consumed(10_000) end, lists:seq(1, NumProduced)),
?assertEqual(NumProduced, length(Consumed)),
```

`receive_consumed/1` returns one message's payload list, and the loop runs `NumProduced` times —
so it counts *messages*, not payloads. With a duplicate in the stream the length check still
passed, the loop stopped early, and the tail was dropped; only the ordered comparison noticed.

## Fix

Collect payloads into a map keyed by payload, so a resend overwrites its first copy, and sort
numerically before comparing. Test-only, no sleeps added.

This still catches a genuinely lost message: the map never reaches `NumProduced` entries, so the
length assertion fires. It tolerates only duplicates, which at-least-once delivery permits.

## Provenance

`dev-59` and `dev-510` already carry this exact code in the same file — `dev-58` was the only
branch left with the old loop, so this is a gap rather than something in flight. Copied
**verbatim from `dev-59`**; both the helper and the `t_resilience` body now diff clean against
it, so the forward sync converges instead of conflicting.

(`dev-60`+ has the same fix, but inside a larger refactor — `7b21bf41b6`, which renamed the
suite — so `dev-59` is the right source to copy from here.)

## Validation

`./scripts/ct/run.sh --ci --app apps/emqx_bridge_pulsar` against real Pulsar + toxiproxy:

```
emqx_bridge_pulsar_connector_SUITE: 20 ok, 0 failed
emqx_bridge_pulsar_v2_SUITE:        11 ok, 0 failed
```