### PR TITLE
ci: add connection memory smoke guard

### DIFF
--- a/.github/workflows/run_docker_tests.yaml
+++ b/.github/workflows/run_docker_tests.yaml
@@ -137,6 +137,28 @@ jobs:
         timeout-minutes: 5
         run: ./scripts/test/essential-auth-smoke/run.sh "$CI_EMQX_DOCKER_IMAGE_TAG"
 
+  # Connect-time log hygiene and per-connection memory regression guard.
+  conn-memory-smoke-test:
+    runs-on: ${{ github.repository_owner == 'emqx' && 'aws-ubuntu22.04-amd64' || 'ubuntu-22.04' }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      EMQX_NAME: emqx-enterprise
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.EMQX_NAME }}-docker-amd64
+      - name: load docker image
+        run: |
+          EMQX_TAG=$(docker load < ${EMQX_NAME}-docker-*.tar.gz 2>/dev/null | sed 's/Loaded image: //g')
+          echo "CI_EMQX_DOCKER_IMAGE_TAG=$EMQX_TAG" | tee -a $GITHUB_ENV
+      - name: connection memory smoke test
+        timeout-minutes: 2
+        run: ./scripts/test/conn-memory-smoke/run.sh "$CI_EMQX_DOCKER_IMAGE_TAG"
+
   # simple smoke test for node_dump
   node-dump-test:
     runs-on: ${{ github.repository_owner == 'emqx' && 'aws-ubuntu22.04-amd64' || 'ubuntu-22.04' }}

