### PR TITLE
fix(ws): bound WebSocket frame size before the protocol parser

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -86,6 +86,7 @@
 -export([
     validate_heap_size/1,
     validate_max_packet_size/1,
+    validate_ws_max_frame_size/1,
     validate_non_negative_bytesize/1,
     convert_max_packet_size/2,
     user_lookup_fun_tr/2,
@@ -1056,6 +1057,7 @@ fields("ws_opts") ->
                 hoconsc:union([infinity, pos_integer()]),
                 #{
                     default => infinity,
+                    validator => fun ?MODULE:validate_ws_max_frame_size/1,
                     desc => ?DESC(fields_ws_opts_max_frame_size)
                 }
             )},
@@ -3359,6 +3361,21 @@ validate_max_packet_size(Siz) when is_integer(Siz) ->
     ok;
 validate_max_packet_size(_SizStr) ->
     {error, invalid_packet_size}.
+
+-doc """
+Validate a WebSocket `max_frame_size`. An explicit value must not exceed the
+largest MQTT packet size. `infinity` selects the listener's default limit.
+""".
+validate_ws_max_frame_size(infinity) ->
+    ok;
+validate_ws_max_frame_size(Siz) when is_integer(Siz), Siz >= 0, Siz =< ?MAX_INT_MQTT_PACKET_SIZE ->
+    ok;
+validate_ws_max_frame_size(_Siz) ->
+    {error, #{
+        cause => invalid_ws_max_frame_size,
+        minimum => 0,
+        maximum => ?MAX_INT_MQTT_PACKET_SIZE
+    }}.
 
 validate_non_negative_bytesize(Bytes) when is_integer(Bytes), Bytes >= 0 ->
     ok;

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -11,6 +11,9 @@
 -include("emqx_external_trace.hrl").
 -include("emqx_config.hrl").
 
+%% Fixed header: 1 byte packet type and flags + up to 4 bytes remaining length.
+-define(MAX_FIXED_HEADER_LEN, 5).
+
 -ifdef(TEST).
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -226,7 +229,7 @@ upgrade(Type, Listener, Req, Opts, WsOpts) ->
         active_n => get_active_n(Type, Listener),
         compress => maps:get(compress, WsOpts),
         deflate_opts => maps:get(deflate_opts, WsOpts),
-        max_frame_size => maps:get(max_frame_size, WsOpts),
+        max_frame_size => max_frame_size(maps:get(max_frame_size, WsOpts), maps:get(zone, Opts)),
         idle_timeout => maps:get(idle_timeout, WsOpts),
         validate_utf8 => maps:get(validate_utf8, WsOpts)
     },
