### PR TITLE
fix(emqx_tables): do not drop new fields when inserting into an existing table

### DIFF
--- a/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
+++ b/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
@@ -452,6 +452,47 @@ t_batch(TCConfig) ->
     end).
 
 -doc """
+Regression test for https://github.com/emqx/emqx/issues/18499.
+
+`init_per_testcase/2` creates the `mqtt` table with only the `(ts, clientid,
+payload)` columns, while the default write syntax also emits `float_value` and
+`bool` (and a `<clientid>_int_value` field). Those fields are not present in the
+existing table, so they used to be dropped silently. They must instead be added
+by GreptimeDB together with the data.
+""".
+t_new_fields_added_to_existing_table() ->
+    [{matrix, true}].
+t_new_fields_added_to_existing_table(matrix) ->
+    [
+        [?tcp, Sync, ?without_batch]
+     || Sync <- [?sync, ?async]
+    ];
+t_new_fields_added_to_existing_table(TCConfig) when is_list(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, _} = create_action_api(TCConfig, #{}),
+    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    C = start_client(#{clientid => ClientId}),
+    Payload = json_encode(#{
+        int_key => 42,
+        uint_key => 7,
+        float_key => 24.5,
+        bool => true
+    }),
+    emqtt:publish(C, Topic, Payload),
+    ?retry(
+        200,
+        10,
+        begin
+            Row = query_by_clientid(ClientId, TCConfig),
+            ?assertMatch(#{<<"payload">> := Payload}, Row),
+            %% These two columns were not part of the pre-created table.
+            ?assertMatch(#{<<"float_value">> := 24.5, <<"bool">> := true}, Row)
+        end
+    ),
+    ok.
+
+-doc """
 Verifies case where batch resolves to multiple tables, and all succeed.
 """.
 t_multiple_tables_success() ->

--- a/changes/ee/fix-18499.en.md
+++ b/changes/ee/fix-18499.en.md
@@ -1,0 +1,3 @@
+Fixed EMQX Tables silently dropping fields that are not present in the destination table.
+
+When a record contained a field or tag that the existing table did not have yet, the GreptimeDB driver built the insert request exclusively from the table's current schema. The unknown columns were therefore left out of the request, so GreptimeDB could not add them and the values were discarded without any error. Input fields and tags that are missing from the table are now inferred and merged into the request schema, while columns that already exist keep their server-side data type and semantic type.

--- a/mix.exs
+++ b/mix.exs
@@ -320,8 +320,13 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:greptimedb),
     do: {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.2"}
 
+  # Carry the fix for https://github.com/emqx/emqx/issues/18499 from the fork
+  # branch until emqx/greptimedb-ingester-erlnif publishes a release with it.
+  # This commit is meant to be replaced by the released tag afterwards.
   def common_dep(:greptimedb_rs),
-    do: {:greptimedb_rs, github: "emqx/greptimedb-ingester-erlnif", tag: "0.1.13"}
+    do:
+      {:greptimedb_rs,
+       github: "JimMoen/greptimedb-ingester-erlnif", branch: "fix/greptimedb-auto-add-columns"}
 
   def common_dep(:sbom), do: {:sbom, "~> 0.8", runtime: false}
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/emqx/emqx/issues/18499.

EMQX Tables silently dropped fields that were not present in the destination table. When a
record carried a field or tag that the existing table did not have yet, the driver built the
insert request exclusively from the table's current schema, so GreptimeDB never saw the new
column and therefore could not add it. The insert still returned success and the value was
lost.

## Commits

1. `test(emqx_tables)`: regression test that inserts a record whose write syntax produces
   fields missing from the pre-created table and asserts that the columns are added together
   with the data (sync and async).
2. `docs`: changelog under `changes/ee/`.
3. `chore(greptimedb_rs)`: pin `greptimedb_rs` to the branch carrying the driver fix.

## Dependency

The driver fix is emqx/greptimedb-ingester-erlnif#18 (branch
`fix/greptimedb-auto-add-columns` in JimMoen's fork). This PR pins the dependency to that
branch; the pin commit is meant to be rewritten to the released tag once the NIF PR is merged
and tagged.

## Test evidence

- New CT case `t_new_fields_added_to_existing_table`, matrix `tcp x {sync, async} x without_batch`:
  `init_per_testcase/2` creates `mqtt` with only `(ts, clientid, payload)` while the default
  write syntax also emits `float_value` and `bool`, so the test asserts that those columns are
  added by GreptimeDB together with the data.
- NIF side: 5 new cases; the full NIF suite is green (`All 58 tests passed.`) against
  GreptimeDB v0.17.2, and the new cases fail with `column_missing_from_table` before the fix.
- Locally on this branch (enterprise test profile), running the case in both group paths gives
  `2 ok, 0 failed`; with the merge disabled in the NIF both cases fail (red check).
