### PR TITLE
ci: report app names in the version-check failure summary

### DIFF
--- a/scripts/apps-version-check.exs
+++ b/scripts/apps-version-check.exs
@@ -378,17 +378,19 @@ defmodule AppsVersionCheck do
 
     invalid_apps =
       apps
-      |> Enum.map(fn app -> Task.async(fn -> has_valid_app_vsn?(app, context) end) end)
+      |> Enum.map(fn app -> Task.async(fn -> {app, has_valid_app_vsn?(app, context)} end) end)
       |> Task.await_many(:infinity)
-      |> Enum.reject(&Function.identity/1)
-      |> Enum.map(&"apps/#{&1}")
+      |> Enum.reject(fn {_app, valid?} -> valid? end)
+      |> Enum.map(fn {app, _} -> "apps/#{app}" end)
 
     invalid_plugins =
       plugins
-      |> Enum.map(fn app -> Task.async(fn -> has_valid_plugin_release_vsn?(app, context) end) end)
+      |> Enum.map(fn app ->
+        Task.async(fn -> {app, has_valid_plugin_release_vsn?(app, context)} end)
+      end)
       |> Task.await_many(:infinity)
-      |> Enum.reject(&Function.identity/1)
-      |> Enum.map(&"plugins/#{&1}")
+      |> Enum.reject(fn {_app, valid?} -> valid? end)
+      |> Enum.map(fn {app, _} -> "plugins/#{app}" end)
 
     (invalid_apps ++ invalid_plugins)
     |> case do


### PR DESCRIPTION
Port of the script fix from #18897 to `dev-60`, where the bug was introduced.

`033fc0879e ci: speed up app vsn check` ran the per-app checks in parallel and collected only
their boolean results, so the failure summary lost the app names and printed `"apps/false"` once
per failing app:

```
Errors were found
Invalid apps/plugin-apps:
["apps/false", "apps/false"]
```

Each task now returns `{app, valid?}` and the summary names the apps. Same fix for the plugin list.

`dev-70` already carries this change through #18897, so the forward sync will find it already
applied. Not included from #18897: the `emqx_mq`/`emqx_streams` version bumps, which are
`dev-70`-only.

Verified on `dev-60`: `mix format --check-formatted` and `./scripts/apps-version-check.exs` both
exit 0.

No changelog: CI-only.