@@ -453,8 +456,6 @@ handle_event({event, disconnected}, State = #state{channel = Channel}) ->
     ClientId = emqx_channel:info(clientid, Channel),
     emqx_cm:set_chan_info(ClientId, info(State)),
     State;
-handle_event({event, {zone_changed, NewZone}}, State0 = #state{}) ->
-    init_zone_specific_state(NewZone, _Opts = #{}, State0);
 handle_event({event, {set_namespace, Namespace}}, State0 = #state{}) ->
     State0#state{namespace = Namespace};
 handle_event({event, _Other}, State = #state{channel = Channel}) ->
@@ -702,6 +703,10 @@ handle_replies([{close, Reason} | Rest], FrameAcc, State) ->
     ?TRACE("SOCKET", "socket_force_closed", #{reason => Reason}),
     Frame = handle_close(Reason),
     handle_replies(Rest, [Frame | FrameAcc], State);
+handle_replies([{event, {zone_changed, NewZone}} | Rest], FrameAcc, State0) ->
+    State = init_zone_specific_state(NewZone, _Opts = #{}, State0),
+    %% Let cowboy's message size limit follow the new zone, as the parser's does.
+    handle_replies(Rest, [set_max_frame_size(State) | FrameAcc], State);
 handle_replies([Event | Rest], FrameAcc, State) ->
     handle_replies(Rest, FrameAcc, handle_event(Event, State));
 handle_replies([], FrameAcc, State) ->
@@ -976,6 +981,18 @@ init_zone_specific_state(Zone, _Opts, #state{} = State0) ->
         idle_timer = IdleTimer,
         zone = Zone
     }.
+
+%% Cowboy's WebSocket message size limit. `infinity' derives it from the zone's
+%% `max_packet_size'. The MQTT parser checks that value against the remaining
+%% length only, so the limit adds the largest fixed header.
+max_frame_size(infinity, Zone) ->
+    emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size]) + ?MAX_FIXED_HEADER_LEN;
+max_frame_size(MaxFrameSize, _Zone) when is_integer(MaxFrameSize) ->
+    MaxFrameSize.
+
+set_max_frame_size(#state{listener = {Type, Listener}, zone = Zone}) ->
+    MaxFrameSize = max_frame_size(get_ws_opt(Type, Listener, max_frame_size), Zone),
+    {set_options, #{max_frame_size => MaxFrameSize}}.
 
 init_parser_and_serializer(FrameOpts0) ->
     Parser0 = init_parser(FrameOpts0),

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -301,6 +301,32 @@ listener_ws_proxy_header_defaults_test() ->
         )
     ).
 
+listener_ws_max_frame_size_test_() ->
+    Sc = #{
+        roots => [mqtt_ws_listener],
+        fields => #{mqtt_ws_listener => emqx_schema:fields("mqtt_ws_listener")}
+    },
+    Check = fun(Websocket) ->
+        #{<<"mqtt_ws_listener">> := #{<<"websocket">> := #{<<"max_frame_size">> := Value}}} =
+            hocon_tconf:check_plain(
+                Sc,
+                #{<<"mqtt_ws_listener">> => #{<<"websocket">> => Websocket}},
+                #{required => false}
+            ),
+        Value
+    end,
+    [
+        ?_assertEqual(infinity, Check(#{})),
+        ?_assertEqual(infinity, Check(#{<<"max_frame_size">> => <<"infinity">>})),
+        ?_assertEqual(1024, Check(#{<<"max_frame_size">> => 1024})),
+        ?_assertEqual(268435455, Check(#{<<"max_frame_size">> => 268435455})),
+        ?_assertThrow(
+            {_, [#{kind := validation_error}]},
+            Check(#{<<"max_frame_size">> => 300 * 1024 * 1024})
+        ),
+        ?_assertThrow({_, [#{kind := validation_error}]}, Check(#{<<"max_frame_size">> => 0}))
+    ].
+
 validate(Schema, Data0) ->
     Sc = #{
         roots => [ssl_opts],

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -14,6 +14,18 @@
 
 -define(ws_conn, emqx_ws_connection).
 
+-define(SMALL_MAX_PACKET_SIZE, 1024).
+%% Cases that set the default zone's `max_packet_size' to ?SMALL_MAX_PACKET_SIZE
+%% and count the handler calls of real `ws:default' listener connections.
+-define(IS_FRAME_SIZE_CASE(TC),
+    (TC =:= t_ws_max_frame_size_derived orelse
+        TC =:= t_ws_max_frame_size_boundary orelse
+        TC =:= t_ws_max_frame_size_fragmented orelse
+        TC =:= t_ws_max_frame_size_compressed orelse
+        TC =:= t_ws_max_frame_size_explicit orelse
+        TC =:= t_ws_zone_changed_sets_max_frame_size)
+).
+
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 %%--------------------------------------------------------------------
@@ -31,6 +43,12 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(apps, Config)).
 
+init_per_testcase(TestCase, Config) when ?IS_FRAME_SIZE_CASE(TestCase) ->
+    {ok, _} = application:ensure_all_started(gun),
+    MaxPacketSize = emqx_config:get_zone_conf(default, [mqtt, max_packet_size]),
+    emqx_config:put_zone_conf(default, [mqtt, max_packet_size], ?SMALL_MAX_PACKET_SIZE),
+    ok = meck:new(?ws_conn, [passthrough, no_link]),
+    [{max_packet_size, MaxPacketSize} | Config];
 init_per_testcase(TestCase, Config) when
     TestCase =/= t_ws_sub_protocols_mqtt_equivalents,
     TestCase =/= t_ws_sub_protocols_mqtt,
@@ -55,6 +73,13 @@ init_per_testcase(t_ws_non_check_origin, Config) ->
 init_per_testcase(_TestCase, Config) ->
     Config.
 
+end_per_testcase(TestCase, Config) when ?IS_FRAME_SIZE_CASE(TestCase) ->
+    meck:unload(?ws_conn),
+    MaxPacketSize = ?config(max_packet_size, Config),
+    emqx_config:put_zone_conf(default, [mqtt, max_packet_size], MaxPacketSize),
+    set_ws_opts(max_frame_size, infinity),
+    set_ws_opts(compress, false),
+    ok;
 end_per_testcase(TestCase, _Config) when
     TestCase =/= t_ws_sub_protocols_mqtt_equivalents,
     TestCase =/= t_ws_sub_protocols_mqtt,
@@ -510,6 +535,181 @@ t_run_gc(_) ->
     GcSt = emqx_gc:init(#{count => 10, bytes => 100}),
     WsSt = st(#{gc_state => GcSt}),
     ?ws_conn:run_gc({100, 10000}, WsSt).
+
+-doc """
+With `websocket.max_frame_size = infinity`, the listener limits a WebSocket
+message to the zone's `max_packet_size` plus 5 bytes. A message of exactly
+that size reaches the connection handler. A message one byte larger closes
+the connection with status code 1009, and the handler never sees it.
+""".
+t_ws_max_frame_size_derived(_) ->
+    Limit = ?SMALL_MAX_PACKET_SIZE + 5,
+    AtLimit = binary:copy(<<0>>, Limit),
+    Ws1 = ws_open(#{}),
+    ok = ws_send(Ws1, {binary, AtLimit}),
+    ok = meck:wait(?ws_conn, websocket_handle, [{binary, AtLimit}, '_'], 5000),
+    ws_close(Ws1),
+    OverLimit = binary:copy(<<0>>, Limit + 1),
+    Ws2 = ws_open(#{}),
+    ok = ws_send(Ws2, {binary, OverLimit}),
+    ?assertEqual(1009, ws_await_close(Ws2)),
+    ?assertNot(meck:called(?ws_conn, websocket_handle, [{binary, OverLimit}, '_'])),
+    ws_close(Ws2).
+
+-doc """
+A PUBLISH packet whose remaining length equals the zone's `max_packet_size`
+is accepted over WebSocket, as it is over TCP.
+""".
+t_ws_max_frame_size_boundary(_) ->
+    Ws = ws_open(#{}),
+    Connect = ?CONNECT_PACKET(#mqtt_packet_connect{
+        proto_name = <<"MQTT">>,
+        proto_ver = ?MQTT_PROTO_V4,
+        clientid = <<"ws_max_frame_size_boundary">>
+    }),
+    ok = ws_send(Ws, {binary, emqx_frame:serialize(Connect)}),
+    ?assertEqual({binary, <<32, 2, 0, 0>>}, ws_await_frame(Ws)),
+    %% Remaining length: 2-byte topic length, 1-byte topic, 2-byte packet ID, payload.
+    Payload = binary:copy(<<0>>, ?SMALL_MAX_PACKET_SIZE - 5),
+    Publish = iolist_to_binary(emqx_frame:serialize(?PUBLISH_PACKET(?QOS_1, <<"t">>, 1, Payload))),
+    %% Fixed header: 1 byte type and flags, 2 bytes remaining length.
+    ?assertEqual(?SMALL_MAX_PACKET_SIZE + 3, byte_size(Publish)),
+    ok = ws_send(Ws, {binary, Publish}),
+    ?assertEqual({binary, <<64, 2, 0, 1>>}, ws_await_frame(Ws)),
+    ws_close(Ws).
+
+-doc """
+A fragmented message whose fragments each fit the limit, but whose total size
+exceeds it, closes the connection with status code 1009. The handler never
+sees the message.
+""".
+t_ws_max_frame_size_fragmented(_) ->
+    Sock = raw_ws_open(),
+    Fragment = binary:copy(<<0>>, 600),
+    %% Opcode 2 starts a binary message, opcode 0 continues it.
+    ok = gen_tcp:send(Sock, masked_frame(0, 2, Fragment)),
+    ok = gen_tcp:send(Sock, masked_frame(1, 0, Fragment)),
+    %% Unmasked close frame with status code 1009.
+    ?assertEqual({ok, <<1:1, 0:3, 8:4, 0:1, 2:7, 1009:16>>}, gen_tcp:recv(Sock, 4, 5000)),
+    ?assertNot(meck:called(?ws_conn, websocket_handle, [{binary, '_'}, '_'])),
+    gen_tcp:close(Sock).
+
+-doc """
+A compressed message that is small on the wire but inflates past the limit
+closes the connection with status code 1009. The handler never sees the
+inflated message.
+""".
+t_ws_max_frame_size_compressed(_) ->
+    set_ws_opts(compress, true),
+    {_, _, Headers} = Ws = ws_open(#{compress => true}),
+    ?assertMatch(
+        <<"permessage-deflate", _/binary>>,
+        proplists:get_value(<<"sec-websocket-extensions">>, Headers)
+    ),
+    Payload = binary:copy(<<0>>, 64 * 1024),
+    ?assert(byte_size(zlib:compress(Payload)) < ?SMALL_MAX_PACKET_SIZE),
+    ok = ws_send(Ws, {binary, Payload}),
+    ?assertEqual(1009, ws_await_close(Ws)),
+    ?assertNot(meck:called(?ws_conn, websocket_handle, [{binary, '_'}, '_'])),
+    ws_close(Ws).
+
+-doc """
+An explicit `websocket.max_frame_size` takes precedence over the limit derived
+from the zone's `max_packet_size`.
+""".
+t_ws_max_frame_size_explicit(_) ->
+    set_ws_opts(max_frame_size, 100),
+    Payload = binary:copy(<<0>>, 101),
+    Ws = ws_open(#{}),
+    ok = ws_send(Ws, {binary, Payload}),
+    ?assertEqual(1009, ws_await_close(Ws)),
+    ?assertNot(meck:called(?ws_conn, websocket_handle, [{binary, Payload}, '_'])),
+    ws_close(Ws).
+
+-doc """
+When the client's zone changes after CONNECT, the connection sends cowboy the
+message size limit for the new zone.
+""".
+t_ws_zone_changed_sets_max_frame_size(_) ->
+    ZoneChanged = [{event, {zone_changed, default}}],
+    ?assertMatch(
+        {[{set_options, #{max_frame_size := ?SMALL_MAX_PACKET_SIZE + 5}}], _},
+        ?ws_conn:handle_replies(ZoneChanged, [], st())
+    ),
+    set_ws_opts(max_frame_size, 100),
+    ?assertMatch(
+        {[{set_options, #{max_frame_size := 100}}], _},
+        ?ws_conn:handle_replies(ZoneChanged, [], st())
+    ).
+
+ws_open(UpgradeOpts) ->
+    {ok, ConnPid} = gun:open("127.0.0.1", 8083, #{retry => 0}),
+    {ok, _} = gun:await_up(ConnPid, 5000),
+    StreamRef = gun:ws_upgrade(ConnPid, "/mqtt", [], UpgradeOpts#{
+        protocols => [{<<"mqtt">>, gun_ws_h}]
+    }),
+    receive
+        {gun_upgrade, ConnPid, StreamRef, [<<"websocket">>], Headers} ->
+            {ConnPid, StreamRef, Headers};
+        {gun_response, ConnPid, StreamRef, _, Status, _} ->
+            ct:fail({ws_upgrade_rejected, Status})
+    after 5000 ->
+        ct:fail(ws_upgrade_timeout)
+    end.
+
+ws_send({ConnPid, StreamRef, _Headers}, Frame) ->
+    gun:ws_send(ConnPid, StreamRef, Frame).
+
+ws_await_frame({ConnPid, StreamRef, _Headers}) ->
+    receive
+        {gun_ws, ConnPid, StreamRef, Frame} -> Frame
+    after 5000 ->
+        ct:fail(ws_frame_timeout)
+    end.
+
+ws_await_close(Ws) ->
+    case ws_await_frame(Ws) of
+        {close, Code, _} -> Code;
+        Frame -> ct:fail({unexpected_ws_frame, Frame})
+    end.
+
+ws_close({ConnPid, _StreamRef, _Headers}) ->
+    gun:close(ConnPid).
+
+%% Gun cannot send a fragmented message, so this client does the WebSocket
+%% handshake on a plain TCP socket.
+raw_ws_open() ->
+    {ok, Sock} = gen_tcp:connect("127.0.0.1", 8083, [binary, {active, false}]),
+    ok = gen_tcp:send(Sock, [
+        "GET /mqtt HTTP/1.1\r\n",
+        "Host: 127.0.0.1:8083\r\n",
+        "Upgrade: websocket\r\n",
+        "Connection: Upgrade\r\n",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n",
+        "Sec-WebSocket-Version: 13\r\n",
+        "Sec-WebSocket-Protocol: mqtt\r\n",
+        "\r\n"
+    ]),
+    ?assertMatch(<<"HTTP/1.1 101 ", _/binary>>, recv_http_head(Sock, <<>>)),
+    Sock.
+
+recv_http_head(Sock, Acc0) ->
+    {ok, Data} = gen_tcp:recv(Sock, 0, 5000),
+    Acc = <<Acc0/binary, Data/binary>>,
+    case binary:match(Acc, <<"\r\n\r\n">>) of
+        nomatch -> recv_http_head(Sock, Acc);
+        _ -> Acc
+    end.
+
+%% A client frame with a zero masking key, so the payload is sent unchanged.
+masked_frame(Fin, Opcode, Payload) when byte_size(Payload) =< 16#ffff ->
+    Len = byte_size(Payload),
+    PayloadLen =
+        case Len =< 125 of
+            true -> <<Len:7>>;
+            false -> <<126:7, Len:16>>
+        end,
+    <<Fin:1, 0:3, Opcode:4, 1:1, PayloadLen/bits, 0:32, Payload/binary>>.
 
 %%--------------------------------------------------------------------
 %% Helper functions

--- a/apps/emqx_gateway/include/emqx_gateway.hrl
+++ b/apps/emqx_gateway/include/emqx_gateway.hrl
@@ -35,4 +35,8 @@
 
 -define(GATEWAY_SUP_NAME, emqx_gateway_sup).
 
+%% Default limit of a single WebSocket message on gateway listeners.
+%% It fits the default NATS `max_payload_size' (1MB) plus the command line.
+-define(DEFAULT_WS_MAX_FRAME_SIZE, 2097152).
+
 -endif.

--- a/apps/emqx_gateway/mix.exs
+++ b/apps/emqx_gateway/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGateway.MixProject do
   def project do
     [
       app: :emqx_gateway,
-      version: "6.3.0",
+      version: "6.3.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn_ws.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn_ws.erl
@@ -191,15 +191,10 @@ call(WsPid, Req, Timeout) when is_pid(WsPid) ->
 init(Req, Opts) ->
     %% WS Transport Idle Timeout
     IdleTimeout = maps:get(idle_timeout, Opts, 7200000),
-    MaxFrameSize =
-        case maps:get(max_frame_size, Opts, 0) of
-            0 -> infinity;
-            I -> I
-        end,
     Compress = emqx_utils_maps:deep_get([websocket, compress], Opts),
     WsOpts = #{
         compress => Compress,
-        max_frame_size => MaxFrameSize,
+        max_frame_size => emqx_gateway_utils:ws_max_frame_size(Opts),
         idle_timeout => IdleTimeout
     },
     case check_origin_header(Req, Opts) of

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -15,6 +15,7 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("typerefl/include/types.hrl").
 -include_lib("emqx_auth/include/emqx_authn_chains.hrl").
+-include("emqx_gateway.hrl").
 
 -type ip_port() :: tuple() | integer().
 -type duration() :: non_neg_integer().
@@ -344,9 +345,10 @@ ws_opts(Override) when is_map(Override) ->
             )},
         {"max_frame_size",
             sc(
-                hoconsc:union([infinity, integer()]),
+                hoconsc:union([infinity, non_neg_integer()]),
                 #{
-                    default => infinity,
+                    default => ?DEFAULT_WS_MAX_FRAME_SIZE,
+                    validator => fun emqx_schema:validate_ws_max_frame_size/1,
                     desc => ?DESC(fields_ws_opts_max_frame_size)
                 }
             )},

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -65,7 +65,8 @@ Utility functions for EMQX gateway.
     init_gc_state/1,
     stats_timer/1,
     idle_timeout/1,
-    oom_policy/1
+    oom_policy/1,
+    ws_max_frame_size/1
 ]).
 
 -export([
@@ -466,6 +467,19 @@ active_n(Options) ->
 -spec idle_timeout(map()) -> pos_integer().
 idle_timeout(Options) ->
     maps:get(idle_timeout, Options, ?DEFAULT_IDLE_TIMEOUT).
+
+-doc """
+Return the WebSocket message size limit for cowboy from the listener's
+`websocket.max_frame_size`. `infinity` and `0` are legacy values; they select
+the default limit, so cowboy always gets a finite limit.
+""".
+-spec ws_max_frame_size(map()) -> pos_integer().
+ws_max_frame_size(Options) ->
+    case emqx_utils_maps:deep_get([websocket, max_frame_size], Options, infinity) of
+        infinity -> ?DEFAULT_WS_MAX_FRAME_SIZE;
+        0 -> ?DEFAULT_WS_MAX_FRAME_SIZE;
+        MaxFrameSize when is_integer(MaxFrameSize), MaxFrameSize > 0 -> MaxFrameSize
+    end.
 
 -spec ratelimit(map()) -> esockd_rate_limit:config() | undefined.
 ratelimit(Options) ->

--- a/apps/emqx_gateway/test/emqx_gateway_conn_ws_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_conn_ws_SUITE.erl
@@ -9,8 +9,44 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_gateway/include/emqx_gateway.hrl").
 
 -define(SOCK_PEER, {{127, 0, 0, 1}, 3456}).
+
+-doc """
+The gateway `websocket.max_frame_size` defaults to a finite value, accepts the
+legacy values `infinity` and `0`, and rejects negative values and values above
+the largest MQTT packet size.
+""".
+t_ws_max_frame_size_schema(_Config) ->
+    Sc = #{roots => [ws], fields => #{ws => emqx_gateway_schema:ws_opts(#{})}},
+    Check = fun(Websocket) ->
+        #{<<"ws">> := #{<<"max_frame_size">> := Value}} =
+            hocon_tconf:check_plain(Sc, #{<<"ws">> => Websocket}, #{required => false}),
+        Value
+    end,
+    ?assertEqual(?DEFAULT_WS_MAX_FRAME_SIZE, Check(#{})),
+    ?assertEqual(infinity, Check(#{<<"max_frame_size">> => <<"infinity">>})),
+    ?assertEqual(0, Check(#{<<"max_frame_size">> => 0})),
+    ?assertEqual(1024, Check(#{<<"max_frame_size">> => 1024})),
+    ?assertThrow({_, [#{kind := validation_error}]}, Check(#{<<"max_frame_size">> => -1})),
+    ?assertThrow(
+        {_, [#{kind := validation_error}]},
+        Check(#{<<"max_frame_size">> => 300 * 1024 * 1024})
+    ).
+
+-doc """
+Cowboy always gets a finite WebSocket message size limit. The legacy values
+`infinity` and `0` select the default limit.
+""".
+t_ws_max_frame_size_to_cowboy(_Config) ->
+    MaxFrameSize = fun(Value) ->
+        emqx_gateway_utils:ws_max_frame_size(#{websocket => #{max_frame_size => Value}})
+    end,
+    ?assertEqual(?DEFAULT_WS_MAX_FRAME_SIZE, MaxFrameSize(infinity)),
+    ?assertEqual(?DEFAULT_WS_MAX_FRAME_SIZE, MaxFrameSize(0)),
+    ?assertEqual(1024, MaxFrameSize(1024)),
+    ?assertEqual(?DEFAULT_WS_MAX_FRAME_SIZE, emqx_gateway_utils:ws_max_frame_size(#{})).
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).

--- a/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
+++ b/apps/emqx_gateway_nats/test/emqx_gateway_nats_SUITE.erl
@@ -690,6 +690,44 @@ t_schema_coverage(_Config) ->
     _ = emqx_nats_schema:desc(wss_listener),
     ok.
 
+-doc """
+A WebSocket gateway listener hands its `websocket.max_frame_size` to cowboy.
+A larger message closes the connection with status code 1009.
+""".
+t_ws_max_frame_size(_Config) ->
+    {ok, _} = application:ensure_all_started(gun),
+    Port = emqx_common_test_helpers:select_free_port(tcp),
+    Listener = #{
+        <<"type">> => <<"ws">>,
+        <<"name">> => <<"default">>,
+        <<"bind">> => Port,
+        <<"websocket">> => #{<<"max_frame_size">> => 1024}
+    },
+    {ok, _} = emqx_gateway_conf:load_gateway(nats, nats_conf_list([Listener])),
+    try
+        {ok, ConnPid} = gun:open("127.0.0.1", Port, #{retry => 0}),
+        {ok, _} = gun:await_up(ConnPid, 5000),
+        StreamRef = gun:ws_upgrade(ConnPid, "/", [], #{protocols => [{<<"NATS">>, gun_ws_h}]}),
+        receive
+            {gun_upgrade, ConnPid, StreamRef, [<<"websocket">>], _} -> ok
+        after 5000 -> ct:fail(ws_upgrade_timeout)
+        end,
+        ok = gun:ws_send(ConnPid, StreamRef, {text, binary:copy(<<"a">>, 1025)}),
+        ?assertEqual(1009, await_ws_close_code(ConnPid, StreamRef)),
+        gun:close(ConnPid)
+    after
+        _ = emqx_gateway_conf:unload_gateway(nats)
+    end.
+
+%% Skip the frames the gateway sends before it closes the connection.
+await_ws_close_code(ConnPid, StreamRef) ->
+    receive
+        {gun_ws, ConnPid, StreamRef, {close, Code, _}} -> Code;
+        {gun_ws, ConnPid, StreamRef, _Frame} -> await_ws_close_code(ConnPid, StreamRef)
+    after 5000 ->
+        ct:fail(ws_close_timeout)
+    end.
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
@@ -192,15 +192,10 @@ call(WsPid, Req, Timeout) when is_pid(WsPid) ->
 init(Req, Opts) ->
     %% WS Transport Idle Timeout
     IdleTimeout = maps:get(idle_timeout, Opts, 7200000),
-    MaxFrameSize =
-        case maps:get(max_frame_size, Opts, 0) of
-            0 -> infinity;
-            I -> I
-        end,
     Compress = emqx_utils_maps:deep_get([websocket, compress], Opts),
     WsOpts = #{
         compress => Compress,
-        max_frame_size => MaxFrameSize,
+        max_frame_size => emqx_gateway_utils:ws_max_frame_size(Opts),
         idle_timeout => IdleTimeout
     },
     case check_origin_header(Req, Opts) of

--- a/apps/emqx_gateway_ocpp/test/emqx_ocpp_SUITE.erl
+++ b/apps/emqx_gateway_ocpp/test/emqx_ocpp_SUITE.erl
@@ -578,11 +578,46 @@ t_active_n(_Config) ->
     ?assertEqual(undefined, emqx_gateway_cm:get_chan_info(ocpp, <<"client1">>)),
     ok.
 
+-doc """
+A WebSocket message larger than the listener's `websocket.max_frame_size`
+closes the connection with status code 1009. The default limit applies when
+the option is not set, and an explicit value replaces it.
+""".
+t_ws_max_frame_size(_Config) ->
+    {ok, Client1} = connect("127.0.0.1", 33033, <<"client_frame_default">>),
+    ok = send_text(Client1, binary:copy(<<"a">>, 2097152 + 1)),
+    ?assertEqual(1009, receive_close_code(Client1)),
+    close(Client1),
+    RawCfg = emqx_conf:get_raw([gateway, ocpp], #{}),
+    ListenerCfg = emqx_utils_maps:deep_get([<<"listeners">>, <<"ws">>, <<"default">>], RawCfg),
+    WsCfg = maps:get(<<"websocket">>, ListenerCfg, #{}),
+    {ok, _} = emqx_gateway_conf:update_listener(ocpp, {ws, default}, ListenerCfg#{
+        <<"websocket">> => WsCfg#{<<"max_frame_size">> => 1024}
+    }),
+    try
+        {ok, Client2} = connect("127.0.0.1", 33033, <<"client_frame_explicit">>),
+        ok = send_text(Client2, binary:copy(<<"a">>, 1025)),
+        ?assertEqual(1009, receive_close_code(Client2)),
+        close(Client2)
+    after
+        {ok, _} = emqx_gateway_conf:update_listener(ocpp, {ws, default}, ListenerCfg)
+    end.
+
 %%--------------------------------------------------------------------
 %% ocpp simple client
 
 connect(Host, Port, ClientId) ->
     connect(Host, Port, ClientId, []).
+
+send_text({ConnPid, StreamRef}, Text) ->
+    gun:ws_send(ConnPid, StreamRef, {text, Text}).
+
+receive_close_code({ConnPid, StreamRef}) ->
+    receive
+        {gun_ws, ConnPid, StreamRef, {close, Code, _}} -> Code
+    after 5000 ->
+        ct:fail({no_ws_close, ?drainMailbox()})
+    end.
 
 connect(Host, Port, ClientId, ExtraHeaders) ->
     Timeout = 5000,

--- a/changes/ee/fix-18882.en.md
+++ b/changes/ee/fix-18882.en.md
@@ -1,0 +1,9 @@
+Protected the broker from excessive memory use when a WebSocket client sends a very large message.
+
+Before this fix, the broker buffered and decompressed a WebSocket message of any size before it checked the MQTT or gateway protocol limits.
+
+- On MQTT WebSocket listeners, when `websocket.max_frame_size` is `infinity` (the default), a message can be at most the zone's `mqtt.max_packet_size` plus 5 bytes. Set `websocket.max_frame_size` explicitly if clients send several MQTT packets in one WebSocket message.
+- On gateway WebSocket listeners, `websocket.max_frame_size` now takes effect. Previously the setting was ignored. The default is 2097152 bytes (2 MiB). The values `infinity` and `0` select this default.
+- `websocket.max_frame_size` accepts values up to 268435455.
+
+When a client sends a larger message, the broker closes the connection with WebSocket status code 1009.

--- a/rel/i18n/emqx_gateway_schema.hocon
+++ b/rel/i18n/emqx_gateway_schema.hocon
@@ -151,7 +151,11 @@ fields_ws_opts_idle_timeout.label:
 """WebSocket Upgrade Timeout"""
 
 fields_ws_opts_max_frame_size.desc:
-"""The maximum length of a single MQTT packet."""
+"""The maximum size of a single WebSocket message, in bytes.
+The limit applies to the message after its fragments are joined, and after decompression when <code>compress</code> is enabled.
+When a client sends a larger message, the gateway closes the connection with WebSocket status code 1009.<br/>
+Set it larger than the largest message that the gateway protocol accepts. The maximum value is 268435455.
+The values <code>infinity</code> and <code>0</code> are accepted for backward compatibility. They select the default value, 2097152."""
 
 fields_ws_opts_max_frame_size.label:
 """Max frame size"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1845,7 +1845,12 @@ overload_protection_backoff_hibernation.label:
 """Skip hibernation"""
 
 fields_ws_opts_max_frame_size.desc:
-"""The maximum length of a single MQTT packet."""
+"""The maximum size of a single WebSocket message, in bytes.
+The limit applies to the message after its fragments are joined, and after decompression when <code>compress</code> is enabled.
+When a client sends a larger message, the broker closes the connection with WebSocket status code 1009.<br/>
+When set to <code>infinity</code> (the default), the limit is the zone's <code>mqtt.max_packet_size</code> plus 5 bytes for the MQTT fixed header.
+Set an explicit value when clients send several MQTT packets in one WebSocket message.
+The maximum value is 268435455."""
 
 fields_ws_opts_max_frame_size.label:
 """Max frame size"""


### PR DESCRIPTION
Fixes: https://github.com/emqx/emqx-dev-team-tasks/issues/369
Release version:
6.3.2, 7.0.0
Introduced in: pre-5.8

## Summary

Every WebSocket listener passed `max_frame_size = infinity` to cowboy. Cowboy buffered, reassembled and inflated a WebSocket message of any size before EMQX parsed it. An unauthenticated client could make the node allocate memory without a bound.

Cowboy 2.13 already checks a finite `max_frame_size` in three places: on the frame header, on reassembled fragments, and on the inflated `permessage-deflate` payload (`max_inflate_size`). No cowboy change is needed. This PR makes every WebSocket listener pass a finite value.

### MQTT listeners (`emqx_ws_connection`)

- `websocket.max_frame_size = infinity` (the default) now means the zone's `mqtt.max_packet_size` plus 5 bytes. `emqx_frame` compares `max_packet_size` with the remaining length only. The fixed header adds up to 5 bytes, so a maximum-size packet still fits in one message.
- I derive the limit instead of adding a literal default. An operator who raised `max_packet_size` and never set the WebSocket option keeps working.
- An explicit value takes precedence.
- When a client's zone changes after CONNECT, the connection returns the cowboy command `{set_options, #{max_frame_size => N}}`. The WebSocket limit follows the new zone, as the parser limit does.
- Behavior change: a client that puts several MQTT packets into one WebSocket message larger than the limit is disconnected. Such a client needs an explicit `websocket.max_frame_size`.

### Gateway listeners (`emqx_gateway_conn_ws`, `emqx_ocpp_connection`)

- `init/2` read a top-level `max_frame_size` key. The listener config holds the option under `websocket`, so it never took effect and cowboy always got `infinity`. Both modules now call `emqx_gateway_utils:ws_max_frame_size/1`.
- The schema default changes from `infinity` to 2097152 (2 MiB). I chose 2 MiB over 1 MiB because the default NATS `max_payload_size` is 1 MiB. A 1 MiB limit would reject a maximum-size NATS `PUB` over WebSocket.
- I did not derive the limit per gateway. Each gateway measures its body limit differently, and a static default keeps the shared connection module free of gateway-specific code.
- `infinity` and `0` stay accepted for compatibility. Both select the default.

### Schema

- Both schemas reject explicit values above 268435455, the largest MQTT packet size. The gateway type changes from `integer()` to `non_neg_integer()`.
- The field name, its union type and the REST API shape do not change.
- Upgrade note: the validator also runs when the node loads its config at boot. A stored value above 268435455, or a negative gateway value, makes config load fail after upgrade. Before this change, a negative gateway value had no effect.
- The i18n text for both fields described the option as "the maximum length of a single MQTT packet". It now describes the WebSocket message limit, the default, and the close status code 1009.

### Tests

- `emqx_ws_connection_SUITE` runs against the live `ws:default` listener, with gun and with a raw socket, using a small zone `max_packet_size`:
  - A message at the derived limit reaches `websocket_handle/2`. A message one byte larger closes the connection with status code 1009, and meck shows `websocket_handle/2` never gets it.
  - A PUBLISH packet whose remaining length equals `max_packet_size` gets a PUBACK.
  - A fragmented message whose fragments fit the limit, but whose total does not, closes with 1009.
  - A compressed message (64 KiB of zeros) that inflates past the limit closes with 1009.
  - An explicit value takes precedence over the derived limit.
  - `zone_changed` produces the `set_options` command.
- `emqx_schema_tests` and `emqx_gateway_conn_ws_SUITE` cover the schema range and default, and the legacy value mapping.
- `emqx_ocpp_SUITE` covers the default limit and an explicit limit on the OCPP listener.
- `emqx_gateway_nats_SUITE` covers an explicit limit through `emqx_gateway_conn_ws`.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
