### PR TITLE
fix(tls): complete a pre-installed default bundle instead of replacing it

### DIFF
--- a/apps/emqx/src/emqx_default_cert.erl
+++ b/apps/emqx/src/emqx_default_cert.erl
@@ -144,7 +144,6 @@ complete_bundle() ->
 %% writing this bundle at the same time.
 do_generate_localhost_bundle() ->
     maybe
-        ok ?= clear_unusable_bundle(),
         {ok, Files} ?= generate(),
         install(Files)
     else
@@ -157,20 +156,8 @@ do_generate_localhost_bundle() ->
             Error
     end.
 
-%% Whatever is stored is incomplete, or there is nothing at all. An incomplete
-%% bundle would block the rename, and this node cannot use it either way.
-clear_unusable_bundle() ->
-    case emqx_managed_certs:delete_bundle_v1(?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME) of
-        ok ->
-            ok;
-        {error, enoent} ->
-            ok;
-        {error, _} = Error ->
-            Error
-    end.
-
 install(Files) ->
-    case emqx_managed_certs:create_bundle(?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME, Files) of
+    case emqx_managed_certs:install_files(?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME, Files) of
         ok ->
             ?SLOG(info, #{
                 msg => "default_tls_certificate_generated",
@@ -178,13 +165,6 @@ install(Files) ->
                 dir => emqx_managed_certs:dir(?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME)
             }),
             ok;
-        {error, exists} ->
-            %% Something appeared after the delete above. Accept it only if it
-            %% is a bundle this node can actually use.
-            case complete_bundle() of
-                {ok, _} -> ok;
-                {error, _} -> {error, unusable_bundle_in_place}
-            end;
         {error, _} = Error ->
             Error
     end.

--- a/apps/emqx/src/emqx_managed_certs.erl
+++ b/apps/emqx/src/emqx_managed_certs.erl
@@ -10,7 +10,7 @@
     delete_bundle/2,
     delete_managed_file/3,
     add_managed_files/3,
-    create_bundle/3,
+    install_files/3,
     find_references/2
 ]).
 
@@ -210,64 +210,41 @@ add_managed_files(Namespace, BundleName, Files) ->
     end.
 
 -doc """
-Creates a bundle on the local node from a complete set of files, and only if no
-bundle is stored under that name yet.
+Writes files into a bundle on the local node, leaving every other file in it
+alone.
 
-Not a replacement for `add_managed_files/3', which merges the given kinds into
-whatever the bundle already holds — uploading only a `ca' there leaves an
-existing key and chain in place. This one writes the bundle it is given and
-nothing else, so the caller must pass every file the bundle should end up with.
+Each file is written under a temporary name in the bundle's own directory and
+renamed over the real one, so a reader sees either the previous file or the
+complete new one. The directory itself is never replaced or removed: it can be
+a mount point, where renaming over it or deleting it fails outright.
 
-The files are written to a temporary directory and moved into place with a
-single rename, so a bundle is never observed half-written and two concurrent
-callers cannot interleave into a mix of each other's files. A caller that finds
-a bundle already there gets `{error, exists}' and leaves it untouched; deciding
-what to do about that is the caller's business.
+Kinds the caller does not pass are left as they are, so writing a key and a
+chain into a bundle that already holds a `ca' keeps that `ca'.
 
 Local only: unlike `add_managed_files/3', nothing is sent to the other nodes.
 """.
