### PR TITLE
ci(bpapi): check each baseline against the newest tag on its line

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -102,6 +102,9 @@ jobs:
       - name: Check apps version
         run: |
           ./scripts/apps-version-check.exs
+      - name: Check BPAPI baselines
+        run: |
+          ./scripts/check-bpapi-baselines.exs
       - name: Check API module scopes
         run: |
           ./scripts/check-api-scopes.sh

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,12 @@ ct: $(REBAR) merge-config render-test-env
 	@env ERL_FLAGS="-kernel prevent_overlapping_partitions false" $(MIX) ct --cover-export-name $(CT_COVER_EXPORT_PREFIX)-ct
 
 ## only check bpapi for enterprise profile because it's a super-set.
+## Compares each committed BPAPI baseline against the newest released tag on its
+## line. Needs git tags, not a build; CI runs it in the sanity-checks job.
+.PHONY: check-bpapi-baselines
+check-bpapi-baselines:
+	./scripts/check-bpapi-baselines.exs
+
 .PHONY: static_checks
 static_checks: $(ELIXIR_COMMON_DEPS)
 	@# the cluster-rpc check reads plugin beams from the shared build tree

--- a/scripts/check-bpapi-baselines.exs
+++ b/scripts/check-bpapi-baselines.exs
@@ -80,6 +80,11 @@ defmodule CheckBpapiBaselines do
   end
 
   # {api, version} for every proto module present at a tag, with its path.
+  #
+  # A tag object can be listed by `git tag -l` while its commit is absent, which
+  # is what a shallow clone looks like. `ls-tree` then fails, and returning an
+  # empty list here would report the baseline as ok having compared it against
+  # nothing. Every real tag has proto modules, so treat both as errors.
   defp protos_at(tag) do
     case git(["ls-tree", "-r", "--name-only", tag]) do
       {:ok, out} ->
@@ -91,9 +96,13 @@ defmodule CheckBpapiBaselines do
             key -> [{key, path}]
           end
         end)
+        |> case do
+          [] -> die("No proto modules at #{tag}; is the tag's commit present?")
+          protos -> protos
+        end
 
       :error ->
-        []
+        die("Cannot read #{tag}; the tag is listed but its commit is missing")
     end
   end
 
@@ -145,8 +154,10 @@ defmodule CheckBpapiBaselines do
           |> Enum.map(&elem(&1, 0))
           |> Enum.sort()
 
+        checked = protos_at(tag) |> length()
+
         case missing do
-          [] -> {:ok, line, tag}
+          [] -> {:ok, line, tag, checked}
           _ -> {:error, line, tag, missing}
         end
     end