--- a/apps/emqx/src/emqx_session_tool.erl
+++ b/apps/emqx/src/emqx_session_tool.erl
@@ -5,16 +5,17 @@
 -module(emqx_session_tool).
 
 -moduledoc """
-Operator-facing diagnostics for finding the top-K sessions by a session
-gauge or counter (e.g. `mqueue_len', `total_payload_bytes',
-`mqueue_dropped', `inflight_cnt').
+Operator-facing diagnostics for inspecting live sessions.
 
-Intended use is from the remote console on a live cluster to locate the
-small set of clients with a backlog or that are dropping messages, in
-deployments with tens of thousands of connections, without paging through
-the full client list.
+The top-K scanner finds sessions by a session gauge or counter (e.g.
+`mqueue_len', `total_payload_bytes', `mqueue_dropped', `inflight_cnt').
 
-Safe to run on a live cluster:
+The top-K scanner is intended for use from the remote console on a live
+cluster to locate the small set of clients with a backlog or that are dropping
+messages, in deployments with tens of thousands of connections, without
+paging through the full client list.
+
+The top-K scanner is safe to run on a live cluster:
 * Streams the `emqx_channel_info' ets table in chunks (via
   `emqx_utils_stream:ets/1'); never builds a whole-table list.
 * Keeps only a fixed-size (top-K) ordered set while scanning; output is
@@ -23,6 +24,11 @@ Safe to run on a live cluster:
 * Reads the metric from the cached per-channel stats already stored in
   the registry; it never messages a channel process, so the scan adds no
   load to the connection processes themselves.
+
+The connection-memory diagnostics have different trade-offs: they inspect
+the local channel processes and `connection_memory/0' sends one
+`sys:get_state/1' request, which wakes the selected hibernated channel. They
+are intended for bounded diagnostics and smoke checks, not frequent polling.
 
 Freshness: the value read for each session is the last stats snapshot the
 connection process published. Connections refresh their cached stats on
@@ -47,7 +53,10 @@ with `engine => mem | persistent_ds' once supported).
     scan/1,
     cluster_top_by/1,
     cluster_top_by/2,
-    available_metrics/0
+    available_metrics/0,
+    hibernated_count/0,
+    connection_memory/0,
+    connection_memory_breakdown/0
 ]).
 
 %% Incremental scan engine (for a caller that owns the cursor/state).
@@ -166,6 +175,123 @@ with `engine => mem | persistent_ds' once supported).
     awaiting_rel_cnt,
     awaiting_rel_max
 ]).
+
+%%--------------------------------------------------------------------
+%% Connection memory diagnostics
+%%--------------------------------------------------------------------
+
+-doc "Return the number of local channel processes currently hibernated.".
+-spec hibernated_count() -> non_neg_integer().
+hibernated_count() ->
+    length(hibernated_channels(emqx_cm:all_channels())).
+
+-doc """
+Summarize the live state size of one idle local channel and the process memory
+range across all local hibernated channels.
+
+Memory is read before `sys:get_state/1' wakes the selected channel. When no
+channel is hibernated, the size and memory values are `undefined'.
+""".
+-spec connection_memory() ->
+    #{
+        connections := non_neg_integer(),
+        hibernated := non_neg_integer(),
+        state_words := non_neg_integer() | undefined,
+        min_memory_bytes := non_neg_integer() | undefined,
+        max_memory_bytes := non_neg_integer() | undefined
+    }.
+connection_memory() ->
+    Pids = emqx_cm:all_channels(),
+    Snapshots = hibernated_memory(Pids),
+    Base = #{
+        connections => length(Pids),
+        hibernated => length(Snapshots)
+    },
+    case Snapshots of
+        [] ->
+            Base#{
+                state_words => undefined,
+                min_memory_bytes => undefined,
+                max_memory_bytes => undefined
+            };
+        [{Pid, _} | _] ->
+            MemoryBytes = [Memory || {_, Memory} <- Snapshots],
+            Base#{
+                state_words => erts_debug:flat_size(sys:get_state(Pid)),
+                min_memory_bytes => lists:min(MemoryBytes),
+                max_memory_bytes => lists:max(MemoryBytes)
+            }
+    end.
+
+-doc """
+Return an actionable process and state-size breakdown for the largest local
+hibernated channel. Returns `#{error => no_hibernated_channels}' when there is
+no eligible channel. The selected channel is woken by `sys:get_state/1'.
+""".
+-spec connection_memory_breakdown() -> map().
+connection_memory_breakdown() ->
+    case hibernated_memory(emqx_cm:all_channels()) of
+        [] ->
+            #{error => no_hibernated_channels};
+        Snapshots ->
+            {Memory, Pid} = lists:max([{Bytes, P} || {P, Bytes} <- Snapshots]),
+            Info = process_info(Pid, [
+                memory,
+                heap_size,
+                total_heap_size,
+                stack_size,
+                message_queue_len,
+                current_function,
+                status,
+                dictionary
+            ]),
+            State = sys:get_state(Pid),
+            Dictionary = proplists:get_value(dictionary, Info, []),
+            #{
+                pid => Pid,
+                hibernated_memory_bytes => Memory,
+                process_info => [{K, V} || {K, V} <- Info, K =/= dictionary],
+                dictionary_keys_and_words => [
+                    {K, erts_debug:flat_size(V)}
+                 || {K, V} <- Dictionary
+                ],
+                state_words => erts_debug:flat_size(State),
+                state_tuple_size => tuple_size(State),
+                state_breakdown => deep_size(State, 3)
+            }
+    end.
+
+hibernated_memory(Pids) ->
+    [
+        {Pid, Memory}
+     || Pid <- hibernated_channels(Pids),
+        {memory, Memory} <- [process_info(Pid, memory)]
+    ].
+
+hibernated_channels(Pids) ->
+    [Pid || Pid <- Pids, is_hibernated(Pid)].
+
+is_hibernated(Pid) ->
+    process_info(Pid, current_function) =:=
+        {current_function, {erlang, hibernate, 3}}.
+
+deep_size(Term, Depth) when is_tuple(Term), Depth > 0 ->
+    [
+        {Index, Size, deep_size(Value, Depth - 1)}
+     || Index <- lists:seq(1, tuple_size(Term)),
+        Value <- [element(Index, Term)],
+        Size <- [erts_debug:flat_size(Value)],
+        Size > 8
+    ];
+deep_size(Term, Depth) when is_map(Term), Depth > 0 ->
+    [
+        {Key, Size, deep_size(Value, Depth - 1)}
+     || {Key, Value} <- maps:to_list(Term),
+        Size <- [erts_debug:flat_size(Value)],
+        Size > 8
+    ];
+deep_size(_Term, _Depth) ->
+    [].
 
 %%--------------------------------------------------------------------
 %% Single-node scan

--- a/scripts/test/conn-memory-smoke/run.sh
+++ b/scripts/test/conn-memory-smoke/run.sh
@@ -13,7 +13,7 @@ IMAGE_TAG="${1:-${_EMQX_DOCKER_IMAGE_TAG:-}}"
 
 ## Measured on dev-63 at f6ac260d00 with 20,000 idle MQTT v5 clients using
 ## the default socket backend: 298-301 state words and 3,896 bytes after
-## hibernation. Re-measure with the memory_probe expression below.
+## hibernation. Re-measure with emqx_session_tool:connection_memory/0.
 MAX_STATE_WORDS=360
 MAX_HIBERNATED_MEMORY_BYTES=4600
 CLIENT_COUNT=200
@@ -59,6 +59,12 @@ cleanup
 
 eval_emqx() {
   docker exec "${CONTAINER}" emqx eval "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
+map_integer() {
+  local key="$1"
+  local map="$2"
+  sed -n "s/.*${key}=>\([0-9][0-9]*\).*/\1/p" <<<"${map}"
 }
 
 count_severe_logs() {
@@ -133,12 +139,7 @@ fi
 
 hibernated=0
 for _ in $(seq 1 10); do
-  hibernated="$(eval_emqx '
-    length([
-      P
-     || P <- emqx_cm:all_channels(),
-        process_info(P, current_function) =:= {current_function, {erlang, hibernate, 3}}
-    ]).')"
+  hibernated="$(eval_emqx 'emqx_session_tool:hibernated_count().')"
   if [ "${hibernated}" -ge "${MIN_HIBERNATED_COUNT}" ]; then
     break
   fi
@@ -149,69 +150,27 @@ if [ "${hibernated}" -lt "${MIN_HIBERNATED_COUNT}" ]; then
   exit 1
 fi
 
-## Keep memory reads ahead of sys:get_state/1 because that system message wakes
-## a hibernated channel. The memory budget applies to the maximum, not the average.
-memory_probe='Pids = emqx_cm:all_channels(),
-Hibernated = [
-    P
- || P <- Pids,
-    process_info(P, current_function) =:= {current_function, {erlang, hibernate, 3}}
-],
-Snapshots = [
-    {P, proplists:get_value(memory, process_info(P, [memory]))}
- || P <- Hibernated
-],
-MemoryBytes = [M || {_, M} <- Snapshots],
-StateWords = erts_debug:flat_size(sys:get_state(hd(Hibernated))),
-{length(Pids), length(Hibernated), StateWords,
- lists:min(MemoryBytes), lists:max(MemoryBytes)}.'
-measurement="$(eval_emqx "${memory_probe}")"
+measurement="$(eval_emqx 'emqx_session_tool:connection_memory().')"
+measured_connections="$(map_integer connections "${measurement}")"
+measured_hibernated="$(map_integer hibernated "${measurement}")"
+state_words="$(map_integer state_words "${measurement}")"
+min_memory_bytes="$(map_integer min_memory_bytes "${measurement}")"
+max_memory_bytes="$(map_integer max_memory_bytes "${measurement}")"
 
-if [[ ! "${measurement}" =~ ^\{([0-9]+),([0-9]+),([0-9]+),([0-9]+),([0-9]+)\}$ ]]; then
+if [ -z "${measured_connections}" ] || [ -z "${measured_hibernated}" ] || \
+   [ -z "${state_words}" ] || [ -z "${min_memory_bytes}" ] || \
+   [ -z "${max_memory_bytes}" ]; then
   echo "Could not parse memory probe result: '${measurement}'"
   exit 1
 fi
-measured_connections="${BASH_REMATCH[1]}"
-measured_hibernated="${BASH_REMATCH[2]}"
-state_words="${BASH_REMATCH[3]}"
-min_memory_bytes="${BASH_REMATCH[4]}"
-max_memory_bytes="${BASH_REMATCH[5]}"
 
 echo "memory probe: connections=${measured_connections}, hibernated=${measured_hibernated}, state=${state_words} words (budget <=${MAX_STATE_WORDS}), memory=${min_memory_bytes}-${max_memory_bytes} bytes (budget <=${MAX_HIBERNATED_MEMORY_BYTES})"
 
 if [ "${state_words}" -gt "${MAX_STATE_WORDS}" ] || \
    [ "${max_memory_bytes}" -gt "${MAX_HIBERNATED_MEMORY_BYTES}" ]; then
   echo "Per-connection memory budget exceeded; channel breakdown follows:"
-  docker exec "${CONTAINER}" emqx eval '
-    Pids = emqx_cm:all_channels(),
-    Hibernated = [
-        P
-     || P <- Pids,
-        process_info(P, current_function) =:= {current_function, {erlang, hibernate, 3}}
-    ],
-    WithMemory = [
-        {proplists:get_value(memory, process_info(P, [memory])), P}
-     || P <- Hibernated
-    ],
-    {_, P} = lists:last(lists:sort(WithMemory)),
-    Info = process_info(P, [memory, heap_size, total_heap_size, stack_size,
-                            message_queue_len, current_function, status, dictionary]),
-    State = sys:get_state(P),
-    Size = fun(Term) -> erts_debug:flat_size(Term) end,
-    Deep = fun(Depth, Recur, Term) when is_tuple(Term), Depth > 0 ->
-                   [{I, Size(element(I, Term)), Recur(Depth - 1, Recur, element(I, Term))}
-                    || I <- lists:seq(1, tuple_size(Term)), Size(element(I, Term)) > 8];
-              (Depth, Recur, Term) when is_map(Term), Depth > 0 ->
-                   [{K, Size(V), Recur(Depth - 1, Recur, V)}
-                    || {K, V} <- maps:to_list(Term), Size(V) > 8];
-              (_, _, _) -> []
-           end,
-    Dictionary = proplists:get_value(dictionary, Info),
-    #{process_info => [{K, V} || {K, V} <- Info, K =/= dictionary],
-      dictionary_keys_and_words => [{K, Size(V)} || {K, V} <- Dictionary],
-      state_words => Size(State),
-      state_tuple_size => tuple_size(State),
-      state_breakdown => Deep(3, Deep, State)}.' || true
+  docker exec "${CONTAINER}" emqx eval \
+    'emqx_session_tool:connection_memory_breakdown().' || true
   exit 1
 fi
 

--- a/scripts/test/conn-memory-smoke/run.sh
+++ b/scripts/test/conn-memory-smoke/run.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+
+## Smoke test: connect a small batch of MQTT clients to a real EMQX release,
+## reject connect-time warning/error logs, and guard the live memory retained by
+## each idle connection.
+##
+## Usage: run.sh IMAGE_TAG   (e.g. run.sh emqx/emqx-enterprise:latest)
+
+set -euo pipefail
+
+IMAGE_TAG="${1:-${_EMQX_DOCKER_IMAGE_TAG:-}}"
+[ -z "${IMAGE_TAG}" ] && { echo "Usage: $0 IMAGE_TAG"; exit 1; }
+
+## Measured on dev-63 at f6ac260d00 with 20,000 idle MQTT v5 clients using
+## the default socket backend: 298-301 state words and 3,896 bytes after
+## hibernation. Re-measure with the memory_probe expression below.
+MAX_STATE_WORDS=360
+MAX_HIBERNATED_MEMORY_BYTES=4600
+CLIENT_COUNT=200
+MIN_HIBERNATED_COUNT=$((CLIENT_COUNT * 9 / 10))
+
+CONTAINER="emqx-conn-memory-smoke"
+CLIENT_CONTAINER="emqtt-conn-memory-smoke"
+EMQTT_BENCH_IMAGE="${EMQTT_BENCH_IMAGE:-emqx/emqtt-bench:0.6.2}"
+START_SECONDS=${SECONDS}
+
+cleanup() {
+  docker rm -f "${CLIENT_CONTAINER}" >/dev/null 2>&1 || true
+  docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+}
+
+capture_logs() {
+  docker logs "${CONTAINER}" 2>&1 || true
+  docker exec "${CONTAINER}" sh -c '
+    for logfile in /opt/emqx/log/emqx.log.*; do
+      [ -f "${logfile}" ] && cat "${logfile}"
+    done
+  ' 2>/dev/null || true
+}
+
+dump_logs() {
+  echo "--- ${CONTAINER} logs ---"
+  capture_logs
+  echo "--- ${CLIENT_CONTAINER} logs ---"
+  docker logs "${CLIENT_CONTAINER}" 2>&1 || true
+}
+
+on_exit() {
+  result=$?
+  trap - EXIT
+  if [ "${result}" -ne 0 ]; then
+    dump_logs
+  fi
+  cleanup
+  exit "${result}"
+}
+trap on_exit EXIT
+cleanup
+
+eval_emqx() {
+  docker exec "${CONTAINER}" emqx eval "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
+count_severe_logs() {
+  grep -Ec '^\S+ \[(warning|error|critical|alert|emergency)\]' <<<"$1" || true
+}
+
+count_hook_callback_exceptions() {
+  grep -c 'hook_callback_exception' <<<"$1" || true
+}
+
+echo "Starting ${CONTAINER} from ${IMAGE_TAG} ..."
+docker run -d --name "${CONTAINER}" \
+  -e EMQX_NODE__NAME="emqx@127.0.0.1" \
+  -e EMQX_LOG__CONSOLE__LEVEL=info \
+  -e EMQX_MQTT__IDLE_TIMEOUT=2s \
+  "${IMAGE_TAG}" >/dev/null
+
+echo "Waiting for the TCP listener ..."
+ready=false
+for _ in $(seq 1 30); do
+  if docker exec "${CONTAINER}" emqx ctl listeners 2>/dev/null \
+       | grep -A6 'tcp:default' | grep -qE 'running *: true'; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+if [ "${ready}" != true ]; then
+  echo "EMQX did not become ready within 30 seconds"
+  exit 1
+fi
+
+before_logs="$(capture_logs)"
+before_severe="$(count_severe_logs "${before_logs}")"
+before_hook_exceptions="$(count_hook_callback_exceptions "${before_logs}")"
+
+echo "Connecting ${CLIENT_COUNT} MQTT v5 clients ..."
+docker run --rm -d --name "${CLIENT_CONTAINER}" \
+  --network "container:${CONTAINER}" \
+  "${EMQTT_BENCH_IMAGE}" \
+  conn -h 127.0.0.1 -p 1883 -V 5 -c "${CLIENT_COUNT}" -R "${CLIENT_COUNT}" -k 300 \
+  --prefix conn-memory-smoke --shortids true --log_to null >/dev/null
+
+connected=0
+for _ in $(seq 1 10); do
+  connected="$(eval_emqx 'emqx_cm:get_connected_client_count().')"
+  if [ "${connected}" = "${CLIENT_COUNT}" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ "${connected}" != "${CLIENT_COUNT}" ]; then
+  echo "Expected ${CLIENT_COUNT} connected clients, got '${connected}'"
+  exit 1
+fi
+
+## Let async logger writes from the last CONNECT reach both handlers.
+sleep 1
+after_logs="$(capture_logs)"
+after_severe="$(count_severe_logs "${after_logs}")"
+after_hook_exceptions="$(count_hook_callback_exceptions "${after_logs}")"
+
+echo "connect log counts: warning-or-above ${before_severe}->${after_severe}, hook_callback_exception ${before_hook_exceptions}->${after_hook_exceptions}"
+if [ "${after_severe}" != "${before_severe}" ]; then
+  echo "Connects emitted warning-or-above log lines"
+  exit 1
+fi
+if [ "${after_hook_exceptions}" -ne 0 ]; then
+  echo "Connects emitted hook_callback_exception"
+  exit 1
+fi
+
+hibernated=0
+for _ in $(seq 1 10); do
+  hibernated="$(eval_emqx '
+    length([
+      P
+     || P <- emqx_cm:all_channels(),
+        process_info(P, current_function) =:= {current_function, {erlang, hibernate, 3}}
+    ]).')"
+  if [ "${hibernated}" -ge "${MIN_HIBERNATED_COUNT}" ]; then
+    break
+  fi
+  sleep 1
+done
+if [ "${hibernated}" -lt "${MIN_HIBERNATED_COUNT}" ]; then
+  echo "Expected at least ${MIN_HIBERNATED_COUNT} hibernated channels, got '${hibernated}'"
+  exit 1
+fi
+
+## Keep memory reads ahead of sys:get_state/1 because that system message wakes
+## a hibernated channel. The memory budget applies to the maximum, not the average.
+memory_probe='Pids = emqx_cm:all_channels(),
+Hibernated = [
+    P
+ || P <- Pids,
+    process_info(P, current_function) =:= {current_function, {erlang, hibernate, 3}}
+],
+Snapshots = [
+    {P, proplists:get_value(memory, process_info(P, [memory]))}
+ || P <- Hibernated
+],
+MemoryBytes = [M || {_, M} <- Snapshots],
+StateWords = erts_debug:flat_size(sys:get_state(hd(Hibernated))),
+{length(Pids), length(Hibernated), StateWords,
+ lists:min(MemoryBytes), lists:max(MemoryBytes)}.'
+measurement="$(eval_emqx "${memory_probe}")"
+
+if [[ ! "${measurement}" =~ ^\{([0-9]+),([0-9]+),([0-9]+),([0-9]+),([0-9]+)\}$ ]]; then
+  echo "Could not parse memory probe result: '${measurement}'"
+  exit 1
+fi
+measured_connections="${BASH_REMATCH[1]}"
+measured_hibernated="${BASH_REMATCH[2]}"
+state_words="${BASH_REMATCH[3]}"
+min_memory_bytes="${BASH_REMATCH[4]}"
+max_memory_bytes="${BASH_REMATCH[5]}"
+
+echo "memory probe: connections=${measured_connections}, hibernated=${measured_hibernated}, state=${state_words} words (budget <=${MAX_STATE_WORDS}), memory=${min_memory_bytes}-${max_memory_bytes} bytes (budget <=${MAX_HIBERNATED_MEMORY_BYTES})"
+
+if [ "${state_words}" -gt "${MAX_STATE_WORDS}" ] || \
+   [ "${max_memory_bytes}" -gt "${MAX_HIBERNATED_MEMORY_BYTES}" ]; then
+  echo "Per-connection memory budget exceeded; channel breakdown follows:"
+  docker exec "${CONTAINER}" emqx eval '
+    Pids = emqx_cm:all_channels(),
+    Hibernated = [
+        P
+     || P <- Pids,
+        process_info(P, current_function) =:= {current_function, {erlang, hibernate, 3}}
+    ],
+    WithMemory = [
+        {proplists:get_value(memory, process_info(P, [memory])), P}
+     || P <- Hibernated
+    ],
+    {_, P} = lists:last(lists:sort(WithMemory)),
+    Info = process_info(P, [memory, heap_size, total_heap_size, stack_size,
+                            message_queue_len, current_function, status, dictionary]),
+    State = sys:get_state(P),
+    Size = fun(Term) -> erts_debug:flat_size(Term) end,
+    Deep = fun(Depth, Recur, Term) when is_tuple(Term), Depth > 0 ->
+                   [{I, Size(element(I, Term)), Recur(Depth - 1, Recur, element(I, Term))}
+                    || I <- lists:seq(1, tuple_size(Term)), Size(element(I, Term)) > 8];
+              (Depth, Recur, Term) when is_map(Term), Depth > 0 ->
+                   [{K, Size(V), Recur(Depth - 1, Recur, V)}
+                    || {K, V} <- maps:to_list(Term), Size(V) > 8];
+              (_, _, _) -> []
+           end,
+    Dictionary = proplists:get_value(dictionary, Info),
+    #{process_info => [{K, V} || {K, V} <- Info, K =/= dictionary],
+      dictionary_keys_and_words => [{K, Size(V)} || {K, V} <- Dictionary],
+      state_words => Size(State),
+      state_tuple_size => tuple_size(State),
+      state_breakdown => Deep(3, Deep, State)}.' || true
+  exit 1
+fi
+
+echo "Connection memory smoke test passed in $((SECONDS - START_SECONDS)) seconds"


### PR DESCRIPTION
## Summary

- run a 200-client MQTT v5 smoke check against the Docker image built by the workflow
- reject any new warning-or-above log lines during CONNECT and any `hook_callback_exception` at any level
- cap one idle channel state at 360 words and every sampled hibernated channel at 4,600 bytes, with a detailed process/state breakdown on failure
- expose the bounded probes as `emqx_session_tool:hibernated_count/0`, `connection_memory/0`, and `connection_memory_breakdown/0`, keeping each `emqx eval` invocation to one function call

The broker uses the image's default socket backend and a 2-second MQTT idle timeout. At least 90% of the clients must be hibernated before the memory probe runs. This is intentionally a release smoke check because the multi-tenancy hook is registered only when the real application set boots.

`connection_memory/0` reads process memory before waking one selected hibernated channel with `sys:get_state/1`. The failure-only breakdown function reports the largest sampled hibernated process plus dictionary and nested state sizes.

## Budgets and measurements

Reference measurements on `dev-63` at `f6ac260d00` with 20,000 idle MQTT v5 clients were 298-301 state words and 3,896 bytes per hibernated channel. The budgets retain headroom while still rejecting the 6.3.0-sized state.

Local measurements:

| Image/probe | Idle state | Hibernated memory | Connect logs | Result | Wall clock |
|---|---:|---:|---|---|---:|
| current branch, helper-based smoke script | 296 words | 3,888 B | 0 warning+, 0 hook exceptions | pass | 23 s |
| `emqx/emqx-enterprise:6.3.0`, equivalent inline probe before helper extraction | 624 words | 5,784 B | 0 warning+, 0 hook exceptions | expected budget failure | 33.76 s |

For the client generator, 200 established connections took 5.4 seconds with `emqtt-bench` 0.6.2 and 5.7 seconds with the Paho/pip pattern on the same broker with warm images. The script uses the version-pinned `emqtt-bench` image to avoid installing a Python package during every run.

## Validation

- EMQX v6 enterprise build (`make`)
- helper-based smoke script against the compiled branch module: 200/200 channels hibernated, 296 state words, 3,888 B maximum, pass in 23 seconds
- `connection_memory_breakdown/0` against five live hibernated channels
- confirmed the 6.3.0-sized channel state exceeds both budgets using the equivalent inline probe
- Bash syntax check and ShellCheck 0.10.0
- erlfmt and Elvis 3.2.6-emqx-1
- actionlint 1.7.7, workflow YAML parse, and `git diff --check`

No Common Test suites are added or run by this PR.
