### PR TITLE
fix(dashboard): handle SSO resource start timeout

### DIFF
--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_manager.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_manager.erl
@@ -323,6 +323,14 @@ start_resource_if_enabled(ResourceId, {ok, _} = Result, #{enable := true, backen
     case emqx_resource:start(ResourceId, ?DEFAULT_START_OPTS) of
         ok ->
             ok;
+        timeout ->
+            ?SLOG(error, #{
+                msg => "start_backend_failed",
+                resource_id => ResourceId,
+                reason => timeout
+            }),
+            update_last_error(Backend, timeout),
+            ok;
         {error, Reason} ->
             SafeReason = emqx_utils:redact(Reason),
             ?SLOG(error, #{

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_ldap_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_ldap_SUITE.erl
@@ -35,6 +35,7 @@
 all() ->
     [
         t_bad_create,
+        t_start_timeout,
         t_create,
         t_update,
         t_get,
@@ -110,6 +111,53 @@ t_bad_create(_) ->
         ?assertMatch([], emqx_resource_manager:list_group(?RESOURCE_GROUP))
     ),
     ok.
+
+t_start_timeout({init, Config}) ->
+    Config;
+t_start_timeout({'end', _Config}) ->
+    ok;
+t_start_timeout(_) ->
+    Path = uri(["sso", "ldap"]),
+    ok = meck:new(emqx_resource, [passthrough, no_history, no_link]),
+    ok = meck:expect(emqx_resource, start, fun(_ResourceId, _Opts) -> timeout end),
+    try
+        Config = ldap_config(#{<<"enable">> => true}),
+        {ok, 400, ErrorBody} = request(put, Path, Config),
+        ?assertNotEqual(nomatch, binary:match(ErrorBody, <<"timeout">>)),
+        State = emqx_dashboard_sso_manager:lookup_state(ldap),
+        ?assertMatch(
+            #{resource_id := _}, State
+        ),
+        ResourceId = maps:get(resource_id, State),
+        ?assertMatch([_], emqx_resource_manager:list_group(?RESOURCE_GROUP)),
+        ?assertMatch(
+            {ok, 400, _},
+            request(put, Path, Config#{<<"filter">> => ?LDAP_FILTER_WITH_GROUP})
+        ),
+        ?assertMatch(
+            #{resource_id := ResourceId}, emqx_dashboard_sso_manager:lookup_state(ldap)
+        ),
+        ok = emqx_dashboard_sso_manager:delete(ldap),
+        ?retry(
+            _Interval = 100,
+            _NAttempts = 10,
+            ?assertMatch([], emqx_resource_manager:list_group(?RESOURCE_GROUP))
+        )
+    after
+        case emqx:get_config(?MOD_KEY_PATH, undefined) of
+            undefined ->
+                ok;
+            null ->
+                ok;
+            _ ->
+                catch emqx_dashboard_sso_manager:delete(ldap)
+        end,
+        lists:foreach(
+            fun(ResId) -> catch emqx_resource:remove_local(ResId) end,
+            emqx_resource_manager:list_group(?RESOURCE_GROUP)
+        ),
+        catch meck:unload(emqx_resource)
+    end.
 
 t_create({init, Config}) ->
     Config;

--- a/changes/ee/fix-18904.en.md
+++ b/changes/ee/fix-18904.en.md
@@ -1,0 +1,3 @@
+Fixed an issue where creating or updating an enabled Dashboard SSO backend could fail with an internal error when its resource remained in the `connecting` state until the start timeout.
+
+The backend now remains tracked with its resource ID so that it can be cleaned up after the start timeout.


### PR DESCRIPTION
Fixes: https://github.com/emqx/emqx-dev-team-tasks/issues/296
Release version: 6.0.4
Introduced in: N/A

## Summary

When an enabled Dashboard SSO backend resource stayed in `connecting` beyond its start timeout, `emqx_resource:start/2` returned the atom `timeout`. The SSO manager handled only `ok` and `{error, Reason}`, so the configuration update crashed with `case_clause` before the provider state, including its `resource_id`, was saved.

The SSO manager now treats `timeout` as a non-fatal resource start failure: it records the error and preserves the successful resource result so the backend remains tracked and can be cleaned up. The LDAP CT suite adds regression coverage for create, update, resource tracking, and cleanup.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-18904.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)