### PR TITLE
feat(kafka): IPv6 support for Kafka, Confluent and Azure Event Hubs connectors

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -3375,8 +3375,6 @@ do_parse_server(Str, Opts) ->
         false ->
             ok
     end,
-    %% do not split with space, there should be no space allowed between host and port
-    Tokens = string:tokens(Str, ":"),
     Context = #{
         not_expecting_port => NotExpectingPort,
         not_expecting_scheme => NotExpectingScheme,
@@ -3384,7 +3382,84 @@ do_parse_server(Str, Opts) ->
         default_scheme => DefaultScheme,
         opts => Opts
     },
-    check_server_parts(Tokens, Context).
+    case parse_ipv6_server(Str) of
+        {ok, Scheme, Host, Port} ->
+            check_ipv6_server(Scheme, Host, Port, Context);
+        false ->
+            %% do not split with space, there should be no space allowed between host and port
+            Tokens = string:tokens(Str, ":"),
+            check_server_parts(Tokens, Context)
+    end.
+
+%% Match `[scheme://][ipv6]:port' (port optional) using emqx_utils_uri:parse/1.
+%% Return `false' for any other form, so it is handled by check_server_parts/2.
+%% The token parser rejects every bracketed IPv6 address, so this adds new
+%% accepted inputs without changing the result for inputs it accepted before.
+parse_ipv6_server(Str) ->
+    maybe
+        true ?= lists:member($[, Str),
+        URIString =
+            case string:find(Str, "//") of
+                nomatch -> "//" ++ Str;
+                _ -> Str
+            end,
+        URIBin = unicode:characters_to_binary(URIString),
+        true ?= is_binary(URIBin),
+        #{
+            scheme := Scheme,
+            path := <<>>,
+            query := undefined,
+            fragment := undefined,
+            authority := #{host_type := ipv6, userinfo := undefined, host := HostBin, port := Port}
+        } ?= emqx_utils_uri:parse(URIBin),
+        Host = binary_to_list(HostBin),
+        {ok, _} ?= inet:parse_ipv6strict_address(Host),
+        {ok, uri_scheme(Scheme), Host, Port}
+    else
+        _ -> false
+    end.
+
+uri_scheme(undefined) -> undefined;
+uri_scheme(Scheme) -> binary_to_list(Scheme).
+
+check_ipv6_server(Scheme, Host, Port, Context) ->
+    #{
+        not_expecting_scheme := NotExpectingScheme,
+        not_expecting_port := NotExpectingPort,
+        default_port := DefaultPort,
+        default_scheme := DefaultScheme,
+        opts := Opts
+    } = Context,
+    SchemePart = check_server_scheme(Scheme, NotExpectingScheme, DefaultScheme, Opts),
+    PortPart = check_server_port(Port, NotExpectingPort, DefaultPort),
+    maps:merge(#{hostname => Host}, maps:merge(SchemePart, PortPart)).
+
+check_server_scheme(undefined, _NotExpectingScheme, DefaultScheme, _Opts) when
+    is_list(DefaultScheme)
+->
+    #{scheme => DefaultScheme};
+check_server_scheme(undefined, true, _DefaultScheme, _Opts) ->
+    #{};
+check_server_scheme(undefined, false, _DefaultScheme, _Opts) ->
+    throw("missing_scheme");
+check_server_scheme(Scheme, NotExpectingScheme, _DefaultScheme, Opts) ->
+    NotExpectingScheme andalso throw("not_expecting_scheme"),
+    #{scheme => check_scheme(Scheme, Opts)}.
+
+check_server_port(undefined, _NotExpectingPort, DefaultPort) when is_integer(DefaultPort) ->
+    #{port => DefaultPort};
+check_server_port(undefined, true, _DefaultPort) ->
+    #{};
+check_server_port(undefined, false, _DefaultPort) ->
+    throw("missing_port_number");
+check_server_port(Port, NotExpectingPort, _DefaultPort) when is_integer(Port) ->
+    NotExpectingPort andalso throw("not_expecting_port_number"),
+    #{port => check_port_range(Port)}.
+
+check_port_range(Port) when Port > 65535 ->
+    throw("port_number_too_large");
+check_port_range(Port) ->
+    Port.
 
 check_server_parts([Scheme, "//" ++ Hostname, Port], Context) ->
     #{

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -697,6 +697,62 @@ parse_server_test_() ->
                     }
                 )
             )
