### PR TITLE
docs(bpapi): allow a freeze to change a key already declared diverged

### DIFF
--- a/apps/emqx_bpapi/README.md
+++ b/apps/emqx_bpapi/README.md
@@ -169,8 +169,14 @@ do add proto versions. Freeze after every cut.
 
 Review the diff rather than taking the regeneration on trust. A freeze may add
 `{API, Version}` keys, and may drop keys already listed in
-`?FORCE_DELETED_APIS`. It must never *change* one — that is a frozen API being
-edited, and the point of the check.
+`?FORCE_DELETED_APIS`.
+
+A key that *changes* is a frozen API being edited, which is the thing the check
+exists to catch. Stop and find out why. The one exception is a key already in
+`?DIVERGED_APIS`: two lines gave it the same number with different contents, no
+single definition can match both, and the freeze records what this line holds.
+The 6.3 freeze changed `{emqx_mgmt_data_backup, 2}` for exactly that reason.
+Nothing else may change.
 
 ## A release cut on one branch freezes the branches upstream of it
 


### PR DESCRIPTION
Fixes:
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: N/A

## Summary

The freeze rule added in #18826 says a freeze diff must never change an
`{API, Version}` key. That is right for the case it was written for — a frozen
API being edited is what the check exists to catch — but it forbids a case that
has already happened legitimately.

When two release lines gave the same key different contents, no single definition
matches both. The key goes in `?DIVERGED_APIS`, and a freeze on either line then
records what that line holds. The 6.3 freeze in #18847 changed
`{emqx_mgmt_data_backup, 2}` on exactly that basis: 6.3.0 shipped it with
`peek_sensitive_table_sets/3`, which #18826 had moved to v4 on dev-60.

So the handbook forbade something the repository had already done for a good
reason. This states the exception and bounds it: a key already in
`?DIVERGED_APIS`, and nothing else.

Docs only.

## PR Checklist
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
