### PR TITLE
test(greptimedb): wait for grpc channel before async write health check

### DIFF
--- a/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_connector_SUITE.erl
+++ b/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_connector_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx_connector/include/emqx_connector.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(GREPTIMEDB_RESOURCE_MOD, emqx_bridge_greptimedb_connector).
 
@@ -89,6 +90,9 @@ t_async_write_after_health_check(Config) ->
     ],
     {ok, Client} = greptimedb:start_client(Options),
     try
+        %% grpcbox adds the channel's subchannel after start_client returns.
+        %% Until then, a health check fails with no_endpoints.
+        ?retry(100, 50, true = greptimedb:is_alive(Client)),
         Ref = make_ref(),
         TestPid = self(),
         [{_, PoolWorker}] = ecpool:workers(Pool),


### PR DESCRIPTION
Test-only fix for a flaky `emqx_bridge_greptimedb_connector_SUITE:t_async_write_after_health_check`.

Seen on dev-510 in runs 33620008353 and 34513872801. Both fail with `{badmatch, false}` at `true = greptimedb:is_alive(Client)`, and the case ran for under 1 ms.

## Cause

`greptimedb_worker` starts its grpcbox channel without `sync_start`. grpcbox 0.17.1 then adds the subchannel to the pool in an internal event after `grpcbox_channel:init/1` returns. So `greptimedb:start_client/1` can return before the channel has a subchannel. The one-point `async_write` is only batched and sends no RPC. The next call, `is_alive`, is the first RPC. It fails at once with `{error, no_endpoints}`.

## Fix

Wait until `greptimedb:is_alive(Client)` returns `true` before the test sequence starts. The strict `is_alive` assertion after `async_write` stays, so the #17952 regression is still covered.

## Local check

300 loops each against a GreptimeDB container, calling `is_alive` after the same calls the case makes:

- without the barrier: 35 `no_endpoints`, 265 `true`
- with the barrier: 300 `true`

dev-60 has the same case in `emqx_bridge_greptimedb_SUITE.erl`; it needs a separate backport.