+        ),
+        ?T(
+            "ipv6 in brackets, no port",
+            ?assertEqual(
+                [#{hostname => "::1", port => DefaultPort}],
+                Parse(<<"[::1]">>)
+            )
+        ),
+        ?T(
+            "ipv6 in brackets, with port",
+            ?assertEqual(
+                [#{hostname => "::1", port => 9999}],
+                Parse(<<"[::1]:9999">>)
+            )
+        ),
+        ?T(
+            "full ipv6 in brackets, with port",
+            ?assertEqual(
+                [#{hostname => "2a00:1098:2b::1:2e12:3a1f", port => 1877}],
+                Parse(<<"[2a00:1098:2b::1:2e12:3a1f]:1877">>)
+            )
+        ),
+        ?T(
+            "ipv6 in brackets with scheme and port",
+            ?assertEqual(
+                #{scheme => "pulsar+ssl", hostname => "::1", port => 6651},
+                emqx_schema:parse_server(
+                    "pulsar+ssl://[::1]:6651",
+                    #{
+                        default_port => 6650,
+                        supported_schemes => ["pulsar", "pulsar+ssl"]
+                    }
+                )
+            )
+        ),
+        ?T(
+            "multiple ipv6 servers in brackets, with ports",
+            ?assertEqual(
+                [
+                    #{hostname => "::1", port => 1234},
+                    #{hostname => "fe80::1", port => 2345}
+                ],
+                Parse("[::1]:1234, [fe80::1]:2345")
+            )
+        ),
+        ?T(
+            "ipv6 in brackets, port too large",
+            ?assertThrow("port_number_too_large", Parse("[::1]:65536"))
+        ),
+        ?T(
+            "invalid ipv6 in brackets",
+            ?assertThrow("bad_host_port", Parse("[zz::1]:1234"))
+        ),
+        ?T(
+            "ipv6 in brackets, with userinfo",
+            ?assertThrow("bad_host_port", Parse("user@[::1]:1234"))
         )
     ].
 

--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     {wolff, "4.1.11"},
-    {kafka_protocol, "4.3.2"},
+    {kafka_protocol, "4.3.7"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.5.5"},
     {snappyer, "1.2.10"},

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
@@ -157,6 +157,21 @@ aeh_producer_test_() ->
                     })
                 )
             )},
+        {"ipv6 bootstrap hosts and ip_family",
+            ?_assertMatch(
+                ?ok_config(
+                    #{
+                        <<"bootstrap_hosts">> := <<"[fd00::5]:9093,[::1]">>,
+                        <<"socket_opts">> := #{<<"ip_family">> := ipv6}
+                    }
+                ),
+                check(
+                    Override(#{
+                        <<"bootstrap_hosts">> => <<"[fd00::5]:9093,[::1]">>,
+                        <<"socket_opts">> => #{<<"ip_family">> => <<"ipv6">>}
+                    })
+                )
+            )},
         {"ssl disabled",
             ?_assertThrow(
                 ?validation_error("Expected: true" ++ _, <<"false">>),

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     {wolff, "4.1.11"},
-    {kafka_protocol, "4.3.2"},
+    {kafka_protocol, "4.3.7"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.5.5"},
     {snappyer, "1.2.10"},

--- a/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_tests.erl
+++ b/apps/emqx_bridge_confluent/test/emqx_bridge_confluent_tests.erl
@@ -142,6 +142,21 @@ confluent_producer_connector_test_() ->
                 ),
                 check_connector(BaseConf)
             )},
