### PR TITLE
test(shared_sub): join the peer before starting its apps

### DIFF
--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -1445,12 +1445,15 @@ setup_node(Node, Port) ->
     ok = pair_gen_rpc(node(), MyPort, PeerPort),
     ok = pair_gen_rpc(Node, PeerPort, MyPort),
 
+    %% warm it up, also assert the peer ndoe name
+    Node = emqx_rpc:call(Node, erlang, node, []),
+    %% Join before starting the apps: a join restarts the app stack,
+    %% which would take the peer's listeners down after they came up.
+    ok = rpc:call(Node, mria, join, [node()]),
+
     %% Here we start the node and make it join the cluster
     ok = rpc:call(Node, emqx_common_test_helpers, start_apps, [[], EnvHandler]),
 
-    %% warm it up, also assert the peer ndoe name
-    Node = emqx_rpc:call(Node, erlang, node, []),
-    rpc:call(Node, mria, join, [node()]),
     ok.
 
 get_tcp_mqtt_port(Node) ->


### PR DESCRIPTION
Test-only fix for a flaky `emqx_shared_sub_SUITE:t_local`.

It failed on #18909 (run 34587140860) with `{'EXIT', {shutdown, econnrefused}}`.

## Cause

`setup_node/2` started the peer apps first and then called `mria:join/1`. The join restarts the app stack on the peer, so the peer's TCP listener was briefly down. The case connected to the peer listener in that window.

## Fix

Join first and check the result, then start the apps. `start_apps` returns after the listeners are up. This is the `setup_node/2` part of cecbe3cf06, which dev-510 and dev-60 already have. The rest of that commit needs `emqx_cth_cluster:sync_routes/2`, which dev-58 lacks, so it is not included.

It covers every case that connects to a peer listener: `t_local`, `t_remote` and `t_stats`.

The dev-58 → dev-59 sync carries this to dev-59.
