### PR TITLE
ci(docker): gate on /opt/emqx size, relax the exported image limit

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -94,9 +94,19 @@ jobs:
           echo "==========="
           echo "_EMQX_DOCKER_IMAGE_TAG=$(head -n 1 .emqx_docker_image_tags)" >> $GITHUB_ENV
 
-      - name: Verify that size of docker image is less than 150 MB
+      # Tight limit: /opt/emqx is the part of the image that EMQX controls.
+      - name: Verify that size of /opt/emqx is less than 190 MB
         run: |
-          docker save $_EMQX_DOCKER_IMAGE_TAG | gzip -c | wc -c | xargs -I {} test {} -lt 150000000
+          SIZE=$(docker run --rm --entrypoint du "$_EMQX_DOCKER_IMAGE_TAG" -sb /opt/emqx | cut -f1)
+          echo "/opt/emqx size: ${SIZE}"
+          test "${SIZE}" -lt 190000000
+
+      # Loose limit: the base image layers change size without EMQX changes.
+      - name: Verify that size of exported docker image is less than 210 MB
+        run: |
+          SIZE=$(docker save "$_EMQX_DOCKER_IMAGE_TAG" | gzip -c | wc -c)
+          echo "Image size: ${SIZE}"
+          test "${SIZE}" -lt 210000000
 
       - name: smoke test
         timeout-minutes: 5


### PR DESCRIPTION
## Summary

The docker image size check fails when the Debian base image changes, not only when EMQX grows. The runtime stage runs `apt-get upgrade`. When Debian publishes a point release before `debian:13-slim` is refreshed, the upgrade adds a second copy of the upgraded packages to the image. Most past changes to the limit followed the base image.

This PR replaces the single check with two checks. Both print the measured size on every run.

| Check | Limit | Measured | Headroom |
|---|---|---|---|
| Uncompressed `/opt/emqx` (tight) | 190,000,000 | 172,498,857 (dev-60 tip, amd64) | 10.1% |
| Gzipped exported image (loose) | 210,000,000 | 167,298,637 (dev-63 CI, amd64) | 25.5% |

## Measurements

`/opt/emqx`, measured with `du -sb` (the same command as the new step):
- Clean local build of dev-60 at 4df91c3467, with the workflow's build command, amd64: 172,498,857.
- Published `emqx/emqx-enterprise:6.0.3`: 171,226,466 (amd64), about 163 MB (arm64).
- amd64 is the largest arch. Published 6.3.0 shows the same ratio: 197,517,557 (amd64), about 187 MB (arm64).

Gzipped exported image:
- dev-63 sync PR run 34696796953: 167,298,637 (amd64), 165,694,992 (arm64).
- dev-61 run 34696792290 (#18938): 161,695,076 (amd64), 160,075,508 (arm64).
- Local dev-60 build with today's base image: 152,169,878 (amd64). This is already above the current 150 MB limit.

## Notes

- The `/opt/emqx` step runs `du` with `--entrypoint du`, so EMQX does not start. The arm64 matrix job runs on a native arm64 runner, so no emulation is involved.
- The `docker-sfodbc` job gets no `/opt/emqx` check. The Snowflake ODBC driver is installed from a `.deb` package outside `/opt/emqx`. The base image check already covers `/opt/emqx`.
- Downstream branches have a larger `/opt/emqx`. 6.3.0 has 197,517,557 bytes (amd64), which is above 190 MB. Each forward-sync hop must set the `/opt/emqx` limit from that branch's own value plus about 10%. The 210 MB exported-image limit covers the whole chain.
- After this change syncs to dev-61, #18938 (raise to 170 MB) is no longer needed.

## Follow-up option (not in this PR)

Make the base image reproducible: pin `RUN_FROM` by digest, drop `apt-get upgrade`, and let a bot bump the digest. The tradeoff is that security fixes wait for the next digest bump. This PR does not change the Dockerfile.