+        {"ipv6 bootstrap hosts and ip_family",
+            ?_assertMatch(
+                ?ok_connector_config(
+                    #{
+                        <<"bootstrap_hosts">> := <<"[fd00::5]:9092,[::1]">>,
+                        <<"socket_opts">> := #{<<"ip_family">> := ipv6}
+                    }
+                ),
+                check_connector(
+                    Override(#{
+                        <<"bootstrap_hosts">> => <<"[fd00::5]:9092,[::1]">>,
+                        <<"socket_opts">> => #{<<"ip_family">> => <<"ipv6">>}
+                    })
+                )
+            )},
         {"ssl disabled",
             ?_assertThrow(
                 ?connector_validation_error("Expected: true" ++ _, <<"false">>),

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     {wolff, "4.1.11"},
-    {kafka_protocol, "4.3.2"},
+    {kafka_protocol, "4.3.7"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.5.5"},
     {snappyer, "1.2.10"},

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -354,7 +354,16 @@ fields(socket_opts) ->
                 default => <<"none">>,
                 desc => ?DESC(emqx_schema, socket_tcp_keepalive),
                 validator => fun emqx_schema:validate_tcp_keepalive/1
-            })}
+            })},
+        {ip_family,
+            mk(
+                enum([auto, ipv4, ipv6]),
+                #{
+                    default => auto,
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC(socket_ip_family)
+                }
+            )}
     ];
 fields(v1_producer_kafka_opts) ->
     OldSchemaFields =

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
@@ -54,6 +54,17 @@ socket_opts_loop([], Acc) ->
 socket_opts_loop([{tcp_keepalive, KeepAlive} | Rest], Acc) ->
     Acc1 = tcp_keepalive(KeepAlive) ++ Acc,
     socket_opts_loop(Rest, Acc1);
+socket_opts_loop([{ip_family, IpFamily} | Rest], Acc) ->
+    %% kafka_protocol connects with one address family only when the
+    %% options include `inet' or `inet6'. Otherwise, it tries IPv4 first
+    %% and falls back to IPv6 for hostnames.
+    Acc1 =
+        case IpFamily of
+            auto -> Acc;
+            ipv4 -> [inet | Acc];
+            ipv6 -> [inet6 | Acc]
+        end,
+    socket_opts_loop(Rest, Acc1);
 socket_opts_loop([{T, Bytes} | Rest], Acc) when
     T =:= sndbuf orelse T =:= recbuf orelse T =:= buffer
 ->

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
@@ -204,6 +204,64 @@ test_keepalive_validation(Name, Conf) ->
         [?_assertThrow(_, check(C)) || C <- InvalidConfs] ++
         [?_assertThrow(_, check_atom_key(C)) || C <- InvalidConfs].
 
