### PR TITLE
fix(api-listeners): gracefully handle pre-6.3.0 node responses

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -654,9 +654,7 @@ format_status(Key, Node, Listener, Acc) ->
         <<"max_connections">> := MaxConnections,
         <<"current_connections">> := CurrentConnections,
         <<"acceptors">> := Acceptors,
-        <<"bind">> := Bind,
-        <<"resolved_address">> := ResolvedAddress,
-        <<"resolved_address_from">> := ResolvedAddressFrom
+        <<"bind">> := Bind
     } = Listener,
     {ok, #{name := Name}} = emqx_listeners:parse_listener_id(Id),
     GroupKey = maps:get(Key, Listener),
@@ -667,16 +665,12 @@ format_status(Key, Node, Listener, Acc) ->
     %% or the connection counts, "inconsistent" would fire on every cluster
     %% using node.default_listener_address = nodename, which is by design,
     %% not a fault to surface at the cluster level.
-    NodeStatusEntry = #{
-        node => Node,
-        status => #{
-            running => Running,
-            max_connections => MaxConnections,
-            current_connections => CurrentConnections,
-            resolved_address => ResolvedAddress,
-            resolved_address_from => ResolvedAddressFrom
-        }
-    },
+    NodeStatus = maybe_add_resolved_address(Listener, #{
+        running => Running,
+        max_connections => MaxConnections,
+        current_connections => CurrentConnections
+    }),
+    NodeStatusEntry = #{node => Node, status => NodeStatus},
     case maps:find(GroupKey, Acc) of
         error ->
             Acc#{
@@ -723,6 +717,23 @@ format_status(Key, Node, Listener, Acc) ->
                     }
             }
     end.
+
+%% NOTE
+%% Nodes running a release older than 6.3.0 do not include those fields in the
+%% `list_listeners/1` BPAPI response.
+maybe_add_resolved_address(
+    #{
+        <<"resolved_address">> := ResolvedAddress,
+        <<"resolved_address_from">> := ResolvedAddressFrom
+    },
+    Status
+) ->
+    Status#{
+        resolved_address => ResolvedAddress,
+        resolved_address_from => ResolvedAddressFrom
+    };
+maybe_add_resolved_address(_Listener, Status) ->
+    Status.
 
 max_conn(_Int1, <<"infinity">>) -> <<"infinity">>;
 max_conn(<<"infinity">>, _Int) -> <<"infinity">>;

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -16,7 +16,8 @@ all() ->
         {group, with_defaults_in_file},
         {group, without_defaults_in_file},
         {group, max_connections},
-        {group, hardened}
+        {group, hardened},
+        {group, mixed_version_cluster}
     ].
 
 groups() ->
@@ -30,11 +31,17 @@ groups() ->
     HardenedTests = [
         t_resolved_address_hardened_bare_port
     ],
+    MixedVersionClusterTests = [
+        t_list_listeners_mixed_version_cluster
+    ],
     [
-        {with_defaults_in_file, AllTests -- (MaxConnTests ++ HardenedTests)},
-        {without_defaults_in_file, AllTests -- (MaxConnTests ++ ZoneTests ++ HardenedTests)},
+        {with_defaults_in_file,
+            AllTests -- (MaxConnTests ++ HardenedTests ++ MixedVersionClusterTests)},
+        {without_defaults_in_file,
+            AllTests -- (MaxConnTests ++ ZoneTests ++ HardenedTests ++ MixedVersionClusterTests)},
         {max_connections, MaxConnTests},
-        {hardened, HardenedTests}
+        {hardened, HardenedTests},
+        {mixed_version_cluster, MixedVersionClusterTests}
     ].
 
 init_per_suite(Config) ->
@@ -70,7 +77,17 @@ init_per_group(hardened, Config) ->
             %% profile into later groups.
             emqx_common_test_helpers:clear_security_profile(),
             erlang:raise(Class, Reason, Stacktrace)
