### PR TITLE
fix(tls): default-certificate follow-ups

### DIFF
--- a/apps/emqx/src/emqx.erl
+++ b/apps/emqx/src/emqx.erl
@@ -58,7 +58,6 @@
     reset_config/3,
     data_dir/0,
     etc_file/1,
-    cert_file/1,
     mutable_certs_dir/0
 ]).
 
@@ -347,11 +346,6 @@ data_dir() ->
 %% @doc Returns the directory for user uploaded certificates.
 mutable_certs_dir() ->
     filename:join([data_dir(), certs]).
-
-%% @doc Returns the absolute path for a PEM certificate file
-%% which is installed or provisioned by sysadmin in $EMQX_ETC_DIR/certs.
-cert_file(SubPath) ->
-    filename:join([etc_dir(), "certs", SubPath]).
 
 %% @doc Returns the absolute path for a file in EMQX's etc dir.
 %% i.e. for rpm and deb installation, it's /etc/emqx/

--- a/apps/emqx/src/emqx_default_cert.erl
+++ b/apps/emqx/src/emqx_default_cert.erl
@@ -162,7 +162,8 @@ install(Files) ->
             ?SLOG(info, #{
                 msg => "default_tls_certificate_generated",
                 bundle => ?NODE_DEFAULT_CERT_BUNDLE_NAME,
-                dir => emqx_managed_certs:dir(?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME)
+                dir => emqx_managed_certs:dir(?global_ns, ?NODE_DEFAULT_CERT_BUNDLE_NAME),
+                key_type => emqx_utils_certs:default_key_type()
             }),
             ok;
         {error, _} = Error ->

