### PR TITLE
build: disable QUIC for Amazon Linux 2

### DIFF
--- a/build
+++ b/build
@@ -66,11 +66,15 @@ fi
 
 SYSTEM="$(./scripts/get-distro.sh)"
 
-if [[ $SYSTEM == "el7" ]];
-then
-    log_red "WARNING: No QUIC support for Centos 7"
-    export BUILD_WITHOUT_QUIC=1
-fi
+case "$SYSTEM" in
+    el7|amzn2)
+        # Both ship OpenSSL 1.x. quicer 0.4.x needs OpenSSL 3 to build
+        # from source, and the el7-named prebuilt (which amzn2 also
+        # resolves to) is not reliable.
+        log_red "WARNING: No QUIC support for $SYSTEM"
+        export BUILD_WITHOUT_QUIC=1
+        ;;
+esac
 
 ARCH="$(uname -m)"
 case "$ARCH" in


### PR DESCRIPTION
Release versions:
6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0

Introduced in:
N/A

## Summary

Port of #18887 (dev-510). On amzn2, quicer resolves `QUICER_TLS_VER=auto` to `quictls`, downloads the `el7`-named prebuilt (amzn2 reports itself as rhel 7 to quicer), fails the sha256 check because the published el7 `.gz` and `.sha256` on the quicer release come from different matrix jobs, and then fails the source build because quictls' `Configure` needs `perl IPC::Cmd`.

`build` now treats amzn2 like el7 and sets `BUILD_WITHOUT_QUIC=1`. dev-60 no longer packages amzn2, so this only affects source builds on amzn2 hosts and keeps the branches consistent.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