--spec create_bundle(maybe_namespace(), bundle_name(), #{file_kind() := contents()}) ->
-    ok | {error, exists} | {error, bad_namespace} | {error, term()}.
-create_bundle(Namespace, BundleName, Files) ->
+-spec install_files(maybe_namespace(), bundle_name(), #{file_kind() := contents()}) ->
+    ok | {error, bad_namespace} | {error, term()}.
+install_files(Namespace, BundleName, Files) ->
     maybe
         ok ?= check_namespace(Namespace),
-        TmpDir = tmp_dir(),
-        try
-            do_create_bundle(TmpDir, Namespace, BundleName, Files)
-        after
-            _ = file:del_dir_r(TmpDir)
-        end
+        Dir = dir(Namespace, BundleName),
+        ok ?= ensure_dir(Dir),
+        write_files_in_place(Dir, Namespace, BundleName, Files)
     end.
 
-do_create_bundle(TmpDir, Namespace, BundleName, Files) ->
-    Dir = dir(Namespace, BundleName),
-    maybe
-        ok ?= write_files_to_dir(TmpDir, Namespace, BundleName, Files),
-        ok ?= filelib:ensure_dir(filename:join(Dir, "dummy")),
-        move_into_place(TmpDir, Dir)
+ensure_dir(Dir) ->
+    case filelib:ensure_path(Dir) of
+        ok -> ok;
+        {error, _} = Error -> Error
     end.
 
-tmp_dir() ->
-    Unique = binary:encode_hex(crypto:strong_rand_bytes(8)),
-    %% Deliberately outside `certs2': `emqx_conf' collects every regular file
-    %% under the directories it syncs to a joining node, so a half-written
-    %% bundle sitting there could be swept into that copy — or vanish under it
-    %% mid-collection when the rename lands. Still under the data directory, so
-    %% the rename stays within one filesystem and remains atomic.
-    filename:join([emqx:data_dir(), tmp, Unique]).
-
-write_files_to_dir(TmpDir, Namespace, BundleName, Files) ->
+write_files_in_place(Dir, Namespace, BundleName, Files) ->
     maps:fold(
         fun
             (Kind, Contents, ok) ->
-                %% Reuse the real layout's file names, so the rename lands a
-                %% directory that is already a valid bundle.
                 Filename = filename:basename(filename(Namespace, BundleName, Kind)),
-                Path = filename:join(TmpDir, Filename),
-                maybe
-                    ok ?= filelib:ensure_dir(Path),
-                    file:write_file(Path, Contents)
-                end;
+                write_file_in_place(filename:join(Dir, Filename), Contents);
             (_Kind, _Contents, {error, _} = Error) ->
                 Error
         end,
@@ -275,15 +252,21 @@ write_files_to_dir(TmpDir, Namespace, BundleName, Files) ->
         Files
     ).
 
-move_into_place(TmpDir, Dir) ->
-    case file:rename(TmpDir, Dir) of
-        ok ->
-            ok;
-        {error, Reason} when Reason =:= eexist; Reason =:= enotempty; Reason =:= eisdir ->
-            %% Renaming onto a directory that is already there does not work.
-            {error, exists};
-        {error, _} = Error ->
-            Error
+%% Written under a temporary name in the same directory and renamed over the
+%% real one, so the rename stays on one filesystem and a reader sees either the
+%% previous file or the complete new one, never a partial write.
+write_file_in_place(Path, Contents) ->
+    %% `Path' may be a binary: build the temporary name without assuming a list.
+    Tmp = iolist_to_binary([Path, ".tmp.", binary:encode_hex(crypto:strong_rand_bytes(8))]),
+    maybe
+        ok ?= file:write_file(Tmp, Contents),
+        case file:rename(Tmp, Path) of
+            ok ->
+                ok;
+            {error, _} = Error ->
+                _ = file:delete(Tmp),
+                Error
+        end
     end.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx/test/emqx_default_cert_SUITE.erl
+++ b/apps/emqx/test/emqx_default_cert_SUITE.erl
@@ -223,6 +223,30 @@ t_bundle_has_chain_and_no_ca_file(_TCConfig) ->
     ).
 
 -doc """
+A bundle holding only a `ca' file is completed rather than replaced: the node
+generates the key and chain it is missing and keeps the CA it was given.
+
+This is how an operator says who to trust for peers without also having to issue
+this node an identity, which is the one part a node can decide for itself.
+""".
+t_installed_ca_file_alone_is_completed(_TCConfig) ->
+    Dir = emqx_managed_certs:dir(?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME),
+    ok = filelib:ensure_path(Dir),
+    Ca = ca_pem(),
+    ok = file:write_file(filename:join(Dir, "ca.pem"), Ca),
+
+    Contents = contents(ensure()),
+    ?assertEqual([ca, chain, key], lists:sort(maps:keys(Contents))),
+    %% The CA is the one that was installed, not one this node made up.
+    ?assertEqual(Ca, maps:get(?FILE_KIND_CA, Contents)),
+    %% And the identity it generated is usable and its own.
+    assert_self_consistent(maps:without([?FILE_KIND_CA], Contents)),
+    ?assertMatch(
+        {ok, #{cacertfile := _, certfile := _, keyfile := _}},
+        emqx_tls_lib:ensure_default_certs(#{})
+    ).
+
+-doc """
 A `ca' file an operator installed in the bundle is served as the `cacertfile',
 so a listener that verifies peers gets the trust anchor its bundle came with.
 The generated bundle holds no such file.
@@ -385,7 +409,7 @@ t_waits_for_holder_instead_of_deleting(_TCConfig) ->
             install -> ok
         end,
         ok = emqx_managed_certs:delete_bundle_v1(?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME),
-        ok = emqx_managed_certs:create_bundle(
+        ok = emqx_managed_certs:install_files(
             ?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME, Installed
         ),
         Parent ! {self(), installed}


### PR DESCRIPTION
Release version:
7.0.0

Introduced in:
N/A

## Summary

An operator can put a `ca` file in the node's default certificate bundle and leave the identity to
the node. The CA names who to trust when verifying peers, which a node cannot decide for itself; the
key and chain are exactly what it can issue. That is the configuration behind "give this container
its trust anchor, let it make its own certificate".

It did not work. A bundle without both a key and a chain counted as unusable, and generation deleted
the whole directory before writing, so the `ca` file went with it:

```
before: ["ca.pem"]
after:  ["key.pem","chain.pem"]
```

This also contradicted #18813's own `use_default_cacertfile/2`, which serves a bundle's `ca` file as
the `cacertfile` and documents an operator installing one — only a *complete* bundle ever survived.

## What changes

Generation writes the files it produces and leaves everything else in the bundle alone, so a bundle
holding just a `ca` is **completed** rather than replaced. A bundle that already has a key and a
chain is still left untouched.

The directory is no longer deleted or renamed over. It can be a mount point — a container handed its
trust anchor from the host — where `del_dir_r` and renaming over it both fail outright. Each file is
written under a temporary name in the bundle's own directory and renamed over the real one, which
keeps the rename on a single filesystem and never lets a reader see a partial write.

`emqx_managed_certs:create_bundle/3` becomes `install_files/3` to say what it now does, and no longer
reports `{error, exists}`: writing into a bundle that is already there is the point.

## A note on the atomicity this drops

The old rename-the-whole-directory gave one more guarantee than per-file renames do: two concurrent
generators could not interleave into a mix of each other's files. Within a node that is still covered
— generation runs under `emqx_utils_proc:singleton/4`. Across nodes it would only matter if two of
them shared one bundle directory, which is already wrong for a different reason: the default
certificate is a per-node identity, and two nodes sharing it share a private key.

## Verification

- `emqx_default_cert_SUITE` 20/20, including a new `t_installed_ca_file_alone_is_completed`: install
  only a `ca`, ask for the bundle, and the CA is still the installed one while the generated identity
  is self-consistent and resolves to all three of `cacertfile`/`certfile`/`keyfile`. It fails with the
  change reverted.
- `emqx_mgmt_api_certs_SUITE` 22/22, `emqx_listeners_SUITE` 36/36, `emqx_conf_app_SUITE` 8/8.
- `make fmt-diff` and `./scripts/elvis-check.sh` clean.

No changelog: the default-certificate feature this refines has not been released.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
