### PR TITLE
ci(bpapi): read each tag's proto modules once in the baseline audit

### DIFF
--- a/scripts/check-bpapi-baselines.exs
+++ b/scripts/check-bpapi-baselines.exs
@@ -145,16 +145,17 @@ defmodule CheckBpapiBaselines do
 
       tag ->
         keys = baseline_keys(file)
+        protos = protos_at(tag)
 
         missing =
-          protos_at(tag)
+          protos
           |> Enum.reject(fn {key, _path} -> MapSet.member?(keys, key) end)
           |> Enum.filter(fn {key, _path} -> MapSet.member?(present, key) end)
           |> Enum.filter(fn {_key, path} -> makes_rpc_call?(tag, path) end)
           |> Enum.map(&elem(&1, 0))
           |> Enum.sort()
 
-        checked = protos_at(tag) |> length()
+        checked = length(protos)
 
         case missing do
           [] -> {:ok, line, tag, checked}


### PR DESCRIPTION
Follow-up to #18890.

`check/2` in `scripts/check-bpapi-baselines.exs` called `protos_at/1` twice for the same tag: once to find the missing versions and once to count what was compared. Each call runs `git ls-tree` over the whole tag.

This binds the result once and uses it for both, so the reported count comes from the same list the comparison used. Output is unchanged:

```
5.10: ok against e5.10.4, 96 versions compared
5.8: ok against e5.8.11, 88 versions compared
5.9: ok against e5.9.3, 95 versions compared
6.0: ok against 6.0.3, 92 versions compared
```