-    end.
+    end;
+init_per_group(mixed_version_cluster = Group, Config) ->
+    Apps = [emqx, emqx_conf, emqx_management],
+    Nodes = emqx_cth_cluster:start(
+        [
+            {mgmt_api_listeners_current, #{role => core, apps => Apps}},
+            {mgmt_api_listeners_legacy, #{role => core, apps => Apps}}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Group, Config)}
+    ),
+    [{cluster_nodes, Nodes} | Config].
 
 init_group_apps(Config, CTConfig) ->
     Apps = emqx_cth_suite:start(
@@ -86,6 +103,8 @@ init_group_apps(Config, CTConfig) ->
 end_per_group(hardened, Config) ->
     ok = emqx_cth_suite:stop(?config(suite_apps, Config)),
     emqx_common_test_helpers:clear_security_profile();
+end_per_group(mixed_version_cluster, Config) ->
+    emqx_cth_cluster:stop(?config(cluster_nodes, Config));
 end_per_group(_Group, Config) ->
     ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
 
@@ -232,6 +251,87 @@ t_api_listeners_list_not_ready(Config) when is_list(Config) ->
         ?assertEqual(length(L2), length(L3), Comment)
     after
         emqx_cth_cluster:stop(Nodes)
+    end.
+
+-doc """
+The 6.3 listener handlers accept the legacy response shape returned by a
+6.2 node during a rolling upgrade. Both nodes run the real aggregation and
+RPC paths. The legacy node's real `do_list_listeners/0` response is intercepted
+and stripped of the 6.3-only fields. The current node remains unmocked. The
+legacy node remains in the aggregate, but its node status omits those fields.
+""".
+t_list_listeners_mixed_version_cluster(Config) when is_list(Config) ->
+    [Node, NodeLegacy] = ?config(cluster_nodes, Config),
+    ok = erpc:call(NodeLegacy, fun() ->
+        ok = meck:new(emqx_mgmt_api_listeners, [passthrough, no_link]),
+        ok = meck:expect(emqx_mgmt_api_listeners, do_list_listeners, fun() ->
+            Response = #{<<"listeners">> := Listeners} = meck:passthrough([]),
+            Response#{
+                <<"listeners">> := [
+                    maps:with(
+                        [
+                            <<"id">>,
+                            <<"type">>,
+                            <<"enable">>,
+                            <<"running">>,
+                            <<"max_connections">>,
+                            <<"current_connections">>,
+                            <<"acceptors">>,
+                            <<"bind">>
+                        ],
+                        Listener
+                    )
+                 || Listener <- Listeners
+                ]
+            }
+        end)
+    end),
+    try
+        {200, [ById]} = erpc:call(
+            Node,
+            emqx_mgmt_api_listeners,
+            list_listeners,
+            [get, #{query_string => #{<<"type">> => ssl}}]
+        ),
+        ?assertMatch(
+            #{
+                id := 'ssl:default',
+                number := 2,
+                node_status := [
+                    #{node := NodeLegacy, status := StatusLegacy},
+                    #{node := Node, status := Status}
+                ]
+            } when
+                is_map_key(resolved_address, Status) andalso
+                    is_map_key(resolved_address_from, Status) andalso
+                    not is_map_key(resolved_address, StatusLegacy) andalso
+                    not is_map_key(resolved_address_from, StatusLegacy),
+            ById
+        ),
+        {200, ByTypes} = erpc:call(
+            Node,
+            emqx_mgmt_api_listeners,
+            listener_type_status,
+            [get, #{}]
+        ),
+        [ByType] = [Listener || Listener = #{type := <<"ssl">>} <- ByTypes],
+        ?assertMatch(
+            #{
+                type := <<"ssl">>,
+                ids := ['ssl:default'],
+                node_status := [
+                    #{node := NodeLegacy, status := StatusLegacy},
+                    #{node := Node, status := Status}
+                ]
+            } when
+                is_map_key(resolved_address, Status) andalso
+                    is_map_key(resolved_address_from, Status) andalso
+                    not is_map_key(resolved_address, StatusLegacy) andalso
+                    not is_map_key(resolved_address_from, StatusLegacy),
+            ByType
+        )
+    after
+        _ = catch erpc:call(NodeLegacy, meck, unload, [emqx_mgmt_api_listeners])
     end.
 
 t_clear_certs(Config) when is_list(Config) ->

--- a/changes/ee/fix-18899.en.md
+++ b/changes/ee/fix-18899.en.md
@@ -1,0 +1,1 @@
+Fixed a regression where `GET /api/v5/listeners` and `GET /api/v5/listeners_status` could return `500 INTERNAL_ERROR` in a mixed-version cluster during a rolling upgrade from an earlier release.


### PR DESCRIPTION
Release version: 6.3.1, 7.0.0
Introduced in: 6.3.0

## Summary

This PR addresses a bug in Listeners API handler causing `500 Internal Error`s similar to the following:
```
{
  "code":"INTERNAL_ERROR",
  "message":"error, {badmatch,#{<<\"acceptors\">> => 16,<<\"access_rules\">> => [<<\"allow all\">>],<<\"bind\">> => <<\"0.0.0.0:8883\">>,<<\"current_connections\">> => 0,<<\"enable\">> => true,<<\"enable_authn\">> => true,<<\"id\">> => 'ssl:default',<<\"max_connections\">> => <<\"infinity\">>,<<\"mountpoint\">> => <<>>,<<\"parse_unit\">> => <<\"frame\">>,<<\"proxy_protocol\">> => false,<<\"proxy_protocol_timeout\">> => <<\"3s\">>,<<\"running\">> => true,<<\"ssl_options\">> => #{<<\"cacertfile\">> => <<\"${EMQX_ETC_DIR}/certs/cacert.pem\">>,<<\"certfile\">> => <<\"${EMQX_ETC_DIR}/certs/cert.pem\">>,<<\"ciphers\">> => [],<<\"client_renegotiation\">> => true,<<\"depth\">> => 10,<<\"enable_crl_check\">> => false,<<\"fail_if_no_peer_cert\">> => false,<<\"gc_after_handshake\">> => false,<<\"handshake_timeout\">> => <<\"15s\">>,<<\"hibernate_after\">> => <<\"5s\">>,<<\"honor_cipher_order\">> => true,<<\"keyfile\">> => <<\"${EMQX_ETC_DIR}/certs/key.pem\">>,<<\"log_level\">> => <<\"notice\">>,<<\"ocsp\">> => #{<<\"enable_ocsp_stapling\">> => false,<<\"refresh_http_timeout\">> => <<\"15s\">>,<<\"refresh_interval\">> => <<\"5m\">>},<<\"reuse_sessions\">> => false,<<\"secure_renegotiate\">> => true,<<\"session_tickets\">> => <<\"disabled\">>,<<\"verify\">> => <<\"verify_none\">>,<<\"versions\">> => [<<\"tlsv1.3\">>,<<\"tlsv1.2\">>]},<<\"tcp_options\">> => #{<<\"active_n\">> => 10,<<\"backlog\">> => 1024,<<\"buffer\">> => <<\"4KB\">>,<<\"high_watermark\">> => <<\"1MB\">>,<<\"keepalive\">> => <<\"none\">>,<<\"nodelay\">> => true,<<\"nolinger\">> => false,<<\"reuseaddr\">> => true,<<\"send_timeout\">> => <<\"15s\">>,<<\"send_timeout_close\">> => true},<<\"type\">> => <<\"ssl\">>,<<\"zone\">> => <<\"default\">>}}, [{emqx_mgmt_api_listeners,format_status,4,[{file,\"emqx_mgmt_api_listeners.erl\"},{line,649}]},{lists,foldl,3,[{file,\"lists.erl\"},{line,2466}]},{emqx_mgmt_api_listeners,listener_status_by_id,2,[{file,\"emqx_mgmt_api_listeners.erl\"},{line,601}]},{emqx_mgmt_api_listeners,listener_status_by_id,1,[{file,\"emqx_mgmt_api_listeners.erl\"},{line,576}]},{emqx_mgmt_api_listeners,list_listeners,2,[{file,\"emqx_mgmt_api_listeners.erl\"},{line,421}]},{minirest_handler,apply_callback,4,[{file,\"/emqx/deps/minirest/src/minirest_handler.erl\"},{line,192}]},{minirest_handler,handle,2,[{file,\"/emqx/deps/minirest/src/minirest_handler.erl\"},{line,73}]},{minirest_handler,init,2,[{file,\"/emqx/deps/minirest/src/minirest_handler.erl\"},{line,32}]},{cowboy_handler,execute,2,[{file,\"/emqx/deps/cowboy/src/cowboy_handler.erl\"},{line,37}]},{cowboy_stream_h,execute,3,[{file,\"/emqx/deps/cowboy/src/cowboy_stream_h.erl\"},{line,310}]},{cowboy_stream_h,request_process,3,[{file,\"/emqx/deps/cowboy/src/cowboy_stream_h.erl\"},{line,299}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,333}]}]"
}
```

See also https://github.com/emqx/emqx-operator/issues/1256.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
