### PR TITLE
ci(docker): raise the image size limit to 170 MB

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -94,11 +94,11 @@ jobs:
           echo "==========="
           echo "_EMQX_DOCKER_IMAGE_TAG=$(head -n 1 .emqx_docker_image_tags)" >> $GITHUB_ENV
 
-      - name: Verify that size of docker image is less than 160 MB
+      - name: Verify that size of docker image is less than 170 MB
         run: |
           SIZE=$(docker save $_EMQX_DOCKER_IMAGE_TAG | gzip -c | wc -c)
           echo "Image size: ${SIZE}"
-          test "${SIZE}" -lt 160000000
+          test "${SIZE}" -lt 170000000
 
       - name: smoke test
         timeout-minutes: 5


### PR DESCRIPTION
## Summary

The docker build job fails its image size check on every PR since 2026-09-12. Images grew by about 10.4 MB with no code change.

The runtime stage runs `apt-get upgrade -y` on `debian:13-slim`. Debian published a 13 point release on 2026-09-12, but Docker Hub has not refreshed `debian:13-slim` yet. The upgrade writes new copies of 7 packages (base-files, bash, gzip, libaudit-common, libc-bin, perl-base, tzdata) into a new layer. The old copies stay in the base layer, so the image carries both.

Measured on the base image CI uses (`debian:13-slim@sha256:d7e12182ce18…`): the upgrade step adds 10,372,930 bytes to the gzipped image.

This raises the limit from 160 MB to 170 MB. The largest image today is 167,304,745 bytes (amd64). The image size should drop back to about 156 MB once `debian:13-slim` is refreshed.

The same change is in the sync PR #18934 for dev-63. dev-62, dev-70 and master get it through the sync chain.
