### PR TITLE
ci: fix the app version check summary and bump mq/streams

### DIFF
--- a/apps/emqx_mq/mix.exs
+++ b/apps/emqx_mq/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMQ.MixProject do
   def project do
     [
       app: :emqx_mq,
-      version: "6.3.0",
+      version: "6.3.1",
       build_path: "../../_build",
       compilers: [:elixir, :asn1, :erlang, :app],
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_streams/mix.exs
+++ b/apps/emqx_streams/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXStreams.MixProject do
   def project do
     [
       app: :emqx_streams,
-      version: "6.3.0",
+      version: "6.3.1",
       build_path: "../../_build",
       compilers: [:elixir, :asn1, :erlang, :app],
       erlc_options: UMP.strict_erlc_options(),

--- a/scripts/apps-version-check.exs
+++ b/scripts/apps-version-check.exs
@@ -406,7 +406,9 @@ defmodule AppsVersionCheck do
 
     invalid_plugins =
       plugins
-      |> Enum.map(fn app -> Task.async(fn -> {app, has_valid_plugin_release_vsn?(app, context)} end) end)
+      |> Enum.map(fn app ->
+        Task.async(fn -> {app, has_valid_plugin_release_vsn?(app, context)} end)
+      end)
       |> Task.await_many(:infinity)
       |> Enum.reject(fn {_app, valid?} -> valid? end)
       |> Enum.map(fn {app, _} -> "plugins/#{app}" end)

--- a/scripts/apps-version-check.exs
+++ b/scripts/apps-version-check.exs
@@ -399,17 +399,17 @@ defmodule AppsVersionCheck do
 
     invalid_apps =
       apps
-      |> Enum.map(fn app -> Task.async(fn -> has_valid_app_vsn?(app, context) end) end)
+      |> Enum.map(fn app -> Task.async(fn -> {app, has_valid_app_vsn?(app, context)} end) end)
       |> Task.await_many(:infinity)
-      |> Enum.reject(&Function.identity/1)
-      |> Enum.map(&"apps/#{&1}")
+      |> Enum.reject(fn {_app, valid?} -> valid? end)
+      |> Enum.map(fn {app, _} -> "apps/#{app}" end)
 
     invalid_plugins =
       plugins
-      |> Enum.map(fn app -> Task.async(fn -> has_valid_plugin_release_vsn?(app, context) end) end)
+      |> Enum.map(fn app -> Task.async(fn -> {app, has_valid_plugin_release_vsn?(app, context)} end) end)
       |> Task.await_many(:infinity)
-      |> Enum.reject(&Function.identity/1)
-      |> Enum.map(&"plugins/#{&1}")
+      |> Enum.reject(fn {_app, valid?} -> valid? end)
+      |> Enum.map(fn {app, _} -> "plugins/#{app}" end)
 
     (invalid_apps ++ invalid_plugins)
     |> case do


### PR DESCRIPTION
Two fixes to the app version check, both found through the red `sanity-checks` on #18876.

**`emqx_mq` and `emqx_streams` need a version bump.** #18769 changed both apps and left them at
`6.3.0`, so `./scripts/apps-version-check.exs` fails on `dev-70` itself and on every pull request
based on it. Bumped to `6.3.1`, which is what `--auto-fix` produces.

**The failure summary printed `"apps/false"`.** `033fc0879e` ran the per-app checks in parallel
and collected only their boolean results, so by the time the summary was built the app names were
gone and each failure became `"apps/false"`:

```
Errors were found
Invalid apps/plugin-apps:
["apps/false", "apps/false"]
```

The per-app `ERROR:` lines above it were still right, because they're logged before the name is
dropped. Each task now returns `{app, valid?}`, and the summary reads
`["apps/emqx_mq", "apps/emqx_streams"]`. Same fix for the plugin list.

The script bug exists from `dev-60` up. This PR only fixes `dev-70`, since that's where the check is
red; the script fix can be carried down separately if wanted.

No changelog: CI-only.