--- a/apps/emqx_gateway/src/emqx_gateway_utils_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils_conf.erl
@@ -70,6 +70,7 @@ This module provides functions make such transformations.
 
 -export([
     to_rt_listener_configs/4,
+    to_rt_listener_configs/5,
     to_rt_listener_ids/2,
     rt_listener_id/1,
     rt_listener_id/2,
@@ -90,6 +91,7 @@ This module provides functions make such transformations.
 -type listener_name() :: atom().
 
 -type esockd_type() :: tcp | ssl | udp | dtls.
+-type rt_opts() :: #{generate_default_certs => boolean()}.
 -type cowboy_type() :: ws | wss.
 
 -type listener_type() :: esockd_type() | cowboy_type().
@@ -171,6 +173,19 @@ Transform gateway config + module config + runtime context into runtime listener
 """.
 -spec to_rt_listener_configs(gw_name(), map(), map(), term()) -> list(listener_runtime_config()).
 to_rt_listener_configs(GwName, GwConfig0, ModConfig0, Ctx) ->
+    to_rt_listener_configs(GwName, GwConfig0, ModConfig0, Ctx, #{}).
+
+-doc """
+Same as `to_rt_listener_configs/4`, with options.
+
+`generate_default_certs` (default `true`): when `false`, a TLS listener with no
+certificate configured is given the node's default certificate only if that
+bundle already exists; nothing is generated. Use it for the configuration a
+gateway is being updated away from, which is read, not served.
+""".
+-spec to_rt_listener_configs(gw_name(), map(), map(), term(), rt_opts()) ->
+    list(listener_runtime_config()).
+to_rt_listener_configs(GwName, GwConfig0, ModConfig0, Ctx, RtOpts) ->
     GwConfig1 = maps:without([listeners], GwConfig0),
 
     %% Get plain list of all listener configurations of all types
@@ -209,13 +224,13 @@ to_rt_listener_configs(GwName, GwConfig0, ModConfig0, Ctx) ->
                     T when ?IS_ESOCKD_LISTENER(T) ->
                         {esockd, #{
                             type => Type,
-                            socket_opts => esockd_opts(Type, ListenerConfig),
+                            socket_opts => esockd_opts(Type, ListenerConfig, RtOpts),
                             mfa => {CallbackModule, start_link, [CallbackConfig]}
                         }};
                     T when ?IS_COWBOY_LISTENER(T) ->
                         {cowboy, #{
                             type => Type,
-                            ranch_opts => cowboy_ranch_opts(Type, ListenOn, ListenerConfig),
+                            ranch_opts => cowboy_ranch_opts(Type, ListenOn, ListenerConfig, RtOpts),
                             ws_opts => cowboy_ws_opts(
                                 ListenerConfig, CallbackModule, CallbackConfig
                             )
@@ -402,7 +417,7 @@ get_effective_mod_config(Type, ModConfig0) ->
 listener_id(GwName, Type, LisName) ->
     emqx_gateway_utils:listener_id(GwName, Type, LisName).
 
-esockd_opts(Type, Opts0) when ?IS_ESOCKD_LISTENER(Type) ->
+esockd_opts(Type, Opts0, RtOpts) when ?IS_ESOCKD_LISTENER(Type) ->
     Opts1 = maps:with(
         [
             acceptors,
@@ -424,13 +439,13 @@ esockd_opts(Type, Opts0) when ?IS_ESOCKD_LISTENER(Type) ->
             ssl ->
                 Opts2#{
                     tcp_options => tcp_opts_with_defaults(Opts0),
-                    ssl_options => ssl_opts(ssl_options, Opts0)
+                    ssl_options => ssl_opts(ssl_options, Opts0, RtOpts)
                 };
             udp ->
                 Opts2#{udp_options => udp_opts(Opts0)};
             dtls ->
                 UDPOpts = udp_opts(Opts0),
-                DTLSOpts = ssl_opts(dtls_options, Opts0),
+                DTLSOpts = ssl_opts(dtls_options, Opts0, RtOpts),
                 Opts2#{
                     udp_options => UDPOpts,
                     dtls_options => DTLSOpts
@@ -438,14 +453,14 @@ esockd_opts(Type, Opts0) when ?IS_ESOCKD_LISTENER(Type) ->
         end
     ).
 
-cowboy_ranch_opts(Type, ListenOn, Opts) ->
+cowboy_ranch_opts(Type, ListenOn, Opts, RtOpts) ->
     NumAcceptors = maps:get(acceptors, Opts, 4),
     MaxConnections = maps:get(max_connections, Opts, 1024),
     SocketOpts1 =
         case Type of
             wss ->
                 tcp_opts(Opts) ++
-                    proplists:delete(handshake_timeout, ssl_opts(ssl_options, Opts));
+                    proplists:delete(handshake_timeout, ssl_opts(ssl_options, Opts, RtOpts));
             ws ->
                 tcp_opts(Opts)
         end,
@@ -484,9 +499,9 @@ udp_opts(Opts) ->
         )
     ).
 
-ssl_opts(Name, Opts) ->
+ssl_opts(Name, Opts, RtOpts) ->
     SSLConf = maps:get(Name, Opts, #{}),
-    SSLOpts = ssl_server_opts(Name, SSLConf),
+    SSLOpts = ssl_server_opts(Name, SSLConf, RtOpts),
     ensure_dtls_protocol(Name, SSLOpts).
 
 ensure_dtls_protocol(dtls_options, SSLOpts) ->
@@ -494,16 +509,20 @@ ensure_dtls_protocol(dtls_options, SSLOpts) ->
 ensure_dtls_protocol(_, SSLOpts) ->
     SSLOpts.
 
-ssl_server_opts(ssl_options, SSLOpts) ->
-    emqx_tls_lib:to_server_opts(tls, with_default_certs(SSLOpts));
-ssl_server_opts(dtls_options, SSLOpts) ->
-    emqx_tls_lib:to_server_opts(dtls, with_default_certs(SSLOpts)).
+ssl_server_opts(ssl_options, SSLOpts, RtOpts) ->
+    emqx_tls_lib:to_server_opts(tls, with_default_certs(SSLOpts, RtOpts));
+ssl_server_opts(dtls_options, SSLOpts, RtOpts) ->
+    emqx_tls_lib:to_server_opts(dtls, with_default_certs(SSLOpts, RtOpts)).
 
+%% A configuration that is only read (the one a gateway is updated away from)
+%% must not generate a certificate as a side effect of being inspected.
+with_default_certs(SSLOpts, #{generate_default_certs := false}) ->
+    emqx_tls_lib:default_certs_if_present(SSLOpts);
 %% A listener that cannot be given the node's own certificate does not start.
 %% Reported as a bad `listeners' config, which is how this module reports every
 %% other unusable listener option, so the gateway fails to load with a message
 %% naming the cause instead of binding a port it cannot serve on.
-with_default_certs(SSLOpts) ->
+with_default_certs(SSLOpts, _RtOpts) ->
     case emqx_tls_lib:ensure_default_certs(SSLOpts) of
         {ok, SSLOpts1} ->
             SSLOpts1;

--- a/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
@@ -196,6 +196,10 @@ init_per_testcase(_CaseName, Conf) ->
 }).
 -define(CONF_STOMP_LISTENER_1, #{<<"bind">> => <<"61613">>}).
 -define(CONF_STOMP_LISTENER_2, #{<<"bind">> => <<"61614">>}).
+-define(CONF_STOMP_LISTENER_SSL_NO_CERTS, #{
+    <<"bind">> => <<"61614">>,
+    <<"ssl_options">> => #{}
+}).
 -define(CONF_STOMP_LISTENER_SSL, #{
     <<"bind">> => <<"61614">>,
     <<"ssl_options">> =>
@@ -234,6 +238,20 @@ init_per_testcase(_CaseName, Conf) ->
     <<"backend">> => <<"built_in_database">>,
     <<"user_id_type">> => <<"username">>
 }).
+
+-doc """
+Removing a TLS listener that served the node's default certificate reads the
+old configuration without regenerating a bundle that was deleted out-of-band.
+""".
+t_remove_listener_does_not_regenerate_default_cert(_) ->
+    StompConf = compose_ssl_listener(?CONF_STOMP_BAISC_1, ?CONF_STOMP_LISTENER_SSL_NO_CERTS),
+    {ok, _} = emqx_gateway_conf:load_gateway(<<"stomp">>, StompConf),
+    ?assertMatch({ok, _}, emqx_default_cert:localhost_bundle()),
+    ok = file:del_dir_r(emqx_managed_certs:dir(global, <<"localhost">>)),
+    ?assertMatch({error, no_bundle}, emqx_default_cert:localhost_bundle()),
+    ok = emqx_gateway_conf:remove_listener(<<"stomp">>, {<<"ssl">>, <<"default">>}),
+    ?assertMatch({error, no_bundle}, emqx_default_cert:localhost_bundle()),
+    ok = emqx_gateway_conf:unload_gateway(<<"stomp">>).
 
 t_load_unload_gateway(_) ->
     StompConf1 = compose(

--- a/apps/emqx_gateway_coap/src/emqx_gateway_coap.erl
+++ b/apps/emqx_gateway_coap/src/emqx_gateway_coap.erl
@@ -68,7 +68,7 @@ on_gateway_update(
 ) ->
     OldModConfig = mod_cfg(OldConfig),
     OldListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-        GwName, OldConfig, OldModConfig, Ctx
+        GwName, OldConfig, OldModConfig, Ctx, #{generate_default_certs => false}
     ),
     NewModConfig = mod_cfg(Config),
     NewListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(

--- a/apps/emqx_gateway_gbt32960/src/emqx_gateway_gbt32960.erl
+++ b/apps/emqx_gateway_gbt32960/src/emqx_gateway_gbt32960.erl
@@ -59,7 +59,7 @@ on_gateway_update(
     Config, _Gateway = #{config := OldConfig, name := GwName}, GwState = #{ctx := Ctx}
 ) ->
     OldListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-        GwName, OldConfig, ?MOD_CFG, Ctx
+        GwName, OldConfig, ?MOD_CFG, Ctx, #{generate_default_certs => false}
     ),
     NewListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
         GwName, Config, ?MOD_CFG, Ctx

--- a/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.erl
@@ -60,7 +60,7 @@ on_gateway_update(
     Config, _Gateway = #{config := OldConfig, name := GwName}, GwState = #{ctx := Ctx}
 ) ->
     OldListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-        GwName, OldConfig, ?MOD_CFG, Ctx
+        GwName, OldConfig, ?MOD_CFG, Ctx, #{generate_default_certs => false}
     ),
     NewListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
         GwName, Config, ?MOD_CFG, Ctx

--- a/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.erl
@@ -74,7 +74,7 @@ on_gateway_update(
     Config, _Gateway = #{config := OldConfig, name := GwName}, GwState = #{ctx := Ctx}
 ) ->
     OldListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-        GwName, OldConfig, ?MOD_CFG, Ctx
+        GwName, OldConfig, ?MOD_CFG, Ctx, #{generate_default_certs => false}
     ),
     NewListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
         GwName, Config, ?MOD_CFG, Ctx

--- a/apps/emqx_gateway_mqttsn/src/emqx_gateway_mqttsn.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_gateway_mqttsn.erl
@@ -71,7 +71,7 @@ on_gateway_update(
         OldConfig1 = maps:without([broadcast, predefined], OldConfig),
         ModConfig = mod_cfg(),
         OldListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-            GwName, OldConfig1, ModConfig, Ctx
+            GwName, OldConfig1, ModConfig, Ctx, #{generate_default_certs => false}
         ),
         NewListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
             GwName, Config1, ModConfig, Ctx

--- a/apps/emqx_gateway_nats/src/emqx_gateway_nats.erl
+++ b/apps/emqx_gateway_nats/src/emqx_gateway_nats.erl
@@ -59,7 +59,7 @@ on_gateway_update(
     Config, _Gateway = #{config := OldConfig, name := GwName}, GwState = #{ctx := Ctx}
 ) ->
     OldListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-        GwName, OldConfig, ?MOD_CFG, Ctx
+        GwName, OldConfig, ?MOD_CFG, Ctx, #{generate_default_certs => false}
     ),
     NewListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
         GwName, Config, ?MOD_CFG, Ctx

--- a/apps/emqx_gateway_ocpp/src/emqx_gateway_ocpp.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_gateway_ocpp.erl
@@ -63,7 +63,7 @@ on_gateway_update(
     Config, _Gateway = #{config := OldConfig, name := GwName}, GwState = #{ctx := Ctx}
 ) ->
     OldListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-        GwName, OldConfig, ?MOD_CFG, Ctx
+        GwName, OldConfig, ?MOD_CFG, Ctx, #{generate_default_certs => false}
     ),
     NewListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
         GwName, Config, ?MOD_CFG, Ctx

--- a/apps/emqx_gateway_stomp/src/emqx_gateway_stomp.erl
+++ b/apps/emqx_gateway_stomp/src/emqx_gateway_stomp.erl
@@ -61,7 +61,7 @@ on_gateway_update(
     Config, _Gateway = #{config := OldConfig, name := GwName}, GwState = #{ctx := Ctx}
 ) ->
     OldListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
-        GwName, OldConfig, ?MOD_CFG, Ctx
+        GwName, OldConfig, ?MOD_CFG, Ctx, #{generate_default_certs => false}
     ),
     NewListenerConfigs = emqx_gateway_utils_conf:to_rt_listener_configs(
         GwName, Config, ?MOD_CFG, Ctx

--- a/apps/emqx_prometheus/mix.exs
+++ b/apps/emqx_prometheus/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXPrometheus.MixProject do
   def project do
     [
       app: :emqx_prometheus,
-      version: "6.3.0",
+      version: "6.3.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -59,7 +59,7 @@
 ]).
 
 -ifdef(TEST).
--export([cert_expiry_at_from_path/1, acl_metric_meta/0]).
+-export([cert_expiry_at_from_path/1, cert_data/1, acl_metric_meta/0]).
 -endif.
 
 %%--------------------------------------------------------------------
@@ -1275,10 +1275,13 @@ gen_point_cert_expiry_at(Type, Name, Path) ->
     {[{listener_type, Type}, {listener_name, Name}], cert_expiry_at_from_path(Path)}.
 
 resolve_listener_certfile(Type, Name, #{enable := true, ssl_options := #{} = SSLOpts0}) ->
+    %% A listener with no certificate configured serves the node's default one;
+    %% report that certificate. Nothing is generated here: a scrape only reads.
+    SSLOpts1 = emqx_tls_lib:default_certs_if_present(SSLOpts0),
     %% `to_server_opts' throws when a `managed_certs' reference cannot be resolved
     %% (e.g. the bundle was deleted out-of-band); one bad listener must not fail the
     %% whole scrape.
-    try emqx_tls_lib:to_server_opts(tls, SSLOpts0) of
+    try emqx_tls_lib:to_server_opts(tls, SSLOpts1) of
         SSLOpts ->
             case lists:keyfind(certfile, 1, SSLOpts) of
                 {certfile, Certfile} ->

--- a/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
@@ -227,6 +227,19 @@ t_cert_expiry_epoch(_) ->
         emqx_prometheus:cert_expiry_at_from_path(Path)
     ).
 
+-doc """
+A TLS listener with no certificate configured serves the node's default
+certificate, and its expiry is reported like any other listener's.
+""".
+t_cert_expiry_default_cert(_) ->
+    {ok, #{chain := #{path := ChainPath}}} = emqx_default_cert:ensure_localhost_bundle(),
+    Expected = emqx_prometheus:cert_expiry_at_from_path(ChainPath),
+    Listeners = #{ssl => #{default => #{enable => true, ssl_options => #{}}}},
+    ?assertEqual(
+        #{emqx_cert_expiry_at => [{[{listener_type, ssl}, {listener_name, default}], Expected}]},
+        emqx_prometheus:cert_data(Listeners)
+    ).
+
 %%--------------------------------------------------------------------
 %% Helper functions
 

--- a/apps/emqx_utils/src/emqx_utils_certs.erl
+++ b/apps/emqx_utils/src/emqx_utils_certs.erl
@@ -19,8 +19,9 @@ Key parameters:
 * The default key type is `ec`, using `secp256r1`: smaller keys and
   faster handshakes than RSA, and universally supported by TLS
   clients. `rsa` (2048 bits) is also available for callers that need
-  it. Both are the current minimum widely accepted for a server
-  certificate.
+  it, and is what the default falls back to on a crypto library
+  without `secp256r1` (see `default_key_type/0`). Both are the current
+  minimum widely accepted for a server certificate.
 * Certificates are valid for 3650 days (about ten years) starting one
   day in the past, so a small clock skew between the generating node
   and a client does not make the certificate look not-yet-valid.
@@ -37,7 +38,8 @@ This module has no callers. It is a pure cryptography library.
 -export([
     generate_ca/1,
     generate_cert/2,
-    self_signed_bundle/1
+    self_signed_bundle/1,
+    default_key_type/0
 ]).
 
 -export_type([pem_pair/0, cert_bundle/0, san/0, key_type/0]).
@@ -67,13 +69,13 @@ This module has no callers. It is a pure cryptography library.
 Generates a root CA certificate and its private key.
 
 Options: `cn` (required) becomes the subject common name; `org` is the
-subject organization name (defaults to `"EMQX"`); `key_type` is `ec`
-(default) or `rsa`. `cn` must not contain control characters or any of
+subject organization name (defaults to `"EMQX"`); `key_type` is `ec` or
+`rsa` (default: `default_key_type/0`). `cn` must not contain control characters or any of
 `#`, `+`, `/`; violating this raises an error.
 """.
 -spec generate_ca(#{cn := string(), org => string(), key_type => key_type()}) -> pem_pair().
 generate_ca(#{cn := _} = Opts) ->
-    Key = gen_key(maps:get(key_type, Opts, ec)),
+    Key = gen_key(maps:get(key_type, Opts, default_key_type())),
     Subject = subject(Opts),
     TBS = tbs_certificate(Subject, Subject, Key, Key, ca_extensions()),
     Der = public_key:pkix_sign(TBS, Key),
@@ -84,8 +86,8 @@ Generates a certificate signed by the given CA.
 
 Options: `cn` (required) becomes the subject common name; `org` is the
 subject organization name (defaults to `"EMQX"`); `sans` is the list of
-subject alternative names (defaults to `[]`); `key_type` is `ec`
-(default) or `rsa`. `cn` must not contain control characters or any of
+subject alternative names (defaults to `[]`); `key_type` is `ec` or
+`rsa` (default: `default_key_type/0`). `cn` must not contain control characters or any of
 `#`, `+`, `/`; violating this raises an error.
 """.
 -spec generate_cert(pem_pair(), #{
@@ -98,7 +100,7 @@ generate_cert(#{cert_pem := CaCertPem, key_pem := CaKeyPem}, Opts) ->
     SANs = maps:get(sans, Opts, []),
     CaKey = pem_to_key(CaKeyPem),
     Issuer = cert_subject(CaCertPem),
-    Key = gen_key(maps:get(key_type, Opts, ec)),
+    Key = gen_key(maps:get(key_type, Opts, default_key_type())),
     TBS = tbs_certificate(subject(Opts), Issuer, Key, CaKey, leaf_extensions(Key, SANs)),
     Der = public_key:pkix_sign(TBS, CaKey),
     #{cert_pem => cert_to_pem(Der), key_pem => key_to_pem(Key)}.
@@ -127,13 +129,32 @@ self_signed_bundle(Opts) ->
     }.
 
 %%--------------------------------------------------------------------
+-doc """
+The key type used when the caller does not choose one: `ec` when the crypto
+library supports `secp256r1`, otherwise `rsa`. A caller that asks for `ec`
+explicitly gets `{curve_unsupported, secp256r1}` on such a library instead.
+""".
+-spec default_key_type() -> key_type().
+default_key_type() ->
+    case curve_supported(?CURVE) of
+        true -> ec;
+        false -> rsa
+    end.
+
+%%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
 
 gen_key(rsa) ->
     public_key:generate_key({rsa, ?RSA_KEY_SIZE, 65537});
 gen_key(ec) ->
+    %% `public_key' raises a bare `badarg' for a curve the crypto library
+    %% lacks; name the curve so the log says what is missing.
+    curve_supported(?CURVE) orelse error({curve_unsupported, ?CURVE}),
     public_key:generate_key({namedCurve, ?CURVE}).
+
+curve_supported(Curve) ->
+    lists:member(Curve, crypto:supports(curves)).
 
 tbs_certificate(Subject, Issuer, SubjectKey, SignerKey, Extensions) ->
     #'OTPTBSCertificate'{

--- a/apps/emqx_utils/test/emqx_utils_certs_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_utils_certs_SUITE.erl
@@ -149,6 +149,21 @@ t_rsa_and_ec_key_types(_TCConfig) ->
         [rsa, ec]
     ).
 
+-doc """
+Without a `key_type` the bundle's key is `ec` when the crypto library supports
+`secp256r1` and `rsa` otherwise, and `default_key_type/0` reports which.
+""".
+t_default_key_type(_TCConfig) ->
+    {ExpectedType, ExpectedRecord} =
+        case lists:member(secp256r1, crypto:supports(curves)) of
+            true -> {ec, 'ECPrivateKey'};
+            false -> {rsa, 'RSAPrivateKey'}
+        end,
+    ?assertEqual(ExpectedType, emqx_utils_certs:default_key_type()),
+    #{key := KeyPem} = emqx_utils_certs:self_signed_bundle(#{cn => "localhost", sans => sans()}),
+    [Entry] = public_key:pem_decode(KeyPem),
+    ?assertEqual(ExpectedRecord, element(1, public_key:pem_entry_decode(Entry))).
+
 -doc "A CN with a control character or an MQTT topic-structural character is rejected.".
 t_invalid_cn_raises(_TCConfig) ->
     Invalid = [


### PR DESCRIPTION
Fixes: <!-- github issue number if applicable -->
Release version: 7.0.0
Introduced in: N/A

## Summary

Four small changes left over from the default-certificate series (#18813, #18884, #18906).

**Prometheus reports `emqx_cert_expiry_at` for listeners serving the node's default certificate.** No changelog: the default certificate is new in 7.0, not released. `resolve_listener_certfile/3` looked for `certfile` in the listener's own configuration, which such a listener does not have, so no point was produced. It now resolves the configuration with `emqx_tls_lib:default_certs_if_present/1` first, which names the bundle's files when the bundle exists and never generates one. Test: `t_cert_expiry_default_cert`.

**Gateways resolve the configuration they are updated away from without generating.** Every gateway module builds runtime listener configurations for both the old and the new configuration on update and diffs them; resolving the old one went through `ensure_default_certs/1`, which generates the bundle when it is missing. `emqx_gateway_utils_conf:to_rt_listener_configs/5` takes `generate_default_certs => false`, and each of the eight gateway modules passes it at the old-config call site. Same fix `emqx_listeners` got in #18813. Test: `t_remove_listener_does_not_regenerate_default_cert` (verified to fail without the change).

**`emqx_utils_certs` falls back to RSA on a crypto library without `secp256r1`.** `default_key_type/0` returns `ec` when the curve is in `crypto:supports(curves)` and `rsa` otherwise, and is the default for callers that do not choose a key type; the node's default certificate is generated that way, and its `default_tls_certificate_generated` log records `key_type`. A caller that asks for `ec` explicitly on such a library gets `{curve_unsupported, secp256r1}` instead of the bare `badarg` `public_key` raises. A reported-unsupported curve is a capability the node lacks and an RSA certificate serves; a failure during generation is something else and still raises. Test: `t_default_key_type`.

**`emqx:cert_file/1` is deleted.** It built `etc/certs/<file>` paths and had no callers.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

