### PR TITLE
test(mqttsn): keep snabbkaffe events in receive_response

### DIFF
--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -3088,9 +3088,6 @@ receive_response(Socket, Timeout) ->
             Bin;
         {mqttc, From, Data2} ->
             ?LOG("receive_response() ignore mqttc From=~p, Data2=~p~n", [From, Data2]),
-            receive_response(Socket);
-        Other ->
-            ?LOG("receive_response() Other message: ~p", [{unexpected_udp_data, Other}]),
             receive_response(Socket)
     after Timeout ->
         udp_receive_timeout


### PR DESCRIPTION
Test-only fix for a flaky `emqx_sn_protocol_SUITE:t_auth_expire`.

Seen on dev-58 and dev-59 PRs, most recently #18909 (job 103536477851): `{badmatch, {ok, timeout}}` from the `?wait_async_action` on `conn_process_terminated`.

## Cause

The connection process terminates as expected. The test discards the event:

- `?wait_async_action` subscribes first, so snabbkaffe sends the matching event to the test process as `{Ref, Event}`.
- `receive_response/2` has a catch-all clause that logs and discards any message other than a UDP datagram or an `mqttc` message.
- When the event reaches the mailbox before the DISCONNECT datagram, `receive_response/2` discards it and then returns the DISCONNECT. The wait then times out.

The CT log of job 103536477851 shows it:

```
TEST: receive_response() Other message: {unexpected_udp_data,
    {#Ref<...>, #{reason => {shutdown,expired}, msg => conn_process_terminated, clientid => <<"t_auth_expire">>, ...}}}
```

## Fix

Remove the catch-all clause. This is the `receive_response/2` hunk of 394d5376a6 (dev-510) and 9b23303b4d (dev-60). #18639 already brought over the `t_auth_expire` part of that commit, but not this hunk.

After this change, `receive_response/2` matches dev-510. The dev-58 → dev-59 sync carries it to dev-59.
