### PR TITLE
build: disable QUIC for Amazon Linux 2 packages, bump to 5.10.5-rc.3

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -19,4 +19,4 @@
 %% NOTE: Also make sure to follow the instructions in end of
 %% `apps/emqx/src/bpapi/README.md'
 
--define(EMQX_RELEASE_EE, "5.10.5-rc.2").
+-define(EMQX_RELEASE_EE, "5.10.5-rc.3").

--- a/build
+++ b/build
@@ -64,11 +64,15 @@ export PKG_VSN
 
 SYSTEM="$(./scripts/get-distro.sh)"
 
-if [[ $SYSTEM == "el7" ]];
-then
-    log_red "WARNING: No QUIC spport for Centos 7"
-    export BUILD_WITHOUT_QUIC=1
-fi
+case "$SYSTEM" in
+    el7|amzn2)
+        # Both ship OpenSSL 1.x. quicer 0.4.x needs OpenSSL 3 to build
+        # from source, and the el7-named prebuilt (which amzn2 also
+        # resolves to) is not reliable.
+        log_red "WARNING: No QUIC support for $SYSTEM"
+        export BUILD_WITHOUT_QUIC=1
+        ;;
+esac
 
 ARCH="$(uname -m)"
 case "$ARCH" in

--- a/deploy/charts/emqx-enterprise/Chart.yaml
+++ b/deploy/charts/emqx-enterprise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.10.5-rc.2
+version: 5.10.5-rc.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 5.10.5-rc.2
+appVersion: 5.10.5-rc.3


### PR DESCRIPTION
Release versions:
5.10.5

Introduced in:
N/A

## Summary

The `e5.10.5-rc.2` package build ([run 34378078605](https://github.com/emqx/emqx/actions/runs/34378078605)) failed on `amzn2` amd64 and arm64; every other platform passed.

On amzn2, quicer resolves `QUICER_TLS_VER=auto` to `quictls` and downloads the `el7`-named prebuilt (amzn2 reports itself as rhel 7 to quicer). That download fails its sha256 check: on the quicer 0.4.9 release the `amzn2` and `el7` matrix jobs both produce `libquicer-<vsn>-otpNN-quictls-el7-<arch>.gz`, and the release job uploads both with `--clobber`, so the published `.gz` and `.sha256` come from different jobs. The source-build fallback then fails in quictls' `Configure` with `Can't locate IPC/Cmd.pm`: the amzn2 builder image has no `perl-IPC-Cmd`.

This PR treats amzn2 like el7 in `build` and sets `BUILD_WITHOUT_QUIC=1`, so amzn2 packages ship without the QUIC listener. Both distros ship OpenSSL 1.x.

Also bumps the version to `5.10.5-rc.3` so a new tag can be cut.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)