### PR TITLE
chore: bump release version to 6.3.1-rc.1

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -19,4 +19,4 @@
 %% NOTE: Also make sure to follow the instructions in end of
 %% `apps/emqx_bpapi/README.md'
 
--define(EMQX_RELEASE_EE, "6.3.0").
+-define(EMQX_RELEASE_EE, "6.3.1-rc.1").

--- a/deploy/charts/emqx-enterprise/Chart.yaml
+++ b/deploy/charts/emqx-enterprise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 6.3.0
+version: 6.3.1-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 6.3.0
+appVersion: 6.3.1-rc.1


### PR DESCRIPTION
Bump the release version to `6.3.1-rc.1`.

- `apps/emqx/include/emqx_release.hrl`: `EMQX_RELEASE_EE` is now `6.3.1-rc.1`.
- `deploy/charts/emqx-enterprise/Chart.yaml`: `version` and `appVersion` are now `6.3.1-rc.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W13dPagsceBHtes32vjZPc