+ipv6_bootstrap_hosts_validation_test_() ->
+    ProducerConf = parse(kafka_producer_new_hocon()),
+    ConsumerConf = parse(kafka_consumer_hocon()),
+    test_ipv6_bootstrap_hosts([<<"kafka">>, <<"myproducer">>], ProducerConf) ++
+        test_ipv6_bootstrap_hosts([<<"kafka_consumer">>, <<"my_consumer">>], ConsumerConf).
+
+test_ipv6_bootstrap_hosts(Name, Conf) ->
+    Path = [<<"bridges">>] ++ Name ++ [<<"bootstrap_hosts">>],
+    ValidConfs = [
+        emqx_utils_maps:deep_force_put(Path, Conf, Hosts)
+     || Hosts <- [<<"[::1]:9092">>, <<"[::1]">>, <<"[fd00::5]:9092,host2:9093">>]
+    ],
+    InvalidConf = emqx_utils_maps:deep_force_put(Path, Conf, <<"::1:9092">>),
+    [?_assertMatch(#{<<"bridges">> := _}, check(C)) || C <- ValidConfs] ++
+        [?_assertMatch(#{bridges := _}, check_atom_key(C)) || C <- ValidConfs] ++
+        [?_assertThrow(_, check(InvalidConf))].
+
+hosts_test_() ->
+    Hosts = fun emqx_bridge_kafka_impl:hosts/1,
+    [
+        ?_assertEqual([{"::1", 9092}], Hosts(<<"[::1]:9092">>)),
+        ?_assertEqual(
+            [{"fd00::5", 9092}, {"host2", 9093}],
+            Hosts(<<"[fd00::5]:9092,host2:9093">>)
+        ),
+        ?_assertEqual(
+            [{"::1", 9092}],
+            Hosts(emqx_schema:parse_servers(<<"[::1]">>, #{default_port => 9092}))
+        )
+    ].
+
+socket_opts_ip_family_test_() ->
+    Conf = parse(kafka_producer_new_hocon()),
+    Path = [<<"bridges">>, <<"kafka">>, <<"myproducer">>, <<"socket_opts">>, <<"ip_family">>],
+    SocketOpts = fun(C) ->
+        #{bridges := #{kafka := #{myproducer := #{socket_opts := Opts}}}} = check_atom_key(C),
+        emqx_bridge_kafka_impl:socket_opts(Opts)
+    end,
+    Families = fun(Opts) -> [F || F <- Opts, F =:= inet orelse F =:= inet6] end,
+    [
+        {"default adds no family option", ?_assertEqual([], Families(SocketOpts(Conf)))},
+        {"auto adds no family option",
+            ?_assertEqual(
+                [], Families(SocketOpts(emqx_utils_maps:deep_force_put(Path, Conf, <<"auto">>)))
+            )},
+        {"ipv4 adds inet",
+            ?_assertEqual(
+                [inet], Families(SocketOpts(emqx_utils_maps:deep_force_put(Path, Conf, <<"ipv4">>)))
+            )},
+        {"ipv6 adds inet6",
+            ?_assertEqual(
+                [inet6],
+                Families(SocketOpts(emqx_utils_maps:deep_force_put(Path, Conf, <<"ipv6">>)))
+            )},
+        {"bad value",
+            ?_assertThrow(_, check(emqx_utils_maps:deep_force_put(Path, Conf, <<"inet6">>)))}
+    ].
+
 %% assert compatibility
 bridge_schema_json_test() ->
     JSON = iolist_to_binary(emqx_dashboard_schema_api:bridge_schema_json()),

--- a/changes/ee/feat-18917.en.md
+++ b/changes/ee/feat-18917.en.md
@@ -1,0 +1,7 @@
+Added IPv6 support to the Kafka, Confluent and Azure Event Hubs connectors.
+
+- `bootstrap_hosts` accepts bracketed IPv6 addresses, for example `[::1]:9092` or `[fd00::5]:9092,host2:9093`.
+- The connectors can reach hostnames that resolve only to IPv6 addresses, and brokers that advertise IPv6 addresses.
+- The new `socket_opts.ip_family` option selects the IP address family. With the default `auto`, a hostname is tried over IPv4 first and then over IPv6. Set it to `ipv6` to connect over IPv6 only, or to `ipv4` to connect over IPv4 only.
+
+The upgraded Kafka client library also fixes a sync produce timeout. It could happen when SASL re-authentication ran while requests were still pending.

--- a/mix.exs
+++ b/mix.exs
@@ -290,13 +290,13 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),
-    do: {:kafka_protocol, "4.3.2", override: true}
+    do: {:kafka_protocol, "4.3.7", override: true}
 
   def common_dep(:brod), do: {:brod, "4.5.5"}
   ## TODO: remove `mix.exs` from `wolff` and remove this override
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.10", override: true}
-  def common_dep(:crc32cer), do: {:crc32cer, "1.1.2", override: true}
+  def common_dep(:crc32cer), do: {:crc32cer, "1.1.4", override: true}
   def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.8.1.1"}
 
   def common_dep(:erlavro),

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -256,6 +256,15 @@ socket_nodelay.desc:
 socket_nodelay.label:
 """No Delay"""
 
+socket_ip_family.desc: """~
+The IP address family used to connect to Kafka brokers.
+- <code>auto</code>: Connect to an IP address with its own family. For a hostname, try IPv4 first, then IPv6 if IPv4 fails.
+- <code>ipv4</code>: Connect over IPv4 only.
+- <code>ipv6</code>: Connect over IPv6 only. Use this when the brokers are reachable only over IPv6.~"""
+
+socket_ip_family.label:
+"""IP Family"""
+
 authentication.desc: """~
 Authentication configs.
 - <code>none</code>: No authentication.


### PR DESCRIPTION
Release versions:
<!--
run script ./scripts/rel-versions to get release versions
-->
5.10.5

Introduced in:
<!--
N/A: If this is a pre-release fix (e.g. found in QA phase).
pre-5.8: If it's an old one (5.8 is the earliest minor actively maintained).
VSN: The exact version wihch introduced the bug.
-->

## Summary

Kafka, Confluent and Azure Event Hubs connectors cannot reach brokers over IPv6 on 5.10:

- `bootstrap_hosts = "[::1]:9092"` fails schema validation with `bad_host_port`.
- kafka_protocol 4.3.2 resolves hosts over IPv4 only. IPv6-only hostnames and IPv6 addresses advertised in broker metadata fail with `nxdomain`.

This PR makes three changes.

1. **Bump kafka_protocol 4.3.2 → 4.3.7.** 4.3.7 connects to an IPv6 address with its own family. For a hostname it tries IPv4 first, then IPv6. It skips the fallback when `extra_sock_opts` contains `inet` or `inet6`. It also parses `[v6]:port` endpoints. 4.3.7 requires crc32cer `~> 1.1.4`. rebar3 now resolves 1.1.4, so the mix override pin moves to 1.1.4 too. The bump also brings the 4.3.4 fix for requests lost during SASL re-authentication. Brokers that metadata advertises with IPv6 addresses need no EMQX change.
2. **Accept bracketed IPv6 in `emqx_schema` server strings.** This ports the IPv6 parsing from f6bbc6834a (#17859), which builds on `emqx_utils_uri:parse/1`. It leaves out the MQTT connector and cluster link parts of that commit, and the SSRF check (dev-510 has none).
   Upstream replaces the colon-token parser for every input. That also rejects some values the old parser accepted, for example `host:`, `host: 1` and `host:+1`. The schema validator runs at boot, so a stored config with such a value would stop the node from starting after a patch upgrade. So here the token parser stays in place. The new code runs only when the bracketed host is a valid IPv6 address (`inet:parse_ipv6strict_address/1`) with no userinfo, path, query or fragment. The token parser rejects all of those inputs. I compared the old and new parsers on about 70 inputs × 7 option sets. Every result that was `ok` before is unchanged. Only bracketed IPv6 inputs differ.
3. **Add `socket_opts.ip_family`** (`auto | ipv4 | ipv6`, default `auto`, low importance). `ipv6` adds `inet6` to `extra_sock_opts`, so kafka_protocol connects over IPv6 only with no IPv4 attempt. `ipv4` adds `inet`. `auto` adds nothing, so existing configs produce the same `extra_sock_opts` as before. Confluent and Azure Event Hubs reuse the Kafka `socket_opts` struct and get the field too.

Why an enum and not an `ipv6_only` boolean: kafka_protocol 4.3.7 adds an IPv6 fallback for hostnames, which 4.3.2 did not have. `ipv4` restores the 4.3.2 behavior exactly for users who do not want that fallback. One enum covers the three kafka_protocol modes, and a later "IPv4 only" request will not need a second boolean. The name `ipv6_probe` (S3) is not reused: it means "try IPv6, then fall back to IPv4", which differs from the IPv6-only mode here.

Other connectors that use `parse_servers`/`servers_validator` (Pulsar, MongoDB, Redis, …) now also accept bracketed IPv6 at validation. Whether they connect over IPv6 depends on their client libraries. This PR does not change those clients.

Tests:
- `emqx_schema_tests`: the upstream IPv6 cases, plus port range, invalid bracketed host and userinfo cases.
- `emqx_bridge_kafka_tests`: bracketed `bootstrap_hosts` pass validation for producer and consumer. `hosts/1` returns `{"::1", 9092}`. `socket_opts/1` emits `inet6`/`inet` only for `ipv6`/`ipv4`, and no family option by default.
- `emqx_bridge_confluent_tests`, `emqx_bridge_azure_event_hub_tests`: bracketed `bootstrap_hosts` and `ip_family = ipv6` pass validation.
- Eunit of the other `parse_servers` users (MQTT, Pulsar, MongoDB, Oracle, SQL Server, InfluxDB, GCP PubSub, Snowflake, cluster link) pass unchanged.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
