### PR TITLE
chore(deps): bump esockd to 5.17.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -175,7 +175,7 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "1.0.1", override: true}
-  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.4", override: true}
+  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.17.5", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.46.5", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.7", override: true}


### PR DESCRIPTION
Bump esockd from 5.17.4 to 5.17.5.

esockd 5.17.5 includes emqx/esockd#230:

- The acceptor counts two new accept results: `closed_early` (the peer closed or reset the socket before the connection process started) and `closed_forbidden` (the access rules denied the peer).
- `closed_other_reasons` now counts only `ignore`, connection start errors and crashes.
- A missing metric row no longer crashes the caller of `esockd_server:inc_stats/3` and `dec_stats/3`.

EMQX does not read the new counters yet. A follow-up PR on `dev-70` shows them in `emqx ctl listeners`.

Release version: 6.3.1, 7.0.0