@@ -161,8 +172,8 @@ defmodule CheckBpapiBaselines do
     end
 
     Enum.each(results, fn
-      {:ok, line, tag} ->
-        IO.puts("  #{line}: ok against #{tag}")
+      {:ok, line, tag, checked} ->
+        IO.puts("  #{line}: ok against #{tag}, #{checked} versions compared")
 
       {:skipped, line, why} ->
         IO.puts("  #{line}: skipped, #{why}")

--- a/scripts/check-bpapi-baselines.exs
+++ b/scripts/check-bpapi-baselines.exs
@@ -1,0 +1,210 @@
+#!/usr/bin/env elixir
+
+# Checks that every committed BPAPI baseline describes the release line it is
+# named for.
+#
+# A baseline is frozen from a branch tip, so it may hold more than the newest
+# released tag on its line. It may not hold less: proto versions only
+# accumulate, so every one present at that tag has to be in the file. A baseline
+# that is short of them was taken from the wrong tree -- which has happened three
+# times, each time going unnoticed for months, because nothing read the file
+# closely enough to tell.
+#
+# Two absences are legitimate. A proto module that makes no RPC call is never in
+# a dump: those exist only to be announced in `bpapi.versions` so callers can
+# gate on the version, and `dump_api/1` records calls. And a module the tag has
+# but the working tree does not has been deleted since, so a baseline frozen
+# after that deletion is right not to hold it.
+#
+# That second rule is why this compares against the working tree rather than
+# reading `?FORCE_DELETED_APIS`: a deletion is visible in the tree, and the tree
+# cannot fall out of step with itself the way a copied list can. It also keeps
+# the check to git and `file:consult/1`, with nothing to build and no Erlang
+# source to parse.
+
+defmodule CheckBpapiBaselines do
+  @data_dir "apps/emqx_bpapi/test/emqx_static_checks_data"
+  @proto_glob "{apps,plugins}/*/src/**/*_proto_v*.erl"
+  @rpc_call ~r/\b(rpc|erpc|emqx_rpc|emqx_cluster_rpc):/
+
+  def main do
+    case baselines() do
+      [] ->
+        die("No baselines found in #{@data_dir}")
+
+      files ->
+        present = protos_in_tree()
+        results = Enum.map(files, &check(&1, present))
+        report(results)
+    end
+  end
+
+  defp baselines do
+    Path.wildcard("#{@data_dir}/*.bpapi*")
+    |> Enum.reject(&(Path.basename(&1) |> String.starts_with?("master.")))
+    |> Enum.sort()
+  end
+
+  # "5.10.bpapi2" -> "5.10"
+  defp line_of(file), do: Path.basename(file) |> String.replace(~r/\.bpapi\d*$/, "")
+
+  # 5.x release tags carry an `e` prefix; 6.0 onwards do not.
+  defp tag_prefix(line) do
+    case String.split(line, ".") do
+      ["5" | _] -> "e"
+      _ -> ""
+    end
+  end
+
+  defp newest_ga_tag(line) do
+    pattern = "#{tag_prefix(line)}#{line}.*"
+
+    case git(["tag", "-l", pattern]) do
+      {:ok, out} ->
+        out
+        |> String.split("\n", trim: true)
+        |> Enum.reject(&String.match?(&1, ~r/-(rc|alpha|beta|patch)/))
+        |> Enum.sort_by(&version_key/1)
+        |> List.last()
+
+      :error ->
+        nil
+    end
+  end
+
+  defp version_key(tag) do
+    tag
+    |> String.replace(~r/^e/, "")
+    |> String.split(".")
+    |> Enum.map(&(Integer.parse(&1) |> elem(0)))
+  end
+
+  # {api, version} for every proto module present at a tag, with its path.
+  defp protos_at(tag) do
+    case git(["ls-tree", "-r", "--name-only", tag]) do
+      {:ok, out} ->
+        out
+        |> String.split("\n", trim: true)
+        |> Enum.flat_map(fn path ->
+          case proto_key(path) do
+            nil -> []
+            key -> [{key, path}]
+          end
+        end)
+
+      :error ->
+        []
+    end
+  end
+
+  defp proto_key(path) do
+    case Regex.run(~r{/proto/([a-z_0-9]+)_proto_v(\d+)\.erl$}, path) do
+      [_, api, vsn] -> {String.to_atom(api), String.to_integer(vsn)}
+      nil -> nil
+    end
+  end
+
+  defp makes_rpc_call?(tag, path) do
+    case git(["show", "#{tag}:#{path}"]) do
+      {:ok, src} -> String.match?(src, @rpc_call)
+      :error -> true
+    end
+  end
+
+  defp baseline_keys(file) do
+    case :file.consult(String.to_charlist(file)) do
+      {:ok, [dump]} -> dump |> Map.fetch!(:api) |> Map.keys() |> MapSet.new()
+      other -> die("Cannot read #{file}: #{inspect(other)}")
+    end
+  end
+
+  # Proto modules that still exist. A tag may name one this tree has deleted;
+  # that absence from a baseline frozen later is correct.
+  defp protos_in_tree do
+    case Path.wildcard(@proto_glob) do
+      [] -> die("Found no proto modules under #{@proto_glob}; the layout must have changed")
+      paths -> paths |> Enum.map(&proto_key/1) |> Enum.reject(&is_nil/1) |> MapSet.new()
+    end
+  end
+
+  defp check(file, present) do
+    line = line_of(file)
+
+    case newest_ga_tag(line) do
+      nil ->
+        {:skipped, line, "no released tag yet"}
+
+      tag ->
+        keys = baseline_keys(file)
+
+        missing =
+          protos_at(tag)
+          |> Enum.reject(fn {key, _path} -> MapSet.member?(keys, key) end)
+          |> Enum.filter(fn {key, _path} -> MapSet.member?(present, key) end)
+          |> Enum.filter(fn {_key, path} -> makes_rpc_call?(tag, path) end)
+          |> Enum.map(&elem(&1, 0))
+          |> Enum.sort()
+
+        case missing do
+          [] -> {:ok, line, tag}
+          _ -> {:error, line, tag, missing}
+        end
+    end
+  end
+
+  defp report(results) do
+    if Enum.all?(results, &match?({:skipped, _, _}, &1)) do
+      die(
+        "No release tags found, so no baseline could be checked.\n" <>
+          "Fetch tags first (a shallow clone has none)."
+      )
+    end
+
+    Enum.each(results, fn
+      {:ok, line, tag} ->
+        IO.puts("  #{line}: ok against #{tag}")
+
+      {:skipped, line, why} ->
+        IO.puts("  #{line}: skipped, #{why}")
+
+      {:error, line, tag, missing} ->
+        IO.puts("  #{line}: FAILED against #{tag}")
+
+        Enum.each(missing, fn {api, vsn} ->
+          IO.puts("      #{api} v#{vsn} is at the tag but not in the baseline")
+        end)
+    end)
+
+    case Enum.filter(results, &match?({:error, _, _, _}, &1)) do
+      [] ->
+        IO.puts("BPAPI baselines ok")
+
+      errors ->
+        IO.puts("""
+
+        #{length(errors)} baseline(s) do not describe their release line.
+
+        A baseline may hold more than its newest released tag, never less. The
+        versions above are at the tag and still in this tree, so the baseline was
+        generated from the wrong one; rebuild it from that line and commit the
+        result. See apps/emqx_bpapi/README.md.
+        """)
+
+        System.halt(1)
+    end
+  end
+
+  defp git(args) do
+    case System.cmd("git", args, stderr_to_stdout: true) do
+      {out, 0} -> {:ok, out}
+      _ -> :error
+    end
+  end
+
+  defp die(msg) do
+    IO.puts(:stderr, msg)
+    System.halt(1)
+  end
+end
+
+CheckBpapiBaselines.main()


### PR DESCRIPTION
Fixes:
Release version: 6.0.4, 6.1.5, 6.2.4, 6.3.1, 7.0.0
Introduced in: N/A

## Summary

Three committed baselines described a different release than their name:

| file | actually held | found by |
|---|---|---|
| `6.0.bpapi2` | the 5.10 surface | #18794 |
| `6.1.bpapi2` | the 6.0.0 surface | #18800 |
| `5.7.bpapi2` | the 5.6 surface | #18812 |

Each had been wrong for months. Nothing read the files closely enough to notice,
and all three were found by hand while chasing something else. This makes the
machine do it.

## The check

A baseline is frozen from a branch tip, so it may hold *more* than the newest
released tag on its line. It may not hold *less*, because proto versions only
accumulate. So compare the two: every `{API, Version}` present at the tag has to
be in the file.

Two absences are legitimate:

- a proto module that makes no RPC call is never in a dump — `dump_api/1` records
  calls, and those modules exist only to be announced in `bpapi.versions` so
  callers can gate on the version (`emqx_prometheus_proto_v3` at 6.1.0 is one);
- a module the tag has but the working tree does not was deleted after the tag
  was cut, so a baseline frozen later is right not to hold it. This is the case
  that lets a tip-frozen baseline legitimately hold less than its tag —
  `6.0.bpapi2` is short of 24 such versions against `6.0.3` today.

That second rule compares against the working tree rather than reading
`?FORCE_DELETED_APIS`. A first draft did read the macro, by regex over the Erlang
source, which is fragile: a comment or a reformatted list changes the result, and
a partial parse fails quietly in whichever direction the regex happens to break.

Reading the tree is better on the merits, not just simpler. A deletion is visible
in the tree directly, and the tree cannot fall out of step with itself the way a
copied list can. It also states the invariant the check is really about — a
version at the tag must be described unless it no longer exists.

Note that building first would not have avoided the parse. Macros do not survive
compilation, so the list is not readable from the beam either; it would have
needed an exported accessor added to `emqx_bpapi_static_checks` purely to be read
back. Comparing against the tree removes the need for both.

## Where it runs

`sanity-checks`, next to `apps-version-check.exs`. It reads git and the
baselines and builds nothing, and that job checks out with `fetch-depth: 0`, so
the tags are there. The `static_checks` job cannot host it: it works from an
unpacked release artifact rather than a checkout.

`make check-bpapi-baselines` runs it locally.

## Verification

Against the real defects, not invented ones:

```
$ git checkout <pre-fix>:…/6.0.bpapi2      # the historical file
  6.0: FAILED against 6.0.3
      emqx_bridge v8 is at the tag but not in the baseline
      emqx_bridge_kinesis v1 …
      emqx_conf v5 …

$ cp 5.8.bpapi2 5.9.bpapi2                  # a copied baseline
  5.9: FAILED against e5.9.3
      emqx_auth_cache v1 …
      emqx_cluster v1 …
      emqx_ds_beamformer v1 …
```

and the current baselines pass:

```
  5.10: ok against e5.10.4
  5.8: ok against e5.8.11
  5.9: ok against e5.9.3
  6.0: ok against 6.0.3
```

`mix format` clean. No changelog: CI tooling, no user-visible change.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
