### PR TITLE
fix(greptimedb): bump driver to v0.2.5-emqx.3

### DIFF
--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -26,7 +26,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
-      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1"}
+      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.3"}
     ]
   end
 end

--- a/apps/emqx_bridge_greptimedb/rebar.config
+++ b/apps/emqx_bridge_greptimedb/rebar.config
@@ -6,7 +6,7 @@
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}},
-    {greptimedb, {git, "https://github.com/emqx/greptimedb-ingester-erl", {tag, "v0.2.5-emqx.1"}}}
+    {greptimedb, {git, "https://github.com/emqx/greptimedb-ingester-erl", {tag, "v0.2.5-emqx.3"}}}
 ]}.
 {plugins, [rebar3_path_deps]}.
 {project_plugins, [erlfmt]}.

--- a/changes/ee/fix-18920.en.md
+++ b/changes/ee/fix-18920.en.md
@@ -1,0 +1,1 @@
+Fixed GreptimeDB connectors that switched between connected and disconnected under heavy write load. The health check no longer waits behind pending writes, so it fails only when GreptimeDB does not respond.

--- a/mix.exs
+++ b/mix.exs
@@ -439,7 +439,7 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:snappyer),
       common_dep(:crc32cer),
       {:opentsdb, github: "emqx/opentsdb-client-erl", tag: "v0.5.1", override: true},
-      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.1", override: true},
+      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.5-emqx.3", override: true},
       # The following two are dependencies of rabbit_common. They are needed here to
       # make mix not complain about conflicting versions
       {:thoas, github: "emqx/thoas", tag: "v1.0.0", override: true},


### PR DESCRIPTION
Release versions:
5.8.12, 5.9.4, 5.10.5

Introduced in:
pre-5.8

## Summary

Bump the GreptimeDB driver from `v0.2.5-emqx.1` to `v0.2.5-emqx.3`.

The driver sent the health check as a `gen_server:call` to a pool worker, with a 1 s timeout. The worker blocks for up to 10 s on each batch write. Under heavy write load the health check timed out, and the connector switched between connected and disconnected. The buffer stops sending while the connector is disconnected.

`v0.2.5-emqx.3` sends the health check RPC from the calling process, on the gRPC channel of one pool worker. Driver changes:

- emqx/greptimedb-ingester-erl#7: send the health check without calling the pool worker.
- emqx/greptimedb-ingester-erl#8: share the channel name function between the worker and the health check.
- emqx/greptimedb-ingester-erl#6 (already in `v0.2.5-emqx.2` on `dev-510`): recover stale gRPC channels. `dev-58` and `dev-59` did not have it yet.

## PR Checklist

- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
