### PR TITLE
fix(connector api): tolerate obfuscated non-string values when updating (d58)

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -31,7 +31,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.23.4"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.5.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.46.3"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.46.4"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}}

--- a/apps/emqx_bridge/src/emqx_bridge.app.src
+++ b/apps/emqx_bridge/src/emqx_bridge.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge, [
     {description, "EMQX bridges"},
-    {vsn, "0.2.10"},
+    {vsn, "0.2.11"},
     {registered, [emqx_bridge_sup]},
     {mod, {emqx_bridge_app, []}},
     {applications, [

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -592,7 +592,11 @@ schema("/bridges_probe") ->
 
 '/bridges_probe'(post, Request) ->
     RequestMeta = #{module => ?MODULE, method => post, path => "/bridges_probe"},
-    case emqx_dashboard_swagger:filter_check_request_and_translate_body(Request, RequestMeta) of
+    case
+        emqx_dashboard_swagger:filter_check_request_and_translate_body(Request, RequestMeta, #{
+            maybe_obfuscated => true
+        })
+    of
         {ok, #{body := #{<<"type">> := BridgeType} = Params}} ->
             Params1 = maybe_deobfuscate_bridge_probe(Params),
             Params2 = maps:remove(<<"type">>, Params1),

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
@@ -17,7 +17,7 @@
     desc/1
 ]).
 -export([
-    service_account_json_validator/1,
+    service_account_json_validator/2,
     service_account_json_converter/2
 ]).
 
@@ -103,7 +103,7 @@ fields(connector_config) ->
                 binary(),
                 #{
                     required => true,
-                    validator => fun ?MODULE:service_account_json_validator/1,
+                    validator => fun ?MODULE:service_account_json_validator/2,
                     converter => fun ?MODULE:service_account_json_converter/2,
                     sensitive => true,
                     desc => ?DESC("service_account_json")
@@ -393,11 +393,22 @@ type_field_consumer() ->
 name_field() ->
     {name, mk(binary(), #{required => true, desc => ?DESC("desc_name")})}.
 
--spec service_account_json_validator(binary()) ->
+-spec service_account_json_validator(binary(), hocon_tconf:opts()) ->
     ok
     | {error, {wrong_type, term()}}
     | {error, {missing_keys, [binary()]}}.
-service_account_json_validator(Val) ->
+service_account_json_validator(Val, Opts) ->
+    MaybeObfuscated = maps:get(maybe_obfuscated, Opts, false),
+    Redacted = emqx_utils_redact:redacted_value(),
+    case Val of
+        Redacted when MaybeObfuscated ->
+            %% we'll deobfuscate in the http api handler
+            ok;
+        _ ->
+            do_service_account_json_validator(Val)
+    end.
+
+do_service_account_json_validator(Val) ->
     case emqx_utils_json:safe_decode(Val, [return_maps]) of
         {ok, Map} ->
             ExpectedKeys = [

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -69,7 +69,8 @@ single_config_tests() ->
         t_get_status_timeout_calling_workers,
         t_on_start_ehttpc_pool_already_started,
         t_attributes,
-        t_bad_attributes
+        t_bad_attributes,
+        t_service_account_json_redacted_round_trip
     ].
 
 only_sync_tests() ->
@@ -1982,4 +1983,39 @@ t_deprecated_connector_resource_opts(Config) ->
             ok
         end
     ),
+    ok.
+
+%% Verifies that the redacted bridge body returned by the v1 HTTP API can be sent back via
+%% update and probe, and that the stored service account JSON is kept.
+t_service_account_json_redacted_round_trip(Config) ->
+    ServiceAccountJSON = ?config(service_account_json, Config),
+    Name = ?config(gcp_pubsub_name, Config),
+    TCConfig = [
+        {bridge_type, ?BRIDGE_V1_TYPE_BIN},
+        {bridge_name, Name},
+        {bridge_config, #{}}
+        | Config
+    ],
+    ?assertMatch({ok, _}, create_bridge_http(Config)),
+    {ok, #{<<"service_account_json">> := <<"******">>} = RedactedParams0} =
+        emqx_bridge_testlib:get_bridge_api(TCConfig),
+    RedactedParams = maps:without(
+        [
+            <<"type">>,
+            <<"name">>,
+            <<"status">>,
+            <<"status_reason">>,
+            <<"node_status">>
+        ],
+        RedactedParams0
+    ),
+    ?assertMatch(
+        {ok, #{<<"service_account_json">> := <<"******">>}},
+        emqx_bridge_testlib:update_bridge_api(TCConfig, RedactedParams)
+    ),
+    ?assertEqual(
+        ServiceAccountJSON,
+        emqx_bridge_gcp_pubsub_utils:persisted_service_account_json(?CONNECTOR_TYPE_BIN, Name)
+    ),
+    ?assertMatch({ok, _}, emqx_bridge_testlib:probe_bridge_api(TCConfig, RedactedParams)),
     ok.

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_tests.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_tests.erl
@@ -65,7 +65,10 @@ parse(Hocon) ->
     Conf.
 
 check(Conf) when is_map(Conf) ->
-    hocon_tconf:check_plain(emqx_bridge_schema, Conf).
+    check(Conf, #{}).
+
+check(Conf, Opts) when is_map(Conf) ->
+    hocon_tconf:check_plain(emqx_bridge_schema, Conf, Opts).
 
 -define(validation_error(Reason, Value),
     {emqx_bridge_schema, [
@@ -143,6 +146,47 @@ producer_attributes_validator_test_() ->
                             }
                         ]
                     })
+                )
+            )}
+    ].
+
+%% The redacted value passes validation only when the caller marks the input as possibly
+%% obfuscated.  The HTTP API handler then restores the stored value.
+service_account_json_redacted_test_() ->
+    emqx_utils:interactive_load(emqx_bridge_enterprise),
+    BaseConf = parse(gcp_pubsub_producer_hocon()),
+    RedactedConf = emqx_utils_maps:deep_put(
+        [<<"bridges">>, <<"gcp_pubsub">>, <<"my_producer">>, <<"service_account_json">>],
+        BaseConf,
+        <<"******">>
+    ),
+    [
+        {"redacted value is not json",
+            ?_assertThrow(
+                ?validation_error("not a json", <<"******">>),
+                check(RedactedConf)
+            )},
+        {"redacted value tolerated when maybe obfuscated",
+            ?_assertMatch(
+                ?ok_config(#{<<"service_account_json">> := <<"******">>}),
+                check(RedactedConf, #{maybe_obfuscated => true})
+            )},
+        {"invalid json still rejected when maybe obfuscated",
+            ?_assertThrow(
+                %% the error value is redacted because the field is sensitive
+                ?validation_error("not a json", _),
+                check(
+                    emqx_utils_maps:deep_put(
+                        [
+                            <<"bridges">>,
+                            <<"gcp_pubsub">>,
+                            <<"my_producer">>,
+                            <<"service_account_json">>
+                        ],
+                        BaseConf,
+                        <<"*****">>
+                    ),
+                    #{maybe_obfuscated => true}
                 )
             )}
     ].

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_utils.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_utils.erl
@@ -7,6 +7,8 @@
 -compile(nowarn_export_all).
 -compile(export_all).
 
+-include_lib("eunit/include/eunit.hrl").
+
 generate_service_account_json() ->
     PrivateKeyPEM = generate_private_key_pem(),
     service_account_json(PrivateKeyPEM).
@@ -32,3 +34,69 @@ service_account_json(PrivateKeyPEM) ->
         <<"client_x509_cert_url">> =>
             <<"https://www.googleapis.com/robot/v1/metadata/x509/test%40myproject.iam.gserviceaccount.com">>
     }.
+
+%% Reads the connector via the HTTP API, then sends the redacted body back via update and
+%% probe.  Both must succeed, and the stored service account JSON must stay unchanged.
+%% Expects the connector to be already created.
+assert_redacted_service_account_json_round_trip(TCConfig) ->
+    #{connector_type := Type, connector_name := Name} =
+        emqx_bridge_v2_testlib:get_common_values(TCConfig),
+    ServiceAccountJSON = proplists:get_value(service_account_json, TCConfig),
+    ?assertEqual(ServiceAccountJSON, persisted_service_account_json(Type, Name)),
+    {200, #{<<"service_account_json">> := <<"******">>} = RedactedParams0} =
+        emqx_bridge_v2_testlib:simplify_result(
+            emqx_bridge_v2_testlib:get_connector_api(Type, Name)
+        ),
+    RedactedParams = maps:without(
+        [
+            <<"actions">>,
+            <<"sources">>,
+            <<"name">>,
+            <<"type">>,
+            <<"status">>,
+            <<"status_reason">>,
+            <<"node_status">>
+        ],
+        RedactedParams0
+    ),
+    ?assertMatch(
+        {200, #{<<"status">> := <<"connected">>, <<"service_account_json">> := <<"******">>}},
+        emqx_bridge_v2_testlib:simplify_result(
+            emqx_bridge_v2_testlib:update_connector_api(Name, Type, RedactedParams)
+        )
+    ),
+    ?assertEqual(ServiceAccountJSON, persisted_service_account_json(Type, Name)),
+    ?assertMatch(
+        {200, #{<<"service_account_json">> := <<"******">>}},
+        emqx_bridge_v2_testlib:simplify_result(
+            emqx_bridge_v2_testlib:get_connector_api(Type, Name)
+        )
+    ),
+    ?assertMatch(
+        {204, _},
+        emqx_bridge_v2_testlib:probe_connector_api2(TCConfig, RedactedParams)
+    ),
+    %% A probe for a connector that does not exist has no stored value to restore.
+    ?assertMatch(
+        {400, _},
+        emqx_bridge_v2_testlib:probe_connector_api2(
+            [{connector_name, <<Name/binary, "_new">>} | TCConfig],
+            RedactedParams
+        )
+    ),
+    ok.
+
+%% Returns the service account JSON stored in cluster.hocon, decoded to a map.
+persisted_service_account_json(Type, Name) ->
+    {ok, Hocon} = hocon:files([application:get_env(emqx, cluster_hocon_file, undefined)]),
+    case
+        emqx_utils_maps:deep_get(
+            [<<"connectors">>, Type, Name, <<"service_account_json">>],
+            Hocon
+        )
+    of
+        Bin when is_binary(Bin) ->
+            emqx_utils_json:decode(Bin, [return_maps]);
+        Map when is_map(Map) ->
+            Map
+    end.

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_consumer_SUITE.erl
@@ -365,3 +365,10 @@ t_legacy_service_account_json_redact(TCConfig) ->
         get_connector_api(TCConfig)
     ),
     ok.
+
+%% Verifies that the redacted connector body returned by the HTTP API can be sent back via
+%% update and probe, and that the stored service account JSON is kept.
+t_service_account_json_redacted_round_trip(TCConfig) ->
+    ?assertMatch({201, _}, create_connector_api(TCConfig, #{})),
+    ok = emqx_bridge_gcp_pubsub_utils:assert_redacted_service_account_json_round_trip(TCConfig),
+    ok.

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_producer_SUITE.erl
@@ -421,3 +421,10 @@ t_legacy_service_account_json_redact(TCConfig) ->
         get_connector_api(TCConfig)
     ),
     ok.
+
+%% Verifies that the redacted connector body returned by the HTTP API can be sent back via
+%% update and probe, and that the stored service account JSON is kept.
+t_service_account_json_redacted_round_trip(TCConfig) ->
+    ?assertMatch({201, _}, create_connector_api(TCConfig, #{})),
+    ok = emqx_bridge_gcp_pubsub_utils:assert_redacted_service_account_json_round_trip(TCConfig),
+    ok.

--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -83,12 +83,14 @@ check_api_schema(Request, #{path := "/connectors/:id", method := put = Method} =
             {_, Ref} = emqx_connector_info:api_schema(ConnectorType, atom_to_list(Method)),
             Schema = hoconsc:mk(Ref),
             emqx_dashboard_swagger:filter_check_request(
-                Request, refine_api_schema(Schema, Metadata)
+                Request, refine_api_schema(Schema, Metadata), #{maybe_obfuscated => true}
             )
     catch
         throw:#{reason := Reason} ->
             ?NOT_FOUND(<<"Invalid connector id, ", Reason/binary>>)
     end;
+check_api_schema(Request, #{path := "/connectors_probe", method := post} = Metadata) ->
+    emqx_dashboard_swagger:filter_check_request(Request, Metadata, #{maybe_obfuscated => true});
 check_api_schema(Request, Metadata) ->
     emqx_dashboard_swagger:filter_check_request(Request, Metadata).
 
@@ -405,7 +407,11 @@ schema("/connectors_probe") ->
 
 '/connectors_probe'(post, Request) ->
     RequestMeta = #{module => ?MODULE, method => post, path => "/connectors_probe"},
-    case emqx_dashboard_swagger:filter_check_request_and_translate_body(Request, RequestMeta) of
+    case
+        emqx_dashboard_swagger:filter_check_request_and_translate_body(Request, RequestMeta, #{
+            maybe_obfuscated => true
+        })
+    of
         {ok, #{body := #{<<"type">> := ConnType} = Params}} ->
             Params1 = maybe_deobfuscate_connector_probe(Params),
             case

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -34,7 +34,9 @@
 
 -export([
     filter_check_request/2,
+    filter_check_request/3,
     filter_check_request_and_translate_body/2,
+    filter_check_request_and_translate_body/3,
     gen_api_schema_json_iodata/3
 ]).
 
@@ -355,10 +357,23 @@ compose_filters(Filter1, Filter2) ->
 %%------------------------------------------------------------------------------
 
 filter_check_request_and_translate_body(Request, RequestMeta) ->
-    translate_req(Request, RequestMeta, fun check_and_translate/3).
+    filter_check_request_and_translate_body(Request, RequestMeta, _Opts = #{}).
+
+filter_check_request_and_translate_body(Request, RequestMeta, Opts) ->
+    translate_req(Request, RequestMeta, with_extra_opts(fun check_and_translate/3, Opts)).
 
 filter_check_request(Request, RequestMeta) ->
-    translate_req(Request, RequestMeta, fun check_only/3).
+    filter_check_request(Request, RequestMeta, _Opts = #{}).
+
+filter_check_request(Request, RequestMeta, Opts) ->
+    translate_req(Request, RequestMeta, with_extra_opts(fun check_only/3, Opts)).
+
+with_extra_opts(CheckFun, Opts1) when map_size(Opts1) =:= 0 ->
+    CheckFun;
+with_extra_opts(CheckFun, Opts1) ->
+    fun(Schema, Map, Opts0) ->
+        CheckFun(Schema, Map, maps:merge(Opts0, Opts1))
+    end.
 
 translate_req(Request, ReqMeta = #{module := Module}, CheckFun) ->
     Spec = find_req_apispec(ReqMeta),

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -18,9 +18,12 @@
 
 -export([redact/1, redact/2, redact_headers/1, is_redacted/2, is_redacted/3]).
 -export([deobfuscate/2]).
+-export([redacted_value/0]).
 
 -define(REDACT_VAL, "******").
 -define(IS_KEY_HEADERS(K), (K == headers orelse K == <<"headers">> orelse K == "headers")).
+
+redacted_value() -> <<?REDACT_VAL>>.
 
 %% NOTE: keep alphabetical order
 is_sensitive_key(access_key_id) -> true;

--- a/mix.exs
+++ b/mix.exs
@@ -189,7 +189,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.4", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.13.0", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
-  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.3", override: true}
+  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.4", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}
   # in conflict by ehttpc and emqtt
   def common_dep(:gun), do: {:gun, "2.1.0", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -97,7 +97,7 @@
     {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.5"}}},
     {getopt, "1.0.2"},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.46.3"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.46.4"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {sasl_auth, "2.3.3"},
     {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}},


### PR DESCRIPTION
Backport of #18365 to dev-58.

Fixes #18907

Release version:
5.8.12, 5.9.4, 5.10.5

## Summary

Since #18317, `GET /connectors/:id` returns `service_account_json` of a GCP PubSub connector as `******`.
The request-body schema check runs before the handler restores redacted values.
The field validator JSON-decodes the value, so it rejects `******` with `not a json`.
As a result, Test Connection and update fail with 400 when the Dashboard sends back the body it read.

Changes:

- `emqx_dashboard_swagger`: add `filter_check_request/3` and `filter_check_request_and_translate_body/3`.
  They merge extra options into the hocon check options.
- `emqx_connector_api`: pass `maybe_obfuscated => true` when checking `PUT /connectors/:id` and `POST /connectors_probe`.
- `emqx_bridge_api`: pass the same option for `POST /bridges_probe`.
  The v1 probe had the same bug. v6 has no v1 bridge API, so #18365 did not cover it.
  `PUT /bridges/:id` does not run a schema check before the handler, so it needs no change.
- `emqx_bridge_gcp_pubsub`: the validator accepts `******` when `maybe_obfuscated` is set.
  The handler then replaces it with the stored value.
  Create requests do not set the option and still reject `******`.
  A probe for a connector that does not exist also still fails, because there is no stored value.
- Bump hocon to 0.46.4 (only change since 0.46.3: arity-2 validators that receive the check options).

No changelog: the regression is only in 5.10.5 release candidates.

## Tests

- `emqx_bridge_v2_gcp_pubsub_{producer,consumer}_SUITE`: GET, PUT the redacted body back, probe with it.
  Check that the stored service account JSON is unchanged and still masked on GET.
- `emqx_bridge_gcp_pubsub_producer_SUITE`: the same round trip through the v1 `/bridges` API.
- `emqx_bridge_gcp_pubsub_tests`: schema check with and without `maybe_obfuscated`.

## Audit of other v5 redaction changes

I checked every key made sensitive in `emqx_utils_redact` since `e5.8.11` / `e5.10.4` for a request-schema type or validator that rejects `******`.

- `service_account_json`: fixed here (connector PUT and probe, v1 bridge probe).
- `client_jwks` (OIDC SSO, made sensitive in 26dfec13f2, first released in `e5.9.3`): not fixed here.
  The field is a union of `none` and a struct. The redacted `******` matches neither, so `PUT /sso/oidc` with the body from `GET` fails schema validation.
  dev-60 fixed this in #18576 and #18646. The fix needs a separate backport.
- The new sensitive header names (`api-key`, `cookie`, `x-api-key`, `x-auth-token`) are values in `map()` fields, and `deobfuscate/2` restores them. No change needed.
- The other new keys (`access_token`, `id_token`, `refresh_token`, `jwk`, `mfa_token`, `old_pwd`, `new_pwd`) are not config schema fields.
