### PR TITLE
fix(mt): accept clients without namespace in post-authn tombstone check

### DIFF
--- a/apps/emqx_mt/src/emqx_mt_hookcb.erl
+++ b/apps/emqx_mt/src/emqx_mt_hookcb.erl
@@ -179,7 +179,10 @@ validate_not_tombstoned(#{client_attrs := #{?CLIENT_ATTR_NAME_TNS := Tns}}) ->
             {stop, {error, server_unavailable}};
         false ->
             ok
-    end.
+    end;
+validate_not_tombstoned(_ClientInfo) ->
+    %% not a multi-tenant client
+    ok.
 
 %% Invoked on the `client.post_authn' hook. If the operator has configured
 %% `multi_tenancy.post_auth_tns_expression', evaluate it against the merged

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -1757,6 +1757,33 @@ t_post_auth_tns_expression_disabled(_Config) ->
     },
     ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(#{client_info => ClientInfo})).
 
+-doc """
+A client without `client_attrs.tns' connects while the post-auth expression is unset.
+The connect succeeds and the post-authn hook does not raise an exception.
+""".
+t_post_auth_no_tns_client({init, Config}) ->
+    ok = clear_post_auth_tns_expression(),
+    Config;
+t_post_auth_no_tns_client({'end', _Config}) ->
+    ok;
+t_post_auth_no_tns_client(Config) when is_list(Config) ->
+    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(#{client_info => #{clientid => <<"c1">>}})),
+    ?check_trace(
+        begin
+            ClientId = ?NEW_CLIENTID(),
+            %% No username, so `client_attrs_init' does not set `tns'.
+            Pid = connect(#{clientid => ClientId}),
+            [ChanPid] = emqx_cm:lookup_channels(ClientId),
+            #{clientinfo := ClientInfo} = emqx_cm:get_chan_info(ClientId, ChanPid),
+            ?assertNot(maps:is_key(<<"tns">>, maps:get(client_attrs, ClientInfo, #{}))),
+            ok = emqtt:stop(Pid)
+        end,
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind(["hook_callback_exception"], Trace)),
+            ok
+        end
+    ).
+
 -doc "Expression reads client_attrs.tag and rewrites client_attrs.tns.".
 t_post_auth_tns_expression_reads_client_attrs_tag({init, Config}) ->
     ok = set_post_auth_tns_expression(<<"client_attrs.tag">>),


### PR DESCRIPTION
## Summary

`emqx_mt_hookcb:validate_not_tombstoned/1` had no clause for a client without `client_attrs.tns`.
It runs on the `client.post_authn` hook when `multi_tenancy.post_auth_tns_expression` is unset, which is the default.
Every client without a namespace raised `function_clause`, and the hook runner logged `hook_callback_exception` on each connect.
The hook fold is not strict, so the connect still succeeded.

This PR adds the fallback clause that accepts the client unchanged.

## Origin

- #18774 (dev-60) added the tombstone check to `on_authenticate/2`, which has a catch-all clause.
- #18796 (sync dev-62 to dev-63) moved the check into the new `validate_not_tombstoned/1` and dropped the no-namespace fallback.

No release tag contains the #18796 merge, so the regression is unreleased and this PR has no changelog.

## Merge audit

The rest of #18796 keeps the dev-60 behavior for clients without a namespace:

- The pre-auth no-tns clause of `do_on_authenticate/2` still denies them when `allow_only_managed_namespaces` is set.
- dev-60 runs no namespace config-errors check for them, and neither does dev-63.

The missing clause is the only gap.

## Tests

`emqx_mt_SUITE:t_post_auth_no_tns_client` connects a client without `tns` and asserts that no `hook_callback_exception` is traced.
It fails without the fix in both the `legacy` and `hardened` groups.
